### PR TITLE
fix: optional config + community files

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: auroracapital

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Sam Renders
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it responsibly:
+
+1. **Do NOT** open a public issue
+2. Email: info@auroracapital.nl
+3. Include: description, reproduction steps, impact assessment
+
+We'll respond within 48 hours and work with you on a fix before public disclosure.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.3.x   | ✅        |
+| < 0.3   | ❌        |
+
+## Security Features
+
+- **Secret scanning**: `.gitleaks.toml` + GitHub secret scanning + push protection enabled
+- **No secrets in code**: All tokens stored in macOS keychain, never in dotfiles or config
+- **Encrypted cookie handling**: Browser cookie decryption uses the app's own keychain key
+- **File permissions**: All temp files created with `umask 077` (mode 0600)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -26,45 +26,52 @@
   "userConfig": {
     "telegram_api_id": {
       "title": "Telegram API ID",
-      "description": "Numeric API ID from https://my.telegram.org/apps — create a personal app, NOT a bot. Required for /ops-inbox telegram.",
+      "description": "Numeric API ID from https://my.telegram.org/apps. Optional — run /ops:setup telegram to auto-configure.",
       "type": "string",
-      "sensitive": true
+      "sensitive": true,
+      "default": ""
     },
     "telegram_api_hash": {
       "title": "Telegram API Hash",
-      "description": "API hash from https://my.telegram.org/apps. Required for /ops-inbox telegram.",
+      "description": "API hash from https://my.telegram.org/apps. Optional — run /ops:setup telegram to auto-configure.",
       "type": "string",
-      "sensitive": true
+      "sensitive": true,
+      "default": ""
     },
     "telegram_phone": {
       "title": "Telegram Phone Number",
-      "description": "Your phone number in E.164 format e.g. '+15551234567'. Used once during first-run --auth. Required for /ops-inbox telegram.",
+      "description": "Your phone number in E.164 format. Optional — run /ops:setup telegram to auto-configure.",
       "type": "string",
-      "sensitive": true
+      "sensitive": true,
+      "default": ""
     },
     "telegram_session": {
       "title": "Telegram Session String",
-      "description": "Persisted gram.js StringSession. Generate once via `node telegram-server/index.js --auth` in a terminal after filling the 3 fields above. Required for /ops-inbox telegram.",
+      "description": "gram.js StringSession. Optional — run /ops:setup telegram to auto-configure.",
       "type": "string",
-      "sensitive": true
+      "sensitive": true,
+      "default": ""
     },
     "sentry_org": {
       "title": "Sentry Organization",
       "description": "Sentry organization slug e.g. 'healify' (optional)",
       "type": "string",
-      "sensitive": false
+      "sensitive": false,
+      "default": ""
     },
     "linear_team": {
       "title": "Linear Team Key",
       "description": "Default Linear team key e.g. 'HEA' (optional)",
       "type": "string",
-      "sensitive": false
+      "sensitive": false,
+      "default": ""
     },
     "aws_region": {
       "title": "AWS Region",
       "description": "Default AWS region for infra checks e.g. 'us-east-1' (optional)",
       "type": "string",
-      "sensitive": false
+      "sensitive": false,
+      "default": "us-east-1"
     }
   }
 }


### PR DESCRIPTION
Makes all userConfig fields optional with defaults. Adds LICENSE, SECURITY.md, FUNDING.yml.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/auroracapital/claude-ops/pull/9" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to repository/community metadata and plugin configuration defaults, with no runtime logic modifications. Main impact is that integrations may now start with empty config values if users don't supply them.
> 
> **Overview**
> Adds community/repo metadata files: `.github/FUNDING.yml`, `LICENSE` (MIT), and `SECURITY.md` with a vulnerability reporting process and supported-version table.
> 
> Updates `claude-ops/.claude-plugin/plugin.json` to make `userConfig` fields effectively optional by adding `default` values (mostly empty strings, `aws_region` defaulting to `us-east-1`) and adjusting Telegram config descriptions to direct users to `/ops:setup telegram` for auto-configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3288bef9e736a0b575d6360eaac9d3cd4698fcce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->