### PR TITLE
feat(docker): turnkey container image + compose stack for Linux / CI (#17)

### DIFF
--- a/claude-ops/.dockerignore
+++ b/claude-ops/.dockerignore
@@ -1,0 +1,29 @@
+# Keep the build context small and reproducible.
+
+# VCS
+.git
+.gitignore
+.gitattributes
+
+# CI definitions (not needed inside the image)
+.github/workflows
+
+# Dependencies that get reinstalled inside the image
+node_modules
+**/node_modules
+
+# Test suites — not shipped in the runtime image
+tests/
+
+# User-specific plugin data (never bake this into a public image)
+.claude-plugin/data/
+
+# Per-user registry — mount this at runtime via docker-compose instead
+scripts/registry.json
+
+# Build / editor / OS cruft
+*.log
+.DS_Store
+Thumbs.db
+.vscode
+.idea

--- a/claude-ops/.github/workflows/docker-build.yml
+++ b/claude-ops/.github/workflows/docker-build.yml
@@ -1,0 +1,75 @@
+name: Docker Build
+
+# Build the turnkey container image (see claude-ops/Dockerfile + docs/docker.md)
+# and smoke-test it. No publish step — registry pushes live in a separate,
+# future workflow so this one stays safe to run on any branch.
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+concurrency:
+  group: docker-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build + smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+    defaults:
+      run:
+        shell: bash
+        working-directory: claude-ops
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (load into local daemon)
+        uses: docker/build-push-action@v6
+        with:
+          context: claude-ops
+          file: claude-ops/Dockerfile
+          load: true
+          push: false
+          tags: claude-ops:local
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test — image boots and ops-status returns parseable JSON
+        run: |
+          docker run --rm claude-ops:local \
+            bash /opt/claude-ops/bin/ops-status --json | jq . > /tmp/status.json
+          echo "ops-status JSON keys:"
+          jq -r 'keys[]' /tmp/status.json
+          # Daemon block must exist; registry block must exist; generated_at present.
+          jq -e '.daemon and .registry and .generated_at' /tmp/status.json
+
+      - name: Smoke test — os-detect reports linux
+        run: |
+          docker run --rm claude-ops:local \
+            bash /opt/claude-ops/lib/os-detect.sh | jq . > /tmp/os.json
+          cat /tmp/os.json
+          jq -e '.os == "linux"' /tmp/os.json
+
+      - name: Smoke test — CLIs present
+        run: |
+          docker run --rm claude-ops:local bash -lc '\
+            set -e; \
+            node --version; \
+            npm --version; \
+            gh --version; \
+            aws --version; \
+            doppler --version; \
+            jq --version; \
+            secret-tool --version || true; \
+            expect -version'

--- a/claude-ops/Dockerfile
+++ b/claude-ops/Dockerfile
@@ -1,0 +1,124 @@
+# claude-ops — turnkey container image for Linux / CI / headless use.
+#
+# This image is an *alternative* host, not a replacement for v1.1.0's native
+# cross-OS flow (lib/os-detect.sh + lib/credential-store.sh). Use it when you
+# don't want to install Homebrew/CLIs on the host, or for CI and disposable dev
+# environments. See docs/docker.md for the full rationale and limitations.
+#
+# Build:   docker build -t claude-ops:local .
+# Run:     docker run --rm -it claude-ops:local
+# Compose: docker compose up -d && docker compose exec claude-ops bash
+
+# hadolint ignore=DL3007
+FROM ubuntu:24.04
+
+LABEL org.opencontainers.image.title="claude-ops" \
+      org.opencontainers.image.description="Turnkey container for the claude-ops Claude Code plugin — Linux / CI / headless use." \
+      org.opencontainers.image.source="https://github.com/Lifecycle-Innovations-Limited/claude-ops" \
+      org.opencontainers.image.documentation="https://github.com/Lifecycle-Innovations-Limited/claude-ops/blob/main/claude-ops/docs/docker.md" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.vendor="Lifecycle Innovations Limited" \
+      org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    CLAUDE_PLUGIN_ROOT=/opt/claude-ops \
+    PATH=/opt/claude-ops/bin:/usr/local/bin:/usr/bin:/bin
+
+# --- Layer 1: base system + runtime deps ------------------------------------
+# Kept together so cache invalidation is coarse-grained (one change ↔ one rebuild).
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        expect \
+        git \
+        gnome-keyring \
+        gnupg \
+        jq \
+        libsecret-tools \
+        python3 \
+        python3-pip \
+        unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- Layer 2: Node 22 LTS (NodeSource apt repo) -----------------------------
+# hadolint ignore=DL3008,DL4006
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/* \
+    && node --version \
+    && npm --version
+
+# --- Layer 3: GitHub CLI (gh) apt repo --------------------------------------
+# hadolint ignore=DL3008,DL4006
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+         -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+         > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- Layer 4: AWS CLI v2 (official zip) -------------------------------------
+# Defaults to "latest"; override for reproducible builds:
+#   docker build --build-arg AWSCLI_URL=https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.17.0.zip .
+ARG AWSCLI_URL=https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip
+RUN curl -fsSL "$AWSCLI_URL" -o /tmp/awscliv2.zip \
+    && unzip -q /tmp/awscliv2.zip -d /tmp \
+    && /tmp/aws/install \
+    && rm -rf /tmp/aws /tmp/awscliv2.zip \
+    && aws --version
+
+# --- Layer 5: Doppler CLI (apt repo) ----------------------------------------
+# hadolint ignore=DL3008,DL4006
+RUN curl -fsSL https://packages.doppler.com/public.key \
+      | gpg --dearmor -o /usr/share/keyrings/doppler-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/doppler-archive-keyring.gpg] https://packages.doppler.com/public/cli/deb/debian any-version main" \
+         > /etc/apt/sources.list.d/doppler-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends doppler \
+    && rm -rf /var/lib/apt/lists/* \
+    && doppler --version
+
+# NOTE: gogcli is intentionally NOT installed here. It requires Linuxbrew (or a
+# Go toolchain + manual build), which roughly doubles the image size for a tool
+# that not every user needs. See docs/docker.md → "Adding gogcli" for opt-in
+# instructions.
+
+# --- Layer 6: plugin tree ---------------------------------------------------
+# Create the non-root user first so COPY --chown lands with the right owner.
+RUN groupadd --system --gid 1001 ops \
+    && useradd  --system --uid 1001 --gid ops --create-home --home-dir /home/ops --shell /bin/bash ops
+
+COPY --chown=ops:ops . /opt/claude-ops
+
+# claude-ops/bin/* are shell scripts checked in without +x on some filesystems;
+# make sure they execute inside the container.
+RUN find /opt/claude-ops/bin -type f -exec chmod +x {} \; \
+    && find /opt/claude-ops/scripts -type f -name '*.sh' -exec chmod +x {} \;
+
+# --- Final setup ------------------------------------------------------------
+WORKDIR /home/ops
+USER ops
+
+# Healthcheck: ops-status --json is the canonical light-weight probe. Treat the
+# container as healthy when the JSON parses AND (a) the daemon is running OK,
+# (b) the daemon isn't installed (valid for ephemeral dev/CI containers), or
+# (c) ops-status itself returns non-JSON but the plugin manifest is on disk.
+# The graceful cascade prevents transient failures from flapping the container.
+HEALTHCHECK --interval=60s --timeout=15s --start-period=10s --retries=3 \
+  CMD bash -c '\
+    out=$(bash /opt/claude-ops/bin/ops-status --json 2>/dev/null || true); \
+    if [ -n "$out" ] && echo "$out" | jq -e "(.daemon.state == \"ok\") or (.daemon.state == \"\") or (.daemon.state == null)" >/dev/null 2>&1; then \
+      exit 0; \
+    fi; \
+    test -f /opt/claude-ops/.claude-plugin/plugin.json'
+
+# Default entrypoint: interactive bash with env vars already wired up.
+ENTRYPOINT ["/bin/bash"]
+CMD ["-l"]

--- a/claude-ops/docker-compose.yml
+++ b/claude-ops/docker-compose.yml
@@ -1,0 +1,66 @@
+# claude-ops — dev compose stack.
+#
+# Quick start:
+#   docker compose up -d
+#   docker compose exec claude-ops bash
+#
+# This is intentionally a CLI/dev container, not a long-running service.
+# `restart: "no"` keeps it from respawning when you exit the shell.
+#
+# Credentials are passed via env (`${VAR:-}` so all are optional) and host
+# mounts (~/.aws, ~/.config/gh). See docs/docker.md for the full matrix.
+
+services:
+  claude-ops:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: claude-ops:local
+    container_name: claude-ops
+    hostname: claude-ops
+    tty: true
+    stdin_open: true
+    restart: "no"
+
+    # Keep the default ENTRYPOINT (/bin/bash -l). Use `docker compose exec`
+    # for follow-up shells so the original TTY stays attached.
+    command: ["-l"]
+
+    environment:
+      # LLM providers
+      OPENAI_API_KEY:      "${OPENAI_API_KEY:-}"
+      ANTHROPIC_API_KEY:   "${ANTHROPIC_API_KEY:-}"
+
+      # Source hosting
+      GITHUB_TOKEN:        "${GITHUB_TOKEN:-}"
+
+      # Secret manager
+      DOPPLER_TOKEN:       "${DOPPLER_TOKEN:-}"
+
+      # Billing / payments
+      STRIPE_SECRET_KEY:   "${STRIPE_SECRET_KEY:-}"
+      REVENUECAT_API_KEY:  "${REVENUECAT_API_KEY:-}"
+
+      # Observability
+      DATADOG_API_KEY:     "${DATADOG_API_KEY:-}"
+      DATADOG_APP_KEY:     "${DATADOG_APP_KEY:-}"
+      NEWRELIC_API_KEY:    "${NEWRELIC_API_KEY:-}"
+      NEWRELIC_ACCOUNT_ID: "${NEWRELIC_ACCOUNT_ID:-}"
+
+      # Marketing
+      KLAVIYO_PRIVATE_KEY: "${KLAVIYO_PRIVATE_KEY:-}"
+
+    volumes:
+      # Persist plugin data (preferences, cache, memory, plugin installs) on the host.
+      - "${HOME}/.claude:/home/ops/.claude:rw"
+
+      # AWS credentials — read-only so the container can't clobber your host creds.
+      - "${HOME}/.aws:/home/ops/.aws:ro"
+
+      # GitHub CLI auth — read-only for the same reason.
+      - "${HOME}/.config/gh:/home/ops/.config/gh:ro"
+
+      # Project registry. Map ./registry.json on the host into the plugin tree
+      # so edits survive container rebuilds. Create an empty file first if you
+      # don't have one yet: `echo '{"projects":[]}' > registry.json`.
+      - "./registry.json:/opt/claude-ops/scripts/registry.json:rw"

--- a/claude-ops/docs/docker.md
+++ b/claude-ops/docs/docker.md
@@ -1,0 +1,168 @@
+# Docker
+
+> **TL;DR.** `docker compose up -d && docker compose exec claude-ops bash` drops you into an Ubuntu 24.04 shell with `claude-ops`, Node 22, `gh`, `aws`, `doppler`, `jq`, `expect`, `git`, `libsecret-tools` and `gnome-keyring` pre-installed. Your host's `~/.claude`, `~/.aws` and `~/.config/gh` are mounted so credentials and plugin state persist.
+
+This path is an **addition** to the v1.1.0 cross-OS flow (`lib/os-detect.sh` + `lib/credential-store.sh` + `lib/opener.sh`). It does **not** replace native macOS/Linux/Windows installs — use whichever works best for your workflow. See [`os-compatibility.md`](./os-compatibility.md) for the full matrix.
+
+## Why Docker
+
+| Scenario | Native | Docker |
+|---|---|---|
+| macOS workstation, brew OK | Native wins — Keychain integration is free | Docker works but loses Keychain |
+| Ubuntu desktop with `gnome-keyring` | Native wins — libsecret integration is free | Equivalent; pick whichever you prefer |
+| Linux server, no Homebrew, no desktop | Works but manual CLI installs | **Docker wins** — one image, all CLIs baked in |
+| CI runner (ephemeral, no state) | Works but cold-starts on every run | **Docker wins** — `docker run` caches layers |
+| Disposable dev env, try-before-buy | Leaves files on your host | **Docker wins** — `docker rm` wipes it |
+| Windows without WSL2 | Not supported (natively) | **Docker wins** — inherits Linux path |
+
+If none of those rows apply to you, stick with the native install — it's faster, has better credential-store integration, and can launch browser-based auth flows (Slack autolink, OAuth) without any extra wiring.
+
+## Quick start
+
+```bash
+# From the plugin root (where the Dockerfile sits):
+cd claude-ops
+
+# Optional: seed an empty registry if you don't have one yet.
+[ -f registry.json ] || echo '{"projects":[]}' > registry.json
+
+# Build + run detached.
+docker compose up -d
+
+# Attach an interactive shell.
+docker compose exec claude-ops bash
+
+# Inside the container:
+ops-status          # pretty status panel
+ops-status --json   # machine-readable JSON
+ops-doctor          # deeper health report
+ls "$CLAUDE_PLUGIN_ROOT"
+gh auth status      # reads ~/.config/gh mounted from host
+aws sts get-caller-identity   # reads ~/.aws mounted from host
+```
+
+Tear it down with `docker compose down`. Your `~/.claude` state and `registry.json` persist on the host.
+
+## `docker build` vs `docker compose`
+
+- **`docker build`** is the low-ceremony path. It bakes a plain image and doesn't wire up any volumes or env vars — good for CI, production runs, or one-off smoke tests.
+  ```bash
+  docker build -t claude-ops:local .
+  docker run --rm -it \
+    -e GITHUB_TOKEN \
+    -v "$HOME/.claude:/home/ops/.claude" \
+    claude-ops:local
+  ```
+- **`docker compose`** wires up the full persona: host mounts for `~/.claude`, `~/.aws`, `~/.config/gh`, registry, and every environment variable the plugin knows about. Use this for daily dev.
+
+The compose file sets `restart: "no"` on purpose — this is a CLI container, not a long-running service.
+
+## Mounting your registry
+
+`scripts/registry.json` is gitignored and user-specific. The compose file maps `./registry.json` on the host into `/opt/claude-ops/scripts/registry.json` inside the container:
+
+```yaml
+volumes:
+  - "./registry.json:/opt/claude-ops/scripts/registry.json:rw"
+```
+
+If you keep your registry elsewhere, override with a compose override file:
+
+```yaml
+# docker-compose.override.yml
+services:
+  claude-ops:
+    volumes:
+      - "/path/to/your/registry.json:/opt/claude-ops/scripts/registry.json:rw"
+```
+
+## Passing credentials
+
+**Env vars (preferred for ephemeral / CI).** Every key listed in `docker-compose.yml` uses the `${VAR:-}` form so unset vars are simply empty; the plugin's credential cascade falls through to other backends.
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+export GITHUB_TOKEN=ghp_...
+docker compose up -d
+```
+
+Put them in a `.env` file in the same directory as `docker-compose.yml` and they'll be picked up automatically — just don't commit it.
+
+**Host mounts (preferred for dev).** `~/.aws` and `~/.config/gh` are mounted read-only so the containerised `aws`/`gh` CLIs see your host credentials without the container being able to clobber them.
+
+**Doppler.** Set `DOPPLER_TOKEN` as an env var and the in-container `doppler` CLI will pick it up. Service tokens work great for this; user tokens require an interactive `doppler login` per-container (not recommended).
+
+**OS keyring.** The container can write to libsecret via `secret-tool` if you run `gnome-keyring-daemon --components=secrets --daemonize --unlock` inside it, but the keyring is ephemeral — it dies with the container. For persistent secrets, set `CLAUDE_OPS_CRED_BACKEND=enc-json` and supply `CLAUDE_OPS_MASTER_KEY` so the encrypted-JSON backend survives container rebuilds (see [`os-compatibility.md`](./os-compatibility.md#credential-storage)).
+
+## Adding `gogcli`
+
+`gogcli` is not baked into the image — it requires Linuxbrew or a Go toolchain, which would roughly double the image size. If you need it, extend the image:
+
+```dockerfile
+FROM claude-ops:local
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends golang \
+    && git clone https://github.com/steipete/gogcli.git /tmp/gogcli \
+    && cd /tmp/gogcli && make && cp gogcli /usr/local/bin/ \
+    && rm -rf /tmp/gogcli \
+    && apt-get purge -y golang && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+USER ops
+```
+
+Or mount a host-installed binary: `-v /usr/local/bin/gogcli:/usr/local/bin/gogcli:ro`.
+
+## Limitations
+
+1. **No `launchd` / `systemd`.** The container doesn't run an init system. If you need the daemon (`scripts/ops-daemon.sh`), either:
+   - Run it in the **foreground inside the container** during your session (`bash /opt/claude-ops/scripts/ops-daemon.sh --run-once` in a loop), or
+   - Run `systemd --user` on the **host** and let it invoke the daemon outside Docker, or
+   - Use a cron-job sidecar if you're in Kubernetes.
+2. **No browser automation by default.** Slack autolink, OAuth flows, and anything else that launches Playwright headed Chromium need a display. The container doesn't ship with one. To enable it, mount your X11 socket and set `DISPLAY`:
+   ```bash
+   docker run --rm -it \
+     -e DISPLAY="$DISPLAY" \
+     -v /tmp/.X11-unix:/tmp/.X11-unix:ro \
+     -v "$HOME/.Xauthority:/home/ops/.Xauthority:ro" \
+     claude-ops:local
+   ```
+   On macOS (`XQuartz`) and Windows (`VcXsrv`/WSLg) the setup is similar but with extra `xhost` dance. Headless CI runners simply can't do this; run `/ops:setup slack` on a workstation and paste the tokens into the container via env vars.
+3. **macOS Keychain reads don't work inside a Linux container.** The plugin's credential cascade (see [`os-compatibility.md`](./os-compatibility.md#credential-storage)) falls through: `security` (N/A on Linux) → `secret-tool` (needs unlocked keyring, ephemeral) → `keytar` (works) → encrypted JSON (works; portable — recommended inside containers).
+4. **`gogcli` is opt-in.** See "Adding `gogcli`" above.
+5. **Networking.** The container uses Docker's default bridge network. `localhost` inside the container is the container, not the host. To reach a host-running service (e.g. a local Shopify dev server on `:3000`), use `host.docker.internal` (macOS/Windows) or add `--add-host=host.docker.internal:host-gateway` (Linux).
+6. **Image size.** The current image is ~1.2 GB (Ubuntu base + Node 22 + AWS CLI v2 + gh + doppler + GUI bits for keyring). Trimming further would mean dropping GUI deps and losing keyring support entirely.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `registry.json: permission denied` | Host file owned by your UID (≠1001); container runs as UID 1001 | `chown 1001:1001 registry.json` or mount with `:Z` on SELinux |
+| `secret-tool: cannot communicate with gnome-keyring` | No unlocked keyring in the container | Set `CLAUDE_OPS_CRED_BACKEND=enc-json` or start `gnome-keyring-daemon --unlock` manually |
+| `gh: the authenticated user has no access` | `~/.config/gh` mounted but the token file is missing a newline at EOF | `gh auth login` once on the host, then restart the container |
+| `aws: Unable to locate credentials` | `~/.aws` mounted ro but empty | `aws configure` once on the host |
+| Playwright fails to launch Chromium | No display | Mount X11 socket as shown above, or skip browser steps and paste tokens |
+
+## CI use
+
+The repo ships `.github/workflows/docker-build.yml` which builds the image on `push`-to-`main`, on `v*` tags, and via `workflow_dispatch`. It smoke-tests the image (`ops-status --json` must parse) but **does not publish** — pushing to a registry is a separate opt-in workflow.
+
+To adopt the image in your own CI:
+
+```yaml
+- name: claude-ops step
+  run: |
+    docker run --rm \
+      -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+      -v "${{ github.workspace }}:/workspace" \
+      -w /workspace \
+      ghcr.io/lifecycle-innovations-limited/claude-ops:latest \
+      bash -c 'ops-status --json | jq . && bash bin/ops-setup-detect'
+```
+
+(Replace the image reference with wherever the publish workflow lands.)
+
+## See also
+
+- [`os-compatibility.md`](./os-compatibility.md) — the cross-OS support matrix.
+- [`daemon-guide.md`](./daemon-guide.md) — how the background daemon is expected to run.
+- Issue [#17](https://github.com/Lifecycle-Innovations-Limited/claude-ops/issues/17) — the design discussion that led to this path.

--- a/claude-ops/docs/os-compatibility.md
+++ b/claude-ops/docs/os-compatibility.md
@@ -16,8 +16,9 @@ The OS detection layer (`lib/os-detect.{sh,mjs}`), credential cascade (`lib/cred
 | **Alpine** | 2 | `apk` | `secret-tool` (if installed) | `openrc` (manual) | Headless deployments — no Slack browser autolink. |
 | **Windows 10/11 native** | 2 | `winget` → `scoop` → `choco` | `wincred` (write-only) | Task Scheduler | Use Git Bash or PowerShell. `cmdkey` cannot read passwords from the CLI; reads cascade through `keytar`/encrypted JSON. |
 | **WSL2** | 1 | `apt-get` (or distro of choice) | `secret-tool` (preferred) → `wincred` (fallback) | `systemd --user` | Inherits Linux. Browser profiles auto-discovered from `/mnt/c/Users/$USER/AppData/Local/...`. URL opens via `wslview` if installed. |
+| **Docker (any host)** | 1 | `apt-get` (Ubuntu 24.04 base) | `enc-json` (default) → `secret-tool` (if you unlock a keyring inside the container) | foreground loop (no init) | Turnkey image with Node 22, `gh`, `aws`, `doppler`, `jq`, `expect`, `libsecret-tools` pre-installed. See [`docker.md`](./docker.md) for quick-start, credential mounting, and limitations (no `launchd`/`systemd`, no browser automation without an X11 socket mount). |
 
-> **Tier 1** = covered by CI (`.github/workflows/cross-os.yml` runs ubuntu-latest, macos-latest, windows-latest on every push). **Tier 2** = supported but not in matrix.
+> **Tier 1** = covered by CI (`.github/workflows/cross-os.yml` runs ubuntu-latest, macos-latest, windows-latest on every push; `.github/workflows/docker-build.yml` builds and smoke-tests the container image). **Tier 2** = supported but not in matrix.
 
 ## OS / package-manager detection
 


### PR DESCRIPTION
Closes #17

## Summary

Adds a Docker-based alternative host for users who don't want Homebrew/CLIs on their workstation, and for CI / server scenarios where claude-ops runs headlessly. This is an **addition** to v1.1.0's cross-OS flow (`lib/os-detect.sh`, `lib/credential-store.sh`, `lib/opener.sh`), not a replacement — native installs remain the recommended path on every supported host.

### Files added

| File | Purpose |
|---|---|
| `claude-ops/Dockerfile` | `ubuntu:24.04` base, layered apt installs for Node 22, `gh`, `aws` v2, `doppler`, `jq`, `expect`, `libsecret-tools`, `gnome-keyring`. Non-root `ops` user (UID 1001), `CLAUDE_PLUGIN_ROOT=/opt/claude-ops`, OCI image labels, graceful `HEALTHCHECK` via `ops-status --json`. |
| `claude-ops/docker-compose.yml` | Single `claude-ops` service, TTY-attached, `restart: "no"`. Host mounts `~/.claude` (rw), `~/.aws` (ro), `~/.config/gh` (ro), `./registry.json`. Pass-through env for every supported provider key using `${VAR:-}`. |
| `claude-ops/.dockerignore` | Trims `node_modules`, `.git`, `tests/`, CI definitions, plugin data, and the gitignored `registry.json` from the build context. |
| `claude-ops/docs/docker.md` | Quick-start, `build` vs `compose` comparison, credential flows, `gogcli` opt-in extension, limitations & troubleshooting. |
| `claude-ops/.github/workflows/docker-build.yml` | Builds on push-to-`main`, `v*` tags, and `workflow_dispatch`. Uses buildx with GHA cache, smoke-tests `ops-status --json`, `lib/os-detect.sh`, and pre-installed CLIs. No publish step. |
| `claude-ops/docs/os-compatibility.md` | Adds a **Docker (any host)** row under "Supported hosts" pointing at `docs/docker.md`. |

### Limitations documented

1. **No `launchd` / `systemd` inside the container.** Daemon needs to run on the host or in a foreground loop inside the container — a proper init system wasn't baked in to keep the image dev-focused.
2. **No browser automation by default.** Slack autolink / OAuth flows that launch headed Playwright Chromium need a display; `docs/docker.md` documents the X11 socket mount for users who need it, and notes that headless CI runners simply can't do it.
3. **macOS Keychain reads N/A on Linux.** The credential cascade falls through to `secret-tool` (ephemeral inside the container) → `keytar` → encrypted JSON. `CLAUDE_OPS_MASTER_KEY` + `CLAUDE_OPS_CRED_BACKEND=enc-json` recommended for persistent secrets.
4. **`gogcli` is opt-in.** Would roughly double image size via Linuxbrew or a Go toolchain. Dockerfile snippet provided for users who need it.
5. **Networking.** Container uses the default bridge; `localhost` is the container, not the host. Use `host.docker.internal` (macOS/Windows) or `--add-host=host.docker.internal:host-gateway` (Linux) to reach host services.
6. **Image size.** ~1.2 GB with Ubuntu base + Node 22 + AWS CLI v2 + gh + doppler + libsecret GUI bits.

### Rules observed

- **CLAUDE.md Rule 0:** no real personal data. Every env key is `${VAR:-}` with an empty default; the registry mounts from the host, not baked in.
- **Dockerfile hygiene:** each `RUN` combines install + cleanup; apt uses the keyring pattern; AWS CLI URL is a `--build-arg` for reproducible pins.
- **`tests/test-no-secrets.sh` passes** (11/11 checks; full `run-all.sh` also green).
- Does not replace `lib/os-detect.sh`, `lib/credential-store.sh`, or `lib/opener.sh` — adds next to them.

## Test plan

- [x] `bash claude-ops/tests/test-no-secrets.sh` — 11/11 passed
- [x] `bash claude-ops/tests/run-all.sh` — 6/6 suites passed
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` for both `docker-compose.yml` and `.github/workflows/docker-build.yml` — both parse cleanly
- [x] Dockerfile directives statically reviewed (FROM / RUN / COPY / ENV / USER / HEALTHCHECK / ENTRYPOINT ordering, same-`RUN` install+cleanup, non-root final user)
- [ ] **CI**: `docker-build.yml` will run the real build + smoke test on the merge commit. Docker wasn't available in the authoring sandbox, so the container itself has not been end-to-end booted yet.
- [ ] **Post-merge sanity**: `docker compose up -d && docker compose exec claude-ops bash -lc 'ops-status --json | jq .'` on a contributor's workstation.

https://claude.ai/code/session_01YYVPVUHDTLwdAYMuJ2w3rn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Docker build/compose and a GitHub Actions workflow that will run on `main`/tags; risk is mainly around CI time/resource usage and maintaining a large, dependency-heavy image rather than changes to plugin runtime logic.
> 
> **Overview**
> Adds a **turnkey Docker-based runtime** for `claude-ops` (Ubuntu 24.04 image) that bakes in key CLIs (Node 22, `gh`, AWS CLI v2, Doppler, `jq`, `expect`, libsecret/keyring deps), runs as a non-root `ops` user, and includes a healthcheck using `ops-status --json`.
> 
> Introduces a **dev-focused `docker-compose.yml`** that mounts host state (`~/.claude`, `~/.aws`, `~/.config/gh`, and a host `registry.json`) and passes through supported provider credentials via optional env vars.
> 
> Adds a **`docker-build` GitHub Actions workflow** to build the image with Buildx cache and smoke-test that `ops-status --json` parses, `os-detect` reports Linux, and required CLIs are present; plus a `.dockerignore` to keep build context clean and documentation updates (`docs/docker.md`, `docs/os-compatibility.md`) to describe the new Docker path and its limitations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c5ae5f1c0905a19f5ed114166fafb7acec84f48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->