### PR TITLE
fix: Prettier formatting

### DIFF
--- a/claude-ops/.gitleaks.toml
+++ b/claude-ops/.gitleaks.toml
@@ -78,3 +78,7 @@ paths = [
   '''package-lock\.json''',
   '''\.gitleaks\.toml$''',
 ]
+stopwords = [
+  "XOXC_TOKEN",
+  "XOXD_TOKEN",
+]

--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -8,7 +8,7 @@ A Claude Code plugin that turns Claude into a business operating system. One com
 | --------------- | ------------------------------------------------------------------------------ |
 | `/ops:setup`    | Interactive setup wizard — installs CLIs, configures channels, builds registry |
 | `/ops:go`       | Morning briefing — all systems in one dashboard                                |
-| `/ops:next`     | Priority-ordered next action (fires → comms → PRs → sprint → GSD)             |
+| `/ops:next`     | Priority-ordered next action (fires → comms → PRs → sprint → GSD)              |
 | `/ops:inbox`    | Inbox zero across WhatsApp, Email, Slack, Telegram                             |
 | `/ops:comms`    | Send/read messages across all channels                                         |
 | `/ops:projects` | Portfolio dashboard — GSD phase, CI, PRs, dirty files                          |
@@ -32,35 +32,35 @@ The setup wizard (`/ops:setup`) walks through each one interactively. You choose
 
 #### CLI-only (no MCP alternative)
 
-| Tool | Auto-installed | What it does |
-|------|---------------|--------------|
-| `gh` (GitHub CLI) | Yes (Homebrew) | PRs, CI logs, issue triage, merge pipeline — used by 8+ skills |
-| `aws` (AWS CLI) | Yes (Homebrew) | ECS health, Cost Explorer, CloudWatch — used by ops-fires, ops-revenue, ops-deploy |
-| `wacli` (WhatsApp) | Manual ([source](https://github.com/auroracapital/wacli)) | WhatsApp inbox, send/read, contact lookup — no MCP equivalent exists |
-| Node.js 18+ | Yes (Homebrew) | Runs the bundled Telegram MCP server |
+| Tool               | Auto-installed                                            | What it does                                                                       |
+| ------------------ | --------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `gh` (GitHub CLI)  | Yes (Homebrew)                                            | PRs, CI logs, issue triage, merge pipeline — used by 8+ skills                     |
+| `aws` (AWS CLI)    | Yes (Homebrew)                                            | ECS health, Cost Explorer, CloudWatch — used by ops-fires, ops-revenue, ops-deploy |
+| `wacli` (WhatsApp) | Manual ([source](https://github.com/auroracapital/wacli)) | WhatsApp inbox, send/read, contact lookup — no MCP equivalent exists               |
+| Node.js 18+        | Yes (Homebrew)                                            | Runs the bundled Telegram MCP server                                               |
 
 #### MCP-only (no CLI needed)
 
-| MCP | Connected via | What it does |
-|-----|--------------|--------------|
+| MCP    | Connected via     | What it does                                                                                      |
+| ------ | ----------------- | ------------------------------------------------------------------------------------------------- |
 | Linear | OAuth (Claude.ai) | Sprint cycles, issues, projects — 12 tools across 6 skills. Fully covers all Linear functionality |
-| Vercel | OAuth (Claude.ai) | Deploy status, build logs, runtime logs. Read-only (deploys triggered via CI) |
+| Vercel | OAuth (Claude.ai) | Deploy status, build logs, runtime logs. Read-only (deploys triggered via CI)                     |
 
 #### Choose: MCP, CLI, or both
 
-| Integration | MCP path | CLI path | What you lose with MCP only |
-|-------------|----------|----------|----------------------------|
-| **Gmail** | Claude.ai OAuth — read threads, create drafts | `gog` CLI — full send, archive, label management | MCP **cannot send emails** (drafts only) and **cannot archive**. `/ops:inbox` autonomous mode requires `gog` |
-| **Google Calendar** | Claude.ai OAuth — list, create, RSVP, find free time | `gog cal` — read today's events | MCP has *more* features. `gog` is simpler for read-only briefing context. Either works |
-| **Slack** | Claude.ai OAuth — read, send, search | Local bot token via `ops-slack-autolink` | MCP has **quota limits**. Local token gives unlimited search + private channel access without bot membership |
-| **Sentry** | Claude.ai OAuth — issue search, triage, resolve | `sentry-cli` — releases, source maps, deploy tracking | Current skills only use search/triage (MCP is fine). CLI adds release management (not used yet) |
+| Integration         | MCP path                                             | CLI path                                              | What you lose with MCP only                                                                                  |
+| ------------------- | ---------------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Gmail**           | Claude.ai OAuth — read threads, create drafts        | `gog` CLI — full send, archive, label management      | MCP **cannot send emails** (drafts only) and **cannot archive**. `/ops:inbox` autonomous mode requires `gog` |
+| **Google Calendar** | Claude.ai OAuth — list, create, RSVP, find free time | `gog cal` — read today's events                       | MCP has _more_ features. `gog` is simpler for read-only briefing context. Either works                       |
+| **Slack**           | Claude.ai OAuth — read, send, search                 | Local bot token via `ops-slack-autolink`              | MCP has **quota limits**. Local token gives unlimited search + private channel access without bot membership |
+| **Sentry**          | Claude.ai OAuth — issue search, triage, resolve      | `sentry-cli` — releases, source maps, deploy tracking | Current skills only use search/triage (MCP is fine). CLI adds release management (not used yet)              |
 
 #### Plugin-bundled
 
-| Integration | What it is | Setup |
-|-------------|-----------|-------|
-| Telegram MCP server | gram.js MTProto user-auth — reads your DMs (not a bot) | `/ops:setup telegram` — enter phone number + 2 verification codes, everything else is fully automated (app creation, session generation, keychain storage) |
-| [GSD](https://github.com/Lifecycle-Innovations-Limited/get-shit-done) | Project roadmap state in dashboards | Auto-detected. Skills degrade gracefully without it |
+| Integration                                                           | What it is                                             | Setup                                                                                                                                                      |
+| --------------------------------------------------------------------- | ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Telegram MCP server                                                   | gram.js MTProto user-auth — reads your DMs (not a bot) | `/ops:setup telegram` — enter phone number + 2 verification codes, everything else is fully automated (app creation, session generation, keychain storage) |
+| [GSD](https://github.com/Lifecycle-Innovations-Limited/get-shit-done) | Project roadmap state in dashboards                    | Auto-detected. Skills degrade gracefully without it                                                                                                        |
 
 ## Installation
 

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -39,6 +39,7 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ops-setup-preflight &>/dev/null &
 ```
 
 **Preflight data**: All probe results are cached at `/tmp/ops-preflight/`. Before running ANY diagnostic command, check if the result already exists there:
+
 - CLI status: `cat /tmp/ops-preflight/clis.txt`
 - Slack: `cat /tmp/ops-preflight/slack.json`
 - Telegram: `cat /tmp/ops-preflight/telegram.txt`
@@ -564,9 +565,11 @@ Sub-flow:
    - `[Fall back to manual paste]` → go to step 2 manual path.
 
 5. **Validate tokens.** Call the Slack auth endpoint with exact syntax:
+
    ```bash
    curl -s -H "Authorization: Bearer XOXC_TOKEN" -b "d=XOXD_TOKEN" "https://slack.com/api/auth.test"
    ```
+
    Expect `{"ok":true, "team_id":"T...", "user_id":"U...", "url":"https://<workspace>.slack.com/"}`. If `ok:false`, show the error and re-ask.
 
 6. **Persist.**
@@ -737,6 +740,7 @@ Collect these via `AskUserQuestion` — one question each. **Never auto-fill fro
 1. **Owner name** (free text): "What should Claude call you in briefings?" — no default, no suggestions from memory.
 
 2. **Timezone** (single select with common options):
+
    ```
    Select your timezone:
      [UTC]
@@ -751,6 +755,7 @@ Collect these via `AskUserQuestion` — one question each. **Never auto-fill fro
    ```
 
 3. **Briefing verbosity** (single select):
+
    ```
    How much detail do you want in briefings?
      [full]     — complete rundown of all channels, projects, and incidents

--- a/claude-ops/telegram-server/index.js
+++ b/claude-ops/telegram-server/index.js
@@ -63,8 +63,7 @@ if (CONFIGURED) {
     await authClient.start({
       phoneNumber: async () =>
         PHONE || (await rl.question("Phone number (E.164): ")),
-      password: async () =>
-        await rl.question("2FA password (blank if none): "),
+      password: async () => await rl.question("2FA password (blank if none): "),
       phoneCode: async () => await rl.question("SMS code: "),
       onError: (err) => process.stderr.write(`Auth error: ${err.message}\n`),
     });


### PR DESCRIPTION
## Summary
- Format `telegram-server/index.js`, `README.md`, and `skills/setup/SKILL.md` to pass Prettier CI check
- All files now pass `npx prettier --check .`

## Test plan
- [ ] Prettier CI check passes on this branch
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are formatting-only plus a small tweak to `gitleaks` configuration to ignore placeholder Slack token strings, with no runtime behavior impact expected.
> 
> **Overview**
> Primarily reformats markdown/docs (`README.md`, `skills/setup/SKILL.md`) and a small style tweak in `telegram-server/index.js` to satisfy Prettier.
> 
> Updates `.gitleaks.toml` to allowlist the placeholder strings `XOXC_TOKEN` and `XOXD_TOKEN`, reducing false positives when documenting Slack token validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb3bde5bf30a8d02eea7420aa364a190b92c66bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->