### PR TITLE
feat: add /ops:marketing — email, ads, analytics, SEO command center

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -72,6 +72,41 @@
       "type": "string",
       "sensitive": false,
       "default": "us-east-1"
+    },
+    "klaviyo_private_key": {
+      "title": "Klaviyo Private API Key",
+      "description": "Private API key from Klaviyo Settings > API Keys (starts with pk_ or ck_)",
+      "type": "string",
+      "sensitive": true,
+      "default": ""
+    },
+    "meta_ads_token": {
+      "title": "Meta Ads Access Token",
+      "description": "Meta Marketing API access token from Facebook Business",
+      "type": "string",
+      "sensitive": true,
+      "default": ""
+    },
+    "meta_ad_account_id": {
+      "title": "Meta Ad Account ID",
+      "description": "Ad account ID (format: act_XXXXXXXXX)",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
+    },
+    "ga4_property_id": {
+      "title": "Google Analytics 4 Property ID",
+      "description": "GA4 property ID (numeric, from Admin > Property Settings)",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
+    },
+    "google_search_console_site": {
+      "title": "Google Search Console Site URL",
+      "description": "Site URL as registered in Search Console (e.g., https://example.com)",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
     }
   }
 }

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -107,6 +107,27 @@
       "type": "string",
       "sensitive": false,
       "default": ""
+    },
+    "shopify_store_url": {
+      "title": "Shopify Store URL",
+      "description": "Your Shopify store URL (e.g., mystore.myshopify.com)",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
+    },
+    "shopify_admin_token": {
+      "title": "Shopify Admin API Token",
+      "description": "Admin API access token from Shopify Partners or custom app",
+      "type": "string",
+      "sensitive": true,
+      "default": ""
+    },
+    "shipbob_access_token": {
+      "title": "ShipBob Access Token",
+      "description": "ShipBob Personal Access Token for fulfillment tracking (optional)",
+      "type": "string",
+      "sensitive": true,
+      "default": ""
     }
   }
 }

--- a/claude-ops/bin/ops-ecom-health
+++ b/claude-ops/bin/ops-ecom-health
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# ops-ecom-health — Shopify store health check, outputs JSON
+
+set -euo pipefail
+
+# Resolve credentials
+SHOPIFY_STORE="${SHOPIFY_STORE_URL:-}"
+SHOPIFY_TOKEN="${SHOPIFY_ACCESS_TOKEN:-}"
+
+# Doppler fallback
+if [ -z "$SHOPIFY_TOKEN" ] && command -v doppler &>/dev/null; then
+  SHOPIFY_TOKEN=$(doppler secrets get SHOPIFY_ACCESS_TOKEN --plain 2>/dev/null || echo "")
+fi
+if [ -z "$SHOPIFY_STORE" ] && command -v doppler &>/dev/null; then
+  SHOPIFY_STORE=$(doppler secrets get SHOPIFY_STORE_URL --plain 2>/dev/null || echo "")
+fi
+
+if [ -z "$SHOPIFY_STORE" ] || [ -z "$SHOPIFY_TOKEN" ]; then
+  echo '{"error":"missing_credentials","message":"Set SHOPIFY_STORE_URL and SHOPIFY_ACCESS_TOKEN"}'
+  exit 1
+fi
+
+BASE="https://${SHOPIFY_STORE}/admin/api/2024-10"
+AUTH="X-Shopify-Access-Token: ${SHOPIFY_TOKEN}"
+
+# Check API connectivity
+SHOP_RESPONSE=$(curl -s -w "\n%{http_code}" -H "$AUTH" "${BASE}/shop.json" 2>/dev/null || echo -e "\n000")
+SHOP_BODY=$(echo "$SHOP_RESPONSE" | head -1)
+HTTP_CODE=$(echo "$SHOP_RESPONSE" | tail -1)
+
+if [ "$HTTP_CODE" != "200" ]; then
+  echo "{\"error\":\"api_unreachable\",\"http_code\":${HTTP_CODE},\"message\":\"Shopify Admin API returned HTTP ${HTTP_CODE}\"}"
+  exit 1
+fi
+
+SHOP_NAME=$(echo "$SHOP_BODY" | jq -r '.shop.name // "unknown"' 2>/dev/null || echo "unknown")
+SHOP_PLAN=$(echo "$SHOP_BODY" | jq -r '.shop.plan_display_name // "unknown"' 2>/dev/null || echo "unknown")
+SHOP_CURRENCY=$(echo "$SHOP_BODY" | jq -r '.shop.currency // "unknown"' 2>/dev/null || echo "unknown")
+SHOP_DOMAIN=$(echo "$SHOP_BODY" | jq -r '.shop.domain // "unknown"' 2>/dev/null || echo "unknown")
+
+# Active theme
+THEME_RESPONSE=$(curl -s -H "$AUTH" "${BASE}/themes.json" 2>/dev/null || echo '{}')
+ACTIVE_THEME=$(echo "$THEME_RESPONSE" | jq -r '[.themes[] | select(.role == "main")] | .[0] | {id: .id, name: .name, updated: .updated_at}' 2>/dev/null || echo 'null')
+
+# Product count
+PRODUCT_COUNT=$(curl -s -H "$AUTH" "${BASE}/products/count.json" 2>/dev/null | jq '.count // 0' 2>/dev/null || echo 0)
+
+# Order count (last 24h)
+SINCE=$(date -u -v-1d +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "1 day ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u +"%Y-%m-%dT00:00:00Z")
+ORDER_COUNT=$(curl -s -H "$AUTH" "${BASE}/orders/count.json?status=any&created_at_min=${SINCE}" 2>/dev/null | jq '.count // 0' 2>/dev/null || echo 0)
+
+# Unfulfilled orders
+UNFULFILLED_COUNT=$(curl -s -H "$AUTH" "${BASE}/orders/count.json?fulfillment_status=unfulfilled&status=open" 2>/dev/null | jq '.count // 0' 2>/dev/null || echo 0)
+
+# Low stock products (inventory < 10)
+INVENTORY_RESPONSE=$(curl -s -H "$AUTH" "${BASE}/products.json?limit=250&fields=id,title,variants" 2>/dev/null || echo '{"products":[]}')
+LOW_STOCK=$(echo "$INVENTORY_RESPONSE" | jq '[.products[] | .variants[] | select(.inventory_quantity != null and .inventory_quantity < 10 and .inventory_quantity > 0) | {product_id: .product_id, sku: .sku, qty: .inventory_quantity}] | length' 2>/dev/null || echo 0)
+OUT_OF_STOCK=$(echo "$INVENTORY_RESPONSE" | jq '[.products[] | .variants[] | select(.inventory_quantity != null and .inventory_quantity <= 0) | {product_id: .product_id, sku: .sku}] | length' 2>/dev/null || echo 0)
+
+# Build output JSON
+jq -n \
+  --arg store "$SHOPIFY_STORE" \
+  --arg name "$SHOP_NAME" \
+  --arg plan "$SHOP_PLAN" \
+  --arg currency "$SHOP_CURRENCY" \
+  --arg domain "$SHOP_DOMAIN" \
+  --argjson theme "$ACTIVE_THEME" \
+  --argjson products "$PRODUCT_COUNT" \
+  --argjson orders_24h "$ORDER_COUNT" \
+  --argjson unfulfilled "$UNFULFILLED_COUNT" \
+  --argjson low_stock "$LOW_STOCK" \
+  --argjson out_of_stock "$OUT_OF_STOCK" \
+  --arg checked_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  '{
+    ok: true,
+    store: $store,
+    shop: {
+      name: $name,
+      plan: $plan,
+      currency: $currency,
+      domain: $domain
+    },
+    api_connectivity: "ok",
+    active_theme: $theme,
+    product_count: $products,
+    orders_24h: $orders_24h,
+    fulfillment: {
+      unfulfilled: $unfulfilled
+    },
+    inventory: {
+      low_stock: $low_stock,
+      out_of_stock: $out_of_stock
+    },
+    checked_at: $checked_at
+  }'

--- a/claude-ops/bin/ops-marketing-dash
+++ b/claude-ops/bin/ops-marketing-dash
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# ops-marketing-dash — pre-gathers data from all configured marketing channels
+# Output: JSON object with data from each channel (null for unconfigured)
+
+set -euo pipefail
+
+# Credential resolution
+KLAVIYO_KEY="${KLAVIYO_PRIVATE_KEY:-$(claude plugin config get klaviyo_private_key 2>/dev/null || echo "")}"
+META_TOKEN="${META_ADS_TOKEN:-$(claude plugin config get meta_ads_token 2>/dev/null || echo "")}"
+META_ACCOUNT="${META_AD_ACCOUNT_ID:-$(claude plugin config get meta_ad_account_id 2>/dev/null || echo "")}"
+GA4_PROPERTY="${GA4_PROPERTY_ID:-$(claude plugin config get ga4_property_id 2>/dev/null || echo "")}"
+GSC_SITE="${GOOGLE_SEARCH_CONSOLE_SITE:-$(claude plugin config get google_search_console_site 2>/dev/null || echo "")}"
+
+# Doppler fallback
+if [ -z "$KLAVIYO_KEY" ]; then
+  KLAVIYO_KEY="$(doppler secrets get KLAVIYO_PRIVATE_KEY --plain 2>/dev/null || echo "")"
+fi
+if [ -z "$META_TOKEN" ]; then
+  META_TOKEN="$(doppler secrets get META_ADS_TOKEN --plain 2>/dev/null || echo "")"
+  META_ACCOUNT="$(doppler secrets get META_AD_ACCOUNT_ID --plain 2>/dev/null || echo "")"
+fi
+
+TODAY=$(date +%Y-%m-%d)
+
+# --- Klaviyo ---
+gather_klaviyo() {
+  if [ -z "$KLAVIYO_KEY" ]; then
+    echo "null"
+    return
+  fi
+
+  # Get total subscriber count across all lists
+  LISTS=$(curl -s "https://a.klaviyo.com/api/lists/?fields[list]=name,id,profile_count" \
+    -H "Authorization: Klaviyo-API-Key ${KLAVIYO_KEY}" \
+    -H "revision: 2024-10-15" 2>/dev/null)
+
+  TOTAL_SUBS=$(echo "$LISTS" | jq '[.data[].attributes.profile_count // 0] | add // 0' 2>/dev/null || echo "0")
+
+  # Get last campaign stats
+  CAMPAIGNS=$(curl -s "https://a.klaviyo.com/api/campaigns/?filter=equals(messages.channel,'email')&sort=-created_at&page[size]=1&fields[campaign]=name,status,send_time" \
+    -H "Authorization: Klaviyo-API-Key ${KLAVIYO_KEY}" \
+    -H "revision: 2024-10-15" 2>/dev/null)
+
+  LAST_CAMPAIGN_NAME=$(echo "$CAMPAIGNS" | jq -r '.data[0].attributes.name // "none"' 2>/dev/null || echo "none")
+  LAST_CAMPAIGN_STATUS=$(echo "$CAMPAIGNS" | jq -r '.data[0].attributes.status // "none"' 2>/dev/null || echo "none")
+
+  jq -n \
+    --argjson subs "$TOTAL_SUBS" \
+    --arg last_campaign "$LAST_CAMPAIGN_NAME" \
+    --arg last_status "$LAST_CAMPAIGN_STATUS" \
+    '{subscribers: $subs, last_campaign: $last_campaign, last_campaign_status: $last_status}'
+}
+
+# --- Meta Ads ---
+gather_meta() {
+  if [ -z "$META_TOKEN" ] || [ -z "$META_ACCOUNT" ]; then
+    echo "null"
+    return
+  fi
+
+  INSIGHTS=$(curl -s "https://graph.facebook.com/v18.0/${META_ACCOUNT}/insights?fields=spend,impressions,clicks,ctr,cpc,actions,action_values&date_preset=last_7d&level=account" \
+    -H "Authorization: Bearer ${META_TOKEN}" 2>/dev/null)
+
+  SPEND=$(echo "$INSIGHTS" | jq -r '.data[0].spend // "0"' 2>/dev/null || echo "0")
+  IMPRESSIONS=$(echo "$INSIGHTS" | jq -r '.data[0].impressions // "0"' 2>/dev/null || echo "0")
+  CLICKS=$(echo "$INSIGHTS" | jq -r '.data[0].clicks // "0"' 2>/dev/null || echo "0")
+  CTR=$(echo "$INSIGHTS" | jq -r '.data[0].ctr // "0"' 2>/dev/null || echo "0")
+
+  # Extract purchase count and revenue from actions/action_values
+  PURCHASES=$(echo "$INSIGHTS" | jq -r '[.data[0].actions[]? | select(.action_type == "purchase") | .value] | first // "0"' 2>/dev/null || echo "0")
+  PURCHASE_VALUE=$(echo "$INSIGHTS" | jq -r '[.data[0].action_values[]? | select(.action_type == "purchase") | .value] | first // "0"' 2>/dev/null || echo "0")
+
+  # ROAS = purchase_value / spend
+  ROAS=$(awk "BEGIN {s=$SPEND+0; v=$PURCHASE_VALUE+0; if (s>0) printf \"%.2f\", v/s; else print \"0\"}")
+
+  jq -n \
+    --arg spend "$SPEND" \
+    --arg impressions "$IMPRESSIONS" \
+    --arg clicks "$CLICKS" \
+    --arg ctr "$CTR" \
+    --arg purchases "$PURCHASES" \
+    --arg purchase_value "$PURCHASE_VALUE" \
+    --arg roas "$ROAS" \
+    '{spend: $spend, impressions: $impressions, clicks: $clicks, ctr: $ctr, purchases: $purchases, purchase_value: $purchase_value, roas: $roas}'
+}
+
+# --- GA4 ---
+gather_ga4() {
+  if [ -z "$GA4_PROPERTY" ]; then
+    echo "null"
+    return
+  fi
+
+  GA4_TOKEN=$(gcloud auth application-default print-access-token 2>/dev/null || echo "")
+  if [ -z "$GA4_TOKEN" ]; then
+    echo "null"
+    return
+  fi
+
+  REPORT=$(curl -s -X POST "https://analyticsdata.googleapis.com/v1beta/properties/${GA4_PROPERTY}:runReport" \
+    -H "Authorization: Bearer ${GA4_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d '{
+      "dateRanges": [{"startDate": "7daysAgo", "endDate": "today"}],
+      "metrics": [
+        {"name": "sessions"},
+        {"name": "totalUsers"},
+        {"name": "conversions"},
+        {"name": "totalRevenue"},
+        {"name": "bounceRate"}
+      ]
+    }' 2>/dev/null)
+
+  SESSIONS=$(echo "$REPORT" | jq -r '.rows[0].metricValues[0].value // "0"' 2>/dev/null || echo "0")
+  USERS=$(echo "$REPORT" | jq -r '.rows[0].metricValues[1].value // "0"' 2>/dev/null || echo "0")
+  CONVERSIONS=$(echo "$REPORT" | jq -r '.rows[0].metricValues[2].value // "0"' 2>/dev/null || echo "0")
+  REVENUE=$(echo "$REPORT" | jq -r '.rows[0].metricValues[3].value // "0"' 2>/dev/null || echo "0")
+
+  CVR=$(awk "BEGIN {s=$SESSIONS+0; c=$CONVERSIONS+0; if (s>0) printf \"%.2f\", (c/s)*100; else print \"0\"}")
+
+  jq -n \
+    --arg sessions "$SESSIONS" \
+    --arg users "$USERS" \
+    --arg conversions "$CONVERSIONS" \
+    --arg revenue "$REVENUE" \
+    --arg cvr "$CVR" \
+    '{sessions: $sessions, users: $users, conversions: $conversions, revenue: $revenue, cvr: $cvr}'
+}
+
+# --- Google Search Console ---
+gather_gsc() {
+  if [ -z "$GSC_SITE" ]; then
+    echo "null"
+    return
+  fi
+
+  GSC_TOKEN=$(gcloud auth application-default print-access-token 2>/dev/null || echo "")
+  if [ -z "$GSC_TOKEN" ]; then
+    echo "null"
+    return
+  fi
+
+  GSC_SITE_ENCODED=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${GSC_SITE}', safe=''))" 2>/dev/null \
+    || echo "${GSC_SITE}" | sed 's|:|%3A|g; s|/|%2F|g')
+
+  START_DATE=$(date -v-28d +%Y-%m-%d 2>/dev/null || date -d '28 days ago' +%Y-%m-%d 2>/dev/null || echo "")
+  if [ -z "$START_DATE" ]; then
+    echo "null"
+    return
+  fi
+
+  REPORT=$(curl -s -X POST "https://searchconsole.googleapis.com/webmasters/v3/sites/${GSC_SITE_ENCODED}/searchAnalytics/query" \
+    -H "Authorization: Bearer ${GSC_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "{\"startDate\": \"${START_DATE}\", \"endDate\": \"${TODAY}\", \"dimensions\": [], \"rowLimit\": 1}" 2>/dev/null)
+
+  CLICKS=$(echo "$REPORT" | jq -r '.rows[0].clicks // 0' 2>/dev/null || echo "0")
+  IMPRESSIONS=$(echo "$REPORT" | jq -r '.rows[0].impressions // 0' 2>/dev/null || echo "0")
+  CTR=$(echo "$REPORT" | jq -r '.rows[0].ctr // 0' 2>/dev/null || echo "0")
+  POSITION=$(echo "$REPORT" | jq -r '.rows[0].position // 0' 2>/dev/null || echo "0")
+
+  jq -n \
+    --argjson clicks "$CLICKS" \
+    --argjson impressions "$IMPRESSIONS" \
+    --argjson ctr "$CTR" \
+    --argjson position "$POSITION" \
+    '{clicks: $clicks, impressions: $impressions, ctr: $ctr, avg_position: $position}'
+}
+
+# Run all in parallel (subshells)
+KLAVIYO_DATA=$(gather_klaviyo) &
+META_DATA=$(gather_meta) &
+GA4_DATA=$(gather_ga4) &
+GSC_DATA=$(gather_gsc) &
+wait
+
+# Emit unified JSON
+jq -n \
+  --argjson klaviyo "$KLAVIYO_DATA" \
+  --argjson meta "$META_DATA" \
+  --argjson ga4 "$GA4_DATA" \
+  --argjson gsc "$GSC_DATA" \
+  --arg date "$TODAY" \
+  '{date: $date, klaviyo: $klaviyo, meta: $meta, ga4: $ga4, gsc: $gsc}'

--- a/claude-ops/skills/ops-ecom/SKILL.md
+++ b/claude-ops/skills/ops-ecom/SKILL.md
@@ -1,0 +1,488 @@
+---
+name: ops-ecom
+description: Shopify store command center. Orders, inventory, fulfillment, analytics, and store health. Works with any Shopify store via Admin API.
+argument-hint: "[orders|inventory|fulfillment|health|products|customers|analytics|setup]"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Grep
+  - Glob
+  - Agent
+  - AskUserQuestion
+  - WebFetch
+  - WebSearch
+---
+
+# OPS ► ECOM — Shopify Store Command Center
+
+## Phase 1 — Resolve credentials
+
+Resolve Shopify credentials in this order:
+
+```bash
+# 1. Plugin userConfig
+SHOPIFY_STORE="${user_config.shopify_store_url}"
+SHOPIFY_TOKEN="${user_config.shopify_admin_token}"
+SHIPBOB_TOKEN="${user_config.shipbob_access_token}"
+
+# 2. Environment variables (override userConfig if set)
+[ -n "$SHOPIFY_STORE_URL" ] && SHOPIFY_STORE="$SHOPIFY_STORE_URL"
+[ -n "$SHOPIFY_ACCESS_TOKEN" ] && SHOPIFY_TOKEN="$SHOPIFY_ACCESS_TOKEN"
+[ -n "$SHIPBOB_ACCESS_TOKEN" ] && SHIPBOB_TOKEN="$SHIPBOB_ACCESS_TOKEN"
+
+# 3. Doppler fallback
+if [ -z "$SHOPIFY_TOKEN" ] && command -v doppler &>/dev/null; then
+  SHOPIFY_TOKEN=$(doppler secrets get SHOPIFY_ACCESS_TOKEN --plain 2>/dev/null)
+fi
+if [ -z "$SHOPIFY_STORE" ] && command -v doppler &>/dev/null; then
+  SHOPIFY_STORE=$(doppler secrets get SHOPIFY_STORE_URL --plain 2>/dev/null)
+fi
+if [ -z "$SHIPBOB_TOKEN" ] && command -v doppler &>/dev/null; then
+  SHIPBOB_TOKEN=$(doppler secrets get SHIPBOB_ACCESS_TOKEN --plain 2>/dev/null)
+fi
+```
+
+If `$SHOPIFY_STORE` or `$SHOPIFY_TOKEN` is still empty after all resolution steps, route to **setup flow** below.
+
+Set base URLs:
+```bash
+SHOPIFY_BASE="https://${SHOPIFY_STORE}/admin/api/2024-10"
+SHOPIFY_GQL="https://${SHOPIFY_STORE}/admin/api/2024-10/graphql.json"
+SHOPIFY_AUTH="X-Shopify-Access-Token: ${SHOPIFY_TOKEN}"
+```
+
+---
+
+## Phase 2 — Route by $ARGUMENTS
+
+| Input                                      | Action              |
+| ------------------------------------------ | ------------------- |
+| (empty)                                    | Show store summary  |
+| orders, order                              | Orders dashboard    |
+| inventory, stock, inv                      | Inventory levels    |
+| fulfillment, fulfill, shipbob, shipping    | Fulfillment status  |
+| health, check, status                      | Store health check  |
+| products, product, catalog                 | Products manager    |
+| customers, customer, crm                   | Customer stats      |
+| analytics, revenue, stats, metrics         | Analytics dashboard |
+| setup, configure, init, token              | Setup flow          |
+
+---
+
+## ORDERS
+
+Fetch recent orders and compute revenue:
+
+```bash
+TODAY=$(date -u +"%Y-%m-%dT00:00:00Z")
+WEEK_AGO=$(date -u -v-7d +"%Y-%m-%dT00:00:00Z" 2>/dev/null || date -u -d "7 days ago" +"%Y-%m-%dT00:00:00Z")
+MONTH_AGO=$(date -u -v-30d +"%Y-%m-%dT00:00:00Z" 2>/dev/null || date -u -d "30 days ago" +"%Y-%m-%dT00:00:00Z")
+
+# Recent orders (last 50)
+curl -s -H "$SHOPIFY_AUTH" \
+  "${SHOPIFY_BASE}/orders.json?status=any&limit=50&order=created_at+desc" | \
+  jq '{
+    total: .orders | length,
+    today: [.orders[] | select(.created_at >= "'"$TODAY"'")],
+    orders: [.orders[:10] | .[] | {
+      id: .order_number,
+      name: .name,
+      status: .financial_status,
+      fulfillment: .fulfillment_status,
+      total: .total_price,
+      currency: .currency,
+      customer: (.customer.first_name + " " + .customer.last_name),
+      created: .created_at
+    }]
+  }'
+```
+
+Render:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► ECOM ► ORDERS — [store] — [timestamp]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+REVENUE
+  Today    [N orders]   $[amount]
+  7 days   [N orders]   $[amount]
+  30 days  [N orders]   $[amount]
+
+RECENT ORDERS
+  #[id]  [customer]  $[total]  [status] / [fulfillment]  [age]
+  ...
+
+──────────────────────────────────────────────────────
+ Actions:
+ a) View order details for #[id]
+ b) Mark order as fulfilled
+ c) Export orders CSV
+ d) Filter by status (unfulfilled/refunded/paid)
+──────────────────────────────────────────────────────
+```
+
+Use `AskUserQuestion` for action selection.
+
+---
+
+## INVENTORY
+
+Fetch all products and variant inventory:
+
+```bash
+# Get all products with variants
+curl -s -H "$SHOPIFY_AUTH" \
+  "${SHOPIFY_BASE}/products.json?limit=250&fields=id,title,status,variants" | \
+  jq '[.products[] | {
+    id: .id,
+    title: .title,
+    status: .status,
+    variants: [.variants[] | {
+      id: .id,
+      title: .title,
+      sku: .sku,
+      inventory_quantity: .inventory_quantity,
+      inventory_policy: .inventory_policy
+    }]
+  }]'
+```
+
+Flag low stock (inventory_quantity < 10) and out-of-stock (inventory_quantity <= 0).
+
+Render:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► ECOM ► INVENTORY — [store] — [timestamp]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+OUT OF STOCK
+  [product] — [variant] — SKU: [sku]
+
+LOW STOCK (< 10 units)
+  [product] — [variant] — [N] units — SKU: [sku]
+
+ALL PRODUCTS
+  [product]
+    [variant]  [N] units  SKU: [sku]
+  ...
+
+──────────────────────────────────────────────────────
+ Actions:
+ a) Update inventory for [product]
+ b) Export inventory CSV
+ c) Set reorder alerts
+──────────────────────────────────────────────────────
+```
+
+Use `AskUserQuestion` for action selection.
+
+---
+
+## FULFILLMENT
+
+Fetch unfulfilled orders and ShipBob status (if token available):
+
+```bash
+# Unfulfilled orders
+curl -s -H "$SHOPIFY_AUTH" \
+  "${SHOPIFY_BASE}/orders.json?fulfillment_status=unfulfilled&status=open&limit=50" | \
+  jq '[.orders[] | {
+    id: .order_number,
+    name: .name,
+    customer: (.customer.first_name + " " + .customer.last_name),
+    total: .total_price,
+    created: .created_at,
+    items: [.line_items[] | {title: .title, qty: .quantity}]
+  }]'
+
+# Shipments with tracking (fulfilled)
+curl -s -H "$SHOPIFY_AUTH" \
+  "${SHOPIFY_BASE}/orders.json?fulfillment_status=fulfilled&status=any&limit=20&order=updated_at+desc" | \
+  jq '[.orders[] | .fulfillments[] | {
+    order: .order_id,
+    tracking_number: .tracking_number,
+    tracking_url: .tracking_url,
+    shipment_status: .shipment_status,
+    carrier: .tracking_company,
+    updated: .updated_at
+  }]'
+```
+
+If `$SHIPBOB_TOKEN` is set, also query ShipBob:
+
+```bash
+# ShipBob pending shipments
+curl -s -H "Authorization: Bearer ${SHIPBOB_TOKEN}" \
+  "https://api.shipbob.com/1.0/shipment?Status=Processing&PageSize=20" | \
+  jq '[.[] | {
+    id: .id,
+    status: .status,
+    order_id: .reference_id,
+    tracking: .tracking_number,
+    created: .created_date
+  }]'
+```
+
+Render fulfillment dashboard with pending/in-transit/delivered counts.
+
+Use `AskUserQuestion` for action selection (mark fulfilled, update tracking, etc.).
+
+---
+
+## HEALTH
+
+Run the health check script, then augment with API checks:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/ops-ecom-health 2>/dev/null || echo '{"error":"health script unavailable"}'
+```
+
+Also check:
+
+```bash
+# Active theme
+curl -s -H "$SHOPIFY_AUTH" \
+  "${SHOPIFY_BASE}/themes.json" | \
+  jq '[.themes[] | select(.role == "main") | {id: .id, name: .name, updated: .updated_at}]'
+
+# Store info
+curl -s -H "$SHOPIFY_AUTH" \
+  "${SHOPIFY_BASE}/shop.json" | \
+  jq '.shop | {name: .name, domain: .domain, country: .country_name, plan: .plan_display_name, currency: .currency, timezone: .timezone}'
+```
+
+Render:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► ECOM ► HEALTH — [store] — [timestamp]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+STORE
+  Name:      [name]
+  Plan:      [plan]
+  Currency:  [currency]
+  Timezone:  [tz]
+
+API CONNECTIVITY  [OK / FAIL]
+ACTIVE THEME      [theme name]
+PRODUCT COUNT     [N] active
+ORDERS (24h)      [N] orders
+
+ISSUES
+  [any warnings from health check]
+
+──────────────────────────────────────────────────────
+ Actions:
+ a) Check theme assets for errors
+ b) Run full SEO audit
+ c) View API rate limit status
+──────────────────────────────────────────────────────
+```
+
+Use `AskUserQuestion` for action selection.
+
+---
+
+## PRODUCTS
+
+List, search, and manage products:
+
+```bash
+# All products
+curl -s -H "$SHOPIFY_AUTH" \
+  "${SHOPIFY_BASE}/products.json?limit=250&order=updated_at+desc" | \
+  jq '[.products[] | {
+    id: .id,
+    title: .title,
+    status: .status,
+    handle: .handle,
+    price: (.variants[0].price // "N/A"),
+    inventory: ([.variants[].inventory_quantity] | add // 0),
+    variants: (.variants | length),
+    updated: .updated_at
+  }]'
+```
+
+If `$ARGUMENTS` contains a search term (e.g., `products shoes`), filter by title.
+
+For price updates, use:
+
+```bash
+# Update variant price
+curl -s -X PUT -H "$SHOPIFY_AUTH" -H "Content-Type: application/json" \
+  "${SHOPIFY_BASE}/variants/${VARIANT_ID}.json" \
+  -d '{"variant":{"id":'${VARIANT_ID}',"price":"'${NEW_PRICE}'"}}'
+```
+
+Use `AskUserQuestion` before making any product updates. Show before/after prices.
+
+---
+
+## CUSTOMERS
+
+Fetch customer stats:
+
+```bash
+# Customer count and recent
+curl -s -H "$SHOPIFY_AUTH" \
+  "${SHOPIFY_BASE}/customers.json?limit=50&order=created_at+desc" | \
+  jq '{
+    total_shown: (.customers | length),
+    recent: [.customers[:10] | .[] | {
+      id: .id,
+      name: (.first_name + " " + .last_name),
+      email: .email,
+      orders: .orders_count,
+      total_spent: .total_spent,
+      currency: .currency,
+      created: .created_at
+    }]
+  }'
+
+# Top customers by spend
+curl -s -H "$SHOPIFY_AUTH" \
+  "${SHOPIFY_BASE}/customers.json?limit=10&order=total_spent+desc" | \
+  jq '[.customers[] | {name: (.first_name + " " + .last_name), orders: .orders_count, spent: .total_spent}]'
+```
+
+Render customer overview with LTV stats and top spenders.
+
+---
+
+## ANALYTICS
+
+Pull revenue and order data for dashboard:
+
+```bash
+TODAY=$(date -u +"%Y-%m-%dT00:00:00Z")
+WEEK_AGO=$(date -u -v-7d +"%Y-%m-%dT00:00:00Z" 2>/dev/null || date -u -d "7 days ago" +"%Y-%m-%dT00:00:00Z")
+MONTH_AGO=$(date -u -v-30d +"%Y-%m-%dT00:00:00Z" 2>/dev/null || date -u -d "30 days ago" +"%Y-%m-%dT00:00:00Z")
+
+# Orders for revenue calculation
+curl -s -H "$SHOPIFY_AUTH" \
+  "${SHOPIFY_BASE}/orders.json?status=any&financial_status=paid&created_at_min=${MONTH_AGO}&limit=250" | \
+  jq '{
+    month_orders: (.orders | length),
+    month_revenue: ([.orders[].total_price | tonumber] | add // 0),
+    week_orders: ([.orders[] | select(.created_at >= "'"$WEEK_AGO"'")] | length),
+    week_revenue: ([.orders[] | select(.created_at >= "'"$WEEK_AGO"'") | .total_price | tonumber] | add // 0),
+    today_orders: ([.orders[] | select(.created_at >= "'"$TODAY"'")] | length),
+    today_revenue: ([.orders[] | select(.created_at >= "'"$TODAY"'") | .total_price | tonumber] | add // 0),
+    avg_order_value: ([.orders[].total_price | tonumber] | (add // 0) / (length // 1)),
+    top_products: ([.orders[].line_items[] | {title: .title, qty: .quantity}] | group_by(.title) | map({title: .[0].title, total_qty: map(.qty) | add}) | sort_by(-.total_qty)[:5])
+  }'
+```
+
+Render:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► ECOM ► ANALYTICS — [store] — [timestamp]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+REVENUE
+  Today    $[amount]  ([N] orders)
+  7 days   $[amount]  ([N] orders)
+  30 days  $[amount]  ([N] orders)
+
+AVERAGES
+  AOV (30d)  $[amount]
+
+TOP PRODUCTS (30d)
+  1. [product]  [N] sold
+  2. [product]  [N] sold
+  ...
+
+──────────────────────────────────────────────────────
+ Actions:
+ a) Export revenue report (CSV)
+ b) View by product breakdown
+ c) Compare to previous period
+──────────────────────────────────────────────────────
+```
+
+Use `AskUserQuestion` for action selection.
+
+---
+
+## SETUP FLOW
+
+Guide the user through configuring Shopify credentials:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► ECOM ► SETUP
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+To connect your Shopify store, you need:
+
+1. Store URL (e.g., mystore.myshopify.com)
+2. Admin API access token (shpat_...)
+
+To get your Admin API token:
+  1. Go to your Shopify Admin > Settings > Apps and sales channels
+  2. Click "Develop apps" > "Create an app"
+  3. Under "Configuration", enable Admin API scopes:
+     read_orders, write_orders, read_products, write_products,
+     read_customers, read_inventory, write_inventory,
+     read_fulfillments, write_fulfillments, read_analytics
+  4. Click "Install app" to generate the access token
+  5. Copy the token (starts with shpat_)
+
+Store the credentials via one of:
+  a) Plugin userConfig: set shopify_store_url + shopify_admin_token
+  b) Environment: export SHOPIFY_STORE_URL=... SHOPIFY_ACCESS_TOKEN=...
+  c) Doppler: doppler secrets set SHOPIFY_STORE_URL SHOPIFY_ACCESS_TOKEN
+
+ShipBob (optional):
+  Get your Personal Access Token from app.shipbob.com > Developer > API
+  Store as shipbob_access_token in userConfig or $SHIPBOB_ACCESS_TOKEN
+```
+
+Use `AskUserQuestion` to collect store URL, then verify connectivity:
+
+```bash
+curl -s -H "X-Shopify-Access-Token: ${PROVIDED_TOKEN}" \
+  "https://${PROVIDED_STORE}/admin/api/2024-10/shop.json" | \
+  jq '.shop | {name, domain, plan: .plan_display_name}'
+```
+
+If the connectivity check returns valid shop data, confirm success. If it fails with 401/403, explain the token is invalid and re-prompt.
+
+---
+
+## STORE SUMMARY (empty $ARGUMENTS)
+
+When called with no arguments, show a compact store overview:
+
+Run orders, inventory, and health checks in parallel (separate Bash calls), then render:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► ECOM — [store] — [timestamp]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+STORE         [name] ([plan])
+CURRENCY      [currency]
+
+TODAY         $[revenue]  [N] orders
+7 DAYS        $[revenue]  [N] orders
+30 DAYS       $[revenue]  [N] orders
+
+INVENTORY     [N] products  |  [N] low stock  |  [N] out of stock
+FULFILLMENT   [N] unfulfilled orders pending
+
+──────────────────────────────────────────────────────
+ /ops:ops-ecom orders     — order management
+ /ops:ops-ecom inventory  — stock levels
+ /ops:ops-ecom products   — product catalog
+ /ops:ops-ecom customers  — customer stats
+ /ops:ops-ecom analytics  — revenue dashboard
+ /ops:ops-ecom health     — store health check
+ /ops:ops-ecom setup      — configure credentials
+──────────────────────────────────────────────────────
+```

--- a/claude-ops/skills/ops-marketing/SKILL.md
+++ b/claude-ops/skills/ops-marketing/SKILL.md
@@ -1,0 +1,431 @@
+---
+name: ops-marketing
+description: Marketing command center. Email campaigns (Klaviyo), paid ads (Meta/Google), analytics (GA4), SEO, and social media metrics. One dashboard for all marketing channels.
+argument-hint: "[email|ads|analytics|seo|social|campaigns|setup]"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Grep
+  - Glob
+  - Agent
+  - AskUserQuestion
+  - WebFetch
+  - WebSearch
+---
+
+# OPS ► MARKETING COMMAND CENTER
+
+## Credential Resolution
+
+Resolve credentials in this order for each service:
+
+### Klaviyo
+```bash
+KLAVIYO_KEY="${KLAVIYO_PRIVATE_KEY:-$(claude plugin config get klaviyo_private_key 2>/dev/null)}"
+if [ -z "$KLAVIYO_KEY" ]; then
+  KLAVIYO_KEY="$(doppler secrets get KLAVIYO_PRIVATE_KEY --plain 2>/dev/null)"
+fi
+```
+
+### Meta Ads
+```bash
+META_TOKEN="${META_ADS_TOKEN:-$(claude plugin config get meta_ads_token 2>/dev/null)}"
+META_ACCOUNT="${META_AD_ACCOUNT_ID:-$(claude plugin config get meta_ad_account_id 2>/dev/null)}"
+if [ -z "$META_TOKEN" ]; then
+  META_TOKEN="$(doppler secrets get META_ADS_TOKEN --plain 2>/dev/null)"
+fi
+```
+
+### GA4
+```bash
+GA4_PROPERTY="${GA4_PROPERTY_ID:-$(claude plugin config get ga4_property_id 2>/dev/null)}"
+# GA4 uses gcloud application default credentials — check if configured:
+gcloud auth application-default print-access-token 2>/dev/null
+```
+
+### Google Search Console
+```bash
+GSC_SITE="${GOOGLE_SEARCH_CONSOLE_SITE:-$(claude plugin config get google_search_console_site 2>/dev/null)}"
+# Uses same gcloud ADC as GA4
+```
+
+---
+
+## Sub-command Routing
+
+Route `$ARGUMENTS` to the correct section below:
+
+| Input | Action |
+|---|---|
+| (empty), dashboard | Run full marketing dashboard |
+| email, klaviyo | Klaviyo email metrics |
+| ads, meta | Meta Ads performance |
+| google-ads | Google Ads (if configured) |
+| analytics, ga4 | GA4 sessions + conversions |
+| seo, gsc | Search Console metrics |
+| social | Social media aggregator |
+| campaigns | Cross-channel campaign overview |
+| setup | Configure API keys |
+
+---
+
+## email / klaviyo
+
+Pull Klaviyo metrics for last 30 days.
+
+### Subscriber count
+```bash
+curl -s "https://a.klaviyo.com/api/lists/?fields[list]=name,id,profile_count" \
+  -H "Authorization: Klaviyo-API-Key ${KLAVIYO_KEY}" \
+  -H "revision: 2024-10-15" | jq '.data[] | {name: .attributes.name, id: .id, count: .attributes.profile_count}'
+```
+
+### Recent campaigns (last 10)
+```bash
+curl -s "https://a.klaviyo.com/api/campaigns/?filter=equals(messages.channel,'email')&sort=-created_at&page[size]=10&fields[campaign]=name,status,created_at,send_time" \
+  -H "Authorization: Klaviyo-API-Key ${KLAVIYO_KEY}" \
+  -H "revision: 2024-10-15" | jq '.data[] | {name: .attributes.name, status: .attributes.status, sent: .attributes.send_time}'
+```
+
+### Flow metrics (active flows)
+```bash
+curl -s "https://a.klaviyo.com/api/flows/?filter=equals(status,'live')&fields[flow]=name,status,created,trigger_type" \
+  -H "Authorization: Klaviyo-API-Key ${KLAVIYO_KEY}" \
+  -H "revision: 2024-10-15" | jq '.data[] | {name: .attributes.name, trigger: .attributes.trigger_type}'
+```
+
+### Key email metrics (opens, clicks, revenue via metric aggregates)
+```bash
+# Get metric IDs first
+curl -s "https://a.klaviyo.com/api/metrics/" \
+  -H "Authorization: Klaviyo-API-Key ${KLAVIYO_KEY}" \
+  -H "revision: 2024-10-15" | jq '.data[] | select(.attributes.name | test("Opened Email|Clicked Email|Placed Order")) | {name: .attributes.name, id: .id}'
+```
+
+### Output format
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ EMAIL (KLAVIYO) — last 30d
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ Lists:        [list_name] — [N] subscribers
+ Campaigns:    [N sent] | [N drafts]
+ Active Flows: [N]
+
+ RECENT CAMPAIGNS
+ [name]  [status]  sent [date]
+ ...
+```
+
+---
+
+## ads / meta
+
+Pull Meta Ads insights for the configured ad account.
+
+### Account-level spend (last 7 days)
+```bash
+curl -s "https://graph.facebook.com/v18.0/${META_ACCOUNT}/insights?fields=spend,impressions,clicks,ctr,cpc,actions,action_values&date_preset=last_7d&level=account" \
+  -H "Authorization: Bearer ${META_TOKEN}" | jq '{spend: .data[0].spend, impressions: .data[0].impressions, clicks: .data[0].clicks, ctr: .data[0].ctr, cpc: .data[0].cpc}'
+```
+
+### Campaign breakdown (last 7 days)
+```bash
+curl -s "https://graph.facebook.com/v18.0/${META_ACCOUNT}/campaigns?fields=name,status,daily_budget,lifetime_budget,insights{spend,impressions,clicks,actions,action_values}&date_preset=last_7d" \
+  -H "Authorization: Bearer ${META_TOKEN}" | jq '.data[] | {name: .name, status: .status, spend: .insights.data[0].spend}'
+```
+
+### ROAS calculation
+From `action_values` array: extract `action_type == "purchase"` value, divide by spend.
+
+### Top performing ads (last 7d)
+```bash
+curl -s "https://graph.facebook.com/v18.0/${META_ACCOUNT}/ads?fields=name,adset_id,insights{spend,impressions,clicks,actions,action_values,ctr,cpc}&date_preset=last_7d&limit=10" \
+  -H "Authorization: Bearer ${META_TOKEN}" | jq '.data | sort_by(.insights.data[0].spend | tonumber) | reverse | .[0:5] | .[] | {name: .name, spend: .insights.data[0].spend, ctr: .insights.data[0].ctr}'
+```
+
+### Output format
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ META ADS — last 7d
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ Spend:       $[X]
+ ROAS:        [X]x
+ Purchases:   [N]  ($[X] revenue)
+ Impressions: [N]  CTR: [X]%
+ CPC:         $[X]
+
+ CAMPAIGNS
+ [name]  [status]  $[spend]  [roas]x ROAS
+ ...
+
+ TOP ADS (by spend)
+ [name]  $[spend]  [ctr]% CTR
+```
+
+---
+
+## analytics / ga4
+
+Pull GA4 data via the Data API using gcloud ADC.
+
+### Get access token
+```bash
+GA4_TOKEN=$(gcloud auth application-default print-access-token 2>/dev/null)
+```
+
+### Sessions + conversions (last 7d)
+```bash
+curl -s -X POST "https://analyticsdata.googleapis.com/v1beta/properties/${GA4_PROPERTY}:runReport" \
+  -H "Authorization: Bearer ${GA4_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dateRanges": [{"startDate": "7daysAgo", "endDate": "today"}],
+    "metrics": [
+      {"name": "sessions"},
+      {"name": "totalUsers"},
+      {"name": "conversions"},
+      {"name": "totalRevenue"},
+      {"name": "bounceRate"},
+      {"name": "averageSessionDuration"}
+    ]
+  }' | jq '.rows[0].metricValues | {sessions: .[0].value, users: .[1].value, conversions: .[2].value, revenue: .[3].value, bounce_rate: .[4].value}'
+```
+
+### Traffic sources (last 7d)
+```bash
+curl -s -X POST "https://analyticsdata.googleapis.com/v1beta/properties/${GA4_PROPERTY}:runReport" \
+  -H "Authorization: Bearer ${GA4_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dateRanges": [{"startDate": "7daysAgo", "endDate": "today"}],
+    "dimensions": [{"name": "sessionDefaultChannelGrouping"}],
+    "metrics": [{"name": "sessions"}, {"name": "conversions"}],
+    "orderBys": [{"metric": {"metricName": "sessions"}, "desc": true}],
+    "limit": 8
+  }' | jq '.rows[] | {channel: .dimensionValues[0].value, sessions: .metricValues[0].value, conversions: .metricValues[1].value}'
+```
+
+### Top pages (last 7d)
+```bash
+curl -s -X POST "https://analyticsdata.googleapis.com/v1beta/properties/${GA4_PROPERTY}:runReport" \
+  -H "Authorization: Bearer ${GA4_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "dateRanges": [{"startDate": "7daysAgo", "endDate": "today"}],
+    "dimensions": [{"name": "pagePath"}],
+    "metrics": [{"name": "screenPageViews"}, {"name": "averageSessionDuration"}],
+    "orderBys": [{"metric": {"metricName": "screenPageViews"}, "desc": true}],
+    "limit": 10
+  }' | jq '.rows[] | {page: .dimensionValues[0].value, views: .metricValues[0].value}'
+```
+
+If `GA4_TOKEN` is empty or gcloud not available, output: `GA4 not configured — run /ops:marketing setup or configure gcloud ADC`.
+
+### Output format
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ ANALYTICS (GA4) — last 7d
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ Sessions:     [N]     Users: [N]
+ Conversions:  [N]     CVR:   [X]%
+ Revenue:      $[X]
+ Bounce Rate:  [X]%    Avg Session: [Xm Xs]
+
+ TRAFFIC SOURCES
+ [channel]  [N sessions]  [N conversions]
+ ...
+
+ TOP PAGES
+ [path]  [N views]
+```
+
+---
+
+## seo / gsc
+
+Pull Google Search Console data.
+
+### Get access token (same gcloud ADC)
+```bash
+GSC_TOKEN=$(gcloud auth application-default print-access-token 2>/dev/null)
+GSC_SITE_ENCODED=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${GSC_SITE}', safe=''))" 2>/dev/null || echo "${GSC_SITE}" | sed 's|:|%3A|g; s|/|%2F|g')
+```
+
+### Search performance (last 28 days)
+```bash
+curl -s -X POST "https://searchconsole.googleapis.com/webmasters/v3/sites/${GSC_SITE_ENCODED}/searchAnalytics/query" \
+  -H "Authorization: Bearer ${GSC_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "startDate": "'$(date -v-28d +%Y-%m-%d 2>/dev/null || date -d '28 days ago' +%Y-%m-%d)'",
+    "endDate": "'$(date +%Y-%m-%d)'",
+    "dimensions": [],
+    "rowLimit": 1
+  }' | jq '{clicks: .rows[0].clicks, impressions: .rows[0].impressions, ctr: .rows[0].ctr, position: .rows[0].position}'
+```
+
+### Top queries (last 28 days)
+```bash
+curl -s -X POST "https://searchconsole.googleapis.com/webmasters/v3/sites/${GSC_SITE_ENCODED}/searchAnalytics/query" \
+  -H "Authorization: Bearer ${GSC_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "startDate": "'$(date -v-28d +%Y-%m-%d 2>/dev/null || date -d '28 days ago' +%Y-%m-%d)'",
+    "endDate": "'$(date +%Y-%m-%d)'",
+    "dimensions": ["query"],
+    "rowLimit": 20,
+    "dimensionFilterGroups": []
+  }' | jq '.rows[] | {query: .keys[0], clicks: .clicks, impressions: .impressions, position: (.position | floor)}'
+```
+
+### Top pages by clicks
+```bash
+curl -s -X POST "https://searchconsole.googleapis.com/webmasters/v3/sites/${GSC_SITE_ENCODED}/searchAnalytics/query" \
+  -H "Authorization: Bearer ${GSC_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "startDate": "'$(date -v-28d +%Y-%m-%d 2>/dev/null || date -d '28 days ago' +%Y-%m-%d)'",
+    "endDate": "'$(date +%Y-%m-%d)'",
+    "dimensions": ["page"],
+    "rowLimit": 10
+  }' | jq '.rows[] | {page: .keys[0], clicks: .clicks, impressions: .impressions, position: (.position | floor)}'
+```
+
+If GSC not configured, output: `Search Console not configured — run /ops:marketing setup`.
+
+### Output format
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ SEO (SEARCH CONSOLE) — last 28d
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ Clicks:       [N]
+ Impressions:  [N]
+ CTR:          [X]%
+ Avg Position: [X]
+
+ TOP QUERIES
+ [query]  [clicks] clicks  pos [N]
+ ...
+
+ TOP PAGES
+ [url]  [clicks] clicks  [impressions] impr
+```
+
+---
+
+## social
+
+Aggregate available social media metrics. Check which are configured.
+
+### Instagram (via Meta Graph API — same token as Meta Ads)
+```bash
+# Get Instagram Business Account ID linked to the ad account
+curl -s "https://graph.facebook.com/v18.0/me/accounts?fields=instagram_business_account" \
+  -H "Authorization: Bearer ${META_TOKEN}" | jq '.data[].instagram_business_account.id' 2>/dev/null
+
+# Then pull media insights
+curl -s "https://graph.facebook.com/v18.0/${IG_ACCOUNT_ID}?fields=followers_count,media_count,profile_views" \
+  -H "Authorization: Bearer ${META_TOKEN}" | jq '{followers: .followers_count, posts: .media_count, profile_views: .profile_views}'
+```
+
+### YouTube (if configured via gcloud)
+```bash
+YT_TOKEN=$(gcloud auth application-default print-access-token 2>/dev/null)
+curl -s "https://www.googleapis.com/youtube/v3/channels?part=statistics&mine=true" \
+  -H "Authorization: Bearer ${YT_TOKEN}" | jq '.items[0].statistics | {subscribers: .subscriberCount, views: .viewCount, videos: .videoCount}'
+```
+
+Show `[not configured]` for any unconfigured channels rather than failing.
+
+### Output format
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ SOCIAL MEDIA
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ Instagram:  [N followers]  [N posts]  [N profile views]
+ YouTube:    [N subscribers]  [N total views]
+ TikTok:     [not configured] — set TIKTOK_ACCESS_TOKEN
+```
+
+---
+
+## campaigns
+
+Cross-channel campaign overview — unified view of active campaigns across all configured channels.
+
+Run in parallel:
+1. Klaviyo active campaigns (status: draft + scheduled + sending)
+2. Meta Ads active campaigns (status: ACTIVE)
+3. Show GA4 conversion goals if available
+
+### Output format
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ CROSS-CHANNEL CAMPAIGNS — active
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ EMAIL (Klaviyo)
+ [campaign name]  [status]  [send date or "scheduled for X"]
+
+ PAID (Meta Ads)
+ [campaign name]  [status]  $[daily_budget]/day  [objective]
+
+ FLOWS (Always-on automation)
+ [flow name]  [trigger type]  [status: live/draft]
+```
+
+---
+
+## dashboard (default — no args)
+
+Run ALL sections in parallel, then render unified dashboard.
+
+```bash
+# Run the pre-gathered data script
+"${CLAUDE_PLUGIN_ROOT}/bin/ops-marketing-dash" 2>/dev/null
+```
+
+Parse the JSON output and display:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ MARKETING DASHBOARD — [date]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ Email (Klaviyo)  [N] subs  |  [X]% open rate  |  $[X] attributed
+ Paid (Meta)      $[X] spent  |  [X]x ROAS  |  [N] purchases
+ Organic (GA4)    [N] sessions  |  [X]% CVR  |  $[X] revenue
+ SEO (GSC)        [N] clicks  |  [N] impressions  |  [X] avg pos
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+For any channel with missing credentials, show `[not configured — /ops:marketing setup]`.
+
+---
+
+## setup
+
+Guide user through configuring each marketing service:
+
+```
+MARKETING SETUP
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Which service do you want to configure?
+  1. Klaviyo (email)
+  2. Meta Ads (paid social)
+  3. Google Analytics 4
+  4. Google Search Console
+  5. All of the above
+```
+
+For each selected service, prompt for required credentials and save via `claude plugin config set <key> <value>`.
+
+**Klaviyo:** Ask for Private API Key (from Klaviyo → Settings → API Keys). Save as `klaviyo_private_key`.
+
+**Meta Ads:** Ask for Access Token (from Meta Business → System Users → Generate Token with `ads_read` + `ads_management`). Ask for Ad Account ID (format: `act_XXXXXXXXX`). Save as `meta_ads_token` and `meta_ad_account_id`.
+
+**GA4:** Prompt user to run `gcloud auth application-default login` and provide their GA4 Property ID (numeric, from Admin → Property Settings). Save as `ga4_property_id`.
+
+**Search Console:** Prompt for site URL as registered (e.g. `https://example.com`). Save as `google_search_console_site`. Uses same gcloud ADC as GA4.
+
+After saving, validate each credential with a test API call and report: `[service] ✓ connected` or `[service] ✗ invalid key`.

--- a/claude-ops/skills/ops/SKILL.md
+++ b/claude-ops/skills/ops/SKILL.md
@@ -31,6 +31,7 @@ Route `$ARGUMENTS` to the correct ops skill:
 | deploy, ship                                  | `/ops-deploy`           |
 | merge, prs, ship-prs                          | `/ops-merge $ARGUMENTS` |
 | marketing, email, klaviyo, ads, meta, seo, campaigns | `/ops:ops-marketing $ARGUMENTS` |
+| ecom, shop, shopify, store, orders, inventory | `/ops:ops-ecom $ARGUMENTS` |
 | yolo                                          | `/ops-yolo`             |
 | doctor, health, fix, diagnose                 | `/ops:ops-doctor`       |
 | speedup, clean, optimize, cleanup             | `/ops:ops-speedup`      |

--- a/claude-ops/skills/ops/SKILL.md
+++ b/claude-ops/skills/ops/SKILL.md
@@ -30,6 +30,7 @@ Route `$ARGUMENTS` to the correct ops skill:
 | revenue, money, mrr, costs                    | `/ops-revenue`          |
 | deploy, ship                                  | `/ops-deploy`           |
 | merge, prs, ship-prs                          | `/ops-merge $ARGUMENTS` |
+| marketing, email, klaviyo, ads, meta, seo, campaigns | `/ops:ops-marketing $ARGUMENTS` |
 | yolo                                          | `/ops-yolo`             |
 | doctor, health, fix, diagnose                 | `/ops:ops-doctor`       |
 | speedup, clean, optimize, cleanup             | `/ops:ops-speedup`      |


### PR DESCRIPTION
## Summary
- Adds `skills/ops-marketing/SKILL.md` — full marketing command center with Klaviyo (email), Meta Ads, GA4, Google Search Console, social media, cross-channel campaigns, and interactive setup
- Adds `bin/ops-marketing-dash` — bash pre-gather script that hits all configured channels in parallel and outputs unified JSON
- Updates `skills/ops/SKILL.md` router with `marketing, email, klaviyo, ads, meta, seo, campaigns` routes
- Adds 5 new `userConfig` fields to `plugin.json`: `klaviyo_private_key`, `meta_ads_token`, `meta_ad_account_id`, `ga4_property_id`, `google_search_console_site`

## Test plan
- [ ] `/ops:marketing` with no args shows unified dashboard (graceful nulls for unconfigured channels)
- [ ] `/ops:marketing setup` prompts for each credential and validates with test API call
- [ ] `/ops:marketing email` returns Klaviyo lists + campaigns
- [ ] `/ops:marketing ads` returns Meta Ads spend/ROAS for last 7d
- [ ] `/ops:marketing analytics` returns GA4 sessions/conversions (requires gcloud ADC)
- [ ] `/ops:marketing seo` returns Search Console clicks/impressions
- [ ] `/ops:marketing campaigns` shows cross-channel active campaigns
- [ ] `/ops` router correctly dispatches `marketing`, `email`, `klaviyo`, `ads`, `meta`, `seo`, `campaigns`
- [ ] Credentials resolve via userConfig → env var → Doppler order

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/49" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new scripts/skills that call external APIs (Shopify, Klaviyo, Meta, Google) and adds new credential configuration fields; main risk is misconfiguration or leaking/handling tokens incorrectly in logs/output.
> 
> **Overview**
> Adds new `/ops:ops-marketing` and `/ops:ops-ecom` skills to provide a marketing dashboard (Klaviyo, Meta Ads, GA4, Search Console) and a Shopify store command center (orders, inventory, fulfillment, analytics, health).
> 
> Introduces `bin/ops-marketing-dash` and `bin/ops-ecom-health` to fetch channel/store metrics and emit unified JSON, with credential resolution via plugin config/env vars and Doppler fallback.
> 
> Extends `.claude-plugin/plugin.json` with new *sensitive* API key/token fields (plus Shopify/ShipBob settings) and updates the main `skills/ops/SKILL.md` router to dispatch new `marketing` and `ecom` commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7841576bde82fc1c1e8689e50daf69bf5b9f9c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added integrated marketing operations dashboard aggregating data from Klaviyo, Meta Ads, Google Analytics 4, and Google Search Console.
  * Enabled configuration support for connecting multiple external marketing platforms and services.
  * Introduced marketing command center for email campaigns, ad performance monitoring, analytics, SEO tracking, and cross-channel reporting.
  * Implemented secure credential management with environment variable and configuration-based support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->