### PR TITLE
fix: prevent telegram rate-limit cascade in setup

### DIFF
--- a/claude-ops/bin/ops-telegram-autolink.mjs
+++ b/claude-ops/bin/ops-telegram-autolink.mjs
@@ -81,7 +81,7 @@ async function waitForCode(maxSec = 300) {
   while (Date.now() - start < maxSec * 1000) {
     if (existsSync(CODE_FILE)) {
       const raw = readFileSync(CODE_FILE, "utf8").trim();
-      if (/^[\w]{3,20}$/.test(raw)) {
+      if (/^[\w\-]{3,20}$/.test(raw)) {
         try {
           unlinkSync(CODE_FILE);
         } catch {}

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -347,6 +347,8 @@ Set up Telegram personal account access?
 
 If the user skips, record `channels.telegram = "skipped"` in `$PREFS_PATH` and move on. Do NOT silently mark Telegram as unconfigured — the explicit skip prevents the status header from showing `○ telegram (no token)` as an action item on subsequent runs.
 
+**Rate-limit guard**: Before starting, check `$PREFS_PATH` for `channels.telegram.status == "rate_limited"`. If `retry_after` is in the future, tell the user: `"Telegram rate-limited until [time]. Skipping — re-run /ops:setup telegram after [time]."` and move to the next channel. Do NOT attempt `send_password` — it will fail immediately and may extend the cooldown.
+
 **Bots cannot read user DMs**, so `/ops-inbox telegram` requires a personal-account MCP. The plugin ships `bin/ops-telegram-autolink.mjs` which:
 
 1. Scans scout sources (keychain → ~/.claude.json → shell profiles → Doppler) for previously-extracted `TELEGRAM_API_ID` / `TELEGRAM_API_HASH` / `TELEGRAM_SESSION`.
@@ -381,12 +383,20 @@ Sub-flow (only runs if user selected Yes above):
 
 5. **Poll the stderr log for `need_code` events.** Every 3 seconds, read `/tmp/ops-telegram-autolink.log` and look for the most recent `{"type":"need_code", ...}` line that hasn't been answered yet. When you see one:
    - Determine which code: `channel: "web_login"` (first) or `channel: "gram_auth"` (second).
-   - Use `AskUserQuestion` with a free-text input: `"Enter the code Telegram just sent to your Telegram app (digits only):"`.
-   - Write the digits to `/tmp/telegram-code.txt` with restrictive perms: `Bash: (umask 077 && printf '%s' "$CODE" > /tmp/telegram-code.txt)`. The `umask 077` is critical — without it the file is created world-readable on macOS (where `/tmp` is `drwxrwxrwt`) and any local process can race to read the code during the 2s poll window.
+   - Use `AskUserQuestion` with a free-text input: `"Enter the code Telegram just sent to your Telegram app:"`. **Do NOT say "digits only"** — Telegram web login codes can contain letters, hyphens, and underscores (e.g. `Zv_-ef77YSU`). The autolink's bridge file accepts any 3-20 character alphanumeric+hyphen+underscore string.
+   - Write the code to `/tmp/telegram-code.txt` with restrictive perms: `Bash: (umask 077 && printf '%s' "$CODE" > /tmp/telegram-code.txt)`. The `umask 077` is critical — without it the file is created world-readable on macOS (where `/tmp` is `drwxrwxrwt`) and any local process can race to read the code during the 2s poll window.
+   - **Verify the code was consumed** within 10 seconds: `ls /tmp/telegram-code.txt 2>/dev/null`. If the file still exists after 10s, the script's validation regex rejected the code. Read the log for errors. Do NOT re-run the script or request a new code — that burns a login attempt.
    - Wait for the next event.
    - If you see `{"type":"need_password"}`, handle 2FA: ask the user via `AskUserQuestion` and write to `/tmp/telegram-password.txt` with `(umask 077 && printf '%s' "$PW" > /tmp/telegram-password.txt)`. Same perm hardening as the code file. The 2FA password is far more sensitive than a one-time code.
 
 6. **Wait for the script to exit.** Poll until the process is no longer running (`ps -p "$(cat /tmp/ops-telegram-autolink.pid)"`). Read `/tmp/ops-telegram-autolink.out` — it should contain a single JSON line with `api_id`, `api_hash`, `phone`, and `session`. **Security note**: the setup skill should have dispatched the autolink with `(umask 077 && node "${CLAUDE_PLUGIN_ROOT}/bin/ops-telegram-autolink.mjs" --phone "$PHONE" 2>/tmp/ops-telegram-autolink.log 1>/tmp/ops-telegram-autolink.out &)` so the .log and .out files get 0600 mode. Verify with `stat -f '%Lp' /tmp/ops-telegram-autolink.out` → must print `600`. Immediately `shred -u` (Linux) or `rm -P` (macOS) the .out file after reading the credentials into memory.
+
+   **Error recovery — CRITICAL: do NOT burn login attempts.** Each `send_password` call counts toward Telegram's rate limit (~3-5 per 8 hours). If the autolink fails:
+
+   - **`"selectors may have changed"` / extraction failure**: The HTML parsing failed but the login succeeded. Do NOT re-run the script. Instead, check if the error includes `html_snippet` — the snippet shows the stripped page text. If it contains a 5-12 digit number near "api_id" and a 32-char hex near "api_hash", extract them directly with grep/regex from the snippet. If the snippet shows a login page or redirect, the session expired during extraction.
+   - **`rate-limited`**: Record `channels.telegram.status = "rate_limited"` and `channels.telegram.retry_after` (now + 8 hours) in `$PREFS_PATH`. Move on to the next channel. On subsequent `/ops:setup` runs, check `retry_after` and skip Telegram if the cooldown hasn't expired.
+   - **Code file not consumed**: If `/tmp/telegram-code.txt` still exists 10+ seconds after writing, the validation regex rejected it. Read the file contents and the log. Do NOT ask the user for another code — the original code is still valid, you just need to fix the bridge.
+   - **General rule**: You get at most 2 `send_password` attempts per setup session. If the first attempt fails for a non-rate-limit reason, diagnose the root cause before trying again. If the second attempt fails, save state and move on.
 
 7. **Persist to keychain + preferences.** macOS only:
 


### PR DESCRIPTION
## Summary
- Code validation regex now accepts hyphens (Telegram codes like `Zv_-ef77YSU`)
- Setup skill no longer tells user "digits only" for Telegram codes
- Rate-limit guard checks prefs before attempting `send_password`
- Error recovery guidance: diagnose root cause before retrying, max 2 attempts per session
- Code-file-not-consumed detection with 10s verification step

Prevents the failure cascade where: bad regex → code rejected → script times out → Claude retries → rate-limited → 8hr lockout.

## Test plan
- [ ] Verify autolink accepts codes with hyphens/underscores
- [ ] Verify setup skips Telegram when rate-limited in prefs
- [ ] Verify "digits only" text removed from AskUserQuestion prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Telegram authentication/setup flow and changes code validation, so mistakes could still block setup or mishandle cooldown state, but the change set is small and well-scoped.
> 
> **Overview**
> Prevents Telegram setup from failing on valid web-login codes by widening the autolink bridge-file validation to accept hyphens/underscores (3–20 chars), not just word characters.
> 
> Updates the setup skill’s Telegram instructions to stop prompting for *digits only*, add a prefs-based **rate-limit cooldown guard**, and introduce a 10s “code consumed” verification plus **error-recovery rules** to avoid re-running the flow and burning limited `send_password` attempts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 141d42064c60c4c39c8e6b13ce11aad1b0284f18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->