### PR TITLE
feat: add /ops:doctor auto-diagnosis and repair command

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,16 +1,13 @@
 {
   "name": "ops",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Business operations command center for Claude Code. Manage communications, projects, infrastructure, and revenue from your terminal. Includes YOLO mode for autonomous business operation.",
   "author": {
     "name": "Sam Renders",
     "url": "https://github.com/Lifecycle-Innovations-Limited"
   },
   "homepage": "https://github.com/Lifecycle-Innovations-Limited/claude-ops",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Lifecycle-Innovations-Limited/claude-ops"
-  },
+  "repository": "https://github.com/Lifecycle-Innovations-Limited/claude-ops",
   "license": "MIT",
   "keywords": [
     "business",

--- a/claude-ops/agents/doctor-agent.md
+++ b/claude-ops/agents/doctor-agent.md
@@ -1,0 +1,96 @@
+---
+name: doctor-agent
+description: Diagnoses and auto-fixes ops plugin configuration errors, manifest issues, broken permissions, invalid JSON, and stale cache copies.
+model: claude-sonnet-4-6
+effort: high
+maxTurns: 30
+tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - Grep
+  - Glob
+disallowedTools:
+  - Agent
+---
+
+# DOCTOR AGENT
+
+You are an automated repair agent for the `claude-ops` plugin. You receive a diagnostic JSON report and must fix every error and warning without user intervention.
+
+## Input
+
+The calling skill provides:
+
+- `DIAGNOSTIC_JSON`: full output from `ops-doctor` bin script
+- `PLUGIN_ROOT`: path to the plugin source directory
+- `CACHE_DIR`: path to the plugin cache directory (`~/.claude/plugins/cache/ops-marketplace/ops`)
+
+## Repair Procedures
+
+### plugin_manifest_repository_type
+The `repository` field in `.claude-plugin/plugin.json` is an object but must be a string.
+- Read the file, extract the URL from `repository.url`, replace the object with the URL string.
+- Apply the same fix to ALL copies: source dir AND every version dir under the cache.
+
+### plugin_manifest_invalid_json
+- Read the file, identify the JSON syntax error, fix it.
+- If unfixable, restore from git: `git checkout -- .claude-plugin/plugin.json`
+
+### plugin_manifest_missing_field_*
+- Read current plugin.json, add the missing field with a sensible default.
+
+### bin_not_executable
+- `chmod +x` each listed script.
+
+### skill_missing_definition
+- Log which skill dirs are missing SKILL.md. Do NOT create placeholder skills — just report them.
+
+### agent_missing_frontmatter
+- Read the agent file, add proper YAML frontmatter based on file content.
+
+### mcp_config_invalid_json
+- Read .mcp.json, fix JSON syntax. If unfixable, restore from git.
+
+### registry_invalid_json
+- Backup the broken file, then restore from git or create a minimal `{"projects":[]}`.
+
+### preferences_invalid_json
+- Backup the broken file, create a minimal `{}`.
+
+### registry_missing
+- Create `scripts/registry.json` with `{"projects":[]}`. Ensure `scripts/` dir exists.
+
+### Cache sync
+After fixing source files, sync fixes to ALL cached versions:
+```bash
+for ver_dir in ~/.claude/plugins/cache/ops-marketplace/ops/*/; do
+  cp "$PLUGIN_ROOT/.claude-plugin/plugin.json" "$ver_dir/.claude-plugin/plugin.json" 2>/dev/null || true
+done
+```
+
+## Execution Rules
+
+1. Fix errors first, then warnings.
+2. Always read a file before editing it.
+3. Never delete files — backup broken ones to `*.bak` before overwriting.
+4. After all fixes, re-run the diagnostic to verify:
+   ```bash
+   ${PLUGIN_ROOT}/bin/ops-doctor 2>/dev/null
+   ```
+5. Report must show 0 errors to succeed.
+
+## Output
+
+End with a structured summary:
+
+```
+DOCTOR RESULT
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Errors fixed:   [count]
+Warnings fixed: [count]
+Remaining:      [count] (list if any)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+[list of each fix applied]
+```

--- a/claude-ops/bin/ops-doctor
+++ b/claude-ops/bin/ops-doctor
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# ops-doctor — Diagnose ops plugin health and emit JSON report
+# Checks: plugin manifest, bin permissions, skill files, MCP config,
+# registry, preferences, env vars, CLI tools, and agent definitions.
+set -euo pipefail
+
+has() { command -v "$1" >/dev/null 2>&1 && echo true || echo false; }
+has_env() { [ -n "${!1:-}" ] && echo true || echo false; }
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PLUGIN_JSON="$SCRIPT_DIR/.claude-plugin/plugin.json"
+REGISTRY="$SCRIPT_DIR/scripts/registry.json"
+MCP_JSON_FILE="$SCRIPT_DIR/.mcp.json"
+PREFS_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+PREFS="$PREFS_DIR/preferences.json"
+if [ ! -f "$PREFS" ] && [ -f "$SCRIPT_DIR/scripts/preferences.json" ]; then
+  PREFS="$SCRIPT_DIR/scripts/preferences.json"
+fi
+
+ERRORS=()
+WARNINGS=()
+INFO=()
+
+# --- 1. Plugin manifest ---
+if [ ! -f "$PLUGIN_JSON" ]; then
+  ERRORS+=("plugin_manifest_missing: .claude-plugin/plugin.json not found")
+else
+  if command -v jq >/dev/null 2>&1; then
+    if ! jq empty "$PLUGIN_JSON" 2>/dev/null; then
+      ERRORS+=("plugin_manifest_invalid_json: plugin.json is not valid JSON")
+    else
+      # Check repository field type
+      REPO_TYPE=$(jq -r 'type_of(.repository) // "null"' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")
+      if [ "$REPO_TYPE" = "unknown" ]; then
+        REPO_TYPE=$(jq -r '.repository | type' "$PLUGIN_JSON" 2>/dev/null || echo "unknown")
+      fi
+      if [ "$REPO_TYPE" = "object" ]; then
+        ERRORS+=("plugin_manifest_repository_type: repository field is an object, must be a string")
+      fi
+      # Check required fields
+      for field in name version description; do
+        VAL=$(jq -r ".$field // empty" "$PLUGIN_JSON" 2>/dev/null)
+        if [ -z "$VAL" ]; then
+          ERRORS+=("plugin_manifest_missing_field_$field: required field '$field' is missing or empty")
+        fi
+      done
+      VERSION=$(jq -r '.version // "unknown"' "$PLUGIN_JSON" 2>/dev/null)
+    fi
+  else
+    WARNINGS+=("jq_missing: cannot validate plugin.json without jq")
+  fi
+fi
+
+# --- 2. Bin script permissions ---
+BIN_ISSUES=()
+for script in "$SCRIPT_DIR"/bin/ops-*; do
+  [ -f "$script" ] || continue
+  if [ ! -x "$script" ]; then
+    BIN_ISSUES+=("$(basename "$script")")
+  fi
+done
+if [ ${#BIN_ISSUES[@]} -gt 0 ]; then
+  WARNINGS+=("bin_not_executable: $(IFS=,; echo "${BIN_ISSUES[*]}")")
+fi
+
+# --- 3. Skill directories ---
+SKILL_ISSUES=()
+for skill_dir in "$SCRIPT_DIR"/skills/*/; do
+  [ -d "$skill_dir" ] || continue
+  if [ ! -f "${skill_dir}SKILL.md" ]; then
+    SKILL_ISSUES+=("$(basename "$skill_dir")")
+  fi
+done
+if [ ${#SKILL_ISSUES[@]} -gt 0 ]; then
+  ERRORS+=("skill_missing_definition: skills without SKILL.md: $(IFS=,; echo "${SKILL_ISSUES[*]}")")
+fi
+
+# --- 4. Agent definitions ---
+AGENT_ISSUES=()
+for agent_file in "$SCRIPT_DIR"/agents/*.md; do
+  [ -f "$agent_file" ] || continue
+  if ! head -1 "$agent_file" | grep -q "^---"; then
+    AGENT_ISSUES+=("$(basename "$agent_file")")
+  fi
+done
+if [ ${#AGENT_ISSUES[@]} -gt 0 ]; then
+  WARNINGS+=("agent_missing_frontmatter: $(IFS=,; echo "${AGENT_ISSUES[*]}")")
+fi
+
+# --- 5. MCP config ---
+if [ ! -f "$MCP_JSON_FILE" ]; then
+  WARNINGS+=("mcp_config_missing: .mcp.json not found")
+elif command -v jq >/dev/null 2>&1; then
+  if ! jq empty "$MCP_JSON_FILE" 2>/dev/null; then
+    ERRORS+=("mcp_config_invalid_json: .mcp.json is not valid JSON")
+  fi
+fi
+
+# --- 6. Registry ---
+REGISTRY_STATUS="missing"
+REGISTRY_COUNT=0
+if [ -f "$REGISTRY" ]; then
+  REGISTRY_STATUS="present"
+  if command -v jq >/dev/null 2>&1; then
+    if ! jq empty "$REGISTRY" 2>/dev/null; then
+      ERRORS+=("registry_invalid_json: registry.json is not valid JSON")
+      REGISTRY_STATUS="invalid"
+    else
+      REGISTRY_COUNT=$(jq '.projects | length' "$REGISTRY" 2>/dev/null || echo 0)
+    fi
+  fi
+else
+  WARNINGS+=("registry_missing: scripts/registry.json not found — run /ops:setup to create")
+fi
+
+# --- 7. Preferences ---
+PREFS_STATUS="missing"
+if [ -f "$PREFS" ]; then
+  PREFS_STATUS="present"
+  if command -v jq >/dev/null 2>&1 && ! jq empty "$PREFS" 2>/dev/null; then
+    ERRORS+=("preferences_invalid_json: preferences.json is not valid JSON")
+    PREFS_STATUS="invalid"
+  fi
+fi
+
+# --- 8. CLI tools ---
+TOOLS_JSON=$(cat <<TOOLS
+{
+  "jq": $(has jq),
+  "git": $(has git),
+  "gh": $(has gh),
+  "aws": $(has aws),
+  "node": $(has node),
+  "wacli": $(has wacli),
+  "gog": $(has gog),
+  "sentry-cli": $(has sentry-cli),
+  "doppler": $(has doppler)
+}
+TOOLS
+)
+
+# --- 9. Env vars ---
+ENV_JSON=$(cat <<ENV
+{
+  "CLAUDE_PLUGIN_ROOT": $(has_env CLAUDE_PLUGIN_ROOT),
+  "CLAUDE_PLUGIN_DATA_DIR": $(has_env CLAUDE_PLUGIN_DATA_DIR),
+  "TELEGRAM_BOT_TOKEN": $(has_env TELEGRAM_BOT_TOKEN),
+  "TELEGRAM_OWNER_ID": $(has_env TELEGRAM_OWNER_ID),
+  "AWS_PROFILE": $(has_env AWS_PROFILE),
+  "GH_TOKEN": $(has_env GH_TOKEN)
+}
+ENV
+)
+
+# --- 10. Cache copies vs source ---
+CACHE_DIR="$HOME/.claude/plugins/cache/ops-marketplace/ops"
+CACHE_VERSIONS=()
+if [ -d "$CACHE_DIR" ]; then
+  for ver_dir in "$CACHE_DIR"/*/; do
+    [ -d "$ver_dir" ] || continue
+    CACHE_VERSIONS+=("$(basename "$ver_dir")")
+  done
+fi
+
+# Build errors/warnings JSON arrays
+err_json="[]"
+warn_json="[]"
+info_json="[]"
+if command -v jq >/dev/null 2>&1; then
+  err_json=$(printf '%s\n' "${ERRORS[@]+"${ERRORS[@]}"}" | grep -v '^$' | jq -R . | jq -s . 2>/dev/null || echo "[]")
+  warn_json=$(printf '%s\n' "${WARNINGS[@]+"${WARNINGS[@]}"}" | grep -v '^$' | jq -R . | jq -s . 2>/dev/null || echo "[]")
+  cache_json=$(printf '%s\n' "${CACHE_VERSIONS[@]+"${CACHE_VERSIONS[@]}"}" | grep -v '^$' | jq -R . | jq -s . 2>/dev/null || echo "[]")
+else
+  cache_json="[]"
+fi
+
+cat <<EOF
+{
+  "plugin_root": "$SCRIPT_DIR",
+  "version": "${VERSION:-unknown}",
+  "errors": $err_json,
+  "warnings": $warn_json,
+  "tools": $TOOLS_JSON,
+  "env_vars": $ENV_JSON,
+  "registry": {
+    "status": "$REGISTRY_STATUS",
+    "project_count": $REGISTRY_COUNT,
+    "path": "$REGISTRY"
+  },
+  "preferences": {
+    "status": "$PREFS_STATUS",
+    "path": "$PREFS"
+  },
+  "cache_versions": $cache_json,
+  "skill_count": $(find "$SCRIPT_DIR/skills" -name "SKILL.md" 2>/dev/null | wc -l | tr -d ' '),
+  "agent_count": $(find "$SCRIPT_DIR/agents" -name "*.md" 2>/dev/null | wc -l | tr -d ' '),
+  "bin_count": $(find "$SCRIPT_DIR/bin" -name "ops-*" 2>/dev/null | wc -l | tr -d ' ')
+}
+EOF

--- a/claude-ops/skills/ops-doctor/SKILL.md
+++ b/claude-ops/skills/ops-doctor/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: ops-doctor
+description: Health check and auto-repair for the ops plugin. Diagnoses manifest errors, broken permissions, invalid configs, stale caches, and missing files — then spawns an agent to fix everything automatically.
+argument-hint: "[--check-only|--verbose]"
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - Agent
+  - AskUserQuestion
+---
+
+# OPS ► DOCTOR
+
+## Phase 1 — Run diagnostics
+
+Run the diagnostic script to get a full health report:
+
+```!
+${CLAUDE_PLUGIN_ROOT}/bin/ops-doctor 2>/dev/null || echo '{"errors":["diagnostic_script_failed"],"warnings":[]}'
+```
+
+Parse the JSON output. Display a summary:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► DOCTOR — [timestamp]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+ Plugin:     [version] at [plugin_root]
+ Skills:     [count] defined
+ Agents:     [count] defined
+ Bin scripts:[count] available
+
+ ERRORS      [count]
+ [list each error with description]
+
+ WARNINGS    [count]
+ [list each warning with description]
+
+ TOOLS
+ [table of CLI tool availability]
+
+ ENV VARS
+ [table of env var status]
+
+ Registry:   [status] ([project_count] projects)
+ Preferences:[status]
+ Cache:      [versions list]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+## Phase 2 — Decision
+
+If `$ARGUMENTS` contains `--check-only`: stop here, display results only.
+
+If there are **errors or warnings**:
+
+Display: "Found [N] issues. Spawning doctor agent to auto-fix..."
+
+Then spawn the doctor agent:
+
+```
+Agent({
+  subagent_type: "ops:doctor-agent",
+  prompt: "Fix the following ops plugin issues.\n\nDIAGNOSTIC_JSON: [paste full JSON]\nPLUGIN_ROOT: ${CLAUDE_PLUGIN_ROOT}\nCACHE_DIR: ~/.claude/plugins/cache/ops-marketplace/ops\n\nFix all errors and warnings. Re-run diagnostics after to verify.",
+  description: "Fix ops plugin issues"
+})
+```
+
+If there are **no errors and no warnings**:
+
+Display: "All checks passed. Plugin is healthy."
+
+## Phase 3 — Post-fix verification
+
+After the agent completes, re-run diagnostics:
+
+```!
+${CLAUDE_PLUGIN_ROOT}/bin/ops-doctor 2>/dev/null
+```
+
+Display updated results. If errors remain, report them to the user with manual fix instructions.

--- a/claude-ops/skills/ops/SKILL.md
+++ b/claude-ops/skills/ops/SKILL.md
@@ -31,6 +31,7 @@ Route `$ARGUMENTS` to the correct ops skill:
 | deploy, ship                                  | `/ops-deploy`           |
 | merge, prs, ship-prs                          | `/ops-merge $ARGUMENTS` |
 | yolo                                          | `/ops-yolo`             |
+| doctor, health, fix, diagnose                 | `/ops:ops-doctor`       |
 | speedup, clean, optimize, cleanup             | `/ops:ops-speedup`      |
 
 If `$ARGUMENTS` is empty, launch the interactive dashboard: invoke `/ops:ops-dash` directly.


### PR DESCRIPTION
## Summary
- Adds `/ops:doctor` command that diagnoses plugin health (manifest, permissions, configs, tools, env vars)
- Spawns a doctor agent to auto-fix any errors found (manifest type mismatches, broken JSON, missing files, permission issues)
- Fixes `repository` field in plugin.json (object → string) that caused installation validation errors
- Bumps version to 0.4.1

## Files
- `bin/ops-doctor` — diagnostic bash script, outputs JSON health report
- `agents/doctor-agent.md` — agent definition for auto-repair
- `skills/ops-doctor/SKILL.md` — skill definition with check-only and auto-fix modes
- `skills/ops/SKILL.md` — router updated with doctor/health/fix/diagnose routes
- `.claude-plugin/plugin.json` — fixed repository field + version bump

## Test plan
- [ ] Run `/ops doctor` and verify diagnostic output
- [ ] Introduce a deliberate error and verify auto-fix
- [ ] Run `/ops doctor --check-only` and verify no agent is spawned
- [ ] Verify plugin installs without validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/41" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new diagnostic/auto-fix flow that can modify local plugin files and cached copies; mistakes could break installations or overwrite user configs. Scope is contained to plugin maintenance tooling and manifest metadata.
> 
> **Overview**
> Adds a new `/ops:ops-doctor` skill that runs a diagnostic pass and, when issues are found, spawns a `doctor-agent` subagent to automatically apply fixes (or supports `--check-only` to just report results).
> 
> Introduces `bin/ops-doctor`, a bash health-check that validates `.claude-plugin/plugin.json`, script executability, skill/agent definitions, `.mcp.json`, `scripts/registry.json`, preferences JSON, plus basic tool/env availability, emitting a structured JSON report.
> 
> Fixes the plugin manifest by changing `repository` from an object to a URL string and bumps the plugin version to `0.4.1`, and wires the new doctor route into the main `ops` router keywords.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b7717e6ca510168b06c8123868d6937c7a93c50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->