### PR TITLE
fix(ecom): correct Recharge, ShipBob, Loop Returns API URLs and auth header

### DIFF
--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -1544,7 +1544,7 @@ If the user provides partner names, process each one in a loop:
      "ecom": {
        "partners": {
          "shipbob": {
-           "api_base_url": "https://developer.shipbob.com/v1",
+           "api_base_url": "https://api.shipbob.com/v1",
            "auth_pattern": "Authorization: Bearer <token>",
            "credentials": { "api_token": "doppler:SHIPBOB_API_TOKEN" },
            "health_endpoint": "/user",
@@ -1567,12 +1567,12 @@ If the user provides partner names, process each one in a loop:
 
 | Partner    | Auth header                              | Base URL                               | Health endpoint        |
 | ---------- | ---------------------------------------- | -------------------------------------- | ---------------------- |
-| ShipBob    | `Authorization: Bearer <token>`          | `https://developer.shipbob.com/v1`     | `/user`                |
-| Recharge   | `X-Recharge-Access-Token: <token>`       | `https://api.rechargeapayments.com/v1` | `/shop`                |
+| ShipBob    | `Authorization: Bearer <token>`          | `https://api.shipbob.com/v1`           | `/user`                |
+| Recharge   | `X-Recharge-Access-Token: <token>`       | `https://api.rechargeapps.com/v1`      | `/shop`                |
 | Yotpo      | `X-Api-Key: <app_key>`                   | `https://api.yotpo.com`                | `/core/v3/stores/<id>` |
 | Shippo     | `Authorization: ShippoToken <token>`     | `https://api.goshippo.com`             | `/carrier_accounts`    |
 | Gorgias    | `Authorization: Basic <base64>`          | `https://<domain>.gorgias.com/api`     | `/account`             |
-| Loop       | `x-loop-signature: <secret>`             | `https://api.loopreturns.com/api/v1`   | `/warehouse`           |
+| Loop       | `X-Authorization: <secret>`              | `https://api.loopreturns.com/api/v1`   | `/warehouse`           |
 | Attentive  | `Authorization: Bearer <token>`          | `https://api.attentivemobile.com/v1`   | `/me`                  |
 
 For any partner not in this table, always web search for current auth docs before asking for credentials.


### PR DESCRIPTION
ShipBob: developer→api, Recharge: rechargeapayments→rechargeapps, Loop: x-loop-signature→X-Authorization
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to the setup wizard’s known partner configuration defaults; low risk except that incorrect values could affect future integration smoke tests and stored preferences.
> 
> **Overview**
> Updates the setup wizard ecommerce partner defaults to match current vendor docs: **ShipBob** now uses `https://api.shipbob.com/v1`, **Recharge** uses `https://api.rechargeapps.com/v1`, and **Loop Returns** switches its known auth header to `X-Authorization: <secret>`.
> 
> Also updates the embedded example `ecom.partners.shipbob.api_base_url` to the new ShipBob endpoint so saved preferences reflect the corrected base URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87efb070dc411b7a8b789e631126ec20c1861c11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->