### PR TITLE
feat(setup): universal credential auto-scan for all setup steps

### DIFF
--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -234,41 +234,86 @@ Only go into the credential auto-scan flow below when the user picks "manually" 
 
 ---
 
-#### Shared: credential auto-scan
+---
 
-**Before prompting the user to paste any token**, scan for it in these sources (in order). Show the user what was found and ask them to confirm or override. Never silently use a token without confirmation.
+## Universal Credential Auto-Scan
 
-For each variable name (e.g. `TELEGRAM_BOT_TOKEN`, `SLACK_BOT_TOKEN`):
+**BEFORE asking the user for ANY credential**, run this scan sequence. This applies to ALL steps — channels, ecommerce, marketing, voice, and MCPs. The user should never be asked to find a key that's already on their system.
+
+For each variable name (e.g. `TELEGRAM_BOT_TOKEN`, `SHOPIFY_ACCESS_TOKEN`, `KLAVIYO_API_KEY`):
 
 1. **Current shell environment** — `printenv <VAR>`. Running shell inherits exports, Doppler injections, dotenv-loaded files. Most likely to be correct.
 2. **Shell profile files** — grep `~/.zshrc`, `~/.bashrc`, `~/.zprofile`, `~/.config/fish/config.fish`, `~/.envrc` (direnv) for `<VAR>=` or `export <VAR>=`. Show the file path next to the value so the user knows where it's from.
-3. **Doppler** — if `command -v doppler` succeeds:
-   - Run `doppler secrets --json 2>/dev/null` on the current Doppler project (if one is configured). Parse the output.
-   - Also try `doppler secrets get <VAR> --plain 2>/dev/null` for an exact-name match across the default project.
-   - If multiple Doppler projects exist, don't iterate all of them — ask the user which project to scan.
-4. **Installed MCP configs** — read each `.mcp.json` the detector found (`mcp_configured` provides the server names, but we also need the raw files). For each server entry, look at `.env` and `.args` for the variable name or for literal values that look like the target (e.g. `123456:ABC-...` for Telegram tokens, `xoxb-...` / `xoxp-...` for Slack tokens). Show the MCP server name as the source.
-5. **System keychain** — do NOT scan. Keychain access requires user approval and leaks cross-app secrets. Skip.
+3. **Doppler (all projects)** — if `command -v doppler` succeeds:
+   ```bash
+   for proj in $(doppler projects --json 2>/dev/null | jq -r '.[].slug'); do
+     doppler secrets --project "$proj" --config prd --json 2>/dev/null | \
+       jq -r --arg var "$VAR" --arg proj "$proj" \
+       'to_entries[] | select(.key == $var) | "\(.value.computed) (doppler:\($proj)/prd)"'
+   done
+   ```
+   Also try the default project config (dev/staging) if prd fails. Show source attribution `(project: <slug>, config: <config>)`.
+4. **Dashlane CLI** — if `command -v dcli` succeeds:
+   ```bash
+   dcli password "$SERVICE_KEYWORD" --output json 2>/dev/null
+   ```
+   Map service keywords: `shopify` → SHOPIFY vars, `klaviyo` → KLAVIYO vars, `bland` / `bland-ai` → BLAND vars, etc.
+5. **macOS Keychain** — for specific services:
+   ```bash
+   security find-generic-password -s "$SERVICE" -w 2>/dev/null
+   ```
+   Use service names matching common patterns (e.g. `shopify-admin-token`, `klaviyo-api-key`, `bland-ai-api-key`).
+6. **OpenClaw config** — if `~/.openclaw/openclaw.json` exists:
+   ```bash
+   jq -r --arg var "$VAR" '.agents.defaults.env[$var] // empty' ~/.openclaw/openclaw.json 2>/dev/null
+   ```
+7. **Installed MCP configs** — read each `.mcp.json` the detector found. For each server entry, look at `.env` and `.args` for the variable name or for literal values that look like the target. Show the MCP server name as the source.
+8. **Plugin preferences** — check existing `$PREFS_PATH` for the key under the relevant section (e.g. `.ecom.shopify.admin_token`, `.marketing.klaviyo.api_key`). If found and not a `doppler:` reference, show it as a source.
+
+**Env var → service keyword mapping for auto-scan:**
+
+| Variable names | Service keyword (Dashlane/Keychain) |
+| --- | --- |
+| `SHOPIFY_ACCESS_TOKEN`, `SHOPIFY_ADMIN_TOKEN`, `SHOPIFY_STORE_URL` | `shopify` |
+| `KLAVIYO_API_KEY`, `KLAVIYO_PRIVATE_KEY` | `klaviyo` |
+| `META_ACCESS_TOKEN`, `FACEBOOK_ACCESS_TOKEN`, `META_AD_ACCOUNT_ID` | `meta`, `facebook` |
+| `GA4_PROPERTY_ID`, `GA_MEASUREMENT_ID` | `google-analytics`, `ga4` |
+| `BLAND_AI_API_KEY`, `BLAND_API_KEY` | `bland-ai`, `bland` |
+| `ELEVENLABS_API_KEY` | `elevenlabs` |
+| `GROQ_API_KEY` | `groq` |
+| `SHIPBOB_ACCESS_TOKEN` | `shipbob` |
+| `TELEGRAM_BOT_TOKEN`, `TELEGRAM_API_ID`, `TELEGRAM_API_HASH` | `telegram` |
+| `SLACK_BOT_TOKEN`, `SLACK_MCP_XOXC_TOKEN` | `slack` |
 
 **Present the findings** with `AskUserQuestion`:
 
 ```
-Found credential for TELEGRAM_BOT_TOKEN:
-  [A] shell env ($TELEGRAM_BOT_TOKEN) — 12345...xyz  (last 4 chars shown, never full)
-  [B] ~/.zshrc line 42 — 12345...xyz  (same value — match)
-  [C] Doppler (project: claude-ops, config: dev) — 67890...abc  (different!)
-  [D] .mcp.json / telegram server — ${user_config.telegram_bot_token} (placeholder, not a value)
-  [E] Enter manually
+Found credential for SHOPIFY_ACCESS_TOKEN:
+  [A] shell env ($SHOPIFY_ACCESS_TOKEN) — shpat_508b...682e  (first 8 + last 4 chars)
+  [B] ~/.zshrc line 42 — shpat_508b...682e  (same value — match)
+  [C] Doppler (project: alwaysbright, config: prd) — shpat_9f2c...a17b  (different!)
+  [D] Dashlane (shopify) — shpat_508b...682e  (matches env)
+  [E] Enter a different one
 ```
 
 Rules for the prompt:
 
-- Only show the **last 4 characters** of any token, never the whole thing.
-- If multiple sources have the **same** value, collapse them into one option with `(matched in env + ~/.zshrc)` appended.
-- If sources **disagree**, show them all and flag the mismatch prominently — the user needs to pick which one is authoritative and the wizard should offer to sync the others.
+- Show the **first 8 and last 4 characters** of any token, never the full value.
+- If multiple sources have the **same** value, collapse them into one option with `(matched in env + ~/.zshrc + Dashlane)` appended.
+- If sources **disagree**, show them all and flag the mismatch prominently — the user needs to pick which one is authoritative.
 - Placeholder values like `${user_config.*}`, `<your-token>`, `CHANGE_ME`, or empty strings count as NOT FOUND.
-- Always include an `[Enter manually]` option.
+- Always include an `[Enter a different one]` option.
+- If NO source has a value, then and only then ask the user to provide it — show instructions for where to find it in the service's dashboard.
 
 **On selection**, use the chosen value as the source of truth and — with the user's consent — optionally propagate it back to the other sources (e.g. "Also update ~/.zshrc and Doppler to match?"). Default to NO for propagation unless the user opts in.
+
+---
+
+#### Shared: credential auto-scan
+
+**This section applies specifically to channel tokens (Telegram, Slack).** For all other steps, see the [Universal Credential Auto-Scan](#universal-credential-auto-scan) section above — the same pattern applies everywhere.
+
+**Before prompting the user to paste any token**, scan for it using the Universal Credential Auto-Scan sequence above. Show the user what was found and ask them to confirm or override. Never silently use a token without confirmation.
 
 ---
 
@@ -1082,24 +1127,47 @@ Add to the shortcuts table: `vault`, `password-manager`, `pm` → Step 3g
 
 ### 3h — Ecommerce (Shopify + dynamic partners)
 
-#### Step 3h.1 — Check existing config
+#### Step 3h.1 — Auto-scan for existing Shopify credentials
 
-Check for existing credentials in this order:
+**Before asking for anything**, run the Universal Credential Auto-Scan for all Shopify-related vars simultaneously:
 
-1. `$PREFS_PATH` — look for `ecom.shopify.store_url` and `ecom.shopify.admin_token`
-2. Shell env — `printenv SHOPIFY_STORE_URL`, `printenv SHOPIFY_ADMIN_TOKEN`
-3. Doppler — `doppler secrets get SHOPIFY_ADMIN_TOKEN --plain 2>/dev/null`
+```bash
+# Scan shell env
+printenv SHOPIFY_ACCESS_TOKEN SHOPIFY_ADMIN_TOKEN SHOPIFY_STORE_URL SHOPIFY_ADMIN_API_ACCESS_TOKEN 2>/dev/null
 
-If both `store_url` and `admin_token` are already set, show:
+# Scan shell profiles
+grep -h 'SHOPIFY\|myshopify' ~/.zshrc ~/.bashrc ~/.zprofile ~/.envrc 2>/dev/null | grep -v '^#'
+
+# Scan Doppler across all projects
+for proj in $(doppler projects --json 2>/dev/null | jq -r '.[].slug'); do
+  doppler secrets --project "$proj" --config prd --json 2>/dev/null | \
+    jq -r --arg proj "$proj" 'to_entries[] | select(.key | test("SHOPIFY|STORE")) | "\(.key)=\(.value.computed) (doppler:\($proj)/prd)"'
+done
+
+# Scan Dashlane
+dcli password shopify --output json 2>/dev/null
+
+# Scan macOS Keychain
+security find-generic-password -s "shopify-admin-token" -w 2>/dev/null
+security find-generic-password -s "shopify-access-token" -w 2>/dev/null
+
+# Scan OpenClaw
+jq -r '.agents.defaults.env | to_entries[] | select(.key | test("SHOPIFY")) | "\(.key)=\(.value)"' ~/.openclaw/openclaw.json 2>/dev/null
+
+# Check existing prefs
+jq -r '.ecom.shopify // empty' "$PREFS_PATH" 2>/dev/null
+```
+
+If both `store_url` and `admin_token` are already found, show:
 ```
 ✓ Shopify — already configured (<store_url>)
   [Keep existing]  [Reconfigure]
 ```
-If the user keeps existing, skip to Step 3h.4. If reconfiguring or not set, continue.
+If the user keeps existing, skip to Step 3h.4. If reconfiguring or no values found, continue.
 
 #### Step 3h.2 — Shopify store URL
 
-Ask via `AskUserQuestion` (free text):
+If `SHOPIFY_STORE_URL` was found in the auto-scan, present it using the Universal Credential Auto-Scan prompt format. Only ask via free text if no value was found:
 ```
 Enter your Shopify store URL:
   Format: yourstore.myshopify.com
@@ -1110,7 +1178,7 @@ Validate the input: strip `https://`, strip trailing slash, check that the resul
 
 #### Step 3h.3 — Shopify Admin API token
 
-Ask via `AskUserQuestion` (free text):
+If `SHOPIFY_ACCESS_TOKEN`, `SHOPIFY_ADMIN_TOKEN`, or `SHOPIFY_ADMIN_API_ACCESS_TOKEN` was found in the auto-scan, present it using the Universal Credential Auto-Scan prompt format with truncated display (`shpat_508b...682e`). Only ask via free text if no value was found:
 ```
 Enter your Shopify Admin API access token:
   To generate one:
@@ -1161,6 +1229,7 @@ If the user provides partner names, process each one in a loop:
    - The auth header pattern (`Authorization: Bearer`, `X-Api-Key`, custom header, etc.)
 
 2. **Ask for each credential** via `AskUserQuestion` (one question per credential field), citing where to find it based on what the docs say. Example for ShipBob:
+   Run the Universal Credential Auto-Scan for `SHIPBOB_ACCESS_TOKEN`, `SHIPBOB_API_TOKEN` before asking. If found, present with source attribution. Only prompt manually if not found:
    ```
    Enter your ShipBob Personal Access Token:
      To generate: ShipBob dashboard → Integrations → API → Personal Access Tokens → Create Token
@@ -1215,7 +1284,31 @@ For any partner not in this table, always web search for current auth docs befor
 
 ### 3i — Marketing (Klaviyo, Meta Ads, GA4, Search Console)
 
-For each service below, check if already configured (check `$PREFS_PATH` under `marketing.*`, then shell env, then Doppler) before prompting. If already set, show `✓ <service> — already configured` and offer `[Keep]` / `[Reconfigure]`.
+**Before showing the service selector**, run the Universal Credential Auto-Scan for all marketing vars simultaneously:
+
+```bash
+# Shell env
+printenv KLAVIYO_API_KEY KLAVIYO_PRIVATE_KEY META_ACCESS_TOKEN FACEBOOK_ACCESS_TOKEN META_AD_ACCOUNT_ID GA4_PROPERTY_ID GA_MEASUREMENT_ID 2>/dev/null
+
+# Shell profiles
+grep -h 'KLAVIYO\|META_\|FACEBOOK\|GA4\|GA_MEASUREMENT' ~/.zshrc ~/.bashrc ~/.zprofile ~/.envrc 2>/dev/null | grep -v '^#'
+
+# Doppler across all projects
+for proj in $(doppler projects --json 2>/dev/null | jq -r '.[].slug'); do
+  doppler secrets --project "$proj" --config prd --json 2>/dev/null | \
+    jq -r --arg proj "$proj" 'to_entries[] | select(.key | test("KLAVIYO|META|FACEBOOK|GA4|GOOGLE")) | "\(.key)=\(.value.computed) (doppler:\($proj)/prd)"'
+done
+
+# Dashlane
+dcli password klaviyo --output json 2>/dev/null
+dcli password facebook --output json 2>/dev/null
+dcli password meta --output json 2>/dev/null
+
+# OpenClaw
+jq -r '.agents.defaults.env | to_entries[] | select(.key | test("KLAVIYO|META_|FACEBOOK|GA4")) | "\(.key)=\(.value)"' ~/.openclaw/openclaw.json 2>/dev/null
+```
+
+Cache these results — use them to pre-fill answers for each sub-step below. For each service below, check if already configured (check `$PREFS_PATH` under `marketing.*`, then the auto-scan results above) before prompting. If already set, show `✓ <service> — already configured` and offer `[Keep]` / `[Reconfigure]`.
 
 Ask which marketing integrations to configure via `AskUserQuestion` with `multiSelect: true`:
 
@@ -1228,7 +1321,7 @@ Ask which marketing integrations to configure via `AskUserQuestion` with `multiS
 
 #### Klaviyo
 
-Ask for the private API key:
+If `KLAVIYO_API_KEY` or `KLAVIYO_PRIVATE_KEY` was found in the auto-scan, present it using the Universal Credential Auto-Scan prompt format. Only ask via free text if not found:
 ```
 Enter your Klaviyo Private API Key:
   To generate one: Klaviyo dashboard → Settings → API Keys → Create Private Key
@@ -1245,6 +1338,8 @@ Expect a number ≥ 0. If the response contains `"detail"` with an auth error, s
 
 #### Meta Ads
 
+If `META_ACCESS_TOKEN` or `FACEBOOK_ACCESS_TOKEN` was found in the auto-scan, present it. If `META_AD_ACCOUNT_ID` was found, present that too. Only ask via free text for values not found.
+
 Ask for:
 1. Access token (explain: Meta Business Suite → Settings → System Users or your personal account → Generate token with `ads_read` permission)
 2. Ad account ID (format: `act_XXXXXXXXXX` — found in Business Manager → Ad Accounts)
@@ -1256,7 +1351,7 @@ curl -s "https://graph.facebook.com/v20.0/$AD_ACCOUNT_ID/campaigns?access_token=
 
 #### Google Analytics 4
 
-Ask for the GA4 Property ID (explain: GA4 dashboard → Admin → Property Settings → Property ID, format: numeric, e.g. `123456789`).
+If `GA4_PROPERTY_ID` or `GA_MEASUREMENT_ID` was found in the auto-scan, present it. Only ask via free text if not found. Ask for the GA4 Property ID (explain: GA4 dashboard → Admin → Property Settings → Property ID, format: numeric, e.g. `123456789`).
 
 No API key needed if `gcloud` is authenticated — the GA4 Data API uses Application Default Credentials. Check:
 ```bash
@@ -1341,7 +1436,31 @@ For any partner not in this table, always web search for current auth docs befor
 
 ### 3j — Voice (Bland AI, ElevenLabs, Groq)
 
-Check existing config in `$PREFS_PATH` under `voice.*`, shell env, and Doppler before prompting each one.
+**Before showing the service selector**, run the Universal Credential Auto-Scan for all voice vars simultaneously:
+
+```bash
+# Shell env
+printenv BLAND_AI_API_KEY BLAND_API_KEY ELEVENLABS_API_KEY GROQ_API_KEY 2>/dev/null
+
+# Shell profiles
+grep -h 'BLAND\|ELEVENLABS\|GROQ' ~/.zshrc ~/.bashrc ~/.zprofile ~/.envrc 2>/dev/null | grep -v '^#'
+
+# Doppler across all projects
+for proj in $(doppler projects --json 2>/dev/null | jq -r '.[].slug'); do
+  doppler secrets --project "$proj" --config prd --json 2>/dev/null | \
+    jq -r --arg proj "$proj" 'to_entries[] | select(.key | test("BLAND|ELEVENLABS|GROQ")) | "\(.key)=\(.value.computed) (doppler:\($proj)/prd)"'
+done
+
+# Dashlane
+dcli password "bland-ai" --output json 2>/dev/null
+dcli password elevenlabs --output json 2>/dev/null
+dcli password groq --output json 2>/dev/null
+
+# OpenClaw (common location for AI service keys)
+jq -r '.agents.defaults.env | to_entries[] | select(.key | test("BLAND|ELEVENLABS|GROQ")) | "\(.key)=\(.value)"' ~/.openclaw/openclaw.json 2>/dev/null
+```
+
+Cache these results — use them to pre-fill answers for each sub-step below. Check existing config in `$PREFS_PATH` under `voice.*` too. If a key is already set, show `✓ <service> — already configured` and offer `[Keep]` / `[Reconfigure]`.
 
 Ask which voice services to configure via `AskUserQuestion` with `multiSelect: true`:
 
@@ -1353,7 +1472,7 @@ Ask which voice services to configure via `AskUserQuestion` with `multiSelect: t
 
 #### Bland AI
 
-Ask for the API key:
+If `BLAND_AI_API_KEY` or `BLAND_API_KEY` was found in the auto-scan, present it using the Universal Credential Auto-Scan prompt format. Only ask via free text if not found:
 ```
 Enter your Bland AI API Key:
   To find it: https://app.bland.ai → Settings → API Key
@@ -1367,7 +1486,7 @@ Expect a non-null user ID.
 
 #### ElevenLabs
 
-Ask for the API key:
+If `ELEVENLABS_API_KEY` was found in the auto-scan, present it using the Universal Credential Auto-Scan prompt format. Only ask via free text if not found:
 ```
 Enter your ElevenLabs API Key:
   To find it: https://elevenlabs.io → Profile (top-right) → API Key
@@ -1381,7 +1500,7 @@ Expect a subscription tier string (e.g. `"free"`, `"starter"`).
 
 #### Groq
 
-Ask for the API key:
+If `GROQ_API_KEY` was found in the auto-scan, present it using the Universal Credential Auto-Scan prompt format. Only ask via free text if not found:
 ```
 Enter your Groq API Key:
   To generate one: https://console.groq.com → API Keys → Create API Key

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -1080,7 +1080,7 @@ Add to the shortcuts table: `vault`, `password-manager`, `pm` → Step 3g
 
 ---
 
-### 3h — Ecommerce (Shopify + ShipBob)
+### 3h — Ecommerce (Shopify + dynamic partners)
 
 #### Step 3h.1 — Check existing config
 
@@ -1095,7 +1095,7 @@ If both `store_url` and `admin_token` are already set, show:
 ✓ Shopify — already configured (<store_url>)
   [Keep existing]  [Reconfigure]
 ```
-If the user keeps existing, skip to the ShipBob check. If reconfiguring or not set, continue.
+If the user keeps existing, skip to Step 3h.4. If reconfiguring or not set, continue.
 
 #### Step 3h.2 — Shopify store URL
 
@@ -1121,45 +1121,16 @@ Enter your Shopify Admin API access token:
   Token starts with "shpat_"
 ```
 
-#### Step 3h.4 — ShipBob (optional)
-
-Ask via `AskUserQuestion`:
-```
-Do you use ShipBob for fulfillment?
-  [Yes — enter ShipBob API token]  [Skip ShipBob]
-```
-
-If Yes, ask for the ShipBob personal access token (explain: ShipBob dashboard → Integrations → API Tokens).
-
-#### Step 3h.5 — Save to preferences
-
-Write to `$PREFS_PATH` (merge):
-```json
-{
-  "ecom": {
-    "shopify": {
-      "store_url": "<yourstore.myshopify.com>",
-      "admin_token": "<shpat_...>"
-    },
-    "shipbob": {
-      "api_token": "<token_or_null>"
-    }
-  }
-}
-```
-
-Do NOT store the admin token in plaintext preferences if Doppler is configured — instead write the Doppler reference and save the actual token to Doppler:
+Save to `$PREFS_PATH` under `ecom.shopify`. Apply the Doppler-reference pattern — if Doppler is configured, run:
 ```bash
 doppler secrets set SHOPIFY_ADMIN_TOKEN="<token>" --project <project> --config <config>
 ```
-Then store `"admin_token": "doppler:SHOPIFY_ADMIN_TOKEN"` in preferences.
+and store `"admin_token": "doppler:SHOPIFY_ADMIN_TOKEN"` in preferences instead of the raw token.
 
-#### Step 3h.6 — Smoke test
-
+Smoke test:
 ```bash
 STORE=$(jq -r '.ecom.shopify.store_url' "$PREFS_PATH")
 TOKEN=$(jq -r '.ecom.shopify.admin_token' "$PREFS_PATH")
-# Resolve Doppler reference if needed
 if [[ "$TOKEN" == doppler:* ]]; then
   KEY="${TOKEN#doppler:}"
   TOKEN=$(doppler secrets get "$KEY" --plain 2>/dev/null)
@@ -1167,13 +1138,78 @@ fi
 curl -s -H "X-Shopify-Access-Token: $TOKEN" \
   "https://$STORE/admin/api/2024-10/shop.json" | jq '.shop.name'
 ```
+Expect a shop name string. If the response contains `errors` or `{"shop":null}`, show the error and ask the user to check the token scopes. Print `✓ Shopify — connected (<shop name>)`.
 
-Expect a shop name string. If the response contains `errors` or `{"shop":null}`, show the error and ask the user to check the token scopes.
+#### Step 3h.4 — Dynamic ecommerce partners
 
-Print:
+After Shopify is configured, ask via `AskUserQuestion` (free text):
 ```
-✓ Shopify — connected (<shop name>)
+Do you use any other ecommerce tools you'd like to connect?
+  Examples: ShipBob (fulfillment), Recharge (subscriptions), Yotpo (reviews),
+            Shippo (shipping rates), Gorgias (support), Attentive (SMS), Loop (returns)
+  Type the names separated by commas, or leave blank to skip.
 ```
+
+If the user provides partner names, process each one in a loop:
+
+**For each partner:**
+
+1. **Research credentials** — web search: `"<partner name> API authentication developer docs 2025"`. Determine:
+   - What credentials are needed (API key, OAuth token, webhook secret, base URL, account ID, etc.)
+   - The API base URL
+   - A suitable health/auth endpoint to smoke test (e.g. `/me`, `/account`, `/v1/ping`, list endpoint with limit=1)
+   - The auth header pattern (`Authorization: Bearer`, `X-Api-Key`, custom header, etc.)
+
+2. **Ask for each credential** via `AskUserQuestion` (one question per credential field), citing where to find it based on what the docs say. Example for ShipBob:
+   ```
+   Enter your ShipBob Personal Access Token:
+     To generate: ShipBob dashboard → Integrations → API → Personal Access Tokens → Create Token
+   ```
+
+3. **Smoke test** using the auth endpoint discovered in step 1:
+   ```bash
+   curl -s -H "<auth_header>: $TOKEN" "<base_url>/<health_endpoint>" | jq '.<identity_field>'
+   ```
+   Show the result. If it fails, show the raw response and offer `[Re-enter credentials]` / `[Skip this partner]`.
+
+4. **Save to preferences** under `ecom.partners.<partner_slug>` where `partner_slug` is the lowercased, hyphenated partner name:
+   ```json
+   {
+     "ecom": {
+       "partners": {
+         "shipbob": {
+           "api_base_url": "https://developer.shipbob.com/v1",
+           "auth_pattern": "Authorization: Bearer <token>",
+           "credentials": { "api_token": "doppler:SHIPBOB_API_TOKEN" },
+           "health_endpoint": "/user",
+           "configured_at": "<ISO timestamp>"
+         }
+       }
+     }
+   }
+   ```
+   Store actual secrets via Doppler (key: `<PARTNER_SLUG_UPPER>_API_TOKEN`) when Doppler is configured, else store inline. The `auth_pattern` and `api_base_url` fields are the memory that future `/ops:ecom` calls use to reach the partner — always populate them from the researched docs.
+
+5. **Print confirmation**:
+   ```
+   ✓ <Partner Name> — connected
+   ```
+
+6. **Loop**: After each partner, ask `AskUserQuestion`: "Any other ecommerce tools to connect?" → `[Yes — add another]` / `[Done]`. This lets users add partners one at a time if they prefer over the initial comma-separated list.
+
+**Partners with known credential patterns** (use these directly without searching, but still verify with a smoke test):
+
+| Partner    | Auth header                              | Base URL                               | Health endpoint        |
+| ---------- | ---------------------------------------- | -------------------------------------- | ---------------------- |
+| ShipBob    | `Authorization: Bearer <token>`          | `https://developer.shipbob.com/v1`     | `/user`                |
+| Recharge   | `X-Recharge-Access-Token: <token>`       | `https://api.rechargeapayments.com/v1` | `/shop`                |
+| Yotpo      | `X-Api-Key: <app_key>`                   | `https://api.yotpo.com`                | `/core/v3/stores/<id>` |
+| Shippo     | `Authorization: ShippoToken <token>`     | `https://api.goshippo.com`             | `/carrier_accounts`    |
+| Gorgias    | `Authorization: Basic <base64>`          | `https://<domain>.gorgias.com/api`     | `/account`             |
+| Loop       | `x-loop-signature: <secret>`             | `https://api.loopreturns.com/api/v1`   | `/warehouse`           |
+| Attentive  | `Authorization: Bearer <token>`          | `https://api.attentivemobile.com/v1`   | `/me`                  |
+
+For any partner not in this table, always web search for current auth docs before asking for credentials.
 
 ---
 
@@ -1254,6 +1290,52 @@ Write to `$PREFS_PATH` (merge):
 ```
 
 Same Doppler-reference pattern as Step 3h — prefer `doppler:KEY_NAME` over raw tokens when Doppler is configured.
+
+#### Dynamic marketing partners
+
+After the known services, ask via `AskUserQuestion` (free text):
+```
+Any other marketing tools you'd like to connect?
+  Examples: Postscript (SMS), Privy (popups), Triple Whale (attribution), Northbeam,
+            Hotjar, Heap, Segment, Mixpanel, Mailchimp, ActiveCampaign, HubSpot
+  Type names separated by commas, or leave blank to skip.
+```
+
+If the user provides partner names, apply the same dynamic partner loop as Step 3h.4 — for each partner:
+
+1. **Research credentials** via web search: `"<partner name> API authentication developer docs 2025"`
+2. **Ask for credentials** via `AskUserQuestion` with instructions sourced from the docs
+3. **Smoke test** against the auth/health endpoint
+4. **Save to preferences** under `marketing.partners.<partner_slug>`:
+   ```json
+   {
+     "marketing": {
+       "partners": {
+         "triple-whale": {
+           "api_base_url": "https://api.triplewhale.com/api/v2",
+           "auth_pattern": "Authorization: Bearer <token>",
+           "credentials": { "api_key": "doppler:TRIPLE_WHALE_API_KEY" },
+           "health_endpoint": "/attribution/get-attribution-data",
+           "configured_at": "<ISO timestamp>"
+         }
+       }
+     }
+   }
+   ```
+5. **Loop** — offer `[Add another]` / `[Done]` after each partner.
+
+**Partners with known credential patterns** (use directly, still smoke test):
+
+| Partner       | Auth header                            | Base URL                                       | Health endpoint     |
+| ------------- | -------------------------------------- | ---------------------------------------------- | ------------------- |
+| HubSpot       | `Authorization: Bearer <token>`        | `https://api.hubapi.com`                       | `/crm/v3/objects/contacts?limit=1` |
+| Mailchimp     | `Authorization: Bearer <api_key>`      | `https://<dc>.api.mailchimp.com/3.0`           | `/ping`             |
+| Segment       | `Authorization: Basic <base64_key:>`   | `https://api.segment.io/v1`                    | n/a — use write key |
+| Mixpanel      | `Authorization: Basic <base64_secret:>` | `https://data.mixpanel.com/api/2.0`           | `/engage?limit=1`   |
+| Postscript    | `Authorization: ApiKey <key>`          | `https://api.postscript.io/api/v2`             | `/shops`            |
+| Triple Whale  | `Authorization: Bearer <token>`        | `https://api.triplewhale.com/api/v2`           | `/attribution/get-attribution-data` |
+
+For any partner not in this table, always web search for current auth docs before asking for credentials.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a top-level **Universal Credential Auto-Scan** section that defines the full 8-source scan sequence (env, shell profiles, Doppler all projects, Dashlane, macOS Keychain, OpenClaw, MCP configs, prefs) with a complete env-var → service-keyword mapping table
- **Step 3h (ecom)**: runs auto-scan for all `SHOPIFY_*` vars before asking for store URL or admin token; checks Doppler across all projects, Dashlane `shopify`, Keychain, and OpenClaw
- **Step 3i (marketing)**: runs auto-scan for `KLAVIYO_*`, `META_*`, `FACEBOOK_*`, `GA4_*` before showing the service selector; caches results for each sub-step (Klaviyo, Meta, GA4)
- **Step 3j (voice)**: runs auto-scan for `BLAND_*`, `ELEVENLABS_*`, `GROQ_*` before showing the service selector; explicitly checks OpenClaw as a known source for AI service keys
- The existing "Shared: credential auto-scan" section is preserved but scoped to channel tokens (Telegram/Slack) and now references the new universal pattern

## Test plan
- [ ] Run `/ops:setup ecom` with `SHOPIFY_ACCESS_TOKEN` set in env — wizard should present found value instead of prompting
- [ ] Run `/ops:setup marketing` with Klaviyo key in Doppler — should show with `(doppler:<proj>/prd)` attribution
- [ ] Run `/ops:setup voice` with `GROQ_API_KEY` in OpenClaw config — should be detected and presented
- [ ] Run with no vars set anywhere — wizard should fall through to manual prompts with dashboard links

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands credential discovery guidance to scan more secret sources (Doppler across projects, Dashlane, macOS Keychain, OpenClaw, prefs) and encourages dynamic partner integrations, which could increase the chance of mis-attributing or mishandling sensitive values if implemented incorrectly.
> 
> **Overview**
> Adds a top-level **Universal Credential Auto-Scan** spec that standardizes how the setup wizard should discover existing credentials (env, shell profiles, Doppler across projects/configs, Dashlane, macOS Keychain, OpenClaw, MCP configs, and existing prefs) and how to present/confirm matches to avoid unnecessary manual key entry.
> 
> Updates setup flows to **run the scan before prompting** for Shopify, marketing (Klaviyo/Meta/GA4), and voice (Bland/ElevenLabs/Groq) credentials, and introduces **dynamic “partner” loops** for ecommerce and marketing that capture auth patterns/base URLs, smoke-test endpoints, and persist partner configs under `ecom.partners.*` / `marketing.partners.*` with Doppler references when available.
> 
> Scopes the prior channel token auto-scan section to Telegram/Slack and aligns it to reference the universal pattern (including new token truncation and “enter a different one” UX rules).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cb8b626b40071243fb188c5f7da3fa56d1060c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->