### PR TITLE
feat(discord): add /ops:comms discord via webhook + bot read (#20)

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -252,6 +252,27 @@
       "type": "string",
       "sensitive": true,
       "default": ""
+    },
+    "discord_bot_token": {
+      "title": "Discord Bot Token",
+      "description": "Bot token from Discord Developer Portal — used for channel reads and DMs. Prefer Doppler reference.",
+      "type": "string",
+      "sensitive": true,
+      "default": ""
+    },
+    "discord_guild_id": {
+      "title": "Discord Guild ID",
+      "description": "Server/guild ID (right-click server in Discord → Copy ID with Developer Mode enabled)",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
+    },
+    "discord_default_webhook_url": {
+      "title": "Discord Default Webhook URL",
+      "description": "Optional default webhook URL (https://discord.com/api/webhooks/…) for /ops:comms discord send. Shared with the ops-fires notification sink (which also reads discord_webhook_url).",
+      "type": "string",
+      "sensitive": true,
+      "default": ""
     }
   }
 }

--- a/claude-ops/bin/ops-discord
+++ b/claude-ops/bin/ops-discord
@@ -1,0 +1,430 @@
+#!/usr/bin/env bash
+# ops-discord — Discord communication helper (v1: webhook send + channel read)
+#
+# Subcommands:
+#   send     <channel-id-or-webhook-url> "message" [--json]
+#   read     <channel-id> [--limit N] [--json]
+#   channels [--json]                  (list channels in configured guild)
+#   --help | -h
+#
+# Credential resolution order:
+#   1. Env vars: DISCORD_BOT_TOKEN, DISCORD_GUILD_ID, DISCORD_WEBHOOK_URL
+#      Per-channel webhooks via DISCORD_WEBHOOK_<CHANNEL_UPPER>
+#   2. ops_cred_get discord <account>   (via lib/credential-store.sh)
+#   3. $PREFS_PATH (preferences.json)    — discord.{bot_token,guild_id,default_webhook_url}
+#
+# v1 scope: webhook-based send + REST channel reads.
+# Deferred (v2 issue): gateway connection, DM support, slash commands.
+set -euo pipefail
+
+# ─── Paths & lib sourcing ───────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LIB_OS_DETECT="$SCRIPT_DIR/lib/os-detect.sh"
+LIB_CRED="$SCRIPT_DIR/lib/credential-store.sh"
+
+# shellcheck disable=SC1090
+[ -r "$LIB_OS_DETECT" ] && . "$LIB_OS_DETECT" || true
+# shellcheck disable=SC1090
+[ -r "$LIB_CRED" ] && . "$LIB_CRED" || true
+
+PREFS_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+PREFS_PATH="${PREFS_PATH:-$PREFS_DIR/preferences.json}"
+
+API_BASE="https://discord.com/api/v10"
+USER_AGENT="ops-discord (claude-ops, v1)"
+
+# ─── Output helpers ─────────────────────────────────────────────────────────
+JSON_MODE=false
+
+emit_err() {
+  local msg="$1"
+  if $JSON_MODE; then
+    printf '{"error":%s}\n' "$(json_escape "$msg")"
+  else
+    printf 'ops-discord: %s\n' "$msg" >&2
+  fi
+}
+
+json_escape() {
+  # Minimal JSON string escape. Prefer jq when available.
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$1" | jq -Rs .
+    return 0
+  fi
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  printf '"%s"' "$s"
+}
+
+# ─── Credential resolution ──────────────────────────────────────────────────
+get_bot_token() {
+  if [[ -n "${DISCORD_BOT_TOKEN:-}" ]]; then
+    printf '%s' "$DISCORD_BOT_TOKEN"
+    return 0
+  fi
+  if declare -F ops_cred_get >/dev/null 2>&1; then
+    local out
+    out="$(ops_cred_get discord bot-token 2>/dev/null || true)"
+    if [[ -n "$out" ]]; then
+      printf '%s' "$out"
+      return 0
+    fi
+  fi
+  if [[ -s "$PREFS_PATH" ]] && command -v jq >/dev/null 2>&1; then
+    local pref
+    pref="$(jq -r '.discord.bot_token // ""' "$PREFS_PATH" 2>/dev/null || true)"
+    if [[ -n "$pref" && "$pref" != "null" ]]; then
+      printf '%s' "$pref"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+get_guild_id() {
+  if [[ -n "${DISCORD_GUILD_ID:-}" ]]; then
+    printf '%s' "$DISCORD_GUILD_ID"
+    return 0
+  fi
+  if [[ -s "$PREFS_PATH" ]] && command -v jq >/dev/null 2>&1; then
+    local pref
+    pref="$(jq -r '.discord.guild_id // ""' "$PREFS_PATH" 2>/dev/null || true)"
+    if [[ -n "$pref" && "$pref" != "null" ]]; then
+      printf '%s' "$pref"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+# Resolve a webhook URL given either a full URL, a channel name/alias, or empty.
+#   - If arg starts with https://discord.com/api/webhooks/ → use directly
+#   - Else look up DISCORD_WEBHOOK_<UPPER> env var
+#   - Else fall back to DISCORD_WEBHOOK_URL env var
+#   - Else fall back to discord.default_webhook_url in prefs
+resolve_webhook() {
+  local raw="${1:-}"
+  if [[ "$raw" =~ ^https://(discord|discordapp)\.com/api/webhooks/ ]]; then
+    printf '%s' "$raw"
+    return 0
+  fi
+  if [[ -n "$raw" ]]; then
+    local upper envvar val
+    upper="$(printf '%s' "$raw" | tr '[:lower:]-' '[:upper:]_' | tr -cd 'A-Z0-9_')"
+    envvar="DISCORD_WEBHOOK_${upper}"
+    val="${!envvar:-}"
+    if [[ -n "$val" ]]; then
+      printf '%s' "$val"
+      return 0
+    fi
+  fi
+  if [[ -n "${DISCORD_WEBHOOK_URL:-}" ]]; then
+    printf '%s' "$DISCORD_WEBHOOK_URL"
+    return 0
+  fi
+  if [[ -s "$PREFS_PATH" ]] && command -v jq >/dev/null 2>&1; then
+    local pref
+    # Try nested form first, then the flat key shared with ops-notify.sh.
+    pref="$(jq -r '.discord.default_webhook_url // .discord.webhook_url // .discord_webhook_url // ""' "$PREFS_PATH" 2>/dev/null || true)"
+    if [[ -n "$pref" && "$pref" != "null" ]]; then
+      printf '%s' "$pref"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+no_credential_exit() {
+  emit_err "no discord credential configured — run /ops:setup discord"
+  exit 1
+}
+
+require_curl() {
+  if ! command -v curl >/dev/null 2>&1; then
+    emit_err "curl is required for ops-discord but is not installed"
+    exit 1
+  fi
+}
+
+# ─── Subcommand: send ───────────────────────────────────────────────────────
+cmd_send() {
+  local target="${1:-}"
+  local message="${2:-}"
+  if [[ -z "$target" || -z "$message" ]]; then
+    emit_err "usage: ops-discord send <channel-id|webhook-url> \"message\" [--json]"
+    exit 2
+  fi
+  require_curl
+
+  local url="" via="" payload http code resp
+  if url="$(resolve_webhook "$target")"; then
+    via="webhook"
+  elif [[ "$target" =~ ^[0-9]{17,20}$ ]]; then
+    # Channel ID (snowflake). Needs bot token + channels/<id>/messages endpoint.
+    local token
+    if ! token="$(get_bot_token)"; then
+      no_credential_exit
+    fi
+    url="$API_BASE/channels/$target/messages"
+    via="bot-channel"
+  else
+    no_credential_exit
+  fi
+
+  if command -v jq >/dev/null 2>&1; then
+    payload="$(jq -nc --arg c "$message" '{content:$c}')"
+  else
+    payload="{\"content\":$(json_escape "$message")}"
+  fi
+
+  local tmp
+  tmp="$(mktemp)"
+  trap 'rm -f "$tmp"' EXIT
+
+  if [[ "$via" == "webhook" ]]; then
+    http=$(curl -sS -o "$tmp" -w '%{http_code}' \
+      -X POST "$url" \
+      -H "Content-Type: application/json" \
+      -H "User-Agent: $USER_AGENT" \
+      -d "$payload" || echo 000)
+  else
+    local token
+    token="$(get_bot_token)" || no_credential_exit
+    http=$(curl -sS -o "$tmp" -w '%{http_code}' \
+      -X POST "$url" \
+      -H "Authorization: Bot $token" \
+      -H "Content-Type: application/json" \
+      -H "User-Agent: $USER_AGENT" \
+      -d "$payload" || echo 000)
+  fi
+
+  resp="$(cat "$tmp" 2>/dev/null || true)"
+  code="$http"
+
+  # Webhooks with no ?wait=true return 204 No Content. Everything else returns 200/201.
+  if [[ "$code" =~ ^2[0-9][0-9]$ ]]; then
+    if $JSON_MODE; then
+      if [[ -n "$resp" ]]; then
+        printf '{"ok":true,"via":"%s","http":%s,"response":%s}\n' \
+          "$via" "$code" "$resp"
+      else
+        printf '{"ok":true,"via":"%s","http":%s}\n' "$via" "$code"
+      fi
+    else
+      printf 'Sent via Discord %s (HTTP %s)\n' "$via" "$code"
+    fi
+    return 0
+  fi
+
+  if $JSON_MODE; then
+    local esc_resp
+    esc_resp="$(json_escape "$resp")"
+    printf '{"ok":false,"via":"%s","http":%s,"response":%s}\n' \
+      "$via" "$code" "$esc_resp"
+  else
+    printf 'ops-discord: send failed (HTTP %s): %s\n' "$code" "$resp" >&2
+  fi
+  exit 1
+}
+
+# ─── Subcommand: read ───────────────────────────────────────────────────────
+cmd_read() {
+  local channel_id="${1:-}"
+  local limit=20
+  shift || true
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --limit)
+        limit="${2:-20}"; shift 2 ;;
+      --limit=*)
+        limit="${1#--limit=}"; shift ;;
+      --json)
+        JSON_MODE=true; shift ;;
+      *)
+        shift ;;
+    esac
+  done
+
+  if [[ -z "$channel_id" ]]; then
+    emit_err "usage: ops-discord read <channel-id> [--limit N] [--json]"
+    exit 2
+  fi
+  if ! [[ "$channel_id" =~ ^[0-9]{17,20}$ ]]; then
+    emit_err "invalid channel id (expected 17-20 digit snowflake): $channel_id"
+    exit 2
+  fi
+  if ! [[ "$limit" =~ ^[0-9]+$ ]] || (( limit < 1 || limit > 100 )); then
+    emit_err "--limit must be an integer between 1 and 100"
+    exit 2
+  fi
+
+  local token
+  if ! token="$(get_bot_token)"; then
+    no_credential_exit
+  fi
+  require_curl
+
+  local url="$API_BASE/channels/$channel_id/messages?limit=$limit"
+  local tmp http resp
+  tmp="$(mktemp)"
+  trap 'rm -f "$tmp"' EXIT
+
+  http=$(curl -sS -o "$tmp" -w '%{http_code}' \
+    "$url" \
+    -H "Authorization: Bot $token" \
+    -H "User-Agent: $USER_AGENT" || echo 000)
+  resp="$(cat "$tmp" 2>/dev/null || true)"
+
+  if [[ "$http" != "200" ]]; then
+    if $JSON_MODE; then
+      printf '{"ok":false,"http":%s,"response":%s}\n' \
+        "$http" "$(json_escape "$resp")"
+    else
+      printf 'ops-discord: read failed (HTTP %s): %s\n' "$http" "$resp" >&2
+    fi
+    exit 1
+  fi
+
+  if $JSON_MODE; then
+    printf '%s\n' "$resp"
+    return 0
+  fi
+
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$resp" | jq -r '
+      .[] | "[\(.timestamp)] \(.author.username // .author.global_name // "?"): \(.content // "(no content)")"
+    '
+  else
+    printf '%s\n' "$resp"
+  fi
+}
+
+# ─── Subcommand: channels ───────────────────────────────────────────────────
+cmd_channels() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json) JSON_MODE=true; shift ;;
+      *) shift ;;
+    esac
+  done
+
+  local token guild
+  if ! token="$(get_bot_token)"; then
+    no_credential_exit
+  fi
+  if ! guild="$(get_guild_id)"; then
+    emit_err "no guild id configured — set DISCORD_GUILD_ID or discord.guild_id in preferences.json"
+    exit 1
+  fi
+  require_curl
+
+  local url="$API_BASE/guilds/$guild/channels"
+  local tmp http resp
+  tmp="$(mktemp)"
+  trap 'rm -f "$tmp"' EXIT
+
+  http=$(curl -sS -o "$tmp" -w '%{http_code}' \
+    "$url" \
+    -H "Authorization: Bot $token" \
+    -H "User-Agent: $USER_AGENT" || echo 000)
+  resp="$(cat "$tmp" 2>/dev/null || true)"
+
+  if [[ "$http" != "200" ]]; then
+    if $JSON_MODE; then
+      printf '{"ok":false,"http":%s,"response":%s}\n' \
+        "$http" "$(json_escape "$resp")"
+    else
+      printf 'ops-discord: channels failed (HTTP %s): %s\n' "$http" "$resp" >&2
+    fi
+    exit 1
+  fi
+
+  if $JSON_MODE; then
+    printf '%s\n' "$resp"
+    return 0
+  fi
+
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$resp" | jq -r '
+      .[] | select(.type == 0 or .type == 5 or .type == 15) |
+      "\(.id)\t#\(.name)\t(type=\(.type))"
+    '
+  else
+    printf '%s\n' "$resp"
+  fi
+}
+
+# ─── Help ───────────────────────────────────────────────────────────────────
+print_help() {
+  cat <<'EOF'
+ops-discord — Discord v1 helper (webhook send + REST channel read)
+
+USAGE
+  ops-discord send <channel-id|webhook-url> "message" [--json]
+  ops-discord read <channel-id> [--limit N] [--json]
+  ops-discord channels [--json]
+  ops-discord --help
+
+SUBCOMMANDS
+  send       Post a message. Accepts either a full webhook URL
+             (https://discord.com/api/webhooks/…) or a channel snowflake
+             (17-20 digit id, routed via bot token).
+  read       Fetch recent messages from a channel via REST. Requires
+             DISCORD_BOT_TOKEN or credential-store entry (discord/bot-token).
+             --limit defaults to 20, max 100.
+  channels   List guild channels. Requires bot token + DISCORD_GUILD_ID.
+
+CREDENTIAL LOOKUP (first hit wins)
+  1. env:    DISCORD_BOT_TOKEN, DISCORD_GUILD_ID,
+             DISCORD_WEBHOOK_URL, DISCORD_WEBHOOK_<CHANNEL_UPPER>
+  2. store:  ops_cred_get discord bot-token   (see lib/credential-store.sh)
+  3. prefs:  $PREFS_PATH → discord.{bot_token,guild_id,default_webhook_url}
+
+EXAMPLES
+  ops-discord send general "deploy green"
+  ops-discord send https://discord.com/api/webhooks/<ID>/<TOKEN> "hi" --json
+  ops-discord read <CHANNEL_ID> --limit 10 --json
+  ops-discord channels --json
+
+NOTES
+  v1 scope: webhook send + REST channel reads. DM + gateway connections
+  are deferred to a v2 issue.
+EOF
+}
+
+# ─── Top-level dispatcher ───────────────────────────────────────────────────
+# Pre-scan for --json anywhere so subcommands can pick it up early.
+args=()
+for a in "$@"; do
+  case "$a" in
+    --json) JSON_MODE=true ;;
+    *) args+=("$a") ;;
+  esac
+done
+
+if [[ ${#args[@]} -eq 0 ]]; then
+  print_help
+  exit 0
+fi
+
+sub="${args[0]}"
+rest=("${args[@]:1}")
+
+case "$sub" in
+  send)
+    cmd_send "${rest[@]:-}" ;;
+  read)
+    cmd_read "${rest[@]:-}" ;;
+  channels)
+    cmd_channels "${rest[@]:-}" ;;
+  -h|--help|help|"")
+    print_help ;;
+  *)
+    emit_err "unknown subcommand: $sub (try --help)"
+    exit 2 ;;
+esac

--- a/claude-ops/docs/notifications.md
+++ b/claude-ops/docs/notifications.md
@@ -65,7 +65,11 @@ env var isn't set), so you don't have to export secrets globally.
 - **Premium iOS/Android →** Pushover. ~$5 one-time per platform, fastest and
   most reliable delivery with priority bypass for CRITICAL.
 - **Team channel →** Discord webhook. Drops the alert into an existing
-  `#incidents` channel where your team already lives.
+  `#incidents` channel where your team already lives. Configure once via
+  `/ops:setup discord` (sub-step 3l) — the same webhook URL powers both
+  fires alerts here and `/ops:comms discord send` (see
+  [`skills-reference.md`](skills-reference.md#opscomms--skillsops-commsskillmd)
+  and `bin/ops-discord`).
 - **Desktop only →** macOS `osascript`. Silent fallback; fine for a dev
   laptop but don't rely on it as your only sink.
 

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -69,13 +69,14 @@ Full inbox management. Reads complete conversation threads (20+ messages), build
 - `/ops:inbox` — all channels
 - `/ops:inbox whatsapp` — WhatsApp only
 - `/ops:inbox email` — Gmail only
-- `/ops:inbox slack` / `/ops:inbox telegram`
+- `/ops:inbox slack` / `/ops:inbox telegram` / `/ops:inbox discord`
 
 ### `/ops:comms` · `skills/ops-comms/SKILL.md`
 Send and read messages across all channels. Full conversation context required before any send. WhatsApp health pre-flight via PreToolUse hook.
 - `/ops:comms send "hey, can we chat?" to John Smith`
 - `/ops:comms read whatsapp`
 - `/ops:comms read slack #general`
+- `/ops:comms send "deploy green" to #ops-alerts on discord` (v1: webhook + REST read via `bin/ops-discord`)
 
 ---
 

--- a/claude-ops/skills/ops-comms/SKILL.md
+++ b/claude-ops/skills/ops-comms/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ops-comms
-description: Send and read messages across all channels. Routes based on arguments — whatsapp, email, slack, telegram, or natural language like "send [msg] to [contact]".
+description: Send and read messages across all channels. Routes based on arguments — whatsapp, email, slack, telegram, discord, or natural language like "send [msg] to [contact]".
 argument-hint: "[channel] | send [message] to [contact] | read [channel]"
 allowed-tools:
   - Bash
@@ -78,9 +78,12 @@ Parse `$ARGUMENTS` and route immediately:
 | `email`       | Show recent email threads via Gmail MCP                 |
 | `slack`       | Show recent Slack activity                              |
 | `telegram`    | Show Telegram recent chats                              |
+| `discord`     | Show recent Discord channel activity (via bin/ops-discord) |
 | `send * to *` | Parse message and contact, determine best channel, send |
 | `read *`      | Read the specified channel or contact's messages        |
 | (empty)       | Show channel picker menu                                |
+
+Natural-language parsing: phrases like `send "deploy done" to #general on discord` or `to #ops-alerts on Discord` should resolve to the `discord` branch below. Extract the channel token (the word after `#`, case-insensitive) and pass it as the first arg to `bin/ops-discord send`.
 
 ---
 
@@ -159,9 +162,31 @@ Use `mcp__claude_ai_Slack__slack_search_public_and_private` with `query: "in:cha
 Use `mcp__claude_ops_telegram__get_updates` (limit: 20) and `mcp__claude_ops_telegram__list_chats`.
 Fall back to: `telegram-cli --exec "dialog_list" 2>/dev/null || echo "Telegram MCP not configured"`
 
+**Discord:**
+`${CLAUDE_PLUGIN_ROOT}/bin/ops-discord read "<CHANNEL_ID>" --limit 20 --json` — requires `DISCORD_BOT_TOKEN` (or credential-store `discord/bot-token`). Fall back to `bin/ops-discord channels --json` if the user doesn't know the channel ID and `DISCORD_GUILD_ID` is set.
+
 ### Telegram send
 
 Use `mcp__claude_ops_telegram__send_message` with `chat_id` (from list_chats) and `text`.
+
+### Discord send
+
+Shell out to `bin/ops-discord send`. Three invocation shapes:
+
+```bash
+# By channel alias (resolves DISCORD_WEBHOOK_<UPPER> or DISCORD_WEBHOOK_URL)
+${CLAUDE_PLUGIN_ROOT}/bin/ops-discord send "<channel-alias>" "<message>" --json
+
+# By channel snowflake (17-20 digit ID, routed through bot token)
+${CLAUDE_PLUGIN_ROOT}/bin/ops-discord send "<CHANNEL_ID>" "<message>" --json
+
+# By full webhook URL (useful when the URL is stored per-project)
+${CLAUDE_PLUGIN_ROOT}/bin/ops-discord send "https://discord.com/api/webhooks/<ID>/<TOKEN>" "<message>" --json
+```
+
+If the script exits 1 with `{"error":"no discord credential configured — run /ops:setup discord"}`, prompt the user via `AskUserQuestion` (≤4 options per Rule 1): `[Run /ops:setup discord]` / `[Paste webhook URL now]` / `[Skip]`. Do NOT silently skip — that violates Rule 3.
+
+Note: `DISCORD_WEBHOOK_URL` is shared with the ops-fires notification sink (`scripts/ops-notify.sh`). When pre-existing, prefer it as the default for `/ops:comms discord send` rather than asking the user to set a separate value.
 
 ---
 

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ops-inbox
-description: Full inbox management across all channels — WhatsApp (wacli), Email (Gmail MCP), Slack (MCP), Telegram (user-auth MCP). Scans FULL inbox (not just unread), identifies messages needing replies, archives handled conversations.
-argument-hint: "[channel: whatsapp|email|slack|telegram|all]"
+description: Full inbox management across all channels — WhatsApp (wacli), Email (Gmail MCP), Slack (MCP), Telegram (user-auth MCP), Discord (webhook + REST read). Scans FULL inbox (not just unread), identifies messages needing replies, archives handled conversations.
+argument-hint: "[channel: whatsapp|email|slack|telegram|discord|all]"
 allowed-tools:
   - Bash
   - Read
@@ -184,6 +184,7 @@ For each channel, detect availability at runtime:
 2. **WhatsApp**: First check `~/.wacli/.health` for keepalive daemon status. If `status=needs_auth` or `status=needs_reauth`, do NOT attempt wacli commands — instead prompt the user: "WhatsApp needs re-authentication. Run `wacli auth` in a separate terminal and scan the QR code, then type 'done'." Use `AskUserQuestion`: `[Done — re-paired]`, `[Skip WhatsApp]`. On Done, restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.claude-ops.wacli-keepalive`, wait 5s, re-check health. If no health file exists, fall back to `wacli doctor` for auth/connection status. If outdated (405 error), advise rebuilding from source.
 3. **Slack**: Only via MCP tools (`mcp__claude_ai_Slack__*`). Check `SLACK_MCP_ENABLED` env var.
 4. **Telegram**: Only via user-auth MCP (tdlib/MTProto). Check `TELEGRAM_ENABLED` env var. Never use BotFather bots.
+5. **Discord**: Via `${CLAUDE_PLUGIN_ROOT}/bin/ops-discord read <CHANNEL_ID> --limit 20 --json`. Requires `DISCORD_BOT_TOKEN` (v1 is channel-scoped — no DM/gateway support yet). Pre-configured read list lives at `${CLAUDE_PLUGIN_DATA_DIR}/preferences.json` under `discord.inbox_channels` (array of channel IDs). If neither a bot token nor a read list is configured, skip Discord with a one-line note ("Discord not configured — run `/ops:setup discord`") rather than prompting — ops-inbox is not a setup flow. Rule 3 still applies to `/ops:setup`.
 
 ## Your task
 
@@ -446,6 +447,27 @@ Use the Telegram user-auth MCP server if available.
 ```
 
 If no Telegram user-auth tool is available, report: "Telegram not configured — needs user-auth MCP server (tdlib/MTProto)".
+
+### Discord (v1 — REST channel scan)
+
+Discord v1 support is channel-scoped (webhook send + REST read). DM + gateway are deferred to a v2 issue.
+
+1. Resolve the read list: read `${CLAUDE_PLUGIN_DATA_DIR}/preferences.json` → `discord.inbox_channels[]`. If empty and `DISCORD_GUILD_ID` is set, fall back to `bin/ops-discord channels --json` (list the guild's text channels and let the user pick via `AskUserQuestion`, ≤4 per Rule 1 — paginate with `[More...]`).
+2. For each channel ID:
+   ```bash
+   ${CLAUDE_PLUGIN_ROOT}/bin/ops-discord read "<CHANNEL_ID>" --limit 20 --json
+   ```
+3. Classify each channel's recent messages:
+   - **NEEDS REPLY**: Latest non-bot message mentions the operator (`<@user-id>`) or is a direct question.
+   - **FYI**: Bot-posted notifications (CI, alerts) — summarize counts and skip.
+4. For replies, reuse the `send` path documented in `skills/ops-comms/SKILL.md` → **Discord send**.
+
+If `bin/ops-discord` exits 1 with `{"error":"no discord credential configured — run /ops:setup discord"}`, print a single-line note and continue to the next channel — do not prompt inside the inbox flow.
+
+```
+💬 DISCORD — activity (last 7d)
+ #channel-name  [N messages] | [M need reply]
+```
 
 ---
 

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -2161,6 +2161,128 @@ Expect `{"status": "ok", ...}` within 60 seconds.
 
 > **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/docs/notifications.md`, `${CLAUDE_PLUGIN_ROOT}/scripts/ops-fires-watcher.sh`, and `${CLAUDE_PLUGIN_ROOT}/scripts/ops-notify.sh` for sink priority rationale, debounce rules, and a troubleshooting walk-through.
 
+### 3l — Discord (webhook + optional bot)
+
+Discord is a v1 integration — webhook-based send + REST channel reads. DM + gateway support are deferred to a v2 issue. The send-side webhook also supplies the Discord notification sink consumed by `scripts/ops-notify.sh`, so configuring it here covers both `/ops:comms discord send` and ops-fires alerts.
+
+**Before showing the credential prompt**, run the Universal Credential Auto-Scan for Discord (Rule 4 — background every bash call unless the next step depends on it):
+
+```bash
+# Shell env
+printenv DISCORD_BOT_TOKEN DISCORD_WEBHOOK_URL DISCORD_GUILD_ID 2>/dev/null
+
+# Shell profiles + .envrc
+grep -hE 'DISCORD_(BOT_TOKEN|WEBHOOK|GUILD_ID)' ~/.zshrc ~/.bashrc ~/.zprofile ~/.envrc 2>/dev/null | grep -v '^#'
+
+# Doppler across all projects
+for proj in $(doppler projects --json 2>/dev/null | jq -r '.[].slug'); do
+  doppler secrets --project "$proj" --config prd --json 2>/dev/null | \
+    jq -r --arg proj "$proj" 'to_entries[] | select(.key | test("DISCORD")) | "\(.key)=\(.value.computed) (doppler:\($proj)/prd)"'
+done
+
+# 1Password
+op item list --categories "API Credential" --format json 2>/dev/null | \
+  jq -r '.[] | select(.title | test("discord"; "i")) | .id' | \
+  while read id; do op item get "$id" --format json 2>/dev/null; done
+
+# Dashlane / Bitwarden
+dcli password discord --output json 2>/dev/null
+bw list items --search discord 2>/dev/null | jq -r '.[] | select(.login.password) | .login.password' | head -1
+
+# macOS Keychain (Darwin only — the setup wizard already guards this at the OS level)
+security find-generic-password -s "discord" -w 2>/dev/null
+
+# Claude-ops credential store (cross-OS)
+"${CLAUDE_PLUGIN_ROOT}/lib/credential-store.sh" get discord bot-token 2>/dev/null
+```
+
+Cache these results. Also check `$PREFS_PATH` under `discord.*` and `discord_webhook_url` (the flat key shared with ops-notify.sh) — if any of `discord.bot_token`, `discord.default_webhook_url`, or `discord_webhook_url` is already present, show `✓ Discord — already configured` and offer `[Keep]` / `[Reconfigure]`.
+
+#### If anything was found
+
+Present via the Universal Credential Auto-Scan prompt format with `[Use this value]` / `[Paste a different one]` / `[Skip]`. If a webhook URL was found but no bot token, note that reads + channel listing will be unavailable (send-only).
+
+#### Per Rule 3 — if nothing was found, ask explicitly (≤4 options per Rule 1)
+
+```
+No Discord credentials found. How do you want to configure Discord?
+  [Paste bot token]
+  [Paste webhook URL only]
+  [Deep hunt — spawn agent]
+  [Skip — I'll configure later]
+```
+
+On `[Deep hunt — spawn agent]`, spawn a background research agent (Rule 4 — `run_in_background: true`):
+
+```
+Agent(
+  subagent_type: "general-purpose",
+  model: "haiku",
+  run_in_background: true,
+  prompt: "Grep the filesystem under $HOME (excluding node_modules, .git, Library/Caches) for Discord credentials. Patterns: bot tokens look like base64 segments separated by dots (e.g. MTAxXXXX.YYYYYY.ZZZZZZZZZZZZ), webhook URLs start with https://discord.com/api/webhooks/ or https://discordapp.com/api/webhooks/, guild IDs are 17-20 digit snowflakes adjacent to the word 'guild' or 'server'. Also scan ~/.config, ~/.env, any .envrc files, and Doppler/1Password exports. Return every hit with file path + line number + 6-char redacted prefix. Do not print full tokens."
+)
+```
+
+While the hunt runs, continue with the next setup sub-step; return to Discord when the agent reports back and present findings via `AskUserQuestion` (paginate to ≤4 per Rule 1).
+
+On `[Paste bot token]`:
+
+```
+Enter your Discord Bot Token:
+  Find it: https://discord.com/developers/applications → your app → Bot → Reset Token
+  Format: MTAxXXXX.YYYYYY.ZZZZZZZZZZZZZZ  (base64 dot-separated)
+  Prefer a Doppler reference (doppler:DISCORD_BOT_TOKEN) over the raw value.
+
+Enter your Discord Guild ID (optional — needed for `channels` listing):
+  Enable Developer Mode in Discord → right-click server → Copy ID.
+```
+
+Smoke test (background via Bash per Rule 4):
+
+```bash
+curl -sS "https://discord.com/api/v10/users/@me" \
+  -H "Authorization: Bot $DISCORD_BOT_TOKEN" \
+  -H "User-Agent: ops-discord (claude-ops, v1)" | jq '.id // .message'
+```
+
+Expect a numeric snowflake `id`. If the response is `{"message":"401: Unauthorized", ...}`, re-ask.
+
+On `[Paste webhook URL only]`:
+
+```
+Enter a default Discord Webhook URL:
+  Find it: Discord → Server Settings → Integrations → Webhooks → New Webhook → Copy URL
+  Format: https://discord.com/api/webhooks/<ID>/<TOKEN>
+```
+
+Smoke test — do NOT send content to the webhook during setup. Instead, issue a GET to confirm the URL resolves to webhook metadata:
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' -X GET "$DISCORD_WEBHOOK_URL"
+```
+
+Expect `200` (webhook metadata returned) or `401` (valid URL, token invalid — user needs to re-copy).
+
+#### Save to preferences
+
+Write to `$PREFS_PATH` (merge):
+
+```json
+{
+  "discord": {
+    "bot_token": "doppler:DISCORD_BOT_TOKEN",
+    "guild_id": "<GUILD_ID>",
+    "default_webhook_url": "doppler:DISCORD_WEBHOOK_URL",
+    "configured_at": "<ISO timestamp>"
+  },
+  "discord_webhook_url": "doppler:DISCORD_WEBHOOK_URL"
+}
+```
+
+Mirror the webhook to the flat `discord_webhook_url` key so `scripts/ops-notify.sh` (the existing fires sink) continues to find it. Prefer a Doppler reference over raw tokens when Doppler is configured. Prefer the credential-store (`ops_cred_set discord bot-token <value>`) over plaintext prefs on systems with a native keyring. If the user picked `[Skip]`, save `{"discord": "skipped"}` so the wizard doesn't re-prompt on the next run.
+
+> **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-comms/SKILL.md` (Discord send/read sections) and `${CLAUDE_PLUGIN_ROOT}/bin/ops-discord` for full operational instructions and subcommand reference.
+
 ---
 
 ## Step 4 — Configure MCPs (if selected)

--- a/claude-ops/tests/test-discord-help.sh
+++ b/claude-ops/tests/test-discord-help.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# test-discord-help.sh — Smoke-tests bin/ops-discord behavior without making
+# any real Discord API calls.
+#
+# Asserts:
+#   1. `bin/ops-discord --help`  exits 0 and prints the expected USAGE banner.
+#   2. `bin/ops-discord` (no args) exits 0 and prints the same banner.
+#   3. `bin/ops-discord read 123456789012345678 --json` exits 1 with
+#      `{"error": "no discord credential configured ..."}` when no creds are set.
+#   4. `bin/ops-discord send` (no args) exits 2 with a usage error.
+#   5. `bin/ops-discord unknown` exits 2.
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$PLUGIN_ROOT/bin/ops-discord"
+
+pass=0
+fail=0
+ok()  { echo "  PASS: $1"; pass=$((pass+1)); }
+err() { echo "  FAIL: $1"; fail=$((fail+1)); }
+
+if [[ ! -x "$SCRIPT" ]]; then
+  err "bin/ops-discord is not executable"
+  exit 1
+fi
+
+# Sandbox: scrub any Discord env that may have leaked in from the parent shell
+# so the `read` test reliably hits the no-credential code path.
+unset DISCORD_BOT_TOKEN DISCORD_GUILD_ID DISCORD_WEBHOOK_URL || true
+export PREFS_PATH="/nonexistent/should-not-be-read.json"
+
+echo "1. --help exits 0 + prints USAGE"
+out="$("$SCRIPT" --help 2>&1)"
+ec=$?
+if [[ $ec -eq 0 ]] && grep -q "USAGE" <<<"$out" && grep -q "ops-discord send" <<<"$out"; then
+  ok "help banner present"
+else
+  err "help banner missing or non-zero exit ($ec)"
+  printf '%s\n' "$out" | head -20
+fi
+
+echo "2. no-arg invocation prints help"
+out="$("$SCRIPT" 2>&1)"
+ec=$?
+if [[ $ec -eq 0 ]] && grep -q "SUBCOMMANDS" <<<"$out"; then
+  ok "no-arg shows help"
+else
+  err "no-arg help missing"
+fi
+
+echo "3. read with --json + no creds → JSON error + exit 1"
+set +e
+out="$("$SCRIPT" read 123456789012345678 --json 2>&1)"
+ec=$?
+set -e
+if [[ $ec -eq 1 ]] && grep -q '"error"' <<<"$out" && grep -q "no discord credential configured" <<<"$out"; then
+  ok "graceful JSON error on missing creds"
+else
+  err "expected JSON error + exit 1, got exit=$ec output=$out"
+fi
+
+echo "4. send with no args → usage error exit 2"
+set +e
+"$SCRIPT" send >/dev/null 2>&1
+ec=$?
+set -e
+if [[ $ec -eq 2 ]]; then
+  ok "send-without-args exits 2"
+else
+  err "expected exit 2, got $ec"
+fi
+
+echo "5. unknown subcommand → exit 2"
+set +e
+"$SCRIPT" frobnicate >/dev/null 2>&1
+ec=$?
+set -e
+if [[ $ec -eq 2 ]]; then
+  ok "unknown subcommand exits 2"
+else
+  err "expected exit 2, got $ec"
+fi
+
+echo ""
+echo "---"
+echo "Results: $pass passed, $fail failed"
+echo ""
+
+if (( fail > 0 )); then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
Closes #20

## Summary

Adds Discord as a first-class communication channel alongside Slack/Telegram/WhatsApp.

**v1 scope: webhook send + channel read via REST. DM + gateway deferred to a v2 issue.**

### What's in this PR

- **`bin/ops-discord`** — bash helper with subcommands:
  - `send <channel-id|webhook-url> "msg"` — POSTs via webhook URL or via bot token if a 17-20 digit snowflake is given
  - `read <channel-id> [--limit N]` — GET `channels/<id>/messages` with `Authorization: Bot $DISCORD_BOT_TOKEN`
  - `channels` — list channels in `DISCORD_GUILD_ID`
  - `--json` on every subcommand
- **`plugin.json`** — three new userConfig keys: `discord_bot_token`, `discord_guild_id`, `discord_default_webhook_url` (the webhook is also mirrored to the flat `discord_webhook_url` consumed by `scripts/ops-notify.sh`, so configuring once covers both `/ops:comms discord send` and ops-fires alerts)
- **`skills/ops-comms/SKILL.md`** — `discord` row in the routing table, send/read sub-flows that shell out to `bin/ops-discord`, natural-language parser hint for "to #foo on discord"
- **`skills/ops-inbox/SKILL.md`** — Discord channel scan section gated on bot token (skips with a one-line note when unconfigured — ops-inbox isn't a setup flow)
- **`skills/setup/SKILL.md`** — sub-step `### 3l — Discord (webhook + optional bot)` with auto-scan, deep-hunt agent, paste-token and paste-webhook prompts, smoke tests, all backgrounded per Rule 4
- **`docs/skills-reference.md`** + **`docs/notifications.md`** — cross-links between the comms / inbox / setup paths
- **`tests/test-discord-help.sh`** — covers help banner, no-arg help, JSON-mode credential error, send-without-args usage error, unknown subcommand handling

### Credential resolution cascade

```
1. env vars        DISCORD_BOT_TOKEN / DISCORD_GUILD_ID /
                   DISCORD_WEBHOOK_URL / DISCORD_WEBHOOK_<CHANNEL_UPPER>
2. credential store ops_cred_get discord bot-token  (lib/credential-store.sh)
3. preferences      $PREFS_PATH → discord.{bot_token, guild_id,
                                            default_webhook_url}
                                  + flat discord_webhook_url fallback
```

### Discord API quirks worth noting

- Webhooks return `204 No Content` (no body) without `?wait=true` — handled in `cmd_send`
- Channel reads require the `Bot ` prefix on the Authorization header (not `Bearer`)
- Channel snowflakes are 17-20 digits — used as the disambiguator between "looks like a webhook url" vs "looks like a channel id" vs "looks like a channel alias env var"
- Webhook URLs accept both `discord.com` and the legacy `discordapp.com` — resolver handles both

### Rule compliance

- Rule 0: zero real tokens, channel IDs, guild IDs, or webhook URLs in any file (only `<DISCORD_BOT_TOKEN>` / `<CHANNEL_ID>` / `<ID>/<TOKEN>` placeholders)
- Rule 1: setup sub-step 3l caps every `AskUserQuestion` at 4 options (`[Paste bot token]` / `[Paste webhook URL only]` / `[Deep hunt — spawn agent]` / `[Skip]`)
- Rule 3: setup never auto-skips Discord even when the auto-scan returns nothing
- Rule 4: all credential scans, OAuth flows, smoke tests in setup are flagged for `run_in_background: true`

## Test plan

- [x] `bash -n bin/ops-discord` — passes
- [x] `jq . claude-ops/.claude-plugin/plugin.json` — valid JSON
- [x] `bash tests/test-no-secrets.sh` — 11/11 pass
- [x] `bash tests/test-discord-help.sh` — 5/5 pass (new test)
- [x] `bash tests/test-bin-scripts.sh` — 71/71 pass (covers shebang, exec bit, macOS guards on the new script)
- [x] `bash tests/test-skills-lint.sh` — 208/208 pass (covers AskUserQuestion ≤4 enforcement on the new setup sub-step)
- [x] `bash tests/run-all.sh` — 6/6 suites green
- [ ] Manual verification with a real bot token: `ops-discord channels --json`, `ops-discord read <CHANNEL_ID>`, `ops-discord send <webhook-url> "test"`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Discord integration path (webhook send + bot-token channel reads) plus new credential configuration surfaces; main risk is misconfiguration or accidental message delivery to wrong channel/webhook rather than core data/security changes.
> 
> **Overview**
> Adds Discord as a first-class channel for `/ops:comms` and `/ops:inbox` using a new `bin/ops-discord` helper that can **send** via webhook (or bot-backed channel ID) and **read/list channels** via Discord’s REST API, with optional `--json` output.
> 
> Extends configuration to include Discord bot/guild/webhook settings (`plugin.json`) and updates the setup wizard to guide discovery, prompting, and persistence of Discord credentials (including mirroring webhook config for the existing fires notification sink). Documentation and skill references are updated accordingly, and a new smoke test (`tests/test-discord-help.sh`) covers basic CLI/help/error behavior without making network calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b6613e9762d3b6769f94f0cd6a355f1a95a354d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->