### PR TITLE
feat: AskUserQuestion confirmations + Agent Teams across all ops skills

### DIFF
--- a/claude-ops/skills/ops-comms/SKILL.md
+++ b/claude-ops/skills/ops-comms/SKILL.md
@@ -46,8 +46,20 @@ Parse `$ARGUMENTS` and route immediately:
    - Check WhatsApp: `wacli contacts --search "[contact]" --json 2>/dev/null`
    - Check Slack: `mcp__claude_ai_Slack__slack_search_users` with `query: "[contact]"`
    - Check email: known from context or ask
-3. If multiple channels found, ask: "Send via (a) WhatsApp (b) Slack (c) Email?"
-4. Send via the chosen channel. Confirm with: `Sent to [contact] via [channel] ✓`
+3. If multiple channels found, use `AskUserQuestion`: `[WhatsApp]` / `[Slack]` / `[Email]`
+4. **Always preview before sending.** Use `AskUserQuestion` to confirm:
+
+```
+Ready to send via [channel]:
+  To: [contact name] ([identifier])
+  Message: "[full message text]"
+
+  [Send now]  [Edit message]  [Cancel]
+```
+
+If user picks "Edit message", use `AskUserQuestion` with free-text to get the revised message, then re-preview.
+
+5. Send via the chosen channel. Confirm with: `Sent to [contact] via [channel] ✓`
 
 ### WhatsApp send
 
@@ -61,7 +73,14 @@ Use `mcp__claude_ai_Slack__slack_send_message` with resolved channel/user ID.
 
 ### Email send (draft)
 
-Use `mcp__claude_ai_Gmail__gmail_create_draft` — always create draft first, confirm before sending.
+Use `mcp__claude_ai_Gmail__gmail_create_draft` — always create draft first. Then use `AskUserQuestion`:
+```
+Draft created for [recipient]:
+  Subject: [subject]
+  Body: [preview]
+
+  [Send now]  [Keep as draft]  [Edit]
+```
 
 ---
 

--- a/claude-ops/skills/ops-deploy/SKILL.md
+++ b/claude-ops/skills/ops-deploy/SKILL.md
@@ -106,4 +106,20 @@ If `$ARGUMENTS` has a project alias, show only that project's deploy info + last
 
 For failing deploys: offer to view logs via `mcp__claude_ai_Vercel__get_deployment_build_logs` or ECS CloudWatch logs.
 
-Use AskUserQuestion after the dashboard.
+Use `AskUserQuestion` after the dashboard for action selection.
+
+**If user selects manual deploy (option b)**, confirm with `AskUserQuestion` before triggering:
+
+```
+Trigger deploy for [project]:
+  Environment: [production/staging]
+  Branch: [branch]
+  Last commit: [sha] — [message]
+
+  [Deploy now]  [View diff since last deploy first]  [Cancel]
+```
+
+**If user selects to view logs**, show the logs and use `AskUserQuestion`:
+```
+  [Dispatch fix agent for this failure]  [Redeploy]  [Back to dashboard]
+```

--- a/claude-ops/skills/ops-fires/SKILL.md
+++ b/claude-ops/skills/ops-fires/SKILL.md
@@ -10,10 +10,27 @@ allowed-tools:
   - Skill
   - Agent
   - AskUserQuestion
+  - TeamCreate
+  - SendMessage
   - mcp__sentry__authenticate
 ---
 
 # OPS ► FIRES
+
+## Agent Teams support
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** when dispatching multiple fix agents simultaneously. This enables:
+- Fix agents share findings (e.g., API agent discovers DB is the root cause → infra agent pivots to DB fix)
+- You can prioritize: "CRITICAL ECS issue first, then CI failures"
+- Real-time progress: agents report as they find root causes, you can merge fixes in optimal order
+
+**Team setup** (only when flag is enabled, dispatch phase):
+```
+TeamCreate("fire-fixers")
+Agent(team_name="fire-fixers", name="fix-[service]", ...)
+```
+
+If the flag is NOT set, use standard parallel subagents.
 
 ## Pre-gathered infrastructure data
 
@@ -91,7 +108,23 @@ If no fires: show "ALL SYSTEMS OPERATIONAL" with last-checked timestamps.
 
 ## Dispatch fix agent
 
-When user selects to fix an issue, spawn an Agent with:
+When user selects to fix an issue, use `AskUserQuestion` to confirm the scope before dispatching:
+
+```
+Dispatch fix agent for: [issue title]
+  Severity: [CRITICAL/HIGH/MEDIUM]
+  Repo: [repo]
+  Error: [brief description]
+  
+  The agent will:
+  - Investigate root cause in [repo]
+  - Create feature branch with fix
+  - Open PR for review
+
+  [Dispatch agent]  [Show me the logs first]  [Skip — I'll fix manually]
+```
+
+On confirmation, spawn an Agent with:
 
 - The error details and logs
 - Access to the relevant repo

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -10,6 +10,8 @@ allowed-tools:
   - Skill
   - Agent
   - AskUserQuestion
+  - TeamCreate
+  - SendMessage
   - mcp__gog__gmail_search
   - mcp__gog__gmail_read_thread
   - mcp__gog__gmail_send
@@ -19,6 +21,26 @@ allowed-tools:
 ---
 
 # OPS ► INBOX ZERO
+
+## Agent Teams support
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** when processing "all channels" mode. This enables:
+- Channel agents run in parallel but can share context (e.g., WhatsApp agent finds a message referencing an email thread → email agent can prioritize it)
+- You can steer agents: "skip WhatsApp for now, focus on email first"
+- Agents report completion per-channel so you can process replies as they come in
+
+**Team setup** (only when flag is enabled, "all channels" mode):
+```
+TeamCreate("inbox-channels")
+Agent(team_name="inbox-channels", name="whatsapp-scanner", ...)
+Agent(team_name="inbox-channels", name="email-scanner", ...)
+Agent(team_name="inbox-channels", name="slack-scanner", ...)
+Agent(team_name="inbox-channels", name="telegram-scanner", ...)
+```
+
+Each agent scans its channel and reports back classified results. You then process NEEDS_REPLY items across all channels in priority order.
+
+If the flag is NOT set, process channels sequentially or use fire-and-forget subagents.
 
 ## Pre-gathered data
 
@@ -123,6 +145,16 @@ Display NEEDS REPLY chats first:
   c) Skip
 ```
 
+Use `AskUserQuestion` for each NEEDS REPLY chat with options `[Read + Reply]` / `[Archive]` / `[Skip]`.
+
+When replying, draft the message and use `AskUserQuestion` to confirm before sending:
+```
+Reply to [Contact] via WhatsApp:
+  "[drafted reply]"
+
+  [Send]  [Edit]  [Skip]
+```
+
 Reply via: `wacli send --to "<JID>" --message "<msg>"`
 
 **wacli troubleshooting:**
@@ -163,6 +195,24 @@ Display NEEDS REPLY threads first:
 
   For FYI section:
   x) Archive all FYI at once
+```
+
+Use `AskUserQuestion` for each NEEDS REPLY email with options `[Read + Reply]` / `[Archive]` / `[Skip]`.
+
+When replying, draft the reply and use `AskUserQuestion` to confirm:
+```
+Reply to [Sender] — [Subject]:
+  "[drafted reply]"
+
+  [Send]  [Edit]  [Skip]
+```
+
+For FYI bulk archive, use `AskUserQuestion`:
+```
+Archive N FYI/newsletter emails?
+  [list of subjects]
+
+  [Archive all N]  [Review each]  [Skip]
 ```
 
 Draft replies via `gog gmail send`. Archive via `gog gmail labels modify --remove INBOX <thread_ids>`.

--- a/claude-ops/skills/ops-merge/SKILL.md
+++ b/claude-ops/skills/ops-merge/SKILL.md
@@ -14,9 +14,28 @@ allowed-tools:
   - TaskUpdate
   - TaskList
   - AskUserQuestion
+  - TeamCreate
+  - SendMessage
 ---
 
 # OPS ► MERGE
+
+## Agent Teams support
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** for fixer agents (Phase 3). This enables:
+- Steering fixers mid-flight if priorities change (e.g., a critical PR should be merged first)
+- Fixers can report blockers and you can redirect them without waiting for completion
+- Shared context: if fixer-A discovers a breaking change that affects fixer-B's PR, you can notify B
+
+**Team setup** (only when flag is enabled, Phase 3):
+```
+TeamCreate("merge-fixers")
+Agent(team_name="merge-fixers", name="fixer-[repo]", ...)
+```
+
+Use `SendMessage(to="fixer-healify-api", content="PR #2958 was just merged — rebase your branch")` to coordinate.
+
+If the flag is NOT set, fall back to standard parallel subagents with `isolation: "worktree"`.
 
 ## Pre-gathered PR data
 
@@ -70,9 +89,21 @@ Ready: N  |  Fix needed: N  |  Blocked: N  |  Draft: N
 
 If `--dry-run`, stop here. Print the queue and exit.
 
-### Phase 2 — Merge ready PRs immediately
+### Phase 2 — Confirm and merge ready PRs
 
-For each `ready` PR:
+Unless `--force` was passed, use `AskUserQuestion` to confirm before merging:
+
+```
+Ready to merge N PRs:
+  [repo]#[number] — [title] → [base]
+  [repo]#[number] — [title] → [base]
+
+  [Merge all N now]  [Let me pick which ones]  [Dry run — don't merge]
+```
+
+If user picks "Let me pick", show each PR with `[Merge]` / `[Skip]` options via `AskUserQuestion`.
+
+For each confirmed PR:
 
 1. Verify CI is still green: `gh pr checks <number> --repo <repo>`
 2. If green: `gh pr merge <number> --repo <repo> --squash --admin`
@@ -116,28 +147,39 @@ For needs-review-response:
 
 After fixing:
   - Report back: what was wrong, what was fixed, is CI green now?
-  - If CI is green and no more blockers: merge with `gh pr merge <number> --repo <repo> --squash --admin`
+  - Do NOT auto-merge after fixing. Report the fix and let Phase 4 handle confirmation.
 ```
 
 Use `model: "sonnet"` for all fixer agents.
 
-### Phase 4 — Collect results and merge
+### Phase 4 — Collect results and confirm merges
 
 As fixers complete:
 
 1. Verify the PR is now green: `gh pr checks <number> --repo <repo>`
-2. If green: merge immediately
-3. If still red: report what's still broken
+2. If green, use `AskUserQuestion` to confirm (unless `--force`):
+   ```
+   Fixer resolved [repo]#[number] — [what was fixed]. CI is now green.
+     [Merge now]  [Skip — I'll review manually]
+   ```
+3. If still red: report what's still broken, do not merge
 
 ### Phase 5 — `--main` sync (only if flag is set)
 
 For each repo that has separate `dev` and `main` branches:
 
 1. Check if dev is ahead of main: `git -C <path> log main..dev --oneline | head -5`
-2. If ahead, create sync PR: `gh pr create --repo <repo> --base main --head dev --title "chore: sync dev → main"`
-3. Wait for CI: `gh pr checks <sync-pr-number> --repo <repo> --watch` (background, max 10 min)
-4. If CI green: `gh pr merge <sync-pr-number> --repo <repo> --merge --admin` (merge commit, not squash)
-5. Pull main back into dev: `git -C <path> fetch origin && git -C <path> checkout dev && git -C <path> merge origin/main --no-edit`
+2. If ahead, show the commits and use `AskUserQuestion`:
+   ```
+   [repo]: dev is N commits ahead of main:
+     [commit list]
+
+     [Create sync PR and merge]  [Create PR only — I'll review]  [Skip this repo]
+   ```
+3. If confirmed: create sync PR: `gh pr create --repo <repo> --base main --head dev --title "chore: sync dev → main"`
+4. Wait for CI: `gh pr checks <sync-pr-number> --repo <repo> --watch` (background, max 10 min)
+5. If CI green: `gh pr merge <sync-pr-number> --repo <repo> --merge --admin` (merge commit, not squash)
+6. Pull main back into dev: `git -C <path> fetch origin && git -C <path> checkout dev && git -C <path> merge origin/main --no-edit`
 
 ### Phase 6 — Final report
 

--- a/claude-ops/skills/ops-speedup/SKILL.md
+++ b/claude-ops/skills/ops-speedup/SKILL.md
@@ -178,6 +178,24 @@ Use AskUserQuestion for the user's choice.
 
 ## Phase 4 — Execute cleanup
 
+**Before executing any cleanup**, use `AskUserQuestion` to confirm the scope and estimated impact:
+
+```
+About to run [quick/full/deep] clean:
+  Brew cache:        [N] MB  ✓
+  npm cache:         [N] MB  ✓
+  Logs:              [N] MB  ✓
+  Tmp files:         [N] MB  ✓
+  [Full: Trash:      [N] MB  ✓]
+  [Full: Docker:     [N] MB  ✓]
+  [Deep: DerivedData [N] MB  ✓]
+  [Deep: Simulators  [N] count ✓]
+  ────────────────────────────
+  Total:             ~[N] GB
+
+  [Proceed]  [Switch to custom — pick categories]  [Cancel]
+```
+
 ### Quick clean (option 1)
 
 ```bash
@@ -225,7 +243,16 @@ Show each category with size and let user toggle on/off.
 
 ### Memory (option 5)
 
-Show top 10 processes by RAM, let user pick which to kill:
+Show top 10 processes by RAM. Use `AskUserQuestion` with `multiSelect` to let user pick which to kill:
+
+```
+Top processes by RAM:
+  [ ] [process] — [N] MB (PID [N])
+  [ ] [process] — [N] MB (PID [N])
+  ...
+
+  [Kill selected]  [Skip]
+```
 
 ```bash
 # macOS

--- a/claude-ops/skills/ops-triage/SKILL.md
+++ b/claude-ops/skills/ops-triage/SKILL.md
@@ -10,6 +10,8 @@ allowed-tools:
   - Skill
   - Agent
   - AskUserQuestion
+  - TeamCreate
+  - SendMessage
   - mcp__sentry__authenticate
   - mcp__claude_ai_Linear__list_issues
   - mcp__claude_ai_Linear__save_issue
@@ -18,6 +20,23 @@ allowed-tools:
 ---
 
 # OPS ► CROSS-PLATFORM TRIAGE
+
+## Agent Teams support
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** when dispatching fix agents for multiple issues. This enables:
+- Fix agents can share findings (e.g., agent fixing Sentry error discovers the same root cause as a Linear issue)
+- You can redirect agents if cross-referencing reveals duplicate issues
+- Agents report progress and you can prioritize which fix to merge first
+
+**Team setup** (only when flag is enabled, Phase 4 dispatch):
+```
+TeamCreate("triage-fixers")
+Agent(team_name="triage-fixers", name="fix-[issue-id]", subagent_type="ops:triage-agent", ...)
+```
+
+Use `broadcast(content="Root cause found: missing index on users.email — check if your issue is related")` to share discoveries.
+
+If the flag is NOT set, fall back to standard parallel subagents.
 
 ## Phase 1 — Gather issues in parallel
 
@@ -67,15 +86,29 @@ For each GitHub Issue:
 
 ---
 
-## Phase 3 — Auto-resolve confirmed fixed issues
+## Phase 3 — Confirm and resolve fixed issues
 
-For issues confirmed fixed in code AND deployed:
+For issues confirmed fixed in code AND deployed, show the full list and use `AskUserQuestion`:
+
+```
+Found N issues confirmed fixed and deployed:
+
+  [Sentry] [title] — fix in [commit], deployed [time ago]
+  [Linear] [title] — fix in [commit], deployed [time ago]
+  [GitHub] #[N] [title] — referenced in merged PR #[M]
+
+  [Resolve all N]  [Review each one]  [Skip — don't auto-resolve]
+```
+
+If user picks "Review each one", show each issue individually with `[Resolve]` / `[Skip]` via `AskUserQuestion`.
+
+For confirmed issues:
 
 - **Sentry**: use Sentry MCP to resolve the issue
 - **Linear**: use `mcp__claude_ai_Linear__save_issue` with `state: "Done"`
 - **GitHub**: `gh issue close [N] --comment "Auto-closed: fix confirmed deployed"`
 
-Log all auto-resolutions.
+Log all resolutions.
 
 ---
 

--- a/claude-ops/skills/ops-yolo/SKILL.md
+++ b/claude-ops/skills/ops-yolo/SKILL.md
@@ -10,6 +10,8 @@ allowed-tools:
   - Skill
   - Agent
   - AskUserQuestion
+  - TeamCreate
+  - SendMessage
   - mcp__claude_ai_Linear__list_issues
   - mcp__claude_ai_Linear__list_cycles
   - mcp__claude_ai_Vercel__list_deployments
@@ -18,6 +20,26 @@ allowed-tools:
 ---
 
 # OPS ► YOLO MODE
+
+## Agent Teams support
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** instead of fire-and-forget subagents for the C-suite analysis (Phase 2). This enables:
+- Agents can share findings mid-analysis (CEO discovers a revenue blocker → CFO factors it into ROI)
+- You can steer agents if early findings change priorities
+- Agents coordinate on the consensus recommendation
+
+**Team setup** (only when flag is enabled):
+```
+TeamCreate("yolo-csuite")
+Agent(team_name="yolo-csuite", name="ceo", subagent_type="ops:yolo-ceo", ...)
+Agent(team_name="yolo-csuite", name="cto", subagent_type="ops:yolo-cto", ...)
+Agent(team_name="yolo-csuite", name="cfo", subagent_type="ops:yolo-cfo", ...)
+Agent(team_name="yolo-csuite", name="coo", subagent_type="ops:yolo-coo", ...)
+```
+
+After initial analysis, use `SendMessage(to="ceo", content="CTO found critical tech debt in auth service — does this change your strategic recommendation?")` to cross-pollinate findings before synthesizing the Hard Truths report.
+
+If the flag is NOT set, fall back to standard parallel subagents (fire-and-forget, no mid-task steering).
 
 ## Phase 1 — Pre-gather ALL data
 
@@ -149,18 +171,35 @@ After all 4 agents complete, synthesize into a unified report:
 
 ## Phase 4 — YOLO Autonomous Mode
 
-If user types `YOLO` (all caps), enter autonomous mode via `/loop`:
+If user types `YOLO` (all caps), enter autonomous mode via `/loop`.
 
-Run the following in sequence, reporting after each step:
+**Before starting**, use `AskUserQuestion` to confirm scope:
 
-1. **Inbox** — Process all unread messages. Reply to humans, archive automated.
-2. **Fires** — Fix any CRITICAL or HIGH production issues (dispatch agents).
-3. **PRs** — Merge all ready-to-merge PRs (CI green, no unresolved comments).
-4. **Triage** — Auto-resolve confirmed-fixed issues across Sentry/Linear/GitHub.
-5. **GSD** — Advance the highest-priority active phase across all projects.
-6. **Linear** — Update sprint board to reflect actual state.
-7. **Deploy** — Trigger any pending deploys that are ready.
-8. **Report** — Summary of everything done, what's left, and blockers.
+```
+YOLO mode will autonomously execute these steps:
+  1. Inbox — reply to humans, archive automated
+  2. Fires — fix CRITICAL/HIGH production issues
+  3. PRs — merge ready PRs (CI green, approved)
+  4. Triage — auto-resolve confirmed-fixed issues
+  5. GSD — advance highest-priority phase
+  6. Linear — sync sprint board
+  7. Deploy — trigger pending deploys
+  8. Report — summary
+
+  [Run all 8 steps]  [Pick which steps to run]  [Cancel]
+```
+
+If user picks "Pick which steps", show each step as a `multiSelect` via `AskUserQuestion`.
+
+Run the selected steps in sequence, reporting after each step.
+
+**Per-step confirmations** (use `AskUserQuestion` before each destructive action):
+
+- **Inbox**: Show drafted replies and ask `[Send all N replies]` / `[Review each one]` / `[Skip inbox]` before sending any messages
+- **Fires**: Show proposed fix and ask `[Dispatch fix agent]` / `[Skip]` before each agent dispatch
+- **PRs**: Show PR list and ask `[Merge all N ready PRs]` / `[Pick which ones]` / `[Skip]` before merging
+- **Triage**: Show issues to close and ask `[Auto-resolve all N confirmed-fixed]` / `[Review each]` / `[Skip]` before closing
+- **Deploy**: Show pending deploys and ask `[Deploy all]` / `[Pick which]` / `[Skip]` before triggering
 
 After each step, check if new fires have appeared before proceeding.
 Report final summary when done.


### PR DESCRIPTION
## Summary
- Added AskUserQuestion confirmations before all destructive actions across 8 skills
- Added Agent Teams (TeamCreate/SendMessage) support to 5 skills for mid-task steering
- Skills affected: ops-merge, ops-yolo, ops-triage, ops-comms, ops-inbox, ops-speedup, ops-fires, ops-deploy

## Changes
**AskUserQuestion** — confirm before: merging PRs, sending messages, auto-resolving issues, dispatching fix agents, running cleanup, triggering deploys, YOLO autonomous steps

**Agent Teams** — when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`: ops-yolo C-suite cross-pollination, ops-merge fixer coordination, ops-triage shared findings, ops-inbox multi-channel parallel scan, ops-fires fix agent coordination

## Test plan
- [x] All 8 SKILL.md files updated with proper AskUserQuestion patterns
- [x] TeamCreate/SendMessage added to allowed-tools where needed
- [x] Agent Teams gated behind feature flag check
- [x] Synced to local cache for immediate testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/45" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operational runbooks for message sending, deploys, merges, cleanup, and auto-triage by inserting new `AskUserQuestion` confirmation gates and optional Agent Teams coordination, which can alter automation flow and potentially block or delay critical actions if misused.
> 
> **Overview**
> Adds **mandatory `AskUserQuestion` previews/confirmations** before destructive or irreversible actions across ops skills (sending messages, triggering deploys, dispatching fix agents, running cleanup, merging PRs, and resolving/closing issues), including edit/cancel paths and multi-select UX where applicable.
> 
> Introduces **feature-flagged Agent Teams** support (`TeamCreate`/`SendMessage`) in several workflows (`ops-merge`, `ops-yolo`, `ops-triage`, `ops-inbox`, `ops-fires`) to coordinate multiple parallel agents with shared context and mid-task steering, and adjusts `ops-merge` to avoid auto-merging fixer results without explicit confirmation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a0b93c44783f666fec809ac4ada405e440eeb23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->