### PR TITLE
fix: default primary project to all active 7d

### DIFF
--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -1833,7 +1833,13 @@ Collect these via `AskUserQuestion` — one question each. **Never auto-fill fro
      [minimal]  — just the fires and urgent items
    ```
 
-4. **Primary project** → select from registry aliases (skip if registry is empty).
+4. **Primary project** → **"All projects active in last 7 days" should be the first/default option.** Most users working across multiple projects want a unified briefing, not a single-project focus:
+   ```
+   Primary project for briefings?
+     [All projects active in last 7 days]  ← default
+     [Pick a specific project...]
+   ```
+   If "specific project", show registry aliases paginated at 3 per page + `[More...]`. Store `"primary_project": "all_active_7d"` for the default, or the specific alias.
 
 5. **YOLO mode** → select `[Yes — auto-approve low-risk actions]`, `[No — always confirm]`.
 


### PR DESCRIPTION
Default option changed from single project to 'All projects active in last 7 days'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/62" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change updating setup wizard guidance for the `primary_project` preference; no runtime logic or data handling changes.
> 
> **Overview**
> Updates the setup wizard docs so the **default `primary_project` selection** becomes *All projects active in last 7 days* instead of forcing a single-project choice.
> 
> Specifies the new prompt flow (default option first, optional specific-project picker with pagination) and the stored preference value `primary_project: "all_active_7d"` when the default is chosen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 544d75c185c33f2887c53084420cae2284d5f623. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->