### PR TITLE
fix(telegram): GSD detection, CSRF guard, schema type check, error text sync

### DIFF
--- a/claude-ops/bin/ops-telegram-autolink.mjs
+++ b/claude-ops/bin/ops-telegram-autolink.mjs
@@ -287,11 +287,11 @@ function extract(html) {
     }
   }
 
-  // Strategy 6: last resort — find ANY 32-char hex string on the page
-  // (api_hash is the only value with that exact shape on /apps)
+  // Strategy 6: last resort — find a 32-char hex string near "api_hash" text
+  // Proximity check prevents CSRF tokens in form fields from being captured.
   if (!apiHash) {
-    const hexes = html.match(/\b[a-f0-9]{32}\b/g);
-    if (hexes && hexes.length === 1) apiHash = hexes[0];
+    const hashProximity = html.match(/api_hash[\s\S]{0,500}?([a-f0-9]{32})/i);
+    if (hashProximity) apiHash = hashProximity[1];
   }
 
   return { apiId, apiHash };

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -176,7 +176,7 @@ GSD is a third-party Claude Code plugin that adds project roadmap tracking. When
 Check if GSD is already installed:
 
 ```bash
-ls ~/.claude/skills/gsd-progress/SKILL.md 2>/dev/null && echo "installed" || echo "not_installed"
+find ~/.claude -name "gsd-progress" -path "*/skills/*" 2>/dev/null | head -1 | grep -q . && echo "installed" || echo "not_installed"
 ```
 
 If not installed, ask via `AskUserQuestion`:
@@ -549,7 +549,7 @@ Set up Telegram personal account access?
 
 If the user skips, record `channels.telegram = "skipped"` in `$PREFS_PATH` and move on. Do NOT silently mark Telegram as unconfigured — the explicit skip prevents the status header from showing `○ telegram (no token)` as an action item on subsequent runs.
 
-**Rate-limit guard**: Before starting, check `$PREFS_PATH` for `channels.telegram.status == "rate_limited"`. If `retry_after` is in the future, tell the user: `"Telegram rate-limited until [time]. Skipping — re-run /ops:setup telegram after [time]."` and move to the next channel. Do NOT attempt `send_password` — it will fail immediately and may extend the cooldown.
+**Rate-limit guard**: Before starting, check `$PREFS_PATH` for `channels.telegram` being an object with `.status == "rate_limited"` — use a type guard: `if (channels.telegram | type) == "object" and .channels.telegram.status == "rate_limited"` (jq: `if (.channels.telegram | type) == "object" then .channels.telegram.status else "skipped" end`). If `retry_after` is in the future, tell the user: `"Telegram rate-limited until [time]. Skipping — re-run /ops:setup telegram after [time]."` and move to the next channel. Do NOT attempt `send_password` — it will fail immediately and may extend the cooldown.
 
 **Bots cannot read user DMs**, so `/ops-inbox telegram` requires a personal-account MCP. The plugin ships `bin/ops-telegram-autolink.mjs` which:
 
@@ -595,7 +595,7 @@ Sub-flow (only runs if user selected Yes above):
 
    **Error recovery — CRITICAL: do NOT burn login attempts.** Each `send_password` call counts toward Telegram's rate limit (~3-5 per 8 hours). If the autolink fails:
 
-   - **`"selectors may have changed"` / extraction failure**: The HTML parsing failed but the login succeeded. Do NOT re-run the script. Instead, check if the error includes `html_snippet` — the snippet shows the stripped page text. If it contains a 5-12 digit number near "api_id" and a 32-char hex near "api_hash", extract them directly with grep/regex from the snippet. If the snippet shows a login page or redirect, the session expired during extraction.
+   - **`"could not extract ... after 6 extraction strategies"` / extraction failure**: The HTML parsing failed but the login succeeded. Do NOT re-run the script. Instead, check if the error includes `html_snippet` — the snippet shows the stripped page text. If it contains a 5-12 digit number near "api_id" and a 32-char hex near "api_hash", extract them directly with grep/regex from the snippet. If the snippet shows a login page or redirect, the session expired during extraction.
    - **`rate-limited`**: Record `channels.telegram.status = "rate_limited"` and `channels.telegram.retry_after` (now + 8 hours) in `$PREFS_PATH`. Move on to the next channel. On subsequent `/ops:setup` runs, check `retry_after` and skip Telegram if the cooldown hasn't expired.
    - **Code file not consumed**: If `/tmp/telegram-code.txt` still exists 10+ seconds after writing, the validation regex rejected it. Read the file contents and the log. Do NOT ask the user for another code — the original code is still valid, you just need to fix the bridge.
    - **General rule**: You get at most 2 `send_password` attempts per setup session. If the first attempt fails for a non-rate-limit reason, diagnose the root cause before trying again. If the second attempt fails, save state and move on.


### PR DESCRIPTION
## Summary
- **GSD detection**: Replace fragile `ls ~/.claude/skills/gsd-progress/SKILL.md` with `find ~/.claude -name "gsd-progress" -path "*/skills/*"` to handle varying install paths
- **CSRF guard (Strategy 6)**: Replace bare `\b[a-f0-9]{32}\b` with proximity match `api_hash[\s\S]{0,500}?([a-f0-9]{32})` — prevents CSRF tokens in HTML forms from being captured as api_hash
- **Schema type check**: Add jq type guard before accessing `channels.telegram.status` — prevents `jq cannot index string with .status` when value is `"skipped"`
- **Error text sync**: Update error recovery note from `"selectors may have changed"` to `"could not extract ... after 6 extraction strategies"` to match current script output

## Test plan
- [ ] GSD detection returns `installed`/`not_installed` when plugin is under any subdirectory of `~/.claude/`
- [ ] Strategy 6 extraction ignores CSRF tokens and only captures values near `api_hash` in the HTML
- [ ] Rate-limit guard does not crash when `channels.telegram` is the string `"skipped"`
- [ ] Error recovery text matches the actual error emitted by `ops-telegram-autolink.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Telegram credential extraction heuristics and setup flow guidance, which could break login/extraction on unexpected HTML variants; scope is small and includes safety guards against mis-parsing sensitive tokens.
> 
> **Overview**
> Improves Telegram autolinking reliability and safety by tightening the fallback `api_hash` extractor to require proximity to `api_hash`, avoiding accidental capture of unrelated 32-hex values like CSRF tokens.
> 
> Updates the setup wizard docs to detect GSD installs via `find` (more robust to different install paths), adds a jq type-guard when checking `channels.telegram` rate-limit state to avoid indexing errors when the value is the string `"skipped"`, and syncs the documented recovery error text to match the script’s current failure message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bcc819f922338bb7a99a3d713bc74d54502dfa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
