### PR TITLE
feat(09-05): @claude-ops/sdk v1.0.0 + marketplace polish

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,10 +9,16 @@
   "plugins": [
     {
       "name": "ops",
-      "description": "Business operations command center for Claude Code",
+      "description": "Business operations command center for Claude Code — 25 skills, 13 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes YOLO autonomous mode with 4 C-suite agents.",
       "source": "./claude-ops",
       "version": "1.0.0",
-      "category": "productivity"
+      "category": "productivity",
+      "screenshots": [
+        "docs/screenshots/dashboard.png",
+        "docs/screenshots/briefing.png",
+        "docs/screenshots/inbox.png",
+        "docs/screenshots/yolo.png"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 ![Version](https://img.shields.io/badge/version-1.0.0-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
-![Skills](https://img.shields.io/badge/skills-22-success)
-![Agents](https://img.shields.io/badge/agents-12-informational)
+![Skills](https://img.shields.io/badge/skills-25-success)
+![Agents](https://img.shields.io/badge/agents-13-informational)
 ![Integrations](https://img.shields.io/badge/integrations-22-orange)
 ![Models](https://img.shields.io/badge/Opus%204.6%20%2F%20Sonnet%204.6%20%2F%20Haiku%204.5-ff69b4)
 

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ops",
   "version": "1.0.0",
-  "description": "Business operations command center for Claude Code — 22 skills, 12 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), and voice (Bland AI/ElevenLabs/Whisper). Includes YOLO mode for autonomous operation.",
+  "description": "Business operations command center for Claude Code — 25 skills, 13 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes YOLO mode for autonomous operation.",
   "author": {
     "name": "Lifecycle Innovations Limited",
     "url": "https://github.com/Lifecycle-Innovations-Limited"

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **`/ops:monitor`** — Unified APM surface for Datadog, New Relic, and OpenTelemetry. Active alerts, error traces, entity health. `--watch` for live polling.
+- **`/ops:settings`** — Post-setup credential manager. Shows integration status, allows selective updates with smoke tests.
+- **`/ops:integrate`** — Onboard any SaaS API into the partner registry (WebSearch discovery → confirm → credential → health check).
+- **`monitor-agent`** — Lightweight haiku-4-5 agent for APM polling.
+- **`templates/nestjs-api/`** — Full NestJS API template with JWT auth, BullMQ queues, Prisma, Fastify, health endpoint, multi-stage Dockerfile.
+- **`templates/nextjs-saas/`** — Full Next.js SaaS App Router template with Auth.js v5, Stripe billing, Prisma, Tailwind, shadcn/ui.
+- **`@claude-ops/sdk`** — npm package with TypeScript types (SkillManifest, AgentManifest, PluginManifest, HooksConfig) and `create-ops-skill` CLI scaffolder for third-party skill authors.
+- **Automated release pipeline** — GitHub Actions workflow triggered on v* tag push, parses CHANGELOG, creates GitHub Release.
+- **Ubuntu 24.04 CI** — Full test suite runs on both ubuntu-latest and ubuntu-24.04.
+- **Merge conflict resolution** — `/ops:merge` now auto-rebases on `origin/main`; on failure offers accept-theirs / accept-ours / manual / skip.
 - **CLAUDE.md plugin rules** — Plugin-root `CLAUDE.md` with two hard rules enforced across all skills: (1) max 4 options per `AskUserQuestion` call (schema limit), (2) never delegate CLI commands to the user — run via Bash tool instead (exception: `wacli auth` QR code).
 - **Shopify admin app template** — `templates/shopify-admin-app/` — full Shopify Admin Remix template with all admin scopes, forked from Shopify/shopify-app-template-remix.
 - **`bin/ops-shopify-create`** — Non-interactive Shopify app scaffolding script. Automates device-code OAuth (auto-opens browser via `expect`), fetches org ID from Shopify Partners API cache, runs `shopify app init` with all flags, and injects client ID into `shopify.app.toml`.

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,0 +1,210 @@
+# @claude-ops/sdk
+
+SDK and scaffolder for building [claude-ops](https://github.com/Lifecycle-Innovations-Limited/claude-ops) skills and agents.
+
+## Overview
+
+The `@claude-ops/sdk` package provides:
+
+- **TypeScript types** — `SkillManifest`, `AgentManifest`, `PluginManifest`, `HooksConfig` interfaces for type-safe skill authoring
+- **Runtime validators** — `isValidSkillManifest`, `isValidAgentManifest` for runtime validation
+- **Helpers** — `parseSkillFrontmatter`, `serializeSkillFrontmatter` utilities
+- **CLI scaffolder** — `create-ops-skill` generates a new skill or agent from templates
+
+## Installation
+
+**For types only** (in your skill's TypeScript project):
+
+```bash
+npm install @claude-ops/sdk
+```
+
+**For scaffolding** (no install needed):
+
+```bash
+npx create-ops-skill my-skill
+npx create-ops-skill my-skill --agent
+```
+
+## Quick Start
+
+```bash
+# 1. Scaffold a new skill
+npx create-ops-skill my-skill
+
+# 2. Edit the generated SKILL.md
+open skills/my-skill/SKILL.md
+
+# 3. Register in the ops router
+# Add routing in skills/ops/SKILL.md
+
+# 4. Run the lint test
+bash tests/test-skills-lint.sh
+```
+
+## `create-ops-skill` CLI
+
+```
+create-ops-skill — Scaffold a new claude-ops skill
+
+Usage:
+  npx create-ops-skill <skill-name> [options]
+
+Options:
+  --agent, -a   Also create an agent .md file for this skill
+  --help, -h    Show this help
+
+Examples:
+  npx create-ops-skill my-skill
+  npx create-ops-skill my-skill --agent
+```
+
+- Skill name is lowercased and sanitized (`[^a-z0-9-]` → `-`)
+- Creates `skills/<name>/SKILL.md` from the built-in template
+- With `--agent`: also creates `agents/<name>-agent.md`
+- Fails with an error if `skills/<name>/` already exists
+
+## Type Reference
+
+### `SkillManifest`
+
+Frontmatter schema for `SKILL.md` files:
+
+```typescript
+interface SkillManifest {
+  name: string;                    // Skill name → slash command routing
+  description: string;             // Shown in /help and marketplace
+  'argument-hint'?: string;        // e.g., "[--watch] [--setup]"
+  'allowed-tools': ToolName[];     // Claude Code tools this skill may use
+  effort?: EffortLevel;            // 'low' | 'medium' | 'high'
+  maxTurns?: number;               // Max agentic turns before auto-exit
+  model?: string;                  // Model override (inherits from settings if omitted)
+  memory?: MemoryScope;            // 'project' | 'global' | 'none'
+  disallowedTools?: ToolName[];    // Tools explicitly blocked
+  isolation?: IsolationMode;       // 'worktree' | 'none'
+}
+```
+
+### `AgentManifest`
+
+Frontmatter schema for agent `.md` files in `agents/`:
+
+```typescript
+interface AgentManifest {
+  name: string;                    // Agent name — referenced by Agent tool calls
+  description: string;             // What the agent does
+  model?: string;                  // Defaults to claude-sonnet-4-6
+  effort?: EffortLevel;
+  maxTurns?: number;
+  tools?: ToolName[];
+  disallowedTools?: ToolName[];
+  memory?: MemoryScope;
+  initialPrompt?: string;          // Injected as first user message
+}
+```
+
+### `PluginManifest`
+
+Schema for `.claude-plugin/plugin.json`:
+
+```typescript
+interface PluginManifest {
+  name: string;
+  version: string;
+  description: string;
+  author: { name: string; url?: string };
+  homepage?: string;
+  repository?: string;
+  license?: string;
+  keywords?: string[];
+  userConfig?: Record<string, UserConfigField>;
+}
+```
+
+### `HooksConfig`
+
+Schema for hooks configuration in Claude Code settings:
+
+```typescript
+interface HooksConfig {
+  PreToolUse?: HookEntry[];
+  PostToolUse?: HookEntry[];
+  UserPromptSubmit?: HookEntry[];
+  Stop?: HookEntry[];
+}
+
+interface HookEntry {
+  matcher?: string;
+  hooks: Array<{
+    type: 'command';
+    command: string;
+    timeout?: number;
+  }>;
+}
+```
+
+## Helper Functions
+
+### `parseSkillFrontmatter(content: string)`
+
+Parses YAML frontmatter from a `SKILL.md` string. Does not require a YAML library — uses a minimal parser sufficient for the flat frontmatter schema used in claude-ops.
+
+```typescript
+import { parseSkillFrontmatter } from '@claude-ops/sdk';
+
+const content = `---
+name: my-skill
+description: Does something.
+allowed-tools: [Bash, Read]
+---
+
+# My Skill body here.
+`;
+
+const { frontmatter, body } = parseSkillFrontmatter(content);
+// frontmatter: { name: 'my-skill', description: 'Does something.', 'allowed-tools': ['Bash', 'Read'] }
+// body: '# My Skill body here.'
+```
+
+### `isValidSkillManifest(obj: unknown): obj is SkillManifest`
+
+Runtime validator — checks that an object has the required fields for a valid skill manifest.
+
+```typescript
+import { parseSkillFrontmatter, isValidSkillManifest } from '@claude-ops/sdk';
+
+const { frontmatter } = parseSkillFrontmatter(content);
+if (!isValidSkillManifest(frontmatter)) {
+  throw new Error('Invalid SKILL.md: missing name, description, or allowed-tools');
+}
+// frontmatter is now typed as SkillManifest
+```
+
+### `isValidAgentManifest(obj: unknown): obj is AgentManifest`
+
+Same for agent manifests — checks for `name` and `description` fields.
+
+## Plugin Rules Summary
+
+All claude-ops skills must follow these rules (enforced by `CLAUDE.md`):
+
+| Rule | Requirement |
+|------|-------------|
+| **Rule 0** | Public repo — no real credentials, names, or URLs in committed files |
+| **Rule 1** | Max 4 options per `AskUserQuestion` call (schema hard limit) |
+| **Rule 2** | Never delegate CLI commands to the user — run via Bash tool instead |
+| **Rule 3** | Never auto-skip setup steps — always offer `[Skip]` explicitly |
+| **Rule 4** | Background-by-default during setup flows (`run_in_background: true`) |
+| **Rule 5** | Destructive actions require per-action confirmation via `AskUserQuestion` |
+
+## Contributing
+
+1. Fork `Lifecycle-Innovations-Limited/claude-ops`
+2. Create a feature branch: `git checkout -b feat/my-skill`
+3. Scaffold your skill: `npx create-ops-skill my-skill`
+4. Add logic, run `bash tests/test-skills-lint.sh`
+5. Open a PR to `main`
+
+## License
+
+MIT © Lifecycle Innovations Limited

--- a/sdk/bin/create-ops-skill.mjs
+++ b/sdk/bin/create-ops-skill.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+import { parseArgs } from 'node:util';
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const { values, positionals } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    agent: { type: 'boolean', short: 'a', default: false },
+    help: { type: 'boolean', short: 'h', default: false },
+  },
+  allowPositionals: true,
+});
+
+if (values.help || positionals.length === 0) {
+  console.log(`
+create-ops-skill — Scaffold a new claude-ops skill
+
+Usage:
+  npx create-ops-skill <skill-name> [options]
+
+Options:
+  --agent, -a   Also create an agent .md file for this skill
+  --help, -h    Show this help
+
+Examples:
+  npx create-ops-skill my-skill
+  npx create-ops-skill my-skill --agent
+`);
+  process.exit(0);
+}
+
+const skillName = positionals[0].toLowerCase().replace(/[^a-z0-9-]/g, '-');
+const skillDir = join(process.cwd(), 'skills', skillName);
+const agentsDir = join(process.cwd(), 'agents');
+
+// Read templates
+const skillTemplate = readFileSync(
+  join(__dirname, '../templates/skill/SKILL.md.template'),
+  'utf8',
+);
+const agentTemplate = values.agent
+  ? readFileSync(join(__dirname, '../templates/agent/AGENT.md.template'), 'utf8')
+  : null;
+
+// Interpolate
+function interpolate(template, vars) {
+  return Object.entries(vars).reduce(
+    (t, [k, v]) => t.replaceAll(`{{${k}}}`, v),
+    template,
+  );
+}
+
+const skillContent = interpolate(skillTemplate, { SKILL_NAME: skillName });
+const agentContent = agentTemplate
+  ? interpolate(agentTemplate, { SKILL_NAME: skillName })
+  : null;
+
+// Write skill
+if (existsSync(skillDir)) {
+  console.error(`Error: skills/${skillName}/ already exists`);
+  process.exit(1);
+}
+mkdirSync(skillDir, { recursive: true });
+writeFileSync(join(skillDir, 'SKILL.md'), skillContent);
+console.log(`✅ Created skills/${skillName}/SKILL.md`);
+
+// Write agent
+if (agentContent) {
+  if (!existsSync(agentsDir)) mkdirSync(agentsDir, { recursive: true });
+  const agentFile = join(agentsDir, `${skillName}-agent.md`);
+  writeFileSync(agentFile, agentContent);
+  console.log(`✅ Created agents/${skillName}-agent.md`);
+}
+
+console.log(`
+Next steps:
+  1. Edit skills/${skillName}/SKILL.md — add your skill logic
+  2. Register the skill in skills/ops/SKILL.md router
+  3. Run: bash tests/test-skills-lint.sh
+`);

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@claude-ops/sdk",
+  "version": "1.0.0",
+  "description": "SDK and scaffolder for building claude-ops skills and agents",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "create-ops-skill": "./bin/create-ops-skill.mjs"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "keywords": ["claude-code", "claude-ops", "plugin", "skill", "agent"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Lifecycle-Innovations-Limited/claude-ops.git",
+    "directory": "sdk"
+  },
+  "license": "MIT",
+  "engines": { "node": ">=18.0.0" },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/sdk/src/helpers.ts
+++ b/sdk/src/helpers.ts
@@ -1,0 +1,55 @@
+/**
+ * Parses YAML frontmatter from a SKILL.md or agent .md string.
+ * Returns the frontmatter as a plain object and the body as a string.
+ * Does NOT require a yaml library — uses a minimal key:value parser
+ * sufficient for the flat frontmatter schema used in claude-ops.
+ */
+export function parseSkillFrontmatter(content: string): {
+  frontmatter: Record<string, unknown>;
+  body: string;
+} {
+  const match = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  if (!match) return { frontmatter: {}, body: content };
+
+  const [, yaml, body] = match;
+  const frontmatter: Record<string, unknown> = {};
+
+  for (const line of yaml.split('\n')) {
+    const colonIdx = line.indexOf(':');
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    const raw = line.slice(colonIdx + 1).trim();
+    // Parse arrays: [a, b, c]
+    if (raw.startsWith('[') && raw.endsWith(']')) {
+      frontmatter[key] = raw
+        .slice(1, -1)
+        .split(',')
+        .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+        .filter(Boolean);
+    } else if (raw === 'true') {
+      frontmatter[key] = true;
+    } else if (raw === 'false') {
+      frontmatter[key] = false;
+    } else if (!isNaN(Number(raw)) && raw !== '') {
+      frontmatter[key] = Number(raw);
+    } else {
+      frontmatter[key] = raw.replace(/^["']|["']$/g, '');
+    }
+  }
+
+  return { frontmatter, body: body.trim() };
+}
+
+/** Serializes a frontmatter object back to YAML frontmatter string */
+export function serializeSkillFrontmatter(fm: Record<string, unknown>, body: string): string {
+  const lines: string[] = ['---'];
+  for (const [k, v] of Object.entries(fm)) {
+    if (Array.isArray(v)) {
+      lines.push(`${k}: [${v.map(String).join(', ')}]`);
+    } else {
+      lines.push(`${k}: ${String(v)}`);
+    }
+  }
+  lines.push('---', '', body);
+  return lines.join('\n');
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,0 +1,3 @@
+export * from './types.js';
+export * from './validators.js';
+export * from './helpers.js';

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -1,0 +1,121 @@
+/** Effort levels for skills and agents */
+export type EffortLevel = 'low' | 'medium' | 'high';
+
+/** Tool names allowed in skill/agent tool lists */
+export type ToolName =
+  | 'Bash' | 'Read' | 'Write' | 'Edit' | 'Grep' | 'Glob'
+  | 'Skill' | 'Agent' | 'AskUserQuestion' | 'WebSearch' | 'WebFetch'
+  | 'TodoRead' | 'TodoWrite' | 'NotebookRead' | 'NotebookEdit'
+  | 'TaskCreate' | 'TaskUpdate' | 'TaskList' | 'TaskGet'
+  | 'TeamCreate' | 'SendMessage' | 'Monitor'
+  | (string & {}); // allow MCP tool names like "mcp__linear__..."
+
+/** Memory scope for agents */
+export type MemoryScope = 'project' | 'global' | 'none';
+
+/** Isolation mode for agents */
+export type IsolationMode = 'worktree' | 'none';
+
+/**
+ * Frontmatter schema for SKILL.md files.
+ * All fields correspond to Claude Code plugin skill manifest specification.
+ */
+export interface SkillManifest {
+  /** Skill name — used in slash command routing (e.g., "ops-monitor" → /ops:ops-monitor) */
+  name: string;
+  /** One-sentence description shown in /help and marketplace */
+  description: string;
+  /** Hint shown after the slash command (e.g., "[--watch] [--setup]") */
+  'argument-hint'?: string;
+  /** Tools this skill is allowed to use. Max: all Claude Code tools + MCP tools. */
+  'allowed-tools': ToolName[];
+  /** Effort level — controls default maxTurns if maxTurns not set */
+  effort?: EffortLevel;
+  /** Maximum number of agentic turns before the skill auto-exits */
+  maxTurns?: number;
+  /** Model override — if omitted, inherits from user's Claude Code settings */
+  model?: string;
+  /** Memory scope — 'project' reads/writes project memory, 'global' reads global memory */
+  memory?: MemoryScope;
+  /** Tools explicitly disallowed (overrides allowed-tools) */
+  disallowedTools?: ToolName[];
+  /** Isolation mode — 'worktree' creates an isolated git worktree for execution */
+  isolation?: IsolationMode;
+}
+
+/**
+ * Frontmatter schema for agent .md files in agents/.
+ */
+export interface AgentManifest {
+  /** Agent name — referenced by Agent tool calls in skills */
+  name: string;
+  /** One-sentence description of what the agent does */
+  description: string;
+  /** Model to use — defaults to claude-sonnet-4-6 if not set */
+  model?: string;
+  /** Effort level */
+  effort?: EffortLevel;
+  /** Maximum agentic turns */
+  maxTurns?: number;
+  /** Tools this agent can use */
+  tools?: ToolName[];
+  /** Tools explicitly blocked */
+  disallowedTools?: ToolName[];
+  /** Memory scope */
+  memory?: MemoryScope;
+  /** Injected as the first user message before the agent body */
+  initialPrompt?: string;
+}
+
+/** A single userConfig field definition in plugin.json */
+export interface UserConfigField {
+  title: string;
+  description: string;
+  type: 'string' | 'boolean' | 'number';
+  sensitive: boolean;
+  default: string | boolean | number;
+}
+
+/**
+ * Schema for .claude-plugin/plugin.json
+ */
+export interface PluginManifest {
+  name: string;
+  version: string;
+  description: string;
+  author: { name: string; url?: string };
+  homepage?: string;
+  repository?: string;
+  license?: string;
+  keywords?: string[];
+  userConfig?: Record<string, UserConfigField>;
+}
+
+/**
+ * Schema for .claude/hooks.json or settings.json hooks section
+ */
+export interface HooksConfig {
+  PreToolUse?: HookEntry[];
+  PostToolUse?: HookEntry[];
+  UserPromptSubmit?: HookEntry[];
+  Stop?: HookEntry[];
+}
+
+export interface HookEntry {
+  matcher?: string;
+  hooks: Array<{
+    type: 'command';
+    command: string;
+    timeout?: number;
+  }>;
+}
+
+/** Marketplace entry for .claude-plugin/marketplace.json */
+export interface MarketplaceEntry {
+  name: string;
+  description: string;
+  source: string;
+  version: string;
+  category: string;
+  screenshots?: string[];
+}

--- a/sdk/src/validators.ts
+++ b/sdk/src/validators.ts
@@ -1,0 +1,19 @@
+import type { SkillManifest, AgentManifest } from './types.js';
+
+/** Returns true if the manifest has required fields for a valid SKILL.md */
+export function isValidSkillManifest(obj: unknown): obj is SkillManifest {
+  if (typeof obj !== 'object' || obj === null) return false;
+  const m = obj as Record<string, unknown>;
+  return (
+    typeof m.name === 'string' &&
+    typeof m.description === 'string' &&
+    Array.isArray(m['allowed-tools'])
+  );
+}
+
+/** Returns true if the manifest has required fields for a valid agent .md */
+export function isValidAgentManifest(obj: unknown): obj is AgentManifest {
+  if (typeof obj !== 'object' || obj === null) return false;
+  const m = obj as Record<string, unknown>;
+  return typeof m.name === 'string' && typeof m.description === 'string';
+}

--- a/sdk/templates/agent/AGENT.md.template
+++ b/sdk/templates/agent/AGENT.md.template
@@ -1,0 +1,31 @@
+---
+name: {{SKILL_NAME}}-agent
+description: Agent for the {{SKILL_NAME}} skill. Describe what this agent does.
+model: claude-sonnet-4-6
+effort: medium
+maxTurns: 25
+tools:
+  - Bash
+  - Read
+disallowedTools:
+  - Write
+  - Edit
+  - Agent
+memory: project
+initialPrompt: "Perform the {{SKILL_NAME}} analysis and return structured JSON results."
+---
+
+# {{SKILL_NAME}} AGENT
+
+Describe what this agent does. Keep it read-only where possible.
+
+## Preflight
+
+```bash
+PREFS="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+# Load required credentials
+```
+
+## Output
+
+Return JSON. Do not print any other text.

--- a/sdk/templates/skill/SKILL.md.template
+++ b/sdk/templates/skill/SKILL.md.template
@@ -1,0 +1,30 @@
+---
+name: {{SKILL_NAME}}
+description: One-sentence description of what this skill does.
+argument-hint: "[args]"
+allowed-tools:
+  - Bash
+  - Read
+  - AskUserQuestion
+effort: medium
+maxTurns: 20
+---
+
+## Runtime Context
+
+Before executing, load:
+1. **Preferences**: `cat ${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json`
+
+# OPS ► {{SKILL_NAME}}
+
+What does this skill do? Add your overview here.
+
+## CLI/API Reference
+
+| Command | Purpose |
+|---------|---------|
+| `example-command` | Does something useful |
+
+## Your task
+
+Describe the task this skill performs.

--- a/sdk/tsconfig.json
+++ b/sdk/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- `sdk/` package (`@claude-ops/sdk`) with TypeScript types (`SkillManifest`, `AgentManifest`, `PluginManifest`, `HooksConfig`) and `create-ops-skill` CLI scaffolder
- `marketplace.json` updated with full v1.0.0 description (25 skills, 13 agents) + screenshots array
- `plugin.json` description updated to 25 skills / 13 agents
- `CHANGELOG.md` Phase 9 additions prepended to `[1.0.0]` section
- `README.md` skills/agents badges updated (22→25, 12→13)

## Test plan

- [x] `node sdk/bin/create-ops-skill.mjs --help` runs without error
- [x] `node sdk/bin/create-ops-skill.mjs test-skill` creates `skills/test-skill/SKILL.md`
- [x] `jq .plugins[0].version .claude-plugin/marketplace.json` → `1.0.0`
- [x] `jq .version claude-ops/.claude-plugin/plugin.json` → `1.0.0`
- [x] `grep "\[1.0.0\]" claude-ops/CHANGELOG.md` → entry exists
- [x] All TypeScript source files in `sdk/src/` are valid (strict mode, no anys except intentional `string & {}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly documentation/metadata updates plus a new standalone SDK package and CLI scaffolder that do not affect the plugin runtime behavior.
> 
> **Overview**
> Adds a new `sdk/` npm package (`@claude-ops/sdk`) that ships TypeScript manifest types, minimal frontmatter parse/serialize helpers, runtime validators, and a `create-ops-skill` CLI to scaffold skill/agent markdown from templates.
> 
> Polishes marketplace and plugin metadata: expands descriptions to reflect **25 skills / 13 agents** and adds `screenshots` to `.claude-plugin/marketplace.json`; updates README badges and prepends new v1.0.0 “Added” changelog entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 463579968a0620d275ed9b8364f1f76633553dfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 3 new skills (25 total) and 1 new agent (13 total)
  * Introduced monitoring, settings, and integration operations
  * Released SDK package with scaffolding tool for creating custom operations
  * Added templates for NestJS, Next.js, and Shopify integrations
  * Enhanced monitoring capabilities with Datadog, New Relic, and OTEL support
  * Automated release pipeline on version tags

* **Documentation**
  * Added comprehensive SDK documentation with CLI usage guide and type references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->