### PR TITLE
feat(ops): merge ops-enhancements into dev (conflict resolution)

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ops",
   "version": "0.2.2",
-  "description": "Business operations command center for Claude Code. Manage communications, projects, infrastructure, and revenue. Includes YOLO mode for autonomous business operation.",
+  "description": "Business operations command center for Claude Code. Manage communications, projects, infrastructure, and revenue from your terminal. Includes YOLO mode for autonomous business operation.",
   "author": {
     "name": "Sam Renders",
     "url": "https://github.com/auroracapital"
@@ -9,7 +9,20 @@
   "homepage": "https://github.com/auroracapital/claude-ops",
   "repository": "https://github.com/auroracapital/claude-ops",
   "license": "MIT",
-  "keywords": ["business", "operations", "communications", "yolo"],
+  "keywords": [
+    "business",
+    "operations",
+    "communications",
+    "whatsapp",
+    "email",
+    "slack",
+    "telegram",
+    "linear",
+    "sentry",
+    "infrastructure",
+    "revenue",
+    "yolo"
+  ],
   "userConfig": {
     "telegram_api_id": {
       "title": "Telegram API ID",


### PR DESCRIPTION
## Summary

Resolution of 19 add/add rebase conflicts between `feature/ops-enhancements` and `dev`. After rebasing, git patch-id matching skipped 5 of 6 feature commits because they were already applied on dev via independent commits (d26531e, 13d4f3c, 06f402a, 9161c21, etc.). Only one commit `51e7408` had genuinely unique content, and on inspection that content consisted entirely of files dev intentionally removed.

**Net delta: a single plugin.json improvement** — broader keywords + description polish — carried from feature branch into dev.

## Per-file decisions

| File | Winner | Reason |
|---|---|---|
| `claude-ops/.claude-plugin/plugin.json` | MERGE (dev base + feature's broader keywords/desc) | dev had newer v0.2.2 user-auth Telegram config; feature had richer keyword list and marketplace description. Merged both. |
| `claude-ops/.mcp.json` | dev | dev uses user-auth MTProto (`TELEGRAM_API_ID/HASH/PHONE/SESSION`), feature used legacy BotFather `TELEGRAM_BOT_TOKEN`. Per Sam's current arch (gram.js, `@aurorasrd` personal account), dev is correct. |
| `claude-ops/CHANGELOG.md` | dev | Longer/more recent (98 vs 57 lines). |
| `claude-ops/README.md` | dev | Longer/more recent (225 vs 193 lines). |
| `claude-ops/bin/ops-unread` | dev | Longer/more complete (110 vs 42 lines). |
| `claude-ops/agents/{comms-scanner,infra-monitor,triage-agent,yolo-ceo,yolo-cfo,yolo-coo,yolo-cto}.md` | dev (all 7) | Dev has opus-4-6 model, C-suite reporting chain synthesis, larger & more recent prompt engineering. Feature was opus-4-5 era. |
| `claude-ops/skills/{ops,ops-deploy,ops-inbox,ops-next,ops-projects,ops-triage}/SKILL.md` | dev (all 6) | Dev uses registry-driven project iteration (generalized) vs feature's hardcoded healify references. ops-inbox is much more substantive on dev (210 vs 126 lines). |
| `claude-ops/telegram-server/index.js` | dev | Dev is the user-auth MTProto rewrite (gram.js, dialogs/messages/reply tools). Feature was bot API. |
| `claude-ops/telegram-server/package.json` | dev | Dev v0.2.0 with `telegram` + `playwright` deps for user-auth; feature was v0.1.0 stub. |

## Dropped from feature branch (intentionally)

- `claude-ops/.planning/**` (17 files) — dev commit `d26531e` "public-repo hygiene v2 — .planning removal" deliberately removed these and added `.planning/` to `claude-ops/.gitignore`.
- `claude-ops/scripts/registry.json` — now gitignored as per-user private config; public template is `registry.example.json`.
- root `LICENSE` — duplicate, `claude-ops/LICENSE` already exists on dev.

## Unresolved

None. All 20 AA conflicts resolved; feature branch is effectively a subset of dev plus the plugin.json enhancement carried in this PR.

## Test plan

- [ ] CI green (JSON validates, no lint errors)
- [ ] `plugin.json` parses as valid JSON (verified locally with `python3 -m json.tool`)
- [ ] Keyword list visible in marketplace listing
- [ ] No regression in `/ops:setup` wizard flow
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/auroracapital/claude-ops/pull/1" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `plugin.json` metadata (description text and keyword list) with no runtime or config schema changes.
> 
> **Overview**
> Updates `claude-ops/.claude-plugin/plugin.json` to polish the plugin description and significantly expand the `keywords` list (adding comms/project/infra/revenue-related terms like WhatsApp, Slack, Telegram, Linear, and Sentry) for better discoverability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3919771f39063e6762535ec2ff2be30a8faf121c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->