### PR TITLE
fix: require per-action confirmation for destructive ops

### DIFF
--- a/claude-ops/CLAUDE.md
+++ b/claude-ops/CLAUDE.md
@@ -45,6 +45,28 @@ When a skill says "tell the user to run X in a separate terminal" or "Run `comma
 
 During setup and configuration flows, NEVER silently skip a channel, service, or integration. If a credential isn't found or a step fails, the user MUST be given an explicit choice via `AskUserQuestion` with options like `[Paste manually]`, `[Deep hunt — spawn agent]`, `[Skip]`. The only acceptable way to skip is the user selecting "Skip". Do not move past a service just because auto-scan returned empty — that is precisely when the user needs to be asked.
 
+## Rule 5 — Destructive actions require explicit per-action confirmation
+
+**NEVER** execute or recommend executing any of the following without first confirming with the user via `AskUserQuestion` for EACH individual action:
+
+- Deleting infrastructure (ECS clusters, RDS instances, ALBs, NAT Gateways, S3 buckets, Lambda functions)
+- Stopping or scaling down running services
+- Canceling domain auto-renewals
+- Rewriting git history (`git filter-repo`, `git rebase`, force-push)
+- Archiving or deleting repositories
+- Disabling CI/CD pipelines or workflows
+- Purging container images (ECR, Docker)
+- Deleting CloudWatch alarms or log groups
+- Any `aws ... delete-*`, `aws ... stop-*`, `aws ... terminate-*` command
+
+**For analysis/report agents** (CTO, CFO, COO, CEO): When recommending infrastructure changes, always:
+1. Verify project status first — check for recent commits, active branches, planning directories, and registry status before labeling anything as "dead" or "archived"
+2. Distinguish "idle" (0 tasks but project is active) from "dead" (project abandoned, no commits in months, no planning)
+3. Flag all destructive recommendations with `⚠️ REQUIRES CONFIRMATION` so the orchestrator knows to ask
+4. Never assume a service scaled to 0 means the project is dead — it may be between deployments or paused intentionally
+
+**For orchestration skills** (ops-yolo, ops-orchestrate, ops-go): Before executing ANY destructive recommendation from a C-suite agent, present it to the user via `AskUserQuestion` with `[Execute]` / `[Skip]` options. Batch confirmations are acceptable (e.g., "Delete these 3 idle ALBs?") but never silently execute.
+
 ## Rule 4 — Background by default during setup and configuration flows
 
 During `/ops:setup` and any skill's setup/configure flow, use `run_in_background: true` on **every** Bash call unless you need the result immediately for the very next decision. This includes: credential scans, CLI installs, OAuth flows, npm installs, brew installs, autolink scripts, smoke tests, keychain writes, Doppler queries, Chrome history queries. While background commands run, continue to the next independent step or ask the user the next question. Never block the conversation waiting for a command the user isn't actively waiting for.

--- a/claude-ops/agents/yolo-ceo.md
+++ b/claude-ops/agents/yolo-ceo.md
@@ -145,3 +145,12 @@ Then write your synthesis to `/tmp/yolo-[session]/ceo-analysis.md`:
 ```
 
 Be specific. Reference actual data. Resolve CTO/CFO/COO conflicts with clear reasoning. No generic advice.
+
+## DESTRUCTIVE ACTION GUARDRAIL
+
+When synthesizing C-suite recommendations:
+1. **Cross-check "kill" recommendations** — if CTO or CFO says "delete" or "kill" a project, verify against COO's operational data and registry status. A project with recent commits, active branches, or planning is NOT dead.
+2. **"What to Kill" section must distinguish**: archive (stop work, keep infra) vs. mothball (stop work, reduce infra) vs. kill (delete everything). Default to mothball unless the project is confirmed abandoned.
+3. **Flag all destructive recommendations** with `⚠️ REQUIRES CONFIRMATION` — the YOLO orchestrator must present each to the user via AskUserQuestion before execution.
+4. **Never recommend canceling domains** for active projects. Verify project is truly abandoned first.
+5. **Err on the side of preservation** — reducing costs (disable Multi-AZ, delete idle ALBs, stop services) is safer than deleting permanently (drop RDS, delete clusters, cancel domains).

--- a/claude-ops/agents/yolo-cfo.md
+++ b/claude-ops/agents/yolo-cfo.md
@@ -158,3 +158,14 @@ Write to `/tmp/yolo-[session]/cfo-analysis.md`:
 ```
 
 Use real numbers. If you can't get a number, say so — don't estimate without data.
+
+## DESTRUCTIVE ACTION GUARDRAIL
+
+Before recommending deletion of ANY infrastructure or cancellation of ANY service:
+1. **Verify project status** — check registry entry, git log recency, active branches, .planning/ directory. A project with recent commits, active planning, or a completed v1.0 is NOT dead.
+2. **"Idle" ≠ "dead"** — a service scaled to 0 may be paused intentionally. Only recommend deletion if confirmed abandoned (no commits 30+ days, no planning, no active branches).
+3. **Flag all destructive recommendations** with `⚠️ REQUIRES CONFIRMATION` — the orchestrator will present each to the user via AskUserQuestion before execution.
+4. **Domain cancellations** — never recommend canceling domains for active projects. Verify the project is truly abandoned first.
+5. **RDS instances** — for active projects, recommend cost reduction (disable Multi-AZ, stop with restart management) NOT deletion.
+6. **ECR image purging** — always require verification that no active task definitions reference the images before recommending deletion.
+7. **Separate "cut" (stop spending) from "kill" (delete permanently)** — right-sizing and pausing are reversible; deletion is not.

--- a/claude-ops/agents/yolo-coo.md
+++ b/claude-ops/agents/yolo-coo.md
@@ -195,3 +195,12 @@ Write to `/tmp/yolo-[session]/coo-analysis.md`:
 ```
 
 No platitudes. Specific findings with specific fixes.
+
+## DESTRUCTIVE ACTION GUARDRAIL
+
+Before recommending deletion, shutdown, or cleanup of ANY infrastructure:
+1. **Verify project status** — check git log recency, active branches, .planning/ directory, and registry entry before labeling anything as zombie/idle/abandoned
+2. **"Idle" ≠ "dead"** — a service with 0 tasks may be an active project paused between deployments or awaiting relaunch. Only flag as zombie if: no commits in 30+ days AND no active planning AND no active branches
+3. **Flag all destructive recommendations** with `⚠️ REQUIRES CONFIRMATION` — the orchestrator will present each to the user via AskUserQuestion before execution
+4. **RDS/cluster deletion** — for active projects, recommend cost reduction (disable Multi-AZ, manage restart cycle, delete idle ALB only) NOT full deletion
+5. **Automations that delete** — never include automated deletion scripts (snapshot + delete, purge, etc.) without the confirmation flag

--- a/claude-ops/agents/yolo-cto.md
+++ b/claude-ops/agents/yolo-cto.md
@@ -156,3 +156,12 @@ Highest risk: [package] [vuln]
 ```
 
 Be specific. Reference actual file paths and line numbers where possible. No generic "improve code quality" advice.
+
+## DESTRUCTIVE ACTION GUARDRAIL
+
+Before recommending deletion, shutdown, or removal of ANY infrastructure:
+1. **Verify project status** — check git log recency, active branches, .planning/ directory, and registry entry
+2. **"Idle" ≠ "dead"** — a service with desiredCount=0 may be an active project between deployments. Only label as DEAD if: no commits in 30+ days AND no active planning AND confirmed abandoned by user
+3. **Flag all destructive recommendations** with `⚠️ REQUIRES CONFIRMATION` — the orchestrator will present these to the user individually via AskUserQuestion before execution
+4. **git filter-repo** — always note that this rewrites ALL history, breaks open PRs/forks, and may not be worth the tradeoff. Suggest credential rotation + .gitignore as the safer default
+5. **Never recommend deleting RDS instances** for active projects — suggest disabling Multi-AZ or stopping (with restart management) instead

--- a/claude-ops/bin/ops-unread
+++ b/claude-ops/bin/ops-unread
@@ -83,7 +83,7 @@ except:
     print(0)
 " 2>/dev/null || echo "0")
     [[ "$EMAIL_COUNT" =~ ^[0-9]+$ ]] || EMAIL_COUNT="0"
-    RESULT=$(echo "$RESULT" | jq --argjson c "$EMAIL_COUNT" '.channels.email = {"unread": $c, "available": true}')
+    RESULT=$(echo "$RESULT" | jq --argjson c "$EMAIL_COUNT" '.channels.email = {"inbox_count": $c, "available": true}')
   else
     RESULT=$(echo "$RESULT" | jq '.channels.email = {"unread": 0, "available": false, "note": "gog not authenticated — run: gog gmail auth"}')
   fi

--- a/claude-ops/scripts/ops-cron-inbox-digest.sh
+++ b/claude-ops/scripts/ops-cron-inbox-digest.sh
@@ -48,7 +48,7 @@ fi
 
 # ── Gather email unread count via gog ────────────────────────────────────
 EMAIL_SUMMARY="Email: unavailable"
-GOG_RAW=$(command -v gog &>/dev/null && gog gmail search "is:unread after:$(date -u -v-4H +%Y/%m/%d 2>/dev/null || date -u -d '4 hours ago' +%Y/%m/%d 2>/dev/null || date -u +%Y/%m/%d)" --json 2>/dev/null || echo "[]")
+GOG_RAW=$(command -v gog &>/dev/null && gog gmail search "in:inbox after:$(date -u -v-4H +%Y/%m/%d 2>/dev/null || date -u -d '4 hours ago' +%Y/%m/%d 2>/dev/null || date -u +%Y/%m/%d)" --json 2>/dev/null || echo "[]")
 EMAIL_COUNT=$(echo "$GOG_RAW" | python3 -c "
 import json, sys
 data = json.load(sys.stdin)

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -339,7 +339,7 @@ print(json.dumps({'total_chats':len(recent),'count':len(data)}))
 " > "$tmpdir/wa.json" 2>/dev/null) &
 
   # Email count
-  (command -v gog &>/dev/null && gog gmail search -j --results-only --no-input --max 10 "in:inbox is:unread" 2>/dev/null | python3 -c "
+  (command -v gog &>/dev/null && gog gmail search -j --results-only --no-input --max 10 "in:inbox" 2>/dev/null | python3 -c "
 import json,sys
 data=json.load(sys.stdin)
 print(json.dumps({'unread_count':len(data)}))

--- a/claude-ops/skills/ops-comms/SKILL.md
+++ b/claude-ops/skills/ops-comms/SKILL.md
@@ -150,10 +150,10 @@ wacli chats --limit 10 --json 2>/dev/null
 Show last 10 chats with sender, preview, timestamp.
 
 **Email:**
-Use `mcp__claude_ai_Gmail__search_threads` with `query: "is:unread"`, show thread list.
+Use `mcp__claude_ai_Gmail__search_threads` with `query: "in:inbox"` (NOT `is:unread` — scan full inbox including read messages), show thread list.
 
 **Slack:**
-Use `mcp__claude_ai_Slack__slack_search_public_and_private` with `query: "is:unread"`.
+Use `mcp__claude_ai_Slack__slack_search_public_and_private` with `query: "in:channel"` (NOT `is:unread` — scan full recent activity).
 
 **Telegram:**
 Use `mcp__claude_ops_telegram__get_updates` (limit: 20) and `mcp__claude_ops_telegram__list_chats`.

--- a/claude-ops/skills/ops-go/SKILL.md
+++ b/claude-ops/skills/ops-go/SKILL.md
@@ -151,7 +151,7 @@ If `$ARGUMENTS` contains a project alias, focus the briefing on that project onl
 
 After the briefing, use **batched AskUserQuestion calls** (max 4 options each) for the "What's next?" prompt. Show the top 3 priority actions + `[More...]` in the first call, then remaining actions + `[/ops-yolo — let me run your business today]` in the second call. Route to the appropriate ops skill or project.
 
-For Slack unread counts: if the pre-gathered data shows `"count": -1`, use `mcp__claude_ai_Slack__slack_search_public_and_private` with query `is:unread` to get actual counts. Do this as a parallel tool call while analyzing other data.
+For Slack counts: if the pre-gathered data shows `"count": -1`, use `mcp__claude_ai_Slack__slack_search_public_and_private` with query `in:channel` (NOT `is:unread` — scan full recent activity) to get actual message counts. Do this as a parallel tool call while analyzing other data.
 
 ---
 

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -417,7 +417,7 @@ Draft replies via `gog gmail send`. Archive via `gog gmail labels modify --remov
 
 ### Slack
 
-Use Slack MCP tools with `query: "is:unread"` for mentions.
+Use Slack MCP tools with `query: "in:channel"` (NOT `is:unread` — scan full recent activity, not just unread) for mentions.
 For each result, show channel, sender, preview. Read thread for context.
 
 ```

--- a/claude-ops/skills/ops-yolo/SKILL.md
+++ b/claude-ops/skills/ops-yolo/SKILL.md
@@ -249,13 +249,21 @@ Call 3 (if "More steps..."): `[Deploy]`, `[Report]`, `[Done selecting]`
 
 Run the selected steps in sequence, reporting after each step.
 
-**Per-step confirmations** (use `AskUserQuestion` before each destructive action):
+**Per-step confirmations** (use `AskUserQuestion` before EACH destructive action):
 
 - **Inbox**: Show drafted replies and ask `[Send all N replies]` / `[Review each one]` / `[Skip inbox]` before sending any messages
 - **Fires**: Show proposed fix and ask `[Dispatch fix agent]` / `[Skip]` before each agent dispatch
 - **PRs**: Show PR list and ask `[Merge all N ready PRs]` / `[Pick which ones]` / `[Skip]` before merging
 - **Triage**: Show issues to close and ask `[Auto-resolve all N confirmed-fixed]` / `[Review each]` / `[Skip]` before closing
 - **Deploy**: Show pending deploys and ask `[Deploy all]` / `[Pick which]` / `[Skip]` before triggering
+- **Infrastructure changes**: For EVERY destructive infra action (delete ALB, stop RDS, disable Multi-AZ, purge images, etc.), present the specific action with context from the C-suite reports and ask `[Execute]` / `[Skip]` individually. NEVER batch destructive infra actions.
+
+**Report-driven execution**: When the user approves executing recommendations from the Hard Truths report:
+1. Read ALL C-suite analysis files (`/tmp/yolo-[session]/*.md`)
+2. Extract specific actionable items marked with `⚠️ REQUIRES CONFIRMATION`
+3. Present each action individually via `AskUserQuestion` with the exact command that will run, the expected outcome, and the source report (CTO/CFO/COO)
+4. Only execute after explicit per-action approval
+5. After each action, verify the result and report back before proceeding to the next
 
 After each step, check if new fires have appeared before proceeding.
 Report final summary when done.


### PR DESCRIPTION
## Summary
- Add Rule 5 to CLAUDE.md: all destructive actions (delete infra, cancel domains, purge images, rewrite git history) require explicit per-action AskUserQuestion confirmation
- Add DESTRUCTIVE ACTION GUARDRAIL section to all 4 C-suite agents — verify project status before labeling dead, distinguish idle vs dead, flag destructive recs
- Fix YOLO Phase 4 to read C-suite report findings and present each destructive action individually for approval
- Fix inbox scanning across all channels: replace `is:unread` with `in:inbox` (full inbox scan, not just unread)
- Rename misleading `"unread"` JSON field to `"inbox_count"` in ops-unread

## Test plan
- [ ] Run `tests/test-no-secrets.sh` — passes
- [ ] Run `/ops:ops-yolo` and verify destructive recommendations are flagged with REQUIRES CONFIRMATION
- [ ] Run `/ops:ops-inbox` and verify email scan uses `in:inbox` not `is:unread`
- [ ] Verify no personal project data in any committed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/64" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes operational orchestration behavior (how YOLO executes infra actions) and modifies inbox/Slack/Gmail query semantics, which can alter what gets processed and displayed.
> 
> **Overview**
> **Safety guardrails:** Introduces a new global rule requiring *explicit `AskUserQuestion` confirmation per destructive action*, and updates YOLO C-suite agents (CEO/CFO/COO/CTO) plus `ops-yolo` execution guidance to flag destructive recommendations with `⚠️ REQUIRES CONFIRMATION` and to present infra actions for individual approval before running them.
> 
> **Inbox/scanning changes:** Updates email/Slack scanning to use full-activity queries (`in:inbox`, `in:channel`) instead of `is:unread`, adjusts cron/daemon Gmail searches accordingly, and renames the email JSON metric in `ops-unread` from `unread` to `inbox_count`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11752d039d649f0ccc687c52a37317dd550ce2ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->