### PR TITLE
fix: never auto-skip + default all channels

### DIFF
--- a/claude-ops/CLAUDE.md
+++ b/claude-ops/CLAUDE.md
@@ -41,6 +41,10 @@ When a skill says "tell the user to run X in a separate terminal" or "Run `comma
 - **Password manager unlock** (`bw unlock`, `dcli configure`): run via Bash tool directly.
 - **Exception — QR-based auth** (`wacli auth`): this genuinely requires the user's phone camera pointed at the terminal. This is the ONLY case where you should tell the user to act in a separate terminal.
 
-## Rule 3 — Background by default during setup and configuration flows
+## Rule 3 — Never auto-skip channels or integrations
+
+During setup and configuration flows, NEVER silently skip a channel, service, or integration. If a credential isn't found or a step fails, the user MUST be given an explicit choice via `AskUserQuestion` with options like `[Paste manually]`, `[Deep hunt — spawn agent]`, `[Skip]`. The only acceptable way to skip is the user selecting "Skip". Do not move past a service just because auto-scan returned empty — that is precisely when the user needs to be asked.
+
+## Rule 4 — Background by default during setup and configuration flows
 
 During `/ops:setup` and any skill's setup/configure flow, use `run_in_background: true` on **every** Bash call unless you need the result immediately for the very next decision. This includes: credential scans, CLI installs, OAuth flows, npm installs, brew installs, autolink scripts, smoke tests, keychain writes, Doppler queries, Chrome history queries. While background commands run, continue to the next independent step or ask the user the next question. Never block the conversation waiting for a command the user isn't actively waiting for.

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -21,6 +21,7 @@ You are running an **interactive configuration wizard** for the `claude-ops` plu
 - This is a _conversation_, not a script dump. Use `AskUserQuestion` for every decision — never ask in prose when a structured selector will do.
 - Never install anything or write any file without explicit user confirmation via `AskUserQuestion`.
 - Skip sections the user declines. Don't nag.
+- **NEVER auto-skip a channel or integration.** Every channel/service the user selected must get an explicit `AskUserQuestion` with skip as one of the options. If a credential isn't found, present the [Paste manually] / [Deep hunt] / [Skip] options. If a smoke test fails, ask the user whether to retry, reconfigure, or skip. The ONLY acceptable way to skip is the user choosing a "Skip" option. Do not silently move past a service because scanning found nothing — that's when the user needs to be asked the most.
 - Show what's already configured first, so the user only fills gaps.
 - **Never show the user's real name or email in output unless the user explicitly provided it in THIS session.** Do not read from memory, existing configs, or environment variables to populate display names.
 - **Max 4 options per `AskUserQuestion` call.** The tool schema enforces `<=4` items in the `options` array. When a step lists >4 choices, filter already-configured items first, then batch the rest into multiple sequential calls of <=4 options each, grouped logically. Use `[More options...]` as the last option to bridge between batches.
@@ -1836,14 +1837,13 @@ Collect these via `AskUserQuestion` — one question each. **Never auto-fill fro
 
 5. **YOLO mode** → select `[Yes — auto-approve low-risk actions]`, `[No — always confirm]`.
 
-6. **Default channels** (multiSelect over configured channels only — never show channels that weren't configured in Step 3):
+6. **Default channels** (multiSelect over configured channels only — never show channels that weren't configured in Step 3). **"All configured" should be the first option and pre-selected by default** — most users want all their channels active:
    ```
    Which channels should ops skills use by default?
-     [ ] whatsapp
-     [ ] email
-     [ ] telegram
-     [ ] slack
+     [x] All configured channels
+     [ ] Pick specific channels...
    ```
+   If the user picks "specific channels", show a follow-up multiSelect with individual channel checkboxes. If they accept "All configured", set `default_channels` to the full list of configured channel names.
 
 Write to `$PREFS_PATH`:
 


### PR DESCRIPTION
## Summary
- Rule 3: never silently skip a channel/service — always present AskUserQuestion
- Default channels selector: "All configured" as first pre-selected option
- Renumbered background-by-default to Rule 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that alter setup wizard behavior expectations but do not change runtime code.
> 
> **Overview**
> **Setup guidance now forbids silent skips.** Adds a new global `Rule 3` in `CLAUDE.md` (and mirrors it in `skills/setup/SKILL.md`) requiring an explicit `AskUserQuestion` choice whenever a selected channel/service can’t be configured or a step fails; skipping is only allowed when the user selects a *Skip* option.
> 
> **Preferences UX updated.** The setup wizard’s *Default channels* step now defaults to **“All configured channels”** (pre-selected) with a follow-up selector only if the user opts to pick specific channels, and the background-by-default rule is renumbered to `Rule 4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67fe88aef64ee8030527d9a2a91b1150ed0881b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/61" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
