### PR TITLE
sync: dev → main (bug fixes, preflight, onboarding)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,7 +4,7 @@
   "description": "Local marketplace for claude-ops plugin",
   "owner": {
     "name": "Sam Renders",
-    "email": "info@auroracapital.nl"
+    "email": "info@lifecycleinnovations.limited"
   },
   "plugins": [
     {

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to Claude Ops Marketplace
+
+Thanks for your interest in contributing!
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork: `git clone https://github.com/<your-username>/claude-ops.git`
+3. Create a feature branch (see branch naming below)
+4. Make your changes, commit, and push
+5. Open a pull request against `dev`
+
+## Branch Naming
+
+| Prefix | Use |
+|--------|-----|
+| `feat/` | New features or integrations |
+| `fix/` | Bug fixes |
+| `docs/` | Documentation only changes |
+
+Examples: `feat/stripe-integration`, `fix/auth-token-refresh`, `docs/setup-guide`
+
+## Pull Request Process
+
+1. Target the `dev` branch (never `main` directly)
+2. Fill out the PR template completely
+3. Ensure all CI checks pass
+4. Request a review from a maintainer
+5. Address feedback promptly — stale PRs may be closed
+
+## Code Style
+
+- TypeScript: follow existing ESLint/Prettier config (`npm run lint`)
+- Shell scripts: `shellcheck`-clean
+- Python: `ruff` for linting, `black` for formatting
+- No placeholder comments or TODOs — ship complete code only
+- Keep changes surgical; avoid scope creep
+
+## Testing
+
+- Add or update unit tests for any logic you change
+- Run the test suite before opening a PR:
+  ```bash
+  npm run type-check && npm run lint && npm run test
+  ```
+- Integration tests must not mock external services
+
+## Reporting Issues
+
+Use the issue templates in `.github/ISSUE_TEMPLATE/`. Include as much context as possible — vague reports are hard to act on.
+
+## License
+
+By contributing, you agree your contributions will be licensed under the project's existing license.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug Report
+about: Report a reproducible bug
+labels: bug
+---
+
+## Description
+
+<!-- A clear and concise description of the bug -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+<!-- What should have happened -->
+
+## Actual Behavior
+
+<!-- What actually happened — include error messages, stack traces, or screenshots -->
+
+## Environment
+
+- **Claude Code version**: <!-- e.g. 1.2.3 — run `claude --version` -->
+- **OS**: <!-- e.g. macOS 15.2, Ubuntu 24.04 -->
+- **Node version** (if applicable): <!-- e.g. 20.11.0 -->
+
+## Integrations Configured
+
+<!-- List any MCP servers, tools, or third-party integrations active when the bug occurred -->
+
+## Additional Context
+
+<!-- Anything else that might help: config snippets, logs, related issues -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+labels: enhancement
+---
+
+## Description
+
+<!-- A clear and concise description of the feature you'd like -->
+
+## Use Case
+
+<!-- Describe the problem this solves or the workflow it enables. Who benefits and how? -->
+
+## Proposed Solution
+
+<!-- How would you like this to work? Include API shapes, UI sketches, or command examples if helpful -->
+
+## Alternatives Considered
+
+<!-- What workarounds or alternative approaches have you tried? Why do they fall short? -->
+
+## Additional Context
+
+<!-- Links, prior art, related issues, or anything else worth knowing -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- What does this PR do and why? 1-3 sentences max -->
+
+## Changes
+
+<!-- Bullet list of meaningful changes — skip obvious ones like "added file X" -->
+
+-
+-
+
+## Test Plan
+
+<!-- How did you verify this works? Include commands run or steps taken -->
+
+-
+
+## Checklist
+
+- [ ] Tests pass (`npm run type-check && npm run lint && npm run test`)
+- [ ] Documentation updated (if applicable)
+- [ ] No secrets, tokens, or credentials in the diff
+- [ ] Targets `dev` (not `main`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install gitleaks
         run: |
-          curl -sSfL https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_8.24.3_linux_amd64.tar.gz | tar xz
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz | tar xz
           chmod +x gitleaks
       - name: Run gitleaks
         run: ./gitleaks detect --source . --config claude-ops/.gitleaks.toml --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,9 @@ jobs:
       - name: Prettier check
         run: cd claude-ops && npx prettier --check "**/*.{js,mjs,json}" --ignore-path .gitignore
 
-      - name: Gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        with:
-          config-path: claude-ops/.gitleaks.toml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+      - name: Install gitleaks
+        run: |
+          curl -sSfL https://github.com/gitleaks/gitleaks/releases/latest/download/gitleaks_8.24.3_linux_amd64.tar.gz | tar xz
+          chmod +x gitleaks
+      - name: Run gitleaks
+        run: ./gitleaks detect --source . --config claude-ops/.gitleaks.toml --verbose

--- a/README.md
+++ b/README.md
@@ -1,12 +1,46 @@
-# claude-ops — Business Operating System for Claude Code
+```
+ ██████╗██╗      █████╗ ██╗   ██╗██████╗ ███████╗       ██████╗ ██████╗ ███████╗
+██╔════╝██║     ██╔══██╗██║   ██║██╔══██╗██╔════╝      ██╔═══██╗██╔══██╗██╔════╝
+██║     ██║     ███████║██║   ██║██║  ██║█████╗  █████╗██║   ██║██████╔╝███████╗
+██║     ██║     ██╔══██║██║   ██║██║  ██║██╔══╝  ╚════╝██║   ██║██╔═══╝ ╚════██║
+╚██████╗███████╗██║  ██║╚██████╔╝██████╔╝███████╗      ╚██████╔╝██║     ███████║
+ ╚═════╝╚══════╝╚═╝  ╚═╝ ╚═════╝ ╚═════╝ ╚══════╝       ╚═════╝ ╚═╝     ╚══════╝
+```
+
+<div align="center">
+
+**Business Operating System for Claude Code**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./claude-ops/LICENSE)
 [![Version](https://img.shields.io/badge/version-0.3.0-blue.svg)](https://github.com/Lifecycle-Innovations-Limited/claude-ops/releases)
 [![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)](https://claude.ai/settings/plugins)
 
-Turn Claude Code into a complete business operating system. One command — `/ops:go` — delivers a morning briefing covering infrastructure health, CI/CD status, unread messages, open PRs, sprint state, and revenue snapshot.
+</div>
 
-## Quick Start
+```
+╭──────────────────────────────────────────────────────────────────────────────╮
+│  /ops:go  ►  MORNING BRIEFING                              2026-04-12  09:03 │
+├─────────────────────────────────┬────────────────────────────────────────────┤
+│  INFRA    ████████████████  ok  │  ECS: 4/4 healthy  RDS: ok  Redis: ok     │
+│  CI/CD    ████████████░░░░  75% │  3 passing  1 failing  (healify-api #847)  │
+│  INBOX    ░░░░░░░░░░░░░░░░  14  │  Slack: 9  Telegram: 3  Gmail: 2 unread   │
+│  PRs      ████████████████  3   │  3 ready to merge  1 needs review          │
+│  SPRINT   ████████████░░░░  67% │  Sprint 24  —  8 of 12 issues complete     │
+│  REVENUE  ████████████████  $   │  $2,847 MTD  ↑12% vs last month           │
+├─────────────────────────────────┴────────────────────────────────────────────┤
+│  Next action: merge feat/user-profile  ·  fix healify-api CI  ·  reply @sam │
+╰──────────────────────────────────────────────────────────────────────────────╯
+```
+
+One command. Sixty seconds. Your entire business, at a glance.
+
+Turn Claude Code into a complete business operating system — infrastructure health, CI/CD status, unified inbox, open PRs, sprint state, revenue snapshot, and autonomous agents that act on your behalf.
+
+```
+╔══════════════════════════════╗
+║        QUICK  START          ║
+╚══════════════════════════════╝
+```
 
 ```bash
 # 1. Add the marketplace
@@ -15,128 +49,158 @@ Turn Claude Code into a complete business operating system. One command — `/op
 # 2. Install the plugin
 /plugin install ops@lifecycle-innovations-limited-claude-ops
 
-# 3. Configure your integrations
+# 3. Configure your integrations (guided wizard)
 /ops:setup
 ```
 
-The setup wizard walks through each integration interactively — install CLIs, connect channels, build your project registry. All credentials stored locally, never transmitted.
+> The setup wizard walks through each integration interactively — install CLIs, connect channels, build your project registry. All credentials stored locally, never transmitted.
 
-### Local Development
+**Local development:**
 
 ```bash
 git clone https://github.com/Lifecycle-Innovations-Limited/claude-ops.git
 claude --plugin-dir ./claude-ops
 ```
 
----
+```
+╔══════════════════════════════╗
+║         COMMAND  SET         ║
+╚══════════════════════════════╝
+```
 
-## What It Does
+```
+┌────────────────┬─────────────────────────────────────────────┬──────────────────────────────────┐
+│  COMMAND       │  WHAT IT DOES                               │  INTEGRATIONS                    │
+├────────────────┼─────────────────────────────────────────────┼──────────────────────────────────┤
+│  /ops:go       │  Full morning briefing — one cmd, 60s       │  GitHub, Linear, Sentry, AWS     │
+│  /ops:inbox    │  Unified inbox — read + triage all channels │  Slack, Telegram, WhatsApp, Gmail│
+│  /ops:merge    │  Autonomous PR review + merge pipeline      │  GitHub Actions, GitHub CLI      │
+│  /ops:comms    │  Send/read messages across any channel      │  Slack, Telegram, WhatsApp, Gmail│
+│  /ops:fires    │  Production incidents + ECS health          │  AWS ECS, Sentry                 │
+│  /ops:revenue  │  AWS spend, credits, runway estimate        │  AWS Cost Explorer               │
+│  /ops:projects │  Portfolio dashboard — all projects         │  GitHub, Linear                  │
+│  /ops:linear   │  Sprint board + issue management            │  Linear                          │
+│  /ops:deploy   │  Deploy status across all projects          │  AWS ECS, Vercel, GitHub Actions │
+│  /ops:triage   │  Cross-platform issue triage                │  Sentry, Linear, GitHub Issues   │
+│  /ops:next     │  Priority-ranked "what should I do next"    │  Everything                      │
+│  /ops:yolo     │  4 parallel C-suite AI agents — autonomous  │  Everything                      │
+└────────────────┴─────────────────────────────────────────────┴──────────────────────────────────┘
+```
 
-| Command | What it does | Integrations |
-|---------|-------------|--------------|
-| `/ops:go` | Full morning briefing — one command, 60 seconds | GitHub, Linear, Sentry, AWS |
-| `/ops:inbox` | Unified inbox — read + triage all channels | Slack, Telegram, WhatsApp, Gmail |
-| `/ops:merge` | Autonomous PR review + merge pipeline | GitHub Actions, GitHub CLI |
-| `/ops:comms` | Send/read messages across any channel | Slack, Telegram, WhatsApp, Gmail |
-| `/ops:fires` | Production incidents + ECS health dashboard | AWS ECS, Sentry |
-| `/ops:revenue` | AWS spend, credits, runway estimate | AWS Cost Explorer |
-| `/ops:projects` | Portfolio dashboard — all projects at a glance | GitHub, Linear |
-| `/ops:linear` | Sprint board, issue management | Linear |
-| `/ops:deploy` | Deploy status across all projects | AWS ECS, Vercel, GitHub Actions |
-| `/ops:triage` | Cross-platform issue triage | Sentry, Linear, GitHub Issues |
-| `/ops:next` | Priority-ranked "what should I do next" | Everything |
-| `/ops:yolo` | 4 parallel C-suite AI agents — fully autonomous | Everything |
+```
+╔══════════════════════════════╗
+║       BEFORE  /  AFTER       ║
+╚══════════════════════════════╝
+```
 
----
+```
+┌────────────────────────────────────────────┬──────────────────────────────────────────────┐
+│  WITHOUT claude-ops                        │  WITH claude-ops                             │
+├────────────────────────────────────────────┼──────────────────────────────────────────────┤
+│  Open 6+ tabs every morning                │  /ops:go  ——  one command, done              │
+│  Context-switch between Slack/Telegram/    │  /ops:inbox  ——  unified view, all channels  │
+│  email                                     │                                              │
+│  Manually review and merge PRs one by one  │  /ops:merge  ——  autonomous pipeline         │
+│  SSH into servers to check health          │  /ops:fires  ——  terminal dashboard          │
+│  Forget to track AWS spend                 │  /ops:revenue  ——  automatic cost snapshot   │
+│  Switch between Linear and GitHub          │  /ops:linear + /ops:projects  ——  unified    │
+└────────────────────────────────────────────┴──────────────────────────────────────────────┘
+```
 
-## Before vs After
-
-| Without claude-ops | With claude-ops |
-|--------------------|-----------------|
-| Open 6+ tabs every morning | `/ops:go` — one command |
-| Context-switch between Slack, Telegram, email | `/ops:inbox` — unified inbox |
-| Manually review and merge PRs | `/ops:merge` — autonomous pipeline |
-| SSH into servers to check health | `/ops:fires` — terminal dashboard |
-| Forget to track AWS spend | `/ops:revenue` — automatic cost snapshot |
-| Switch between Linear and GitHub | `/ops:linear` + `/ops:projects` — unified view |
-
----
-
-## Requirements
+```
+╔══════════════════════════════╗
+║         REQUIREMENTS         ║
+╚══════════════════════════════╝
+```
 
 Just [Claude Code](https://claude.ai/code) 1.0+. Everything else is installed automatically.
 
 The setup wizard (`/ops:setup`) walks you through each integration interactively — "Do you want AWS CLI? [Yes/No]", "Connect Slack? [OAuth/Skip]", etc. Missing CLIs are auto-installed via Homebrew. MCP servers connect via OAuth. No config files to edit manually.
 
-### Integrations: MCP vs CLI
+```
+╔══════════════════════════════════════════╗
+║      INTEGRATIONS: MCP  vs  CLI          ║
+╚══════════════════════════════════════════╝
+```
 
 Most integrations offer two paths. The setup wizard lets you choose per-integration.
 
-| Integration | MCP-only (zero-config OAuth) | + CLI tool | What you lose without the CLI |
-|-------------|------------------------------|------------|-------------------------------|
-| **GitHub** | -- | `gh` (auto-installed) | **Everything** — GitHub is CLI-only. CI logs, PR merge, issue triage all require `gh` |
-| **AWS** | -- | `aws` (auto-installed) | **Everything** — ECS health, cost tracking, revenue dashboard are CLI-only |
-| **Linear** | OAuth via Claude.ai | -- | Nothing — fully covered by MCP. 12 tools used across 6 skills |
-| **Vercel** | OAuth via Claude.ai | -- | Nothing — deploy status, build logs, runtime logs all via MCP |
-| **Slack** | OAuth via Claude.ai | local bot token | MCP works for most users. Local token adds: unlimited search (no quota), private channel access without bot membership |
-| **Gmail** | OAuth via Claude.ai | `gog` CLI | MCP can only **create drafts** — cannot send or archive. `gog` enables autonomous send + archive in `/ops:inbox` |
-| **Calendar** | OAuth via Claude.ai | `gog` CLI | MCP actually has *more* features (create events, RSVP, find free time). `gog` only reads. Either works for briefings |
-| **Sentry** | OAuth via Claude.ai | `sentry-cli` | MCP covers issue search + triage. CLI adds: source map upload, release tracking (not used by current skills) |
-| **WhatsApp** | -- | `wacli` | **Everything** — no MCP exists. `wacli` is the only path for WhatsApp inbox |
-| **Telegram** | -- | bundled MCP server | **Everything** — no Claude.ai connector exists. Plugin ships its own MTProto MCP server. Setup is fully automated: enter phone + 2 codes, done |
-| **GSD** | -- | auto-detected | Project roadmap state in dashboards. Fully optional — skills degrade gracefully |
+```
+┌─────────────┬──────────────────────────────────┬────────────────────┬───────────────────────────────────────────────────────────────────┐
+│  SERVICE    │  MCP (zero-config OAuth)          │  + CLI tool        │  WHAT YOU LOSE WITHOUT THE CLI                                    │
+├─────────────┼──────────────────────────────────┼────────────────────┼───────────────────────────────────────────────────────────────────┤
+│  GitHub     │  —                               │  gh  (auto)        │  EVERYTHING — CI logs, PR merge, issue triage all require gh      │
+│  AWS        │  —                               │  aws  (auto)       │  EVERYTHING — ECS health, cost tracking, revenue are CLI-only     │
+│  Linear     │  OAuth via Claude.ai  (12 tools) │  —                 │  Nothing — fully covered. 12 tools across 6 skills                │
+│  Vercel     │  OAuth via Claude.ai             │  —                 │  Nothing — deploy status, build logs, runtime logs via MCP        │
+│  Slack      │  OAuth via Claude.ai             │  local bot token   │  MCP covers most users. Token adds: unlimited search, private ch  │
+│  Gmail      │  OAuth via Claude.ai  (read)     │  gog  (send+archive│  MCP = read-only. CLI enables autonomous send + archive           │
+│  Calendar   │  OAuth via Claude.ai  (full)     │  gog  (read-only)  │  MCP has MORE features. Either works for briefings                │
+│  Sentry     │  OAuth via Claude.ai             │  sentry-cli        │  MCP covers triage. CLI adds: source maps, release tracking       │
+│  WhatsApp   │  —                               │  wacli             │  EVERYTHING — no MCP exists. wacli is the only path               │
+│  Telegram   │  —                               │  bundled MCP server│  EVERYTHING — plugin ships its own MTProto server. Fully automated │
+│  GSD        │  —                               │  auto-detected     │  Optional — roadmap state in dashboards. Skills degrade gracefully │
+└─────────────┴──────────────────────────────────┴────────────────────┴───────────────────────────────────────────────────────────────────┘
+```
 
-**TL;DR**: Linear and Vercel are MCP-only (and that's fine). GitHub and AWS are CLI-only (auto-installed). Gmail is where the choice matters most — MCP gives you read-only, CLI gives you full autonomous inbox management.
+> **TL;DR** — Linear and Vercel are MCP-only (and that's fine). GitHub and AWS are CLI-only (auto-installed). Gmail is where the choice matters most: MCP gives you read-only, CLI gives you full autonomous inbox management.
 
----
+```
+╔══════════════════════════════╗
+║         ARCHITECTURE         ║
+╚══════════════════════════════╝
+```
 
-## Architecture
-
-### Token Efficiency
+**Token Efficiency**
 
 All skills use pre-execution shell blocks (`!` fences) that gather data *before* the model context loads — zero extra latency, minimal token overhead.
 
-### Plugin Structure
+**Plugin Structure**
 
 ```
 claude-ops/
 ├── .claude-plugin/
-│   └── plugin.json        # Plugin manifest + userConfig schema
-├── skills/                # 14 slash command skills
-│   ├── ops/               # Router — dispatches to sub-skills
-│   ├── ops-go/            # Morning briefing
-│   ├── ops-inbox/         # Unified inbox
-│   ├── ops-comms/         # Cross-channel messaging
-│   ├── ops-merge/         # Autonomous PR pipeline
-│   ├── ops-fires/         # Production incidents
-│   ├── ops-deploy/        # Deploy status
-│   ├── ops-revenue/       # Cost tracking
-│   ├── ops-projects/      # Portfolio dashboard
-│   ├── ops-linear/        # Sprint management
-│   ├── ops-triage/        # Issue triage
-│   ├── ops-next/          # Next action advisor
-│   ├── ops-yolo/          # YOLO autonomous mode
-│   └── setup/             # Interactive setup wizard
-├── agents/                # 9 autonomous agents
-│   ├── yolo-ceo.md        # CEO synthesizer (Opus)
-│   ├── yolo-cto.md        # CTO technical analysis
-│   ├── yolo-cfo.md        # CFO financial analysis
-│   ├── yolo-coo.md        # COO operations analysis
-│   ├── triage-agent.md    # Issue investigation + fix
-│   ├── comms-scanner.md   # Inbox state scanner
-│   ├── infra-monitor.md   # Infrastructure health
-│   ├── project-scanner.md # Project portfolio scanner
-│   └── revenue-tracker.md # Revenue/cost monitor
-├── bin/                   # Shell scripts for data gathering
-├── hooks/                 # SessionStart health check
-├── telegram-server/       # Bundled MCP server (gram.js)
-├── scripts/               # Setup scripts + project registry
-└── .mcp.json              # MCP server declarations
+│   └── plugin.json            # Plugin manifest + userConfig schema
+│
+├── skills/                    # 14 slash command skills
+│   ├── ops/                   # Router — dispatches to sub-skills
+│   ├── ops-go/                # Morning briefing
+│   ├── ops-inbox/             # Unified inbox
+│   ├── ops-comms/             # Cross-channel messaging
+│   ├── ops-merge/             # Autonomous PR pipeline
+│   ├── ops-fires/             # Production incidents
+│   ├── ops-deploy/            # Deploy status
+│   ├── ops-revenue/           # Cost tracking
+│   ├── ops-projects/          # Portfolio dashboard
+│   ├── ops-linear/            # Sprint management
+│   ├── ops-triage/            # Issue triage
+│   ├── ops-next/              # Next action advisor
+│   ├── ops-yolo/              # YOLO autonomous mode
+│   └── setup/                 # Interactive setup wizard
+│
+├── agents/                    # 9 autonomous agents
+│   ├── yolo-ceo.md            # CEO synthesizer (Opus)
+│   ├── yolo-cto.md            # CTO technical analysis
+│   ├── yolo-cfo.md            # CFO financial analysis
+│   ├── yolo-coo.md            # COO operations analysis
+│   ├── triage-agent.md        # Issue investigation + fix
+│   ├── comms-scanner.md       # Inbox state scanner
+│   ├── infra-monitor.md       # Infrastructure health
+│   ├── project-scanner.md     # Project portfolio scanner
+│   └── revenue-tracker.md     # Revenue/cost monitor
+│
+├── bin/                       # Shell scripts for data gathering
+├── hooks/                     # SessionStart health check
+├── telegram-server/           # Bundled MCP server (gram.js)
+├── scripts/                   # Setup scripts + project registry
+└── .mcp.json                  # MCP server declarations
 ```
 
----
-
-## Contributing
+```
+╔══════════════════════════════╗
+║          CONTRIBUTING        ║
+╚══════════════════════════════╝
+```
 
 PRs welcome. See [`claude-ops/README.md`](./claude-ops/README.md) for detailed documentation on each skill, agent, and integration.
 
@@ -148,6 +212,16 @@ claude --plugin-dir ./claude-ops
 /reload-plugins
 ```
 
-## License
+```
+╔══════════════════════════════╗
+║            LICENSE           ║
+╚══════════════════════════════╝
+```
 
 [MIT](./claude-ops/LICENSE) — built by [Lifecycle Innovations Limited](https://github.com/Lifecycle-Innovations-Limited)
+
+```
+─────────────────────────────────────────────────────────────────────────────
+  claude-ops  v0.3.0  ·  MIT  ·  github.com/Lifecycle-Innovations-Limited
+─────────────────────────────────────────────────────────────────────────────
+```

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Most integrations offer two paths. The setup wizard lets you choose per-integrat
 | **Calendar** | OAuth via Claude.ai | `gog` CLI | MCP actually has *more* features (create events, RSVP, find free time). `gog` only reads. Either works for briefings |
 | **Sentry** | OAuth via Claude.ai | `sentry-cli` | MCP covers issue search + triage. CLI adds: source map upload, release tracking (not used by current skills) |
 | **WhatsApp** | -- | `wacli` | **Everything** — no MCP exists. `wacli` is the only path for WhatsApp inbox |
-| **Telegram** | -- | bundled MCP server | **Everything** — no Claude.ai connector exists. Plugin ships its own MTProto MCP server |
+| **Telegram** | -- | bundled MCP server | **Everything** — no Claude.ai connector exists. Plugin ships its own MTProto MCP server. Setup is fully automated: enter phone + 2 codes, done |
 | **GSD** | -- | auto-detected | Project roadmap state in dashboards. Fully optional — skills degrade gracefully |
 
 **TL;DR**: Linear and Vercel are MCP-only (and that's fine). GitHub and AWS are CLI-only (auto-installed). Gmail is where the choice matters most — MCP gives you read-only, CLI gives you full autonomous inbox management.

--- a/README.md
+++ b/README.md
@@ -1,140 +1,153 @@
 # claude-ops — Business Operating System for Claude Code
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./claude-ops/LICENSE)
-[![Version](https://img.shields.io/badge/version-0.3.0-blue.svg)](https://github.com/auroracapital/claude-ops/releases)
-[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)](https://github.com/anthropics/claude-plugins-official)
-[![Stars](https://img.shields.io/github/stars/auroracapital/claude-ops?style=social)](https://github.com/auroracapital/claude-ops/stargazers)
+[![Version](https://img.shields.io/badge/version-0.3.0-blue.svg)](https://github.com/Lifecycle-Innovations-Limited/claude-ops/releases)
+[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)](https://claude.ai/settings/plugins)
 
-A **claude code plugin** that turns Claude into a complete business operating system. One command — `/ops:go` — delivers a morning briefing covering every dimension of your business: infrastructure health, CI/CD status, unread messages, open PRs, sprint state, and revenue snapshot.
+Turn Claude Code into a complete business operating system. One command — `/ops:go` — delivers a morning briefing covering infrastructure health, CI/CD status, unread messages, open PRs, sprint state, and revenue snapshot.
+
+## Quick Start
 
 ```bash
-# Install — add to Claude Code settings.json
-{
-  "plugins": [{ "source": "https://github.com/auroracapital/claude-ops" }]
-}
-# Then run:
+# 1. Add the marketplace
+/plugin marketplace add Lifecycle-Innovations-Limited/claude-ops
+
+# 2. Install the plugin
+/plugin install ops@lifecycle-innovations-limited-claude-ops
+
+# 3. Configure your integrations
 /ops:setup
 ```
 
-> Also installable via: `/plugin install claude-ops@claude-plugins-official`
+The setup wizard walks through each integration interactively — install CLIs, connect channels, build your project registry. All credentials stored locally, never transmitted.
+
+### Local Development
+
+```bash
+git clone https://github.com/Lifecycle-Innovations-Limited/claude-ops.git
+claude --plugin-dir ./claude-ops
+```
 
 ---
 
-## What claude-ops does
+## What It Does
 
-| Area | Skills | Integrations |
-|------|--------|--------------|
-| Morning briefing | `/ops:go` — full cross-platform snapshot | GitHub, Linear, Sentry, AWS |
-| Inbox zero | `/ops:inbox` — read + triage all channels | Slack, Telegram, WhatsApp, email |
-| PR automation | `/ops:merge` — autonomous PR review + merge pipeline | GitHub |
-| Slack integration | `/ops:comms slack` — send/read messages | Slack API |
-| Telegram bot | `/ops:comms telegram` — full message history | Telegram MTProto |
-| WhatsApp automation | `/ops:comms whatsapp` — WhatsApp Web bridge | WhatsApp |
-| DevOps dashboard | `/ops:fires` — production incidents + ECS health | AWS ECS, Sentry |
-| Revenue tracker | `/ops:revenue` — AWS spend + billing snapshot | AWS Cost Explorer |
-| Project status | `/ops:projects` — all active projects at a glance | Linear, GitHub |
-| YOLO mode | `/ops:yolo` — 4 parallel C-suite agents, fully autonomous | Everything |
+| Command | What it does | Integrations |
+|---------|-------------|--------------|
+| `/ops:go` | Full morning briefing — one command, 60 seconds | GitHub, Linear, Sentry, AWS |
+| `/ops:inbox` | Unified inbox — read + triage all channels | Slack, Telegram, WhatsApp, Gmail |
+| `/ops:merge` | Autonomous PR review + merge pipeline | GitHub Actions, GitHub CLI |
+| `/ops:comms` | Send/read messages across any channel | Slack, Telegram, WhatsApp, Gmail |
+| `/ops:fires` | Production incidents + ECS health dashboard | AWS ECS, Sentry |
+| `/ops:revenue` | AWS spend, credits, runway estimate | AWS Cost Explorer |
+| `/ops:projects` | Portfolio dashboard — all projects at a glance | GitHub, Linear |
+| `/ops:linear` | Sprint board, issue management | Linear |
+| `/ops:deploy` | Deploy status across all projects | AWS ECS, Vercel, GitHub Actions |
+| `/ops:triage` | Cross-platform issue triage | Sentry, Linear, GitHub Issues |
+| `/ops:next` | Priority-ranked "what should I do next" | Everything |
+| `/ops:yolo` | 4 parallel C-suite AI agents — fully autonomous | Everything |
 
 ---
 
-## Why claude-ops vs manual
+## Before vs After
 
 | Without claude-ops | With claude-ops |
 |--------------------|-----------------|
-| Open 6 tabs every morning | `/ops:go` — one command, 60 seconds |
-| Manually check Slack + Telegram + email | `/ops:inbox` — unified inbox, zero switching |
-| Copy-paste PR descriptions | `/ops:merge` — full PR automation pipeline |
-| SSH into servers to check health | `/ops:fires` — production dashboard in Claude |
+| Open 6+ tabs every morning | `/ops:go` — one command |
+| Context-switch between Slack, Telegram, email | `/ops:inbox` — unified inbox |
+| Manually review and merge PRs | `/ops:merge` — autonomous pipeline |
+| SSH into servers to check health | `/ops:fires` — terminal dashboard |
 | Forget to track AWS spend | `/ops:revenue` — automatic cost snapshot |
-| Context-switch between Linear + GitHub | `/ops:linear` + `/ops:projects` — unified view |
+| Switch between Linear and GitHub | `/ops:linear` + `/ops:projects` — unified view |
 
 ---
 
-## Features
+## Requirements
 
-- **Morning briefing** — infra health, CI status, unread messages, open PRs, sprint velocity, revenue in one shot
-- **Inbox zero** — unified read/triage across Slack, Telegram, WhatsApp, and email
-- **PR automation** — autonomous review, approval, and merge pipeline with `/ops:merge`
-- **Slack integration** — full send/read/search via Slack API
-- **Telegram bot** — MTProto client, full message history and send
-- **WhatsApp automation** — WhatsApp Web bridge for automated messaging
-- **DevOps dashboard** — ECS health, Sentry incidents, CloudWatch alerts
-- **Revenue tracker** — AWS Cost Explorer snapshot, spend anomaly detection
-- **YOLO mode** — 4 parallel autonomous agents handling all ops simultaneously
-- **Business operations** — `/ops:linear`, `/ops:deploy`, `/ops:next`, and 15+ more skills
+Just [Claude Code](https://claude.ai/code) 1.0+. Everything else is installed automatically.
 
----
+The setup wizard (`/ops:setup`) walks you through each integration interactively — "Do you want AWS CLI? [Yes/No]", "Connect Slack? [OAuth/Skip]", etc. Missing CLIs are auto-installed via Homebrew. MCP servers connect via OAuth. No config files to edit manually.
 
-## Installation
+### Integrations: MCP vs CLI
 
-Add to `~/.claude/settings.json`:
+Most integrations offer two paths. The setup wizard lets you choose per-integration.
 
-```json
-{
-  "plugins": [
-    {
-      "source": "https://github.com/auroracapital/claude-ops"
-    }
-  ]
-}
-```
+| Integration | MCP-only (zero-config OAuth) | + CLI tool | What you lose without the CLI |
+|-------------|------------------------------|------------|-------------------------------|
+| **GitHub** | -- | `gh` (auto-installed) | **Everything** — GitHub is CLI-only. CI logs, PR merge, issue triage all require `gh` |
+| **AWS** | -- | `aws` (auto-installed) | **Everything** — ECS health, cost tracking, revenue dashboard are CLI-only |
+| **Linear** | OAuth via Claude.ai | -- | Nothing — fully covered by MCP. 12 tools used across 6 skills |
+| **Vercel** | OAuth via Claude.ai | -- | Nothing — deploy status, build logs, runtime logs all via MCP |
+| **Slack** | OAuth via Claude.ai | local bot token | MCP works for most users. Local token adds: unlimited search (no quota), private channel access without bot membership |
+| **Gmail** | OAuth via Claude.ai | `gog` CLI | MCP can only **create drafts** — cannot send or archive. `gog` enables autonomous send + archive in `/ops:inbox` |
+| **Calendar** | OAuth via Claude.ai | `gog` CLI | MCP actually has *more* features (create events, RSVP, find free time). `gog` only reads. Either works for briefings |
+| **Sentry** | OAuth via Claude.ai | `sentry-cli` | MCP covers issue search + triage. CLI adds: source map upload, release tracking (not used by current skills) |
+| **WhatsApp** | -- | `wacli` | **Everything** — no MCP exists. `wacli` is the only path for WhatsApp inbox |
+| **Telegram** | -- | bundled MCP server | **Everything** — no Claude.ai connector exists. Plugin ships its own MTProto MCP server |
+| **GSD** | -- | auto-detected | Project roadmap state in dashboards. Fully optional — skills degrade gracefully |
 
-Then configure integrations:
-
-```
-/ops:setup
-```
-
-The setup wizard walks through Slack, Telegram, Linear, Sentry, and AWS configuration. All credentials stored locally — never transmitted.
+**TL;DR**: Linear and Vercel are MCP-only (and that's fine). GitHub and AWS are CLI-only (auto-installed). Gmail is where the choice matters most — MCP gives you read-only, CLI gives you full autonomous inbox management.
 
 ---
 
-## Skill Reference
+## Architecture
 
-| Skill | Description |
-|-------|-------------|
-| `/ops:go` | Token-efficient morning briefing across all platforms |
-| `/ops:inbox` | Full inbox management — read, triage, reply |
-| `/ops:comms` | Send and read messages across Slack, Telegram, WhatsApp |
-| `/ops:merge` | Autonomous PR merge pipeline |
-| `/ops:fires` | Production incidents dashboard |
-| `/ops:deploy` | Deploy status across all projects |
-| `/ops:revenue` | Revenue and AWS cost tracker |
-| `/ops:projects` | Portfolio dashboard |
-| `/ops:linear` | Linear command center |
-| `/ops:next` | Business-level "what should I do next" |
-| `/ops:yolo` | Spawns 4 parallel C-suite agents for autonomous ops |
-| `/ops:triage` | Cross-platform issue triage (Sentry + Linear + GitHub) |
-| `/ops:setup` | Interactive setup wizard |
+### Token Efficiency
 
----
+All skills use pre-execution shell blocks (`!` fences) that gather data *before* the model context loads — zero extra latency, minimal token overhead.
 
-## Screenshots / Demo
-
-> Screenshots and GIF demo coming soon. Star the repo to get notified.
-
----
-
-## Repository Structure
+### Plugin Structure
 
 ```
-claude-ops-marketplace/
+claude-ops/
 ├── .claude-plugin/
-│   └── marketplace.json   # Marketplace registry
-└── claude-ops/            # Plugin source
-    ├── README.md          # Full plugin documentation
-    ├── skills/            # All /ops:* skill implementations
-    ├── agents/            # Autonomous agent definitions
-    ├── bin/               # CLI entry points
-    └── hooks/             # Claude Code lifecycle hooks
+│   └── plugin.json        # Plugin manifest + userConfig schema
+├── skills/                # 14 slash command skills
+│   ├── ops/               # Router — dispatches to sub-skills
+│   ├── ops-go/            # Morning briefing
+│   ├── ops-inbox/         # Unified inbox
+│   ├── ops-comms/         # Cross-channel messaging
+│   ├── ops-merge/         # Autonomous PR pipeline
+│   ├── ops-fires/         # Production incidents
+│   ├── ops-deploy/        # Deploy status
+│   ├── ops-revenue/       # Cost tracking
+│   ├── ops-projects/      # Portfolio dashboard
+│   ├── ops-linear/        # Sprint management
+│   ├── ops-triage/        # Issue triage
+│   ├── ops-next/          # Next action advisor
+│   ├── ops-yolo/          # YOLO autonomous mode
+│   └── setup/             # Interactive setup wizard
+├── agents/                # 9 autonomous agents
+│   ├── yolo-ceo.md        # CEO synthesizer (Opus)
+│   ├── yolo-cto.md        # CTO technical analysis
+│   ├── yolo-cfo.md        # CFO financial analysis
+│   ├── yolo-coo.md        # COO operations analysis
+│   ├── triage-agent.md    # Issue investigation + fix
+│   ├── comms-scanner.md   # Inbox state scanner
+│   ├── infra-monitor.md   # Infrastructure health
+│   ├── project-scanner.md # Project portfolio scanner
+│   └── revenue-tracker.md # Revenue/cost monitor
+├── bin/                   # Shell scripts for data gathering
+├── hooks/                 # SessionStart health check
+├── telegram-server/       # Bundled MCP server (gram.js)
+├── scripts/               # Setup scripts + project registry
+└── .mcp.json              # MCP server declarations
 ```
 
 ---
 
 ## Contributing
 
-PRs welcome. See [`claude-ops/README.md`](./claude-ops/README.md) for full documentation.
+PRs welcome. See [`claude-ops/README.md`](./claude-ops/README.md) for detailed documentation on each skill, agent, and integration.
+
+```bash
+# Development mode — load plugin from local directory
+claude --plugin-dir ./claude-ops
+
+# Reload after changes
+/reload-plugins
+```
 
 ## License
 
-[MIT](./claude-ops/LICENSE) — built by [auroracapital](https://github.com/auroracapital)
+[MIT](./claude-ops/LICENSE) — built by [Lifecycle Innovations Limited](https://github.com/Lifecycle-Innovations-Limited)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 If you discover a security vulnerability, please report it responsibly:
 
 1. **Do NOT** open a public issue
-2. Email: info@auroracapital.nl
+2. Email: info@lifecycleinnovations.limited
 3. Include: description, reproduction steps, impact assessment
 
 We'll respond within 48 hours and work with you on a fix before public disclosure.

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -4,10 +4,10 @@
   "description": "Business operations command center for Claude Code. Manage communications, projects, infrastructure, and revenue from your terminal. Includes YOLO mode for autonomous business operation.",
   "author": {
     "name": "Sam Renders",
-    "url": "https://github.com/auroracapital"
+    "url": "https://github.com/Lifecycle-Innovations-Limited"
   },
-  "homepage": "https://github.com/auroracapital/claude-ops",
-  "repository": "https://github.com/auroracapital/claude-ops",
+  "homepage": "https://github.com/Lifecycle-Innovations-Limited/claude-ops",
+  "repository": "https://github.com/Lifecycle-Innovations-Limited/claude-ops",
   "license": "MIT",
   "keywords": [
     "business",

--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -59,7 +59,7 @@ The setup wizard (`/ops:setup`) walks through each one interactively. You choose
 
 | Integration | What it is | Setup |
 |-------------|-----------|-------|
-| Telegram MCP server | gram.js MTProto user-auth — reads your DMs (not a bot) | `/ops:setup telegram` guides you through my.telegram.org app creation + session auth |
+| Telegram MCP server | gram.js MTProto user-auth — reads your DMs (not a bot) | `/ops:setup telegram` — enter phone number + 2 verification codes, everything else is fully automated (app creation, session generation, keychain storage) |
 | [GSD](https://github.com/Lifecycle-Innovations-Limited/get-shit-done) | Project roadmap state in dashboards | Auto-detected. Skills degrade gracefully without it |
 
 ## Installation

--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -1,58 +1,79 @@
 # claude-ops
 
-A Claude Code plugin that turns Claude into a business operating system. One command — `/ops-go` — gives you a complete morning briefing: infra health, CI status, unread messages, open PRs, sprint state, and revenue snapshot. Then route to any sub-skill for deep work.
+A Claude Code plugin that turns Claude into a business operating system. One command — `/ops:go` — gives you a complete morning briefing: infra health, CI status, unread messages, open PRs, sprint state, and revenue snapshot. Then route to any sub-skill for deep work.
 
 ## Features
 
 | Skill           | Description                                                                    |
 | --------------- | ------------------------------------------------------------------------------ |
 | `/ops:setup`    | Interactive setup wizard — installs CLIs, configures channels, builds registry |
-| `/ops-go`       | Morning briefing — all systems in one dashboard                                |
-| `/ops-next`     | Priority-ordered next action (fires → comms → PRs → sprint → GSD)              |
-| `/ops-inbox`    | Inbox zero across WhatsApp, Email, Slack, Telegram                             |
-| `/ops-comms`    | Send/read messages across all channels                                         |
-| `/ops-projects` | Portfolio dashboard — GSD phase, CI, PRs, dirty files                          |
-| `/ops-linear`   | Linear sprint board, issue management, GSD sync                                |
-| `/ops-triage`   | Cross-platform issue triage (Sentry + Linear + GitHub)                         |
-| `/ops-fires`    | Production incidents dashboard with agent dispatch                             |
-| `/ops-deploy`   | ECS + Vercel + GitHub Actions deploy status                                    |
-| `/ops-revenue`  | AWS costs, credits, revenue pipeline, runway                                   |
-| `/ops-yolo`     | 4-agent C-suite analysis + autonomous mode                                     |
+| `/ops:go`       | Morning briefing — all systems in one dashboard                                |
+| `/ops:next`     | Priority-ordered next action (fires → comms → PRs → sprint → GSD)             |
+| `/ops:inbox`    | Inbox zero across WhatsApp, Email, Slack, Telegram                             |
+| `/ops:comms`    | Send/read messages across all channels                                         |
+| `/ops:projects` | Portfolio dashboard — GSD phase, CI, PRs, dirty files                          |
+| `/ops:linear`   | Linear sprint board, issue management, GSD sync                                |
+| `/ops:triage`   | Cross-platform issue triage (Sentry + Linear + GitHub)                         |
+| `/ops:fires`    | Production incidents dashboard with agent dispatch                             |
+| `/ops:deploy`   | ECS + Vercel + GitHub Actions deploy status                                    |
+| `/ops:revenue`  | AWS costs, credits, revenue pipeline, runway                                   |
+| `/ops:yolo`     | 4-agent C-suite analysis + autonomous mode                                     |
 
 ## Requirements
 
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) 1.0+
-- [GSD](https://github.com/auroracapital/get-shit-done) (prerequisite — provides project roadmap state)
-- Node.js 18+ (for Telegram MCP server)
-- AWS CLI (configured, for ECS + cost data)
-- GitHub CLI (`gh`, for PRs and CI)
+- [Claude Code](https://claude.ai/code) 1.0+
+- GitHub CLI (`gh`) — for PRs and CI status
 
-### Optional integrations
+Everything else is optional. The setup wizard (`/ops:setup`) auto-detects what's installed and configures accordingly.
 
-- `wacli` — WhatsApp CLI (for WhatsApp inbox)
-- Gmail MCP — mcp**claude_ai_Gmail**\* (for email)
-- Slack MCP — mcp**claude_ai_Slack**\* (for Slack)
-- Linear MCP — mcp**claude_ai_Linear**\* (for sprint management)
-- Sentry MCP — mcp**sentry**\* (for error triage)
-- Vercel MCP — mcp**claude_ai_Vercel**\* (for deploy status)
+### Integrations
+
+The setup wizard (`/ops:setup`) walks through each one interactively. You choose per-integration whether to install the CLI, connect the MCP, or skip.
+
+#### CLI-only (no MCP alternative)
+
+| Tool | Auto-installed | What it does |
+|------|---------------|--------------|
+| `gh` (GitHub CLI) | Yes (Homebrew) | PRs, CI logs, issue triage, merge pipeline — used by 8+ skills |
+| `aws` (AWS CLI) | Yes (Homebrew) | ECS health, Cost Explorer, CloudWatch — used by ops-fires, ops-revenue, ops-deploy |
+| `wacli` (WhatsApp) | Manual ([source](https://github.com/auroracapital/wacli)) | WhatsApp inbox, send/read, contact lookup — no MCP equivalent exists |
+| Node.js 18+ | Yes (Homebrew) | Runs the bundled Telegram MCP server |
+
+#### MCP-only (no CLI needed)
+
+| MCP | Connected via | What it does |
+|-----|--------------|--------------|
+| Linear | OAuth (Claude.ai) | Sprint cycles, issues, projects — 12 tools across 6 skills. Fully covers all Linear functionality |
+| Vercel | OAuth (Claude.ai) | Deploy status, build logs, runtime logs. Read-only (deploys triggered via CI) |
+
+#### Choose: MCP, CLI, or both
+
+| Integration | MCP path | CLI path | What you lose with MCP only |
+|-------------|----------|----------|----------------------------|
+| **Gmail** | Claude.ai OAuth — read threads, create drafts | `gog` CLI — full send, archive, label management | MCP **cannot send emails** (drafts only) and **cannot archive**. `/ops:inbox` autonomous mode requires `gog` |
+| **Google Calendar** | Claude.ai OAuth — list, create, RSVP, find free time | `gog cal` — read today's events | MCP has *more* features. `gog` is simpler for read-only briefing context. Either works |
+| **Slack** | Claude.ai OAuth — read, send, search | Local bot token via `ops-slack-autolink` | MCP has **quota limits**. Local token gives unlimited search + private channel access without bot membership |
+| **Sentry** | Claude.ai OAuth — issue search, triage, resolve | `sentry-cli` — releases, source maps, deploy tracking | Current skills only use search/triage (MCP is fine). CLI adds release management (not used yet) |
+
+#### Plugin-bundled
+
+| Integration | What it is | Setup |
+|-------------|-----------|-------|
+| Telegram MCP server | gram.js MTProto user-auth — reads your DMs (not a bot) | `/ops:setup telegram` guides you through my.telegram.org app creation + session auth |
+| [GSD](https://github.com/Lifecycle-Innovations-Limited/get-shit-done) | Project roadmap state in dashboards | Auto-detected. Skills degrade gracefully without it |
 
 ## Installation
 
 `claude-ops` is distributed as a Claude Code marketplace plugin. Install it directly from inside Claude Code — you don't need to clone anything manually or edit any settings files.
 
-```text
-# 1. Inside Claude Code, register the marketplace (one-time)
-/plugin marketplace add auroracapital/claude-ops
+```bash
+# 1. Add the marketplace (one-time)
+/plugin marketplace add Lifecycle-Innovations-Limited/claude-ops
 
-# 2. Open the plugin manager and install the "ops" plugin
-/plugin
-#   → select "ops-marketplace"
-#   → install "ops"
+# 2. Install the plugin
+/plugin install ops@lifecycle-innovations-limited-claude-ops
 
-# 3. Fill in plugin user_config when prompted, or later via /plugin settings
-#    (Telegram API creds, Sentry org, Linear team, AWS region — all optional)
-
-# 4. Run the interactive setup wizard to auto-detect tools and configure channels
+# 3. Configure integrations (Telegram, Slack, AWS, etc.)
 /ops:setup
 ```
 
@@ -61,7 +82,7 @@ The plugin's Telegram MCP server auto-installs its Node dependencies on first ru
 If you prefer a local directory marketplace (useful for plugin development), clone the repo anywhere and register it:
 
 ```bash
-git clone https://github.com/auroracapital/claude-ops ~/Projects/claude-ops-marketplace
+git clone https://github.com/Lifecycle-Innovations-Limited/claude-ops ~/Projects/claude-ops-marketplace
 # then inside Claude Code:
 /plugin marketplace add ~/Projects/claude-ops-marketplace
 ```
@@ -111,7 +132,7 @@ Copy `scripts/registry.example.json` to `scripts/registry.json` (which is gitign
 
 ### Telegram (optional — user-auth, not bot)
 
-The plugin uses **your personal Telegram account** via gram.js MTProto — not a bot — because bots can't read user DMs, which is the main use case for `/ops-inbox telegram`.
+The plugin uses **your personal Telegram account** via gram.js MTProto — not a bot — because bots can't read user DMs, which is the main use case for `/ops:inbox telegram`.
 
 **Recommended path — let the wizard do it:**
 
@@ -130,14 +151,14 @@ After the wizard finishes, it prints the values you need to paste into `/plugin 
 3. Generate a session string: `node ~/.claude/plugins/cache/ops-marketplace/ops/<latest>/telegram-server/index.js --auth`. Prompts for code + 2FA, prints a `TELEGRAM_SESSION` string.
 4. Paste into `telegram_session` in plugin settings. Restart Claude Code.
 
-After that, `/ops-inbox telegram`, `/ops-comms send "..." to John Smith`, and the YOLO autonomous loop can read and reply to your DMs directly.
+After that, `/ops:inbox telegram`, `/ops:comms send "..." to John Smith`, and the YOLO autonomous loop can read and reply to your DMs directly.
 
 ## Usage
 
 ### Morning Briefing
 
 ```
-/ops-go
+/ops:go
 ```
 
 Pre-gathers all data in parallel via shell scripts, then presents a unified dashboard in <10 seconds.
@@ -145,8 +166,8 @@ Pre-gathers all data in parallel via shell scripts, then presents a unified dash
 ### Next Action
 
 ```
-/ops-next
-/ops-next focus on <project-alias>
+/ops:next
+/ops:next focus on <project-alias>
 ```
 
 Applies the priority stack: fires > urgent comms > ready-to-merge PRs > Linear sprint > GSD work.
@@ -154,23 +175,23 @@ Applies the priority stack: fires > urgent comms > ready-to-merge PRs > Linear s
 ### Inbox Zero
 
 ```
-/ops-inbox          # all channels
-/ops-inbox email    # email only
-/ops-inbox slack    # slack only
+/ops:inbox          # all channels
+/ops:inbox email    # email only
+/ops:inbox slack    # slack only
 ```
 
 ### Send a Message
 
 ```
-/ops-comms send "hey, can we chat?" to John Smith
-/ops-comms read whatsapp
+/ops:comms send "hey, can we chat?" to John Smith
+/ops:comms read whatsapp
 ```
 
 ### Fires Dashboard
 
 ```
-/ops-fires
-/ops-fires <project-alias>
+/ops:fires
+/ops:fires <project-alias>
 ```
 
 Shows production incidents, ECS health, Sentry errors. Dispatches fix agents.
@@ -178,7 +199,7 @@ Shows production incidents, ECS health, Sentry errors. Dispatches fix agents.
 ### YOLO Mode
 
 ```
-/ops-yolo
+/ops:yolo
 ```
 
 Spawns 4 C-suite agents (CEO, CTO, CFO, COO) in parallel. Each analyzes the business from their perspective with full data access. Produces an unfiltered Hard Truths report.
@@ -217,7 +238,7 @@ This runs shell scripts *before* the model context is loaded, so data is pre-gat
 
 ### Telegram MCP Server
 
-The `telegram-server/` directory contains an MCP server built on [gram.js](https://gram.js.org) (MTProto) that authenticates as your personal Telegram account — **not** as a bot. This is a hard requirement for `/ops-inbox telegram` because the Bot API cannot read user DMs.
+The `telegram-server/` directory contains an MCP server built on [gram.js](https://gram.js.org) (MTProto) that authenticates as your personal Telegram account — **not** as a bot. This is a hard requirement for `/ops:inbox telegram` because the Bot API cannot read user DMs.
 
 Tools:
 - `list_dialogs` — list recent conversations (DMs, groups, channels)

--- a/claude-ops/bin/ops-setup-complete
+++ b/claude-ops/bin/ops-setup-complete
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# ops-setup-complete — Post-setup celebration banner
+# Usage: ops-setup-complete --channels N --projects N --agents N --skills N
+set -euo pipefail
+
+# --- Parse arguments ---
+CHANNELS=0 PROJECTS=0 AGENTS=9 SKILLS=15
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --channels) CHANNELS="$2"; shift 2 ;;
+    --projects) PROJECTS="$2"; shift 2 ;;
+    --agents)   AGENTS="$2";   shift 2 ;;
+    --skills)   SKILLS="$2";   shift 2 ;;
+    *) shift ;;
+  esac
+done
+
+# --- Color setup ---
+if [[ -z "${NO_COLOR:-}" && "${TERM:-dumb}" != "dumb" ]]; then
+  RST=$'\033[0m'
+  BOLD=$'\033[1m'
+  DIM=$'\033[2m'
+  CYN=$'\033[36m'
+  GRN=$'\033[32m'
+  YLW=$'\033[33m'
+  BCYN=$'\033[1;36m'
+  BGRN=$'\033[1;32m'
+  BWHT=$'\033[1;37m'
+else
+  RST="" BOLD="" DIM="" CYN="" GRN="" YLW="" BCYN="" BGRN="" BWHT=""
+fi
+
+D=0.025
+p() { printf '%s\n' "$1"; sleep "$D"; }
+
+# --- Header ---
+p ""
+p "  ${DIM}${CYN}╔══════════════════════════════════════════════════╗${RST}"
+p "  ${DIM}${CYN}║${RST}                                                  ${DIM}${CYN}║${RST}"
+p "  ${DIM}${CYN}║${RST}    ${BGRN}SYSTEM ONLINE${RST}                                  ${DIM}${CYN}║${RST}"
+p "  ${DIM}${CYN}║${RST}    ${DIM}claude-ops v0.3.0 configured successfully${RST}       ${DIM}${CYN}║${RST}"
+p "  ${DIM}${CYN}║${RST}                                                  ${DIM}${CYN}║${RST}"
+p "  ${DIM}${CYN}╚══════════════════════════════════════════════════╝${RST}"
+
+sleep 0.1
+p ""
+
+# --- Dashboard ---
+p "  ${DIM}${CYN}┌──────────────────────────────────────────────────┐${RST}"
+p "  ${DIM}${CYN}│${RST}  ${BWHT}OPERATIONAL DASHBOARD${RST}                            ${DIM}${CYN}│${RST}"
+p "  ${DIM}${CYN}├──────────────────────────────────────────────────┤${RST}"
+
+# Channels row
+if [[ "$CHANNELS" -gt 0 ]]; then
+  printf '  %s%s│%s  %s[*]%s Channels     %s%-33s%s%s│%s\n' \
+    "$DIM" "$CYN" "$RST" "$GRN" "$RST" "$BWHT" "$CHANNELS active" "$RST" "$DIM$CYN" "$RST"
+  sleep "$D"
+else
+  printf '  %s%s│%s  %s[ ]%s Channels     %s%-33s%s%s│%s\n' \
+    "$DIM" "$CYN" "$RST" "$YLW" "$RST" "$DIM" "none configured" "$RST" "$DIM$CYN" "$RST"
+  sleep "$D"
+fi
+
+# Projects row
+if [[ "$PROJECTS" -gt 0 ]]; then
+  printf '  %s%s│%s  %s[*]%s Projects     %s%-33s%s%s│%s\n' \
+    "$DIM" "$CYN" "$RST" "$GRN" "$RST" "$BWHT" "$PROJECTS registered" "$RST" "$DIM$CYN" "$RST"
+  sleep "$D"
+else
+  printf '  %s%s│%s  %s[ ]%s Projects     %s%-33s%s%s│%s\n' \
+    "$DIM" "$CYN" "$RST" "$YLW" "$RST" "$DIM" "none registered" "$RST" "$DIM$CYN" "$RST"
+  sleep "$D"
+fi
+
+# Agents row
+printf '  %s%s│%s  %s[*]%s Agents       %s%-33s%s%s│%s\n' \
+  "$DIM" "$CYN" "$RST" "$GRN" "$RST" "$BWHT" "$AGENTS standing by" "$RST" "$DIM$CYN" "$RST"
+sleep "$D"
+
+# Skills row
+printf '  %s%s│%s  %s[*]%s Skills       %s%-33s%s%s│%s\n' \
+  "$DIM" "$CYN" "$RST" "$GRN" "$RST" "$BWHT" "$SKILLS loaded" "$RST" "$DIM$CYN" "$RST"
+sleep "$D"
+
+p "  ${DIM}${CYN}└──────────────────────────────────────────────────┘${RST}"
+
+sleep 0.1
+p ""
+p "  ${DIM}${CYN}────────────────────────────────────────────────────${RST}"
+p ""
+p "  ${BWHT}You're ready.${RST} Type ${BCYN}/ops:go${RST} for your first briefing."
+p ""

--- a/claude-ops/bin/ops-setup-detect
+++ b/claude-ops/bin/ops-setup-detect
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 # ops-setup-detect — Emit current configuration state as JSON
 # Used by /ops:setup wizard to decide what still needs configuring.
+# Reads from /tmp/ops-preflight/ cache when available (populated by ops-setup-preflight).
 set -euo pipefail
 
 has() { command -v "$1" >/dev/null 2>&1 && echo true || echo false; }
 has_env() { [ -n "${!1:-}" ] && echo true || echo false; }
+
+PREFLIGHT="/tmp/ops-preflight"
+USE_CACHE=false
+if [ -f "$PREFLIGHT/.complete" ]; then
+  USE_CACHE=true
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 REGISTRY="$SCRIPT_DIR/scripts/registry.json"
@@ -20,7 +27,11 @@ if [ ! -f "$PREFS" ] && [ -f "$SCRIPT_DIR/scripts/preferences.json" ]; then
 fi
 
 PROJECT_COUNT=0
-if [ -f "$REGISTRY" ] && command -v jq >/dev/null 2>&1; then
+# Prefer cached registry from preflight
+CACHED_REGISTRY="$PREFLIGHT/existing-registry.json"
+if [ "$USE_CACHE" = true ] && [ -f "$CACHED_REGISTRY" ] && command -v jq >/dev/null 2>&1; then
+  PROJECT_COUNT=$(jq '.projects | length' "$CACHED_REGISTRY" 2>/dev/null || echo 0)
+elif [ -f "$REGISTRY" ] && command -v jq >/dev/null 2>&1; then
   PROJECT_COUNT=$(jq '.projects | length' "$REGISTRY" 2>/dev/null || echo 0)
 fi
 
@@ -34,16 +45,22 @@ esac
 
 PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
-# Detect configured MCP servers by inspecting .mcp.json files in common locations
+# Detect configured MCP servers — use preflight cache if available
 MCP_CONFIGURED=()
-for f in "$SCRIPT_DIR/.mcp.json" "$HOME/.claude/.mcp.json" "$HOME/.claude.json"; do
-  [ -f "$f" ] || continue
-  if command -v jq >/dev/null 2>&1; then
-    while IFS= read -r name; do
-      [ -n "$name" ] && MCP_CONFIGURED+=("$name")
-    done < <(jq -r '(.mcpServers // {}) | keys[]' "$f" 2>/dev/null || true)
-  fi
-done
+if [ "$USE_CACHE" = true ] && [ -f "$PREFLIGHT/mcp-servers.txt" ]; then
+  while IFS= read -r name; do
+    [ -n "$name" ] && MCP_CONFIGURED+=("$name")
+  done < "$PREFLIGHT/mcp-servers.txt"
+else
+  for f in "$SCRIPT_DIR/.mcp.json" "$HOME/.claude/.mcp.json" "$HOME/.claude.json"; do
+    [ -f "$f" ] || continue
+    if command -v jq >/dev/null 2>&1; then
+      while IFS= read -r name; do
+        [ -n "$name" ] && MCP_CONFIGURED+=("$name")
+      done < <(jq -r '(.mcpServers // {}) | keys[]' "$f" 2>/dev/null || true)
+    fi
+  done
+fi
 
 # Deduplicate
 MCP_JSON="[]"
@@ -51,23 +68,38 @@ if [ ${#MCP_CONFIGURED[@]} -gt 0 ] && command -v jq >/dev/null 2>&1; then
   MCP_JSON=$(printf '%s\n' "${MCP_CONFIGURED[@]}" | sort -u | jq -R . | jq -s .)
 fi
 
+# Helper: check cache or live for a tool
+tool_status() {
+  local tool="$1"
+  if [ "$USE_CACHE" = true ] && [ -f "$PREFLIGHT/clis.txt" ]; then
+    local cached
+    cached=$(grep "^${tool}=" "$PREFLIGHT/clis.txt" 2>/dev/null | head -1 || echo "")
+    if [ -n "$cached" ]; then
+      if echo "$cached" | grep -q "=missing$"; then echo false; else echo true; fi
+      return
+    fi
+  fi
+  has "$tool"
+}
+
 cat <<EOF
 {
   "platform": "$PLATFORM",
   "shell": "$SHELL_NAME",
   "profile_file": "$PROFILE_FILE",
   "plugin_root": "$SCRIPT_DIR",
+  "preflight_cache": $USE_CACHE,
   "tools": {
-    "jq": $(has jq),
-    "git": $(has git),
-    "gh": $(has gh),
-    "aws": $(has aws),
-    "node": $(has node),
-    "brew": $(has brew),
-    "doppler": $(has doppler),
-    "wacli": $(has wacli),
-    "gog": $(has gog),
-    "sentry-cli": $(has sentry-cli)
+    "jq": $(tool_status jq),
+    "git": $(tool_status git),
+    "gh": $(tool_status gh),
+    "aws": $(tool_status aws),
+    "node": $(tool_status node),
+    "brew": $(tool_status brew),
+    "doppler": $(tool_status doppler),
+    "wacli": $(tool_status wacli),
+    "gog": $(tool_status gog),
+    "sentry-cli": $(tool_status sentry-cli)
   },
   "env_vars": {
     "CLAUDE_PLUGIN_ROOT": $(has_env CLAUDE_PLUGIN_ROOT),

--- a/claude-ops/bin/ops-setup-preflight
+++ b/claude-ops/bin/ops-setup-preflight
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# ops-setup-preflight — gather all setup data in parallel (runs in background)
+# Results written to /tmp/ops-preflight/ for the setup wizard to read
+set -euo pipefail
+
+OUT="/tmp/ops-preflight"
+rm -rf "$OUT" && mkdir -p "$OUT"
+
+# All probes run in parallel as background jobs
+{
+  # CLI detection
+  for tool in jq git gh aws node brew doppler wacli gog sentry-cli; do
+    if command -v "$tool" &>/dev/null; then
+      ver=$("$tool" --version 2>/dev/null | head -1 || echo "installed")
+      echo "$tool=$ver" >> "$OUT/clis.txt"
+    else
+      echo "$tool=missing" >> "$OUT/clis.txt"
+    fi
+  done
+} &
+
+{
+  # Slack keychain scout
+  xoxc=$(security find-generic-password -s slack-xoxc -w 2>/dev/null || echo "")
+  xoxd=$(security find-generic-password -s slack-xoxd -w 2>/dev/null || echo "")
+  if [ -n "$xoxc" ] && [ -n "$xoxd" ]; then
+    # Validate
+    result=$(curl -s -H "Authorization: Bearer $xoxc" -b "d=$xoxd" "https://slack.com/api/auth.test" 2>/dev/null || echo '{"ok":false}')
+    echo "$result" > "$OUT/slack.json"
+  else
+    echo '{"ok":false,"reason":"no_keychain_tokens"}' > "$OUT/slack.json"
+  fi
+} &
+
+{
+  # Telegram keychain scout
+  for key in telegram-api-id telegram-api-hash telegram-phone telegram-session; do
+    val=$(security find-generic-password -s "$key" -w 2>/dev/null || echo "")
+    echo "$key=$( [ -n "$val" ] && echo "found" || echo "missing" )" >> "$OUT/telegram.txt"
+  done
+} &
+
+{
+  # gog/Gmail probe
+  if command -v gog &>/dev/null; then
+    gog auth status 2>&1 > "$OUT/gog-auth.txt"
+    gog gmail labels list --json 2>/dev/null | head -5 > "$OUT/gog-gmail.json" || echo '{"error":"failed"}' > "$OUT/gog-gmail.json"
+    gog cal list --json --max 3 2>/dev/null | head -30 > "$OUT/gog-cal.json" || echo '{"error":"failed"}' > "$OUT/gog-cal.json"
+  else
+    echo "gog=missing" > "$OUT/gog-auth.txt"
+  fi
+} &
+
+{
+  # WhatsApp probe
+  if command -v wacli &>/dev/null; then
+    wacli doctor --json 2>/dev/null > "$OUT/wacli-doctor.json" || echo '{"success":false}' > "$OUT/wacli-doctor.json"
+    wacli chats list --json 2>/dev/null > "$OUT/wacli-chats.json" || echo '{"success":false,"data":[]}' > "$OUT/wacli-chats.json"
+  else
+    echo '{"success":false,"reason":"not_installed"}' > "$OUT/wacli-doctor.json"
+  fi
+} &
+
+{
+  # MCP detection (scan ~/.claude.json)
+  if [ -f "$HOME/.claude.json" ]; then
+    jq -r '.mcpServers // {} | keys[]' "$HOME/.claude.json" 2>/dev/null > "$OUT/mcp-servers.txt" || true
+  fi
+} &
+
+{
+  # GitHub auth check
+  gh auth status 2>&1 > "$OUT/gh-auth.txt" || true
+} &
+
+{
+  # AWS identity check
+  aws sts get-caller-identity --output json 2>/dev/null > "$OUT/aws-identity.json" || echo '{"error":"not_configured"}' > "$OUT/aws-identity.json"
+} &
+
+{
+  # Project discovery (fast — maxdepth 2, exclude heavy dirs)
+  find ~/Projects -maxdepth 2 -name ".git" -type d 2>/dev/null | sed 's|/.git$||' | sort > "$OUT/projects.txt"
+} &
+
+{
+  # Existing registry
+  PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+  if [ -z "$PLUGIN_ROOT" ]; then
+    PLUGIN_ROOT=$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1)
+  fi
+  if [ -n "$PLUGIN_ROOT" ] && [ -f "$PLUGIN_ROOT/scripts/registry.json" ]; then
+    cp "$PLUGIN_ROOT/scripts/registry.json" "$OUT/existing-registry.json"
+  fi
+} &
+
+{
+  # Existing preferences
+  PREFS="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+  if [ -f "$PREFS" ]; then
+    cp "$PREFS" "$OUT/existing-prefs.json"
+  fi
+} &
+
+# Wait for all background jobs
+wait
+
+# Write completion marker
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$OUT/.complete"

--- a/claude-ops/bin/ops-welcome
+++ b/claude-ops/bin/ops-welcome
@@ -76,9 +76,14 @@ progress_step "${BGRN}Ready${RST}" 16
 
 sleep 0.1
 
+# --- Dynamic counts ---
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL_COUNT=$(ls -d "${PLUGIN_ROOT}/skills"/*/ 2>/dev/null | wc -l | tr -d ' ')
+AGENT_COUNT=$(ls "${PLUGIN_ROOT}/agents"/*.md 2>/dev/null | wc -l | tr -d ' ')
+
 # --- Summary line ---
 p ""
-p "  ${BWHT}15${RST} skills loaded  ${DIM}|${RST}  ${BWHT}9${RST} agents standing by"
+p "  ${BWHT}${SKILL_COUNT}${RST} skills loaded  ${DIM}|${RST}  ${BWHT}${AGENT_COUNT}${RST} agents standing by"
 p ""
 
 # --- Separator ---

--- a/claude-ops/bin/ops-welcome
+++ b/claude-ops/bin/ops-welcome
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# ops-welcome — First-run animated welcome banner for claude-ops
+# Called by SessionStart hook. Prints nothing if preferences.json already exists.
+set -euo pipefail
+
+# --- First-run gate ---
+PREFS="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+[ ! -f "$PREFS" ] || exit 0
+
+# --- Color setup (degrade gracefully) ---
+if [[ -z "${NO_COLOR:-}" && "${TERM:-dumb}" != "dumb" ]]; then
+  RST=$'\033[0m'
+  BOLD=$'\033[1m'
+  DIM=$'\033[2m'
+  CYN=$'\033[36m'
+  GRN=$'\033[32m'
+  YLW=$'\033[33m'
+  WHT=$'\033[37m'
+  BCYN=$'\033[1;36m'
+  BGRN=$'\033[1;32m'
+  BWHT=$'\033[1;37m'
+else
+  RST="" BOLD="" DIM="" CYN="" GRN="" YLW="" WHT="" BCYN="" BGRN="" BWHT=""
+fi
+
+# --- Helpers ---
+D=0.025  # delay between lines
+p() { printf '%s\n' "$1"; sleep "$D"; }
+dp() { sleep "${2:-0.08}"; printf '%s\n' "$1"; }
+
+# --- Blank line spacer ---
+p ""
+
+# --- Logo reveal ---
+p "${DIM}${CYN}  ╔══════════════════════════════════════════════════╗${RST}"
+p "${DIM}${CYN}  ║${RST}                                                  ${DIM}${CYN}║${RST}"
+p "${DIM}${CYN}  ║${RST}   ${BCYN}░█████╗░██╗░░░░░░█████╗░██╗░░░██╗██████╗░${RST}   ${DIM}${CYN}║${RST}"
+p "${DIM}${CYN}  ║${RST}   ${BCYN}██╔══██╗██║░░░░░██╔══██╗██║░░░██║██╔══██╗${RST}   ${DIM}${CYN}║${RST}"
+p "${DIM}${CYN}  ║${RST}   ${BCYN}██║░░╚═╝██║░░░░░███████║██║░░░██║██║░░██║${RST}   ${DIM}${CYN}║${RST}"
+p "${DIM}${CYN}  ║${RST}   ${BCYN}██║░░██╗██║░░░░░██╔══██║██║░░░██║██║░░██║${RST}   ${DIM}${CYN}║${RST}"
+p "${DIM}${CYN}  ║${RST}   ${BCYN}╚█████╔╝███████╗██║░░██║╚██████╔╝██████╔╝${RST}   ${DIM}${CYN}║${RST}"
+p "${DIM}${CYN}  ║${RST}   ${BCYN}░╚════╝░╚══════╝╚═╝░░╚═╝░╚═════╝░╚═════╝░${RST}  ${DIM}${CYN}║${RST}"
+p "${DIM}${CYN}  ║${RST}                                                  ${DIM}${CYN}║${RST}"
+p "${DIM}${CYN}  ║${RST}   ${BWHT}░█████╗░██████╗░░██████╗${RST}   ${DIM}v0.3.0${RST}            ${DIM}${CYN}║${RST}"
+p "${DIM}${CYN}  ║${RST}   ${BWHT}██╔══██╗██╔══██╗██╔════╝${RST}                      ${DIM}${CYN}║${RST}"
+p "${DIM}${CYN}  ║${RST}   ${BWHT}██║░░██║██████╔╝╚█████╗░${RST}   ${DIM}Business OS${RST}      ${DIM}${CYN}║${RST}"
+p "${DIM}${CYN}  ║${RST}   ${BWHT}██║░░██║██╔═══╝░░╚═══██╗${RST}   ${DIM}for Claude Code${RST}  ${DIM}${CYN}║${RST}"
+p "${DIM}${CYN}  ║${RST}   ${BWHT}╚█████╔╝██║░░░░░██████╔╝${RST}                      ${DIM}${CYN}║${RST}"
+p "${DIM}${CYN}  ║${RST}   ${BWHT}░╚════╝░╚═╝░░░░░╚═════╝░${RST}                     ${DIM}${CYN}║${RST}"
+p "${DIM}${CYN}  ║${RST}                                                  ${DIM}${CYN}║${RST}"
+p "${DIM}${CYN}  ╚══════════════════════════════════════════════════╝${RST}"
+
+sleep 0.15
+
+# --- Boot sequence ---
+p ""
+p "  ${DIM}Initializing systems...${RST}"
+p ""
+
+# Animated progress bars
+progress_step() {
+  local label="$1" fill="$2"
+  local bar=""
+  local empty=""
+  for ((i=0; i<fill; i++)); do bar+="#"; done
+  for ((i=fill; i<16; i++)); do empty+="."; done
+  printf '    %s[%s%s%s%s]%s  %s\n' \
+    "$DIM" "$GRN" "$bar" "$DIM" "$empty" "$RST" "$label"
+  sleep 0.12
+}
+
+progress_step "${WHT}Scanning CLIs${RST}" 4
+progress_step "${WHT}Detecting channels${RST}" 8
+progress_step "${WHT}Loading integrations${RST}" 12
+progress_step "${BGRN}Ready${RST}" 16
+
+sleep 0.1
+
+# --- Summary line ---
+p ""
+p "  ${BWHT}15${RST} skills loaded  ${DIM}|${RST}  ${BWHT}9${RST} agents standing by"
+p ""
+
+# --- Separator ---
+p "  ${DIM}${CYN}────────────────────────────────────────────────────${RST}"
+p ""
+p "  Run ${BCYN}/ops:setup${RST} to configure your integrations"
+p "  or  ${BCYN}/ops:go${RST}    for your first morning briefing"
+p ""

--- a/claude-ops/hooks/hooks.json
+++ b/claude-ops/hooks/hooks.json
@@ -5,6 +5,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-welcome 2>/dev/null || true"
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh 2>/dev/null | grep '✗' | head -3 || true"
           }
         ]

--- a/claude-ops/scripts/setup.sh
+++ b/claude-ops/scripts/setup.sh
@@ -1,67 +1,61 @@
 #!/usr/bin/env bash
-# ops setup — Validate CLI tools and report readiness
-# Run this after installing the ops plugin to check what's available
-
+# ops setup — Auto-install missing tools + validate readiness
+# Called by SessionStart hook and /ops:setup
 set -euo pipefail
 
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo " OPS ► SETUP CHECK"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo ""
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
+MISSING=()
+INSTALLED=()
 
-check_tool() {
-  local name="$1"
-  local cmd="$2"
-  local purpose="$3"
-  local required="$4"
-
-  if command -v "$cmd" &>/dev/null; then
-    version=$($cmd --version 2>/dev/null | head -1 || echo "installed")
-    echo "  ✓ $name — $version"
-  else
-    if [ "$required" = "required" ]; then
-      echo "  ✗ $name — NOT FOUND (required for $purpose)"
-    else
-      echo "  ○ $name — not found (optional, needed for $purpose)"
+# ─── Auto-install core tools ────────────────────────────────────────
+auto_install() {
+  local tool="$1"
+  local brew_pkg="$2"
+  if ! command -v "$tool" &>/dev/null; then
+    if command -v brew &>/dev/null; then
+      brew install "$brew_pkg" 2>/dev/null && INSTALLED+=("$tool") && return 0
     fi
+    MISSING+=("$tool")
+    return 1
   fi
+  return 0
 }
 
-echo "## Core Tools (required)"
-check_tool "jq" "jq" "JSON processing" "required"
-check_tool "git" "git" "repository management" "required"
-check_tool "gh" "gh" "GitHub PRs and CI" "required"
+# Core (auto-installed silently)
+auto_install jq jq
+auto_install gh gh
+auto_install git git
 
-echo ""
-echo "## Communication Tools"
-check_tool "wacli" "wacli" "/ops-comms whatsapp" "optional"
-check_tool "gog" "gog" "/ops-comms email + calendar" "optional"
+# Infrastructure (auto-installed if brew available)
+auto_install aws awscli
+auto_install node node
 
-echo ""
-echo "## Infrastructure Tools"
-check_tool "aws" "aws" "/ops-infra ECS health" "optional"
-check_tool "sentry-cli" "sentry-cli" "/ops-triage Sentry issues" "optional"
-
-echo ""
-echo "## Other Tools"
-check_tool "doppler" "doppler" "secrets management" "optional"
-check_tool "node" "node" "Telegram MCP server" "optional"
-
-echo ""
-
-# Check registry
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REGISTRY="$SCRIPT_DIR/registry.json"
-if [ -f "$REGISTRY" ]; then
-  PROJECT_COUNT=$(jq '.projects | length' "$REGISTRY")
-  echo "## Registry"
-  echo "  ✓ registry.json — $PROJECT_COUNT projects configured"
-else
-  echo "## Registry"
-  echo "  ✗ registry.json — NOT FOUND (copy from template and configure)"
+# Telegram MCP server deps
+if [ -f "$PLUGIN_ROOT/telegram-server/package.json" ] && command -v node &>/dev/null; then
+  if [ ! -d "$PLUGIN_ROOT/telegram-server/node_modules" ]; then
+    (cd "$PLUGIN_ROOT/telegram-server" && npm install --silent 2>/dev/null) && INSTALLED+=("telegram-deps")
+  fi
 fi
 
-echo ""
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo " Setup complete. Run /ops-go for your first briefing."
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+# Plugin bin deps
+if [ -f "$PLUGIN_ROOT/package.json" ] && command -v node &>/dev/null; then
+  if [ ! -d "$PLUGIN_ROOT/node_modules" ]; then
+    (cd "$PLUGIN_ROOT" && npm install --silent 2>/dev/null) && INSTALLED+=("plugin-deps")
+  fi
+fi
+
+# ─── Report only problems ───────────────────────────────────────────
+if [ ${#INSTALLED[@]} -gt 0 ]; then
+  echo "  ops: auto-installed ${INSTALLED[*]}"
+fi
+
+for tool in "${MISSING[@]}"; do
+  echo "  ✗ ops: $tool not found — run /ops:setup to configure"
+done
+
+# Check registry
+REGISTRY="$SCRIPT_DIR/registry.json"
+if [ ! -f "$REGISTRY" ]; then
+  echo "  ✗ ops: no project registry — run /ops:setup to create one"
+fi

--- a/claude-ops/scripts/setup.sh
+++ b/claude-ops/scripts/setup.sh
@@ -14,7 +14,7 @@ auto_install() {
   local brew_pkg="$2"
   if ! command -v "$tool" &>/dev/null; then
     if command -v brew &>/dev/null; then
-      brew install "$brew_pkg" 2>/dev/null && INSTALLED+=("$tool") && return 0
+      timeout 30 brew install "$brew_pkg" &>/dev/null && INSTALLED+=("$tool") && return 0
     fi
     MISSING+=("$tool")
     return 1
@@ -34,14 +34,14 @@ auto_install node node
 # Telegram MCP server deps
 if [ -f "$PLUGIN_ROOT/telegram-server/package.json" ] && command -v node &>/dev/null; then
   if [ ! -d "$PLUGIN_ROOT/telegram-server/node_modules" ]; then
-    (cd "$PLUGIN_ROOT/telegram-server" && npm install --silent 2>/dev/null) && INSTALLED+=("telegram-deps")
+    (cd "$PLUGIN_ROOT/telegram-server" && npm install --silent &>/dev/null) && INSTALLED+=("telegram-deps")
   fi
 fi
 
 # Plugin bin deps
 if [ -f "$PLUGIN_ROOT/package.json" ] && command -v node &>/dev/null; then
   if [ ! -d "$PLUGIN_ROOT/node_modules" ]; then
-    (cd "$PLUGIN_ROOT" && npm install --silent 2>/dev/null) && INSTALLED+=("plugin-deps")
+    (cd "$PLUGIN_ROOT" && npm install --silent &>/dev/null) && INSTALLED+=("plugin-deps")
   fi
 fi
 

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -20,6 +20,9 @@ You are running an **interactive configuration wizard** for the `claude-ops` plu
 - Never install anything or write any file without explicit user confirmation via `AskUserQuestion`.
 - Skip sections the user declines. Don't nag.
 - Show what's already configured first, so the user only fills gaps.
+- **Never show the user's real name or email in output unless the user explicitly provided it in THIS session.** Do not read from memory, existing configs, or environment variables to populate display names.
+- Run ALL diagnostic/probe commands in parallel when possible. Use multiple Bash tool calls in a single message. Never run sequential probes when they're independent (e.g., `gog auth status` AND `wacli doctor` AND keychain scouts should all run simultaneously).
+- Background any command that might take >2 seconds (sync, backfill, npm install, brew install).
 - All writes go to one of these paths — and nothing else:
   - **`$PREFS_PATH`** — per-user preferences + secrets. Resolves to `${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json`. Lives in Claude Code's plugin data dir so it survives plugin reinstalls and version bumps. Never committed to git.
   - **`${CLAUDE_PLUGIN_ROOT}/scripts/registry.json`** — per-user project registry (gitignored in the source repo). `mkdir -p` its parent if missing.
@@ -225,6 +228,16 @@ Rules for the prompt:
 
 ### 3a — Telegram (user-auth via ops-telegram-autolink)
 
+**Always ask before starting the Telegram flow** — even when the user selected "all channels". Use `AskUserQuestion`:
+
+```
+Set up Telegram personal account access?
+  [Yes — enter my phone number and authenticate]
+  [Skip Telegram]
+```
+
+If the user skips, record `channels.telegram = "skipped"` in `$PREFS_PATH` and move on. Do NOT silently mark Telegram as unconfigured — the explicit skip prevents the status header from showing `○ telegram (no token)` as an action item on subsequent runs.
+
 **Bots cannot read user DMs**, so `/ops-inbox telegram` requires a personal-account MCP. The plugin ships `bin/ops-telegram-autolink.mjs` which:
 
 1. Scans scout sources (keychain → ~/.claude.json → shell profiles → Doppler) for previously-extracted `TELEGRAM_API_ID` / `TELEGRAM_API_HASH` / `TELEGRAM_SESSION`.
@@ -232,7 +245,7 @@ Rules for the prompt:
 3. Runs gram.js `client.start()` to generate a session string, bridging the second code via the same file.
 4. Emits final JSON on stdout: `{api_id, api_hash, phone, session}`.
 
-Sub-flow:
+Sub-flow (only runs if user selected Yes above):
 
 1. **Scout first.** Run `${CLAUDE_PLUGIN_ROOT}/bin/ops-slack-autolink --scout-only` equivalent check for Telegram:
 
@@ -322,7 +335,7 @@ Run these in parallel:
 wacli doctor --json 2>&1
 wacli auth status --json 2>&1
 wacli messages list --after="$(date -v-1d +%Y-%m-%d)" --limit=5 --json 2>&1
-wacli chats --json 2>&1 | head -c 4000
+wacli chats list --json 2>&1 | head -c 4000
 ```
 
 Parse:
@@ -381,21 +394,23 @@ This is usually a cold cache. Go to Step 3b.4 (backfill).
 **E. Healthy (messages flowing)**
 If `messages.data.messages` has ≥1 entry from the last 24h, print a ✓ summary and skip to Step 3b.5.
 
-#### Step 3b.4 — Historical backfill (automatic)
+#### Step 3b.4 — Historical backfill (background, silent)
 
 Always run this after a fresh re-pair, AND run it when rule D matches. Never skip unless the user explicitly declines.
 
+Backfill is a background optimization — it should not produce verbose output or alarming status messages. Run it silently and swallow non-fatal errors.
+
 1. Load the top 10 chats by recency:
    ```bash
-   wacli chats --json 2>&1 | jq -r '[.data[] | select(.jid) | {jid, name, last_msg: .last_message_ts}] | sort_by(.last_msg) | reverse | .[0:10]'
+   wacli chats list --json 2>&1 | jq -r '[.data[] | select(.jid) | {jid, name, last_msg: .last_message_ts}] | sort_by(.last_msg) | reverse | .[0:10]'
    ```
-2. Tell the user: `"Running historical backfill on your 10 most-recent chats (up to 50 messages each). This may take 1–2 minutes."`
+2. Tell the user: `"Running historical backfill on your 10 most-recent chats. This runs in the background."` Do not print per-chat progress or 0-message results.
 3. For each chat JID, run **sequentially** (backfill shares the store lock, can't parallelize):
    ```bash
    wacli history backfill --chat="<jid>" --count=50 --requests=2 --wait=30s --idle-exit=5s --json 2>&1
    ```
-4. After each, print a one-line progress: `✓ <name> — N messages backfilled` or `○ <name> — 0 (likely already synced)`.
-5. Re-probe after the loop: `wacli messages list --after="$(date -v-1d +%Y-%m-%d)" --limit=5 --json`. If still empty, tell the user: "Backfill completed but no new messages appeared. This usually means your primary device is offline or the chats haven't had activity. Try again later or check your phone."
+4. **Suppress all per-chat output.** If the command exits non-zero, swallow the error silently — backfill failures are not user-visible events. Do NOT print "0 messages synced", error tracebacks, or explanations about device connectivity.
+5. After the loop completes, print only the final health summary (Step 3b.6).
 
 #### Step 3b.5 — FTS index check (optional)
 
@@ -413,8 +428,10 @@ Don't block on this.
 Write `channels.whatsapp = "wacli"` to `$PREFS_PATH` and print the final ✓ summary:
 
 ```
-✓ WhatsApp — wacli authenticated, N chats, M recent messages
+✓ WhatsApp — wacli authenticated, N chats
 ```
+
+Never include message counts or backfill results in this summary line.
 
 ### 3c — Email
 
@@ -432,7 +449,11 @@ Email has two possible backends, tried in this order:
      then come back and re-run /ops:setup email.
      ```
      Do **not** try to automate the OAuth flow — it needs an interactive browser.
-   - If auth is green, probe with `gog inbox list --limit 1 --json 2>&1 || true` to confirm the token actually works against Gmail. Report ✓/✗.
+   - If auth is green, probe with:
+     ```bash
+     gog gmail labels list --json 2>&1 | head -5
+     ```
+     If this returns JSON containing a `labels` array, gog is authenticated and the Gmail API is working. Report ✓. If the output is an error or empty, treat as broken and instruct the user to re-run `gog auth login`.
    - Record `channels.email = "gog"` in `$PREFS_PATH` and stop here.
 
 #### Fallback: Claude Gmail MCP connector
@@ -514,7 +535,11 @@ Sub-flow:
    - `[Install Playwright now]` → run `cd ${CLAUDE_PLUGIN_ROOT}/telegram-server && npm install playwright && npx playwright install chromium` (background, ~150MB download, report progress).
    - `[Fall back to manual paste]` → go to step 2 manual path.
 
-5. **Validate tokens.** Call `https://slack.com/api/auth.test` with header `Authorization: Bearer <xoxc>` and cookie `d=<xoxd>`. Expect `{"ok":true, "team_id":"T...", "user_id":"U...", "url":"https://<workspace>.slack.com/"}`. If `ok:false`, show the error and re-ask.
+5. **Validate tokens.** Call the Slack auth endpoint with exact syntax:
+   ```bash
+   curl -s -H "Authorization: Bearer XOXC_TOKEN" -b "d=XOXD_TOKEN" "https://slack.com/api/auth.test"
+   ```
+   Expect `{"ok":true, "team_id":"T...", "user_id":"U...", "url":"https://<workspace>.slack.com/"}`. If `ok:false`, show the error and re-ask.
 
 6. **Persist.**
    - Keychain: `security add-generic-password -U -s slack-xoxc -a "$USER" -w "$XOXC"; security add-generic-password -U -s slack-xoxd -a "$USER" -w "$XOXD"`.
@@ -552,10 +577,9 @@ Calendar isn't a messaging channel, but every other ops skill (briefings, `/ops-
 1. Check `gog` on PATH with `command -v gog`.
 2. **If installed and already authed from Step 3c**, probe:
    ```bash
-   gog cal list --max 1 --json 2>&1 || true
-   gog cal events --time-min="$(date -u +%Y-%m-%dT00:00:00Z)" --max 5 --json 2>&1 || true
+   gog cal list --json --max 3 2>&1 | head -20
    ```
-   If either returns events, print `✓ Calendar — gog cal, N calendars, M upcoming events today` and record `channels.calendar = "gog"` in `$PREFS_PATH`. Stop here.
+   If this returns JSON with calendar data, record `channels.calendar = "gog"` in `$PREFS_PATH` and print `✓ Calendar — gog cal`. Stop here.
 3. **If gog is installed but calendar scope is missing** (typical error: `insufficient scope` or `403 insufficient_permissions`), print:
    ```
    Your gog OAuth token doesn't include the calendar scope.
@@ -622,35 +646,102 @@ Offer `[Open Claude Code docs]`, `[Skip]`. Do **not** try to register MCPs from 
 
 ## Step 5 — Build the project registry (if selected)
 
-1. If `registry.json` already has projects, ask: `[Keep existing 19 projects]`, `[Add more projects]`, `[Start from scratch]`.
-2. If "Start from scratch", write an empty skeleton first (`{"version":"1.0","owner":"","projects":[]}`) — **prompt to confirm before overwriting**.
-3. For "Add more", loop:
-   - Ask `AskUserQuestion`: "Add another project?" → `[Yes]`, `[Done]`.
-   - If Yes, collect these fields **one `AskUserQuestion` at a time** (plain text inputs):
-     - `alias` (short name, required)
-     - `paths` (comma-separated absolute paths, required)
-     - `repos` (comma-separated `org/repo`, required)
-     - `type` → select `[monorepo]`, `[multi-repo]`
-     - `infra.platform` → select `[aws]`, `[vercel]`, `[cloudflare]`, `[other]`
-     - `revenue.model` → select `[saas]`, `[subscription]`, `[marketplace]`, `[internal]`, `[portfolio]`, `[other]`
-     - `revenue.stage` → select `[pre-launch]`, `[development]`, `[growth]`, `[active]`
-     - `gsd` → select `[Yes]`, `[No]`
-     - `priority` (1-99, defaults to max+1)
-   - Read the current registry with `jq`, append the new project, write back atomically (`jq ... > tmp && mv tmp registry.json`).
-4. After each addition, print the running count and offer `[Add another]` / `[Done]`.
+### Auto-discover from filesystem
+
+Before asking the user to manually enter projects, scan for existing git repositories:
+
+```bash
+find ~ ~/Projects -maxdepth 2 -name ".git" -type d 2>/dev/null | sed 's|/.git||' | sort
+```
+
+Present the discovered paths to the user via `AskUserQuestion` with `multiSelect: true`:
+
+```
+Found these git repositories on your filesystem. Select the ones to add to your registry:
+  [ ] ~/Projects/healify
+  [ ] ~/Projects/healify-api
+  [ ] ~/Projects/healify-langgraphs
+  [ ] ~/src/sam-manager
+  ...
+  [ ] None — I'll enter projects manually
+```
+
+For each selected project, collect these fields one `AskUserQuestion` at a time:
+
+- `alias` (short name, required — suggest the directory name as default)
+- `org` (GitHub org or owner, e.g. `auroracapital` or `Lifecycle-Innovations-Limited`)
+- `infra.platform` → select `[aws]`, `[vercel]`, `[cloudflare]`, `[other]`
+- `revenue.model` → select `[saas]`, `[subscription]`, `[marketplace]`, `[internal]`, `[portfolio]`, `[other]`
+
+### Existing registry
+
+If `registry.json` already has projects, ask first: `[Keep existing N projects]`, `[Add more projects]`, `[Auto-detect from existing registry]`, `[Start from scratch]`.
+
+- "Keep existing" → skip this step.
+- "Auto-detect from existing registry" → re-read the registry, show a summary of what's already there, and offer to add missing fields or newly-discovered repos.
+- "Start from scratch" → write an empty skeleton first (`{"version":"1.0","owner":"","projects":[]}`) — **prompt to confirm before overwriting**.
+- "Add more" → run the auto-discover scan above, then offer manual entry as a fallback.
+
+### Manual add loop
+
+After auto-discovery (or if the user selects "I'll enter projects manually"):
+
+- Ask `AskUserQuestion`: "Add another project?" → `[Yes]`, `[Done]`.
+- If Yes, collect these fields **one `AskUserQuestion` at a time**:
+  - `alias` (short name, required)
+  - `paths` (comma-separated absolute paths, required)
+  - `repos` (comma-separated `org/repo`, required)
+  - `type` → select `[monorepo]`, `[multi-repo]`
+  - `infra.platform` → select `[aws]`, `[vercel]`, `[cloudflare]`, `[other]`
+  - `revenue.model` → select `[saas]`, `[subscription]`, `[marketplace]`, `[internal]`, `[portfolio]`, `[other]`
+  - `revenue.stage` → select `[pre-launch]`, `[development]`, `[growth]`, `[active]`
+  - `gsd` → select `[Yes]`, `[No]`
+  - `priority` (1-99, defaults to max+1)
+- Read the current registry with `jq`, append the new project, write back atomically (`jq ... > tmp && mv tmp registry.json`).
+- After each addition, print the running count and offer `[Add another]` / `[Done]`.
 
 ---
 
 ## Step 6 — Save preferences (if selected)
 
-Collect (one `AskUserQuestion` each, skip any the user leaves blank):
+Collect these via `AskUserQuestion` — one question each. **Never auto-fill from memory, existing configs, or previous sessions. Always ask explicitly.**
 
-- `owner` (display name for briefings)
-- `primary_project` → select from registry aliases
-- `timezone` → select `[Europe/Amsterdam]`, `[UTC]`, `[America/New_York]`, `[Other — type it]`
-- `briefing_verbosity` → select `[compact]`, `[full]`
-- `yolo_enabled` → select `[Yes]`, `[No]`
-- `default_channels` → multiSelect over configured channels
+1. **Owner name** (free text): "What should Claude call you in briefings?" — no default, no suggestions from memory.
+
+2. **Timezone** (single select with common options):
+   ```
+   Select your timezone:
+     [UTC]
+     [America/New_York]
+     [America/Los_Angeles]
+     [Europe/London]
+     [Europe/Amsterdam]
+     [Asia/Bangkok]
+     [Asia/Tokyo]
+     [Australia/Sydney]
+     [Other — type it]
+   ```
+
+3. **Briefing verbosity** (single select):
+   ```
+   How much detail do you want in briefings?
+     [full]     — complete rundown of all channels, projects, and incidents
+     [compact]  — key signals only, one line per item
+     [minimal]  — just the fires and urgent items
+   ```
+
+4. **Primary project** → select from registry aliases (skip if registry is empty).
+
+5. **YOLO mode** → select `[Yes — auto-approve low-risk actions]`, `[No — always confirm]`.
+
+6. **Default channels** (multiSelect over configured channels only — never show channels that weren't configured in Step 3):
+   ```
+   Which channels should ops skills use by default?
+     [ ] whatsapp
+     [ ] email
+     [ ] telegram
+     [ ] slack
+   ```
 
 Write to `$PREFS_PATH`:
 
@@ -702,6 +793,14 @@ Re-run the detector and present a final status dashboard:
 
 If any required tool is still missing, list it with the exact command to install it and stop short of claiming success.
 
+After displaying the summary, run the completion banner to celebrate the successful setup. Pass the actual counts from the setup session:
+
+```!
+bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-setup-complete --channels <N> --projects <N> --agents 9 --skills 15
+```
+
+Where `<N>` is replaced with the actual number of channels configured and projects registered during this session.
+
 ---
 
 ## Invocation shortcuts
@@ -732,3 +831,78 @@ Empty argument → full wizard from Step 0.
 - **Never** overwrite an existing file without showing the diff and asking.
 - **Never** put secrets in `registry.json` or commit them. Secrets only go in `$PREFS_PATH` (outside the plugin source tree entirely — Claude Code's per-plugin data dir) or the user's shell profile.
 - **Never** touch `~/.claude.json` or `~/.claude/settings.json` — MCP registration is Claude Code's job, not yours.
+- **Never** show the user's real name or email in output unless they explicitly provided it in the current session. Do not read from memory files, existing preferences, or environment variables to populate display names.
+
+---
+
+## Appendix: CLI Reference (EXACT SYNTAX — never guess)
+
+### gog (v0.12.0+)
+
+```bash
+# Auth check
+gog auth status
+
+# Gmail — probe if API works
+gog gmail labels list --json
+
+# Gmail — search (query is positional, NOT --query flag)
+gog gmail search "newer_than:1d" --max 5 --json --results-only
+
+# Gmail — read thread
+gog gmail read THREAD_ID --json
+
+# Gmail — send
+gog gmail send --to "user@example.com" --subject "test" --body "hello"
+
+# Gmail — archive (remove INBOX label)
+gog gmail labels modify MESSAGE_ID --remove INBOX
+
+# Calendar — list today's events (NOT --time-min, use `gog cal list`)
+gog cal list --json --max 10
+
+# Calendar — auth with calendar scope
+gog auth login --scopes=gmail,calendar
+```
+
+### wacli
+
+```bash
+# Health check
+wacli doctor --json
+
+# Auth status
+wacli auth status --json
+
+# List chats (MUST use subcommand `list`)
+wacli chats list --json
+
+# List messages (--after flag uses YYYY-MM-DD)
+wacli messages list --after="$(date -v-1d +%Y-%m-%d)" --limit=5 --json
+
+# Send message
+wacli send --to "JID" --message "text"
+
+# Sync (connect and pull)
+wacli sync
+
+# Backfill history
+wacli history backfill --chat="JID" --count=50 --requests=2 --wait=30s --idle-exit=5s --json
+
+# Contact lookup
+wacli contacts --search "name" --json
+```
+
+### Slack token validation
+
+```bash
+curl -s -H "Authorization: Bearer XOXC_TOKEN" -b "d=XOXD_TOKEN" "https://slack.com/api/auth.test"
+```
+
+### macOS Keychain
+
+```bash
+security find-generic-password -s "KEY_NAME" -w 2>/dev/null
+security add-generic-password -U -s "KEY_NAME" -a "$USER" -w "VALUE"
+security delete-generic-password -s "KEY_NAME" 2>/dev/null
+```

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -74,6 +74,7 @@ Use `AskUserQuestion` with `multiSelect: true`. Offer **only sections that need 
 | Install CLIs       | cli      | Install missing command-line tools via Homebrew  |
 | Configure channels | channels | Set tokens for Telegram, WhatsApp, Email, Slack  |
 | Configure MCPs     | mcp      | Enable Linear, Sentry, Vercel, Gmail MCP servers |
+| Companion plugins  | plugins  | Install GSD for project roadmap tracking         |
 | Build registry     | registry | Register projects Claude should manage           |
 | Save preferences   | prefs    | Owner name, timezone, default priorities         |
 | Shell env          | env      | Export `CLAUDE_PLUGIN_ROOT` in shell profile     |
@@ -101,6 +102,45 @@ ${PLUGIN_ROOT}/bin/ops-setup-install <tool>
 Report success/failure. If Homebrew is missing on macOS, stop and tell the user to install it from https://brew.sh first — do not attempt to install brew automatically.
 
 After installation, re-run `ops-setup-detect` to refresh status before continuing.
+
+---
+
+## Step 2b — Companion plugins (if selected)
+
+### GSD (Get Shit Done)
+
+GSD is a third-party Claude Code plugin that adds project roadmap tracking. When installed, claude-ops dashboards (`/ops:go`, `/ops:projects`, `/ops:next`, `/ops:yolo`) automatically show active phases, progress, and next actions per project. Without it, those sections are simply omitted.
+
+Check if GSD is already installed:
+
+```bash
+ls ~/.claude/plugins/cache/*/gsd*/skills/gsd-progress/SKILL.md 2>/dev/null && echo "installed" || echo "not_installed"
+```
+
+If not installed, ask via `AskUserQuestion`:
+
+```
+GSD adds project roadmap tracking to your ops dashboards.
+  /ops:go shows active phases and progress per project
+  /ops:projects shows GSD state alongside CI/PR status
+  /ops:next factors in GSD work priority
+
+  [Install GSD (latest)] [Skip — I don't need roadmap tracking]
+```
+
+On install, run:
+
+```bash
+claude plugin marketplace add auroracapital/get-shit-done && claude plugin install gsd@auroracapital-get-shit-done
+```
+
+Report success/failure. If it fails (e.g. marketplace not reachable), print:
+
+```
+Could not auto-install GSD. You can install it manually later:
+  /plugin marketplace add auroracapital/get-shit-done
+  /plugin install gsd@auroracapital-get-shit-done
+```
 
 ---
 

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -32,9 +32,33 @@ You are running an **interactive configuration wizard** for the `claude-ops` plu
 
 ---
 
-## Step 0 — Detect current state
+## Step 0 — Preflight (runs in background while you read)
 
-Run the detector and parse its JSON output:
+```!
+${CLAUDE_PLUGIN_ROOT}/bin/ops-setup-preflight &>/dev/null &
+```
+
+**Preflight data**: All probe results are cached at `/tmp/ops-preflight/`. Before running ANY diagnostic command, check if the result already exists there:
+- CLI status: `cat /tmp/ops-preflight/clis.txt`
+- Slack: `cat /tmp/ops-preflight/slack.json`
+- Telegram: `cat /tmp/ops-preflight/telegram.txt`
+- gog/Gmail: `cat /tmp/ops-preflight/gog-gmail.json`
+- gog/Calendar: `cat /tmp/ops-preflight/gog-cal.json`
+- WhatsApp: `cat /tmp/ops-preflight/wacli-doctor.json` and `wacli-chats.json`
+- MCP servers: `cat /tmp/ops-preflight/mcp-servers.txt`
+- GitHub: `cat /tmp/ops-preflight/gh-auth.txt`
+- AWS: `cat /tmp/ops-preflight/aws-identity.json`
+- Projects: `cat /tmp/ops-preflight/projects.txt`
+- Existing registry: `cat /tmp/ops-preflight/existing-registry.json`
+- Existing prefs: `cat /tmp/ops-preflight/existing-prefs.json`
+
+Wait for `/tmp/ops-preflight/.complete` to exist before reading (it should be ready within 2-3 seconds). NEVER re-run a probe that already has cached results — read the cache file instead.
+
+---
+
+## Step 0b — Detect current state
+
+Run the detector and parse its JSON output (or read from preflight cache if available):
 
 ```!
 ${CLAUDE_PLUGIN_ROOT}/bin/ops-setup-detect 2>/dev/null
@@ -131,16 +155,20 @@ GSD adds project roadmap tracking to your ops dashboards.
   [Install GSD (latest)] [Skip — I don't need roadmap tracking]
 ```
 
-On install, run:
-
-```bash
-claude plugin marketplace add auroracapital/get-shit-done && claude plugin install gsd@auroracapital-get-shit-done
-```
-
-Report success/failure. If it fails (e.g. marketplace not reachable), print:
+On install, tell the user:
 
 ```
-Could not auto-install GSD. You can install it manually later:
+To install GSD, run these commands in Claude Code:
+  /plugin marketplace add auroracapital/get-shit-done
+  /plugin install gsd@auroracapital-get-shit-done
+```
+
+These are slash commands — run them in the Claude Code interface, not in a terminal. After running them, come back and re-run `/ops:setup` to continue.
+
+Report success/failure. If the user confirms they've installed it, record `plugins.gsd = "installed"` in `$PREFS_PATH`. If they skip:
+
+```
+Skipped GSD install. You can install it later:
   /plugin marketplace add auroracapital/get-shit-done
   /plugin install gsd@auroracapital-get-shit-done
 ```
@@ -247,11 +275,11 @@ If the user skips, record `channels.telegram = "skipped"` in `$PREFS_PATH` and m
 
 Sub-flow (only runs if user selected Yes above):
 
-1. **Scout first.** Run `${CLAUDE_PLUGIN_ROOT}/bin/ops-slack-autolink --scout-only` equivalent check for Telegram:
+1. **Scout first.** Check keychain for previously-extracted Telegram credentials:
 
    ```bash
    for svc in telegram-api-id telegram-api-hash telegram-phone telegram-session; do
-     security find-generic-password -s "$svc" -w 2>/dev/null
+     security find-generic-password -s "$svc" -w 2>/dev/null && echo "FOUND: $svc"
    done
    ```
 
@@ -334,7 +362,7 @@ Run these in parallel:
 ```bash
 wacli doctor --json 2>&1
 wacli auth status --json 2>&1
-wacli messages list --after="$(date -v-1d +%Y-%m-%d)" --limit=5 --json 2>&1
+wacli messages list --after="$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d '1 day ago' +%Y-%m-%d)" --limit=5 --json 2>&1
 wacli chats list --json 2>&1 | head -c 4000
 ```
 
@@ -795,7 +823,7 @@ If any required tool is still missing, list it with the exact command to install
 
 After displaying the summary, run the completion banner to celebrate the successful setup. Pass the actual counts from the setup session:
 
-```!
+```bash
 bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-setup-complete --channels <N> --projects <N> --agents 9 --skills 15
 ```
 
@@ -878,7 +906,10 @@ wacli auth status --json
 wacli chats list --json
 
 # List messages (--after flag uses YYYY-MM-DD)
+# macOS
 wacli messages list --after="$(date -v-1d +%Y-%m-%d)" --limit=5 --json
+# Linux
+wacli messages list --after="$(date -d '1 day ago' +%Y-%m-%d)" --limit=5 --json
 
 # Send message
 wacli send --to "JID" --message "text"

--- a/claude-ops/skills/uninstall/SKILL.md
+++ b/claude-ops/skills/uninstall/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: uninstall
+description: Completely remove claude-ops plugin, all stored credentials, cached files, shell exports, and MCP registrations. Confirms each step before deletion.
+allowed-tools:
+  - Bash
+  - Read
+  - AskUserQuestion
+---
+
+# OPS > UNINSTALL
+
+You are running a **complete uninstall** of the claude-ops plugin. This removes everything the plugin and `/ops:setup` created. Every deletion step requires user confirmation via `AskUserQuestion` — never delete silently.
+
+---
+
+## Step 1 — Confirm intent
+
+Use `AskUserQuestion`:
+
+```
+This will completely remove claude-ops and all its data:
+  - Plugin installation and marketplace registration
+  - Stored preferences and project registry
+  - Cached plugin files
+  - Keychain credentials (Telegram, Slack tokens)
+  - Shell profile exports (CLAUDE_PLUGIN_ROOT)
+  - MCP server registrations (Telegram, Slack)
+
+  [Uninstall everything]  [Cancel]
+```
+
+If cancelled, stop immediately.
+
+---
+
+## Step 2 — Detect what exists
+
+Scan for all claude-ops artifacts. Build a list of what's present:
+
+```bash
+# Preferences
+PREFS_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+ls -la "$PREFS_DIR" 2>/dev/null
+
+# Cache
+CACHE_DIR="$HOME/.claude/plugins/cache/ops-marketplace"
+ls -la "$CACHE_DIR" 2>/dev/null
+
+# Keychain entries (macOS)
+for key in telegram-api-id telegram-api-hash telegram-phone telegram-session slack-xoxc slack-xoxd; do
+  security find-generic-password -s "$key" 2>/dev/null && echo "FOUND: $key"
+done
+
+# Shell profile exports
+grep -l 'CLAUDE_PLUGIN_ROOT' ~/.zshrc ~/.bashrc ~/.zprofile ~/.bash_profile 2>/dev/null
+
+# MCP registrations
+grep -l 'telegram\|slack-mcp' ~/.claude.json 2>/dev/null
+```
+
+Print a summary of what was found, then proceed to delete each category.
+
+---
+
+## Step 3 — Remove keychain credentials
+
+For each found keychain entry, ask via `AskUserQuestion`:
+
+```
+Remove keychain credential: <key-name>?
+  [Yes]  [Skip]
+```
+
+On Yes:
+
+```bash
+security delete-generic-password -s "<key-name>" 2>/dev/null
+```
+
+---
+
+## Step 4 — Remove preferences and cache
+
+Ask via `AskUserQuestion`:
+
+```
+Remove plugin data?
+  - Preferences: <prefs-dir>
+  - Cache: <cache-dir>
+
+  [Yes, delete both]  [Skip]
+```
+
+On Yes:
+
+```bash
+rm -rf "$PREFS_DIR"
+rm -rf "$CACHE_DIR"
+```
+
+---
+
+## Step 5 — Clean shell profile
+
+For each shell profile file that contains `CLAUDE_PLUGIN_ROOT`:
+
+Ask via `AskUserQuestion`:
+
+```
+Remove CLAUDE_PLUGIN_ROOT export from <file>?
+  [Yes]  [Skip]
+```
+
+On Yes, read the file and remove lines containing `CLAUDE_PLUGIN_ROOT`. Use `sed` or similar — do NOT rewrite the entire file. Only remove the specific export line.
+
+```bash
+sed -i '' '/CLAUDE_PLUGIN_ROOT/d' "<file>"
+```
+
+---
+
+## Step 6 — Remove MCP registrations
+
+Check if `~/.claude.json` contains MCP server entries added by the plugin (telegram, slack-mcp). For each:
+
+Ask via `AskUserQuestion`:
+
+```
+Remove MCP server registration: <server-name> from ~/.claude.json?
+  [Yes]  [Skip]
+```
+
+On Yes, use `jq` to remove the entry:
+
+```bash
+jq 'del(.mcpServers["<server-name>"])' ~/.claude.json > /tmp/claude-json-tmp && mv /tmp/claude-json-tmp ~/.claude.json
+```
+
+---
+
+## Step 7 — Uninstall plugin and marketplace
+
+Run the Claude Code uninstall commands:
+
+```bash
+claude plugin uninstall ops@lifecycle-innovations-limited-claude-ops 2>/dev/null || true
+claude plugin marketplace remove lifecycle-innovations-limited-claude-ops 2>/dev/null || true
+```
+
+If these commands fail (e.g. not in an interactive Claude Code session), print:
+
+```
+Run these manually in Claude Code:
+  /plugin uninstall ops@lifecycle-innovations-limited-claude-ops
+  /plugin marketplace remove lifecycle-innovations-limited-claude-ops
+```
+
+---
+
+## Step 8 — Final confirmation
+
+Print:
+
+```
+claude-ops has been completely removed.
+
+  Keychain:    <N> credentials deleted
+  Preferences: deleted
+  Cache:       deleted
+  Shell:       <N> exports removed
+  MCP:         <N> servers removed
+  Plugin:      uninstalled
+
+To reinstall later:
+  /plugin marketplace add Lifecycle-Innovations-Limited/claude-ops
+  /plugin install ops@lifecycle-innovations-limited-claude-ops
+  /ops:setup
+```

--- a/claude-ops/telegram-server/index.js
+++ b/claude-ops/telegram-server/index.js
@@ -38,64 +38,76 @@ const API_HASH = process.env.TELEGRAM_API_HASH || "";
 const SESSION_STRING = process.env.TELEGRAM_SESSION || "";
 const PHONE = process.env.TELEGRAM_PHONE || "";
 
-if (!API_ID || !API_HASH) {
-  process.stderr.write(
-    "ERROR: TELEGRAM_API_ID and TELEGRAM_API_HASH are required.\n" +
-      "Get them from https://my.telegram.org/apps (create a personal app, NOT a bot).\n",
-  );
-  process.exit(1);
-}
+// Detect whether credentials are present — server always starts regardless
+const CONFIGURED = !!(API_ID && API_HASH && SESSION_STRING);
+const NOT_CONFIGURED_MSG =
+  "Telegram not configured. Run /ops:setup telegram to set up your credentials.";
 
-const stringSession = new StringSession(SESSION_STRING);
-const client = new TelegramClient(stringSession, API_ID, API_HASH, {
-  connectionRetries: 5,
-  baseLogger: {
-    log: () => {},
-    warn: () => {},
-    error: (...args) => process.stderr.write(args.join(" ") + "\n"),
-    info: () => {},
-    debug: () => {},
-  },
-});
+let client = null;
 
-// First-run interactive auth mode
-if (process.argv.includes("--auth")) {
-  const rl = readline.createInterface({ input, output });
-  await client.start({
-    phoneNumber: async () =>
-      PHONE || (await rl.question("Phone number (E.164): ")),
-    password: async () => await rl.question("2FA password (blank if none): "),
-    phoneCode: async () => await rl.question("SMS code: "),
-    onError: (err) => process.stderr.write(`Auth error: ${err.message}\n`),
-  });
-  rl.close();
-  const saved = client.session.save();
-  process.stdout.write("\n=== AUTH SUCCESSFUL ===\n");
-  process.stdout.write("Save this to TELEGRAM_SESSION env var:\n\n");
-  process.stdout.write(saved + "\n");
-  await client.disconnect();
-  process.exit(0);
-}
-
-// Non-interactive mode — requires saved session
-if (!SESSION_STRING) {
-  process.stderr.write(
-    "ERROR: TELEGRAM_SESSION is not set. Run `node index.js --auth` first to generate it.\n",
-  );
-  process.exit(1);
-}
-
-// Connect using saved session
-try {
-  await client.connect();
-  if (!(await client.checkAuthorization())) {
-    throw new Error(
-      "Session is no longer valid — re-run `node index.js --auth`",
-    );
+if (CONFIGURED) {
+  // First-run interactive auth mode (only when creds are available)
+  if (process.argv.includes("--auth")) {
+    const stringSession = new StringSession(SESSION_STRING);
+    const authClient = new TelegramClient(stringSession, API_ID, API_HASH, {
+      connectionRetries: 5,
+      baseLogger: {
+        log: () => {},
+        warn: () => {},
+        error: (...args) => process.stderr.write(args.join(" ") + "\n"),
+        info: () => {},
+        debug: () => {},
+      },
+    });
+    const rl = readline.createInterface({ input, output });
+    await authClient.start({
+      phoneNumber: async () =>
+        PHONE || (await rl.question("Phone number (E.164): ")),
+      password: async () =>
+        await rl.question("2FA password (blank if none): "),
+      phoneCode: async () => await rl.question("SMS code: "),
+      onError: (err) => process.stderr.write(`Auth error: ${err.message}\n`),
+    });
+    rl.close();
+    const saved = authClient.session.save();
+    process.stdout.write("\n=== AUTH SUCCESSFUL ===\n");
+    process.stdout.write("Save this to TELEGRAM_SESSION env var:\n\n");
+    process.stdout.write(saved + "\n");
+    await authClient.disconnect();
+    process.exit(0);
   }
-} catch (err) {
-  process.stderr.write(`Failed to connect: ${err.message}\n`);
-  process.exit(1);
+
+  // Connect using saved session
+  const stringSession = new StringSession(SESSION_STRING);
+  client = new TelegramClient(stringSession, API_ID, API_HASH, {
+    connectionRetries: 5,
+    baseLogger: {
+      log: () => {},
+      warn: () => {},
+      error: (...args) => process.stderr.write(args.join(" ") + "\n"),
+      info: () => {},
+      debug: () => {},
+    },
+  });
+
+  try {
+    await client.connect();
+    if (!(await client.checkAuthorization())) {
+      process.stderr.write(
+        "Warning: Telegram session is no longer valid. Re-run `node index.js --auth`.\n",
+      );
+      client = null;
+    }
+  } catch (err) {
+    process.stderr.write(
+      `Warning: Failed to connect to Telegram: ${err.message}\n`,
+    );
+    client = null;
+  }
+} else {
+  process.stderr.write(
+    "Telegram credentials not set — server starting in unconfigured mode.\n",
+  );
 }
 
 // ── MCP server setup ──
@@ -203,6 +215,13 @@ function resolveChatArg(chat) {
 
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
+
+  if (!client) {
+    return {
+      content: [{ type: "text", text: NOT_CONFIGURED_MSG }],
+      isError: true,
+    };
+  }
 
   try {
     if (name === "list_dialogs") {
@@ -344,10 +363,10 @@ process.stderr.write("Telegram MCP server running (user-auth mode)\n");
 
 // Graceful shutdown
 process.on("SIGINT", async () => {
-  await client.disconnect();
+  if (client) await client.disconnect();
   process.exit(0);
 });
 process.on("SIGTERM", async () => {
-  await client.disconnect();
+  if (client) await client.disconnect();
   process.exit(0);
 });


### PR DESCRIPTION
PRs #28-34
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes SessionStart behavior and setup scripts to auto-install tools/run background probes, plus adjusts the Telegram MCP server to run in an unconfigured mode; issues could affect local environments or onboarding reliability. No core business logic changes, but it touches security-adjacent areas (keychain/token probing and secret scanning in CI).
> 
> **Overview**
> **Improves onboarding and setup UX for `claude-ops`.** Adds background preflight caching (`ops-setup-preflight`), a first-run SessionStart banner (`ops-welcome`), and a post-setup completion banner (`ops-setup-complete`), while updating the setup detector to read cached results when available.
> 
> **Setup validation now does more automation.** `scripts/setup.sh` switches from a pure readiness check to silently auto-installing core CLIs via Homebrew and installing Node dependencies as needed, and the setup wizard documentation is expanded (privacy rules, GSD companion plugin option, auto-discovery of local git repos, and more precise CLI command guidance).
> 
> **Operational/packaging updates.** Telegram MCP server now starts even when credentials are missing and returns a friendly error on tool calls; CI replaces the gitleaks GitHub Action with an explicit download+run; repo metadata/docs are refreshed (new issue/PR templates, contributing guide, updated ownership/links/emails, and `/ops:*` command naming consistency).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d6ab82a69214d68e612d751ba3c0f20c0cf33f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->