### PR TITLE
fix(setup): jq env var, Agent tool access, rule contradictions, multiSelect, scan count, safety

### DIFF
--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -8,6 +8,7 @@ allowed-tools:
   - Write
   - Edit
   - AskUserQuestion
+  - Agent
 effort: high
 maxTurns: 80
 ---
@@ -423,7 +424,7 @@ Only go into the credential auto-scan flow below when the user picks "manually" 
 
 **BEFORE asking the user for ANY credential**, run this scan sequence. This applies to ALL steps — channels, ecommerce, marketing, voice, and MCPs. The user should never be asked to find a key that's already on their system.
 
-**CRITICAL — exhaust ALL sources before reporting.** Run every scan source (1-8 below) in a single batch, THEN analyze the combined results. Do NOT report "no credentials found" after checking only env vars and Dashlane — Chrome history, .env files, Doppler, and keychain may have the answer. If API tokens are missing but the store/service identity was found (e.g. store URL in Chrome history, login entry in Dashlane), report what you found and skip to the token step with the identity pre-filled. The user saying "find it" or "check all available sources" means you did not search thoroughly enough — never ask the user to look for something you can find programmatically.
+**CRITICAL — exhaust ALL sources before reporting.** Run every scan source (1-10 below) in a single batch, THEN analyze the combined results. Do NOT report "no credentials found" after checking only env vars and Dashlane — Chrome history, .env files, Doppler, and keychain may have the answer. If API tokens are missing but the store/service identity was found (e.g. store URL in Chrome history, login entry in Dashlane), report what you found and skip to the token step with the identity pre-filled. The user saying "find it" or "check all available sources" means you did not search thoroughly enough — never ask the user to look for something you can find programmatically.
 
 For each variable name (e.g. `TELEGRAM_BOT_TOKEN`, `SHOPIFY_ACCESS_TOKEN`, `KLAVIYO_API_KEY`):
 
@@ -513,10 +514,9 @@ Rules for the prompt:
     3. macOS Keychain (security find-generic-password with various service name patterns)
     4. Dashlane CLI (dcli password <service> + related keywords)
     5. Chrome browser — navigate to <service_admin_url> via Kapture/Playwright MCP, log in if needed, and extract the credential from the settings page
-    6. ~/.claude.json MCP server env vars
-    7. All shell profile files (~/.zshrc, ~/.bashrc, ~/.zprofile, ~/.envrc, ~/.config/fish/*)
-    8. 1Password CLI (op item list --tags <service>) if available
-    9. AWS Secrets Manager / SSM Parameter Store if aws cli authenticated
+    6. All shell profile files (~/.zshrc, ~/.bashrc, ~/.zprofile, ~/.envrc, ~/.config/fish/*)
+    7. 1Password CLI (op item list --tags <service>) if available
+    8. AWS Secrets Manager / SSM Parameter Store if aws cli authenticated
 
     Return the credential value if found, or a detailed report of everywhere you checked and what you found (partial matches, expired tokens, wrong-format values).
     ```
@@ -549,7 +549,13 @@ Set up Telegram personal account access?
 
 If the user skips, record `channels.telegram = "skipped"` in `$PREFS_PATH` and move on. Do NOT silently mark Telegram as unconfigured — the explicit skip prevents the status header from showing `○ telegram (no token)` as an action item on subsequent runs.
 
-**Rate-limit guard**: Before starting, check `$PREFS_PATH` for `channels.telegram.status == "rate_limited"`. If `retry_after` is in the future, tell the user: `"Telegram rate-limited until [time]. Skipping — re-run /ops:setup telegram after [time]."` and move to the next channel. Do NOT attempt `send_password` — it will fail immediately and may extend the cooldown.
+**Rate-limit guard**: Before starting, check `$PREFS_PATH` for `channels.telegram.status == "rate_limited"`. If `retry_after` is in the future, present the user with `AskUserQuestion`:
+```
+Telegram is rate-limited until [time]. What would you like to do?
+  [Wait and retry after cooldown — re-run /ops:setup telegram after [time]]
+  [Skip Telegram for now]
+```
+Do NOT attempt `send_password` during a rate-limit window — it will fail immediately and may extend the cooldown. If the user selects Skip, record the skip in `$PREFS_PATH` and move to the next channel.
 
 **Bots cannot read user DMs**, so `/ops-inbox telegram` requires a personal-account MCP. The plugin ships `bin/ops-telegram-autolink.mjs` which:
 
@@ -1465,7 +1471,7 @@ If `SHOPIFY_ACCESS_TOKEN`, `SHOPIFY_ADMIN_TOKEN`, or `SHOPIFY_ADMIN_API_ACCESS_T
    ```bash
    for proj in $(doppler projects --json 2>/dev/null | jq -r '.[].slug'); do
      doppler secrets --project "$proj" --config prd --json 2>/dev/null | \
-       jq -r 'to_entries[] | select(.key | test("SHOPIFY.*TOKEN|SHOPIFY.*ACCESS"; "i")) | "\(.key)=\(.value.computed | .[0:12])... (doppler:\($ENV.proj)/prd)"'
+       jq -r --arg proj "$proj" 'to_entries[] | select(.key | test("SHOPIFY.*TOKEN|SHOPIFY.*ACCESS"; "i")) | "\(.key)=\(.value.computed | .[0:12])... (doppler:\($proj)/prd)"'
    done
    ```
 2. **Try Shopify CLI** if installed (`command -v shopify`):
@@ -2198,11 +2204,11 @@ Collect these via `AskUserQuestion` — one question each. **Never auto-fill fro
 
 5. **YOLO mode** → select `[Yes — auto-approve low-risk actions]`, `[No — always confirm]`.
 
-6. **Default channels** (multiSelect over configured channels only — never show channels that weren't configured in Step 3). **"All configured" should be the first option and pre-selected by default** — most users want all their channels active:
+6. **Default channels** (single-select — these two options are mutually exclusive). **"All configured" should be the first option and pre-selected by default** — most users want all their channels active:
    ```
    Which channels should ops skills use by default?
-     [x] All configured channels
-     [ ] Pick specific channels...
+     [All configured channels]
+     [Pick specific channels...]
    ```
    If the user picks "specific channels", show a follow-up multiSelect with individual channel checkboxes. If they accept "All configured", set `default_channels` to the full list of configured channel names.
 


### PR DESCRIPTION
## Summary

- Bug 1: Add --arg proj to Shopify jq call ($ENV.proj fails for unexported shell vars)
- Bug 2: Add Agent to allowed-tools in skill frontmatter
- Bug 3: Replace Telegram rate-limit auto-skip with AskUserQuestion (Wait/Skip) per Rule 3
- Bug 4: Change Default channels from multiSelect to single-select (mutually exclusive options)
- Bug 5: Update scan sources count from 1-8 to 1-10
- Bug 6: Remove ~/.claude.json from deep-hunt sources (Safety rule prohibits touching it)

## Test plan
- [ ] Verify $ENV.proj no longer appears in SKILL.md
- [ ] Verify Agent is in allowed-tools frontmatter
- [ ] Verify rate-limit guard uses AskUserQuestion
- [ ] Verify Default channels uses single-select wording
- [ ] Verify scan sources text reads 1-10 below
- [ ] Verify ~/.claude.json removed from deep-hunt list

Generated with Claude Code
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes setup-wizard decision logic and credential-discovery guidance (Telegram flow, deep-hunt sources, default channels selection), which can affect how secrets are handled and how users proceed through setup.
> 
> **Overview**
> Tightens the `setup` skill’s frontmatter and interaction rules by adding `Agent` to `allowed-tools`, updating the universal credential scan wording to reflect more sources, and removing `~/.claude.json` from the deep-hunt search list for safety.
> 
> Adjusts user-facing flows to resolve rule contradictions: Telegram rate-limit handling now prompts the user to *wait/retry vs skip* instead of auto-skipping, and the preferences step changes “Default channels” to a single-select choice (with a follow-up multi-select only when picking specific channels).
> 
> Fixes a Shopify Doppler `jq` snippet to pass the project slug via `--arg proj` instead of relying on `$ENV.proj`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c14279fec7b7c5bbc31b4faeb67bc80b3b068ead. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->