### PR TITLE
release: v1.0.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code",
       "source": "./claude-ops",
-      "version": "0.8.0",
+      "version": "1.0.0",
       "category": "productivity"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-0.8.0-blue)
+![Version](https://img.shields.io/badge/version-1.0.0-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-22-success)
@@ -239,7 +239,7 @@ Just [Claude Code](https://claude.ai/code) 1.0+. Everything else is installed au
 
 ---
 
-## What's New in v0.8.0
+## What's New in v1.0.0
 
 - **CLAUDE.md plugin rules** — 5 non-negotiable rules enforced across every skill
 - **Shopify Admin template** + `bin/ops-shopify-create`
@@ -280,6 +280,6 @@ See [`claude-ops/README.md`](./claude-ops/README.md) for detailed documentation 
 
 <div align="center">
 
-**v0.8.0 · MIT · github.com/Lifecycle-Innovations-Limited**
+**v1.0.0 · MIT · github.com/Lifecycle-Innovations-Limited**
 
 </div>

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "description": "Business operations command center for Claude Code — 22 skills, 12 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), and voice (Bland AI/ElevenLabs/Whisper). Includes YOLO mode for autonomous operation.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.8.0] — 2026-04-13
+## [1.0.0] — 2026-04-14
 
 ### Added
 

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 *All 12 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain*
 
-[![version](https://img.shields.io/badge/version-0.8.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-1.0.0-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-12-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)
@@ -14,13 +14,13 @@
 
 ---
 
-All 12 agents in claude-ops v0.8.0. Agent files live in `agents/`.
+All 12 agents in claude-ops v1.0.0. Agent files live in `agents/`.
 
 > [!NOTE]
 > Agents are spawned by skills — they are not invoked directly. Each has a `memory` scope for cross-session learning and a defined `effort` level that controls token budget.
 
 > [!IMPORTANT]
-> **v0.8.0 model bumps:** All scanner, fix, and daemon agents upgraded to **`claude-sonnet-4-6`**. All C-suite analysts upgraded to **`claude-opus-4-6`**. The `memory-extractor` stays on Haiku for cost — it's the only background service that runs every 30 min on every box.
+> **v1.0.0 model bumps:** All scanner, fix, and daemon agents upgraded to **`claude-sonnet-4-6`**. All C-suite analysts upgraded to **`claude-opus-4-6`**. The `memory-extractor` stays on Haiku for cost — it's the only background service that runs every 30 min on every box.
 
 ---
 
@@ -85,7 +85,7 @@ These agents are dispatched when issues are found and need resolution.
 All four run in **parallel** when `/ops:yolo` is invoked. Each uses **Opus 4.6** for maximum analytical depth.
 
 > [!IMPORTANT]
-> **v0.8.0 bump:** all four C-suite agents now run on `claude-opus-4-6` (up from `claude-opus-4-5` in v0.7.x). Expect sharper reasoning and slightly higher per-run token cost.
+> **v1.0.0 bump:** all four C-suite agents now run on `claude-opus-4-6` (up from `claude-opus-4-5` in v0.7.x). Expect sharper reasoning and slightly higher per-run token cost.
 
 ### C-Suite Spawn Flow
 

--- a/claude-ops/docs/daemon-guide.md
+++ b/claude-ops/docs/daemon-guide.md
@@ -4,7 +4,7 @@
 
 *The unified background process manager that pre-warms briefings, syncs WhatsApp, extracts memories, and watches your fires — persistently, via launchd*
 
-[![version](https://img.shields.io/badge/version-0.8.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-1.0.0-blue)](../CHANGELOG.md)
 [![services](https://img.shields.io/badge/services-7-f59e0b)](.)
 [![launchd](https://img.shields.io/badge/runtime-launchd-6366f1)](.)
 [![pre--warm](https://img.shields.io/badge/pre--warm-every%202%20min-22c55e)](.)
@@ -13,10 +13,10 @@
 
 ---
 
-The **ops-daemon** is a unified background process manager that runs persistently via macOS launchd. It replaced per-service launchd agents (introduced in v0.5.0, expanded in v0.8.0).
+The **ops-daemon** is a unified background process manager that runs persistently via macOS launchd. It replaced per-service launchd agents (introduced in v0.5.0, expanded in v1.0.0).
 
 > [!NOTE]
-> As of **v0.8.0**, the daemon installs at **setup Step 2c** (not 5b) so it begins pre-warming the briefing cache while the rest of setup is still running. By the time you finish configuring integrations, `/ops:go` is already instant.
+> As of **v1.0.0**, the daemon installs at **setup Step 2c** (not 5b) so it begins pre-warming the briefing cache while the rest of setup is still running. By the time you finish configuring integrations, `/ops:go` is already instant.
 
 ---
 
@@ -83,7 +83,7 @@ sequenceDiagram
 ```
 
 > [!IMPORTANT]
-> **Step 5b changed in v0.8.0.** It used to be "install daemon + launchd plist" (fresh install). It is now "**daemon service reconciliation**" — the daemon is already running from Step 2c; Step 5b just reconciles the active service set with whatever integrations the user configured in Steps 3–7 (enables `store-health` only if Shopify was configured, etc.).
+> **Step 5b changed in v1.0.0.** It used to be "install daemon + launchd plist" (fresh install). It is now "**daemon service reconciliation**" — the daemon is already running from Step 2c; Step 5b just reconciles the active service set with whatever integrations the user configured in Steps 3–7 (enables `store-health` only if Shopify was configured, etc.).
 
 ---
 

--- a/claude-ops/docs/memories-system.md
+++ b/claude-ops/docs/memories-system.md
@@ -4,7 +4,7 @@
 
 *Persistent local context about people, projects, and your communication patterns — extracted from your chats, stored as markdown, never sent anywhere*
 
-[![version](https://img.shields.io/badge/version-0.8.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-1.0.0-blue)](../CHANGELOG.md)
 [![storage](https://img.shields.io/badge/storage-local%20markdown-22c55e)](.)
 [![privacy](https://img.shields.io/badge/privacy-on--device-6366f1)](.)
 [![extractor](https://img.shields.io/badge/extractor-haiku--4--5-f59e0b)](.)
@@ -13,7 +13,7 @@
 
 ---
 
-The memories system gives claude-ops persistent context about people, projects, and your communication patterns. Introduced in v0.5.0, upgraded in v0.8.0 with richer project context blocks.
+The memories system gives claude-ops persistent context about people, projects, and your communication patterns. Introduced in v0.5.0, upgraded in v1.0.0 with richer project context blocks.
 
 > [!IMPORTANT]
 > **Files never leave your machine.** Memories are plain markdown on your local disk at `~/.claude/plugins/data/ops-ops-marketplace/memories/`. The extractor reads your local wacli database and local email cache — nothing is uploaded. See [Privacy](#-privacy) below.

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 *All 21 skills available in claude-ops — your business operations command surface*
 
-[![version](https://img.shields.io/badge/version-0.8.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-1.0.0-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-21-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/package-lock.json
+++ b/claude-ops/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-ops-bin",
-  "version": "0.2.2",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-ops-bin",
-      "version": "0.2.2",
+      "version": "1.0.0",
       "dependencies": {
         "classic-level": "^3.0.0",
         "input": "^1.0.1",

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "0.2.2",
+  "version": "1.0.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 <!-- generated-by: gsd-doc-writer -->
 # Architecture
 
-claude-ops is a Claude Code plugin (v0.8.0) that installs as a business operating system on top of the Claude Code CLI. It exposes 22 slash-command skills that orchestrate 12 autonomous agents, a persistent background daemon, and a bundled Telegram MCP server. The primary inputs are tool calls from Claude Code sessions; the primary outputs are structured reports, drafted communications, and autonomous code/infrastructure actions executed via shell and API calls.
+claude-ops is a Claude Code plugin (v1.0.0) that installs as a business operating system on top of the Claude Code CLI. It exposes 22 slash-command skills that orchestrate 12 autonomous agents, a persistent background daemon, and a bundled Telegram MCP server. The primary inputs are tool calls from Claude Code sessions; the primary outputs are structured reports, drafted communications, and autonomous code/infrastructure actions executed via shell and API calls.
 
 ---
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -1,7 +1,7 @@
 <!-- generated-by: gsd-doc-writer -->
 # Getting Started with claude-ops
 
-claude-ops v0.8.0 — Business Operating System for Claude Code. This guide takes you from zero to your first morning briefing in under five minutes.
+claude-ops v1.0.0 — Business Operating System for Claude Code. This guide takes you from zero to your first morning briefing in under five minutes.
 
 ---
 
@@ -90,7 +90,7 @@ The doctor runs a diagnostic script and displays a report:
  OPS ► DOCTOR — 2026-04-14 09:00
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
- Plugin:      0.8.0 at /path/to/plugin
+ Plugin:      1.0.0 at /path/to/plugin
  Skills:      22 defined
  Agents:      12 defined
  Bin scripts: 8 available


### PR DESCRIPTION
## Summary
- Bumps all version references from 0.8.0 → 1.0.0
- Updates plugin.json, marketplace.json, package.json, README, CHANGELOG, and all docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/85" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure release bookkeeping: updates version strings and documentation; no runtime logic changes, so risk is limited to packaging/metadata mismatches.
> 
> **Overview**
> Bumps claude-ops release version references from **`0.8.0` → `1.0.0`** across marketplace/plugin manifests, npm metadata (`package.json`/`package-lock.json`), and top-level documentation.
> 
> Refreshes the README/docs headings and badges (and the changelog release header/date) to align with the `v1.0.0` release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 832f49405f62ca1b33fcee5ccc017126fae76b10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->