### PR TITLE
fix(inbox): consistent JSON keys, correct Gmail query semantics, valid Slack search syntax

### DIFF
--- a/claude-ops/bin/ops-unread
+++ b/claude-ops/bin/ops-unread
@@ -85,10 +85,10 @@ except:
     [[ "$EMAIL_COUNT" =~ ^[0-9]+$ ]] || EMAIL_COUNT="0"
     RESULT=$(echo "$RESULT" | jq --argjson c "$EMAIL_COUNT" '.channels.email = {"inbox_count": $c, "available": true}')
   else
-    RESULT=$(echo "$RESULT" | jq '.channels.email = {"unread": 0, "available": false, "note": "gog not authenticated — run: gog gmail auth"}')
+    RESULT=$(echo "$RESULT" | jq '.channels.email = {"inbox_count": 0, "available": false, "note": "gog not authenticated — run: gog gmail auth"}')
   fi
 else
-  RESULT=$(echo "$RESULT" | jq '.channels.email = {"unread": 0, "available": false, "note": "gog not installed — run: npm install -g @auroracapital/gog (or bun install -g @auroracapital/gog, or clone github.com/auroracapital/gog)"}')
+  RESULT=$(echo "$RESULT" | jq '.channels.email = {"inbox_count": 0, "available": false, "note": "gog not installed — run: npm install -g @auroracapital/gog (or bun install -g @auroracapital/gog, or clone github.com/auroracapital/gog)"}')
 fi
 
 # ── Slack — MCP-based, check env ──

--- a/claude-ops/scripts/ops-cron-inbox-digest.sh
+++ b/claude-ops/scripts/ops-cron-inbox-digest.sh
@@ -64,7 +64,7 @@ data = json.load(sys.stdin)
 subjects = [m.get('subject', '')[:50] for m in (data if isinstance(data, list) else [])[:3]]
 print('\n  - '.join(subjects))
 " 2>/dev/null || echo "")
-  EMAIL_SUMMARY="Email: $EMAIL_COUNT unread"
+  EMAIL_SUMMARY="Email: $EMAIL_COUNT in inbox"
   [[ -n "$EMAIL_SUBJECTS" ]] && EMAIL_SUMMARY="$EMAIL_SUMMARY
   - $EMAIL_SUBJECTS"
 fi

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -417,7 +417,7 @@ Draft replies via `gog gmail send`. Archive via `gog gmail labels modify --remov
 
 ### Slack
 
-Use Slack MCP tools with `query: "in:channel"` (NOT `is:unread` — scan full recent activity, not just unread) for mentions.
+Use Slack MCP tools with `query: "in:*"` (NOT `is:unread` — scan full recent activity, not just unread) for mentions.
 For each result, show channel, sender, preview. Read thread for context.
 
 ```


### PR DESCRIPTION
## Summary
- `ops-cron-inbox-digest.sh`: Changed alert text from "unread" to "in inbox" to match the `in:inbox` Gmail query (not `is:unread`)
- `bin/ops-unread`: Changed error/fallback paths to emit `inbox_count` (was `unread`) so all paths use the same key
- `skills/ops-inbox/SKILL.md`: Changed invalid Slack search `in:channel` to `in:*` (valid wildcard syntax)

## Test plan
- [ ] Verify `ops-cron-inbox-digest.sh` Telegram alert reads "X in inbox" not "X unread"
- [ ] Verify `ops-unread` JSON always has `email.inbox_count` regardless of auth state
- [ ] Verify Slack MCP query `in:*` is accepted by the Slack search API

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: wording/JSON-key alignment changes in ops scripts and docs; behavior is largely the same but downstream consumers expecting `email.unread` in error paths may need to follow the new `inbox_count` key.
> 
> **Overview**
> Makes inbox count reporting consistent with the `in:inbox` Gmail query.
> 
> `ops-unread` now always emits `channels.email.inbox_count` (including unauthenticated/not-installed fallbacks) instead of mixing in an `unread` key, and the 4h digest message text is updated from “unread” to “in inbox”. The ops inbox skill docs also fix the Slack MCP search example to use the valid wildcard query `in:*`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e2a967ac7e25350195fe30d00f8faf9b57137b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->