### PR TITLE
feat: GSD companion plugin auto-install in setup wizard

### DIFF
--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -74,6 +74,7 @@ Use `AskUserQuestion` with `multiSelect: true`. Offer **only sections that need 
 | Install CLIs       | cli      | Install missing command-line tools via Homebrew  |
 | Configure channels | channels | Set tokens for Telegram, WhatsApp, Email, Slack  |
 | Configure MCPs     | mcp      | Enable Linear, Sentry, Vercel, Gmail MCP servers |
+| Companion plugins  | plugins  | Install GSD for project roadmap tracking         |
 | Build registry     | registry | Register projects Claude should manage           |
 | Save preferences   | prefs    | Owner name, timezone, default priorities         |
 | Shell env          | env      | Export `CLAUDE_PLUGIN_ROOT` in shell profile     |
@@ -101,6 +102,45 @@ ${PLUGIN_ROOT}/bin/ops-setup-install <tool>
 Report success/failure. If Homebrew is missing on macOS, stop and tell the user to install it from https://brew.sh first — do not attempt to install brew automatically.
 
 After installation, re-run `ops-setup-detect` to refresh status before continuing.
+
+---
+
+## Step 2b — Companion plugins (if selected)
+
+### GSD (Get Shit Done)
+
+GSD is a third-party Claude Code plugin that adds project roadmap tracking. When installed, claude-ops dashboards (`/ops:go`, `/ops:projects`, `/ops:next`, `/ops:yolo`) automatically show active phases, progress, and next actions per project. Without it, those sections are simply omitted.
+
+Check if GSD is already installed:
+
+```bash
+ls ~/.claude/plugins/cache/*/gsd*/skills/gsd-progress/SKILL.md 2>/dev/null && echo "installed" || echo "not_installed"
+```
+
+If not installed, ask via `AskUserQuestion`:
+
+```
+GSD adds project roadmap tracking to your ops dashboards.
+  /ops:go shows active phases and progress per project
+  /ops:projects shows GSD state alongside CI/PR status
+  /ops:next factors in GSD work priority
+
+  [Install GSD (latest)] [Skip — I don't need roadmap tracking]
+```
+
+On install, run:
+
+```bash
+claude plugin marketplace add auroracapital/get-shit-done && claude plugin install gsd@auroracapital-get-shit-done
+```
+
+Report success/failure. If it fails (e.g. marketplace not reachable), print:
+
+```
+Could not auto-install GSD. You can install it manually later:
+  /plugin marketplace add auroracapital/get-shit-done
+  /plugin install gsd@auroracapital-get-shit-done
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- Setup wizard Step 2b offers to install GSD (Get Shit Done) as a companion plugin
- Auto-installs via `claude plugin marketplace add` + `plugin install` (latest version)
- Users choose [Install GSD (latest)] or [Skip]
- Enhances /ops:go, /ops:projects, /ops:next with project roadmap state

## Test plan
- [ ] Run /ops:setup and verify GSD prompt appears when GSD not installed
- [ ] Verify auto-install command works
- [ ] Verify skip path works cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only update to the setup wizard; no runtime code paths or credential handling logic are modified.
> 
> **Overview**
> Adds a new optional **“Companion plugins”** section to the `/ops:setup` wizard, letting users install the third-party GSD plugin for roadmap tracking.
> 
> The wizard now detects whether GSD is already present, prompts to install or skip, runs `claude plugin marketplace add ...` + `claude plugin install ...` on confirmation, and provides manual install instructions on failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e247bf068f77a98b54266dce9b6505196fad9ec4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->