### PR TITLE
fix(uninstall): add /reload-plugins to reinstall instructions

### DIFF
--- a/claude-ops/skills/uninstall/SKILL.md
+++ b/claude-ops/skills/uninstall/SKILL.md
@@ -243,10 +243,12 @@ claude-ops has been completely removed.
   Settings:    cleaned (installed_plugins, known_marketplaces, settings)
   Directories: removed (marketplace, cache, data)
 
-Run `/plugin` in Claude Code to verify ops no longer appears.
+Run `/reload-plugins` then `/plugin` in Claude Code to verify ops no longer appears.
 
 To reinstall later:
+  /reload-plugins
   /plugin marketplace add Lifecycle-Innovations-Limited/claude-ops
   /plugin install ops@lifecycle-innovations-limited-claude-ops
+  /reload-plugins
   /ops:setup
 ```


### PR DESCRIPTION
## Summary
- Adds `/reload-plugins` to uninstall skill's reinstall instructions so plugin changes are visible immediately

## Test plan
- [ ] Run `/ops:uninstall` and verify updated instructions appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates the uninstall skill’s final instructions; no runtime logic or data handling is modified.
> 
> **Overview**
> Updates the `uninstall` skill’s final output to instruct users to run `/reload-plugins` before verifying removal with `/plugin`, and adds `/reload-plugins` before and after the reinstall commands so marketplace/install changes are reflected immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abc7283ed06009f420f4a1c0d811750ed0dfc3ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->