### PR TITLE
docs: track marketplace submission status across 4 destinations (#22)

### DIFF
--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -338,6 +338,7 @@ PRs welcome. See [`docs/`](docs/) for reference documentation:
 - [`docs/daemon-guide.md`](docs/daemon-guide.md) — background brain: services, cron, health
 - [`docs/memories-system.md`](docs/memories-system.md) — long-term memory store + extraction
 - [`docs/os-compatibility.md`](docs/os-compatibility.md) — macOS/Linux/WSL/Windows support matrix, per-channel install paths, credential cascade, daemon registration
+- [`docs/marketplace-submissions.md`](docs/marketplace-submissions.md) — submission status across platform.claude.com, buildwithclaude.com, aitmpl.com, claudemarketplaces.com
 
 Cross-platform support is tested in CI via [`.github/workflows/cross-os.yml`](.github/workflows/cross-os.yml) (ubuntu-latest, macos-latest, windows-latest).
 

--- a/claude-ops/docs/marketplace-submissions.md
+++ b/claude-ops/docs/marketplace-submissions.md
@@ -1,0 +1,68 @@
+<div align="center">
+
+# Marketplace Submissions
+
+*Tracking where claude-ops is listed (or pending listing) across the Claude plugin ecosystem*
+
+[![version](https://img.shields.io/badge/version-1.1.0-blue)](../CHANGELOG.md)
+[![destinations](https://img.shields.io/badge/destinations-4-6366f1)](.)
+[![status](https://img.shields.io/badge/status-in--progress-f59e0b)](.)
+
+</div>
+
+---
+
+This doc tracks where claude-ops is listed (or pending listing) across the Claude plugin ecosystem. Update the Status column when submission state changes.
+
+## Status board
+
+| Marketplace | URL | Status | Version listed | Submission PR | Last updated |
+|---|---|---|---|---|---|
+| **Anthropic official** | platform.claude.com | unknown — needs manual check | … | … | … |
+| **Build With Claude** | buildwithclaude.com | unknown — needs manual check | … | #116 | … |
+| **AI Template Hub** | aitmpl.com | unknown — needs manual check | … | #518 | … |
+| **Claude Marketplaces** | claudemarketplaces.com | unknown — needs manual check | … | … | … |
+
+Status values: `not-submitted` · `submitted` · `pending-review` · `listed` · `rejected` · `update-needed`.
+
+## Per-marketplace requirements
+
+### Anthropic official (platform.claude.com)
+
+- Submission flow: …
+- Required fields: …
+- Approval timeline: …
+- Our current state: unknown — needs manual check
+
+### Build With Claude (buildwithclaude.com)
+
+- Submission flow: PR to their repo
+- Required fields: …
+- Approval timeline: …
+- Our PR: #116 → pending URL
+- Our current state: unknown — needs manual check
+
+### AI Template Hub (aitmpl.com)
+
+- Submission flow: …
+- PR #518 → pending URL
+- Required fields: …
+- Our current state: unknown — needs manual check
+
+### Claude Marketplaces (claudemarketplaces.com)
+
+- Submission flow: …
+- Required fields: …
+- Our current state: unknown — needs manual check
+
+## Update process
+
+When a submission changes state:
+
+1. Edit the Status column + Last updated date in the table above.
+2. Add a dated note under the relevant per-marketplace section if there's nuance.
+3. Include the version that's listed (they drift — v1.1.0 may be live on one but not another).
+
+## Review cadence
+
+Check monthly, or when we cut a major release. After `v1.2.0` tag, re-verify every listing reflects the new version number.


### PR DESCRIPTION
Closes #22

## Summary

- Adds `claude-ops/docs/marketplace-submissions.md` — a status board tracking claude-ops listings across 4 destinations: platform.claude.com, buildwithclaude.com (PR #116), aitmpl.com (PR #518), and claudemarketplaces.com.
- Includes per-marketplace requirements sections, update process, status-value vocabulary, and review cadence.
- Uses placeholders / `unknown — needs manual check` for unverified state per Rule 0 — no invented submission status.
- Links the new doc from the `README.md` docs bullet list under Contributing.

## Why

Future contributors (and future us) need a single place to see where we're listed, what each marketplace requires, and which version is live on each one — they drift.

## Test plan

- [x] `bash claude-ops/tests/test-no-secrets.sh` — 11 passed, 0 failed
- [ ] Reviewer sanity-check the table schema and per-marketplace section structure

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change adding a tracking page and a README link; no runtime code or configuration behavior is affected.
> 
> **Overview**
> Adds a new `docs/marketplace-submissions.md` page to track listing/submission status across four Claude plugin marketplaces, including a shared status vocabulary, per-marketplace requirement notes, and an update/review cadence.
> 
> Links this new tracker from the `README.md` Contributing docs list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d5979118c94d1d05b0d2d97dccb9445c2f99bc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced a marketplace submissions tracker documenting where claude-ops is listed across multiple platforms, including submission status, version information, and update tracking details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->