### PR TITLE
feat: integrate Claude Code native tools across all ops skills

### DIFF
--- a/claude-ops/skills/ops-dash/SKILL.md
+++ b/claude-ops/skills/ops-dash/SKILL.md
@@ -10,6 +10,9 @@ allowed-tools:
   - Skill
   - Agent
   - AskUserQuestion
+  - CronCreate
+  - CronList
+  - CronDelete
 ---
 
 # OPS > DASH — Interactive Command Center

--- a/claude-ops/skills/ops-deploy/SKILL.md
+++ b/claude-ops/skills/ops-deploy/SKILL.md
@@ -8,7 +8,12 @@ allowed-tools:
   - Grep
   - Glob
   - Skill
+  - Agent
   - AskUserQuestion
+  - TaskCreate
+  - TaskUpdate
+  - Monitor
+  - WebFetch
   - mcp__claude_ai_Vercel__list_deployments
   - mcp__claude_ai_Vercel__list_projects
   - mcp__claude_ai_Vercel__get_deployment
@@ -122,4 +127,27 @@ Trigger deploy for [project]:
 **If user selects to view logs**, show the logs and use `AskUserQuestion`:
 ```
   [Dispatch fix agent for this failure]  [Redeploy]  [Back to dashboard]
+```
+
+---
+
+## Native tool usage
+
+### Monitor — live deploy streaming
+
+When watching a deploy in progress, use `Monitor` to stream logs:
+```
+Monitor(command: "gh run watch <run-id> --repo <repo>")
+```
+For ECS deploys: `Monitor(command: "aws ecs wait services-stable --cluster <cluster> --services <service>")`
+
+### Tasks — deploy tracking
+
+Use `TaskCreate` per project being deployed. Update with `TaskUpdate` as deploys succeed/fail.
+
+### WebFetch — Vercel fallback
+
+When Vercel MCP tools are unavailable, use `WebFetch` with the Vercel API directly:
+```
+WebFetch(url: "https://api.vercel.com/v6/deployments?projectId=<id>&limit=5", headers: {"Authorization": "Bearer $VERCEL_TOKEN"})
 ```

--- a/claude-ops/skills/ops-doctor/SKILL.md
+++ b/claude-ops/skills/ops-doctor/SKILL.md
@@ -9,6 +9,8 @@ allowed-tools:
   - Glob
   - Agent
   - AskUserQuestion
+  - WebSearch
+  - WebFetch
 ---
 
 # OPS ► DOCTOR
@@ -82,3 +84,15 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ops-doctor 2>/dev/null
 ```
 
 Display updated results. If errors remain, report them to the user with manual fix instructions.
+
+---
+
+## Native tool usage
+
+### WebSearch — known issue lookup
+
+When diagnostics find errors, use `WebSearch` to check if the issue is a known Claude Code plugin bug, MCP server issue, or configuration problem. Include links to relevant GitHub issues or docs.
+
+### WebFetch — MCP health check
+
+For MCP servers that appear disconnected, use `WebFetch` to test their underlying APIs directly (e.g., `https://api.linear.app/graphql` with a simple query) to distinguish between "MCP broken" and "API down".

--- a/claude-ops/skills/ops-fires/SKILL.md
+++ b/claude-ops/skills/ops-fires/SKILL.md
@@ -12,6 +12,11 @@ allowed-tools:
   - AskUserQuestion
   - TeamCreate
   - SendMessage
+  - TaskCreate
+  - TaskUpdate
+  - Monitor
+  - WebFetch
+  - WebSearch
   - mcp__sentry__authenticate
 ---
 
@@ -134,3 +139,26 @@ On confirmation, spawn an Agent with:
 Use the `agents/infra-monitor.md` agent definition for infra issues.
 
 If `$ARGUMENTS` contains a project alias, filter to that project's services only.
+
+---
+
+## Native tool usage
+
+### Monitor — live service health
+
+Use `Monitor` to stream ECS task logs or GitHub Actions runs when investigating fires:
+```
+Monitor(command: "aws logs tail /ecs/<service> --follow --since 5m")
+```
+
+### Tasks — incident tracking
+
+Use `TaskCreate` for each active fire. Update with `TaskUpdate` as fires are investigated/fixed/escalated.
+
+### WebFetch — status pages
+
+When diagnosing fires, use `WebFetch` to check AWS status page (`https://health.aws.amazon.com/health/status`), Vercel status, or third-party API status pages.
+
+### WebSearch — known outage patterns
+
+Use `WebSearch` to find if the error pattern matches a known AWS/infrastructure issue (e.g., "ECS task stopped CannotPullContainerError" → known ECR throttling).

--- a/claude-ops/skills/ops-go/SKILL.md
+++ b/claude-ops/skills/ops-go/SKILL.md
@@ -10,6 +10,12 @@ allowed-tools:
   - Skill
   - Agent
   - AskUserQuestion
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+  - CronCreate
+  - CronList
+  - WebFetch
 ---
 
 # OPS ► MORNING BRIEFING
@@ -116,3 +122,26 @@ If `$ARGUMENTS` contains a project alias, focus the briefing on that project onl
 After presenting, use AskUserQuestion for the user's choice and route to the appropriate ops skill or project.
 
 For Slack unread counts: if the pre-gathered data shows `"count": -1`, use `mcp__claude_ai_Slack__slack_search_public_and_private` with query `is:unread` to get actual counts. Do this as a parallel tool call while analyzing other data.
+
+---
+
+## Native tool usage
+
+### Tasks — briefing action tracking
+
+After presenting the briefing, create a `TaskCreate` for each recommended priority action. As the user works through them (or delegates via skill routing), update with `TaskUpdate`. This gives continuity across the session.
+
+### Cron — scheduled briefings
+
+After the first briefing, offer to schedule recurring briefings via `AskUserQuestion`:
+```
+  [Schedule daily at 9am]  [Schedule weekday mornings]  [No schedule]
+```
+Use `CronCreate` to set up the schedule. Show existing schedules with `CronList`.
+
+### WebFetch — calendar enrichment
+
+When `gog cal` fails, use `WebFetch` with the Google Calendar API as fallback:
+```
+WebFetch(url: "https://www.googleapis.com/calendar/v3/calendars/primary/events?timeMin=<today>T00:00:00Z&timeMax=<today>T23:59:59Z")
+```

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -12,6 +12,11 @@ allowed-tools:
   - AskUserQuestion
   - TeamCreate
   - SendMessage
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+  - CronCreate
+  - CronList
   - mcp__gog__gmail_search
   - mcp__gog__gmail_read_thread
   - mcp__gog__gmail_send
@@ -263,3 +268,19 @@ After all selected channels are processed, print:
 ```
 
 If `$ARGUMENTS` specifies a channel (e.g. `whatsapp`), skip the menu and go directly to that channel.
+
+---
+
+## Native tool usage
+
+### Tasks — inbox progress
+
+Use `TaskCreate` for each channel being processed. Update with `TaskUpdate` as messages are replied/archived/skipped. Gives the user a live inbox-zero progress bar.
+
+### Cron — scheduled inbox checks
+
+After processing, offer to schedule recurring inbox checks via `AskUserQuestion`:
+```
+  [Schedule inbox check every 2 hours]  [Schedule morning + evening]  [No schedule]
+```
+Use `CronCreate` if selected. Show existing schedules with `CronList`.

--- a/claude-ops/skills/ops-linear/SKILL.md
+++ b/claude-ops/skills/ops-linear/SKILL.md
@@ -9,6 +9,9 @@ allowed-tools:
   - Glob
   - Skill
   - AskUserQuestion
+  - TaskCreate
+  - TaskUpdate
+  - WebFetch
   - mcp__claude_ai_Linear__list_issues
   - mcp__claude_ai_Linear__list_cycles
   - mcp__claude_ai_Linear__list_teams
@@ -111,3 +114,18 @@ Read all active GSD STATE.md files across projects. For each active phase:
 Update Linear issues to match GSD phase completion status.
 
 Use AskUserQuestion after displaying any view to get the next action.
+
+---
+
+## Native tool usage
+
+### Tasks — sprint work tracking
+
+When the user starts working on a Linear issue, use `TaskCreate` to track it locally. Update with `TaskUpdate` as the issue progresses. This bridges Linear state with local session state.
+
+### WebFetch — Linear API fallback
+
+When Linear MCP tools hit quota limits or fail, fall back to `WebFetch` with the Linear GraphQL API:
+```
+WebFetch(url: "https://api.linear.app/graphql", method: "POST", headers: {"Authorization": "$LINEAR_API_KEY"}, body: '{"query":"{ issues(filter: {cycle: {id: {eq: \"<id>\"}}}}) { nodes { id title state { name } } } }"}')
+```

--- a/claude-ops/skills/ops-merge/SKILL.md
+++ b/claude-ops/skills/ops-merge/SKILL.md
@@ -16,6 +16,8 @@ allowed-tools:
   - AskUserQuestion
   - TeamCreate
   - SendMessage
+  - Monitor
+  - WebSearch
 ---
 
 # OPS ► MERGE
@@ -214,3 +216,23 @@ Main sync: N repos synced (dev → main → dev)
 - **ALWAYS use `--admin` only for squash merges to dev** (not main, unless `--main` flag)
 - **Max 10 PRs per invocation** to avoid GitHub API throttling
 - **If a PR has > 50 files changed**, flag it for manual review instead of auto-merging
+
+---
+
+## Native tool usage
+
+### Monitor — live CI watching
+
+When waiting for CI after a fixer pushes (Phase 3-4), use `Monitor` to stream the GitHub Actions run output instead of polling:
+```
+Monitor(command: "gh run watch <run-id> --repo <repo>")
+```
+This avoids sleep loops and gives real-time feedback on CI progress.
+
+### Tasks — progress tracking
+
+Create a `TaskCreate` for the overall merge pipeline and individual tasks per PR. Update with `TaskUpdate` as each PR is fixed/merged/skipped. This gives the user a live checklist view.
+
+### WebSearch — CI failure context
+
+When a fixer agent encounters an obscure CI failure, use `WebSearch` to find known issues (e.g., npm registry outages, GitHub Actions incidents, flaky test patterns).

--- a/claude-ops/skills/ops-next/SKILL.md
+++ b/claude-ops/skills/ops-next/SKILL.md
@@ -10,6 +10,9 @@ allowed-tools:
   - Skill
   - Agent
   - AskUserQuestion
+  - TaskCreate
+  - TaskUpdate
+  - WebFetch
   - mcp__claude_ai_Linear__list_issues
   - mcp__claude_ai_Linear__list_cycles
   - mcp__claude_ai_Slack__slack_search_public_and_private
@@ -126,3 +129,15 @@ Revenue weighting: read `revenue.stage` and `priority` from `scripts/registry.js
 Use AskUserQuestion. When user selects an option, invoke the corresponding skill directly — don't describe it, do it.
 
 If `$ARGUMENTS` contains context (e.g., "focus on <project-alias>"), constrain the analysis to that context.
+
+---
+
+## Native tool usage
+
+### Tasks — action tracking
+
+After the user selects an action, use `TaskCreate` to track it. When routing to the corresponding skill, the task persists as a reminder of what the user chose to focus on.
+
+### WebFetch — enrichment fallback
+
+When pre-gathered data is stale or incomplete, use `WebFetch` to pull fresh data from APIs (Linear GraphQL, Sentry, GitHub) directly.

--- a/claude-ops/skills/ops-projects/SKILL.md
+++ b/claude-ops/skills/ops-projects/SKILL.md
@@ -10,6 +10,9 @@ allowed-tools:
   - Skill
   - Agent
   - AskUserQuestion
+  - TaskCreate
+  - TaskUpdate
+  - WebFetch
 ---
 
 # OPS ► PROJECTS DASHBOARD
@@ -114,3 +117,15 @@ If `$ARGUMENTS` contains a project alias, show a deep-dive for that project:
 ```
 
 Use AskUserQuestion after displaying either view.
+
+---
+
+## Native tool usage
+
+### Tasks — project action tracking
+
+When the user jumps to a project, use `TaskCreate` to track the action they take. This carries context forward if they switch between projects.
+
+### WebFetch — CI enrichment
+
+When `gh` is slow or rate-limited, use `WebFetch` to query GitHub Actions API directly for run status.

--- a/claude-ops/skills/ops-revenue/SKILL.md
+++ b/claude-ops/skills/ops-revenue/SKILL.md
@@ -9,6 +9,8 @@ allowed-tools:
   - Glob
   - Skill
   - AskUserQuestion
+  - WebFetch
+  - Write
 ---
 
 # OPS ► REVENUE & COSTS
@@ -124,3 +126,18 @@ RUNWAY ESTIMATE
 | (empty)  | Show full dashboard          |
 
 Use AskUserQuestion after the dashboard for next action.
+
+---
+
+## Native tool usage
+
+### WebFetch — billing API fallback
+
+When `aws ce` commands fail or return incomplete data, use `WebFetch` to query the AWS Cost Explorer API directly. Also useful for fetching Stripe/billing provider data if configured.
+
+### Write — export reports
+
+When user selects "Export cost report" (option c), use `Write` to save the report as a dated file:
+```
+Write(file_path: "/tmp/ops-revenue-[date].md", content: "[formatted report]")
+```

--- a/claude-ops/skills/ops-triage/SKILL.md
+++ b/claude-ops/skills/ops-triage/SKILL.md
@@ -12,6 +12,12 @@ allowed-tools:
   - AskUserQuestion
   - TeamCreate
   - SendMessage
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+  - WebFetch
+  - WebSearch
+  - LSP
   - mcp__sentry__authenticate
   - mcp__claude_ai_Linear__list_issues
   - mcp__claude_ai_Linear__save_issue
@@ -152,3 +158,23 @@ When dispatching for an issue, spawn an Agent using `agents/triage-agent.md` wit
 - Report back on completion or if blocked
 
 Filter to `$ARGUMENTS` project/source if specified.
+
+---
+
+## Native tool usage
+
+### Tasks — triage progress
+
+Use `TaskCreate` for each issue being investigated. Update with `TaskUpdate` as issues are resolved/dispatched/skipped. Gives the user a live triage checklist.
+
+### WebFetch — Sentry/GitHub enrichment
+
+When Sentry MCP hits quota limits, fall back to `WebFetch` with `https://sentry.io/api/0/projects/<org>/<project>/issues/?query=is:unresolved` (using `SENTRY_AUTH_TOKEN` header). Same for GitHub issue details when `gh` is slow.
+
+### WebSearch — error context
+
+Use `WebSearch` to find known solutions for recurring errors (e.g., "AWS RDS connection reset", "ECS task stopped reason"). Include findings in the triage board as context.
+
+### LSP — code navigation for fix agents
+
+When dispatching fix agents, use `LSP` to find symbol definitions, references, and call hierarchies. This helps agents navigate unfamiliar codebases faster than grep.

--- a/claude-ops/skills/ops-yolo/SKILL.md
+++ b/claude-ops/skills/ops-yolo/SKILL.md
@@ -12,6 +12,17 @@ allowed-tools:
   - AskUserQuestion
   - TeamCreate
   - SendMessage
+  - TaskCreate
+  - TaskUpdate
+  - TaskList
+  - EnterPlanMode
+  - ExitPlanMode
+  - CronCreate
+  - CronList
+  - CronDelete
+  - Monitor
+  - WebFetch
+  - WebSearch
   - mcp__claude_ai_Linear__list_issues
   - mcp__claude_ai_Linear__list_cycles
   - mcp__claude_ai_Vercel__list_deployments
@@ -207,3 +218,31 @@ Report final summary when done.
 If `$ARGUMENTS` is `analyze` or empty, go straight to Phase 1.
 If `$ARGUMENTS` is `YOLO`, skip to Phase 4.
 If `$ARGUMENTS` is `report`, skip to Phase 3 (reads existing analysis files if present).
+
+---
+
+## Native tool usage
+
+### Tasks — progress tracking
+
+Use `TaskCreate` at the start of Phase 4 to create a task for each YOLO step. Update with `TaskUpdate` as each completes. This gives the user a live progress view across the autonomous run.
+
+### PlanMode — review before autonomous
+
+Before Phase 4 execution, use `EnterPlanMode` to present the full execution plan. The user reviews what YOLO will do, approves or modifies, then `ExitPlanMode` to begin execution.
+
+### Cron — schedule daily YOLO
+
+After Phase 4 completes, offer to schedule recurring YOLO via `AskUserQuestion`:
+```
+  [Schedule daily YOLO at 9am]  [Schedule weekly Monday briefing]  [No schedule]
+```
+Use `CronCreate` if selected. Use `CronList`/`CronDelete` to manage existing schedules.
+
+### Monitor — live CI/deploy watching
+
+When YOLO dispatches fix agents or triggers deploys, use `Monitor` to stream CI output in real-time instead of polling with sleep loops.
+
+### WebFetch/WebSearch — enrichment
+
+Use `WebFetch` to pull Grafana dashboards, Sentry event details, or AWS status pages when MCPs are unavailable. Use `WebSearch` to find context on production errors (e.g., known AWS outages).


### PR DESCRIPTION
## Summary
- Added Monitor, Tasks, WebFetch, WebSearch, Cron, PlanMode, LSP, Write to 13 ops skills
- Each skill gets allowed-tools entries + usage instructions explaining when/how to use each tool

## Tool distribution
| Tool | Skills |
|------|--------|
| Monitor | merge, fires, deploy, yolo |
| Tasks | yolo, triage, inbox, fires, deploy, go, next, projects, linear |
| WebFetch | fires, triage, deploy, go, next, revenue, projects, linear, doctor |
| WebSearch | merge, triage, fires, doctor, yolo |
| Cron | yolo, inbox, go, dash |
| PlanMode | yolo |
| LSP | triage |
| Write | revenue |

## Test plan
- [x] All 13 SKILL.md files updated
- [x] Synced to local cache
- [x] No breaking changes to existing flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/46" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily updates skill manifests/docs, but it expands `allowed-tools` (e.g., `WebFetch`, `Write`, `Cron*`, `Monitor`) which changes what skills are permitted to do at runtime and could impact safety if misused.
> 
> **Overview**
> Adds Claude Code *native tool integration* across the ops skill suite by expanding `allowed-tools` and documenting when to use each tool.
> 
> Skills now explicitly support **task/progress tracking** (`TaskCreate`/`TaskUpdate`/`TaskList`), **live streaming** (`Monitor`), and **API fallbacks/enrichment** (`WebFetch`, `WebSearch`) for deploys, fires, triage, merge, briefing/next/projects, Linear, and doctor.
> 
> Introduces **scheduling hooks** (`CronCreate`/`CronList`/`CronDelete`) for recurring briefings/inbox checks/YOLO/dash flows, plus targeted additions like **PlanMode** (`EnterPlanMode`/`ExitPlanMode`) for YOLO pre-flight review, **LSP** for triage code navigation, and **Write** for exporting revenue reports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dad0c691f63586824ed55f99fa38ee8280ddd6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->