### PR TITLE
fix: resilient telegram extraction + correct GSD repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,47 +157,43 @@ All skills use pre-execution shell blocks (`!` fences) that gather data *before*
 
 **Plugin Structure**
 
+> **Why the nested `claude-ops/claude-ops/` directory?** Claude Code's plugin marketplace system requires a two-level layout: the **repo root** acts as a marketplace container (with `.claude-plugin/marketplace.json` pointing `"source": "./claude-ops"`), while the **inner directory** is the actual plugin root (with `.claude-plugin/plugin.json`, skills, agents, etc.). This is how Claude Code resolves and caches plugins — it cannot be flattened.
+
 ```
-claude-ops/
+claude-ops/                        ← marketplace root (repo)
 ├── .claude-plugin/
-│   └── plugin.json            # Plugin manifest + userConfig schema
+│   └── marketplace.json           # Points to ./claude-ops as the plugin source
+├── README.md                      # This file
 │
-├── skills/                    # 14 slash command skills
-│   ├── ops/                   # Router — dispatches to sub-skills
-│   ├── ops-go/                # Morning briefing
-│   ├── ops-inbox/             # Unified inbox
-│   ├── ops-comms/             # Cross-channel messaging
-│   ├── ops-merge/             # Autonomous PR pipeline
-│   ├── ops-fires/             # Production incidents
-│   ├── ops-deploy/            # Deploy status
-│   ├── ops-revenue/           # Cost tracking
-│   ├── ops-projects/          # Portfolio dashboard
-│   ├── ops-linear/            # Sprint management
-│   ├── ops-triage/            # Issue triage
-│   ├── ops-next/              # Next action advisor
-│   ├── ops-yolo/              # YOLO autonomous mode
-│   └── setup/                 # Interactive setup wizard
-│
-├── agents/                    # 9 autonomous agents
-│   ├── yolo-ceo.md            # CEO synthesizer (Opus)
-│   ├── yolo-cto.md            # CTO technical analysis
-│   ├── yolo-cfo.md            # CFO financial analysis
-│   ├── yolo-coo.md            # COO operations analysis
-│   ├── triage-agent.md        # Issue investigation + fix
-│   ├── comms-scanner.md       # Inbox state scanner
-│   ├── infra-monitor.md       # Infrastructure health
-│   ├── project-scanner.md     # Project portfolio scanner
-│   └── revenue-tracker.md     # Revenue/cost monitor
-│
-├── bin/                       # Shell scripts + ops-shopify-create
-├── hooks/                     # SessionStart health check
-├── telegram-server/           # Bundled MCP server (gram.js)
-├── templates/                 # App scaffolding templates
-│   └── shopify-admin-app/     # Shopify Admin Remix template
-├── tests/                     # Bash-based validation suite
-├── scripts/                   # Setup scripts + project registry
-├── CLAUDE.md                  # Plugin-root rules (AskUserQuestion <=4, no delegation)
-└── .mcp.json                  # MCP server declarations
+└── claude-ops/                    ← plugin root (where Claude Code loads from)
+    ├── .claude-plugin/
+    │   └── plugin.json            # Plugin manifest + userConfig schema
+    │
+    ├── skills/                    # 14 slash command skills
+    │   ├── ops/                   # Router — dispatches to sub-skills
+    │   ├── ops-go/                # Morning briefing
+    │   ├── ops-inbox/             # Unified inbox
+    │   ├── ops-comms/             # Cross-channel messaging
+    │   ├── ops-merge/             # Autonomous PR pipeline
+    │   ├── ops-fires/             # Production incidents
+    │   ├── ops-deploy/            # Deploy status
+    │   ├── ops-revenue/           # Cost tracking
+    │   ├── ops-projects/          # Portfolio dashboard
+    │   ├── ops-linear/            # Sprint management
+    │   ├── ops-triage/            # Issue triage
+    │   ├── ops-next/              # Next action advisor
+    │   ├── ops-yolo/              # YOLO autonomous mode
+    │   └── setup/                 # Interactive setup wizard
+    │
+    ├── agents/                    # 9 autonomous agents
+    ├── bin/                       # Shell scripts + ops-shopify-create
+    ├── hooks/                     # SessionStart health check
+    ├── telegram-server/           # Bundled MCP server (gram.js)
+    ├── templates/                 # App scaffolding templates
+    ├── tests/                     # Bash-based validation suite
+    ├── scripts/                   # Setup scripts + project registry
+    ├── CLAUDE.md                  # Plugin-root rules
+    └── .mcp.json                  # MCP server declarations
 ```
 
 ```

--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -113,7 +113,7 @@ The setup wizard (`/ops:setup`) walks through each one interactively. You choose
 | Integration | What it is | Setup |
 |-------------|-----------|-------|
 | Telegram MCP server | gram.js MTProto user-auth — reads your DMs (not a bot) | `/ops:setup telegram` — enter phone number + 2 verification codes, everything else is fully automated (app creation, session generation, keychain storage) |
-| [GSD](https://github.com/Lifecycle-Innovations-Limited/get-shit-done) | Project roadmap state in dashboards | Auto-detected. Skills degrade gracefully without it |
+| [GSD](https://github.com/gsd-build/get-shit-done) | Project roadmap state in dashboards | Auto-detected. Skills degrade gracefully without it |
 
 ## Installation
 

--- a/claude-ops/bin/ops-telegram-autolink.mjs
+++ b/claude-ops/bin/ops-telegram-autolink.mjs
@@ -216,22 +216,85 @@ emit({ type: "step", message: "GET /apps" });
 let appsRes = await httpGet("https://my.telegram.org/apps");
 let appsHtml = await appsRes.text();
 
-// Parse selectors based on esfelurm/Apis-Telegram reference:
-//   <label>App api_id:</label> ... <div>...<span>12345678</span>...
-// Works as long as my.telegram.org keeps its server-side HTML shape.
+/**
+ * Extract api_id and api_hash from my.telegram.org /apps HTML.
+ * Uses a cascade of increasingly broad strategies so HTML layout
+ * changes don't break extraction. The values have known formats:
+ *   api_id  = 5-12 digit number
+ *   api_hash = 32-char lowercase hex string
+ * These formats are stable (Telegram API contract), only the HTML
+ * wrapping changes.
+ */
 function extract(html) {
-  const idMatch = html.match(
-    /App api_id[^<]*<\/label>[\s\S]*?<span[^>]*>\s*(\d{5,12})\s*<\/span>/i,
+  let apiId = null;
+  let apiHash = null;
+
+  // Strategy 1: label + nearby span (original layout)
+  const idS1 = html.match(
+    /api_id[^<]*<\/label>[\s\S]*?<span[^>]*>\s*(\d{5,12})\s*<\/span>/i,
   );
-  const hashMatch = html.match(
-    /App api_hash[^<]*<\/label>[\s\S]*?<span[^>]*>\s*([a-f0-9]{32})\s*<\/span>/i,
+  const hashS1 = html.match(
+    /api_hash[^<]*<\/label>[\s\S]*?<span[^>]*>\s*([a-f0-9]{32})\s*<\/span>/i,
   );
-  // Fallback: plain code tags sometimes used
-  const altHash = html.match(/api_hash[^<]*<[^>]+>\s*([a-f0-9]{32})/i);
-  return {
-    apiId: idMatch ? idMatch[1] : null,
-    apiHash: hashMatch ? hashMatch[1] : altHash ? altHash[1] : null,
-  };
+  if (idS1) apiId = idS1[1];
+  if (hashS1) apiHash = hashS1[1];
+
+  // Strategy 2: api_id/api_hash near any tag containing the value
+  if (!apiId) {
+    const idS2 = html.match(/api_id[^<]*<[^>]+>\s*(\d{5,12})\s*</i);
+    if (idS2) apiId = idS2[1];
+  }
+  if (!apiHash) {
+    const hashS2 = html.match(/api_hash[^<]*<[^>]+>\s*([a-f0-9]{32})\s*</i);
+    if (hashS2) apiHash = hashS2[1];
+  }
+
+  // Strategy 3: value in any tag on same line or nearby text as keyword
+  if (!apiId) {
+    const idS3 = html.match(/api_id[\s\S]{0,200}?(\d{5,12})/i);
+    if (idS3) apiId = idS3[1];
+  }
+  if (!apiHash) {
+    const hashS3 = html.match(/api_hash[\s\S]{0,200}?([a-f0-9]{32})/i);
+    if (hashS3) apiHash = hashS3[1];
+  }
+
+  // Strategy 4: input/hidden fields with api_id/api_hash as name or id
+  if (!apiId) {
+    const idS4 = html.match(
+      /(?:name|id)=['"]?api_id['"]?[^>]*value=['"]?(\d{5,12})['"]?/i,
+    );
+    if (idS4) apiId = idS4[1];
+  }
+  if (!apiHash) {
+    const hashS4 = html.match(
+      /(?:name|id)=['"]?api_hash['"]?[^>]*value=['"]?([a-f0-9]{32})['"]?/i,
+    );
+    if (hashS4) apiHash = hashS4[1];
+  }
+
+  // Strategy 5: brute-force — strip all HTML tags and look for the
+  // characteristic patterns near their keywords in plain text
+  if (!apiId || !apiHash) {
+    const text = html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ");
+    if (!apiId) {
+      const idS5 = text.match(/api_id\s*:?\s*(\d{5,12})/i);
+      if (idS5) apiId = idS5[1];
+    }
+    if (!apiHash) {
+      const hashS5 = text.match(/api_hash\s*:?\s*([a-f0-9]{32})/i);
+      if (hashS5) apiHash = hashS5[1];
+    }
+  }
+
+  // Strategy 6: last resort — find ANY 32-char hex string on the page
+  // (api_hash is the only value with that exact shape on /apps)
+  if (!apiHash) {
+    const hexes = html.match(/\b[a-f0-9]{32}\b/g);
+    if (hexes && hexes.length === 1) apiHash = hexes[0];
+  }
+
+  return { apiId, apiHash };
 }
 
 let { apiId, apiHash } = extract(appsHtml);
@@ -268,8 +331,17 @@ if (!apiId || !apiHash) {
 }
 
 if (!apiId || !apiHash) {
+  // Dump a snippet of the HTML so the caller can diagnose what changed
+  const snippet = appsHtml
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<style[\s\S]*?<\/style>/gi, "")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 500);
   die(
-    "could not extract api_id/api_hash from /apps HTML — selectors may have changed",
+    `could not extract ${!apiId ? "api_id" : ""}${!apiId && !apiHash ? " or " : ""}${!apiHash ? "api_hash" : ""} from /apps HTML after 6 extraction strategies`,
+    { html_snippet: snippet },
   );
 }
 

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -162,7 +162,7 @@ GSD is a third-party Claude Code plugin that adds project roadmap tracking. When
 Check if GSD is already installed:
 
 ```bash
-ls ~/.claude/plugins/cache/*/gsd*/skills/gsd-progress/SKILL.md 2>/dev/null && echo "installed" || echo "not_installed"
+ls ~/.claude/skills/gsd-progress/SKILL.md 2>/dev/null && echo "installed" || echo "not_installed"
 ```
 
 If not installed, ask via `AskUserQuestion`:
@@ -180,17 +180,17 @@ On install, run the commands directly — do NOT tell the user to run them manua
 
 ```bash
 # Install GSD in one shot — no user intervention needed
-claude plugin marketplace add Lifecycle-Innovations-Limited/get-shit-done 2>/dev/null && \
-claude plugin install gsd@Lifecycle-Innovations-Limited-get-shit-done 2>/dev/null
+claude plugin marketplace add gsd-build/get-shit-done 2>/dev/null && \
+claude plugin install gsd@gsd-build-get-shit-done 2>/dev/null
 ```
 
 If `claude` CLI is not available in the path, fall back to the plugin cache mechanism:
 
 ```bash
 # Direct marketplace clone fallback
-GSD_MARKETPLACE_DIR="$HOME/.claude/plugins/marketplaces/Lifecycle-Innovations-Limited-get-shit-done"
+GSD_MARKETPLACE_DIR="$HOME/.claude/plugins/marketplaces/gsd-build-get-shit-done"
 if [ ! -d "$GSD_MARKETPLACE_DIR" ]; then
-  git clone https://github.com/Lifecycle-Innovations-Limited/get-shit-done.git "$GSD_MARKETPLACE_DIR" 2>/dev/null
+  git clone https://github.com/gsd-build/get-shit-done.git "$GSD_MARKETPLACE_DIR" 2>/dev/null
 fi
 ```
 
@@ -199,7 +199,7 @@ Report success/failure. Record `plugins.gsd = "installed"` in `$PREFS_PATH`.
 If they skip:
 
 ```
-Skipped GSD. Install later with: /plugin marketplace add Lifecycle-Innovations-Limited/get-shit-done
+Skipped GSD. Install later with: /plugin marketplace add gsd-build/get-shit-done
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Telegram autolink `extract()` now uses 6 cascading regex strategies to find `api_id`/`api_hash` regardless of HTML layout changes on my.telegram.org
- GSD plugin references updated from non-existent `Lifecycle-Innovations-Limited/get-shit-done` to the actual public repo `gsd-build/get-shit-done`
- Detection path updated from plugin cache to `~/.claude/skills/gsd-progress/`

## Test plan
- [ ] Run `/ops:setup` and verify GSD install step uses correct repo URL
- [ ] Run telegram autolink against current my.telegram.org HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the Telegram setup autolink parsing logic and related error handling, which could impact onboarding if the new heuristics mis-extract credentials; other changes are documentation and repo/link updates.
> 
> **Overview**
> Improves the Telegram setup flow by rewriting `ops-telegram-autolink.mjs` credential scraping to use multiple fallback extraction strategies for `api_id`/`api_hash`, and enhances failure diagnostics with an HTML text snippet in the error payload.
> 
> Updates all GSD companion-plugin references (docs and setup instructions) to the correct `gsd-build/get-shit-done` repo and switches the install detection check to `~/.claude/skills/gsd-progress/SKILL.md`. Also clarifies the required nested marketplace vs plugin-root directory structure in the top-level `README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad21a1b3c74cc08c279290ae4cb742ee645ce094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->