### PR TITLE
feat: deep hunt fallback + never auto-skip rule

### DIFF
--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -330,7 +330,37 @@ Rules for the prompt:
 - If sources **disagree**, show each distinct value as a separate option. If there are more than 3 distinct values (rare), batch into multiple calls with `[More sources...]`.
 - Placeholder values like `${user_config.*}`, `<your-token>`, `CHANGE_ME`, or empty strings count as NOT FOUND.
 - Always include an `[Enter a different one]` option as the last option.
-- If NO source has a value, then and only then ask the user to provide it — show instructions for where to find it in the service's dashboard.
+- If NO source has a value, present the user with options via `AskUserQuestion`:
+
+```
+<SERVICE_NAME> — no credential found after scanning all sources.
+
+  [I have it — let me paste it]
+  [Deep hunt — spawn an agent to find it]
+  [Skip this service]
+```
+
+  - **"I have it"** → show instructions for where to find the credential in the service's dashboard, then accept free-text input.
+  - **"Deep hunt"** → spawn a Haiku subagent in the background with this mandate:
+
+    ```
+    Find the <CREDENTIAL_NAME> for <SERVICE_NAME>. Search exhaustively:
+    1. All Doppler projects and configs (dev/stg/prd/ci)
+    2. All .env* files across ~/Projects/ recursively
+    3. macOS Keychain (security find-generic-password with various service name patterns)
+    4. Dashlane CLI (dcli password <service> + related keywords)
+    5. Chrome browser — navigate to <service_admin_url> via Kapture/Playwright MCP, log in if needed, and extract the credential from the settings page
+    6. ~/.claude.json MCP server env vars
+    7. All shell profile files (~/.zshrc, ~/.bashrc, ~/.zprofile, ~/.envrc, ~/.config/fish/*)
+    8. 1Password CLI (op item list --tags <service>) if available
+    9. AWS Secrets Manager / SSM Parameter Store if aws cli authenticated
+
+    Return the credential value if found, or a detailed report of everywhere you checked and what you found (partial matches, expired tokens, wrong-format values).
+    ```
+
+    Use `Agent(subagent_type: "general-purpose", model: "haiku")` with `run_in_background: true`. Continue to the next service while the hunt runs. When the agent returns, present findings to the user for confirmation.
+
+  - **"Skip"** → record as skipped in `$PREFS_PATH`, move on.
 
 **On selection**, use the chosen value as the source of truth and — with the user's consent — optionally propagate it back to the other sources (e.g. "Also update ~/.zshrc and Doppler to match?"). Default to NO for propagation unless the user opts in.
 


### PR DESCRIPTION
## Summary
- When auto-scan finds nothing, offer 3 options: paste manually, deep hunt (Haiku subagent), or skip
- Deep hunt spawns background agent searching all auth sources + browser automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the setup wizard’s credential prompt flow; no runtime code or security logic is modified.
> 
> **Overview**
> Updates `setup/SKILL.md` to change the *no-credential-found* behavior in the Universal Credential Auto-Scan flow.
> 
> When nothing is discovered, the wizard must now present explicit options to **paste manually**, **run a background “deep hunt” Haiku subagent** with an expanded search mandate (Doppler, project `.env` files, keychain, password managers, AWS secrets, and optional browser automation), or **skip** and record the skip in `$PREFS_PATH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a11d16a7b0ffb027141b0957bdda978c50e027c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/60" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
