### PR TITLE
docs: add CONTRIBUTING.md with branch strategy and protection rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,64 @@
+# Contributing to claude-ops
+
+PRs welcome from anyone. This document covers the branch strategy, protection rules, and PR workflow.
+
+## Branch Strategy
+
+- **`main`** is the only long-lived branch and the default branch.
+- All work happens on **feature branches** (e.g., `fix/setup-gog-url`, `feat/stripe-revenue`).
+- Feature branches are merged into `main` via PR.
+- There is no `dev` branch.
+
+## Branch Protection
+
+`main` is protected by three layers of rulesets (repo-level + org-level):
+
+| Rule | Maintainer | External contributors |
+|---|---|---|
+| Direct push | Allowed | Blocked |
+| Force push | Blocked | Blocked |
+| Delete branch | Blocked | Blocked |
+| Merge PR without approval | Allowed | Requires 1 approval |
+| Unresolved review threads | Allowed | Blocked |
+
+These rules are enforced at both the repository and organization level and cannot be overridden by repository settings alone.
+
+## PR Workflow
+
+### For external contributors
+
+1. Fork the repo
+2. Create a feature branch from `main`
+3. Make your changes
+4. Open a PR targeting `main`
+5. Wait for review and approval from a maintainer
+6. Once approved, a maintainer will merge your PR
+
+### For maintainers
+
+1. Create a feature branch from `main`
+2. Push the branch and open a PR targeting `main`
+3. Resolve any automated review comments (Copilot code review runs on push)
+4. Merge via `gh pr merge --merge --admin`
+
+## Local Development
+
+```bash
+# Clone and run in development mode
+git clone https://github.com/Lifecycle-Innovations-Limited/claude-ops.git
+cd claude-ops
+claude --plugin-dir ./claude-ops/claude-ops
+
+# After making changes, reload without restarting
+/reload-plugins
+```
+
+## Code Review
+
+- Copilot code review runs automatically on every push and may leave review threads.
+- All review threads must be resolved before merge (for non-maintainers).
+- Maintainers can resolve threads and merge without external approval.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](./claude-ops/LICENSE).

--- a/README.md
+++ b/README.md
@@ -258,7 +258,9 @@ Just [Claude Code](https://claude.ai/code) 1.0+. Everything else is installed au
 
 ## Contributing
 
-PRs welcome. See [`claude-ops/README.md`](./claude-ops/README.md) for detailed documentation on each skill, agent, and integration. Full guides, troubleshooting, and the threat model live on the [wiki](https://github.com/Lifecycle-Innovations-Limited/claude-ops/wiki).
+PRs welcome — see [CONTRIBUTING.md](./CONTRIBUTING.md) for the full guide, branch rules, and PR workflow.
+
+**Branch strategy:** `main` is the only long-lived branch. All work goes through feature branches → PR to `main`. Branch protection is enforced at repo and org level — no direct pushes, no force pushes, no branch deletion.
 
 ```bash
 # Development mode — load plugin from local directory
@@ -267,6 +269,8 @@ claude --plugin-dir ./claude-ops/claude-ops
 # Reload after changes
 /reload-plugins
 ```
+
+See [`claude-ops/README.md`](./claude-ops/README.md) for detailed documentation on each skill, agent, and integration. Full guides, troubleshooting, and the threat model live on the [wiki](https://github.com/Lifecycle-Innovations-Limited/claude-ops/wiki).
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds CONTRIBUTING.md documenting main-only branch strategy, 3-layer ruleset protection, and PR workflow
- Updates README Contributing section to link to CONTRIBUTING.md

## Test plan
- [ ] Verify CONTRIBUTING.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/70" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that don’t affect runtime behavior or interfaces.
> 
> **Overview**
> Adds a new `CONTRIBUTING.md` documenting the project’s **main-only branch strategy**, **branch protection expectations**, and the PR workflow for maintainers vs external contributors (including local dev/reload commands).
> 
> Updates the README Contributing section to link to `CONTRIBUTING.md` and briefly restate the branch/PR rules, while keeping the existing dev snippet and pointing readers to the deeper docs/wiki.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dd1d22da1cd2fa973b3fd7cb2c370577c6f05e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->