### PR TITLE
fix(revenue): correct Stripe churn calculation and add pagination for 100+ items

### DIFF
--- a/claude-ops/agents/revenue-tracker.md
+++ b/claude-ops/agents/revenue-tracker.md
@@ -32,20 +32,38 @@ Only run if `STRIPE_SECRET_KEY` is set. If not, emit `stripe: not_configured` an
 ### Recent charges (for MTD + trailing-30d gross)
 
 ```bash
-curl -s https://api.stripe.com/v1/charges?limit=100 \
-  -u "$STRIPE_SECRET_KEY:" 2>/dev/null
+# Paginate through all charges using has_more + starting_after loop
+AFTER=""
+while true; do
+  PARAMS="limit=100${AFTER:+&starting_after=$AFTER}"
+  PAGE=$(curl -s "https://api.stripe.com/v1/charges?$PARAMS" \
+    -u "$STRIPE_SECRET_KEY:" 2>/dev/null)
+  echo "$PAGE"
+  HAS_MORE=$(echo "$PAGE" | jq -r '.has_more')
+  [ "$HAS_MORE" = "true" ] || break
+  AFTER=$(echo "$PAGE" | jq -r '.data[-1].id')
+done
 ```
 
-Filter `data[].created >= first-of-month` for MTD gross; filter `data[].created >= now - 30d` for trailing-30d gross. Sum `amount` in cents, divide by 100. Only count `status=succeeded` and `paid=true`; subtract `amount_refunded`.
+Collect all pages. Filter `data[].created >= first-of-month` for MTD gross; filter `data[].created >= now - 30d` for trailing-30d gross. Sum `amount` in cents, divide by 100. Only count `status=succeeded` and `paid=true`; subtract `amount_refunded`.
 
 ### Active subscriptions (MRR)
 
 ```bash
-curl -s "https://api.stripe.com/v1/subscriptions?status=active&limit=100" \
-  -u "$STRIPE_SECRET_KEY:" 2>/dev/null
+# Paginate through all active subscriptions using has_more + starting_after loop
+AFTER=""
+while true; do
+  PARAMS="status=active&limit=100${AFTER:+&starting_after=$AFTER}"
+  PAGE=$(curl -s "https://api.stripe.com/v1/subscriptions?$PARAMS" \
+    -u "$STRIPE_SECRET_KEY:" 2>/dev/null)
+  echo "$PAGE"
+  HAS_MORE=$(echo "$PAGE" | jq -r '.has_more')
+  [ "$HAS_MORE" = "true" ] || break
+  AFTER=$(echo "$PAGE" | jq -r '.data[-1].id')
+done
 ```
 
-MRR = sum over `data[].items.data[].price.unit_amount * items.data[].quantity`, normalised to monthly (divide by 12 for yearly, by 3 for quarterly, multiply by appropriate factor for weekly/daily). Convert cents → dollars.
+MRR = sum over all pages: `data[].items.data[].price.unit_amount * items.data[].quantity`, normalised to monthly (divide by 12 for yearly, by 3 for quarterly, multiply by appropriate factor for weekly/daily). Convert cents → dollars.
 
 ### Balance (pending + available)
 
@@ -73,15 +91,24 @@ curl -s "https://api.stripe.com/v1/invoices?status=open&limit=50" \
 
 Count and sum `amount_due`.
 
-### Churn — subscriptions 30d ago
+### Churn — subscriptions cancelled in the last 30d
 
 ```bash
 TS_30D=$(date -v-30d +%s 2>/dev/null || date -d "-30 days" +%s)
-curl -s "https://api.stripe.com/v1/subscriptions?status=active&created[lte]=$TS_30D&limit=100" \
-  -u "$STRIPE_SECRET_KEY:" 2>/dev/null
+# Paginate through all recently-cancelled subscriptions
+AFTER=""
+while true; do
+  PARAMS="status=canceled&canceled_at[gte]=$TS_30D&limit=100${AFTER:+&starting_after=$AFTER}"
+  PAGE=$(curl -s "https://api.stripe.com/v1/subscriptions?$PARAMS" \
+    -u "$STRIPE_SECRET_KEY:" 2>/dev/null)
+  echo "$PAGE"
+  HAS_MORE=$(echo "$PAGE" | jq -r '.has_more')
+  [ "$HAS_MORE" = "true" ] || break
+  AFTER=$(echo "$PAGE" | jq -r '.data[-1].id')
+done
 ```
 
-Compare `data | length` to current active count. `churn_rate_pct = max(0, (subs_30d_ago - subs_now) / subs_30d_ago * 100)`.
+Count total cancelled subs across all pages as `recently_cancelled`. Use the active sub count from the MRR query above as `subs_now`. `churn_rate_pct = recently_cancelled / (subs_now + recently_cancelled) * 100` (0 if denominator is 0).
 
 ---
 


### PR DESCRIPTION
## Summary
- **Churn calc bug**: replaced `status=active&created[lte]=$TS_30D` (always returned active subs, delta always 0%) with `status=canceled&canceled_at[gte]=$TS_30D` to correctly count recently-cancelled subs; churn rate is now `cancelled / (active + cancelled) * 100`
- **Pagination cap**: both charge and subscription list queries were capped at `limit=100` with no loop; replaced with `has_more` + `starting_after` pagination loops so accounts with 100+ items get full coverage

## Test plan
- [ ] Verify churn rate is non-zero on an account with recent cancellations
- [ ] Verify all charges/subscriptions are fetched on accounts with >100 items

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the Stripe queries and churn formula used for financial reporting; low blast radius but it can materially change reported revenue/churn numbers if the new pagination/filtering is wrong.
> 
> **Overview**
> Improves the Stripe portion of the `revenue-tracker` agent by **adding `has_more`/`starting_after` pagination loops** for charges and active subscriptions so accounts with >100 items are fully included in MTD/trailing-30d gross and MRR calculations.
> 
> Fixes churn reporting by switching from a (non-informative) “active subs created before 30d ago” query to fetching **subscriptions canceled in the last 30d** and redefining churn as `recently_cancelled / (subs_now + recently_cancelled) * 100` (with a zero-denominator guard).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f543471a92f62e782c8410843b04bcca369a41c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->