### PR TITLE
feat: ops-autofix for silent self-healing

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Business operations command center for Claude Code. Manage communications, projects, infrastructure, and revenue from your terminal. Includes YOLO mode for autonomous business operation.",
   "author": {
     "name": "Sam Renders",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.2] — 2026-04-13
+
+### Added
+
+- **`bin/ops-autofix`** — Silent auto-repair script for common ops issues. Fixes wacli FTS5 (rebuilds with `sqlite_fts5` Go build tag), registers Slack MCP (from keychain tokens), and registers Vercel MCP. Runs non-interactively with `--json` output. Supports `--fix=all|wacli-fts|slack-mcp|vercel-mcp` targeting.
+
+### Changed
+
+- **`bin/ops-doctor`** — Now runs `ops-autofix` after diagnostics and reports any auto-applied fixes.
+- **`bin/ops-setup-preflight`** — Now runs `ops-autofix` as a background job during preflight, so `/ops:setup` auto-repairs issues before the wizard even starts.
+
 ## [0.4.0] — 2026-04-13
 
 ### Added

--- a/claude-ops/bin/ops-autofix
+++ b/claude-ops/bin/ops-autofix
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# ops-autofix — Automatically fix common ops plugin issues without user interaction
+# Called by /ops:setup and /ops:doctor to silently repair what can be repaired.
+# Usage: ops-autofix [--json] [--fix=all|wacli-fts|slack-mcp|vercel-mcp]
+set -euo pipefail
+
+JSON_OUTPUT=false
+FIX_TARGET="all"
+
+for arg in "$@"; do
+  case "$arg" in
+    --json)       JSON_OUTPUT=true ;;
+    --fix=*)      FIX_TARGET="${arg#--fix=}" ;;
+  esac
+done
+
+FIXES_APPLIED=()
+FIXES_FAILED=()
+FIXES_SKIPPED=()
+
+log_fix() { FIXES_APPLIED+=("$1"); }
+log_fail() { FIXES_FAILED+=("$1"); }
+log_skip() { FIXES_SKIPPED+=("$1"); }
+
+# ─── 1. WhatsApp FTS5 ───────────────────────────────────────────────────────
+fix_wacli_fts() {
+  if ! command -v wacli >/dev/null 2>&1; then
+    log_skip "wacli-fts: wacli not installed"
+    return
+  fi
+
+  # Check if FTS is already enabled
+  FTS_STATUS=$(wacli doctor --json 2>/dev/null | jq -r '.data.fts_enabled // false' 2>/dev/null || echo "false")
+  if [ "$FTS_STATUS" = "true" ]; then
+    log_skip "wacli-fts: already enabled"
+    return
+  fi
+
+  # Check if Go is available for rebuild
+  if ! command -v go >/dev/null 2>&1; then
+    log_fail "wacli-fts: Go toolchain not installed (needed to rebuild wacli with FTS5)"
+    return
+  fi
+
+  # Check if wacli was built without sqlite_fts5 tag
+  WACLI_PATH=$(which wacli)
+  HAS_FTS5_TAG=$(strings "$WACLI_PATH" 2>/dev/null | grep -c "sqlite_fts5" || echo "0")
+
+  # Find or clone wacli source
+  WACLI_SRC=""
+  for candidate in ~/src/wacli /tmp/wacli-rebuild; do
+    if [ -f "$candidate/go.mod" ] && grep -q "wacli" "$candidate/go.mod" 2>/dev/null; then
+      WACLI_SRC="$candidate"
+      break
+    fi
+  done
+
+  if [ -z "$WACLI_SRC" ]; then
+    # Clone source
+    WACLI_SRC="/tmp/wacli-rebuild"
+    rm -rf "$WACLI_SRC"
+    if ! git clone --depth 1 https://github.com/steipete/wacli.git "$WACLI_SRC" 2>/dev/null; then
+      log_fail "wacli-fts: failed to clone wacli source"
+      return
+    fi
+  fi
+
+  # Rebuild with FTS5 tag
+  if (cd "$WACLI_SRC" && CGO_ENABLED=1 go build -tags "sqlite_fts5" -o "$WACLI_PATH" ./cmd/wacli 2>/dev/null); then
+    # Verify
+    NEW_FTS=$(wacli doctor --json 2>/dev/null | jq -r '.data.fts_enabled // false' 2>/dev/null || echo "false")
+    if [ "$NEW_FTS" = "true" ]; then
+      log_fix "wacli-fts: rebuilt with FTS5 support"
+    else
+      log_fail "wacli-fts: rebuilt binary but FTS still reports disabled"
+    fi
+  else
+    log_fail "wacli-fts: go build failed"
+  fi
+}
+
+# ─── 2. Slack MCP ───────────────────────────────────────────────────────────
+fix_slack_mcp() {
+  # Check if already registered
+  if [ -f "$HOME/.claude.json" ] && jq -e '.mcpServers.slack' "$HOME/.claude.json" >/dev/null 2>&1; then
+    log_skip "slack-mcp: already registered"
+    return
+  fi
+
+  # Check for tokens in keychain
+  XOXC=$(security find-generic-password -s slack-xoxc -w 2>/dev/null || echo "")
+  XOXD=$(security find-generic-password -s slack-xoxd -w 2>/dev/null || echo "")
+
+  if [ -z "$XOXC" ] || [ -z "$XOXD" ]; then
+    log_skip "slack-mcp: no tokens in keychain (run /ops:setup slack to extract)"
+    return
+  fi
+
+  # Validate tokens
+  AUTH_OK=$(curl -s -H "Authorization: Bearer $XOXC" -b "d=$XOXD" "https://slack.com/api/auth.test" 2>/dev/null | jq -r '.ok // false' 2>/dev/null || echo "false")
+  if [ "$AUTH_OK" != "true" ]; then
+    log_fail "slack-mcp: tokens in keychain are expired/invalid"
+    return
+  fi
+
+  # Register MCP
+  if command -v claude >/dev/null 2>&1; then
+    if claude mcp add slack -e SLACK_XOXC_TOKEN="$XOXC" -e SLACK_XOXD_TOKEN="$XOXD" -s user -- npx -y @anthropic-ai/slack-mcp-server 2>/dev/null; then
+      log_fix "slack-mcp: registered with valid tokens from keychain"
+    else
+      log_fail "slack-mcp: claude mcp add failed"
+    fi
+  else
+    log_fail "slack-mcp: claude CLI not found"
+  fi
+}
+
+# ─── 3. Vercel MCP ──────────────────────────────────────────────────────────
+fix_vercel_mcp() {
+  # Check if already registered
+  if [ -f "$HOME/.claude.json" ] && jq -e '.mcpServers.vercel' "$HOME/.claude.json" >/dev/null 2>&1; then
+    log_skip "vercel-mcp: already registered"
+    return
+  fi
+
+  if command -v claude >/dev/null 2>&1; then
+    if claude mcp add vercel -s user -- npx -y vercel-mcp-server@latest 2>/dev/null; then
+      log_fix "vercel-mcp: registered"
+    else
+      log_fail "vercel-mcp: claude mcp add failed"
+    fi
+  else
+    log_fail "vercel-mcp: claude CLI not found"
+  fi
+}
+
+# ─── Run fixes ───────────────────────────────────────────────────────────────
+case "$FIX_TARGET" in
+  all)
+    fix_wacli_fts
+    fix_slack_mcp
+    fix_vercel_mcp
+    ;;
+  wacli-fts)   fix_wacli_fts ;;
+  slack-mcp)   fix_slack_mcp ;;
+  vercel-mcp)  fix_vercel_mcp ;;
+  *)
+    echo "Unknown fix target: $FIX_TARGET" >&2
+    exit 1
+    ;;
+esac
+
+# ─── Output ──────────────────────────────────────────────────────────────────
+if [ "$JSON_OUTPUT" = true ]; then
+  applied_json="[]"
+  failed_json="[]"
+  skipped_json="[]"
+  if command -v jq >/dev/null 2>&1; then
+    [ ${#FIXES_APPLIED[@]} -gt 0 ] && applied_json=$(printf '%s\n' "${FIXES_APPLIED[@]}" | jq -R . | jq -s .)
+    [ ${#FIXES_FAILED[@]} -gt 0 ] && failed_json=$(printf '%s\n' "${FIXES_FAILED[@]}" | jq -R . | jq -s .)
+    [ ${#FIXES_SKIPPED[@]} -gt 0 ] && skipped_json=$(printf '%s\n' "${FIXES_SKIPPED[@]}" | jq -R . | jq -s .)
+  fi
+  cat <<EOF
+{
+  "applied": $applied_json,
+  "failed": $failed_json,
+  "skipped": $skipped_json
+}
+EOF
+else
+  for fix in "${FIXES_APPLIED[@]}"; do echo "✓ $fix"; done
+  for fix in "${FIXES_FAILED[@]}"; do echo "✗ $fix"; done
+  for fix in "${FIXES_SKIPPED[@]}"; do echo "○ $fix"; done
+  echo ""
+  echo "Applied: ${#FIXES_APPLIED[@]}, Failed: ${#FIXES_FAILED[@]}, Skipped: ${#FIXES_SKIPPED[@]}"
+fi

--- a/claude-ops/bin/ops-doctor
+++ b/claude-ops/bin/ops-doctor
@@ -343,3 +343,17 @@ cat <<EOF
   "bin_count": $(find "$SCRIPT_DIR/bin" -name "ops-*" 2>/dev/null | wc -l | tr -d ' ')
 }
 EOF
+
+# --- 11. Auto-fix pass (silent, best-effort) ---
+# Run autofix for known issues. This is non-interactive and safe to run every time.
+if [ -x "$SCRIPT_DIR/bin/ops-autofix" ]; then
+  AUTOFIX_RESULT=$("$SCRIPT_DIR/bin/ops-autofix" --json 2>/dev/null || echo '{"applied":[],"failed":[],"skipped":[]}')
+  AUTOFIX_APPLIED=$(echo "$AUTOFIX_RESULT" | jq -r '.applied | length' 2>/dev/null || echo "0")
+  if [ "$AUTOFIX_APPLIED" -gt 0 ]; then
+    echo ""
+    echo "── Auto-fixes applied ──"
+    echo "$AUTOFIX_RESULT" | jq -r '.applied[]' 2>/dev/null | while read -r fix; do
+      echo "  ✓ $fix"
+    done
+  fi
+fi

--- a/claude-ops/bin/ops-setup-preflight
+++ b/claude-ops/bin/ops-setup-preflight
@@ -102,6 +102,14 @@ rm -rf "$OUT" && mkdir -p "$OUT"
   fi
 } &
 
+{
+  # Auto-fix pass: silently repair wacli FTS, missing MCPs, etc.
+  SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+  if [ -x "$SCRIPT_DIR/bin/ops-autofix" ]; then
+    "$SCRIPT_DIR/bin/ops-autofix" --json > "$OUT/autofix.json" 2>/dev/null || true
+  fi
+} &
+
 # Wait for all background jobs
 wait
 


### PR DESCRIPTION
## Summary
- New `bin/ops-autofix` script that silently repairs common issues without user interaction
- Fixes: wacli FTS5 rebuild, Slack MCP registration from keychain, Vercel MCP registration
- Integrated into `ops-doctor` and `ops-setup-preflight` for automatic healing on every run
- Bumped to v0.4.2

## Test plan
- [x] `ops-autofix --json` returns correct applied/failed/skipped arrays
- [x] wacli FTS5 verified working after rebuild
- [x] Slack/Vercel MCP registration verified in ~/.claude.json
- [x] Idempotent — re-running skips already-fixed items

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/44" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an automated, non-interactive repair path that can rebuild binaries, run network calls, and register MCP servers, so failures or unexpected side effects could impact local environments. Changes are mostly additive but now execute during `ops-doctor` and setup preflight runs.
> 
> **Overview**
> Adds **`bin/ops-autofix`** to silently self-heal common issues (rebuild `wacli` with `sqlite_fts5`, register Slack MCP from keychain tokens after validation, and register Vercel MCP), with optional `--json` output and targeted `--fix=` modes.
> 
> Updates **`ops-doctor`** to run `ops-autofix` after diagnostics and report any applied fixes, and updates **`ops-setup-preflight`** to run `ops-autofix` in the background and persist results for the setup wizard. Bumps plugin version to `0.4.2` and documents the release in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b429541198fc00df5c463cb0f13d8239dc1d0044. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic repair tool for common plugin issues, including wacli FTS optimization, Slack MCP, and Vercel MCP setup.
  * Auto-fixes now integrate into setup and diagnostic workflows, running silently in the background.
  * JSON output support for programmatic use and integration.

* **Chores**
  * Version bumped to 0.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->