### PR TITLE
fix(ci): allowlist curl-auth-user in docs for gitleaks

### DIFF
--- a/claude-ops/.gitleaks.toml
+++ b/claude-ops/.gitleaks.toml
@@ -155,6 +155,18 @@ allowlist.paths = [
   '''CHANGELOG\.md$''',
 ]
 
+# Override default curl-auth-user rule to allowlist docs
+[[rules]]
+id = "curl-auth-user"
+description = "Curl with auth user (override default to allowlist docs)"
+regex = '''curl.*-u\s+[^\s]+'''
+allowlist.paths = [
+  '''SKILL\.md$''',
+  '''README\.md$''',
+  '''docs/''',
+  '''CONFIGURATION\.md$''',
+]
+
 [allowlist]
 paths = [
   '''node_modules''',


### PR DESCRIPTION
## Summary
- Fixes gitleaks false positive on `curl -u` patterns in SKILL.md documentation files
- Unblocks dependabot PRs #89, #90, #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes secret-scanning configuration by overriding the default `curl-auth-user` rule, which could reduce detection if the regex/allowlist is too permissive. Scope is limited to documentation paths.
> 
> **Overview**
> Resolves `gitleaks` false positives for documentation examples by adding an explicit `curl-auth-user` rule override that allowlists `curl -u ...` matches in `SKILL.md`, `README.md`, `CONFIGURATION.md`, and `docs/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ad966885cf79bc1065d229a9564687f1e2be3e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->