### PR TITLE
chore: bump plugin/marketplace/package versions to 1.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 25 skills, 13 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes YOLO autonomous mode with 4 C-suite agents.",
       "source": "./claude-ops",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "category": "productivity",
       "screenshots": [
         "docs/screenshots/dashboard.png",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Business operations command center for Claude Code — 25 skills, 13 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes YOLO mode for autonomous operation.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
## Summary

The release pipeline (`.github/workflows/release.yml`) tries to push version bumps directly to `main` after a `v*` tag is published, but the org ruleset on `main` requires PR review and rejects non-PR pushes — so `v1.1.1` (https://github.com/Lifecycle-Innovations-Limited/claude-ops/releases/tag/v1.1.1) published with `plugin.json` and `marketplace.json` still reading `1.1.0`.

This PR cleans up the discrepancy.

## Bumps

| File | Before | After |
|---|---|---|
| `claude-ops/.claude-plugin/plugin.json` | 1.1.0 | 1.1.1 |
| `.claude-plugin/marketplace.json` (`plugins.ops.version`) | 1.1.0 | 1.1.1 |
| `claude-ops/package.json` | 1.1.0 | 1.1.1 |

## Follow-up suggestion

The release workflow should be updated to either:
1. Open a PR for the version bump instead of pushing to main, or
2. Run with a token that's allowed to bypass the ruleset.

Otherwise every release will need a manual chase-up bump PR.

## Note on signing

Commit unsigned (`-c commit.gpgsign=false`) — same sandbox-scoped signing-key reason as #100/#101/#102.

https://claude.ai/code/session_01SappBC7MZ7ZvENGQgq2rZy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only bumps version strings in manifest/package files, with no runtime or logic changes.
> 
> **Overview**
> Aligns the `ops` plugin release metadata by bumping version numbers from `1.1.0` to `1.1.1` in `.claude-plugin/marketplace.json`, `claude-ops/.claude-plugin/plugin.json`, and `claude-ops/package.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bffbce780cd5f4ccd09f69f24b279003a0a48e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->