### PR TITLE
fix: replace gitleaks-action with local binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,9 @@ jobs:
       - name: Prettier check
         run: cd claude-ops && npx prettier --check "**/*.{js,mjs,json}" --ignore-path .gitignore
 
-      - name: Gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        with:
-          config-path: claude-ops/.gitleaks.toml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_8.24.3_linux_amd64.tar.gz | tar xz
+          chmod +x gitleaks
+      - name: Run gitleaks
+        run: ./gitleaks detect --source . --config claude-ops/.gitleaks.toml --verbose


### PR DESCRIPTION
Replaces `gitleaks/gitleaks-action@v2` with a direct binary install to avoid the GITLEAKS_LICENSE requirement for org repos.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change; main impact is CI secret scanning now depends on downloading/executing a specific gitleaks binary and correct curl/GitHub availability.
> 
> **Overview**
> CI secret scanning switches from `gitleaks/gitleaks-action@v2` to downloading the `gitleaks` v8.24.3 Linux binary via `curl` and running `gitleaks detect` with `claude-ops/.gitleaks.toml`.
> 
> This removes the action-specific configuration and env requirements (including the `GITLEAKS_LICENSE` secret) and makes the scan step an explicit install+run sequence in `.github/workflows/ci.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e43aa7b91c331f303a5abc1eb3024102466cac42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->