### PR TITLE
feat: daemon cron jobs, /ops:voice skill, message listener

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -128,6 +128,27 @@
       "type": "string",
       "sensitive": true,
       "default": ""
+    },
+    "bland_ai_api_key": {
+      "title": "Bland AI API Key",
+      "description": "API key from https://app.bland.ai — used for /ops:ops-voice call",
+      "type": "string",
+      "sensitive": true,
+      "default": ""
+    },
+    "elevenlabs_api_key": {
+      "title": "ElevenLabs API Key",
+      "description": "API key from https://elevenlabs.io — used for /ops:ops-voice tts",
+      "type": "string",
+      "sensitive": true,
+      "default": ""
+    },
+    "groq_api_key": {
+      "title": "Groq API Key",
+      "description": "API key from https://console.groq.com — used for /ops:ops-voice transcribe (Whisper)",
+      "type": "string",
+      "sensitive": true,
+      "default": ""
     }
   }
 }

--- a/claude-ops/scripts/daemon-services.example.json
+++ b/claude-ops/scripts/daemon-services.example.json
@@ -1,0 +1,49 @@
+{
+  "_comment": "Copy this file to ~/.claude/plugins/data/ops-ops-marketplace/daemon-services.json and customize.",
+  "_variables": {
+    "CLAUDE_PLUGIN_ROOT": "Resolved at runtime to the claude-ops plugin install directory",
+    "OPS_DATA_DIR": "Override default data dir (~/.claude/plugins/data/ops-ops-marketplace)"
+  },
+  "services": {
+    "wacli-sync": {
+      "enabled": true,
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/wacli-keepalive.sh",
+      "health_file": "~/.wacli/health.txt",
+      "restart_delay": 60,
+      "max_restarts": 10
+    },
+    "inbox-digest": {
+      "enabled": false,
+      "cron": "0 */4 * * *",
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-cron-inbox-digest.sh",
+      "_note": "Requires: TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID env vars. Uses gog for email."
+    },
+    "store-health": {
+      "enabled": false,
+      "cron": "0 9 * * *",
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-cron-store-health.sh",
+      "_note": "Requires: SHOPIFY_STOREFRONT_TOKEN, SHOPIFY_STORE_DOMAIN, TELEGRAM_BOT_TOKEN"
+    },
+    "competitor-intel": {
+      "enabled": false,
+      "cron": "0 10 * * 1",
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-cron-competitor-intel.sh",
+      "_note": "Requires: TELEGRAM_BOT_TOKEN. Optional: TAVILY_API_KEY for better search results."
+    },
+    "message-listener": {
+      "enabled": false,
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-message-listener.sh",
+      "health_file": "~/.claude/plugins/data/ops-ops-marketplace/listener-health.txt",
+      "restart_delay": 30,
+      "max_restarts": 20,
+      "_note": "Requires: wacli installed. Optional: TELEGRAM_BOT_TOKEN, TELEGRAM_OWNER_ID."
+    },
+    "memory-extractor": {
+      "enabled": false,
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-memory-extractor.sh",
+      "health_file": "~/.claude/plugins/data/ops-ops-marketplace/memories/.health",
+      "restart_delay": 3600,
+      "cron": "*/30 * * * *"
+    }
+  }
+}

--- a/claude-ops/scripts/ops-cron-competitor-intel.sh
+++ b/claude-ops/scripts/ops-cron-competitor-intel.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# ops-cron-competitor-intel.sh — Weekly Competitor Intel cron job
+# Migrated from OpenClaw "Weekly Competitor Intel" (cron: 0 10 * * MON, tz: Europe/Amsterdam)
+# Searches competitors (AG1, Huel), own brand reviews, reports to Telegram
+set -euo pipefail
+
+DATA_DIR="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+LOG_DIR="$DATA_DIR/logs"
+LOG="$LOG_DIR/competitor-intel.log"
+
+mkdir -p "$LOG_DIR"
+log() { printf '%s [competitor-intel] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" | tee -a "$LOG"; }
+
+# ── Resolve credentials ───────────────────────────────────────────────────
+TELEGRAM_TOKEN="${TELEGRAM_BOT_TOKEN:-}"
+TELEGRAM_CHAT="${TELEGRAM_CHAT_ID:-1335137548}"
+TAVILY_KEY="${TAVILY_API_KEY:-}"
+
+if [[ -z "$TELEGRAM_TOKEN" ]]; then
+  TELEGRAM_TOKEN=$(doppler secrets get TELEGRAM_BOT_TOKEN --plain 2>/dev/null || true)
+fi
+if [[ -z "$TAVILY_KEY" ]]; then
+  TAVILY_KEY=$(doppler secrets get TAVILY_API_KEY --plain 2>/dev/null || true)
+fi
+
+YEAR=$(date +%Y)
+FINDINGS=()
+
+# ── Search function via Tavily (or fallback curl) ─────────────────────────
+search_web() {
+  local query="$1"
+  local label="$2"
+  local result=""
+
+  if [[ -n "$TAVILY_KEY" ]]; then
+    result=$(curl -s -X POST "https://api.tavily.com/search" \
+      -H "Content-Type: application/json" \
+      -H "Authorization: Bearer ${TAVILY_KEY}" \
+      -d "{\"query\": \"$query\", \"max_results\": 3, \"search_depth\": \"basic\"}" \
+      2>/dev/null | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+results = data.get('results', [])
+if not results:
+    print('No results found')
+else:
+    snippets = [r.get('title','') + ': ' + r.get('content','')[:120] for r in results[:2]]
+    print(' | '.join(snippets))
+" 2>/dev/null || echo "search unavailable")
+  else
+    # Fallback: SerpAPI-compatible curl search via DuckDuckGo HTML (best-effort)
+    result=$(curl -s -A "Mozilla/5.0" \
+      "https://html.duckduckgo.com/html/?q=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote('$query'))")" \
+      2>/dev/null | python3 -c "
+import sys, re
+html = sys.stdin.read()
+titles = re.findall(r'class=\"result__title\"[^>]*>.*?<a[^>]*>(.*?)</a>', html, re.DOTALL)
+clean = [re.sub('<[^>]+>','',t).strip() for t in titles[:3]]
+print(' | '.join(clean[:2]) if clean else 'No results')
+" 2>/dev/null || echo "search unavailable")
+  fi
+
+  log "Search [$label]: ${result:0:100}..."
+  echo "$result"
+}
+
+# ── Run searches ──────────────────────────────────────────────────────────
+log "Running weekly competitor intelligence searches"
+
+AG1_RESULT=$(search_web "AG1 Athletic Greens price change $YEAR" "AG1 price")
+HUEL_RESULT=$(search_web "Huel Daily Greens new products $YEAR" "Huel new")
+BRAND_RESULT=$(search_web "AlwaysBright supplement reviews $YEAR" "AlwaysBright reviews")
+
+# ── Build report ──────────────────────────────────────────────────────────
+DATE_LABEL=$(TZ="Europe/Amsterdam" date "+%a %d %b %Y")
+REPORT="*Weekly Competitor Intel* ($DATE_LABEL)
+
+*AG1 / Athletic Greens:*
+$AG1_RESULT
+
+*Huel Daily Greens:*
+$HUEL_RESULT
+
+*AlwaysBright Brand Mentions:*
+$BRAND_RESULT"
+
+log "Report built — sending to Telegram"
+
+# ── Send to Telegram ──────────────────────────────────────────────────────
+if [[ -n "$TELEGRAM_TOKEN" ]]; then
+  curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage" \
+    -H "Content-Type: application/json" \
+    -d "{\"chat_id\": \"$TELEGRAM_CHAT\", \"text\": $(echo "$REPORT" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'), \"parse_mode\": \"Markdown\"}" \
+    >> "$LOG" 2>&1
+  log "Competitor intel sent to Telegram chat=$TELEGRAM_CHAT"
+else
+  log "WARN: TELEGRAM_BOT_TOKEN not set — printing report to stdout"
+  echo "$REPORT"
+fi
+
+log "HEARTBEAT_OK"

--- a/claude-ops/scripts/ops-cron-inbox-digest.sh
+++ b/claude-ops/scripts/ops-cron-inbox-digest.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# ops-cron-inbox-digest.sh — 4h Inbox Digest cron job
+# Migrated from OpenClaw "4h Inbox Digest" (cron: 0 */4 * * *, tz: Europe/Amsterdam)
+# Scans unread WhatsApp messages + email, sends digest to Telegram chat 1335137548
+set -euo pipefail
+
+DATA_DIR="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+LOG_DIR="$DATA_DIR/logs"
+LOG="$LOG_DIR/inbox-digest.log"
+WACLI="${WACLI_BIN:-$(command -v wacli 2>/dev/null || echo /usr/local/bin/wacli)}"
+
+mkdir -p "$LOG_DIR"
+log() { printf '%s [inbox-digest] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" | tee -a "$LOG"; }
+
+# ── Resolve Telegram token ────────────────────────────────────────────────
+TELEGRAM_TOKEN="${TELEGRAM_BOT_TOKEN:-}"
+TELEGRAM_CHAT="${TELEGRAM_CHAT_ID:-1335137548}"
+
+if [[ -z "$TELEGRAM_TOKEN" ]]; then
+  TELEGRAM_TOKEN=$(doppler secrets get TELEGRAM_BOT_TOKEN --plain 2>/dev/null || true)
+fi
+
+# ── Gather WhatsApp unread count ──────────────────────────────────────────
+WA_SUMMARY="WhatsApp: unavailable"
+if command -v wacli &>/dev/null || [[ -x "$WACLI" ]]; then
+  SINCE=$(date -u -v-4H "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "4 hours ago" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u "+%Y-%m-%dT%H:%M:%SZ")
+  WA_RAW=$("$WACLI" messages list --after="$SINCE" --limit 20 --json 2>/dev/null || echo "[]")
+  WA_COUNT=$(echo "$WA_RAW" | python3 -c "
+import json, sys
+msgs = json.load(sys.stdin)
+# Filter out messages from Sam (from_me=true)
+unread = [m for m in msgs if not m.get('from_me', False)]
+print(len(unread))
+" 2>/dev/null || echo "0")
+
+  if [[ "$WA_COUNT" == "0" ]]; then
+    WA_SUMMARY="WhatsApp: geen nieuwe berichten"
+  else
+    WA_SENDERS=$(echo "$WA_RAW" | python3 -c "
+import json, sys
+msgs = json.load(sys.stdin)
+unread = [m for m in msgs if not m.get('from_me', False)]
+senders = list({m.get('contact_name', m.get('from', 'unknown')) for m in unread})[:5]
+print(', '.join(senders))
+" 2>/dev/null || echo "unknown")
+    WA_SUMMARY="WhatsApp: $WA_COUNT unread from $WA_SENDERS"
+  fi
+fi
+
+# ── Gather email unread count via gog ────────────────────────────────────
+EMAIL_SUMMARY="Email: unavailable"
+GOG_RAW=$(command -v gog &>/dev/null && gog gmail search "is:unread after:$(date -u -v-4H +%Y/%m/%d 2>/dev/null || date -u -d '4 hours ago' +%Y/%m/%d 2>/dev/null || date -u +%Y/%m/%d)" --json 2>/dev/null || echo "[]")
+EMAIL_COUNT=$(echo "$GOG_RAW" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(len(data) if isinstance(data, list) else 0)
+" 2>/dev/null || echo "0")
+
+if [[ "$EMAIL_COUNT" == "0" ]]; then
+  EMAIL_SUMMARY="Email: geen nieuwe berichten"
+else
+  EMAIL_SUBJECTS=$(echo "$GOG_RAW" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+subjects = [m.get('subject', '')[:50] for m in (data if isinstance(data, list) else [])[:3]]
+print('\n  - '.join(subjects))
+" 2>/dev/null || echo "")
+  EMAIL_SUMMARY="Email: $EMAIL_COUNT unread"
+  [[ -n "$EMAIL_SUBJECTS" ]] && EMAIL_SUMMARY="$EMAIL_SUMMARY
+  - $EMAIL_SUBJECTS"
+fi
+
+# ── Build digest ──────────────────────────────────────────────────────────
+TIMESTAMP=$(TZ="Europe/Amsterdam" date "+%H:%M %Z")
+DIGEST="*4h Inbox Digest* ($TIMESTAMP)
+
+$WA_SUMMARY
+$EMAIL_SUMMARY"
+
+# ── Check if anything actionable ─────────────────────────────────────────
+if [[ "$WA_SUMMARY" == *"geen nieuwe berichten"* ]] && [[ "$EMAIL_SUMMARY" == *"geen nieuwe berichten"* ]]; then
+  log "No new messages — skipping Telegram notification (HEARTBEAT_OK)"
+  exit 0
+fi
+
+log "Sending digest: WA=$WA_COUNT email=$EMAIL_COUNT"
+
+# ── Send to Telegram ──────────────────────────────────────────────────────
+if [[ -n "$TELEGRAM_TOKEN" ]]; then
+  curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage" \
+    -H "Content-Type: application/json" \
+    -d "{\"chat_id\": \"$TELEGRAM_CHAT\", \"text\": $(echo "$DIGEST" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'), \"parse_mode\": \"Markdown\"}" \
+    >> "$LOG" 2>&1
+  log "Digest sent to Telegram chat=$TELEGRAM_CHAT"
+else
+  log "WARN: TELEGRAM_BOT_TOKEN not set — digest not sent"
+  echo "$DIGEST"
+fi
+
+log "HEARTBEAT_OK"

--- a/claude-ops/scripts/ops-cron-store-health.sh
+++ b/claude-ops/scripts/ops-cron-store-health.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# ops-cron-store-health.sh — Daily Store Health cron job
+# Migrated from OpenClaw "Daily Store Health" (cron: 0 9 * * *, tz: Europe/Amsterdam)
+# Queries Shopify API, reports inventory status to Telegram
+set -euo pipefail
+
+DATA_DIR="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+LOG_DIR="$DATA_DIR/logs"
+LOG="$LOG_DIR/store-health.log"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/ops-marketplace/claude-ops}"
+
+mkdir -p "$LOG_DIR"
+log() { printf '%s [store-health] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" | tee -a "$LOG"; }
+
+# ── Resolve credentials ───────────────────────────────────────────────────
+SHOPIFY_STORE="${SHOPIFY_STORE_DOMAIN:-}"
+SHOPIFY_TOKEN="${SHOPIFY_STOREFRONT_TOKEN:-}"
+TELEGRAM_TOKEN="${TELEGRAM_BOT_TOKEN:-}"
+TELEGRAM_CHAT="${TELEGRAM_CHAT_ID:-1335137548}"
+LOW_STOCK_THRESHOLD="${LOW_STOCK_THRESHOLD:-20}"
+
+if [[ -z "$SHOPIFY_TOKEN" ]]; then
+  SHOPIFY_TOKEN=$(doppler secrets get SHOPIFY_STOREFRONT_TOKEN --plain 2>/dev/null || true)
+fi
+if [[ -z "$SHOPIFY_STORE" ]]; then
+  SHOPIFY_STORE=$(doppler secrets get SHOPIFY_STORE_DOMAIN --plain 2>/dev/null || echo "abshelf.myshopify.com")
+fi
+if [[ -z "$TELEGRAM_TOKEN" ]]; then
+  TELEGRAM_TOKEN=$(doppler secrets get TELEGRAM_BOT_TOKEN --plain 2>/dev/null || true)
+fi
+
+# ── Try bin/ops-ecom-health first ─────────────────────────────────────────
+ECOM_HEALTH_BIN="$PLUGIN_ROOT/bin/ops-ecom-health"
+if [[ -x "$ECOM_HEALTH_BIN" ]]; then
+  log "Running ops-ecom-health bin"
+  HEALTH_OUTPUT=$("$ECOM_HEALTH_BIN" --json 2>/dev/null || "$ECOM_HEALTH_BIN" 2>/dev/null || true)
+  if [[ -n "$HEALTH_OUTPUT" ]]; then
+    log "ops-ecom-health output received"
+    REPORT="$HEALTH_OUTPUT"
+  fi
+fi
+
+# ── Fallback: direct Shopify Storefront API call ──────────────────────────
+if [[ -z "${REPORT:-}" ]]; then
+  if [[ -z "$SHOPIFY_TOKEN" ]]; then
+    log "ERROR: SHOPIFY_STOREFRONT_TOKEN not set and ops-ecom-health unavailable"
+    exit 1
+  fi
+
+  log "Querying Shopify Storefront API: $SHOPIFY_STORE"
+  INVENTORY_JSON=$(curl -s -X POST \
+    "https://${SHOPIFY_STORE}/api/2024-04/graphql.json" \
+    -H "X-Shopify-Storefront-Access-Token: ${SHOPIFY_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d '{"query": "{ products(first: 10) { edges { node { title variants(first: 10) { edges { node { title quantityAvailable availableForSale } } } } } } }"}' \
+    2>/dev/null || echo '{"errors":[{"message":"request failed"}]}')
+
+  REPORT=$(echo "$INVENTORY_JSON" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+
+if 'errors' in data:
+    print('Store Health: ERROR — ' + data['errors'][0].get('message', 'unknown'))
+    sys.exit(0)
+
+products = data.get('data', {}).get('products', {}).get('edges', [])
+threshold = int('${LOW_STOCK_THRESHOLD}')
+lines = ['*Daily Store Health*', '']
+low_stock = []
+all_ok = []
+
+for p in products:
+    node = p['node']
+    name = node['title']
+    for v in node.get('variants', {}).get('edges', []):
+        vn = v['node']
+        qty = vn.get('quantityAvailable') or 0
+        avail = vn.get('availableForSale', False)
+        label = vn['title'] if vn['title'] != 'Default Title' else ''
+        display = f'{name}' + (f' — {label}' if label else '')
+        if qty < threshold or not avail:
+            low_stock.append(f'  LOW: {display} ({qty} units)')
+        else:
+            all_ok.append(f'  OK: {display} ({qty} units)')
+
+if low_stock:
+    lines.append('*LOW STOCK ALERTS:*')
+    lines.extend(low_stock)
+    lines.append('')
+lines.append('*In Stock:*')
+lines.extend(all_ok[:5])
+if len(all_ok) > 5:
+    lines.append(f'  ...and {len(all_ok)-5} more')
+print('\n'.join(lines))
+" 2>/dev/null || echo "Store Health: failed to parse inventory response")
+fi
+
+log "Report generated — sending to Telegram"
+
+# ── Send to Telegram ──────────────────────────────────────────────────────
+if [[ -n "$TELEGRAM_TOKEN" ]]; then
+  curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage" \
+    -H "Content-Type: application/json" \
+    -d "{\"chat_id\": \"$TELEGRAM_CHAT\", \"text\": $(echo "$REPORT" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'), \"parse_mode\": \"Markdown\"}" \
+    >> "$LOG" 2>&1
+  log "Store health sent to Telegram chat=$TELEGRAM_CHAT"
+else
+  log "WARN: TELEGRAM_BOT_TOKEN not set — printing report to stdout"
+  echo "$REPORT"
+fi
+
+log "HEARTBEAT_OK"

--- a/claude-ops/scripts/ops-message-listener.sh
+++ b/claude-ops/scripts/ops-message-listener.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# ops-message-listener.sh — Poll-based message listener (replaces OpenClaw WebSocket gateway)
+# Supervised by ops-daemon. Polls WhatsApp (wacli) + Telegram every 60s.
+# New non-Sam messages → written to inbox-queue.json for /ops:inbox to consume.
+# Health status written to listener-health.txt for daemon monitoring.
+set -euo pipefail
+
+DATA_DIR="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+LOG_DIR="$DATA_DIR/logs"
+LOG="$LOG_DIR/message-listener.log"
+QUEUE_FILE="$DATA_DIR/inbox-queue.json"
+HEALTH_FILE="$DATA_DIR/listener-health.txt"
+STATE_FILE="$DATA_DIR/listener-state.json"
+WACLI="${WACLI_BIN:-$(command -v wacli 2>/dev/null || echo /usr/local/bin/wacli)}"
+POLL_INTERVAL="${OPS_LISTENER_POLL_INTERVAL:-60}"
+
+mkdir -p "$LOG_DIR" "$DATA_DIR"
+
+log() { printf '%s [listener] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" | tee -a "$LOG"; }
+
+write_health() {
+  local status="$1" detail="${2:-}"
+  printf 'status=%s\ntimestamp=%s\ndetail=%s\n' \
+    "$status" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$detail" > "$HEALTH_FILE"
+}
+
+# ── Initialize queue file ─────────────────────────────────────────────────
+if [[ ! -f "$QUEUE_FILE" ]]; then
+  echo '{"messages": [], "last_updated": null}' > "$QUEUE_FILE"
+fi
+
+# ── Load last-seen state ──────────────────────────────────────────────────
+load_state() {
+  python3 -c "
+import json, os
+f = '$STATE_FILE'
+if os.path.exists(f):
+    data = json.load(open(f))
+else:
+    data = {'wa_last_seen': None, 'tg_last_seen': None}
+print(data.get('wa_last_seen') or '')
+print(data.get('tg_last_seen') or '')
+" 2>/dev/null || printf '\n\n'
+}
+
+save_state() {
+  local wa_ts="$1" tg_ts="$2"
+  python3 -c "
+import json
+data = {'wa_last_seen': '$wa_ts', 'tg_last_seen': '$tg_ts'}
+json.dump(data, open('$STATE_FILE', 'w'))
+" 2>/dev/null || true
+}
+
+# ── Append messages to queue ──────────────────────────────────────────────
+append_to_queue() {
+  local new_msgs_json="$1"
+  python3 -c "
+import json, sys
+from datetime import datetime, timezone
+
+queue_file = '$QUEUE_FILE'
+try:
+    queue = json.load(open(queue_file))
+except:
+    queue = {'messages': [], 'last_updated': None}
+
+new_msgs = json.loads('''$new_msgs_json''')
+# Dedup by message id
+existing_ids = {m.get('id') for m in queue['messages']}
+added = 0
+for msg in new_msgs:
+    if msg.get('id') not in existing_ids:
+        queue['messages'].append(msg)
+        existing_ids.add(msg.get('id'))
+        added += 1
+
+# Keep last 200 messages max
+queue['messages'] = queue['messages'][-200:]
+queue['last_updated'] = datetime.now(timezone.utc).isoformat()
+
+json.dump(queue, open(queue_file, 'w'), indent=2)
+print(added)
+" 2>/dev/null || echo 0
+}
+
+# ── Poll WhatsApp ─────────────────────────────────────────────────────────
+poll_whatsapp() {
+  local since="$1"
+  if ! command -v wacli &>/dev/null && [[ ! -x "$WACLI" ]]; then
+    echo "[]"
+    return
+  fi
+
+  local since_flag=""
+  [[ -n "$since" ]] && since_flag="--after=$since"
+
+  local raw
+  raw=$("$WACLI" messages list $since_flag --limit 20 --json 2>/dev/null || echo "[]")
+
+  # Filter: only non-Sam (from_me=false) messages
+  echo "$raw" | python3 -c "
+import json, sys
+msgs = json.load(sys.stdin)
+filtered = []
+for m in msgs:
+    if not m.get('from_me', False):
+        filtered.append({
+            'id': m.get('id', ''),
+            'channel': 'whatsapp',
+            'from': m.get('contact_name', m.get('from', '')),
+            'text': m.get('body', m.get('text', '')),
+            'timestamp': m.get('timestamp', ''),
+            'raw': m
+        })
+print(json.dumps(filtered))
+" 2>/dev/null || echo "[]"
+}
+
+# ── Poll Telegram ─────────────────────────────────────────────────────────
+poll_telegram() {
+  local since_update_id="${1:-0}"
+  local tg_token="${TELEGRAM_BOT_TOKEN:-}"
+
+  if [[ -z "$tg_token" ]]; then
+    tg_token=$(doppler secrets get TELEGRAM_BOT_TOKEN --plain 2>/dev/null || true)
+  fi
+  [[ -z "$tg_token" ]] && echo "[]" && return
+
+  local offset=$(( since_update_id + 1 ))
+  local raw
+  raw=$(curl -s "https://api.telegram.org/bot${tg_token}/getUpdates?offset=${offset}&limit=20&timeout=5" 2>/dev/null || echo '{"ok":false}')
+
+  echo "$raw" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+if not data.get('ok'):
+    print('[]')
+    sys.exit(0)
+filtered = []
+for upd in data.get('result', []):
+    msg = upd.get('message', {})
+    sender = msg.get('from', {})
+    # Skip Sam's own messages (add TELEGRAM_OWNER_ID to env to filter by user_id)
+    owner_id = '${TELEGRAM_OWNER_ID:-}'
+    if owner_id and str(sender.get('id', '')) == owner_id:
+        continue
+    if msg:
+        filtered.append({
+            'id': str(upd.get('update_id', '')),
+            'channel': 'telegram',
+            'from': sender.get('username', sender.get('first_name', 'unknown')),
+            'text': msg.get('text', ''),
+            'timestamp': str(msg.get('date', '')),
+            'update_id': upd.get('update_id', 0),
+            'raw': msg
+        })
+print(json.dumps(filtered))
+" 2>/dev/null || echo "[]"
+}
+
+# ── Trap for clean shutdown ───────────────────────────────────────────────
+cleanup() {
+  log "SHUTDOWN received — writing final health"
+  write_health "stopped" "SIGTERM received"
+  exit 0
+}
+trap cleanup SIGTERM SIGINT
+
+# ── Main poll loop ────────────────────────────────────────────────────────
+log "START: ops-message-listener polling every ${POLL_INTERVAL}s"
+write_health "polling" "starting"
+
+# Load initial state
+read -r WA_LAST_SEEN TG_LAST_UPDATE_ID <<< "$(load_state | tr '\n' ' ')"
+WA_LAST_SEEN="${WA_LAST_SEEN:-}"
+TG_LAST_UPDATE_ID="${TG_LAST_UPDATE_ID:-0}"
+
+# Bootstrap WA since: use 2 minutes ago on first run
+if [[ -z "$WA_LAST_SEEN" ]]; then
+  WA_LAST_SEEN=$(date -u -v-2M "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "2 minutes ago" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u "+%Y-%m-%dT%H:%M:%SZ")
+fi
+
+POLL_COUNT=0
+while true; do
+  POLL_COUNT=$(( POLL_COUNT + 1 ))
+  POLL_TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+  # ── WhatsApp poll ──────────────────────────────────────────────────────
+  WA_MSGS=$(poll_whatsapp "$WA_LAST_SEEN")
+  WA_COUNT=$(echo "$WA_MSGS" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo 0)
+
+  if [[ "$WA_COUNT" -gt 0 ]]; then
+    ADDED=$(append_to_queue "$WA_MSGS")
+    log "WhatsApp: $WA_COUNT new messages (queued $ADDED)"
+    # Update last seen to most recent timestamp
+    WA_LAST_SEEN=$(echo "$WA_MSGS" | python3 -c "
+import json, sys
+msgs = json.load(sys.stdin)
+ts = [m.get('timestamp','') for m in msgs if m.get('timestamp','')]
+print(max(ts) if ts else '$WA_LAST_SEEN')
+" 2>/dev/null || echo "$WA_LAST_SEEN")
+  fi
+
+  # ── Telegram poll ──────────────────────────────────────────────────────
+  TG_MSGS=$(poll_telegram "$TG_LAST_UPDATE_ID")
+  TG_COUNT=$(echo "$TG_MSGS" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo 0)
+
+  if [[ "$TG_COUNT" -gt 0 ]]; then
+    ADDED=$(append_to_queue "$TG_MSGS")
+    log "Telegram: $TG_COUNT new messages (queued $ADDED)"
+    TG_LAST_UPDATE_ID=$(echo "$TG_MSGS" | python3 -c "
+import json, sys
+msgs = json.load(sys.stdin)
+ids = [m.get('update_id', 0) for m in msgs]
+print(max(ids) if ids else $TG_LAST_UPDATE_ID)
+" 2>/dev/null || echo "$TG_LAST_UPDATE_ID")
+  fi
+
+  # ── Save state ──────────────────────────────────────────────────────────
+  save_state "$WA_LAST_SEEN" "$TG_LAST_UPDATE_ID"
+
+  # ── Write health ──────────────────────────────────────────────────────
+  write_health "polling" "poll=$POLL_COUNT wa_new=$WA_COUNT tg_new=$TG_COUNT ts=$POLL_TS"
+
+  if [[ $(( POLL_COUNT % 10 )) -eq 0 ]]; then
+    log "Heartbeat: poll #$POLL_COUNT — wa_seen=$WA_LAST_SEEN tg_offset=$TG_LAST_UPDATE_ID"
+  fi
+
+  sleep "$POLL_INTERVAL"
+done

--- a/claude-ops/skills/ops-voice/SKILL.md
+++ b/claude-ops/skills/ops-voice/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: ops-voice
+description: Voice operations — make phone calls (Bland AI), text-to-speech (ElevenLabs), transcribe audio (Whisper/Groq). Replace OpenClaw voice capabilities.
+argument-hint: "[call|tts|transcribe|setup]"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - AskUserQuestion
+  - WebFetch
+---
+
+# OPS:VOICE — Voice Operations
+
+Voice interface commands. All API calls via curl — no SDK dependencies.
+
+**Credential resolution order:** userConfig → env vars → Doppler secrets
+
+---
+
+## Sub-commands
+
+Parse `$ARGUMENTS` for the command keyword, then execute:
+
+---
+
+### `call [phone] [prompt]` — Bland AI phone call
+
+**Requires:** `bland_ai_api_key` in userConfig or `BLAND_AI_API_KEY` env or Doppler.
+
+```bash
+BLAND_KEY="${BLAND_AI_API_KEY:-$(doppler secrets get BLAND_AI_API_KEY --plain 2>/dev/null || true)}"
+PHONE="<extracted from $ARGUMENTS>"
+PROMPT="<extracted from $ARGUMENTS or ask user>"
+MAX_DURATION="${BLAND_MAX_DURATION:-300}"  # seconds
+VOICE="${BLAND_VOICE:-male}"
+
+# Make the call
+RESPONSE=$(curl -s -X POST "https://api.bland.ai/v1/calls" \
+  -H "authorization: $BLAND_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"phone_number\": \"$PHONE\",
+    \"task\": \"$PROMPT\",
+    \"voice\": \"$VOICE\",
+    \"max_duration\": $MAX_DURATION,
+    \"record\": true
+  }")
+
+CALL_ID=$(echo "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin).get('call_id',''))" 2>/dev/null)
+
+# Poll for completion (up to 5 min)
+if [ -n "$CALL_ID" ]; then
+  echo "Call initiated: $CALL_ID"
+  for i in $(seq 1 30); do
+    sleep 10
+    STATUS=$(curl -s "https://api.bland.ai/v1/calls/$CALL_ID" \
+      -H "authorization: $BLAND_KEY" | \
+      python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('status',''), d.get('transcripts','')[-1].get('text','') if d.get('transcripts') else '')" 2>/dev/null)
+    echo "Status: $STATUS"
+    [[ "$STATUS" == completed* ]] && break
+  done
+fi
+```
+
+**Output:** Call ID, live status, transcript when complete.
+
+---
+
+### `tts [text] [--voice voice_id] [--out file.mp3]` — ElevenLabs text-to-speech
+
+**Requires:** `elevenlabs_api_key` in userConfig or `ELEVENLABS_API_KEY` env or Doppler.
+
+```bash
+EL_KEY="${ELEVENLABS_API_KEY:-$(doppler secrets get ELEVENLABS_API_KEY --plain 2>/dev/null || true)}"
+VOICE_ID="${ELEVENLABS_VOICE_ID:-21m00Tcm4TlvDq8ikWAM}"  # Rachel (default)
+TEXT="<extracted from $ARGUMENTS>"
+OUT_FILE="${OUT_FILE:-/tmp/ops-tts-$(date +%s).mp3}"
+
+# List voices if voice name provided (not an ID)
+# Synthesize
+curl -s -X POST "https://api.elevenlabs.io/v1/text-to-speech/${VOICE_ID}" \
+  -H "xi-api-key: $EL_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"text\": \"$TEXT\",
+    \"model_id\": \"eleven_monolingual_v1\",
+    \"voice_settings\": {\"stability\": 0.5, \"similarity_boost\": 0.75}
+  }" \
+  --output "$OUT_FILE"
+
+echo "Audio saved to: $OUT_FILE"
+# Auto-play on macOS
+command -v afplay &>/dev/null && afplay "$OUT_FILE" &
+```
+
+**Output:** Audio file path. Auto-plays on macOS via `afplay`.
+
+---
+
+### `transcribe [file_path]` — Groq Whisper transcription
+
+**Requires:** `groq_api_key` in userConfig or `GROQ_API_KEY` env or Doppler.
+
+```bash
+GROQ_KEY="${GROQ_API_KEY:-$(doppler secrets get GROQ_API_KEY --plain 2>/dev/null || true)}"
+AUDIO_FILE="<extracted from $ARGUMENTS>"
+
+if [ ! -f "$AUDIO_FILE" ]; then
+  echo "ERROR: File not found: $AUDIO_FILE"
+  exit 1
+fi
+
+TRANSCRIPT=$(curl -s -X POST "https://api.groq.com/openai/v1/audio/transcriptions" \
+  -H "Authorization: Bearer $GROQ_KEY" \
+  -F "file=@$AUDIO_FILE" \
+  -F "model=whisper-large-v3" \
+  -F "response_format=json" | \
+  python3 -c "import json,sys; print(json.load(sys.stdin).get('text',''))" 2>/dev/null)
+
+echo "$TRANSCRIPT"
+```
+
+**Output:** Transcript text printed to stdout.
+
+---
+
+### `setup` — Configure voice API keys
+
+Walk through credential setup interactively. Check which keys are missing, then prompt for each:
+
+1. Check `BLAND_AI_API_KEY` → if missing, prompt and add to Doppler or shell profile
+2. Check `ELEVENLABS_API_KEY` → if missing, prompt
+3. Check `GROQ_API_KEY` → if missing, prompt
+4. Verify each key with a lightweight API call (list voices for ElevenLabs, check balance for Bland AI, list models for Groq)
+5. Report status for all three services
+
+---
+
+## Execution
+
+1. Resolve the sub-command from `$ARGUMENTS` (first word: call / tts / transcribe / setup)
+2. Resolve credentials in order: env → Doppler
+3. Execute the matching curl block above
+4. If a required key is missing and `setup` was not invoked, suggest `/ops:ops-voice setup`

--- a/claude-ops/skills/ops/SKILL.md
+++ b/claude-ops/skills/ops/SKILL.md
@@ -34,6 +34,7 @@ Route `$ARGUMENTS` to the correct ops skill:
 | merge, prs, ship-prs                          | `/ops-merge $ARGUMENTS` |
 | marketing, email, klaviyo, ads, meta, seo, campaigns | `/ops:ops-marketing $ARGUMENTS` |
 | ecom, shop, shopify, store, orders, inventory | `/ops:ops-ecom $ARGUMENTS` |
+| voice, call, tts, transcribe, phone           | `/ops:ops-voice $ARGUMENTS` |
 | yolo                                          | `/ops-yolo`             |
 | doctor, health, fix, diagnose                 | `/ops:ops-doctor`       |
 | speedup, clean, optimize, cleanup             | `/ops:ops-speedup`      |


### PR DESCRIPTION
## Summary

- **3 OpenClaw cron jobs migrated** as supervised bash scripts: `ops-cron-inbox-digest.sh` (every 4h), `ops-cron-store-health.sh` (9am daily), `ops-cron-competitor-intel.sh` (Monday 10am) — all TZ Europe/Amsterdam, Telegram delivery
- **`ops-message-listener.sh`** — poll-based WhatsApp+Telegram listener (every 60s) replaces OpenClaw's always-on WebSocket gateway; writes to `inbox-queue.json`, health file for daemon monitoring
- **`~/.claude/plugins/data/ops-ops-marketplace/daemon-services.json`** — user config with all 5 services enabled (wacli-sync, inbox-digest, store-health, competitor-intel, message-listener)
- **`scripts/daemon-services.example.json`** — repo template with all services (disabled by default) for new plugin users
- **`skills/ops-voice/SKILL.md`** — `/ops:ops-voice` skill with `call` (Bland AI), `tts` (ElevenLabs), `transcribe` (Groq Whisper), `setup` sub-commands; all pure curl
- **`plugin.json` userConfig** — adds `bland_ai_api_key`, `elevenlabs_api_key`, `groq_api_key`
- **Ops router** — routes `voice/call/tts/transcribe/phone` → `/ops:ops-voice`

## Notes

- `daemon-services.json` (user config) NOT committed — lives in `~/.claude/plugins/data/` only
- All credentials via env → Doppler, no hardcoded tokens
- Cron scripts have Tavily fallback for competitor-intel searches

## Test plan

- [ ] `bash scripts/ops-cron-inbox-digest.sh` — verify no crash without credentials
- [ ] `bash scripts/ops-message-listener.sh` — verify health file written to `listener-health.txt`
- [ ] `/ops voice setup` — verify credential prompts appear
- [ ] Restart ops-daemon — verify all 5 services appear in `daemon-health.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/50" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new daemon-supervised background scripts that poll external services (WhatsApp/Telegram) and run scheduled Shopify/search jobs, plus new voice integrations that require API keys. Risk is mainly operational: misconfiguration or polling/cron behavior could spam notifications or create unexpected external API usage.
> 
> **Overview**
> Adds a new `daemon-services.example.json` template plus three new cron-oriented scripts (`ops-cron-inbox-digest.sh`, `ops-cron-store-health.sh`, `ops-cron-competitor-intel.sh`) that generate periodic operational digests/health reports and deliver them to Telegram, with secrets resolved via env/Doppler.
> 
> Introduces `ops-message-listener.sh`, a daemon-supervised poller that ingests WhatsApp (`wacli`) and Telegram messages, dedupes them into `inbox-queue.json`, and emits a health file for monitoring.
> 
> Adds a new `/ops:ops-voice` skill (Bland AI calls, ElevenLabs TTS, Groq Whisper transcription) and wires routing for voice-related keywords; `plugin.json` is updated with new sensitive userConfig keys for these providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a69695b5d32500430b37c8a8c4549004498c193. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->