### PR TITLE
feat(registry): ship starter templates for 4 common stacks (#16)

### DIFF
--- a/claude-ops/scripts/registry.templates/README.md
+++ b/claude-ops/scripts/registry.templates/README.md
@@ -1,0 +1,12 @@
+# Registry Templates
+
+Pre-baked starter `registry.json` files for common stacks. Diff against `scripts/registry.example.json` and adapt.
+
+| Template | When to use |
+|---|---|
+| nextjs-saas.json | Single Next.js SaaS on Vercel |
+| react-native-mobile.json | Mobile subscription app on EAS + RevenueCat |
+| python-microservices.json | Multiple Python services on AWS ECS |
+| monorepo.json | Monorepo with multiple apps/services in one repo |
+
+Copy a template to `scripts/registry.json` and edit to match your projects, or run `/ops:setup registry` to go through the guided wizard.

--- a/claude-ops/scripts/registry.templates/monorepo.json
+++ b/claude-ops/scripts/registry.templates/monorepo.json
@@ -1,0 +1,28 @@
+{
+  "version": "1.0",
+  "owner": "owner",
+  "projects": [
+    {
+      "alias": "company-monorepo",
+      "paths": [
+        "~/Projects/company/apps/web",
+        "~/Projects/company/apps/mobile",
+        "~/Projects/company/services/api"
+      ],
+      "repos": ["your-org/company"],
+      "org": "your-org",
+      "type": "monorepo",
+      "infra": {
+        "ecs_clusters": ["company-production"],
+        "vercel_project": "company-web",
+        "platform": "aws"
+      },
+      "revenue": {
+        "model": "saas",
+        "stage": "growth"
+      },
+      "gsd": true,
+      "priority": 1
+    }
+  ]
+}

--- a/claude-ops/scripts/registry.templates/monorepo.json
+++ b/claude-ops/scripts/registry.templates/monorepo.json
@@ -4,11 +4,7 @@
   "projects": [
     {
       "alias": "company-monorepo",
-      "paths": [
-        "~/Projects/company/apps/web",
-        "~/Projects/company/apps/mobile",
-        "~/Projects/company/services/api"
-      ],
+      "paths": ["~/Projects/company/apps/web", "~/Projects/company/apps/mobile", "~/Projects/company/services/api"],
       "repos": ["your-org/company"],
       "org": "your-org",
       "type": "monorepo",

--- a/claude-ops/scripts/registry.templates/nextjs-saas.json
+++ b/claude-ops/scripts/registry.templates/nextjs-saas.json
@@ -1,0 +1,24 @@
+{
+  "version": "1.0",
+  "owner": "owner",
+  "projects": [
+    {
+      "alias": "my-saas",
+      "paths": ["~/Projects/my-saas"],
+      "repos": ["your-org/my-saas"],
+      "org": "your-org",
+      "type": "monorepo",
+      "infra": {
+        "vercel_project": "my-saas",
+        "platform": "vercel"
+      },
+      "revenue": {
+        "model": "saas",
+        "stage": "growth",
+        "mrr": 2500
+      },
+      "gsd": true,
+      "priority": 1
+    }
+  ]
+}

--- a/claude-ops/scripts/registry.templates/python-microservices.json
+++ b/claude-ops/scripts/registry.templates/python-microservices.json
@@ -1,0 +1,57 @@
+{
+  "version": "1.0",
+  "owner": "owner",
+  "projects": [
+    {
+      "alias": "auth-service",
+      "paths": ["~/Projects/auth-service"],
+      "repos": ["your-org/auth-service"],
+      "org": "your-org",
+      "type": "multi-repo",
+      "infra": {
+        "ecs_clusters": ["shared-production"],
+        "platform": "aws"
+      },
+      "revenue": {
+        "model": "internal",
+        "stage": "production"
+      },
+      "gsd": true,
+      "priority": 1
+    },
+    {
+      "alias": "api-gateway",
+      "paths": ["~/Projects/api-gateway"],
+      "repos": ["your-org/api-gateway"],
+      "org": "your-org",
+      "type": "multi-repo",
+      "infra": {
+        "ecs_clusters": ["shared-production"],
+        "platform": "aws"
+      },
+      "revenue": {
+        "model": "saas",
+        "stage": "growth"
+      },
+      "gsd": true,
+      "priority": 1
+    },
+    {
+      "alias": "worker-queue",
+      "paths": ["~/Projects/worker-queue"],
+      "repos": ["your-org/worker-queue"],
+      "org": "your-org",
+      "type": "multi-repo",
+      "infra": {
+        "ecs_clusters": ["shared-production"],
+        "platform": "aws"
+      },
+      "revenue": {
+        "model": "internal",
+        "stage": "pre-launch"
+      },
+      "gsd": true,
+      "priority": 2
+    }
+  ]
+}

--- a/claude-ops/scripts/registry.templates/react-native-mobile.json
+++ b/claude-ops/scripts/registry.templates/react-native-mobile.json
@@ -1,0 +1,24 @@
+{
+  "version": "1.0",
+  "owner": "owner",
+  "projects": [
+    {
+      "alias": "my-mobile-app",
+      "paths": ["~/Projects/my-mobile-app"],
+      "repos": ["your-org/my-mobile-app"],
+      "org": "your-org",
+      "type": "monorepo",
+      "infra": {
+        "platform": "mobile-ci",
+        "ci_provider": "eas"
+      },
+      "revenue": {
+        "model": "subs",
+        "stage": "growth",
+        "revenuecat_project_id": "proj_XXX"
+      },
+      "gsd": true,
+      "priority": 1
+    }
+  ]
+}

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -2086,6 +2086,8 @@ Offer `[Add now]`, `[Skip]` for each. Do **not** try to register MCPs from the s
 
 ## Step 5 — Build the project registry (if selected)
 
+> **Templates:** a pre-baked starter for common stacks lives in `${CLAUDE_PLUGIN_ROOT}/scripts/registry.templates/`. If you want to start from one, `cp "${CLAUDE_PLUGIN_ROOT}/scripts/registry.templates/<stack>.json" "${CLAUDE_PLUGIN_ROOT}/scripts/registry.json"` then edit — or continue the wizard below for interactive discovery.
+
 ### Auto-discover from filesystem
 
 Before asking the user to manually enter projects, scan for existing git repositories:


### PR DESCRIPTION
Closes #16

## Summary
- Add four starter `registry.json` templates under `claude-ops/scripts/registry.templates/` — `nextjs-saas.json`, `react-native-mobile.json`, `python-microservices.json`, `monorepo.json` — each a realistic, diff-friendly example that matches the schema of `scripts/registry.example.json`.
- Add `registry.templates/README.md` with a one-line explainer plus a "when to use which" table and a pointer to `/ops:setup registry` for the guided wizard.
- Patch `skills/setup/SKILL.md` Step 5 to link to the templates directory so wizard users can shortcut to `cp` a template instead of going through full interactive discovery.
- All templates use Rule 0 placeholders only (`owner`, `your-org/...`, `~/Projects/...`, no real names/revenue).

## Test plan
- [x] `jq . <file> >/dev/null` passes for each of the 4 templates
- [x] `bash claude-ops/tests/test-no-secrets.sh` passes (11/11)
- [x] Each template schema-matches `scripts/registry.example.json` (version, owner, projects[] with alias/paths/repos/org/type/infra/revenue/gsd/priority)
- [ ] Manual: copy a template to `scripts/registry.json`, run `/ops:go`, verify registry loads
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new template JSON files and a small documentation link in the setup wizard, without changing runtime logic or existing registry parsing.
> 
> **Overview**
> Adds a new `${CLAUDE_PLUGIN_ROOT}/scripts/registry.templates/` directory containing four **starter `registry.json` templates** (Next.js SaaS, React Native mobile, Python microservices, and a monorepo) plus a short README describing when to use each.
> 
> Updates the setup wizard docs (`skills/setup/SKILL.md` Step 5) to point users at these templates as an optional shortcut (copy a template to `scripts/registry.json`) before continuing the interactive registry discovery flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcc683f8fe9bf70c7a8c6a58fa9171c94c55d02b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->