### PR TITLE
fix(telegram): graceful degradation when credentials are missing

### DIFF
--- a/claude-ops/telegram-server/index.js
+++ b/claude-ops/telegram-server/index.js
@@ -38,64 +38,76 @@ const API_HASH = process.env.TELEGRAM_API_HASH || "";
 const SESSION_STRING = process.env.TELEGRAM_SESSION || "";
 const PHONE = process.env.TELEGRAM_PHONE || "";
 
-if (!API_ID || !API_HASH) {
-  process.stderr.write(
-    "ERROR: TELEGRAM_API_ID and TELEGRAM_API_HASH are required.\n" +
-      "Get them from https://my.telegram.org/apps (create a personal app, NOT a bot).\n",
-  );
-  process.exit(1);
-}
+// Detect whether credentials are present — server always starts regardless
+const CONFIGURED = !!(API_ID && API_HASH && SESSION_STRING);
+const NOT_CONFIGURED_MSG =
+  "Telegram not configured. Run /ops:setup telegram to set up your credentials.";
 
-const stringSession = new StringSession(SESSION_STRING);
-const client = new TelegramClient(stringSession, API_ID, API_HASH, {
-  connectionRetries: 5,
-  baseLogger: {
-    log: () => {},
-    warn: () => {},
-    error: (...args) => process.stderr.write(args.join(" ") + "\n"),
-    info: () => {},
-    debug: () => {},
-  },
-});
+let client = null;
 
-// First-run interactive auth mode
-if (process.argv.includes("--auth")) {
-  const rl = readline.createInterface({ input, output });
-  await client.start({
-    phoneNumber: async () =>
-      PHONE || (await rl.question("Phone number (E.164): ")),
-    password: async () => await rl.question("2FA password (blank if none): "),
-    phoneCode: async () => await rl.question("SMS code: "),
-    onError: (err) => process.stderr.write(`Auth error: ${err.message}\n`),
-  });
-  rl.close();
-  const saved = client.session.save();
-  process.stdout.write("\n=== AUTH SUCCESSFUL ===\n");
-  process.stdout.write("Save this to TELEGRAM_SESSION env var:\n\n");
-  process.stdout.write(saved + "\n");
-  await client.disconnect();
-  process.exit(0);
-}
-
-// Non-interactive mode — requires saved session
-if (!SESSION_STRING) {
-  process.stderr.write(
-    "ERROR: TELEGRAM_SESSION is not set. Run `node index.js --auth` first to generate it.\n",
-  );
-  process.exit(1);
-}
-
-// Connect using saved session
-try {
-  await client.connect();
-  if (!(await client.checkAuthorization())) {
-    throw new Error(
-      "Session is no longer valid — re-run `node index.js --auth`",
-    );
+if (CONFIGURED) {
+  // First-run interactive auth mode (only when creds are available)
+  if (process.argv.includes("--auth")) {
+    const stringSession = new StringSession(SESSION_STRING);
+    const authClient = new TelegramClient(stringSession, API_ID, API_HASH, {
+      connectionRetries: 5,
+      baseLogger: {
+        log: () => {},
+        warn: () => {},
+        error: (...args) => process.stderr.write(args.join(" ") + "\n"),
+        info: () => {},
+        debug: () => {},
+      },
+    });
+    const rl = readline.createInterface({ input, output });
+    await authClient.start({
+      phoneNumber: async () =>
+        PHONE || (await rl.question("Phone number (E.164): ")),
+      password: async () =>
+        await rl.question("2FA password (blank if none): "),
+      phoneCode: async () => await rl.question("SMS code: "),
+      onError: (err) => process.stderr.write(`Auth error: ${err.message}\n`),
+    });
+    rl.close();
+    const saved = authClient.session.save();
+    process.stdout.write("\n=== AUTH SUCCESSFUL ===\n");
+    process.stdout.write("Save this to TELEGRAM_SESSION env var:\n\n");
+    process.stdout.write(saved + "\n");
+    await authClient.disconnect();
+    process.exit(0);
   }
-} catch (err) {
-  process.stderr.write(`Failed to connect: ${err.message}\n`);
-  process.exit(1);
+
+  // Connect using saved session
+  const stringSession = new StringSession(SESSION_STRING);
+  client = new TelegramClient(stringSession, API_ID, API_HASH, {
+    connectionRetries: 5,
+    baseLogger: {
+      log: () => {},
+      warn: () => {},
+      error: (...args) => process.stderr.write(args.join(" ") + "\n"),
+      info: () => {},
+      debug: () => {},
+    },
+  });
+
+  try {
+    await client.connect();
+    if (!(await client.checkAuthorization())) {
+      process.stderr.write(
+        "Warning: Telegram session is no longer valid. Re-run `node index.js --auth`.\n",
+      );
+      client = null;
+    }
+  } catch (err) {
+    process.stderr.write(
+      `Warning: Failed to connect to Telegram: ${err.message}\n`,
+    );
+    client = null;
+  }
+} else {
+  process.stderr.write(
+    "Telegram credentials not set — server starting in unconfigured mode.\n",
+  );
 }
 
 // ── MCP server setup ──
@@ -203,6 +215,13 @@ function resolveChatArg(chat) {
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
+
+  if (!client) {
+    return {
+      content: [{ type: "text", text: NOT_CONFIGURED_MSG }],
+      isError: true,
+    };
+  }
 
   try {
     if (name === "list_dialogs") {
@@ -344,10 +363,10 @@ process.stderr.write("Telegram MCP server running (user-auth mode)\n");
 
 // Graceful shutdown
 process.on("SIGINT", async () => {
-  await client.disconnect();
+  if (client) await client.disconnect();
   process.exit(0);
 });
 process.on("SIGTERM", async () => {
-  await client.disconnect();
+  if (client) await client.disconnect();
   process.exit(0);
 });


### PR DESCRIPTION
## Summary
- Telegram MCP server no longer calls `process.exit(1)` at startup when `TELEGRAM_API_ID`, `TELEGRAM_API_HASH`, or `TELEGRAM_SESSION` are unset
- Server always starts as a valid MCP server; tool calls return `"Telegram not configured. Run /ops:setup telegram to set up."` when credentials are missing
- Guards added to shutdown handlers to avoid null-dereference on `client.disconnect()`

## Test plan
- [ ] Start claude-ops with Telegram env vars unset — plugin should load without error
- [ ] Call any Telegram tool — should receive the not-configured message instead of a crash
- [ ] Set credentials and restart — normal Telegram functionality should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk behavioral change limited to Telegram server startup and tool-call gating; main risk is unintentionally masking misconfiguration by running in degraded mode instead of failing fast.
> 
> **Overview**
> The Telegram MCP server now **gracefully degrades** when `TELEGRAM_API_ID`/`TELEGRAM_API_HASH`/`TELEGRAM_SESSION` are missing or the session is invalid: it starts in an *unconfigured mode* instead of exiting at startup.
> 
> All tool invocations are gated on an initialized Telegram client; when unconfigured (or connection/auth fails) calls return a consistent `Telegram not configured...` error message, and shutdown handlers now `disconnect()` only when a client exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4400e2bebd759a42ad0bd67727bc7a69a3674514. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->