### PR TITLE
fix: ops-doctor detects unconfigured MCP user_config values

### DIFF
--- a/claude-ops/agents/doctor-agent.md
+++ b/claude-ops/agents/doctor-agent.md
@@ -53,6 +53,23 @@ The `repository` field in `.claude-plugin/plugin.json` is an object but must be 
 ### mcp_config_invalid_json
 - Read .mcp.json, fix JSON syntax. If unfixable, restore from git.
 
+### mcp_missing_user_config_*
+An MCP server references `${user_config.*}` variables that have no value configured.
+- Read the plugin's preferences.json (at `$CLAUDE_PLUGIN_DATA_DIR/preferences.json` or `~/.claude/plugins/data/ops-ops-marketplace/preferences.json`)
+- Check if the missing keys can be populated from environment variables, existing config files, or keychain
+- If values can be found automatically, write them to preferences.json under `user_config.<key>`
+- If values cannot be found (e.g., API keys that need manual entry), report them as "needs manual configuration via /ops:setup"
+- This is the same issue Claude Code's native `/doctor` flags as "Missing required user configuration value"
+
+### unconfigured_sensitive_keys
+Sensitive userConfig values (API keys, tokens) declared in plugin.json are not set.
+- Same resolution as mcp_missing_user_config — try to auto-populate from env/keychain, otherwise report for manual setup
+
+### claude_mcp_unresolved_vars_*
+An MCP server in Claude Code's global config has unresolved `${...}` variable references.
+- Read the referenced config file and check if the variables should be replaced with actual values
+- If the server belongs to this plugin, ensure the plugin's userConfig is properly set
+
 ### registry_invalid_json
 - Backup the broken file, then restore from git or create a minimal `{"projects":[]}`.
 

--- a/claude-ops/bin/ops-doctor
+++ b/claude-ops/bin/ops-doctor
@@ -93,6 +93,84 @@ if [ ! -f "$MCP_JSON_FILE" ]; then
 elif command -v jq >/dev/null 2>&1; then
   if ! jq empty "$MCP_JSON_FILE" 2>/dev/null; then
     ERRORS+=("mcp_config_invalid_json: .mcp.json is not valid JSON")
+  else
+    # Check each MCP server for user_config references and validate they're configured
+    MCP_SERVERS=$(jq -r '.mcpServers // {} | keys[]' "$MCP_JSON_FILE" 2>/dev/null || true)
+    for server in $MCP_SERVERS; do
+      # Extract all ${user_config.*} references from this server's config
+      USER_CONFIG_REFS=$(jq -r "
+        .mcpServers[\"$server\"] | .. | strings | select(test(\"\\\\$\\{user_config\\.\")) |
+        [scan(\"\\\\$\\{user_config\\.([^}]+)\\}\")] | .[][]
+      " "$MCP_JSON_FILE" 2>/dev/null | sort -u || true)
+
+      if [ -n "$USER_CONFIG_REFS" ]; then
+        MISSING_CONFIGS=()
+        for config_key in $USER_CONFIG_REFS; do
+          # Check if this userConfig key has a non-empty value set
+          # Look in preferences.json for saved values
+          HAS_VALUE=false
+          if [ -f "$PREFS" ]; then
+            SAVED_VAL=$(jq -r ".user_config.\"$config_key\" // empty" "$PREFS" 2>/dev/null || true)
+            if [ -n "$SAVED_VAL" ]; then
+              HAS_VALUE=true
+            fi
+          fi
+          # Also check if plugin.json userConfig declares it with a non-empty default
+          if [ "$HAS_VALUE" = false ] && [ -f "$PLUGIN_JSON" ]; then
+            DEFAULT_VAL=$(jq -r ".userConfig.\"$config_key\".default // empty" "$PLUGIN_JSON" 2>/dev/null || true)
+            if [ -n "$DEFAULT_VAL" ]; then
+              HAS_VALUE=true
+            fi
+          fi
+          if [ "$HAS_VALUE" = false ]; then
+            MISSING_CONFIGS+=("$config_key")
+          fi
+        done
+        if [ ${#MISSING_CONFIGS[@]} -gt 0 ]; then
+          ERRORS+=("mcp_missing_user_config_${server}: MCP server '$server' references unconfigured user_config values: $(IFS=,; echo "${MISSING_CONFIGS[*]}"). Run /ops:setup to configure.")
+        fi
+      fi
+    done
+  fi
+fi
+
+# --- 5b. Claude Code native diagnostics ---
+# Check for issues that Claude Code's /doctor would flag
+# Scan all MCP configs Claude Code reads for env var issues
+CLAUDE_MCP_CONFIGS=("$HOME/.claude/.mcp.json" "$HOME/.claude.json")
+for mcp_cfg in "${CLAUDE_MCP_CONFIGS[@]}"; do
+  [ -f "$mcp_cfg" ] || continue
+  if command -v jq >/dev/null 2>&1 && jq empty "$mcp_cfg" 2>/dev/null; then
+    # Check for servers with empty/placeholder env values
+    BROKEN_SERVERS=$(jq -r '
+      .mcpServers // {} | to_entries[] |
+      select(.value.env != null) |
+      select(.value.env | to_entries[] | .value | test("^\\$\\{") ) |
+      .key
+    ' "$mcp_cfg" 2>/dev/null | sort -u || true)
+    for srv in $BROKEN_SERVERS; do
+      WARNINGS+=("claude_mcp_unresolved_vars_${srv}: MCP server '$srv' in $(basename "$mcp_cfg") has unresolved variable references")
+    done
+  fi
+done
+
+# Check plugin data dir for user_config values that are required but missing
+if [ -f "$PLUGIN_JSON" ] && command -v jq >/dev/null 2>&1; then
+  # Get all userConfig keys that have sensitive=true (likely required credentials)
+  SENSITIVE_KEYS=$(jq -r '.userConfig // {} | to_entries[] | select(.value.sensitive == true) | .key' "$PLUGIN_JSON" 2>/dev/null || true)
+  UNCONFIGURED_SENSITIVE=()
+  for skey in $SENSITIVE_KEYS; do
+    IS_SET=false
+    if [ -f "$PREFS" ]; then
+      SVAL=$(jq -r ".user_config.\"$skey\" // empty" "$PREFS" 2>/dev/null || true)
+      [ -n "$SVAL" ] && IS_SET=true
+    fi
+    if [ "$IS_SET" = false ]; then
+      UNCONFIGURED_SENSITIVE+=("$skey")
+    fi
+  done
+  if [ ${#UNCONFIGURED_SENSITIVE[@]} -gt 0 ]; then
+    WARNINGS+=("unconfigured_sensitive_keys: Sensitive user config values not set: $(IFS=,; echo "${UNCONFIGURED_SENSITIVE[*]}"). MCP servers depending on these will fail. Run /ops:setup to configure.")
   fi
 fi
 
@@ -165,13 +243,17 @@ fi
 # Build errors/warnings JSON arrays
 err_json="[]"
 warn_json="[]"
-info_json="[]"
+cache_json="[]"
 if command -v jq >/dev/null 2>&1; then
-  err_json=$(printf '%s\n' "${ERRORS[@]+"${ERRORS[@]}"}" | grep -v '^$' | jq -R . | jq -s . 2>/dev/null || echo "[]")
-  warn_json=$(printf '%s\n' "${WARNINGS[@]+"${WARNINGS[@]}"}" | grep -v '^$' | jq -R . | jq -s . 2>/dev/null || echo "[]")
-  cache_json=$(printf '%s\n' "${CACHE_VERSIONS[@]+"${CACHE_VERSIONS[@]}"}" | grep -v '^$' | jq -R . | jq -s . 2>/dev/null || echo "[]")
-else
-  cache_json="[]"
+  if [ ${#ERRORS[@]} -gt 0 ]; then
+    err_json=$(printf '%s\n' "${ERRORS[@]}" | jq -R . | jq -s . 2>/dev/null || echo "[]")
+  fi
+  if [ ${#WARNINGS[@]} -gt 0 ]; then
+    warn_json=$(printf '%s\n' "${WARNINGS[@]}" | jq -R . | jq -s . 2>/dev/null || echo "[]")
+  fi
+  if [ ${#CACHE_VERSIONS[@]} -gt 0 ]; then
+    cache_json=$(printf '%s\n' "${CACHE_VERSIONS[@]}" | jq -R . | jq -s . 2>/dev/null || echo "[]")
+  fi
 fi
 
 cat <<EOF


### PR DESCRIPTION
## Summary
- ops-doctor now checks MCP servers for `${user_config.*}` references with no configured value
- Detects sensitive userConfig keys (API tokens/secrets) that aren't set
- Scans Claude Code's global MCP configs for unresolved variable references
- Fixes JSON serialization bug for empty error/warning arrays
- Catches the same "Missing required user configuration value" that Claude Code's native `/doctor` flags

## Test plan
- [ ] Run `/ops:ops-doctor` — should show telegram config warning
- [ ] Compare output with native `/doctor` — should flag same MCP issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/42" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it expands `ops-doctor` to parse MCP configs and user preferences (including sensitive keys), which could introduce false positives/negatives or break diagnostics if jq queries behave unexpectedly.
> 
> **Overview**
> `ops-doctor` now scans `.mcp.json` for `${user_config.*}` references and reports per-server `mcp_missing_user_config_*` errors when referenced keys aren’t configured via `preferences.json` or a non-empty `plugin.json` default.
> 
> It also adds Claude Code-style diagnostics by warning on unresolved `${...}` variables in global MCP configs (`~/.claude/.mcp.json`, `~/.claude.json`) and warning when `plugin.json` `userConfig` entries marked `sensitive` are unset.
> 
> Finally, it fixes JSON serialization so empty `errors`/`warnings`/`cache_versions` arrays reliably emit `[]`, and updates `doctor-agent.md` with new remediation procedures for these diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c55a817c83a5d7f85f48492922c238d36d946b6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->