### PR TITLE
docs: add v1.1.1 changelog + link os-compatibility.md from README

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.1] — 2026-04-14
+
+### Added
+
+- **`docs/os-compatibility.md`** — Authoritative cross-OS reference: support matrix (macOS, Debian/Fedora/Arch/SUSE/Alpine, Windows, WSL2), per-channel install tables, credential cascade explainer, daemon registration mechanisms, browser-profile discovery roots, URL opener resolution, dev/CI guidance, known limitations, contributor testing notes (#100).
+
+### Fixed
+
+- **`bin/ops-setup-preflight`** — Restored `gog calendar calendars --json` (the v1.1.0 release dropped this fix during merge, leaving a probe of the non-existent `gog cal list` that silently wrote `{"error":"failed"}` to the calendar cache) (#101).
+- **`bin/ops-unread`** — Error message no longer suggests `npm install -g @auroracapital/gog` (a package that doesn't exist on npm); now points to `brew install gogcli` / `winget install -e --id steipete.gogcli` / source build (#101).
+- **`skills/ops-inbox/CHANNELS.md`** — Install snippet replaced the private `auroracapital/gog` references and invalid `gog auth login` command with an OS-aware `gogcli` install + `gog auth add` flow (#101).
+- **`skills/ops-go/SKILL.md`** — Wording fix: "When `gog cal` fails" → "When `gog calendar` fails" (#101).
+- **`bin/ops-autofix` + `bin/ops-setup-preflight`** — Back-compat `_cred_*` wrappers now gated by `IS_MACOS` / `[[ "$(uname)" == "Darwin" ]]` so the macOS-only `security` fallback never runs on Linux/Windows (would have crashed under `set -euo pipefail`) (#101).
+- **`tests/test-bin-scripts.sh`** — macOS-tool detector now recognizes broader guard patterns (`if [ "$OS" = "macos" ]`, `case "$(uname)" in Darwin)`, the `else` branch of `if declare -F ops_cred_*`), eliminating false-positive failures on `ops-speedup`, `ops-autofix`, and `ops-setup-preflight` that were blocking PR merges (#101).
+
+---
+
 ## [1.1.0] — 2026-04-14
 
 ### Added

--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -331,7 +331,15 @@ See [telegram-server/README.md](telegram-server/README.md) for first-run auth fl
 
 ## Contributing
 
-PRs welcome. See [`docs/`](docs/) for detailed reference documentation on skills, agents, the daemon, and the memories system.
+PRs welcome. See [`docs/`](docs/) for reference documentation:
+
+- [`docs/skills-reference.md`](docs/skills-reference.md) — every skill, its triggers, and what it does
+- [`docs/agents-reference.md`](docs/agents-reference.md) — agents and their tool surfaces
+- [`docs/daemon-guide.md`](docs/daemon-guide.md) — background brain: services, cron, health
+- [`docs/memories-system.md`](docs/memories-system.md) — long-term memory store + extraction
+- [`docs/os-compatibility.md`](docs/os-compatibility.md) — macOS/Linux/WSL/Windows support matrix, per-channel install paths, credential cascade, daemon registration
+
+Cross-platform support is tested in CI via [`.github/workflows/cross-os.yml`](.github/workflows/cross-os.yml) (ubuntu-latest, macos-latest, windows-latest).
 
 ## License
 


### PR DESCRIPTION
## Summary

Documentation hygiene after the v1.1.0 release + #100/#101 follow-ups:

- **CHANGELOG.md** gains a `[1.1.1]` patch entry that records the docs PR (#100) and the cleanup PR (#101). Notably documents the silent regression in `ops-setup-preflight` that v1.1.0 inherited (probing the non-existent `gog cal list` and writing `{"error":"failed"}` to the calendar cache) and how #101 fixes it.
- **README.md** Contributing section is expanded from a single bare `docs/` link to per-doc enumeration, including the new `docs/os-compatibility.md`. Adds a pointer to `.github/workflows/cross-os.yml` so reviewers know the OS matrix is CI-enforced.

## Files changed

- `claude-ops/CHANGELOG.md` (+17)
- `claude-ops/README.md` (+9 / -1)

## Test plan

- [ ] CHANGELOG renders cleanly on GitHub (no broken markdown)
- [ ] README docs links resolve correctly
- [ ] No code changes — CI lint-and-check should be a no-op pass

## Note on signing

Commit unsigned (`-c commit.gpgsign=false`) — same sandbox-scoped signing-key reason as #100 / #101.

https://claude.ai/code/session_01SappBC7MZ7ZvENGQgq2rZy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates (changelog and README links) with no runtime behavior changes.
> 
> **Overview**
> Adds a `v1.1.1` entry to `CHANGELOG.md`, documenting the new `docs/os-compatibility.md` reference and several #101 follow-up fixes (gog calendar probe, gogcli install guidance, macOS-only credential guard, and improved cross-OS script test detection).
> 
> Expands `README.md`’s Contributing section to link directly to key docs (including `docs/os-compatibility.md`) and notes the cross-OS CI workflow (`.github/workflows/cross-os.yml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2d79e7b755e75ff3db83d2c0210192f360c418d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->