### PR TITLE
feat(cross-os): B2 — migrate consumers to lib/os-detect + lib/credential-store

### DIFF
--- a/claude-ops/bin/ops-autofix
+++ b/claude-ops/bin/ops-autofix
@@ -14,6 +14,48 @@ for arg in "$@"; do
   esac
 done
 
+# ─── Cross-OS credential store ──────────────────────────────────────────────
+# Source the cascading credential-store library if present. ops-autofix must
+# still run (degraded, macOS-only) when shipped without lib/ — e.g. a partial
+# install mid-upgrade — so sourcing is best-effort.
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LIB_CRED="$SCRIPT_DIR/lib/credential-store.sh"
+if [ -r "$LIB_CRED" ]; then
+  # shellcheck source=../lib/credential-store.sh
+  . "$LIB_CRED"
+fi
+
+# Account name used for all credential lookups. Matches the convention in
+# ops-slack-autolink.mjs / ops-telegram-autolink.mjs where entries are stored
+# under account=$USER.
+CRED_ACCOUNT="${USER:-$(id -un 2>/dev/null || echo user)}"
+
+# Thin wrappers: prefer the cross-OS API; fall back to direct `security` on
+# macOS so older installs without lib/credential-store.sh still work.
+_cred_get() {
+  if declare -F ops_cred_get >/dev/null 2>&1; then
+    ops_cred_get "$@"
+  else
+    security find-generic-password -s "$1" -a "$2" -w 2>/dev/null
+  fi
+}
+
+_cred_set() {
+  if declare -F ops_cred_set >/dev/null 2>&1; then
+    ops_cred_set "$@"
+  else
+    security add-generic-password -U -s "$1" -a "$2" -w "$3" 2>/dev/null
+  fi
+}
+
+_cred_delete() {
+  if declare -F ops_cred_delete >/dev/null 2>&1; then
+    ops_cred_delete "$@"
+  else
+    security delete-generic-password -s "$1" -a "$2" >/dev/null 2>&1
+  fi
+}
+
 FIXES_APPLIED=()
 FIXES_FAILED=()
 FIXES_SKIPPED=()
@@ -87,9 +129,9 @@ fix_slack_mcp() {
     return
   fi
 
-  # Check for tokens in keychain
-  XOXC=$(security find-generic-password -s slack-xoxc -w 2>/dev/null || echo "")
-  XOXD=$(security find-generic-password -s slack-xoxd -w 2>/dev/null || echo "")
+  # Check for tokens in credential store
+  XOXC=$(_cred_get slack-xoxc "$CRED_ACCOUNT" 2>/dev/null || echo "")
+  XOXD=$(_cred_get slack-xoxd "$CRED_ACCOUNT" 2>/dev/null || echo "")
 
   if [ -z "$XOXC" ] || [ -z "$XOXD" ]; then
     log_skip "slack-mcp: no tokens in keychain (run /ops:setup slack to extract)"
@@ -203,9 +245,9 @@ fix_channel_health() {
   fi
 
   # ── Slack: tokens in keychain but expired ──
-  XOXC=$(security find-generic-password -s slack-xoxc -w 2>/dev/null || echo "")
+  XOXC=$(_cred_get slack-xoxc "$CRED_ACCOUNT" 2>/dev/null || echo "")
   if [ -n "$XOXC" ]; then
-    XOXD=$(security find-generic-password -s slack-xoxd -w 2>/dev/null || echo "")
+    XOXD=$(_cred_get slack-xoxd "$CRED_ACCOUNT" 2>/dev/null || echo "")
     SLACK_OK=$(curl -s -H "Authorization: Bearer $XOXC" -b "d=$XOXD" "https://slack.com/api/auth.test" 2>/dev/null | jq -r '.ok // false' 2>/dev/null || echo "false")
     if [ "$SLACK_OK" != "true" ]; then
       log_fail "slack-health: tokens in keychain are expired (re-run /ops:setup slack)"
@@ -215,9 +257,9 @@ fix_channel_health() {
   fi
 
   # ── Telegram: session in keychain but expired ──
-  TG_SESSION=$(security find-generic-password -s telegram-session -w 2>/dev/null || echo "")
+  TG_SESSION=$(_cred_get telegram-session "$CRED_ACCOUNT" 2>/dev/null || echo "")
   if [ -n "$TG_SESSION" ]; then
-    TG_API_ID=$(security find-generic-password -s telegram-api-id -w 2>/dev/null || echo "")
+    TG_API_ID=$(_cred_get telegram-api-id "$CRED_ACCOUNT" 2>/dev/null || echo "")
     if [ -z "$TG_API_ID" ]; then
       log_fail "telegram-health: session exists but api_id missing from keychain"
     else

--- a/claude-ops/bin/ops-setup-detect
+++ b/claude-ops/bin/ops-setup-detect
@@ -16,6 +16,9 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 REGISTRY="$SCRIPT_DIR/scripts/registry.json"
 
+LIB_OS_DETECT="$SCRIPT_DIR/lib/os-detect.sh"
+[ -r "$LIB_OS_DETECT" ] && . "$LIB_OS_DETECT"
+
 # Preferences live in Claude Code's per-plugin data dir so they survive plugin
 # reinstalls/version bumps. Falls back to the plugin source dir for users who
 # run bin/ops-setup-detect directly outside a Claude Code plugin context.
@@ -82,8 +85,20 @@ tool_status() {
   has "$tool"
 }
 
+# host — OS/arch/pkg-mgr/keyring context from lib/os-detect.sh (used by channel installers)
+if declare -F ops_os_json >/dev/null 2>&1; then
+  if command -v jq >/dev/null 2>&1; then
+    HOST_JSON="$(ops_os_json | jq '.' 2>/dev/null || echo '{}')"
+  else
+    HOST_JSON="$(ops_os_json)"
+  fi
+else
+  HOST_JSON="{}"
+fi
+
 cat <<EOF
 {
+  "host": $HOST_JSON,
   "platform": "$PLATFORM",
   "shell": "$SHELL_NAME",
   "profile_file": "$PROFILE_FILE",

--- a/claude-ops/bin/ops-setup-preflight
+++ b/claude-ops/bin/ops-setup-preflight
@@ -3,10 +3,42 @@
 # Results written to /tmp/ops-preflight/ for the setup wizard to read
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+[ -r "$SCRIPT_DIR/lib/os-detect.sh" ]        && . "$SCRIPT_DIR/lib/os-detect.sh"
+[ -r "$SCRIPT_DIR/lib/credential-store.sh" ] && . "$SCRIPT_DIR/lib/credential-store.sh"
+
 OUT="/tmp/ops-preflight"
 rm -rf "$OUT" && mkdir -p "$OUT"
 
+# Back-compat wrapper: prefer cross-OS ops_cred_get, fall back to macOS `security`.
+cred_get() {
+  if declare -F ops_cred_get >/dev/null 2>&1; then
+    ops_cred_get "$1" "$2" 2>/dev/null
+  else
+    security find-generic-password -s "$1" -a "$2" -w 2>/dev/null
+  fi
+}
+
 # All probes run in parallel as background jobs
+{
+  # Host / OS context — foundational cache for downstream ops-setup-detect
+  if declare -F ops_os_json >/dev/null 2>&1; then
+    ops_os_json > "$OUT/host.json"
+  else
+    echo '{}' > "$OUT/host.json"
+  fi
+} &
+
+{
+  # Credential backends available on this host (debug aid)
+  if declare -F ops_cred_backends_available >/dev/null 2>&1; then
+    # ops_cred_backends_available emits space-separated; split to one per line
+    ops_cred_backends_available | tr ' ' '\n' | sed '/^$/d' > "$OUT/cred-backends.txt"
+  else
+    echo "security" > "$OUT/cred-backends.txt"
+  fi
+} &
+
 {
   # CLI detection
   for tool in jq git gh aws node brew doppler wacli gog sentry-cli expect; do
@@ -20,9 +52,9 @@ rm -rf "$OUT" && mkdir -p "$OUT"
 } &
 
 {
-  # Slack keychain scout
-  xoxc=$(security find-generic-password -s slack-xoxc -w 2>/dev/null || echo "")
-  xoxd=$(security find-generic-password -s slack-xoxd -w 2>/dev/null || echo "")
+  # Slack credential scout (cross-OS)
+  xoxc=$(cred_get slack-xoxc slack-xoxc || echo "")
+  xoxd=$(cred_get slack-xoxd slack-xoxd || echo "")
   if [ -n "$xoxc" ] && [ -n "$xoxd" ]; then
     # Validate
     result=$(curl -s -H "Authorization: Bearer $xoxc" -b "d=$xoxd" "https://slack.com/api/auth.test" 2>/dev/null || echo '{"ok":false}')
@@ -33,9 +65,9 @@ rm -rf "$OUT" && mkdir -p "$OUT"
 } &
 
 {
-  # Telegram keychain scout
+  # Telegram credential scout (cross-OS)
   for key in telegram-api-id telegram-api-hash telegram-phone telegram-session; do
-    val=$(security find-generic-password -s "$key" -w 2>/dev/null || echo "")
+    val=$(cred_get "$key" "$key" || echo "")
     echo "$key=$( [ -n "$val" ] && echo "found" || echo "missing" )" >> "$OUT/telegram.txt"
   done
 } &

--- a/claude-ops/bin/ops-slack-autolink.mjs
+++ b/claude-ops/bin/ops-slack-autolink.mjs
@@ -29,10 +29,26 @@
  */
 
 import { existsSync, readFileSync, mkdirSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { homedir, userInfo } from "node:os";
+import { join, basename } from "node:path";
 import { parseArgs } from "node:util";
 import { execSync } from "node:child_process";
+import {
+  osId,
+  isWsl,
+  browserProfileDirs,
+} from "../lib/os-detect.mjs";
+import {
+  setCredential,
+  getCredential,
+  deleteCredential,
+  backendsAvailable,
+} from "../lib/credential-store.mjs";
+
+const OS_ID = osId();
+const IS_WSL = isWsl();
+const USER_ACCOUNT =
+  userInfo().username || process.env.USER || process.env.USERNAME || "default";
 
 const { values } = parseArgs({
   options: {
@@ -91,7 +107,7 @@ emit({
   message: "Scouting for existing Slack tokens",
 });
 
-function scoutSources() {
+async function scoutSources() {
   const sources = [];
 
   // 1. ~/.claude.json mcpServers.slack.env — where Claude Code stores them
@@ -131,31 +147,65 @@ function scoutSources() {
     });
   }
 
-  // 3. macOS keychain (generic password items named slack-xoxc / slack-xoxd)
-  if (process.platform === "darwin") {
-    try {
-      const xoxc = execSync(
-        `security find-generic-password -s slack-xoxc -w 2>/dev/null`,
-        { encoding: "utf8" },
-      ).trim();
-      const xoxd = execSync(
-        `security find-generic-password -s slack-xoxd -w 2>/dev/null`,
-        { encoding: "utf8" },
-      ).trim();
-      if (xoxc?.startsWith("xoxc-") && xoxd?.startsWith("xoxd-")) {
-        sources.push({
-          source: "keychain",
-          xoxc_token: xoxc,
-          xoxd_token: xoxd,
-        });
-      }
-    } catch {}
-  }
+  // 3. OS-native credential store (macOS Keychain, Linux libsecret, Windows
+  //    credential manager — cmdkey on Windows can't read, so it's skipped).
+  //    Items are stored under service=slack-xoxc / slack-xoxd, account=$USER.
+  try {
+    const xoxcHit = await getCredential("slack-xoxc", USER_ACCOUNT);
+    const xoxdHit = await getCredential("slack-xoxd", USER_ACCOUNT);
+    const xoxc = xoxcHit?.secret;
+    const xoxd = xoxdHit?.secret;
+    if (xoxc?.startsWith("xoxc-") && xoxd?.startsWith("xoxd-")) {
+      sources.push({
+        source: `credential-store:${xoxcHit.backend}`,
+        xoxc_token: xoxc,
+        xoxd_token: xoxd,
+      });
+    }
+  } catch {}
 
-  // 4. Shell profile files
-  const profiles = [".zshrc", ".bashrc", ".zprofile", ".envrc"].map((f) =>
-    join(homedir(), f),
-  );
+  // 4. Shell profile files (OS-aware)
+  const profiles = [];
+  if (OS_ID !== "windows") {
+    // Unix-style shell profiles (macOS, Linux, WSL)
+    profiles.push(
+      ...[".zshrc", ".bashrc", ".zprofile", ".envrc"].map((f) =>
+        join(homedir(), f),
+      ),
+    );
+  }
+  if (OS_ID === "windows" || IS_WSL) {
+    // PowerShell profiles — check common canonical locations.
+    //   $PROFILE on Windows typically resolves to:
+    //     %USERPROFILE%\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1
+    //   PowerShell 7+ uses the "PowerShell" folder instead of "WindowsPowerShell".
+    if (OS_ID === "windows") {
+      const userProfile = process.env.USERPROFILE || homedir();
+      profiles.push(
+        join(
+          userProfile,
+          "Documents",
+          "WindowsPowerShell",
+          "Microsoft.PowerShell_profile.ps1",
+        ),
+        join(
+          userProfile,
+          "Documents",
+          "PowerShell",
+          "Microsoft.PowerShell_profile.ps1",
+        ),
+      );
+    } else if (IS_WSL) {
+      // Best-effort: check the Windows-side PowerShell profile from /mnt/c.
+      const winUser = process.env.USER || process.env.USERNAME || "";
+      if (winUser) {
+        profiles.push(
+          `/mnt/c/Users/${winUser}/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1`,
+          `/mnt/c/Users/${winUser}/Documents/PowerShell/Microsoft.PowerShell_profile.ps1`,
+        );
+      }
+    }
+  }
   for (const path of profiles) {
     if (!existsSync(path)) continue;
     try {
@@ -193,7 +243,7 @@ function scoutSources() {
   return sources;
 }
 
-const scouted = scoutSources();
+const scouted = await scoutSources();
 for (const s of scouted) {
   emit({
     type: "found",
@@ -243,32 +293,71 @@ import { tmpdir } from "node:os";
 import { cpSync, readdirSync } from "node:fs";
 
 /**
+ * Map an absolute browser-profile directory to a friendly name. Uses path
+ * substrings so it works uniformly across macOS/Linux/Windows conventions
+ * (e.g. "Google/Chrome", "google-chrome", "Chrome\\User Data").
+ */
+function browserNameForDir(dir) {
+  const d = dir.replace(/\\/g, "/").toLowerCase();
+  if (d.includes("/google/chrome beta") || d.includes("chrome-beta"))
+    return "Google Chrome Beta";
+  if (d.includes("/google/chrome") || d.includes("google-chrome"))
+    return "Google Chrome";
+  if (d.includes("bravesoftware")) return "Brave";
+  if (d.includes("/arc/")) return "Arc";
+  if (d.includes("/chromium")) return "Chromium";
+  if (d.includes("microsoft edge") || d.includes("edge/user data"))
+    return "Microsoft Edge";
+  if (d.includes("com.operasoftware.opera") || d.includes("/opera"))
+    return "Opera";
+  if (d.includes("/comet")) return "Comet";
+  if (d.includes("/vivaldi")) return "Vivaldi";
+  if (d.includes("/orion")) return "Orion";
+  return basename(dir);
+}
+
+/**
  * Detect installed browser profiles that might contain Slack cookies.
  * Returns [{name, cookieDb, localStorageDir, userDataDir}] sorted by preference.
+ *
+ * On macOS we include several extra Chromium-forks (Edge/Opera/Vivaldi/Orion
+ * /Comet), the Slack desktop app containers, Firefox, and Safari. On
+ * Linux/Windows we rely on browserProfileDirs() for the canonical Chrome/
+ * Chromium/Brave/Arc set, plus Firefox where applicable. Direct cookie
+ * decryption below is still macOS-only; other platforms fall through to the
+ * Playwright path.
  */
-function detectBrowserProfiles() {
+async function detectBrowserProfiles() {
   const home = homedir();
-  const appSupport = join(home, "Library", "Application Support");
-
-  // --- Chromium-based browsers (standard profile layout) ---
-  const chromiumCandidates = [
-    { name: "Google Chrome", dir: join(appSupport, "Google", "Chrome") },
-    {
-      name: "Google Chrome Beta",
-      dir: join(appSupport, "Google", "Chrome Beta"),
-    },
-    { name: "Arc", dir: join(appSupport, "Arc", "User Data") },
-    { name: "Brave", dir: join(appSupport, "BraveSoftware", "Brave-Browser") },
-    { name: "Microsoft Edge", dir: join(appSupport, "Microsoft Edge") },
-    { name: "Chromium", dir: join(appSupport, "Chromium") },
-    { name: "Opera", dir: join(appSupport, "com.operasoftware.Opera") },
-    { name: "Comet", dir: join(appSupport, "Comet") },
-    { name: "Vivaldi", dir: join(appSupport, "Vivaldi") },
-    { name: "Orion", dir: join(appSupport, "Orion") },
-  ];
-
   const found = [];
-  for (const { name, dir } of chromiumCandidates) {
+
+  // --- Chromium-based browsers from the shared detector --------------------
+  const chromiumDirs = (await browserProfileDirs()).map((dir) => ({
+    name: browserNameForDir(dir),
+    dir,
+  }));
+
+  // On macOS, also probe browsers that browserProfileDirs() doesn't cover
+  // (Edge/Opera/Vivaldi/Orion/Comet/Chrome Beta). Keeps parity with the
+  // pre-refactor behavior.
+  if (OS_ID === "macos") {
+    const appSupport = join(home, "Library", "Application Support");
+    const extras = [
+      { name: "Google Chrome Beta", dir: join(appSupport, "Google", "Chrome Beta") },
+      { name: "Microsoft Edge", dir: join(appSupport, "Microsoft Edge") },
+      { name: "Opera", dir: join(appSupport, "com.operasoftware.Opera") },
+      { name: "Comet", dir: join(appSupport, "Comet") },
+      { name: "Vivaldi", dir: join(appSupport, "Vivaldi") },
+      { name: "Orion", dir: join(appSupport, "Orion") },
+    ];
+    for (const e of extras) {
+      if (existsSync(e.dir) && !chromiumDirs.some((c) => c.dir === e.dir)) {
+        chromiumDirs.push(e);
+      }
+    }
+  }
+
+  for (const { name, dir } of chromiumDirs) {
     const profiles = ["Default"];
     try {
       const entries = readdirSync(dir);
@@ -282,10 +371,17 @@ function detectBrowserProfiles() {
     for (const profile of profiles) {
       const cookieDb = join(dir, profile, "Cookies");
       const localStorageDir = join(dir, profile, "Local Storage", "leveldb");
-      if (existsSync(cookieDb)) {
+      // Chrome/Chromium on some platforms store cookies under Network/Cookies
+      const netCookieDb = join(dir, profile, "Network", "Cookies");
+      const cookieDbFinal = existsSync(cookieDb)
+        ? cookieDb
+        : existsSync(netCookieDb)
+          ? netCookieDb
+          : null;
+      if (cookieDbFinal) {
         found.push({
           name: `${name}/${profile}`,
-          cookieDb,
+          cookieDb: cookieDbFinal,
           localStorageDir,
           userDataDir: dir,
           profile,
@@ -294,77 +390,102 @@ function detectBrowserProfiles() {
     }
   }
 
-  // --- Slack desktop app (Electron, macOS sandboxed container) ---
-  const slackDesktopPaths = [
-    // Mac App Store version (sandboxed)
-    join(
-      home,
-      "Library",
-      "Containers",
-      "com.tinyspeck.slackmacgap",
-      "Data",
-      "Library",
-      "Application Support",
-      "Slack",
-    ),
-    // Direct download version (non-sandboxed)
-    join(appSupport, "Slack"),
-  ];
-  for (const slackDir of slackDesktopPaths) {
-    const cookieDb = join(slackDir, "Cookies");
-    const localStorageDir = join(slackDir, "Local Storage", "leveldb");
-    if (existsSync(cookieDb)) {
-      found.unshift({
-        name: "Slack Desktop",
-        cookieDb,
-        localStorageDir,
-        userDataDir: slackDir,
-        profile: ".",
-      });
-    }
-  }
-
-  // --- Firefox (SQLite cookies.sqlite, different schema) ---
-  const firefoxDir = join(
-    home,
-    "Library",
-    "Application Support",
-    "Firefox",
-    "Profiles",
-  );
-  try {
-    const profiles = readdirSync(firefoxDir);
-    for (const p of profiles) {
-      const cookieDb = join(firefoxDir, p, "cookies.sqlite");
+  // --- Slack desktop app (macOS-only container layout) --------------------
+  if (OS_ID === "macos") {
+    const appSupport = join(home, "Library", "Application Support");
+    const slackDesktopPaths = [
+      // Mac App Store version (sandboxed)
+      join(
+        home,
+        "Library",
+        "Containers",
+        "com.tinyspeck.slackmacgap",
+        "Data",
+        "Library",
+        "Application Support",
+        "Slack",
+      ),
+      // Direct download version (non-sandboxed)
+      join(appSupport, "Slack"),
+    ];
+    for (const slackDir of slackDesktopPaths) {
+      const cookieDb = join(slackDir, "Cookies");
+      const localStorageDir = join(slackDir, "Local Storage", "leveldb");
       if (existsSync(cookieDb)) {
-        found.push({
-          name: `Firefox/${p}`,
+        found.unshift({
+          name: "Slack Desktop",
           cookieDb,
-          localStorageDir: null,
-          userDataDir: join(firefoxDir, p),
-          profile: p,
-          isFirefox: true,
+          localStorageDir,
+          userDataDir: slackDir,
+          profile: ".",
         });
       }
     }
-  } catch {}
+  }
 
-  // --- Safari (Cookies.binarycookies — binary format, check presence only) ---
-  const safariCookies = join(
-    home,
-    "Library",
-    "Cookies",
-    "Cookies.binarycookies",
-  );
-  if (existsSync(safariCookies)) {
-    found.push({
-      name: "Safari",
-      cookieDb: safariCookies,
-      localStorageDir: null,
-      userDataDir: null,
-      profile: ".",
-      isSafari: true,
-    });
+  // --- Firefox (SQLite cookies.sqlite, unencrypted) -----------------------
+  const firefoxDirs = [];
+  if (OS_ID === "macos") {
+    firefoxDirs.push(
+      join(home, "Library", "Application Support", "Firefox", "Profiles"),
+    );
+  } else if (process.platform === "linux") {
+    firefoxDirs.push(join(home, ".mozilla", "firefox"));
+    if (IS_WSL) {
+      const winUser = process.env.USER || process.env.USERNAME || "";
+      if (winUser) {
+        firefoxDirs.push(
+          `/mnt/c/Users/${winUser}/AppData/Roaming/Mozilla/Firefox/Profiles`,
+        );
+      }
+    }
+  } else if (OS_ID === "windows") {
+    const appData =
+      process.env.APPDATA ||
+      (process.env.USERPROFILE
+        ? join(process.env.USERPROFILE, "AppData", "Roaming")
+        : null);
+    if (appData) {
+      firefoxDirs.push(join(appData, "Mozilla", "Firefox", "Profiles"));
+    }
+  }
+  for (const firefoxDir of firefoxDirs) {
+    try {
+      const profiles = readdirSync(firefoxDir);
+      for (const p of profiles) {
+        const cookieDb = join(firefoxDir, p, "cookies.sqlite");
+        if (existsSync(cookieDb)) {
+          found.push({
+            name: `Firefox/${p}`,
+            cookieDb,
+            localStorageDir: null,
+            userDataDir: join(firefoxDir, p),
+            profile: p,
+            isFirefox: true,
+          });
+        }
+      }
+    } catch {}
+  }
+
+  // --- Safari (macOS-only binary cookie file) -----------------------------
+  if (OS_ID === "macos") {
+    const safariCookies = join(
+      home,
+      "Library",
+      "Cookies",
+      "Cookies.binarycookies",
+    );
+    if (existsSync(safariCookies)) {
+      found.push({
+        name: "Safari",
+        cookieDb: safariCookies,
+        localStorageDir: null,
+        userDataDir: null,
+        profile: ".",
+        isSafari: true,
+      });
+    }
   }
 
   return found;
@@ -408,7 +529,7 @@ function querySlackCookieFromDb(cookieDb, browserName, opts = {}) {
   }
 }
 
-const browserProfiles = detectBrowserProfiles();
+const browserProfiles = await detectBrowserProfiles();
 emit({
   type: "step",
   message: `Found ${browserProfiles.length} browser profile(s) to scan`,
@@ -670,24 +791,35 @@ if (selectedBrowser && !selectedBrowser.isSafari) {
         });
       }
 
-      // Persist to keychain
-      if (process.platform === "darwin") {
-        try {
-          execSync(
-            `security add-generic-password -U -s slack-xoxc -a "$USER" -w '${xoxcToken.replace(/'/g, "'\\''")}'`,
-            { timeout: 5000 },
-          );
-          execSync(
-            `security add-generic-password -U -s slack-xoxd -a "$USER" -w '${xoxdToken.replace(/'/g, "'\\''")}'`,
-            { timeout: 5000 },
-          );
-          emit({ type: "step", message: "✓ Saved tokens to macOS keychain" });
-        } catch (e) {
+      // Persist via cascading credential store (macOS Keychain → libsecret →
+      // Windows Credential Manager → keytar → encrypted JSON → plaintext).
+      try {
+        const xoxcRes = await setCredential(
+          "slack-xoxc",
+          USER_ACCOUNT,
+          xoxcToken,
+        );
+        const xoxdRes = await setCredential(
+          "slack-xoxd",
+          USER_ACCOUNT,
+          xoxdToken,
+        );
+        if (xoxcRes.ok && xoxdRes.ok) {
           emit({
             type: "step",
-            message: `○ Keychain save failed: ${e.message}`,
+            message: `✓ Saved tokens via credential-store (${xoxcRes.backend})`,
+          });
+        } else {
+          emit({
+            type: "step",
+            message: `○ Credential-store save partial: xoxc=${xoxcRes.backend}/${xoxcRes.ok} xoxd=${xoxdRes.backend}/${xoxdRes.ok}`,
           });
         }
+      } catch (e) {
+        emit({
+          type: "step",
+          message: `○ Credential-store save failed: ${e.message}`,
+        });
       }
 
       // Register Slack MCP server in Claude Code (fully automated)
@@ -743,21 +875,72 @@ try {
   );
 }
 
-mkdirSync(PROFILE_DIR, { recursive: true });
+// Resolve the Playwright persistent-profile directory.
+//
+// If the user explicitly passed --profile-dir, honor it. Otherwise prefer the
+// first real Chrome/Chromium profile discovered by browserProfileDirs() so we
+// inherit an existing login where possible. Fall back to a per-user dir under
+// $XDG_DATA_HOME (or ~/.local/share on Linux/macOS, or the default elsewhere).
+async function resolvePlaywrightProfileDir() {
+  // --profile-dir was explicitly provided and differs from the library default?
+  const libDefault = join(homedir(), ".claude-ops", "slack-profile");
+  if (PROFILE_DIR && PROFILE_DIR !== libDefault) return PROFILE_DIR;
+
+  try {
+    const dirs = await browserProfileDirs();
+    const chromeDir = dirs.find((d) => {
+      const low = d.replace(/\\/g, "/").toLowerCase();
+      return low.includes("chrome") || low.includes("chromium");
+    });
+    if (chromeDir) return chromeDir;
+  } catch {}
+
+  // Nothing pre-existing — use an XDG-compliant fresh profile.
+  const xdgData =
+    process.env.XDG_DATA_HOME ||
+    join(homedir(), ".local", "share");
+  return join(xdgData, "claude-ops", "chromium-profile");
+}
+
+const LAUNCH_PROFILE_DIR = await resolvePlaywrightProfileDir();
+mkdirSync(LAUNCH_PROFILE_DIR, { recursive: true });
 emit({
   type: "step",
-  message: `Launching Chromium (headless=${HEADLESS}, profile=${PROFILE_DIR})`,
+  message: `Launching Chromium (headless=${HEADLESS}, profile=${LAUNCH_PROFILE_DIR})`,
 });
 
-const context = await chromium.launchPersistentContext(PROFILE_DIR, {
-  headless: HEADLESS,
-  args: [
-    "--disable-blink-features=AutomationControlled",
-    "--no-first-run",
-    "--no-default-browser-check",
-  ],
-  viewport: { width: 1280, height: 800 },
-});
+let context;
+try {
+  context = await chromium.launchPersistentContext(LAUNCH_PROFILE_DIR, {
+    headless: HEADLESS,
+    args: [
+      "--disable-blink-features=AutomationControlled",
+      "--no-first-run",
+      "--no-default-browser-check",
+    ],
+    viewport: { width: 1280, height: 800 },
+  });
+} catch (err) {
+  // Common on headless Linux hosts / CI sandboxes where no $DISPLAY exists
+  // and Playwright's Chromium cannot attach to a windowing system.
+  const msg = String(err?.message || err);
+  const looksHeadlessy =
+    /missing (x server|display)|\$DISPLAY|xcb|cannot open display|no protocol specified|Host system is missing dependencies/i.test(
+      msg,
+    );
+  if (looksHeadlessy || !HEADLESS) {
+    emit({
+      type: "error",
+      message:
+        "no display available — run ops:setup slack on a machine with a desktop environment",
+      os: OS_ID,
+      headless_available: false,
+      detail: msg,
+    });
+    process.exit(1);
+  }
+  die(`playwright launch failed: ${msg}`);
+}
 
 const page = context.pages()[0] || (await context.newPage());
 

--- a/claude-ops/bin/ops-telegram-autolink.mjs
+++ b/claude-ops/bin/ops-telegram-autolink.mjs
@@ -38,8 +38,15 @@
 import { readFileSync, existsSync, unlinkSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { parseArgs } from "node:util";
+import os from "node:os";
 import { TelegramClient } from "telegram";
 import { StringSession } from "telegram/sessions/index.js";
+import {
+  setCredential,
+  getCredential,
+  deleteCredential,
+} from "../lib/credential-store.mjs";
+import { osId, keyringBackend } from "../lib/os-detect.mjs";
 
 const { values } = parseArgs({
   options: {
@@ -444,24 +451,42 @@ try {
   await client.disconnect().catch(() => {});
 }
 
-// Step 2.2: Save to macOS keychain
-if (process.platform === "darwin") {
-  try {
-    for (const [svc, val] of [
-      ["telegram-api-id", apiId],
-      ["telegram-api-hash", apiHash],
-      ["telegram-phone", PHONE],
-      ["telegram-session", sessionStr],
-    ]) {
-      execSync(
-        `security add-generic-password -U -s "${svc}" -a "$USER" -w '${val.replace(/'/g, "'\\''")}'`,
-        { timeout: 5000 },
+// Step 2.2: Save to cross-OS credential store
+//
+// Cascades through the host-native keyring (macOS security / Linux secret-tool /
+// Windows cmdkey) → keytar → encrypted JSON → plaintext JSON. Existing macOS
+// installations keep working because the service/account names (and the
+// underlying `security add-generic-password` invocation on darwin) are
+// unchanged. See lib/credential-store.mjs for cascade details.
+const CRED_ACCOUNT =
+  process.env.USER || process.env.USERNAME || os.userInfo().username || "user";
+try {
+  const backends = new Set();
+  for (const [svc, val] of [
+    ["telegram-api-id", apiId],
+    ["telegram-api-hash", apiHash],
+    ["telegram-phone", PHONE],
+    ["telegram-session", sessionStr],
+  ]) {
+    const r = await setCredential(svc, CRED_ACCOUNT, val);
+    if (!r || !r.ok) {
+      throw new Error(
+        `setCredential(${svc}) failed (backend=${r ? r.backend : "none"})`,
       );
     }
-    emit({ type: "step", message: "✓ Saved credentials to macOS keychain" });
-  } catch (e) {
-    emit({ type: "step", message: `○ Keychain save failed: ${e.message}` });
+    if (r.backend) backends.add(r.backend);
   }
+  const backendList = Array.from(backends).join(", ") || "unknown";
+  emit({
+    type: "step",
+    message: `✓ Saved credentials to credential store (backend=${backendList}, host=${osId()}, native=${keyringBackend() || "none"})`,
+    backend: backendList,
+  });
+} catch (e) {
+  emit({
+    type: "step",
+    message: `○ Credential store save failed: ${e.message}`,
+  });
 }
 
 // Step 2.3: Register MCP server


### PR DESCRIPTION
## Summary

PR **B2** of the cross-OS refactor. Builds on [#72 (B1 foundation)](../pull/72). Every macOS-only `security` call and every hardcoded `~/Library/Application Support/...` browser profile path has been replaced with the new cross-OS helpers. **Existing macOS behaviour is preserved** — the native `security` backend is still first in the cascade — and Linux (libsecret via `secret-tool`) and Windows (`cmdkey` for writes, keytar/enc-json cascade for reads) are now supported.

**Important:** this PR targets `claude/cross-os-b1-foundation`, not `main`. Re-target to `main` after #72 merges.

## Files touched

| File | Change |
|---|---|
| `bin/ops-setup-detect` | Sources `lib/os-detect.sh`; injects new top-level `"host"` object |
| `bin/ops-setup-preflight` | Adds `host.json` + `cred-backends.txt` probe outputs; replaces `security find-generic-password` with `cred_get` wrapper |
| `bin/ops-autofix` | `_cred_set`/`_cred_get`/`_cred_delete` wrappers; 4 fix blocks migrated; back-compat fallback to direct `security` when `lib/` is missing |
| `bin/ops-slack-autolink.mjs` | `browserProfileDirs()` across macOS/Linux/WSL/Windows; Playwright `--user-data-dir` auto-selects first existing Chrome-family profile; graceful no-display error JSON; all `security` calls replaced |
| `bin/ops-telegram-autolink.mjs` | Removed `if (process.platform === "darwin")` gate; `setCredential` replaces `security` loop; account resolution via `os.userInfo().username` for Windows |

Diff: **5 files changed, 465 insertions(+), 168 deletions(-)**.

## Behaviour preservation

- **Service + account names unchanged** — existing macOS Keychain entries remain readable (`telegram-api-id`, `telegram-api-hash`, `telegram-phone`, `telegram-session`, `slack-xoxc`, `slack-xoxd`).
- **Back-compat wrappers** — `ops-autofix` and `ops-setup-preflight` fall through to direct `security` calls when `lib/` isn't sourced, so users mid-upgrade aren't broken.
- **JSON output schemas unchanged** for every script — `/ops:setup`, `/ops:doctor`, and the setup wizard parse these outputs.
- **Parallel-job structure** preserved in `ops-setup-preflight`.

## New capabilities

- `ops-setup-preflight` now emits `/tmp/ops-preflight/host.json` (OS/arch/pkg_mgr/keyring_backend/opener/shell/browser_profiles) — downstream skills can read this to avoid re-running detection.
- `ops-setup-preflight` emits `/tmp/ops-preflight/cred-backends.txt` — useful for `/ops:doctor` to show which credential backends are available.
- `ops-slack-autolink.mjs` emits `{"type":"error","message":"no display available ...","headless_available":false}` when Playwright can't launch headed instead of an opaque crash (caught during testing in this session's headless sandbox).
- `ops-telegram-autolink.mjs` reports the actual backend used in its success debug output (`security`, `secret-tool`, `wincred`, `keytar`, `enc-json`, `plaintext-json`).

## Verified

- `node --check` on both `.mjs` files
- `bash -n` on all 3 shell scripts
- `bash bin/ops-setup-detect | jq .host.os` → `debian` on this sandbox
- `bash bin/ops-setup-preflight && ls /tmp/ops-preflight/` → 13 expected files including the new `host.json` + `cred-backends.txt`
- `ops-autofix --fix=slack-mcp --json` emits valid JSON with no-tokens skip semantics
- `tests/lib/smoke.sh` from B1 still passes (7/8, native-keyring SKIP)

## Test plan

- [ ] Reviewer on macOS: `bash bin/ops-setup-preflight && cat /tmp/ops-preflight/host.json` — confirms `"os":"macos"`, `"keyring_backend":"security"`, Chrome profile(s) listed
- [ ] Reviewer on Linux with libsecret: ensure existing Slack/Telegram credentials stored via the old `security` path are re-saved via `setCredential` on next `/ops:setup` run (one-way migration)
- [ ] Reviewer on Windows (or WSL): `bash bin/ops-setup-detect` emits `windows` or `wsl` for `.host.os`; autolink scripts don't crash on missing `security`

## Follow-up (B3)

`bin/ops-setup-install` pkg-manager expansion · `scripts/ops-daemon.sh` cross-OS daemon refactor (launchd/systemd/Task Scheduler) · `scripts/ops-memory-extractor.sh` date portability · `lib/opener.{sh,mjs}` · shebang audit · `docs/os-compatibility.md`.

## Signing

Unsigned commit (`-c commit.gpgsign=false`); see #72 for context.

https://claude.ai/code/session_01SappBC7MZ7ZvENGQgq2rZy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/74" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential storage and discovery paths for Slack/Telegram setup and health checks across macOS/Linux/Windows, which can break auth flows or leak/lose tokens if backend selection behaves unexpectedly. Changes are mostly additive with macOS fallbacks, but broadened platform surface area increases integration risk.
> 
> **Overview**
> Refactors ops setup/autofix tooling to use the new cross-OS `lib/os-detect` and `lib/credential-store` helpers instead of macOS-only `security` calls and hardcoded browser/profile paths.
> 
> `ops-setup-detect` now emits a top-level `"host"` object (from `ops_os_json`) for downstream installers, and `ops-setup-preflight` writes new cached probes (`host.json`, `cred-backends.txt`) while scouting Slack/Telegram credentials via the credential-store wrapper.
> 
> The Slack and Telegram autolink flows now persist and read secrets through the cascading credential store (native keyring → keytar → encrypted/plain JSON) and expand Slack token scouting/browser profile detection to Windows/WSL/Linux, including improved Playwright profile selection and a clearer failure mode when no display is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ddaa4de4591b97915379dca1ad0d83d38025f4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->