### PR TITLE
v0.8.0 docs + Phase 4 upgrades — Stripe/RC revenue, full AWS infra, Sonnet 4.6 subagents, daemon pre-warm, OS-agnostic speedup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
-```
- ██████╗██╗      █████╗ ██╗   ██╗██████╗ ███████╗       ██████╗ ██████╗ ███████╗
-██╔════╝██║     ██╔══██╗██║   ██║██╔══██╗██╔════╝      ██╔═══██╗██╔══██╗██╔════╝
-██║     ██║     ███████║██║   ██║██║  ██║█████╗  █████╗██║   ██║██████╔╝███████╗
-██║     ██║     ██╔══██║██║   ██║██║  ██║██╔══╝  ╚════╝██║   ██║██╔═══╝ ╚════██║
-╚██████╗███████╗██║  ██║╚██████╔╝██████╔╝███████╗      ╚██████╔╝██║     ███████║
- ╚═════╝╚══════╝╚═╝  ╚═╝ ╚═════╝ ╚═════╝ ╚══════╝       ╚═════╝ ╚═╝     ╚══════╝
-```
-
 <div align="center">
+
+# claude-ops
 
 **Business Operating System for Claude Code**
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./claude-ops/LICENSE)
-[![Version](https://img.shields.io/badge/version-0.8.0-blue.svg)](https://github.com/Lifecycle-Innovations-Limited/claude-ops/releases)
-[![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)](https://claude.ai/settings/plugins)
+![Version](https://img.shields.io/badge/version-0.8.0-blue)
+![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
+![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
+![Skills](https://img.shields.io/badge/skills-22-success)
+![Agents](https://img.shields.io/badge/agents-12-informational)
+![Integrations](https://img.shields.io/badge/integrations-22-orange)
+![Models](https://img.shields.io/badge/Opus%204.6%20%2F%20Sonnet%204.6%20%2F%20Haiku%204.5-ff69b4)
+
+**One command. Sixty seconds. Your entire business, at a glance.**
 
 </div>
 
@@ -32,15 +31,11 @@
 ╰──────────────────────────────────────────────────────────────────────────────╯
 ```
 
-One command. Sixty seconds. Your entire business, at a glance.
+Turn Claude Code into a complete business operating system — infrastructure health, CI/CD status, unified inbox, open PRs, sprint state, revenue snapshot (Stripe + RevenueCat + AWS), and autonomous C-suite agents that act on your behalf.
 
-Turn Claude Code into a complete business operating system — infrastructure health, CI/CD status, unified inbox, open PRs, sprint state, revenue snapshot, and autonomous agents that act on your behalf.
+---
 
-```
-╔══════════════════════════════╗
-║        QUICK  START          ║
-╚══════════════════════════════╝
-```
+## Quick Start
 
 ```bash
 # 1. Add the marketplace
@@ -49,49 +44,73 @@ Turn Claude Code into a complete business operating system — infrastructure he
 # 2. Install the plugin
 /plugin install ops@lifecycle-innovations-limited-claude-ops
 
-# 3. Configure your integrations (guided wizard)
+# 3. Run the guided setup wizard
 /ops:setup
 ```
 
-> The setup wizard walks through each integration interactively — install CLIs, connect channels, build your project registry. All credentials stored locally, never transmitted.
+> [!TIP]
+> **The wizard installs the background daemon EARLY (Step 2c).** While you're still answering "connect Slack? [OAuth/Skip]" questions, `briefing-pre-warm` is already running every 2 minutes — pre-fetching ECS health, git state, PRs, CI, and unread counts. By the time setup finishes, your first `/ops:go` briefing loads in **<3 seconds** from warm cache instead of ~30s cold.
 
 **Local development:**
 
 ```bash
 git clone https://github.com/Lifecycle-Innovations-Limited/claude-ops.git
-claude --plugin-dir ./claude-ops
+claude --plugin-dir ./claude-ops/claude-ops
 ```
 
-```
-╔══════════════════════════════╗
-║         COMMAND  SET         ║
-╚══════════════════════════════╝
+---
+
+## Commands
+
+All 22 skills, grouped by category:
+
+| 🧭 Navigation | 📊 Daily Ops |
+|---|---|
+| `/ops` — pixel-art dashboard | `/ops:go` — morning briefing |
+| `/ops:dash` — same + hotkeys | `/ops:next` — priority next action |
+| `/ops:setup` — guided wizard | `/ops:inbox` — deep-context inbox zero |
+| `/ops:uninstall` — clean removal | `/ops:comms` — send/read any channel |
+|                                   | `/ops:merge` — autonomous PR pipeline |
+
+| 🛠️ Project & Eng | 💰 Business |
+|---|---|
+| `/ops:projects` — portfolio | `/ops:revenue` — **Stripe + RevenueCat** + AWS |
+| `/ops:linear` — sprint board | `/ops:ecom` — Shopify operations |
+| `/ops:triage` — cross-platform issues | `/ops:marketing` — Klaviyo/Meta/GA4/GSC |
+| `/ops:fires` — incidents + **all AWS** | `/ops:voice` — Bland AI/ElevenLabs/Whisper |
+| `/ops:deploy` — ECS/Vercel/Actions | |
+
+| 🤖 Automation | 🧰 Maintenance |
+|---|---|
+| `/ops:orchestrate` — parallel engine | `/ops:speedup` — **OS+HW adaptive** |
+| `/ops:yolo` — 4 parallel C-suite agents | `/ops:doctor` — plugin auto-repair |
+
+### Skill routing
+
+```mermaid
+flowchart TD
+    U[User] --> O[/ops]
+    O --> D[Dashboard]
+    D --> Daily[Daily Ops]
+    D --> Eng[Project & Eng]
+    D --> Biz[Business]
+    D --> Auto[Automation]
+    Daily --> go[/ops:go]
+    Daily --> inbox[/ops:inbox]
+    Daily --> merge[/ops:merge]
+    Eng --> projects[/ops:projects]
+    Eng --> linear[/ops:linear]
+    Eng --> fires[/ops:fires]
+    Biz --> revenue[/ops:revenue]
+    Biz --> ecom[/ops:ecom]
+    Biz --> marketing[/ops:marketing]
+    Auto --> yolo[/ops:yolo]
+    Auto --> orchestrate[/ops:orchestrate]
 ```
 
-```
-┌────────────────┬─────────────────────────────────────────────┬──────────────────────────────────┐
-│  COMMAND       │  WHAT IT DOES                               │  INTEGRATIONS                    │
-├────────────────┼─────────────────────────────────────────────┼──────────────────────────────────┤
-│  /ops:go       │  Full morning briefing — one cmd, 60s       │  GitHub, Linear, Sentry, AWS     │
-│  /ops:inbox    │  Unified inbox — read + triage all channels │  Slack, Telegram, WhatsApp, Gmail│
-│  /ops:merge    │  Autonomous PR review + merge pipeline      │  GitHub Actions, GitHub CLI      │
-│  /ops:comms    │  Send/read messages across any channel      │  Slack, Telegram, WhatsApp, Gmail│
-│  /ops:fires    │  Production incidents + ECS health          │  AWS ECS, Sentry                 │
-│  /ops:revenue  │  AWS spend, credits, runway estimate        │  AWS Cost Explorer               │
-│  /ops:projects │  Portfolio dashboard — all projects         │  GitHub, Linear                  │
-│  /ops:linear   │  Sprint board + issue management            │  Linear                          │
-│  /ops:deploy   │  Deploy status across all projects          │  AWS ECS, Vercel, GitHub Actions │
-│  /ops:triage   │  Cross-platform issue triage                │  Sentry, Linear, GitHub Issues   │
-│  /ops:next     │  Priority-ranked "what should I do next"    │  Everything                      │
-│  /ops:yolo     │  4 parallel C-suite AI agents — autonomous  │  Everything                      │
-└────────────────┴─────────────────────────────────────────────┴──────────────────────────────────┘
-```
+---
 
-```
-╔══════════════════════════════╗
-║       BEFORE  /  AFTER       ║
-╚══════════════════════════════╝
-```
+## Before / After
 
 ```
 ┌────────────────────────────────────────────┬──────────────────────────────────────────────┐
@@ -107,121 +126,156 @@ claude --plugin-dir ./claude-ops
 └────────────────────────────────────────────┴──────────────────────────────────────────────┘
 ```
 
+---
+
+## Integrations (22 services)
+
+Most integrations offer two paths — MCP (zero-config OAuth) or CLI (fuller feature set). The setup wizard lets you choose per-integration.
+
+| SERVICE | MCP | CLI | WHAT YOU LOSE WITHOUT CLI |
+|---|---|---|---|
+| GitHub | — | `gh` (auto) | EVERYTHING — CI logs, PR merge, triage all require `gh` |
+| AWS | — | `aws` (auto) | EVERYTHING — 17+ services probed by `infra-monitor` |
+| **Stripe** | — | **API key** | **Required for `/ops:revenue` MRR — web + desktop subs** |
+| **RevenueCat** | — | **API key + project ID** | **Required for mobile-app subscription MRR** |
+| Linear | OAuth via Claude.ai (12 tools) | — | Nothing — fully covered |
+| Vercel | OAuth via Claude.ai | — | Nothing — deploy status, build + runtime logs |
+| Slack | OAuth via Claude.ai | local bot token | MCP covers most. Token adds: unlimited search, private ch |
+| Gmail | OAuth (read) | `gog` (send+archive) | MCP = read-only. CLI = full autonomous inbox |
+| Calendar | OAuth via Claude.ai | `gog` (read-only) | MCP has more features — either works |
+| Sentry | OAuth via Claude.ai | `sentry-cli` | MCP covers triage. CLI adds source maps + releases |
+| WhatsApp | — | `wacli` | EVERYTHING — no MCP exists |
+| Telegram | — | bundled MCP server | EVERYTHING — plugin ships its own MTProto server |
+| Shopify | — | Admin API + template | Store ops, order mgmt, inventory via `/ops:ecom` |
+| Klaviyo | — | API key | Email/SMS campaigns via `/ops:marketing` |
+| Meta Ads | — | API token | Paid-social reporting via `/ops:marketing` |
+| GA4 | — | service account | Analytics via `/ops:marketing` |
+| GSC | — | service account | Search Console via `/ops:marketing` |
+| Bland AI | — | API key | Outbound voice via `/ops:voice` |
+| ElevenLabs | — | API key | TTS + cloning via `/ops:voice` |
+| Whisper | — | API key | Transcription via `/ops:voice` |
+| GSD | — | auto-detected | Optional — roadmap state; degrades gracefully |
+| Doppler | — | `doppler` CLI | Optional secret source; falls through to next resolver |
+
+> [!NOTE]
+> **`infra-monitor` now covers every AWS service you have IAM for** — ECS, EC2, RDS, Lambda, S3, CloudFront, ALB/NLB, API Gateway, SQS, SNS, DynamoDB, ElastiCache, Route 53, ACM, CloudWatch, Budgets, IAM. Probes run in parallel; services you can't access are silently skipped.
+
+---
+
+## Architecture
+
+```mermaid
+flowchart TB
+    CC[Claude Code] --> S[Skills · 22]
+    CC --> A[Agents · 12]
+    CC --> H[Hooks]
+    S & A & H --> RC[Runtime Context]
+    RC --> P[preferences.json]
+    RC --> M[memories/]
+    RC --> SEC[Doppler · PW Mgr · Keychain · env]
+    CC <--> D[ops-daemon<br/>launchd · 7 services]
 ```
-╔══════════════════════════════╗
-║         REQUIREMENTS         ║
-╚══════════════════════════════╝
-```
 
-Just [Claude Code](https://claude.ai/code) 1.0+. Everything else is installed automatically.
-
-The setup wizard (`/ops:setup`) walks you through each integration interactively — "Do you want AWS CLI? [Yes/No]", "Connect Slack? [OAuth/Skip]", etc. Missing CLIs are auto-installed via Homebrew. MCP servers connect via OAuth. No config files to edit manually.
-
-```
-╔══════════════════════════════════════════╗
-║      INTEGRATIONS: MCP  vs  CLI          ║
-╚══════════════════════════════════════════╝
-```
-
-Most integrations offer two paths. The setup wizard lets you choose per-integration.
-
-```
-┌─────────────┬──────────────────────────────────┬────────────────────┬───────────────────────────────────────────────────────────────────┐
-│  SERVICE    │  MCP (zero-config OAuth)          │  + CLI tool        │  WHAT YOU LOSE WITHOUT THE CLI                                    │
-├─────────────┼──────────────────────────────────┼────────────────────┼───────────────────────────────────────────────────────────────────┤
-│  GitHub     │  —                               │  gh  (auto)        │  EVERYTHING — CI logs, PR merge, issue triage all require gh      │
-│  AWS        │  —                               │  aws  (auto)       │  EVERYTHING — ECS health, cost tracking, revenue are CLI-only     │
-│  Linear     │  OAuth via Claude.ai  (12 tools) │  —                 │  Nothing — fully covered. 12 tools across 6 skills                │
-│  Vercel     │  OAuth via Claude.ai             │  —                 │  Nothing — deploy status, build logs, runtime logs via MCP        │
-│  Slack      │  OAuth via Claude.ai             │  local bot token   │  MCP covers most users. Token adds: unlimited search, private ch  │
-│  Gmail      │  OAuth via Claude.ai  (read)     │  gog  (send+archive│  MCP = read-only. CLI enables autonomous send + archive           │
-│  Calendar   │  OAuth via Claude.ai  (full)     │  gog  (read-only)  │  MCP has MORE features. Either works for briefings                │
-│  Sentry     │  OAuth via Claude.ai             │  sentry-cli        │  MCP covers triage. CLI adds: source maps, release tracking       │
-│  WhatsApp   │  —                               │  wacli             │  EVERYTHING — no MCP exists. wacli is the only path               │
-│  Telegram   │  —                               │  bundled MCP server│  EVERYTHING — plugin ships its own MTProto server. Fully automated │
-│  GSD        │  —                               │  auto-detected     │  Optional — roadmap state in dashboards. Skills degrade gracefully │
-└─────────────┴──────────────────────────────────┴────────────────────┴───────────────────────────────────────────────────────────────────┘
-```
-
-> **TL;DR** — Linear and Vercel are MCP-only (and that's fine). GitHub and AWS are CLI-only (auto-installed). Gmail is where the choice matters most: MCP gives you read-only, CLI gives you full autonomous inbox management.
-
-```
-╔══════════════════════════════╗
-║         ARCHITECTURE         ║
-╚══════════════════════════════╝
-```
-
-**Token Efficiency**
-
-All skills use pre-execution shell blocks (`!` fences) that gather data *before* the model context loads — zero extra latency, minimal token overhead.
-
-**Plugin Structure**
+All skills use pre-execution shell blocks (`!` fences) that gather data *before* model context loads — zero extra latency, minimal token overhead. The `ops-daemon` pre-warms briefing data so `/ops:go` hits warm cache.
 
 > **Why the nested `claude-ops/claude-ops/` directory?** Claude Code's plugin marketplace system requires a two-level layout: the **repo root** acts as a marketplace container (with `.claude-plugin/marketplace.json` pointing `"source": "./claude-ops"`), while the **inner directory** is the actual plugin root (with `.claude-plugin/plugin.json`, skills, agents, etc.). This is how Claude Code resolves and caches plugins — it cannot be flattened.
 
 ```
-claude-ops/                        ← marketplace root (repo)
+claude-ops/                        ← marketplace root (this repo, this README)
 ├── .claude-plugin/
-│   └── marketplace.json           # Points to ./claude-ops as the plugin source
-├── README.md                      # This file
+│   └── marketplace.json           # points to ./claude-ops as plugin source
+├── README.md                      # ← you are here
 │
-└── claude-ops/                    ← plugin root (where Claude Code loads from)
-    ├── .claude-plugin/
-    │   └── plugin.json            # Plugin manifest + userConfig schema
-    │
-    ├── skills/                    # 14 slash command skills
-    │   ├── ops/                   # Router — dispatches to sub-skills
-    │   ├── ops-go/                # Morning briefing
-    │   ├── ops-inbox/             # Unified inbox
-    │   ├── ops-comms/             # Cross-channel messaging
-    │   ├── ops-merge/             # Autonomous PR pipeline
-    │   ├── ops-fires/             # Production incidents
-    │   ├── ops-deploy/            # Deploy status
-    │   ├── ops-revenue/           # Cost tracking
-    │   ├── ops-projects/          # Portfolio dashboard
-    │   ├── ops-linear/            # Sprint management
-    │   ├── ops-triage/            # Issue triage
-    │   ├── ops-next/              # Next action advisor
-    │   ├── ops-yolo/              # YOLO autonomous mode
-    │   └── setup/                 # Interactive setup wizard
-    │
-    ├── agents/                    # 9 autonomous agents
-    ├── bin/                       # Shell scripts + ops-shopify-create
+└── claude-ops/                    ← plugin root (Claude Code loads from here)
+    ├── .claude-plugin/plugin.json
+    ├── CLAUDE.md                  # 5 non-negotiable plugin rules
+    ├── skills/                    # 22 slash commands
+    ├── agents/                    # 12 autonomous agents (Opus/Sonnet/Haiku)
+    ├── bin/                       # ops-gather · ops-shopify-create · gog fallback
     ├── hooks/                     # SessionStart health check
-    ├── telegram-server/           # Bundled MCP server (gram.js)
-    ├── templates/                 # App scaffolding templates
-    ├── tests/                     # Bash-based validation suite
-    ├── scripts/                   # Setup scripts + project registry
-    ├── CLAUDE.md                  # Plugin-root rules
+    ├── telegram-server/           # bundled MCP server (gram.js)
+    ├── templates/                 # Shopify Admin + app scaffolding
+    ├── tests/                     # bash validation · test-no-secrets.sh
     └── .mcp.json                  # MCP server declarations
 ```
 
-```
-╔══════════════════════════════╗
-║          CONTRIBUTING        ║
-╚══════════════════════════════╝
-```
+---
 
-PRs welcome. See [`claude-ops/README.md`](./claude-ops/README.md) for detailed documentation on each skill, agent, and integration.
+## Privacy & Security
+
+> [!IMPORTANT]
+> **Transparency matters.** claude-ops reads from your AWS, GitHub, Linear, Sentry, WhatsApp, Email, Slack, Telegram, Shopify, Stripe, RevenueCat, and more. You should know exactly what it touches.
+
+**Credential resolution chain (in order):** Doppler → 1Password/Dashlane/Bitwarden → macOS Keychain → env vars → Claude Code's encrypted `userConfig` (`~/.claude.json`).
+
+**Setup auto-scan sources (only during `/ops:setup`):** env, shell profiles, Doppler, 1Password, Dashlane, Bitwarden, macOS Keychain, Claude Code's `~/.claude.json`, Chrome history URL list (never page content), Slack Playwright profile (only if chosen).
+
+**The plugin does NOT:**
+- Phone home. No telemetry. No analytics. No crash reports.
+- Upload data to any third party you haven't configured.
+- Access clipboard, camera, microphone, or SSH keys.
+- Perform disk-wide scans — every scan is a targeted path.
+
+**Background daemon services (only those you enable):**
+- `briefing-pre-warm` every 2 min — parallel `ops-gather` for ECS/git/PRs/CI/unread. Local only.
+- `wacli-sync` continuous — WhatsApp Web protocol, same as standalone `wacli`.
+- `memory-extractor` every 30 min — Haiku summarizes local chats to `memories/`.
+- `inbox-digest` every 4h — aggregates for your configured Telegram bot (if any).
+- `store-health` daily 9am — Shopify Admin API, read-only.
+- `competitor-intel` weekly — your configured competitor feeds.
+- `message-listener` continuous — local polling, never sends outbound on its own.
+
+**Security measures:** `umask 077` on preferences.json · credentials in Claude Code's encrypted `userConfig` · registry/preferences gitignored · `tests/test-no-secrets.sh` pre-commit · Rule 5 blocks destructive actions without confirmation · append-only shell profile writes.
+
+**Your rights:** `/ops:uninstall` removes everything · memory files are plain markdown · MIT licensed, source is public and auditable.
+
+See the [Privacy & Security wiki page](https://github.com/Lifecycle-Innovations-Limited/claude-ops/wiki/Privacy-and-Security) for the full scan inventory and threat model.
+
+---
+
+## Requirements
+
+Just [Claude Code](https://claude.ai/code) 1.0+. Everything else is installed automatically by `/ops:setup` via Homebrew (macOS), apt (Linux), or winget (Windows). `/ops:speedup` auto-detects macOS / Linux / WSL / Windows and applies host-appropriate tuning (no manual flags needed).
+
+---
+
+## What's New in v0.8.0
+
+- **CLAUDE.md plugin rules** — 5 non-negotiable rules enforced across every skill
+- **Shopify Admin template** + `bin/ops-shopify-create`
+- **Early daemon install at setup Step 2c** — `briefing-pre-warm` runs every 2 min so `/ops:go` loads in <3s
+- **All scanner/fix/daemon agents bumped to Sonnet 4.6** · C-suite agents on **Opus 4.6**
+- **`yolo-ceo` now runs as a parallel peer** (not synthesizer) — the main `/ops:yolo` skill synthesizes all 4 C-suite reports
+- **`/ops:revenue` tracks actual revenue** via Stripe + RevenueCat
+- **`infra-monitor` covers every accessible AWS service** (17+ services probed)
+- **`gog` install fix** — npm/bun → git-clone fallback
+- **`/ops:speedup` OS+hardware-adaptive** — macOS / Linux / WSL / Windows
+- **Agent Teams adoption** — `TeamCreate` + `SendMessage` in 6 parallel-dispatch skills
+- **AskUserQuestion ≤4 compliance** — all 22 skills audited, batch `[More options...]` bridges
+- **10-source credential auto-scan** + deep-hunt agent fallback
+
+---
+
+## Contributing
+
+PRs welcome. See [`claude-ops/README.md`](./claude-ops/README.md) for detailed documentation on each skill, agent, and integration. Full guides, troubleshooting, and the threat model live on the [wiki](https://github.com/Lifecycle-Innovations-Limited/claude-ops/wiki).
 
 ```bash
 # Development mode — load plugin from local directory
-claude --plugin-dir ./claude-ops
+claude --plugin-dir ./claude-ops/claude-ops
 
 # Reload after changes
 /reload-plugins
 ```
 
-```
-╔══════════════════════════════╗
-║            LICENSE           ║
-╚══════════════════════════════╝
-```
+---
 
-[MIT](./claude-ops/LICENSE) — built by [Lifecycle Innovations Limited](https://github.com/Lifecycle-Innovations-Limited)
+## License
 
-```
-─────────────────────────────────────────────────────────────────────────────
-  claude-ops  v0.8.0  ·  MIT  ·  github.com/Lifecycle-Innovations-Limited
-─────────────────────────────────────────────────────────────────────────────
-```
+[MIT](./claude-ops/LICENSE) — built by [Lifecycle Innovations Limited](https://github.com/Lifecycle-Innovations-Limited).
+
+<div align="center">
+
+**v0.8.0 · MIT · github.com/Lifecycle-Innovations-Limited**
+
+</div>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,25 +1,70 @@
 # Security Policy
 
+[![Last Audit](https://img.shields.io/badge/last%20audit-2026--04--14-blue)](#)
+[![Response Time](https://img.shields.io/badge/response-%3C48h-brightgreen)](#reporting-a-vulnerability)
+[![License](https://img.shields.io/badge/license-MIT-informational)](./LICENSE)
+
+## Supported Versions
+
+`claude-ops` follows semantic versioning. Security patches are backported one major version behind the current release.
+
+| Version | Supported          | Notes                                           |
+|---------|--------------------|-------------------------------------------------|
+| 0.8.x   | Yes (current)      | Active development; patches land here first.   |
+| 0.7.x   | Yes (backport)     | Security fixes only until 0.9.0 ships.         |
+| < 0.7   | No                 | Please upgrade.                                 |
+
 ## Reporting a Vulnerability
 
 If you discover a security vulnerability, please report it responsibly:
 
-1. **Do NOT** open a public issue
-2. Email: security@example.com (replace with your contact)
-3. Include: description, reproduction steps, impact assessment
+1. **Do NOT** open a public GitHub issue.
+2. Email: `security@example.com`
+3. Include: description, reproduction steps, affected version, and impact assessment.
 
-We'll respond within 48 hours and work with you on a fix before public disclosure.
+**Expected response time:** we acknowledge within 48 hours and aim to ship a fix or mitigation within 14 days. We will coordinate a disclosure timeline with you and credit you in the release notes (unless you prefer to remain anonymous).
 
-## Supported Versions
+## Scope
 
-| Version | Supported |
-|---------|-----------|
-| 0.3.x   | ✅        |
-| < 0.3   | ❌        |
+### In scope
 
-## Security Features
+- Skills under `claude-ops/skills/`
+- Agents under `claude-ops/agents/`
+- Shell scripts under `claude-ops/bin/`
+- Setup wizard (`claude-ops/skills/setup/`, `bin/ops-setup-*`)
+- Background daemon (`ops-daemon`, services: `wacli-keepalive`, `memory-extractor`, `briefing-pre-warm`)
+- Telegram MCP server (`claude-ops/telegram-server/`)
+- Plugin hooks (PreToolUse, Stop) and plugin rule enforcement (`CLAUDE.md`)
+- `plugin.json` / `marketplace.json` userConfig handling
 
-- **Secret scanning**: `.gitleaks.toml` + GitHub secret scanning + push protection enabled
-- **No secrets in code**: All tokens stored in macOS keychain, never in dotfiles or config
-- **Encrypted cookie handling**: Browser cookie decryption uses the app's own keychain key
-- **File permissions**: All temp files created with `umask 077` (mode 0600)
+### NOT in scope
+
+The following are outside the plugin's security boundary:
+
+- **User-supplied credentials in `userConfig`** — these live in Claude Code's own settings store; see Claude Code's security policy.
+- **Third-party CLI tools** shipped or wrapped by the plugin, including `wacli` (WhatsApp), `gog` (Google workspace CLI), the Linear MCP, the Sentry MCP, the Gmail MCP connector, and the Google Calendar MCP connector. Report issues to those projects upstream.
+- **Vendor APIs** (Stripe, RevenueCat, Shopify, Klaviyo, Meta, GA4, Search Console, Bland AI, ElevenLabs, Groq, AWS). We consume their APIs; we do not operate them.
+- **The user's own AWS account, infrastructure, and IAM policies** — `infra-monitor` only reports on what the user's credentials can already access.
+
+## Known Limitations
+
+- **No sandboxing beyond Claude Code's worktree isolation.** The plugin runs with the user's full shell permissions. Only the `triage-agent` runs with `isolation: worktree`; every other skill and agent executes under the same UID and filesystem access as Claude Code itself.
+- **Private repositories referenced.** `@auroracapital/gog` and some internal registry examples reference private repos. Install paths that require them will fail gracefully, but users need their own access credentials; the plugin does not embed any.
+- **WhatsApp via `wacli` uses a QR-paired session.** `wacli` exchanges messages over WhatsApp's own E2E-encrypted protocol, but the session state on disk (pairing keys, message history, app state keys) is not encrypted at the plugin layer. Treat `~/.wacli/` as sensitive.
+- **No telemetry, no phone-home.** The plugin does not emit analytics, crash reports, or usage pings. All network traffic is either (a) to services the user explicitly configured credentials for, or (b) to `api.anthropic.com` via Claude Code itself.
+
+## Security Measures
+
+- **Secret scanning** — `.gitleaks.toml`, GitHub secret scanning, and push protection enabled on the repo.
+- **No secrets in source** — tokens live in the OS keychain, Doppler, a password manager, or the user's `userConfig`; never in tracked files.
+- **Credential scrubbing in CI** — `tests/test-no-secrets.sh` runs on every commit and blocks real names, emails, phones, tokens, store URLs, and `/Users/...` paths (see `CLAUDE.md` Rule 0).
+- **Encrypted cookie handling** — browser cookie extraction (Slack `xoxd-`, etc.) uses the browser's own keychain key and never persists cleartext cookies to disk.
+- **File permissions** — all plugin-generated temp files are created with `umask 077` (mode `0600`).
+- **Destructive-action gating** — `CLAUDE.md` Rule 5 requires explicit per-action `AskUserQuestion` confirmation before any deletion, stop, scale-down, history rewrite, or auto-renewal cancellation.
+- **Plugin rule enforcement** — `CLAUDE.md` at plugin root codifies Rules 0–5 (privacy, question limits, command delegation, skip behavior, background defaults, destructive-action confirmation) and overrides any conflicting instruction in individual skills.
+
+## Further Reading
+
+- [Privacy and Security wiki page](https://github.com/Lifecycle-Innovations-Limited/claude-ops/wiki/Privacy-and-Security) — full breakdown of every credential scan source, what the daemon touches on disk, and the plugin's no-telemetry stance.
+- [Plugin Rules wiki page](https://github.com/Lifecycle-Innovations-Limited/claude-ops/wiki/Plugin-Rules) — the six hard rules every skill must follow.
+- [Daemon Guide](https://github.com/Lifecycle-Innovations-Limited/claude-ops/wiki/Daemon-Guide) — what `ops-daemon` runs and how to inspect it.

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ops",
-  "version": "0.6.0",
-  "description": "Business operations command center for Claude Code. Manage communications, projects, infrastructure, and revenue from your terminal. Includes YOLO mode for autonomous business operation.",
+  "version": "0.8.0",
+  "description": "Business operations command center for Claude Code — 22 skills, 12 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), and voice (Bland AI/ElevenLabs/Whisper). Includes YOLO mode for autonomous operation.",
   "author": {
     "name": "Lifecycle Innovations Limited",
     "url": "https://github.com/Lifecycle-Innovations-Limited"
@@ -21,7 +21,26 @@
     "sentry",
     "infrastructure",
     "revenue",
-    "yolo"
+    "yolo",
+    "shopify",
+    "ecommerce",
+    "marketing",
+    "klaviyo",
+    "meta-ads",
+    "ga4",
+    "voice",
+    "bland-ai",
+    "elevenlabs",
+    "whisper",
+    "daemon",
+    "orchestration",
+    "memories",
+    "doppler",
+    "1password",
+    "stripe",
+    "revenuecat",
+    "mrr",
+    "aws-monitoring"
   ],
   "userConfig": {
     "telegram_api_id": {
@@ -148,6 +167,27 @@
       "description": "API key from https://console.groq.com — used for /ops:ops-voice transcribe (Whisper)",
       "type": "string",
       "sensitive": true,
+      "default": ""
+    },
+    "stripe_secret_key": {
+      "title": "Stripe Secret Key",
+      "description": "Stripe secret key (sk_live_... or sk_test_...) for revenue tracking. Prefer Doppler reference.",
+      "type": "string",
+      "sensitive": true,
+      "default": ""
+    },
+    "revenuecat_api_key": {
+      "title": "RevenueCat API Key",
+      "description": "RevenueCat V1 API key for mobile subscription revenue tracking.",
+      "type": "string",
+      "sensitive": true,
+      "default": ""
+    },
+    "revenuecat_project_id": {
+      "title": "RevenueCat Project ID",
+      "description": "RevenueCat project ID (from app.revenuecat.com URL)",
+      "type": "string",
+      "sensitive": false,
       "default": ""
     }
   }

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -11,10 +11,24 @@ All notable changes to this project will be documented in this file.
 - **`bin/ops-shopify-create`** — Non-interactive Shopify app scaffolding script. Automates device-code OAuth (auto-opens browser via `expect`), fetches org ID from Shopify Partners API cache, runs `shopify app init` with all flags, and injects client ID into `shopify.app.toml`.
 - **`expect` as required CLI** — Added to `bin/ops-setup-preflight` detection and `bin/ops-setup-install` for browser-automation flows.
 - **Test suite** — New `tests/` directory with bash-based validation covering skills, bin scripts, hooks, templates, and secrets.
+- **`briefing-pre-warm` daemon service** — Runs `bin/ops-gather` every 2 minutes and caches dashboards so `/ops:go` loads in <3s instead of <10s. Registered under `ops-daemon` alongside wacli-keepalive and memory-extractor.
+- **Early daemon install (Step 2c of setup wizard)** — Setup wizard now installs `ops-daemon` immediately after CLI tooling so the `briefing-pre-warm` service can start caching `/ops:go` data while the remaining setup steps run. Step 5b became "daemon service reconciliation" (verify + restart) instead of fresh install.
+- **`/ops:revenue` actual revenue tracking** — `revenue-tracker` agent now queries Stripe (charges, subscriptions → MRR, balance, disputes, open invoices, churn) and RevenueCat (mobile subscription MRR, active subs, churn). AWS cost data still included alongside revenue. `/ops:setup` Step 3k prompts for Stripe + RevenueCat credentials.
+- **New `userConfig` keys** — `stripe_secret_key`, `revenuecat_api_key`, `revenuecat_project_id` added to `plugin.json`.
+- **`infra-monitor` full-AWS coverage** — Service discovery probes IAM access per service, then reports on ECS, EC2, RDS, Lambda, S3 (flags public buckets), CloudFront, ALB/NLB, API Gateway, SQS (backlogs + DLQ), SNS, DynamoDB, ElastiCache, Route 53, ACM (cert expiry), CloudWatch alarms, Budgets, and IAM (stale access keys).
+- **Wiki revamp** — 10 wiki pages rewritten with 2026 GitHub formatting (badges, mermaid diagrams, alert callouts). New pages: `Daemon-Guide`, `Memories-System`, `Plugin-Rules`, `Changelog`, `Privacy-and-Security`.
+- **Privacy & Security transparency** — new `Privacy-and-Security.md` wiki page and README section explicitly document every credential scan source, what the daemon does on disk, and the plugin's no-telemetry / no-phone-home stance.
 
 ### Changed
 
 - **AskUserQuestion <=4 enforcement** — All 15 skills audited and fixed. setup section picker (11→batched 4+4+3), setup channel picker (7→4+3), ops-comms / deploy / fires / go / inbox / linear / projects / revenue / speedup / triage / yolo all batch >4 menus with `[More options...]` bridges. ops-dash hotkey menu refactored.
+- **Subagent models bumped Sonnet 4.5 → Sonnet 4.6** — `comms-scanner`, `infra-monitor`, `project-scanner`, `revenue-tracker`, and `triage-agent` now run on `claude-sonnet-4-6`. `yolo-*` agents stayed on `claude-opus-4-6`; `memory-extractor` stayed on `claude-haiku-4-5`.
+- **Agent Teams adoption** — `/ops:fires`, `/ops:inbox`, `/ops:merge`, `/ops:orchestrate`, `/ops:triage`, and `/ops:yolo` now use the `TeamCreate` + `SendMessage` primitives for parallel agent coordination instead of sequential `Task`-based dispatch.
+- **`/ops:speedup` is now OS- and hardware-agnostic** — auto-detects macOS / Linux / WSL / Windows, selects the right sub-script per platform, and degrades gracefully when tools are missing instead of erroring out.
+
+### Fixed
+
+- **`gog` install fallback chain** — Setup wizard now tries `npm install -g @auroracapital/gog` → `bun install -g @auroracapital/gog` → `git clone https://github.com/auroracapital/gog ~/.gog && ./install.sh` → clear manual instructions. Removed the previous incorrect pointer to `Lifecycle-Innovations-Limited/tap/gog` (Homebrew) — `gog` is a private `@auroracapital` CLI and is not distributed via Homebrew.
 
 ## [0.6.0] — 2026-04-13
 

--- a/claude-ops/agents/comms-scanner.md
+++ b/claude-ops/agents/comms-scanner.md
@@ -1,7 +1,7 @@
 ---
 name: comms-scanner
 description: Scans all communication channels for FULL inbox state (not just unread). Classifies each conversation as NEEDS_REPLY, WAITING, or HANDLED. Returns structured JSON. Used by ops-inbox and ops-go.
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 effort: low
 maxTurns: 10
 tools:

--- a/claude-ops/agents/infra-monitor.md
+++ b/claude-ops/agents/infra-monitor.md
@@ -1,9 +1,9 @@
 ---
 name: infra-monitor
-description: ECS, Vercel, and AWS health checker. Returns structured JSON with service health, recent deployments, and anomaly flags. Used by ops-fires and ops-deploy.
-model: claude-sonnet-4-5
-effort: low
-maxTurns: 15
+description: Multi-service infrastructure health checker. Probes every AWS service the caller has IAM access to (ECS, EC2, RDS, Lambda, S3, CloudFront, ALB/NLB, API Gateway, SQS, SNS, DynamoDB, ElastiCache, Route 53, ACM, CloudWatch, Budgets, IAM) plus Vercel and GitHub Actions. Returns structured JSON with service health, accessible/inaccessible service lists, and severity-ranked anomaly flags. Used by ops-fires and ops-deploy.
+model: claude-sonnet-4-6
+effort: medium
+maxTurns: 25
 tools:
   - Bash
   - Read
@@ -16,46 +16,286 @@ disallowedTools:
   - Edit
   - Agent
 memory: project
-initialPrompt: "Check ECS, Vercel, and AWS health. Return structured JSON with service status."
+initialPrompt: "Probe all accessible AWS services, Vercel, and GitHub Actions. Return structured JSON with per-service status and anomaly flags."
 ---
 
 # INFRA MONITOR AGENT
 
-Scan all infrastructure and return structured health data. Read-only.
+Scan all infrastructure the caller can reach and return structured health data. Read-only only. Never call `delete-*`, `stop-*`, `terminate-*`, `put-*`, `create-*`, `update-*`, or any mutating verb.
 
-## Task
+## Preflight
 
-Run all checks in parallel:
-
-### ECS health
+Run in order. Fail fast with JSON on any blocking error.
 
 ```bash
-for cluster in $(aws ecs list-clusters --output json 2>/dev/null | jq -r '.clusterArns[]'); do
-  name=$(basename "$cluster")
-  aws ecs describe-clusters --clusters "$name" \
-    --include STATISTICS \
-    --output json 2>/dev/null | \
-    jq --arg c "$name" '{cluster: $c, services: .clusters[0].statistics, status: .clusters[0].status}'
+# 1. CLI present?
+command -v aws >/dev/null 2>&1 || { echo '{"error":"aws cli not installed"}'; exit 0; }
 
-  aws ecs list-services --cluster "$name" --output json 2>/dev/null | \
+# 2. Authenticated?
+IDENTITY=$(aws sts get-caller-identity --output json --no-cli-pager 2>/dev/null) || {
+  echo '{"error":"aws not authenticated"}'; exit 0;
+}
+
+# 3. Region (env override, fallback us-east-1)
+REGION="${AWS_REGION:-us-east-1}"
+export AWS_DEFAULT_REGION="$REGION"
+
+# 4. Registry (optional — drives project-scoped deep scans)
+REGISTRY="${CLAUDE_PLUGIN_ROOT}/scripts/registry.json"
+[ -f "$REGISTRY" ] || REGISTRY="${CLAUDE_PLUGIN_ROOT}/scripts/registry.example.json"
+```
+
+## Service discovery
+
+Probe each service with a cheap list call. If it returns 0, the service is accessible. Capture into a shell array. Every call is wrapped in `|| true` so one AccessDenied never kills the scan.
+
+```bash
+SERVICES="ec2 ecs rds lambda s3 cloudfront elbv2 apigateway sqs sns dynamodb elasticache route53 acm cloudwatch budgets iam"
+ACCESSIBLE=()
+INACCESSIBLE=()
+
+probe() {
+  local svc="$1"; local cmd="$2"
+  if eval "$cmd" --max-items 1 --output json --no-cli-pager >/dev/null 2>&1; then
+    ACCESSIBLE+=("$svc")
+  else
+    INACCESSIBLE+=("$svc")
+  fi
+}
+
+probe ec2         "aws ec2 describe-instances"
+probe ecs         "aws ecs list-clusters"
+probe rds         "aws rds describe-db-instances"
+probe lambda      "aws lambda list-functions"
+probe s3          "aws s3api list-buckets"
+probe cloudfront  "aws cloudfront list-distributions"
+probe elbv2       "aws elbv2 describe-load-balancers"
+probe apigateway  "aws apigateway get-rest-apis"
+probe sqs         "aws sqs list-queues"
+probe sns         "aws sns list-topics"
+probe dynamodb    "aws dynamodb list-tables"
+probe elasticache "aws elasticache describe-cache-clusters"
+probe route53     "aws route53 list-hosted-zones"
+probe acm         "aws acm list-certificates"
+probe cloudwatch  "aws cloudwatch describe-alarms"
+probe budgets     "aws budgets describe-budgets --account-id $(echo \"$IDENTITY\" | jq -r .Account)"
+probe iam         "aws iam list-users"
+```
+
+## Per-service read-only checks
+
+Run only for services in `ACCESSIBLE`. All commands use `--output json --no-cli-pager`, all wrapped `|| true`.
+
+### ECS (existing)
+
+```bash
+for cluster_arn in $(aws ecs list-clusters --output json --no-cli-pager 2>/dev/null | jq -r '.clusterArns[]' || true); do
+  name=$(basename "$cluster_arn")
+  aws ecs describe-clusters --clusters "$name" --include STATISTICS \
+    --output json --no-cli-pager 2>/dev/null | \
+    jq --arg c "$name" '{cluster: $c, services: .clusters[0].statistics, status: .clusters[0].status}' || true
+  aws ecs list-services --cluster "$name" --output json --no-cli-pager 2>/dev/null | \
     jq -r '.serviceArns[]' | while read svc; do
     aws ecs describe-services --cluster "$name" --services "$(basename $svc)" \
-      --output json 2>/dev/null | \
-      jq '.services[] | {name: .serviceName, desired: .desiredCount, running: .runningCount, pending: .pendingCount, status: .status, rolloutState: (.deployments[0].rolloutState // "STABLE"), lastEvent: (.events[0].message // "none")}'
+      --output json --no-cli-pager 2>/dev/null | \
+      jq '.services[] | {name: .serviceName, desired: .desiredCount, running: .runningCount, pending: .pendingCount, status: .status, rolloutState: (.deployments[0].rolloutState // "STABLE"), lastEvent: (.events[0].message // "none")}' || true
+  done
+  # Stopped task reasons
+  aws ecs list-tasks --cluster "$name" --desired-status STOPPED --max-items 5 \
+    --output json --no-cli-pager 2>/dev/null | jq -r '.taskArns[]' | while read t; do
+    aws ecs describe-tasks --cluster "$name" --tasks "$t" \
+      --output json --no-cli-pager 2>/dev/null | \
+      jq '.tasks[] | {stoppedReason, stopCode, containers: [.containers[] | {name, exitCode, reason}]}' || true
   done
 done
 ```
 
-### Recent ECS events (anomalies, registry-driven)
+### EC2
 
 ```bash
-REGISTRY="${CLAUDE_PLUGIN_ROOT}/scripts/registry.json"
-[ -f "$REGISTRY" ] || REGISTRY="${CLAUDE_PLUGIN_ROOT}/scripts/registry.example.json"
-jq -r '.projects[] | select(.infra.ecs_clusters) | .infra.ecs_clusters[]' "$REGISTRY" 2>/dev/null | while read cluster; do
-  aws ecs list-services --cluster "$cluster" --output text --query 'serviceArns[*]' 2>/dev/null | tr '\t' '\n' | while read svc_arn; do
+aws ec2 describe-instances --output json --no-cli-pager 2>/dev/null | \
+  jq '{
+    running: [.Reservations[].Instances[] | select(.State.Name=="running")] | length,
+    stopped: [.Reservations[].Instances[] | select(.State.Name=="stopped")] | length,
+    other:   [.Reservations[].Instances[] | select(.State.Name!="running" and .State.Name!="stopped")] | length
+  }' || true
+
+# EBS volumes — unattached flagged
+aws ec2 describe-volumes --output json --no-cli-pager 2>/dev/null | \
+  jq '{total: (.Volumes|length), unattached: [.Volumes[] | select(.State=="available")] | length}' || true
+
+# AMI age (own AMIs only)
+aws ec2 describe-images --owners self --output json --no-cli-pager 2>/dev/null | \
+  jq '[.Images[] | {id: .ImageId, created: .CreationDate}] | sort_by(.created)' || true
+```
+
+### RDS
+
+```bash
+aws rds describe-db-instances --output json --no-cli-pager 2>/dev/null | \
+  jq '[.DBInstances[] | {
+    id: .DBInstanceIdentifier,
+    state: .DBInstanceStatus,
+    engine: .Engine,
+    allocated_gb: .AllocatedStorage,
+    pending: (.PendingModifiedValues // {}),
+    maintenance: (.PendingMaintenanceActions // [])
+  }]' || true
+```
+
+### Lambda
+
+```bash
+aws lambda list-functions --output json --no-cli-pager 2>/dev/null | \
+  jq '[.Functions[] | {name: .FunctionName, runtime: .Runtime, lastModified: .LastModified}]' || true
+
+# CloudWatch error metric (last 1h) for each function — sample cap at 20
+aws lambda list-functions --output json --no-cli-pager --max-items 20 2>/dev/null | \
+  jq -r '.Functions[].FunctionName' | while read fn; do
+  aws cloudwatch get-metric-statistics --namespace AWS/Lambda --metric-name Errors \
+    --dimensions Name=FunctionName,Value="$fn" \
+    --start-time "$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)" \
+    --end-time   "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --period 3600 --statistics Sum \
+    --output json --no-cli-pager 2>/dev/null | \
+    jq --arg f "$fn" '{function: $f, errors: ([.Datapoints[].Sum] | add // 0)}' || true
+done
+```
+
+### S3 — FLAG public buckets
+
+```bash
+aws s3api list-buckets --output json --no-cli-pager 2>/dev/null | \
+  jq -r '.Buckets[].Name' | while read b; do
+  pab=$(aws s3api get-public-access-block --bucket "$b" \
+    --output json --no-cli-pager 2>/dev/null | \
+    jq -r '.PublicAccessBlockConfiguration | [.BlockPublicAcls, .IgnorePublicAcls, .BlockPublicPolicy, .RestrictPublicBuckets] | all' || echo "false")
+  vers=$(aws s3api get-bucket-versioning --bucket "$b" \
+    --output json --no-cli-pager 2>/dev/null | jq -r '.Status // "Disabled"' || echo "Unknown")
+  jq -n --arg b "$b" --arg pab "$pab" --arg v "$vers" \
+    '{bucket: $b, public_access_blocked: ($pab=="true"), versioning: $v}'
+done
+```
+
+### CloudFront
+
+```bash
+aws cloudfront list-distributions --output json --no-cli-pager 2>/dev/null | \
+  jq '[.DistributionList.Items[]? | {id: .Id, domain: .DomainName, status: .Status, enabled: .Enabled}]' || true
+```
+
+### ALB / NLB
+
+```bash
+aws elbv2 describe-load-balancers --output json --no-cli-pager 2>/dev/null | \
+  jq -r '.LoadBalancers[].LoadBalancerArn' | while read lb; do
+  aws elbv2 describe-target-groups --load-balancer-arn "$lb" \
+    --output json --no-cli-pager 2>/dev/null | \
+    jq -r '.TargetGroups[].TargetGroupArn' | while read tg; do
+    aws elbv2 describe-target-health --target-group-arn "$tg" \
+      --output json --no-cli-pager 2>/dev/null | \
+      jq --arg tg "$tg" '{target_group: $tg, healthy: [.TargetHealthDescriptions[] | select(.TargetHealth.State=="healthy")] | length, unhealthy: [.TargetHealthDescriptions[] | select(.TargetHealth.State!="healthy")] | length}' || true
+  done
+done
+```
+
+### API Gateway
+
+```bash
+aws apigateway get-rest-apis --output json --no-cli-pager 2>/dev/null | \
+  jq '[.items[] | {id: .id, name: .name}]' || true
+```
+
+### SQS
+
+```bash
+aws sqs list-queues --output json --no-cli-pager 2>/dev/null | \
+  jq -r '.QueueUrls[]?' | while read q; do
+  aws sqs get-queue-attributes --queue-url "$q" \
+    --attribute-names ApproximateNumberOfMessages ApproximateNumberOfMessagesNotVisible RedrivePolicy \
+    --output json --no-cli-pager 2>/dev/null | \
+    jq --arg q "$q" '{queue: $q, backlog: (.Attributes.ApproximateNumberOfMessages|tonumber? // 0), in_flight: (.Attributes.ApproximateNumberOfMessagesNotVisible|tonumber? // 0), is_dlq_target: (.Attributes.RedrivePolicy != null)}' || true
+done
+```
+
+### SNS
+
+```bash
+aws sns list-topics --output json --no-cli-pager 2>/dev/null | \
+  jq '{topic_count: (.Topics|length)}' || true
+```
+
+### DynamoDB
+
+```bash
+aws dynamodb list-tables --output json --no-cli-pager 2>/dev/null | \
+  jq -r '.TableNames[]?' | while read t; do
+  aws dynamodb describe-table --table-name "$t" \
+    --output json --no-cli-pager 2>/dev/null | \
+    jq '.Table | {name: .TableName, status: .TableStatus, items: .ItemCount, size_bytes: .TableSizeBytes}' || true
+done
+```
+
+### ElastiCache
+
+```bash
+aws elasticache describe-cache-clusters --output json --no-cli-pager 2>/dev/null | \
+  jq '[.CacheClusters[] | {id: .CacheClusterId, engine: .Engine, status: .CacheClusterStatus, nodes: .NumCacheNodes}]' || true
+```
+
+### Route 53
+
+```bash
+aws route53 list-hosted-zones --output json --no-cli-pager 2>/dev/null | \
+  jq '{zones: (.HostedZones|length)}' || true
+aws route53 list-health-checks --output json --no-cli-pager 2>/dev/null | \
+  jq '[.HealthChecks[]? | {id: .Id, type: .HealthCheckConfig.Type}]' || true
+```
+
+### ACM — FLAG expiry <30 days
+
+```bash
+aws acm list-certificates --output json --no-cli-pager 2>/dev/null | \
+  jq -r '.CertificateSummaryList[]?.CertificateArn' | while read arn; do
+  aws acm describe-certificate --certificate-arn "$arn" \
+    --output json --no-cli-pager 2>/dev/null | \
+    jq '.Certificate | {arn: .CertificateArn, domain: .DomainName, status: .Status, not_after: .NotAfter}' || true
+done
+```
+
+### CloudWatch alarms
+
+```bash
+aws cloudwatch describe-alarms --state-value ALARM --output json --no-cli-pager 2>/dev/null | \
+  jq '{in_alarm: (.MetricAlarms|length), alarms: [.MetricAlarms[] | {name: .AlarmName, state: .StateValue, reason: .StateReason}]}' || true
+```
+
+### Budgets
+
+```bash
+ACCOUNT=$(echo "$IDENTITY" | jq -r .Account)
+aws budgets describe-budgets --account-id "$ACCOUNT" --output json --no-cli-pager 2>/dev/null | \
+  jq '[.Budgets[]? | {name: .BudgetName, limit: .BudgetLimit.Amount, actual: .CalculatedSpend.ActualSpend.Amount, forecast: .CalculatedSpend.ForecastedSpend.Amount}]' || true
+```
+
+### IAM — FLAG access keys >90 days
+
+```bash
+aws iam list-users --output json --no-cli-pager 2>/dev/null | \
+  jq -r '.Users[].UserName' | while read u; do
+  aws iam list-access-keys --user-name "$u" --output json --no-cli-pager 2>/dev/null | \
+    jq --arg u "$u" '[.AccessKeyMetadata[] | {user: $u, key_id: .AccessKeyId, status: .Status, created: .CreateDate}]' || true
+done
+```
+
+### Recent ECS events (registry-driven, project-scoped)
+
+```bash
+jq -r '.projects[]? | select(.infra.ecs_clusters) | .infra.ecs_clusters[]' "$REGISTRY" 2>/dev/null | while read cluster; do
+  aws ecs list-services --cluster "$cluster" --output text --query 'serviceArns[*]' --no-cli-pager 2>/dev/null | tr '\t' '\n' | while read svc_arn; do
     svc=$(basename "$svc_arn")
-    aws ecs describe-services --cluster "$cluster" --services "$svc" --output json 2>/dev/null | \
-      jq --arg c "$cluster" --arg s "$svc" '{cluster: $c, service: $s, events: .services[0].events[:5]}'
+    aws ecs describe-services --cluster "$cluster" --services "$svc" --output json --no-cli-pager 2>/dev/null | \
+      jq --arg c "$cluster" --arg s "$svc" '{cluster: $c, service: $s, events: .services[0].events[:5]}' || true
   done
 done
 ```
@@ -69,11 +309,22 @@ Fetch via `mcp__claude_ai_Vercel__list_projects`, then for each project call `mc
 ### GitHub Actions (recent runs, registry-driven)
 
 ```bash
-for repo in $(jq -r '.projects[] | select(.gsd == true) | .repos[]' "$REGISTRY" 2>/dev/null); do
+for repo in $(jq -r '.projects[]? | select(.gsd == true) | .repos[]?' "$REGISTRY" 2>/dev/null); do
   gh run list --repo "$repo" --limit 3 \
     --json status,conclusion,name,headBranch,createdAt 2>/dev/null | \
-    jq --arg r "$repo" 'map(. + {repo: $r})'
+    jq --arg r "$repo" 'map(. + {repo: $r})' || true
 done | jq -s 'add // []'
+```
+
+### Optional multi-region sweep
+
+If the caller wants a multi-region view, iterate accessible regions (skip on permission error):
+
+```bash
+for r in $(aws ec2 describe-regions --query 'Regions[].RegionName' --output text --no-cli-pager 2>/dev/null); do
+  AWS_DEFAULT_REGION="$r" aws cloudwatch describe-alarms --state-value ALARM \
+    --output json --no-cli-pager 2>/dev/null | jq --arg r "$r" '{region: $r, in_alarm: (.MetricAlarms|length)}' || true
+done
 ```
 
 ## Output format
@@ -81,24 +332,47 @@ done | jq -s 'add // []'
 ```json
 {
   "timestamp": "[ISO8601]",
+  "account": "[aws account id]",
+  "region": "[aws region]",
   "overall_health": "healthy|degraded|critical",
-  "ecs": {
-    "clusters": [
-      {
-        "name": "[cluster]",
-        "services": [
-          {
-            "name": "[service]",
-            "desired": 0,
-            "running": 0,
-            "pending": 0,
-            "status": "ACTIVE|INACTIVE",
-            "health": "healthy|degraded|stopped",
-            "last_event": "[text]"
-          }
-        ]
-      }
-    ]
+  "accessible_services": ["ec2", "ecs", "rds", "lambda", "s3", "cloudfront", "elbv2", "apigateway", "sqs", "sns", "dynamodb", "elasticache", "route53", "acm", "cloudwatch", "budgets", "iam"],
+  "inaccessible": ["[service where CLI returned AccessDenied or errored]"],
+  "services": {
+    "ecs": {
+      "clusters": [
+        {
+          "name": "[cluster]",
+          "services": [
+            {
+              "name": "[service]",
+              "desired": 0,
+              "running": 0,
+              "pending": 0,
+              "status": "ACTIVE|INACTIVE",
+              "health": "healthy|degraded|stopped",
+              "last_event": "[text]"
+            }
+          ],
+          "stopped_task_reasons": []
+        }
+      ]
+    },
+    "ec2":         { "running": 0, "stopped": 0, "other": 0, "unattached_volumes": 0, "anomalies": [] },
+    "rds":         { "instances": [], "anomalies": [] },
+    "lambda":      { "functions": [], "errors_last_hour": [], "anomalies": [] },
+    "s3":          { "buckets": [], "public_buckets": [], "anomalies": [] },
+    "cloudfront":  { "distributions": [], "anomalies": [] },
+    "elbv2":       { "load_balancers": [], "target_health": [], "anomalies": [] },
+    "apigateway":  { "apis": [], "anomalies": [] },
+    "sqs":         { "queues": [], "backlogs": [], "anomalies": [] },
+    "sns":         { "topic_count": 0, "anomalies": [] },
+    "dynamodb":    { "tables": [], "anomalies": [] },
+    "elasticache": { "clusters": [], "anomalies": [] },
+    "route53":     { "zones": 0, "health_checks": [], "anomalies": [] },
+    "acm":         { "certificates": [], "expiring_soon": [], "anomalies": [] },
+    "cloudwatch":  { "in_alarm": 0, "alarms": [], "anomalies": [] },
+    "budgets":     { "budgets": [], "anomalies": [] },
+    "iam":         { "stale_access_keys": [], "anomalies": [] }
   },
   "vercel": {
     "projects": [
@@ -113,32 +387,60 @@ done | jq -s 'add // []'
       }
     ]
   },
-  "ci": {
-    "recent_runs": []
-  },
-  "fires": [
+  "ci": { "recent_runs": [] },
+  "anomalies": [
     {
-      "severity": "critical|high|medium",
+      "severity": "critical|high|medium|low",
       "service": "[name]",
       "issue": "[description]",
+      "resource": "[arn or id]",
       "since": "[ISO8601]"
     }
   ]
 }
 ```
 
+The `anomalies` array is sorted highest-severity first and aggregates all per-service flags so callers can triage without walking the whole tree.
+
 ## Fire detection rules
 
 Flag as `critical` if:
 
 - ECS service running < desired AND running == 0
+- RDS instance state in {failed, storage-full, incompatible-parameters, incompatible-restore}
+- S3 bucket public access NOT blocked on all four flags
+- ACM certificate expires in <7 days
+- CloudWatch alarm count in ALARM state > 0 on a resource marked critical in registry
 - Vercel deployment state == "ERROR" on production
 - CI conclusion == "failure" on `main` or `dev` branch
 
 Flag as `high` if:
 
 - ECS service running < desired (partial)
+- EC2 instance in state other than running/stopped (e.g., stopping, terminated recently)
+- Lambda errors > 10 in last hour
+- SQS DLQ depth > 0 OR queue backlog > 1000
+- ACM certificate expires in <30 days
+- IAM access key active >90 days
+- RDS pending maintenance actions present
 - Vercel deployment state == "ERROR" on preview
 - CI failure on feature branch with open PR
 
-Print only the JSON to stdout.
+Flag as `medium` if:
+
+- EBS volume unattached
+- DynamoDB throttle events in last hour
+- ElastiCache evictions rising
+- CloudWatch alarm in INSUFFICIENT_DATA
+
+Flag as `low` for informational findings (AMI age, versioning disabled on non-critical buckets, etc.).
+
+## Rules
+
+- Read-only only — never run any mutating AWS verb.
+- Registry-driven — all project-specific inputs (clusters, repos, critical-resource marks) come from `$REGISTRY`, never hardcoded.
+- Region — read from `$AWS_REGION` env, default `us-east-1`. Never hardcode a region.
+- Account — read from `aws sts get-caller-identity`. Never hardcode an account ID.
+- No personal data — follow Rule 0 in `claude-ops/CLAUDE.md`. Do not echo user names, emails, or real resource ARNs into logs beyond what the structured JSON requires.
+- Graceful degradation — a service that returns AccessDenied goes into `inaccessible`, never crashes the scan.
+- Print only the JSON to stdout.

--- a/claude-ops/agents/project-scanner.md
+++ b/claude-ops/agents/project-scanner.md
@@ -1,7 +1,7 @@
 ---
 name: project-scanner
 description: Git, PR, and CI status scanner across all registered repos. Returns structured JSON with branch state, uncommitted files, open PRs, and CI status for each project.
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 effort: low
 maxTurns: 15
 tools:

--- a/claude-ops/agents/revenue-tracker.md
+++ b/claude-ops/agents/revenue-tracker.md
@@ -1,9 +1,9 @@
 ---
 name: revenue-tracker
-description: Revenue, billing, and credits analysis agent. Queries AWS Cost Explorer, checks credit balances, cross-references project revenue stages. Returns structured financial snapshot.
-model: claude-sonnet-4-5
-effort: medium
-maxTurns: 20
+description: Revenue, billing, and credits analysis agent. Pulls real revenue data from Stripe (SaaS) and RevenueCat (mobile subs), queries AWS Cost Explorer for spend, and cross-references project revenue stages. Returns structured financial snapshot.
+model: claude-sonnet-4-6
+effort: high
+maxTurns: 30
 tools:
   - Bash
   - Read
@@ -12,16 +12,106 @@ disallowedTools:
   - Edit
   - Agent
 memory: project
-initialPrompt: "Query AWS costs, check credit balances, and cross-reference project revenue. Return financial snapshot."
+initialPrompt: "Pull live revenue from Stripe + RevenueCat, query AWS costs, check credit balances, and cross-reference project revenue. Return financial snapshot."
 ---
 
 # REVENUE TRACKER AGENT
 
-Pull all financial data and return a structured snapshot. Read-only.
+Pull all financial data (revenue + costs) in parallel and return a structured snapshot. Read-only.
 
 ## Task
 
-Run all AWS cost queries in parallel:
+Run all queries in parallel. Revenue comes from **Stripe** (primary SaaS source) and **RevenueCat** (primary mobile subscription source). Costs come from AWS Cost Explorer. Fall back to `registry.json` only when both revenue APIs are unconfigured.
+
+---
+
+## Revenue — Stripe (SaaS)
+
+Only run if `STRIPE_SECRET_KEY` is set. If not, emit `stripe: not_configured` and skip this block.
+
+### Recent charges (for MTD + trailing-30d gross)
+
+```bash
+curl -s https://api.stripe.com/v1/charges?limit=100 \
+  -u "$STRIPE_SECRET_KEY:" 2>/dev/null
+```
+
+Filter `data[].created >= first-of-month` for MTD gross; filter `data[].created >= now - 30d` for trailing-30d gross. Sum `amount` in cents, divide by 100. Only count `status=succeeded` and `paid=true`; subtract `amount_refunded`.
+
+### Active subscriptions (MRR)
+
+```bash
+curl -s "https://api.stripe.com/v1/subscriptions?status=active&limit=100" \
+  -u "$STRIPE_SECRET_KEY:" 2>/dev/null
+```
+
+MRR = sum over `data[].items.data[].price.unit_amount * items.data[].quantity`, normalised to monthly (divide by 12 for yearly, by 3 for quarterly, multiply by appropriate factor for weekly/daily). Convert cents → dollars.
+
+### Balance (pending + available)
+
+```bash
+curl -s https://api.stripe.com/v1/balance -u "$STRIPE_SECRET_KEY:" 2>/dev/null
+```
+
+Sum USD entries in `.pending[]` and `.available[]`.
+
+### Disputes
+
+```bash
+curl -s "https://api.stripe.com/v1/disputes?limit=10" \
+  -u "$STRIPE_SECRET_KEY:" 2>/dev/null
+```
+
+Count entries and sum `amount` in USD.
+
+### Open (unpaid) invoices
+
+```bash
+curl -s "https://api.stripe.com/v1/invoices?status=open&limit=50" \
+  -u "$STRIPE_SECRET_KEY:" 2>/dev/null
+```
+
+Count and sum `amount_due`.
+
+### Churn — subscriptions 30d ago
+
+```bash
+TS_30D=$(date -v-30d +%s 2>/dev/null || date -d "-30 days" +%s)
+curl -s "https://api.stripe.com/v1/subscriptions?status=active&created[lte]=$TS_30D&limit=100" \
+  -u "$STRIPE_SECRET_KEY:" 2>/dev/null
+```
+
+Compare `data | length` to current active count. `churn_rate_pct = max(0, (subs_30d_ago - subs_now) / subs_30d_ago * 100)`.
+
+---
+
+## Revenue — RevenueCat (mobile subscriptions)
+
+Only run if `REVENUECAT_API_KEY` is set AND a project ID is available (from `$REVENUECAT_PROJECT_ID` env or `$PREFS_PATH` → `revenue.revenuecat.project_id`). If either is missing, emit `revenuecat: not_configured` and skip.
+
+### Overview metrics (MRR, revenue, active subs)
+
+```bash
+curl -s -H "Authorization: Bearer $REVENUECAT_API_KEY" \
+  "https://api.revenuecat.com/v1/projects/$REVENUECAT_PROJECT_ID/metrics/overview" 2>/dev/null
+```
+
+Extract `mrr`, `revenue` (trailing 30d), `active_subscriptions`, `active_trials`.
+
+### Active subscribers (count)
+
+```bash
+curl -s -H "Authorization: Bearer $REVENUECAT_API_KEY" \
+  "https://api.revenuecat.com/v1/projects/$REVENUECAT_PROJECT_ID/metrics/active_subscribers" 2>/dev/null
+```
+
+### Churn rate
+
+Pull from the metrics overview response (`churn_rate` or equivalent field). If not present, compute from `active_subscriptions` now vs. 30d ago using the same endpoint with a `period` query param.
+
+---
+
+## Costs — AWS (existing)
 
 ### Current month costs by service
 
@@ -64,48 +154,79 @@ aws ce get-anomalies \
   --output json 2>/dev/null || echo '{"Anomalies": []}'
 ```
 
-### Project registry (revenue metadata)
+### Project registry (revenue metadata — fallback)
 
 ```bash
 cat "${CLAUDE_PLUGIN_ROOT}/scripts/registry.json" 2>/dev/null | \
   jq '[.projects[] | {alias, name, revenue_stage: (.revenue_stage // "pre-revenue"), mrr: (.mrr // 0), arr: (.arr // 0)}]'
 ```
 
+Use this only if BOTH `STRIPE_SECRET_KEY` and `REVENUECAT_API_KEY` are unset. In that case populate `revenue.mrr` as the sum of `registry.json` project `mrr` values and set `mrr_source: "registry.json"`.
+
+---
+
+## Error handling
+
+- If `STRIPE_SECRET_KEY` not set: skip Stripe block, include `"stripe": "not_configured"` in the output under `revenue.sources`.
+- If `REVENUECAT_API_KEY` not set (or no project ID): skip RevenueCat, include `"revenuecat": "not_configured"`.
+- If a curl returns a non-200 body (e.g. `{"error": ...}`), include the error key name in `revenue.errors[]` but do not abort — continue with partial data.
+- If both Stripe and RevenueCat are missing: fall back to `registry.json` `revenue.mrr` per project (legacy behaviour) and set `mrr_source: "registry.json"`.
+
+---
+
 ## Output format
 
 ```json
 {
   "timestamp": "[ISO8601]",
-  "current_month": {
-    "to_date": 0.0,
-    "forecast_eom": 0.0,
-    "by_service": [{ "service": "[name]", "cost": 0.0, "pct": 0.0 }]
-  },
-  "trend": [{ "month": "[YYYY-MM]", "cost": 0.0 }],
-  "mom_change_pct": 0.0,
-  "anomalies": [],
-  "credits": {
-    "remaining": null,
-    "expires": null,
-    "note": "check AWS console"
-  },
   "revenue": {
+    "mrr": 0,
+    "mrr_source": "stripe+revenuecat",
+    "mtd_gross": 0,
+    "trailing_30d": 0,
+    "breakdown": { "stripe_mrr": 0, "revenuecat_mrr": 0 },
+    "subscriptions": { "active": 0, "30d_ago": 0, "churn_rate_pct": 0.0 },
+    "open_invoices": { "count": 0, "total_usd": 0 },
+    "disputes": { "count": 0, "total_usd": 0 },
+    "pending_balance_usd": 0,
+    "available_balance_usd": 0,
+    "sources": { "stripe": "ok", "revenuecat": "ok" },
     "projects": [],
-    "total_mrr": 0,
-    "total_arr": 0
+    "errors": []
   },
-  "burn_rate": {
-    "monthly_aws": 0.0,
-    "net_burn": 0.0,
-    "runway_months_credits": null,
-    "runway_months_cash": null
+  "costs": {
+    "current_month": {
+      "to_date": 0.0,
+      "forecast_eom": 0.0,
+      "by_service": [{ "service": "[name]", "cost": 0.0, "pct": 0.0 }]
+    },
+    "trend": [{ "month": "[YYYY-MM]", "cost": 0.0 }],
+    "mom_change_pct": 0.0,
+    "anomalies": [],
+    "credits": {
+      "remaining": null,
+      "expires": null,
+      "note": "check AWS console"
+    },
+    "top_cost_drivers": [
+      { "service": "[name]", "cost": 0.0, "trend": "up|down|stable" }
+    ]
   },
-  "top_cost_drivers": [
-    { "service": "[name]", "cost": 0.0, "trend": "up|down|stable" }
-  ]
+  "runway": {
+    "burn_rate_monthly": 0.0,
+    "net_monthly": 0.0,
+    "runway_months": "net positive"
+  }
 }
 ```
 
-Calculate `net_burn` as `monthly_aws - total_mrr`. Positive = burning money, negative = profitable.
+Calculations:
+
+- `burn_rate_monthly` = `costs.current_month.forecast_eom` (or last full month if forecast unavailable).
+- `net_monthly` = `revenue.mrr - burn_rate_monthly`. Positive = profitable, negative = burning.
+- `runway_months`:
+  - If `net_monthly >= 0`, set to `"net positive"`.
+  - If `net_monthly < 0` and a cash balance is known (`revenue.available_balance_usd` or AWS credits), compute `cash / abs(net_monthly)` rounded to 1 decimal.
+  - Otherwise `null`.
 
 Print only the JSON to stdout.

--- a/claude-ops/agents/triage-agent.md
+++ b/claude-ops/agents/triage-agent.md
@@ -1,7 +1,7 @@
 ---
 name: triage-agent
 description: Investigates a specific issue from Sentry, Linear, or GitHub. Finds the root cause in code, checks if it's already fixed, and either confirms resolution or creates a fix branch with a PR.
-model: claude-sonnet-4-5
+model: claude-sonnet-4-6
 effort: high
 maxTurns: 40
 tools:

--- a/claude-ops/agents/yolo-ceo.md
+++ b/claude-ops/agents/yolo-ceo.md
@@ -1,6 +1,6 @@
 ---
 name: yolo-ceo
-description: Strategic priority agent. Analyzes the business from a CEO perspective — growth blockers, resource allocation, build vs. buy decisions, investor-readiness. No sugar-coating.
+description: Strategic priority agent. Analyzes the business from a CEO perspective — growth blockers, resource allocation, build vs. buy decisions, investor-readiness. No sugar-coating. Runs in parallel with CTO/CFO/COO.
 model: claude-opus-4-6
 effort: high
 maxTurns: 20
@@ -24,18 +24,13 @@ You are the CEO of this business. You have access to all data — technical, fin
 
 ## Reporting Chain
 
-You are the FINAL synthesizer. The CTO, CFO, and COO agents run in parallel and produce their own analysis files. Your job is to:
+You are ONE OF FOUR parallel analysis agents (CEO, CTO, CFO, COO). You each run independently and produce your own analysis file. The `/ops:yolo` skill (the main Claude Code orchestrator) reads all four reports and synthesizes them into the unified Hard Truths report presented to the user.
 
-1. Read their reports from `/tmp/yolo-[session]/cto-analysis.md`, `/tmp/yolo-[session]/cfo-analysis.md`, `/tmp/yolo-[session]/coo-analysis.md`
-2. Synthesize their findings into a unified CEO report
-3. Resolve any conflicts between their recommendations (CFO says cut, CTO says invest → you decide)
-4. Present the FINAL executive summary to the user
-
-You are the only agent that talks to the user. CTO/CFO/COO report to you.
+**You do NOT synthesize the other agents' reports.** Do not read their files. Do not wait for them. Produce your own strategic CEO analysis based on the pre-gathered context provided by the calling skill.
 
 ## Data available
 
-The calling skill has pre-gathered all data and passed it as context. You also have the CTO, CFO, and COO analysis files. Read them all before writing your report.
+The calling skill (`/ops:yolo`) has pre-gathered all data and passed it as context: infrastructure health, git/PR/CI state, unread messages, AWS costs, project registry, GSD state. Plus any contact memories loaded via Runtime Context. Analyze from a strategic CEO lens — you are not the CTO, CFO, or COO.
 
 ## Your mandate
 
@@ -63,55 +58,18 @@ Given everything you see — the tech debt, the half-finished features, the open
 
 ## Output
 
-First, read the C-suite reports:
-
-```bash
-cat /tmp/yolo-*/cto-analysis.md 2>/dev/null || echo "CTO report not available"
-cat /tmp/yolo-*/cfo-analysis.md 2>/dev/null || echo "CFO report not available"
-cat /tmp/yolo-*/coo-analysis.md 2>/dev/null || echo "COO report not available"
-```
-
-Then write your synthesis to `/tmp/yolo-[session]/ceo-analysis.md`:
+Write your CEO analysis to `/tmp/yolo-[session]/ceo-analysis.md`. The calling `/ops:yolo` skill will pick it up along with the other three agents' files and synthesize them into the final Hard Truths report.
 
 ```markdown
-# CEO EXECUTIVE BRIEFING — [date]
-
-## C-Suite Synthesis
-
-### From the CTO:
-
-[key technical findings — infrastructure health, debt, security]
-
-### From the CFO:
-
-[key financial findings — burn, waste, ROI]
-
-### From the COO:
-
-[key operational findings — execution gaps, broken processes]
-
-## Hard Truths
-
-1. [thing nobody is saying #1 — synthesized from all reports]
-2. [thing nobody is saying #2]
-3. [thing nobody is saying #3]
+# CEO STRATEGIC ANALYSIS — [date]
 
 ## #1 Growth Blocker
 
-[brutal assessment — supported by data from CTO/CFO/COO]
+[brutal assessment — one specific thing, backed by evidence from pre-gathered data]
 
 ## Are We Building the Right Things?
 
 [Yes/No + evidence from sprint/GSD/Linear data]
-
-## Infrastructure Health Summary
-
-| Area         | Status             | Finding    | Action |
-| ------------ | ------------------ | ---------- | ------ |
-| AWS Services | [green/yellow/red] | [from CTO] | [fix]  |
-| Costs        | [green/yellow/red] | [from CFO] | [fix]  |
-| Deploys      | [green/yellow/red] | [from COO] | [fix]  |
-| Security     | [green/yellow/red] | [from CTO] | [fix]  |
 
 ## Biggest Time Sinks
 
@@ -120,37 +78,26 @@ Then write your synthesis to `/tmp/yolo-[session]/ceo-analysis.md`:
 
 ## Honest Investor Pitch
 
-[3 sentences, no polish]
+[3 sentences, no polish — growth rate, current state, biggest risk]
 
-## The Plan (next 8 hours, synthesized from all C-suite input)
+## What We Should Start Over On This Month
 
-| Time | Action   | Source        | Expected Outcome |
-| ---- | -------- | ------------- | ---------------- |
-| 0:00 | [action] | [CTO/CFO/COO] | [outcome]        |
-| ...  | ...      | ...           | ...              |
+[what was the wrong priority — with specific evidence]
 
-## What to Kill
-
-[projects/features that CFO says cut AND CTO agrees aren't worth maintaining]
-
-## What to Double Down On
-
-[projects closest to revenue that CTO says are technically sound]
-
-## Top 3 CEO Actions (ranked by combined impact)
+## Strategic Recommendations
 
 1. [action] — [expected outcome] — data: [supporting evidence]
 2. [action] — [expected outcome] — data: [supporting evidence]
 3. [action] — [expected outcome] — data: [supporting evidence]
 ```
 
-Be specific. Reference actual data. Resolve CTO/CFO/COO conflicts with clear reasoning. No generic advice.
+Be specific. Reference actual data. No generic advice. No synthesis of other agents' work — just your own unfiltered CEO perspective.
 
 ## DESTRUCTIVE ACTION GUARDRAIL
 
-When synthesizing C-suite recommendations:
-1. **Cross-check "kill" recommendations** — if CTO or CFO says "delete" or "kill" a project, verify against COO's operational data and registry status. A project with recent commits, active branches, or planning is NOT dead.
-2. **"What to Kill" section must distinguish**: archive (stop work, keep infra) vs. mothball (stop work, reduce infra) vs. kill (delete everything). Default to mothball unless the project is confirmed abandoned.
-3. **Flag all destructive recommendations** with `⚠️ REQUIRES CONFIRMATION` — the YOLO orchestrator must present each to the user via AskUserQuestion before execution.
-4. **Never recommend canceling domains** for active projects. Verify project is truly abandoned first.
-5. **Err on the side of preservation** — reducing costs (disable Multi-AZ, delete idle ALBs, stop services) is safer than deleting permanently (drop RDS, delete clusters, cancel domains).
+When recommending organizational changes:
+
+1. **Never label a project "dead"** without verifying against the registry, recent commits, active branches, and planning state. An idle project is not the same as an abandoned one.
+2. **Flag all destructive recommendations** with `⚠️ REQUIRES CONFIRMATION` — the YOLO orchestrator will present each to the user via `AskUserQuestion` before execution (Rule 5).
+3. **Distinguish "kill" vs "pause"** — recommending infrastructure deletion (drop RDS, cancel domain, delete cluster) is very different from pausing work on a project. Default to pause unless the evidence for permanent deletion is overwhelming.
+4. **Err on the side of preservation** — reducing costs is safer than deleting permanently.

--- a/claude-ops/agents/yolo-cfo.md
+++ b/claude-ops/agents/yolo-cfo.md
@@ -85,10 +85,11 @@ for i in 3 2 1; do
 done
 
 # Reserved instances utilization
-aws ce get-reservation-utilization --time-period "Start=$(date -v-30d +%Y-%m-%d),End=$(date +%Y-%m-%d)" --output json 2>/dev/null
+RES_START=$(date -v-30d +%Y-%m-%d 2>/dev/null || date -d '30 days ago' +%Y-%m-%d)
+aws ce get-reservation-utilization --time-period "Start=$RES_START,End=$(date +%Y-%m-%d)" --output json 2>/dev/null
 
 # Savings plans utilization
-aws ce get-savings-plans-utilization --time-period "Start=$(date -v-30d +%Y-%m-%d),End=$(date +%Y-%m-%d)" --output json 2>/dev/null
+aws ce get-savings-plans-utilization --time-period "Start=$RES_START,End=$(date +%Y-%m-%d)" --output json 2>/dev/null
 
 # NAT Gateway costs (common silent killer)
 aws ce get-cost-and-usage --time-period "Start=$(date +%Y-%m-01),End=$(date +%Y-%m-%d)" --granularity MONTHLY --metrics UnblendedCost --filter '{"Dimensions":{"Key":"USAGE_TYPE","Values":["NatGateway-Bytes"]}}' --output json 2>/dev/null

--- a/claude-ops/bin/ops-autofix
+++ b/claude-ops/bin/ops-autofix
@@ -4,6 +4,10 @@
 # Usage: ops-autofix [--json] [--fix=all|wacli-fts|slack-mcp|vercel-mcp]
 set -euo pipefail
 
+# Platform detection — Keychain-based fixes only run on macOS
+IS_MAC=0
+[ "$(uname -s)" = "Darwin" ] && IS_MAC=1
+
 JSON_OUTPUT=false
 FIX_TARGET="all"
 
@@ -87,7 +91,11 @@ fix_slack_mcp() {
     return
   fi
 
-  # Check for tokens in keychain
+  # Check for tokens in keychain (macOS only — Keychain is macOS-specific)
+  if [ "$IS_MAC" != "1" ]; then
+    log_skip "slack-mcp: Keychain unavailable (not macOS) — use env vars or Doppler"
+    return
+  fi
   XOXC=$(security find-generic-password -s slack-xoxc -w 2>/dev/null || echo "")
   XOXD=$(security find-generic-password -s slack-xoxd -w 2>/dev/null || echo "")
 
@@ -202,27 +210,32 @@ fix_channel_health() {
     fi
   fi
 
-  # ── Slack: tokens in keychain but expired ──
-  XOXC=$(security find-generic-password -s slack-xoxc -w 2>/dev/null || echo "")
-  if [ -n "$XOXC" ]; then
-    XOXD=$(security find-generic-password -s slack-xoxd -w 2>/dev/null || echo "")
-    SLACK_OK=$(curl -s -H "Authorization: Bearer $XOXC" -b "d=$XOXD" "https://slack.com/api/auth.test" 2>/dev/null | jq -r '.ok // false' 2>/dev/null || echo "false")
-    if [ "$SLACK_OK" != "true" ]; then
-      log_fail "slack-health: tokens in keychain are expired (re-run /ops:setup slack)"
-    else
-      log_skip "slack-health: tokens valid"
+  # ── Slack: tokens in keychain but expired (macOS only) ──
+  if [ "$IS_MAC" = "1" ]; then
+    XOXC=$(security find-generic-password -s slack-xoxc -w 2>/dev/null || echo "")
+    if [ -n "$XOXC" ]; then
+      XOXD=$(security find-generic-password -s slack-xoxd -w 2>/dev/null || echo "")
+      SLACK_OK=$(curl -s -H "Authorization: Bearer $XOXC" -b "d=$XOXD" "https://slack.com/api/auth.test" 2>/dev/null | jq -r '.ok // false' 2>/dev/null || echo "false")
+      if [ "$SLACK_OK" != "true" ]; then
+        log_fail "slack-health: tokens in keychain are expired (re-run /ops:setup slack)"
+      else
+        log_skip "slack-health: tokens valid"
+      fi
     fi
-  fi
 
-  # ── Telegram: session in keychain but expired ──
-  TG_SESSION=$(security find-generic-password -s telegram-session -w 2>/dev/null || echo "")
-  if [ -n "$TG_SESSION" ]; then
-    TG_API_ID=$(security find-generic-password -s telegram-api-id -w 2>/dev/null || echo "")
-    if [ -z "$TG_API_ID" ]; then
-      log_fail "telegram-health: session exists but api_id missing from keychain"
-    else
-      log_skip "telegram-health: credentials present (runtime validation requires MCP)"
+    # ── Telegram: session in keychain but expired ──
+    TG_SESSION=$(security find-generic-password -s telegram-session -w 2>/dev/null || echo "")
+    if [ -n "$TG_SESSION" ]; then
+      TG_API_ID=$(security find-generic-password -s telegram-api-id -w 2>/dev/null || echo "")
+      if [ -z "$TG_API_ID" ]; then
+        log_fail "telegram-health: session exists but api_id missing from keychain"
+      else
+        log_skip "telegram-health: credentials present (runtime validation requires MCP)"
+      fi
     fi
+  else
+    log_skip "slack-health: Keychain unavailable (not macOS)"
+    log_skip "telegram-health: Keychain unavailable (not macOS)"
   fi
 }
 

--- a/claude-ops/bin/ops-setup-install
+++ b/claude-ops/bin/ops-setup-install
@@ -22,9 +22,33 @@ install_mac() {
     sentry-cli) brew install getsentry/tools/sentry-cli ;;
     expect)     brew install expect ;;
     wacli)      echo "○ wacli is not on Homebrew — install manually: https://github.com/wacli/wacli" >&2; return 2 ;;
-    gog)        echo "○ gog is not on Homebrew — install manually or skip email integration." >&2; return 2 ;;
+    gog)        install_gog ;;
     *) echo "✗ Unknown tool: $tool" >&2; return 1 ;;
   esac
+}
+
+# install_gog — try npm, then bun, then source-clone (private repo).
+# Returns 0 on success, 2 on failure (with manual instructions printed).
+install_gog() {
+  if command -v npm >/dev/null 2>&1 && npm install -g @auroracapital/gog >/dev/null 2>&1; then
+    echo "✓ gog installed via npm"
+    return 0
+  fi
+  if command -v bun >/dev/null 2>&1 && bun install -g @auroracapital/gog >/dev/null 2>&1; then
+    echo "✓ gog installed via bun"
+    return 0
+  fi
+  if command -v git >/dev/null 2>&1 && \
+     git clone https://github.com/auroracapital/gog "$HOME/.gog" >/dev/null 2>&1 && \
+     ( cd "$HOME/.gog" && ./install.sh >/dev/null 2>&1 ); then
+    echo "✓ gog installed from source (~/.gog)"
+    return 0
+  fi
+  echo "✗ Could not install gog. Options:" >&2
+  echo "  1. Ask Sam (internal team) for the latest release binary" >&2
+  echo "  2. Request access to github.com/auroracapital/gog" >&2
+  echo "  3. Use the Gmail MCP fallback (read-only, drafts only)" >&2
+  return 2
 }
 
 install_linux() {

--- a/claude-ops/bin/ops-setup-preflight
+++ b/claude-ops/bin/ops-setup-preflight
@@ -6,6 +6,10 @@ set -euo pipefail
 OUT="/tmp/ops-preflight"
 rm -rf "$OUT" && mkdir -p "$OUT"
 
+# Platform detection — Keychain-based probes only run on macOS
+IS_MAC=0
+[ "$(uname -s)" = "Darwin" ] && IS_MAC=1
+
 # All probes run in parallel as background jobs
 {
   # CLI detection
@@ -20,9 +24,14 @@ rm -rf "$OUT" && mkdir -p "$OUT"
 } &
 
 {
-  # Slack keychain scout
-  xoxc=$(security find-generic-password -s slack-xoxc -w 2>/dev/null || echo "")
-  xoxd=$(security find-generic-password -s slack-xoxd -w 2>/dev/null || echo "")
+  # Slack keychain scout (macOS only — Keychain is macOS-specific)
+  if [ "$IS_MAC" = "1" ]; then
+    xoxc=$(security find-generic-password -s slack-xoxc -w 2>/dev/null || echo "")
+    xoxd=$(security find-generic-password -s slack-xoxd -w 2>/dev/null || echo "")
+  else
+    xoxc=""
+    xoxd=""
+  fi
   if [ -n "$xoxc" ] && [ -n "$xoxd" ]; then
     # Validate
     result=$(curl -s -H "Authorization: Bearer $xoxc" -b "d=$xoxd" "https://slack.com/api/auth.test" 2>/dev/null || echo '{"ok":false}')
@@ -33,11 +42,17 @@ rm -rf "$OUT" && mkdir -p "$OUT"
 } &
 
 {
-  # Telegram keychain scout
-  for key in telegram-api-id telegram-api-hash telegram-phone telegram-session; do
-    val=$(security find-generic-password -s "$key" -w 2>/dev/null || echo "")
-    echo "$key=$( [ -n "$val" ] && echo "found" || echo "missing" )" >> "$OUT/telegram.txt"
-  done
+  # Telegram keychain scout (macOS only — Keychain is macOS-specific)
+  if [ "$IS_MAC" = "1" ]; then
+    for key in telegram-api-id telegram-api-hash telegram-phone telegram-session; do
+      val=$(security find-generic-password -s "$key" -w 2>/dev/null || echo "")
+      echo "$key=$( [ -n "$val" ] && echo "found" || echo "missing" )" >> "$OUT/telegram.txt"
+    done
+  else
+    for key in telegram-api-id telegram-api-hash telegram-phone telegram-session; do
+      echo "$key=missing" >> "$OUT/telegram.txt"
+    done
+  fi
 } &
 
 {

--- a/claude-ops/bin/ops-unread
+++ b/claude-ops/bin/ops-unread
@@ -88,7 +88,7 @@ except:
     RESULT=$(echo "$RESULT" | jq '.channels.email = {"unread": 0, "available": false, "note": "gog not authenticated — run: gog gmail auth"}')
   fi
 else
-  RESULT=$(echo "$RESULT" | jq '.channels.email = {"unread": 0, "available": false, "note": "gog not installed — see github.com/Lifecycle-Innovations-Limited/gog"}')
+  RESULT=$(echo "$RESULT" | jq '.channels.email = {"unread": 0, "available": false, "note": "gog not installed — run: npm install -g @auroracapital/gog (or bun install -g @auroracapital/gog, or clone github.com/auroracapital/gog)"}')
 fi
 
 # ── Slack — MCP-based, check env ──

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -1,38 +1,63 @@
+<div align="center">
+
 # Agents Reference
 
-All 12 agents in claude-ops v0.5.0. Agent files live in `agents/`.
+*All 12 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain*
 
-Agents are spawned by skills — they are not invoked directly. Each has `memory` scope for cross-session learning and a defined `effort` level that controls token budget.
+[![version](https://img.shields.io/badge/version-0.8.0-blue)](../CHANGELOG.md)
+[![agents](https://img.shields.io/badge/agents-12-8b5cf6)](.)
+[![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
+[![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)
+[![haiku](https://img.shields.io/badge/model-haiku--4--5-22c55e)](.)
+
+</div>
 
 ---
 
-## Background Scanner Agents
+All 12 agents in claude-ops v0.8.0. Agent files live in `agents/`.
+
+> [!NOTE]
+> Agents are spawned by skills — they are not invoked directly. Each has a `memory` scope for cross-session learning and a defined `effort` level that controls token budget.
+
+> [!IMPORTANT]
+> **v0.8.0 model bumps:** All scanner, fix, and daemon agents upgraded to **`claude-sonnet-4-6`**. All C-suite analysts upgraded to **`claude-opus-4-6`**. The `memory-extractor` stays on Haiku for cost — it's the only background service that runs every 30 min on every box.
+
+---
+
+## 🔎 Background Scanner Agents
 
 These agents run in the background, feeding structured JSON data to the main skills.
 
+| Agent | Model | Effort | maxTurns | Tools | Consumed by |
+|-------|-------|--------|----------|-------|-------------|
+| `comms-scanner` | `claude-sonnet-4-6` | low | 10 | Bash (read-only) | `ops-inbox`, `ops-go` |
+| `infra-monitor` | `claude-sonnet-4-6` | low | 15 | Bash | `ops-fires`, `ops-deploy` |
+| `project-scanner` | `claude-sonnet-4-6` | low | 15 | Bash | `ops-projects`, `ops-go` |
+| `revenue-tracker` | `claude-sonnet-4-6` | medium | 20 | Bash | `ops-revenue`, `ops-go` |
+
 ### `comms-scanner` · `agents/comms-scanner.md`
-- **Model**: claude-sonnet-4-5
+- **Model**: `claude-sonnet-4-6`
 - **Effort**: low · **maxTurns**: 10
 - **Memory**: project scope
 - **Tools**: Bash only (read-only)
 - **Purpose**: Scans all communication channels (WhatsApp, Email, Slack, Telegram) for FULL inbox state. Classifies each conversation as `NEEDS_REPLY`, `WAITING`, or `HANDLED`. Returns structured JSON consumed by `ops-inbox` and `ops-go`.
 
 ### `infra-monitor` · `agents/infra-monitor.md`
-- **Model**: claude-sonnet-4-5
+- **Model**: `claude-sonnet-4-6`
 - **Effort**: low · **maxTurns**: 15
 - **Memory**: project scope
 - **Tools**: Bash only
 - **Purpose**: ECS, Vercel, and AWS health checker. Returns structured JSON with service health, recent deployments, and anomaly flags. Used by `ops-fires` and `ops-deploy`.
 
 ### `project-scanner` · `agents/project-scanner.md`
-- **Model**: claude-sonnet-4-5
+- **Model**: `claude-sonnet-4-6`
 - **Effort**: low · **maxTurns**: 15
 - **Memory**: project scope
 - **Tools**: Bash only
 - **Purpose**: Git, PR, and CI status scanner across all registered repos. Returns structured JSON with branch state, uncommitted files, open PRs, and CI status for each project.
 
 ### `revenue-tracker` · `agents/revenue-tracker.md`
-- **Model**: claude-sonnet-4-5
+- **Model**: `claude-sonnet-4-6`
 - **Effort**: medium · **maxTurns**: 20
 - **Memory**: project scope
 - **Tools**: Bash only
@@ -40,70 +65,125 @@ These agents run in the background, feeding structured JSON data to the main ski
 
 ---
 
-## Fix Agents
+## 🛠️ Fix Agents
 
 These agents are dispatched when issues are found and need resolution.
 
 ### `triage-agent` · `agents/triage-agent.md`
-- **Model**: claude-sonnet-4-5
+- **Model**: `claude-sonnet-4-6`
 - **Effort**: high · **maxTurns**: 40
 - **Isolation**: worktree (sandboxed)
 - **Purpose**: Investigates a specific issue from Sentry, Linear, or GitHub. Finds the root cause in code, checks if it's already fixed, and either confirms resolution or creates a fix branch with a PR. Runs in an isolated worktree to avoid polluting the main working tree.
 
+> [!TIP]
+> `triage-agent` runs in a sandboxed worktree — changes never bleed into your main working tree until a PR lands. Safe to fire-and-forget from `/ops:triage`.
+
 ---
 
-## C-Suite Analysis Agents
+## 💼 C-Suite Analysis Agents
 
-All four run in parallel when `/ops:yolo` is invoked. Each uses Opus for maximum analytical depth.
+All four run in **parallel** when `/ops:yolo` is invoked. Each uses **Opus 4.6** for maximum analytical depth.
+
+> [!IMPORTANT]
+> **v0.8.0 bump:** all four C-suite agents now run on `claude-opus-4-6` (up from `claude-opus-4-5` in v0.7.x). Expect sharper reasoning and slightly higher per-run token cost.
+
+### C-Suite Spawn Flow
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User
+    participant YOLO as /ops:yolo
+    participant Ctx as Context Gatherer
+    participant CEO as yolo-ceo (opus-4-6)
+    participant CTO as yolo-cto (opus-4-6)
+    participant CFO as yolo-cfo (opus-4-6)
+    participant COO as yolo-coo (opus-4-6)
+    participant Merger as Hard Truths Merger
+
+    User->>YOLO: /ops:yolo [YOLO]
+    YOLO->>Ctx: gather ops-infra + ops-dash
+    Ctx-->>YOLO: unified context JSON
+
+    par Parallel spawn
+        YOLO->>CEO: strategic analysis
+        YOLO->>CTO: technical analysis
+        YOLO->>CFO: financial analysis
+        YOLO->>COO: operational analysis
+    end
+
+    CEO-->>Merger: blockers, allocation, build-vs-buy
+    CTO-->>Merger: architecture, debt, risks
+    CFO-->>Merger: burn, runway, ROI
+    COO-->>Merger: stale work, broken processes
+
+    Merger->>User: unified Hard Truths report
+    alt YOLO mode
+        User->>YOLO: confirm autonomous execution
+        YOLO->>User: execute with per-action confirm
+    end
+```
+
+> [!IMPORTANT]
+> `Hard Truths Merger` in the diagram above is the **main `/ops:yolo` skill orchestrator** running in the Claude Code main agent context — NOT a separate agent. It reads all four parallel analysis files (`ceo-analysis.md`, `cto-analysis.md`, `cfo-analysis.md`, `coo-analysis.md`) and composes the unified report. `yolo-ceo` is a peer agent with its own strategic perspective; it does not synthesize the others' work.
 
 ### `yolo-ceo` · `agents/yolo-ceo.md`
-- **Model**: claude-opus-4-6
+- **Model**: `claude-opus-4-6`
 - **Effort**: high · **maxTurns**: 20
 - **Purpose**: Strategic priority analysis. Growth blockers, resource allocation, build vs. buy decisions, investor-readiness. No sugar-coating.
 
 ### `yolo-cto` · `agents/yolo-cto.md`
-- **Model**: claude-opus-4-6
+- **Model**: `claude-opus-4-6`
 - **Effort**: high · **maxTurns**: 25
 - **Purpose**: Technical health analysis. Architecture, tech debt, production risks, scalability limits, and cut corners. Brutally honest about what will break.
 
 ### `yolo-cfo` · `agents/yolo-cfo.md`
-- **Model**: claude-opus-4-6
+- **Model**: `claude-opus-4-6`
 - **Effort**: high · **maxTurns**: 20
 - **Purpose**: Financial analysis. AWS burn rate, runway, ROI on current work, credits expiry, cost anomalies. No optimism without data.
 
 ### `yolo-coo` · `agents/yolo-coo.md`
-- **Model**: claude-opus-4-6
+- **Model**: `claude-opus-4-6`
 - **Effort**: high · **maxTurns**: 25
 - **Purpose**: Operations execution analysis. Stale work, broken processes, missing automation, communication failures. What the CEO doesn't see.
 
+> [!WARNING]
+> C-suite agents produce unfiltered "Hard Truths" — they will flag risks, dead projects, and wasted spend by name. Review before sharing with investors or teammates.
+
 ---
 
-## Daemon & System Agents
+## ⚙️ Daemon & System Agents
 
 ### `daemon-agent` · `agents/daemon-agent.md`
-- **Model**: claude-sonnet-4-6
+- **Model**: `claude-sonnet-4-6`
 - **Effort**: low · **maxTurns**: 10
 - **Memory**: project scope
 - **Purpose**: Manages the ops background daemon — start, stop, restart services, check health. Spawned by `ops-doctor` and `ops-setup` when daemon configuration changes are needed.
 
 ### `doctor-agent` · `agents/doctor-agent.md`
-- **Model**: claude-sonnet-4-6
+- **Model**: `claude-sonnet-4-6`
 - **Effort**: high · **maxTurns**: 30
 - **Tools**: Bash, Read, Write, Edit, Grep, Glob (no Agent spawning)
 - **Purpose**: Diagnoses and auto-fixes ops plugin configuration errors, manifest issues, broken permissions, invalid JSON, and stale cache copies. Spawned by `/ops:doctor`.
 
 ### `memory-extractor` · `agents/memory-extractor.md`
-- **Model**: claude-haiku-4-5-20251001
+- **Model**: `claude-haiku-4-5-20251001`
 - **Effort**: low · **maxTurns**: 10
 - **Memory**: project scope
 - **Purpose**: Background agent that extracts user profiles, contact cards, and behavioral patterns from chat history. Runs as a daemon service every 30 minutes. Writes structured markdown to `memories/`. Used by all communication skills for context-aware drafting.
 
+> [!NOTE]
+> The `memory-extractor` is the only agent that still runs on **Haiku 4.5** — it's optimised for cheap high-frequency extraction. See [`memories-system.md`](memories-system.md) for details.
+
 ---
 
-## Agent Memory Scopes
+## 🧠 Agent Memory Scopes
 
 | Scope | What persists |
 |-------|--------------|
 | `project` | Remembered across sessions within the same project context |
 | `user` | Remembered across all projects for the same user |
-| worktree isolation | Agent runs in a sandboxed worktree, changes don't bleed into main tree |
+| worktree isolation | Agent runs in a sandboxed worktree — changes don't bleed into main tree |
+
+> [!TIP]
+> Memory scope is declared in each agent file's frontmatter. To reset an agent's memory, delete the matching subdirectory in `~/.claude/plugins/data/ops-ops-marketplace/memories/`.

--- a/claude-ops/docs/daemon-guide.md
+++ b/claude-ops/docs/daemon-guide.md
@@ -1,24 +1,103 @@
+<div align="center">
+
 # Daemon Guide
 
-The ops-daemon is a unified background process manager that runs persistently via macOS launchd. It replaced per-service launchd agents (introduced in v0.5.0).
+*The unified background process manager that pre-warms briefings, syncs WhatsApp, extracts memories, and watches your fires — persistently, via launchd*
 
-## What the Daemon Does
+[![version](https://img.shields.io/badge/version-0.8.0-blue)](../CHANGELOG.md)
+[![services](https://img.shields.io/badge/services-7-f59e0b)](.)
+[![launchd](https://img.shields.io/badge/runtime-launchd-6366f1)](.)
+[![pre--warm](https://img.shields.io/badge/pre--warm-every%202%20min-22c55e)](.)
 
-1. **Keeps WhatsApp connected** — runs `wacli follow` in persistent mode with auto-reconnect on disconnect
-2. **Auto-backfills @lid chats** — detects empty chats from the `@lid` addressing format and backfills message history
-3. **Triggers memory extraction** — every 30 minutes, spawns the `memory-extractor` agent to update `memories/`
-4. **Writes a health file** — maintains `~/.wacli/.health` so skills can pre-flight check before attempting WhatsApp reads
+</div>
 
-## Setup
+---
+
+The **ops-daemon** is a unified background process manager that runs persistently via macOS launchd. It replaced per-service launchd agents (introduced in v0.5.0, expanded in v0.8.0).
+
+> [!NOTE]
+> As of **v0.8.0**, the daemon installs at **setup Step 2c** (not 5b) so it begins pre-warming the briefing cache while the rest of setup is still running. By the time you finish configuring integrations, `/ops:go` is already instant.
+
+---
+
+## 🧭 What the Daemon Does
+
+The daemon supervises **seven** long-lived services:
+
+| Service | Cadence | Purpose |
+|---------|---------|---------|
+| `briefing-pre-warm` | every **2 min** | Runs `bin/ops-gather` to keep `/ops:go` cache hot |
+| `wacli-sync` | persistent | Keeps WhatsApp connected, auto-reconnects, backfills `@lid` chats |
+| `memory-extractor` | every 30 min | Spawns `memory-extractor` agent to refresh `memories/` |
+| `inbox-digest` | every 15 min | Pre-classifies comms across channels for `/ops:inbox` |
+| `store-health` | every 10 min | Shopify orders + inventory polling (if configured) |
+| `competitor-intel` | hourly | Background market/competitor monitoring |
+| `message-listener` | persistent | Surfaces urgent patterns (your name, "urgent", "ASAP", "fire", "down") |
+
+> [!TIP]
+> The `briefing-pre-warm` service is what makes `/ops:go` feel instant. It runs `bin/ops-gather` every 2 minutes so the cache is always <2 min stale when you ask.
+
+---
+
+## ⚡ The Pre-Warm Strategy
+
+Installing the daemon at **setup Step 2c** is a deliberate optimisation. While you're still clicking through OAuth prompts and pasting API keys in Steps 3–7, the daemon is already warming your briefing cache in the background.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User
+    participant Setup as /ops:setup
+    participant Daemon as ops-daemon
+    participant PreWarm as briefing-pre-warm
+    participant Cache as daemon-cache.json
+    participant Go as /ops:go
+
+    User->>Setup: start setup wizard
+    Setup->>Setup: Step 1 — detect environment
+    Setup->>Setup: Step 2a — install CLIs
+    Setup->>Setup: Step 2b — configure secrets manager
+    Setup->>Daemon: Step 2c — INSTALL DAEMON (early!)
+    activate Daemon
+    Daemon->>PreWarm: spawn briefing-pre-warm
+    Note over Daemon,PreWarm: Daemon is live before<br/>setup completes
+
+    par Setup continues
+        Setup->>Setup: Steps 3–7 — integrations, registry, smoke tests
+    and Pre-warm loops
+        loop every 2 min
+            PreWarm->>Cache: bin/ops-gather → write cache
+        end
+    end
+
+    Setup->>Setup: Step 5b — daemon service reconciliation
+    Note right of Setup: Step 5b is now<br/>RECONCILE (not fresh install)
+    Setup->>Daemon: reconcile service set
+    Setup-->>User: setup complete
+
+    User->>Go: /ops:go
+    Go->>Cache: read daemon-cache.json
+    Cache-->>Go: <2 min fresh data
+    Go-->>User: briefing in ~1s
+    deactivate Daemon
+```
+
+> [!IMPORTANT]
+> **Step 5b changed in v0.8.0.** It used to be "install daemon + launchd plist" (fresh install). It is now "**daemon service reconciliation**" — the daemon is already running from Step 2c; Step 5b just reconciles the active service set with whatever integrations the user configured in Steps 3–7 (enables `store-health` only if Shopify was configured, etc.).
+
+---
+
+## 🛠️ Setup
 
 The daemon is configured automatically by the setup wizard:
 
 ```
 /ops:setup
-# Step 5b: Background daemon
+# Step 2c: Install ops-daemon + briefing-pre-warm (early install)
+# Step 5b: Daemon service reconciliation (enable/disable per integration)
 ```
 
-Or start it manually:
+Or manage it manually:
 
 ```bash
 # Start via launchd (recommended — survives reboots)
@@ -29,11 +108,19 @@ launchctl load ~/Library/LaunchAgents/com.claude-ops.daemon.plist
 
 # Check status
 ~/.claude/plugins/cache/.../scripts/ops-daemon.sh status
+
+# List active services
+~/.claude/plugins/cache/.../scripts/ops-daemon.sh services
 ```
 
 The daemon script lives at `scripts/ops-daemon.sh`.
 
-## Health File Contract
+> [!TIP]
+> Run `/ops:doctor` anytime the daemon misbehaves. It diagnoses missing plists, stale PIDs, failed services, and reconciles the service set for you.
+
+---
+
+## 📋 Health File Contract
 
 The daemon writes `~/.wacli/.health` on every successful wacli sync. Skills read this file before any WhatsApp operation.
 
@@ -53,9 +140,12 @@ The daemon writes `~/.wacli/.health` on every successful wacli sync. Skills read
 | `wacli_pid` | PID of the running wacli process |
 | `message_count` | Total messages in local DB |
 
-If `last_sync` is more than 10 minutes ago, the PreToolUse hook surfaces a warning before any WhatsApp command.
+> [!WARNING]
+> If `last_sync` is more than **10 minutes** ago, the PreToolUse hook surfaces a warning before any WhatsApp command. Running `/ops:doctor` will auto-restart the daemon if this happens.
 
-## PreToolUse Hook
+---
+
+## 🪝 PreToolUse Hook
 
 `hooks/whatsapp-health-check.sh` runs automatically before any `wacli` call. It checks the health file and either:
 - Proceeds silently if `status === ok` and `last_sync` is recent
@@ -63,20 +153,28 @@ If `last_sync` is more than 10 minutes ago, the PreToolUse hook surfaces a warni
 
 The hook is registered in `.claude/settings.json` under `preToolUse`.
 
-## Brain Layer
+---
+
+## 🧠 Brain Layer
 
 The daemon includes a lightweight brain layer (`bin/ops-brain`) that:
-- Pre-fetches briefing data every 5 minutes and caches it to `~/.claude/plugins/data/.../daemon-cache.json`
+- Pre-fetches briefing data every **2 minutes** via `briefing-pre-warm` and caches it to `~/.claude/plugins/data/.../daemon-cache.json`
 - Detects urgent message patterns (mentions of your name, "urgent", "ASAP", "fire", "down")
 - Writes urgent flags to the health file so `/ops:go` can surface them instantly
 
-This makes `/ops:go` load in under 3 seconds instead of gathering data live.
+This makes `/ops:go` load in under **3 seconds** instead of gathering data live (typically ~1s off a hot cache).
 
-## Troubleshooting
+---
+
+## 🔧 Troubleshooting
 
 ```bash
 # View daemon logs
 tail -f /tmp/com.claude-ops.daemon.log
+
+# View a specific service's logs
+tail -f /tmp/com.claude-ops.briefing-pre-warm.log
+tail -f /tmp/com.claude-ops.memory-extractor.log
 
 # Force restart
 launchctl unload ~/Library/LaunchAgents/com.claude-ops.daemon.plist
@@ -87,6 +185,14 @@ launchctl load ~/Library/LaunchAgents/com.claude-ops.daemon.plist
 ```
 
 Common issues:
-- **`wacli not connected`** — run `/ops:setup whatsapp` to re-authenticate
-- **`health file stale`** — daemon may have crashed; check `/tmp/com.claude-ops.daemon.log`
-- **`memory extractor not running`** — check that haiku API key is configured in preferences or Doppler
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `wacli not connected` | Auth expired | `/ops:setup whatsapp` to re-authenticate |
+| `health file stale` | Daemon crashed | Check `/tmp/com.claude-ops.daemon.log`, restart via launchctl |
+| `memory extractor not running` | Missing Haiku API key | Configure in preferences or Doppler |
+| `briefing-pre-warm errors` | `bin/ops-gather` failing | Run `bin/ops-gather` manually to see the error, often a missing CLI |
+| `Step 5b keeps re-enabling stopped services` | Expected — reconciliation enables anything configured | Use `ops-daemon.sh disable <service>` to opt out |
+
+> [!CAUTION]
+> Don't manually delete `~/Library/LaunchAgents/com.claude-ops.daemon.plist` while the daemon is running — launchctl will leave orphan processes. Always `launchctl unload` first, then remove the plist.

--- a/claude-ops/docs/memories-system.md
+++ b/claude-ops/docs/memories-system.md
@@ -1,14 +1,79 @@
+<div align="center">
+
 # Memories System
 
-The memories system gives claude-ops persistent context about people, projects, and your communication patterns. Introduced in v0.5.0.
+*Persistent local context about people, projects, and your communication patterns — extracted from your chats, stored as markdown, never sent anywhere*
 
-## How It Works
+[![version](https://img.shields.io/badge/version-0.8.0-blue)](../CHANGELOG.md)
+[![storage](https://img.shields.io/badge/storage-local%20markdown-22c55e)](.)
+[![privacy](https://img.shields.io/badge/privacy-on--device-6366f1)](.)
+[![extractor](https://img.shields.io/badge/extractor-haiku--4--5-f59e0b)](.)
+
+</div>
+
+---
+
+The memories system gives claude-ops persistent context about people, projects, and your communication patterns. Introduced in v0.5.0, upgraded in v0.8.0 with richer project context blocks.
+
+> [!IMPORTANT]
+> **Files never leave your machine.** Memories are plain markdown on your local disk at `~/.claude/plugins/data/ops-ops-marketplace/memories/`. The extractor reads your local wacli database and local email cache — nothing is uploaded. See [Privacy](#-privacy) below.
+
+---
+
+## 🧠 How It Works
 
 1. **Extraction** — the `memory-extractor` agent (`agents/memory-extractor.md`) runs every 30 minutes as a daemon service. It reads recent WhatsApp messages (via `wacli`) and email threads (via `gog`) and calls Claude Haiku to extract structured profiles.
-2. **Storage** — profiles are written as markdown files to `~/.claude/plugins/data/ops-ops-marketplace/memories/`
-3. **Consumption** — skills load the relevant memory files at runtime via the Runtime Context block at the top of each SKILL.md
+2. **Storage** — profiles are written as markdown files to `~/.claude/plugins/data/ops-ops-marketplace/memories/`.
+3. **Consumption** — skills load the relevant memory files at runtime via the Runtime Context block at the top of each `SKILL.md`.
 
-## File Format
+### Extraction Flow
+
+```mermaid
+flowchart TB
+    Trigger{Trigger?}
+    Trigger -->|30 min elapsed| Start[memory-extractor agent spawns]
+    Trigger -->|msg count +5| Start
+    Trigger -->|/ops:doctor --run-memory-extractor| Start
+
+    Start --> ReadLocal[Read LOCAL sources only]
+    ReadLocal --> Wacli[(~/.wacli<br/>local SQLite)]
+    ReadLocal --> Gog[(~/.gog<br/>local email cache)]
+
+    Wacli --> Haiku[Claude Haiku 4.5<br/>structured extraction]
+    Gog --> Haiku
+
+    Haiku --> Merge[Merge into existing<br/>profiles — never overwrite]
+    Merge --> Write[Write markdown]
+
+    Write --> Contacts[memories/contacts/&lt;name&gt;.md]
+    Write --> Prefs[memories/preferences.md]
+    Write --> Projects[memories/projects/&lt;alias&gt;.md]
+
+    Contacts --> Consumed[Consumed by skills<br/>at runtime]
+    Prefs --> Consumed
+    Projects --> Consumed
+
+    Consumed --> Inbox[/ops:inbox]
+    Consumed --> Comms[/ops:comms]
+    Consumed --> Go[/ops:go]
+
+    classDef primary fill:#6366f1,color:#fff
+    classDef daemon fill:#f59e0b,color:#fff
+    classDef agent fill:#8b5cf6,color:#fff
+    classDef success fill:#22c55e,color:#fff
+
+    class Trigger,ReadLocal primary
+    class Start,Haiku agent
+    class Wacli,Gog,Contacts,Prefs,Projects daemon
+    class Consumed,Inbox,Comms,Go success
+```
+
+> [!NOTE]
+> The extractor **merges** new information into existing profiles rather than overwriting — context accumulates over time. Rename or delete files manually if you want to reset a profile.
+
+---
+
+## 📄 File Format
 
 ### Contact profiles (`memories/contacts/<name>.md`)
 
@@ -67,18 +132,20 @@ The memories system gives claude-ops persistent context about people, projects, 
 - Bob (backend): bob@example.com
 ```
 
-## How Skills Consume Memories
+---
+
+## 🔌 How Skills Consume Memories
 
 Every skill has a Runtime Context block that loads memories at execution time:
 
-```markdown
+````markdown
 ```!
 # Load memories
 MEMORIES_DIR="$CLAUDE_PLUGIN_ROOT/../data/memories"
 cat "$MEMORIES_DIR/preferences.md" 2>/dev/null || echo "No preferences found"
 ls "$MEMORIES_DIR/contacts/" 2>/dev/null | head -20
 ```
-```
+````
 
 The `ops-inbox` and `ops-comms` skills do a contact lookup before drafting any reply:
 
@@ -86,7 +153,12 @@ The `ops-inbox` and `ops-comms` skills do a contact lookup before drafting any r
 2. Check `memories/projects/` for relevant project context
 3. Draft reply matching the contact's expected tone and the conversation's topic
 
-## Manual Memory Management
+> [!TIP]
+> Drop a pre-written contact card into `memories/contacts/` by hand and the extractor will merge future extractions into it rather than replacing it — useful for seeding context on new contacts.
+
+---
+
+## 🧰 Manual Memory Management
 
 ```bash
 # View all contact profiles
@@ -101,15 +173,36 @@ vim ~/.claude/plugins/data/ops-ops-marketplace/memories/contacts/john-smith.md
 /ops:doctor --run-memory-extractor
 ```
 
-## Memory Extraction Trigger
+---
 
-The daemon triggers extraction when:
-- 30 minutes have elapsed since the last run
-- The message count in `~/.wacli/.health` has increased by more than 5
-- `/ops:doctor` is run with `--run-memory-extractor`
+## ⏱️ Memory Extraction Trigger
+
+The daemon triggers extraction when **any** of these conditions are met:
+
+| Trigger | Condition |
+|---------|-----------|
+| Time-based | 30 minutes elapsed since last run |
+| Volume-based | Message count in `~/.wacli/.health` increased by more than 5 |
+| Manual | `/ops:doctor --run-memory-extractor` |
 
 The extractor uses `claude-haiku-4-5-20251001` (fast + cheap) for all extraction work. It merges new information into existing profiles rather than overwriting, so context accumulates over time.
 
-## Privacy
+> [!NOTE]
+> Haiku 4.5 is used deliberately here — memory extraction is a high-frequency, low-reasoning-depth workload. The tradeoff: cost stays low enough to run every 30 min on every user's machine.
 
-Memory files live entirely on your local machine at `~/.claude/plugins/data/ops-ops-marketplace/memories/`. They are never sent anywhere — they are just files on disk that skills read. The extractor reads your local wacli database and local email cache, not cloud APIs.
+---
+
+## 🔒 Privacy
+
+> [!IMPORTANT]
+> **Memory files never leave your machine.**
+>
+> - **Location:** `~/.claude/plugins/data/ops-ops-marketplace/memories/`
+> - **Storage:** plain markdown files on your local disk
+> - **Sources:** the extractor reads your **local** wacli database and **local** email cache — not cloud APIs
+> - **Upload:** nothing is sent to any server. Files are read by skills at runtime and that's it.
+>
+> If you want to wipe everything: `rm -rf ~/.claude/plugins/data/ops-ops-marketplace/memories/`.
+
+> [!CAUTION]
+> The **content** of a memory file may get included in the prompt context when a skill runs — which does reach Anthropic's API for that request, as with any Claude conversation. If you have contacts whose details you don't want included in any prompt, remove or redact their contact cards before running comms skills.

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -1,8 +1,24 @@
+<div align="center">
+
 # Skills Reference
 
-All 21 skills available in claude-ops v0.8.0. Skills live in `skills/<name>/SKILL.md`.
+*All 21 skills available in claude-ops — your business operations command surface*
 
-## AskUserQuestion Batching Pattern
+[![version](https://img.shields.io/badge/version-0.8.0-blue)](../CHANGELOG.md)
+[![skills](https://img.shields.io/badge/skills-21-8b5cf6)](.)
+[![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
+[![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)
+
+</div>
+
+---
+
+Skills live in `skills/<name>/SKILL.md`.
+
+> [!NOTE]
+> Skills are the user-facing slash commands. They route work to agents, orchestrate multi-step flows, and present results. See [`agents-reference.md`](agents-reference.md) for the agents they spawn.
+
+## 🧩 AskUserQuestion Batching Pattern
 
 All skills enforce a hard limit of **<=4 options per `AskUserQuestion` call** (plugin-root CLAUDE.md rule, enforced by the tool schema). When a menu has more than 4 entries, apply this strategy:
 
@@ -10,9 +26,14 @@ All skills enforce a hard limit of **<=4 options per `AskUserQuestion` call** (p
 2. **Batch with "More..."** — split remaining items into sequential calls of <=4. Last option in each non-final batch is `[More options...]` to advance to the next batch.
 3. **Paginate dynamic lists** — any runtime list (projects, configs) that may exceed 4 items must be paginated at 4 per page.
 
+> [!IMPORTANT]
+> Passing more than 4 options causes an `InputValidationError` and the skill crashes. Always filter and batch.
+
 Examples in this release: setup section picker (11 items → 4+4+3), setup channel picker (7 items → 4+3), ops-comms / deploy / fires / go / inbox / linear / projects / revenue / speedup / triage / yolo all use "More..." bridges where needed. ops-dash hotkey menu was refactored to comply.
 
-## Core Navigation
+---
+
+## 🧭 Core Navigation
 
 ### `/ops` · `skills/ops/SKILL.md`
 Business operations router. Routes to the right skill based on arguments, or launches the dashboard with no args.
@@ -28,12 +49,15 @@ Interactive pixel-art command center. Visual HQ with live status indicators (fir
 
 ---
 
-## Daily Operations
+## ☀️ Daily Operations
 
 ### `/ops:go` · `skills/ops-go/SKILL.md`
 Token-efficient morning briefing. Pre-gathers all data via shell scripts (`bin/ops-infra`, `bin/ops-dash`) in parallel, then presents a unified dashboard in under 10 seconds.
 - `/ops:go` — full briefing
 - `/ops:go my-app` — briefing scoped to one project alias
+
+> [!TIP]
+> `/ops:go` hits the pre-warmed daemon cache — first load is typically <3s. Run the briefing pre-warm service (see [`daemon-guide.md`](daemon-guide.md)) to keep it snappy.
 
 ### `/ops:next` · `skills/ops-next/SKILL.md`
 Priority-ordered next action. Applies the priority stack: fires > urgent comms > ready-to-merge PRs > Linear sprint > GSD work.
@@ -55,7 +79,7 @@ Send and read messages across all channels. Full conversation context required b
 
 ---
 
-## Project & Engineering
+## 🛠️ Project & Engineering
 
 ### `/ops:projects` · `skills/ops-projects/SKILL.md`
 Portfolio dashboard. Shows all registered projects with GSD phase, branch state, uncommitted files, open PRs, and CI status.
@@ -92,9 +116,40 @@ Autonomous PR merge pipeline. Dispatches subagents to fix CI, resolve conflicts,
 - `/ops:merge --dry-run` — preview only
 - `/ops:merge --repo Lifecycle-Innovations-Limited/my-app`
 
+#### `/ops:merge` Flow
+
+```mermaid
+flowchart TB
+    Start([/ops:merge]) --> Scan[Scan open PRs<br/>across registered repos]
+    Scan --> Ready{PR ready<br/>to merge?}
+    Ready -->|CI red| FixCI[Dispatch CI-fix<br/>subagent]
+    Ready -->|Conflicts| Resolve[Dispatch conflict<br/>resolver subagent]
+    Ready -->|Review comments| Address[Dispatch review<br/>addressor subagent]
+    Ready -->|Clean| Merge[Merge PR]
+    FixCI --> Recheck[Re-check status]
+    Resolve --> Recheck
+    Address --> Recheck
+    Recheck --> Ready
+    Merge --> Sync{--main flag?}
+    Sync -->|Yes| DevMain[Sync dev → main]
+    Sync -->|No| Done([Report])
+    DevMain --> Done
+
+    classDef primary fill:#6366f1,color:#fff
+    classDef agent fill:#8b5cf6,color:#fff
+    classDef success fill:#22c55e,color:#fff
+
+    class Start,Scan,Recheck primary
+    class FixCI,Resolve,Address agent
+    class Merge,DevMain,Done success
+```
+
+> [!WARNING]
+> `/ops:merge` merges PRs autonomously. Run `--dry-run` first on new repos to confirm the pipeline behaves correctly before letting it merge for real.
+
 ---
 
-## Business Intelligence
+## 📊 Business Intelligence
 
 ### `/ops:revenue` · `skills/ops-revenue/SKILL.md`
 Revenue and costs dashboard. AWS spend via Cost Explorer, credits tracker, project revenue stages, burn rate, and runway estimate.
@@ -107,9 +162,41 @@ C-suite analysis + autonomous mode. Spawns 4 parallel agents (CEO, CTO, CFO, COO
 - `/ops:yolo` — run C-suite analysis
 - `/ops:yolo YOLO` — autonomous mode
 
+#### `/ops:yolo` Flow
+
+```mermaid
+flowchart LR
+    Invoke([/ops:yolo]) --> Gather[Gather context<br/>ops-infra + ops-dash]
+    Gather --> Fanout{Parallel spawn}
+    Fanout --> CEO[yolo-ceo<br/>strategic]
+    Fanout --> CTO[yolo-cto<br/>technical]
+    Fanout --> CFO[yolo-cfo<br/>financial]
+    Fanout --> COO[yolo-coo<br/>operational]
+    CEO --> Merge[Merge perspectives<br/>into Hard Truths]
+    CTO --> Merge
+    CFO --> Merge
+    COO --> Merge
+    Merge --> Mode{YOLO mode?}
+    Mode -->|No| Report([Present report])
+    Mode -->|YOLO| Auto[Execute recommendations<br/>with per-action confirm]
+
+    classDef primary fill:#6366f1,color:#fff
+    classDef agent fill:#8b5cf6,color:#fff
+    classDef danger fill:#ef4444,color:#fff
+    classDef success fill:#22c55e,color:#fff
+
+    class Invoke,Gather,Merge primary
+    class CEO,CTO,CFO,COO agent
+    class Auto danger
+    class Report success
+```
+
+> [!CAUTION]
+> YOLO autonomous mode executes recommendations directly. Destructive actions (delete ECS, stop services, rewrite git history) still require per-action confirmation per CLAUDE.md Rule 5, but everything else runs without pause. Use with intent.
+
 ---
 
-## E-Commerce & Marketing
+## 🛒 E-Commerce & Marketing
 
 ### `/ops:ecom` · `skills/ops-ecom/SKILL.md`
 Shopify store command center. Orders, inventory, fulfillment, analytics, and store health via Shopify Admin API.
@@ -134,7 +221,7 @@ Voice channel management. Make phone calls (Bland AI), text-to-speech (ElevenLab
 
 ---
 
-## Orchestration & Automation
+## 🤖 Orchestration & Automation
 
 ### `/ops:orchestrate` · `skills/ops-orchestrate/SKILL.md`
 Autonomous multi-project orchestration engine. Audits all registered projects, structures work into dependency-wired tasks, dispatches parallel agents, audits completions, and ships PRs.
@@ -148,7 +235,7 @@ Autonomous multi-project orchestration engine. Audits all registered projects, s
 
 ---
 
-## Setup & Maintenance
+## 🔧 Setup & Maintenance
 
 ### `/ops:setup` · `skills/setup/SKILL.md`
 Interactive setup wizard. Installs CLIs, configures secrets (Doppler, 1Password, Bitwarden), connects integrations (Telegram, WhatsApp, Email, Slack, Linear, Sentry, Vercel), builds project registry.
@@ -173,3 +260,6 @@ Cross-platform system optimizer. Detects macOS/Linux/WSL, scans for reclaimable 
 Complete removal of the plugin, all credentials, cached files, shell exports, and MCP registrations. Confirms each step before deletion.
 - `/ops:uninstall` — guided removal
 - `/ops:uninstall --confirm` — skip confirmations
+
+> [!CAUTION]
+> `/ops:uninstall --confirm` skips all confirmations and removes credentials, MCP registrations, and shell exports. There's no undo — back up `~/.claude/plugins/data/` first if you have memories you want to keep.

--- a/claude-ops/scripts/daemon-services.default.json
+++ b/claude-ops/scripts/daemon-services.default.json
@@ -1,5 +1,11 @@
 {
   "services": {
+    "briefing-pre-warm": {
+      "enabled": true,
+      "command": "__SCRIPTS_DIR__/../bin/ops-gather",
+      "cron": "*/2 * * * *",
+      "_note": "Pre-warms /ops:go briefing cache every 2 minutes. Runs immediately after daemon install so /ops:go is instant by the time setup finishes."
+    },
     "wacli-sync": {
       "enabled": true,
       "command": "__SCRIPTS_DIR__/wacli-keepalive.sh",

--- a/claude-ops/skills/ops-inbox/CHANNELS.md
+++ b/claude-ops/skills/ops-inbox/CHANNELS.md
@@ -59,11 +59,17 @@ wacli sync --follow
 **Setup:**
 
 ```bash
-# Install gog
-brew install Lifecycle-Innovations-Limited/tap/gog
+# Install gog (private auroracapital/gog CLI — try npm/bun first, fall back to source)
+npm install -g @auroracapital/gog 2>/dev/null || \
+bun install -g @auroracapital/gog 2>/dev/null || \
+(git clone https://github.com/auroracapital/gog ~/.gog && cd ~/.gog && ./install.sh) || \
+{ echo "Could not install gog. Options:"; \
+  echo "  1. Ask Sam (internal team) for the latest release binary"; \
+  echo "  2. Request access to github.com/auroracapital/gog"; \
+  echo "  3. Use the Gmail MCP fallback (read-only, drafts only)"; }
 
 # Authenticate
-gog gmail auth
+gog auth login
 ```
 
 **Env vars (optional):**

--- a/claude-ops/skills/ops-revenue/SKILL.md
+++ b/claude-ops/skills/ops-revenue/SKILL.md
@@ -65,7 +65,7 @@ aws ce get-cost-and-usage \
 
 ```bash
 aws ce get-cost-and-usage \
-  --time-period "Start=$(date -v-3m +%Y-%m-01),End=$(date +%Y-%m-%d)" \
+  --time-period "Start=$(date -v-3m +%Y-%m-01 2>/dev/null || date -d '3 months ago' +%Y-%m-01),End=$(date +%Y-%m-%d)" \
   --granularity MONTHLY \
   --metrics "UnblendedCost" \
   --output json 2>/dev/null

--- a/claude-ops/skills/ops-speedup/SKILL.md
+++ b/claude-ops/skills/ops-speedup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ops-speedup
-description: Cross-platform system speedup and cleanup. Auto-detects macOS/Linux/WSL, scans for reclaimable disk space, memory pressure, runaway processes, startup bloat, network issues. CleanMyMac built into Claude Code.
+description: Cross-platform, hardware-adaptive system optimizer. Auto-detects macOS / Linux / WSL / Windows (MINGW/Cygwin/MSYS2) and CPU/RAM/disk/GPU profile, then picks the right cleanup strategy. Scans reclaimable disk space, memory pressure, runaway processes, startup bloat, network issues. CleanMyMac built into Claude Code.
 argument-hint: "[scan|clean|deep|auto]"
 allowed-tools:
   - Bash

--- a/claude-ops/skills/ops-yolo/SKILL.md
+++ b/claude-ops/skills/ops-yolo/SKILL.md
@@ -77,7 +77,7 @@ Agent(team_name="yolo-csuite", name="cfo", subagent_type="ops:yolo-cfo", ...)
 Agent(team_name="yolo-csuite", name="coo", subagent_type="ops:yolo-coo", ...)
 ```
 
-After initial analysis, use `SendMessage(to="ceo", content="CTO found critical tech debt in auth service — does this change your strategic recommendation?")` to cross-pollinate findings before synthesizing the Hard Truths report.
+After initial analysis, use `SendMessage(to="cto", content="CFO flagged $400/mo in waste — does this change your tech-debt ranking?")` or similar to cross-pollinate findings between peer agents. The **main `/ops:yolo` orchestrator** (this skill) then reads all four analysis files (ceo-analysis.md, cto-analysis.md, cfo-analysis.md, coo-analysis.md) and synthesizes them into the Hard Truths report. `yolo-ceo` is a parallel peer, not the synthesizer.
 
 If the flag is NOT set, fall back to standard parallel subagents (fire-and-forget, no mid-task steering).
 
@@ -164,9 +164,9 @@ Uses `agents/yolo-coo.md`. Writes `/tmp/yolo-[session]/coo-analysis.md`.
 
 ---
 
-## Phase 3 — Hard Truths Report
+## Phase 3 — Hard Truths Report (orchestrator synthesis)
 
-After all 4 agents complete, synthesize into a unified report:
+**This skill (the main orchestrator) is the synthesizer** — NOT `yolo-ceo`. After all 4 parallel agents complete and have written their analysis files to `/tmp/yolo-[session]/{ceo,cto,cfo,coo}-analysis.md`, read all four files here in the main context and synthesize them into a unified report:
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -36,6 +36,18 @@ You are running an **interactive configuration wizard** for the `claude-ops` plu
 
 ---
 
+## Setup agent delegation pattern
+
+When the user asks a complex integration-specific question during setup (e.g., "how does /ops:ecom handle multi-store setups?"), the setup agent can load the related skill's SKILL.md for deeper context:
+
+```bash
+cat "${CLAUDE_PLUGIN_ROOT}/skills/ops-ecom/SKILL.md"
+```
+
+Each sub-step below includes a `> **Deep-dive:**` pointer to the related skill file. Follow these pointers instead of duplicating operational details in this wizard.
+
+---
+
 ## Step 0 — Preflight (runs in background while you read)
 
 ```!
@@ -102,14 +114,14 @@ Use `✓` for present/set, `○` for missing/unset, `✗` for broken.
 
 Use `AskUserQuestion` with `multiSelect: true`. Offer **only sections that need attention** (skip ones already green). Because AskUserQuestion allows max 4 options, batch into logical groups:
 
-**Batch 1 — Core setup:**
+**Batch 1 — Core setup (run early so the daemon can pre-warm caches while you finish):**
 
-| Option             | Header   | Description                                                   |
-| ------------------ | -------- | ------------------------------------------------------------- |
-| Install CLIs       | cli      | Install missing command-line tools via Homebrew               |
-| Configure MCPs      | mcp      | Enable Linear, Sentry, Vercel, Gmail MCP servers              |
-| Build registry      | registry | Register projects Claude should manage                        |
-| Shell env           | env      | Export `CLAUDE_PLUGIN_ROOT` in shell profile                  |
+| Option             | Header   | Description                                                                   |
+| ------------------ | -------- | ----------------------------------------------------------------------------- |
+| Install CLIs       | cli      | Install missing command-line tools via Homebrew                               |
+| Background daemon  | daemon   | Install ops-daemon early — pre-warms briefing cache while remaining setup runs |
+| Configure MCPs      | mcp      | Enable Linear, Sentry, Vercel, Gmail MCP servers                              |
+| Build registry      | registry | Register projects Claude should manage                                        |
 
 **Batch 2 — Channels & plugins:**
 
@@ -118,7 +130,7 @@ Use `AskUserQuestion` with `multiSelect: true`. Offer **only sections that need 
 | Configure channels  | channels | Set tokens for Telegram, WhatsApp, Email, Slack               |
 | Companion plugins   | plugins  | Install GSD for project roadmap tracking                      |
 | Save preferences    | prefs    | Owner name, timezone, default priorities                      |
-| Background daemon   | daemon   | Install ops-daemon for persistent wacli-sync + memory extract |
+| Shell env           | env      | Export `CLAUDE_PLUGIN_ROOT` in shell profile                  |
 
 **Batch 3 — Extras (only show if not already configured):**
 
@@ -127,6 +139,7 @@ Use `AskUserQuestion` with `multiSelect: true`. Offer **only sections that need 
 | Configure ecommerce | ecom     | Set Shopify store URL + admin token, ShipBob                  |
 | Configure marketing | mktg     | Set Klaviyo, Meta Ads, GA4, Search Console keys               |
 | Configure voice     | voice    | Set Bland AI, ElevenLabs, Groq API keys                       |
+| Configure revenue   | revenue  | Set Stripe + RevenueCat keys for live MRR tracking            |
 
 Present each batch as a separate `AskUserQuestion` call. Skip batches where all items are already green. Collect all selections across batches and run each selected section in order.
 
@@ -202,6 +215,117 @@ If they skip:
 ```
 Skipped GSD. Install later with: /plugin marketplace add gsd-build/get-shit-done
 ```
+
+---
+
+## Step 2c — Background Daemon (early install, pre-warm caches)
+
+**Why install the daemon this early?** Running the daemon in parallel with the rest of setup lets it start pre-warming the briefing cache (`ops-gather` results for infra/git/PRs/CI), so by the time the user reaches Step 7 and runs `/ops:go`, the briefing is already cached and loads in under 3 seconds instead of 10. Channel-dependent services (wacli-sync, message-listener, inbox-digest, store-health) are added later in Step 5b once their channels are configured.
+
+### Platform support
+
+The background daemon ships with a `launchd` integration (macOS only). Detect the platform before attempting install:
+
+```bash
+case "$(uname -s)" in
+  Darwin)                OS=macos ;;
+  Linux)                 grep -qi microsoft /proc/version 2>/dev/null && OS=wsl || OS=linux ;;
+  MINGW*|MSYS*|CYGWIN*)  OS=windows ;;
+  *)                     OS=unknown ;;
+esac
+```
+
+- **macOS** (`OS=macos`): proceed with the full `launchctl bootstrap` flow below.
+- **Linux / WSL** (`OS=linux|wsl`): `launchctl` is not available. The daemon script (`${CLAUDE_PLUGIN_ROOT}/scripts/ops-daemon.sh`) runs fine under `bash`, but installing it as a user service requires `systemd --user` (Linux) or a custom cron/at wrapper (WSL). That work is **out of scope for this patch** — track as future work. For now, print:
+
+  ```
+  ○ Background daemon — skipped (Linux/WSL install via systemd --user is pending; see docs/daemon-guide.md).
+    You can still launch it manually with:  nohup ${CLAUDE_PLUGIN_ROOT}/scripts/ops-daemon.sh &
+  ```
+
+  Write `daemon.enabled = false` and `daemon.skip_reason = "platform:<os>"` to `$PREFS_PATH` and continue to Step 3.
+- **Windows** (native, `OS=windows`): the daemon is **not installed**. Print `○ Background daemon — not supported on native Windows. Use WSL or run ops-daemon.sh manually.` and continue.
+
+If `OS=macos`, check whether the daemon is already installed:
+
+```bash
+launchctl print gui/$(id -u)/com.claude-ops.daemon 2>/dev/null | head -1
+```
+
+If already loaded, print `✓ Background daemon already running — will reconcile services in Step 5b.` and skip to Step 3.
+
+Otherwise ask via `AskUserQuestion`:
+
+```
+Install the ops background daemon now?
+  Starts pre-warming briefing cache while you finish the rest of setup.
+  Auto-heals on failure. Single launchd agent (com.claude-ops.daemon).
+  Channel services (wacli-sync, message-listener) added after channels are set up.
+  [Yes — install now]  [Skip — I'll run it manually later]
+```
+
+On `Yes`, run the install (use `run_in_background: true` per Rule 4 — this runs in parallel with the next wizard steps):
+
+```bash
+DAEMON_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/ops-daemon.sh"
+chmod +x "$DAEMON_SCRIPT"
+PLIST_TEMPLATE="${CLAUDE_PLUGIN_ROOT}/scripts/com.claude-ops.daemon.plist"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.claude-ops.daemon.plist"
+DATA_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+LOG_DIR="$DATA_DIR/logs"
+mkdir -p "$LOG_DIR"
+
+# Generate plist
+sed -e "s|__DAEMON_SCRIPT_PATH__|$DAEMON_SCRIPT|g" \
+    -e "s|__LOG_DIR__|$LOG_DIR|g" \
+    -e "s|__HOME__|$HOME|g" \
+    "$PLIST_TEMPLATE" > "$PLIST_DEST"
+
+# Write a minimal initial services config — only the services that don't depend on
+# channels yet. `briefing-pre-warm` runs ops-gather every 2 minutes so the next
+# /ops:go is instant. `memory-extractor` runs but stays idle until channels exist.
+SERVICES_CONFIG="$DATA_DIR/daemon-services.json"
+cat > "$SERVICES_CONFIG" <<JSON
+{
+  "services": {
+    "briefing-pre-warm": {
+      "enabled": true,
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/ops-gather",
+      "cron": "*/2 * * * *",
+      "_note": "Pre-warms /ops:go cache. Runs every 2 minutes."
+    },
+    "memory-extractor": {
+      "enabled": true,
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-memory-extractor.sh",
+      "cron": "*/30 * * * *",
+      "health_file": "~/.claude/plugins/data/ops-ops-marketplace/memories/.health",
+      "_note": "Idle until channels are configured; will extract profiles once wacli/gog are live."
+    }
+  }
+}
+JSON
+
+# Remove the old standalone wacli keepalive if present
+launchctl bootout gui/$(id -u)/com.claude-ops.wacli-keepalive 2>/dev/null || true
+rm -f "$HOME/Library/LaunchAgents/com.claude-ops.wacli-keepalive.plist"
+
+# Load daemon in background — does NOT block the wizard
+launchctl bootout gui/$(id -u) "$PLIST_DEST" 2>/dev/null || true
+launchctl bootstrap gui/$(id -u) "$PLIST_DEST"
+```
+
+Write `daemon.enabled = true` and `daemon.installed_at_step = "2c"` to `$PREFS_PATH` so Step 5b knows to reconcile services instead of re-installing.
+
+Print:
+
+```
+✓ Background daemon — installed. Pre-warming briefing cache in parallel while you finish setup.
+  Channel-dependent services will be added after channels are configured (Step 5b).
+```
+
+Continue immediately to Step 3 — do NOT wait for the daemon to confirm startup. The health file check is deferred to Step 5b.
+
+> **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/docs/daemon-guide.md` for full operational instructions, CLI reference, and troubleshooting for the background daemon. The setup agent can load that file directly when it needs more depth than this wizard provides.
 
 ---
 
@@ -542,6 +666,8 @@ Sub-flow (only runs if user selected Yes above):
 - If you already have a gram.js / Telethon session for another project, you can skip this and paste those values manually into `/plugin settings`.
 - If Telegram replies "Sorry, too many tries. Please try again later." your account is rate-limited for ~8 hours — the wizard cannot bypass this. Wait and retry.
 
+> **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-comms/SKILL.md` for full operational instructions, CLI reference, and troubleshooting for this integration. The setup agent can load that file directly when it needs more depth than this wizard provides.
+
 ### 3b — WhatsApp (doctor + self-heal + backfill)
 
 WhatsApp is the channel that most often breaks silently. The wizard must **auto-diagnose, doctor, and fix** — not just report status and give up. Run this whole sub-flow top-to-bottom, stopping only when the system is healthy or the user declines a remediation.
@@ -746,6 +872,8 @@ All ops skills that use WhatsApp (`ops-inbox`, `ops-comms`, `ops-go`) MUST check
 
 This ensures the user is never silently left with a broken WhatsApp connection — every ops skill surfaces the problem and walks them through the fix.
 
+> **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-comms/SKILL.md` and `${CLAUDE_PLUGIN_ROOT}/skills/ops-inbox/SKILL.md` for full operational instructions, CLI reference, and troubleshooting for this integration. The setup agent can load those files directly when it needs more depth than this wizard provides.
+
 ### 3c — Email
 
 Email has two possible backends, tried in this order:
@@ -807,6 +935,8 @@ If `gog` is not on PATH, look at the detector's `mcp_configured` array for any e
    - `[Add a Gmail MCP — show docs]` → print `claude mcp add gmail` and tell the user to re-run `/ops:setup email` after
    - `[Skip email for now]`
 7. Whatever the user picks, record the resulting state in `$PREFS_PATH` (either `channels.email = "gog"`, `channels.email = "mcp:<name>"`, or omit the key entirely).
+
+> **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-inbox/SKILL.md` and `${CLAUDE_PLUGIN_ROOT}/skills/ops-comms/SKILL.md` for full operational instructions, CLI reference, and troubleshooting for this integration. The setup agent can load those files directly when it needs more depth than this wizard provides.
 
 ### 3d — Slack (scout + ops-slack-autolink)
 
@@ -884,6 +1014,8 @@ Sub-flow:
 - Logging out of Slack invalidates the `d` cookie and breaks the MCP. Use `/ops:setup slack` to re-extract.
 - Slack's Terms of Service allow personal-session-token use for your own account. Do not use this flow to access accounts you don't own.
 
+> **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-comms/SKILL.md` and `${CLAUDE_PLUGIN_ROOT}/skills/ops-inbox/SKILL.md` for full operational instructions, CLI reference, and troubleshooting for this integration. The setup agent can load those files directly when it needs more depth than this wizard provides.
+
 ### 3e — Calendar
 
 Calendar isn't a messaging channel, but every other ops skill (briefings, `/ops-next`, `/ops-go`) benefits massively from knowing the user's schedule — meetings blocking deep work, deploy windows, travel days. The wizard wires it up the same way as email: `gog calendar` primary, Google Calendar MCP connector fallback.
@@ -925,7 +1057,7 @@ Calendar isn't a messaging channel, but every other ops skill (briefings, `/ops-
       If you want ops-next to auto-block focus time or ops-comms to confirm
       meetings, install `gog` instead.
    ```
-7. On "Install gog instead", print the same gog install snippet as Step 3c.
+7. On "Install gog instead", **run the install via Bash** (Rule 2) using the same npm → bun → source-clone chain as Step 3c — either inline the snippet or call `${CLAUDE_PLUGIN_ROOT}/bin/ops-setup-install gog` (background per Rule 4). Only fall back to printing manual instructions if all four attempts fail.
 
 #### Neither available
 
@@ -942,6 +1074,8 @@ Downstream skills (`/ops-go`, `/ops-next`, `/ops-fires`) read `channels.calendar
 - `/ops-next` deprioritizes deep work when a meeting is <30min away
 - `/ops-fires` warns if a production incident falls during a scheduled call
   So this section is not optional for users who want context-aware briefings.
+
+> **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-go/SKILL.md` for full operational instructions, CLI reference, and troubleshooting for this integration (calendar context feeds `/ops:go` briefings). The setup agent can load that file directly when it needs more depth than this wizard provides.
 
 ### 3f — Doppler (secrets management)
 
@@ -1063,6 +1197,8 @@ For example:
 The project and config above are the defaults saved to preferences.
 Individual skills can override with --project / --config flags.
 ```
+
+> **Deep-dive:** no dedicated skill ships with Doppler — see `${CLAUDE_PLUGIN_ROOT}/docs/memories-system.md` (Runtime Context section) for how downstream skills consume the `secrets_manager` / `doppler.*` values from `$PREFS_PATH` and resolve `doppler:KEY_NAME` references at runtime. The setup agent can load that file directly when it needs more depth than this wizard provides.
 
 ### 3g — Password Manager (credential vault)
 
@@ -1248,6 +1384,8 @@ Omit this line entirely if `password_manager` is `"none"` or unset.
 
 Add to the shortcuts table: `vault`, `password-manager`, `pm` → Step 3g
 
+> **Deep-dive:** no dedicated skill ships with the password manager integration — see `${CLAUDE_PLUGIN_ROOT}/docs/memories-system.md` (Runtime Context section) for how downstream skills resolve `password_manager` + related vault references from `$PREFS_PATH`. Privacy-and-security guidance lives in this SKILL.md (keychain-only storage of API hashes/session strings, `umask 077` for bridge files). The setup agent can load that file directly when it needs more depth than this wizard provides.
+
 ---
 
 ### 3h — Ecommerce (Shopify + dynamic partners)
@@ -1421,6 +1559,8 @@ If the user provides partner names, process each one in a loop:
 
 For any partner not in this table, always web search for current auth docs before asking for credentials.
 
+> **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-ecom/SKILL.md` for full operational instructions, CLI reference, and troubleshooting for the ecommerce integration (multi-store Shopify, partner dispatching, store-health daemon). The setup agent can load that file directly when it needs more depth than this wizard provides.
+
 ---
 
 ### 3i — Marketing (Klaviyo, Meta Ads, GA4, Search Console)
@@ -1573,6 +1713,8 @@ If the user provides partner names, apply the same dynamic partner loop as Step 
 
 For any partner not in this table, always web search for current auth docs before asking for credentials.
 
+> **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-marketing/SKILL.md` for full operational instructions, CLI reference, and troubleshooting for marketing integrations (Klaviyo flows, Meta Ads, GA4, Search Console). The setup agent can load that file directly when it needs more depth than this wizard provides.
+
 ---
 
 ### 3j — Voice (Bland AI, ElevenLabs, Groq)
@@ -1670,6 +1812,159 @@ Write to `$PREFS_PATH` (merge):
 
 Same Doppler-reference pattern — prefer `doppler:KEY_NAME` over raw tokens when Doppler is configured.
 
+> **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-voice/SKILL.md` for full operational instructions, CLI reference, and troubleshooting for voice integrations (Bland AI call flows, ElevenLabs TTS, Groq transcription). The setup agent can load that file directly when it needs more depth than this wizard provides.
+
+---
+
+### 3k — Revenue (Stripe + RevenueCat)
+
+**Before showing the service selector**, run the Universal Credential Auto-Scan for all revenue vars simultaneously (Rule 4 — background these):
+
+```bash
+# Shell env
+printenv STRIPE_SECRET_KEY STRIPE_API_KEY REVENUECAT_API_KEY REVENUECAT_SECRET_KEY REVENUECAT_PROJECT_ID 2>/dev/null
+
+# Shell profiles + .envrc files
+grep -h 'STRIPE\|REVENUECAT\|RC_API' ~/.zshrc ~/.bashrc ~/.zprofile ~/.envrc 2>/dev/null | grep -v '^#'
+
+# Doppler across all projects
+for proj in $(doppler projects --json 2>/dev/null | jq -r '.[].slug'); do
+  doppler secrets --project "$proj" --config prd --json 2>/dev/null | \
+    jq -r --arg proj "$proj" 'to_entries[] | select(.key | test("STRIPE|REVENUECAT|RC_API")) | "\(.key)=\(.value.computed) (doppler:\($proj)/prd)"'
+done
+
+# 1Password
+op item list --categories "API Credential" --format json 2>/dev/null | \
+  jq -r '.[] | select(.title | test("stripe|revenuecat"; "i")) | .id' | \
+  while read id; do op item get "$id" --format json 2>/dev/null; done
+
+# Dashlane
+dcli password stripe --output json 2>/dev/null
+dcli password revenuecat --output json 2>/dev/null
+
+# Bitwarden
+bw list items --search stripe 2>/dev/null | jq -r '.[] | select(.login.password) | .login.password' | head -1
+bw list items --search revenuecat 2>/dev/null | jq -r '.[] | select(.login.password) | .login.password' | head -1
+
+# macOS Keychain
+security find-generic-password -s "stripe" -w 2>/dev/null
+security find-generic-password -s "revenuecat" -w 2>/dev/null
+
+# OpenClaw
+jq -r '.agents.defaults.env | to_entries[] | select(.key | test("STRIPE|REVENUECAT")) | "\(.key)=\(.value)"' ~/.openclaw/openclaw.json 2>/dev/null
+```
+
+Cache these results. Also check `$PREFS_PATH` under `revenue.stripe.*` and `revenue.revenuecat.*` — if already set, show `✓ <service> — already configured` and offer `[Keep]` / `[Reconfigure]`.
+
+Ask which revenue integrations to configure via `AskUserQuestion` with `multiSelect: true`:
+
+| Option       | Header       | Description                                                    |
+| ------------ | ------------ | -------------------------------------------------------------- |
+| Stripe       | stripe       | SaaS revenue — secret key for MRR, charges, disputes           |
+| RevenueCat   | revenuecat   | Mobile subs — API key + project ID for mobile MRR              |
+
+#### Stripe
+
+If `STRIPE_SECRET_KEY` was found in the auto-scan, present it using the Universal Credential Auto-Scan prompt format with `[Use this value]` / `[Paste a different one]` / `[Skip]`.
+
+Per Rule 3 — if nothing was found, offer (≤4 options):
+```
+No Stripe secret key found. How do you want to provide one?
+  [Paste Stripe secret key manually]
+  [Deep hunt — spawn agent]
+  [Skip — use registry.json values]
+```
+
+On `[Deep hunt — spawn agent]`, spawn a background research agent per Rule 3:
+
+```
+Agent(
+  subagent_type: "general-purpose",
+  model: "haiku",
+  run_in_background: true,
+  prompt: "Grep the filesystem under $HOME (excluding node_modules, .git, Library/Caches) for Stripe secret key patterns: sk_live_[A-Za-z0-9]+ and sk_test_[A-Za-z0-9]+. Also scan ~/.config, ~/.aws, ~/.docker, any .env files, and known secrets directories. Return every hit with file path + line number + 6 chars of redacted prefix (e.g. sk_live_abc***). Do not print full keys."
+)
+```
+
+While it runs, continue to the RevenueCat block. Return to Stripe when the agent reports results; present findings via `AskUserQuestion` (paginate to ≤4 per Rule 1).
+
+On `[Paste Stripe secret key manually]`:
+```
+Enter your Stripe Secret Key:
+  Format: sk_live_XXX  (production)  or  sk_test_XXX  (test mode)
+  Find it: Stripe Dashboard → Developers → API keys → Secret key → Reveal
+  Prefer a Doppler reference (e.g. doppler:STRIPE_SECRET_KEY) over the raw value.
+```
+
+Smoke test:
+```bash
+curl -s -u "$STRIPE_SECRET_KEY:" "https://api.stripe.com/v1/balance" | jq '.available | length'
+```
+Expect a non-zero integer. If `{"error": ...}`, show the message and re-ask.
+
+#### RevenueCat
+
+If `REVENUECAT_API_KEY` and `REVENUECAT_PROJECT_ID` were both found in the auto-scan, present them together with `[Use these values]` / `[Paste different ones]` / `[Skip]`.
+
+Per Rule 3 — if not found, offer:
+```
+No RevenueCat credentials found. How do you want to provide them?
+  [Paste RevenueCat API key manually]
+  [Deep hunt — spawn agent]
+  [Skip — mobile MRR will be omitted]
+```
+
+On `[Deep hunt — spawn agent]`, spawn (background, Rule 4):
+
+```
+Agent(
+  subagent_type: "general-purpose",
+  model: "haiku",
+  run_in_background: true,
+  prompt: "Grep the filesystem under $HOME (excluding node_modules, .git, Library/Caches) for RevenueCat credential patterns: rcb_[A-Za-z0-9]+ (V2 secret), sk_[A-Za-z0-9]+ near the literal string 'revenuecat', and any env vars matching REVENUECAT_* or RC_API_*. Also look for project IDs (32-char alphanum strings) adjacent to any revenuecat match. Return each hit with file path + line number + 6-char redacted prefix. Do not print full keys."
+)
+```
+
+On `[Paste RevenueCat API key manually]`:
+```
+Enter your RevenueCat V1 API Key:
+  Find it: app.revenuecat.com → Project settings → API keys → V1 secret key
+  Format: rcb_XXX (V2)  or  legacy secret (starts with sk_)
+
+Enter your RevenueCat Project ID:
+  Find it in the URL: app.revenuecat.com/projects/<project_id>/...
+```
+
+Smoke test:
+```bash
+curl -s -H "Authorization: Bearer $REVENUECAT_API_KEY" \
+  "https://api.revenuecat.com/v1/projects/$REVENUECAT_PROJECT_ID/metrics/overview" | jq '.mrr // .object'
+```
+Expect a numeric `mrr` or an object descriptor. If the response is `{"code": 7243, ...}` (auth error), re-ask.
+
+#### Save to preferences
+
+Write to `$PREFS_PATH` (merge):
+```json
+{
+  "revenue": {
+    "stripe": {
+      "secret_key": "doppler:STRIPE_SECRET_KEY",
+      "configured_at": "<ISO timestamp>"
+    },
+    "revenuecat": {
+      "api_key": "doppler:REVENUECAT_API_KEY",
+      "project_id": "<project_id>",
+      "configured_at": "<ISO timestamp>"
+    }
+  }
+}
+```
+
+Prefer a Doppler reference (`doppler:STRIPE_SECRET_KEY`, `doppler:REVENUECAT_API_KEY`) over raw tokens when Doppler is configured. For either service, if the user picked `[Skip]`, save `{"revenue": {"<service>": "skipped"}}` so the wizard doesn't re-prompt on the next run — but `/ops:revenue` will fall back to `scripts/registry.json` `revenue.mrr` values as documented in the `revenue-tracker` agent.
+
+> **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-revenue/SKILL.md` for full operational instructions, CLI reference, and troubleshooting for revenue integrations (Stripe MRR/ARR queries, RevenueCat subscription metrics, registry fallbacks). The setup agent can load that file directly when it needs more depth than this wizard provides.
+
 ---
 
 ## Step 4 — Configure MCPs (if selected)
@@ -1687,6 +1982,8 @@ Gmail:   claude mcp add gmail   (fallback only — prefer `gog` CLI, see Step 3c
 Offer `[Open Claude Code docs]`, `[Skip]`. Do **not** try to register MCPs from the skill — the plugin can't do that safely.
 
 **Email note:** the ops plugin's primary email path is the `gog` CLI (full read + send, own OAuth). The Gmail MCP connector works as a fallback but **cannot send** without extra permission config in Claude Desktop → Settings → Connectors. The wizard handles that detection in Step 3c; this step only lists it so users who deliberately prefer MCP can install it here.
+
+> **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-linear/SKILL.md`, `${CLAUDE_PLUGIN_ROOT}/skills/ops-triage/SKILL.md`, and `${CLAUDE_PLUGIN_ROOT}/skills/ops-fires/SKILL.md` for full operational instructions, CLI reference, and troubleshooting for the MCP-backed integrations (Linear issue flows, triage routing, Sentry/Vercel fires). The setup agent can load those files directly when it needs more depth than this wizard provides.
 
 ---
 
@@ -1746,58 +2043,29 @@ After auto-discovery (or if the user selects "I'll enter projects manually"):
 - Read the current registry with `jq`, append the new project, write back atomically (`jq ... > tmp && mv tmp registry.json`).
 - After each addition, print the running count and offer `[Add another]` / `[Done]`.
 
+> **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-projects/SKILL.md` for full operational instructions, CLI reference, and troubleshooting for the project registry (auto-discovery, registry schema, GSD filters, priority ordering). The setup agent can load that file directly when it needs more depth than this wizard provides.
+
 ---
 
-## Step 5b — Background Daemon (if selected)
+## Step 5b — Daemon Service Reconciliation
 
-The ops-daemon manages persistent background services — WhatsApp sync, memory extraction, and future integrations — under a single launchd agent. It auto-heals on failure and writes a shared health file that all ops skills can read.
+By now, the daemon was already installed in Step 2c and has been pre-warming the briefing cache in the background while the user configured channels. This step adds **channel-dependent services** (`wacli-sync`, `message-listener`, `inbox-digest`, `store-health`, `competitor-intel`) now that we know which channels and integrations are configured.
 
-**What the daemon does:** Manages persistent connections (WhatsApp sync, memory extraction) and auto-heals on failure. All services run under a single launchd agent (`com.claude-ops.daemon`) that restarts itself if it crashes, with per-service health tracking written to `daemon-health.json`.
+**Skip conditions:**
+- If the user declined daemon install in Step 2c, skip this step entirely.
+- If `daemon.enabled != true` in `$PREFS_PATH`, skip.
 
-Ask the user via `AskUserQuestion`:
+Otherwise continue — reconcile the services list:
 
-```
-Install the ops background daemon?
-  Manages background services persistently — recommended for reliable briefings and monitoring.
-  Services enabled depend on what was configured earlier in setup.
-  [Yes — install daemon]  [Skip — use standalone keepalive instead]
-```
-
-If the user skips, fall back to the standalone keepalive path in Step 3b.7.
-
-On `Yes`:
-
-**1. Install and configure the daemon:**
+**1. Verify the daemon is running:**
 
 ```bash
-DAEMON_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/ops-daemon.sh"
-chmod +x "$DAEMON_SCRIPT"
-PLIST_TEMPLATE="${CLAUDE_PLUGIN_ROOT}/scripts/com.claude-ops.daemon.plist"
-PLIST_DEST="$HOME/Library/LaunchAgents/com.claude-ops.daemon.plist"
 DATA_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
-LOG_DIR="$DATA_DIR/logs"
-mkdir -p "$LOG_DIR"
-
-# Generate plist
-sed -e "s|__DAEMON_SCRIPT_PATH__|$DAEMON_SCRIPT|g" \
-    -e "s|__LOG_DIR__|$LOG_DIR|g" \
-    -e "s|__HOME__|$HOME|g" \
-    "$PLIST_TEMPLATE" > "$PLIST_DEST"
-
-# Copy default services config if none exists
-SERVICES_CONFIG="$DATA_DIR/daemon-services.json"
-if [[ ! -f "$SERVICES_CONFIG" ]]; then
-  sed "s|__SCRIPTS_DIR__|${CLAUDE_PLUGIN_ROOT}/scripts|g" \
-    "${CLAUDE_PLUGIN_ROOT}/scripts/daemon-services.default.json" > "$SERVICES_CONFIG"
-fi
-
-# Remove the old standalone wacli keepalive if present
-launchctl bootout gui/$(id -u)/com.claude-ops.wacli-keepalive 2>/dev/null || true
-rm -f "$HOME/Library/LaunchAgents/com.claude-ops.wacli-keepalive.plist"
-
-# Load daemon
-launchctl bootout gui/$(id -u) "$PLIST_DEST" 2>/dev/null || true
-launchctl bootstrap gui/$(id -u) "$PLIST_DEST"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.claude-ops.daemon.plist"
+launchctl print gui/$(id -u)/com.claude-ops.daemon >/dev/null 2>&1 || {
+  # Daemon not running — install it now as a fallback
+  launchctl bootstrap gui/$(id -u) "$PLIST_DEST" 2>/dev/null
+}
 ```
 
 **2. Verify health after 5 seconds:**
@@ -1820,9 +2088,9 @@ If the health file is missing (daemon may still be initializing), wait 5 more se
   tail -20 ~/.claude/plugins/data/ops-ops-marketplace/logs/ops-daemon.log
 ```
 
-**3. Build the services list and record in preferences:**
+**3. Build the full services list and reconcile with the config written in Step 2c:**
 
-Determine which services to enable based on what was configured in earlier steps:
+Determine which services to enable based on what was configured in earlier steps. The `briefing-pre-warm` and `memory-extractor` services were already enabled at Step 2c — preserve them. Add channel-dependent services based on what's now configured:
 
 - `wacli-sync` — always include if WhatsApp is configured (`channels.whatsapp` is set)
 - `memory-extractor` — always include
@@ -1831,9 +2099,9 @@ Determine which services to enable based on what was configured in earlier steps
 - `competitor-intel` — always include (runs weekly Monday 10am)
 - `message-listener` — include if WhatsApp or Telegram is configured (persistent poller)
 
-Build the services array programmatically:
+Build the services array programmatically (starting from the 2c baseline):
 ```bash
-SERVICES='["memory-extractor","inbox-digest","competitor-intel"]'
+SERVICES='["briefing-pre-warm","memory-extractor","inbox-digest","competitor-intel"]'
 PREFS=$(cat "$PREFS_PATH" 2>/dev/null || echo '{}')
 # Add wacli-sync + message-listener if WhatsApp is configured
 if echo "$PREFS" | jq -e '.channels.whatsapp' > /dev/null 2>&1; then
@@ -1850,15 +2118,28 @@ fi
 echo "Services to enable: $SERVICES"
 ```
 
-Write daemon services config to `$DATA_DIR/daemon-services.json` — merge with or replace the default, enabling only the services determined above. Each service entry should include:
-- `wacli-sync`: `{ "enabled": true, "interval": "continuous" }`
-- `memory-extractor`: `{ "enabled": true, "interval": "300" }` (every 5 min)
-- `inbox-digest`: `{ "enabled": true, "schedule": "0 */4 * * *" }` (every 4h)
-- `store-health`: `{ "enabled": true, "schedule": "0 9 * * *" }` (daily 9am) — only if ecom configured
-- `competitor-intel`: `{ "enabled": true, "schedule": "0 10 * * 1" }` (weekly Monday 10am)
-- `message-listener`: `{ "enabled": true, "interval": "continuous" }`
+Write daemon services config to `$DATA_DIR/daemon-services.json` — merge with the existing config from Step 2c, preserving `briefing-pre-warm` and `memory-extractor`, and enabling the new channel-dependent services. Each service entry should include:
+- `briefing-pre-warm`: `{ "enabled": true, "cron": "*/2 * * * *" }` — pre-warms /ops:go cache (installed in 2c)
+- `wacli-sync`: `{ "enabled": true, "interval": "continuous" }` — only if WhatsApp configured
+- `memory-extractor`: `{ "enabled": true, "cron": "*/30 * * * *" }` — every 30 min (installed in 2c)
+- `inbox-digest`: `{ "enabled": true, "cron": "0 */4 * * *" }` — every 4h
+- `store-health`: `{ "enabled": true, "cron": "0 9 * * *" }` — daily 9am, only if ecom configured
+- `competitor-intel`: `{ "enabled": true, "cron": "0 10 * * 1" }` — weekly Monday 10am
+- `message-listener`: `{ "enabled": true, "interval": "continuous" }` — only if WhatsApp or Telegram configured
 
-Write `daemon.enabled = true` and `daemon.services` (the computed array) to `$PREFS_PATH`.
+After rewriting the services config, reload the daemon so it picks up the new services:
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.claude-ops.daemon
+```
+
+Write `daemon.enabled = true` and `daemon.services` (the reconciled array) to `$PREFS_PATH`. Print a summary:
+
+```
+✓ Daemon services reconciled — N services enabled (briefing-pre-warm, memory-extractor, wacli-sync, ...)
+```
+
+> **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/docs/daemon-guide.md` for full operational instructions, CLI reference, and troubleshooting for the background daemon (service lifecycle, launchctl/systemd integration, health reporting, reconciliation semantics). The setup agent can load that file directly when it needs more depth than this wizard provides.
 
 ---
 


### PR DESCRIPTION
## CLOSED — obsolete

Main has advanced to **v1.1.0** (25 skills, 13 agents) while this branch was being prepared, and the team has already landed every substantive change this PR proposed:

- ✅ `yolo-ceo` corrected to parallel peer (wording on main is essentially identical to this branch)
- ✅ `infra-monitor` AWS full coverage (ECS/EC2/RDS/Lambda/S3/CloudFront/ALB/NLB/API-GW/SQS/SNS/DynamoDB/ElastiCache/Route 53/ACM/CloudWatch/Budgets/IAM)
- ✅ `revenue-tracker` Stripe + RevenueCat
- ✅ All scanner/fix/daemon agents on Sonnet 4.6
- ✅ Step 2c early daemon install · Step 3k Stripe/RC in setup SKILL
- ✅ Rule 4 expanded to "RULE ZERO — every Bash call uses `run_in_background`"
- ✅ Privacy & Security section in the main README (with the same no-telemetry / scan-inventory content)
- ✅ `gog` install fix, `/ops:speedup` OS detection, security audit fixes

What this PR added uniquely was a root README rewrite for v0.8.0 — now stale. Main also added Datadog / New Relic / OTEL integrations, `@claude-ops/sdk` v1.0.0, NestJS API template, "configure-all" setup mode that weren't in scope here.

**What's still valuable from this session:** the **wiki pages** (already pushed to the `.wiki.git` repo), which I will now bring up to v1.1.0 in a separate pass. Closing this PR as obsolete.