### PR TITLE
fix(daemon): services work out of the box on fresh install

### DIFF
--- a/claude-ops/scripts/com.claude-ops.daemon.plist
+++ b/claude-ops/scripts/com.claude-ops.daemon.plist
@@ -7,7 +7,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
+        <string>__BASH_PATH__</string>
         <string>__DAEMON_SCRIPT_PATH__</string>
     </array>
 
@@ -32,6 +32,8 @@
         <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
         <key>HOME</key>
         <string>__HOME__</string>
+        <key>CLAUDE_PLUGIN_ROOT</key>
+        <string>__PLUGIN_ROOT__</string>
     </dict>
 </dict>
 </plist>

--- a/claude-ops/scripts/com.claude-ops.wacli-keepalive.plist
+++ b/claude-ops/scripts/com.claude-ops.wacli-keepalive.plist
@@ -7,7 +7,7 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/bash</string>
+        <string>__BASH_PATH__</string>
         <string>__KEEPALIVE_SCRIPT_PATH__</string>
     </array>
 

--- a/claude-ops/scripts/daemon-services.default.json
+++ b/claude-ops/scripts/daemon-services.default.json
@@ -2,27 +2,27 @@
   "services": {
     "briefing-pre-warm": {
       "enabled": true,
-      "command": "__SCRIPTS_DIR__/../bin/ops-gather",
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/ops-gather",
       "cron": "*/2 * * * *",
       "_note": "Pre-warms /ops:go briefing cache every 2 minutes. Runs immediately after daemon install so /ops:go is instant by the time setup finishes."
     },
     "wacli-sync": {
       "enabled": true,
-      "command": "__SCRIPTS_DIR__/wacli-keepalive.sh",
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/wacli-keepalive.sh",
       "health_file": "~/.wacli/.health",
       "restart_delay": 60,
       "max_restarts": 10
     },
     "memory-extractor": {
       "enabled": true,
-      "command": "__SCRIPTS_DIR__/ops-memory-extractor.sh",
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-memory-extractor.sh",
       "health_file": "~/.claude/plugins/data/ops-ops-marketplace/memories/.health",
       "restart_delay": 3600,
       "cron": "*/30 * * * *"
     },
     "fires-watcher": {
       "enabled": false,
-      "command": "__SCRIPTS_DIR__/ops-fires-watcher.sh",
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-fires-watcher.sh",
       "health_file": "~/.claude/plugins/data/ops-ops-marketplace/fires-watcher.health",
       "restart_delay": 60,
       "max_restarts": 20,

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -135,6 +135,9 @@ start_service() {
     return 1
   fi
 
+  # Expand env vars in command path (e.g. ${CLAUDE_PLUGIN_ROOT}/scripts/...)
+  cmd=$(eval echo "$cmd")
+
   log "START: launching $name — $cmd"
   # Export daemon identity so child scripts can detect they're managed
   export OPS_DAEMON_PID=$$
@@ -328,6 +331,9 @@ run_cron_service() {
   local cmd
   cmd=$(get_service_field "$name" "command")
   if [[ -z "$cmd" ]]; then return; fi
+
+  # Expand env vars in command path
+  cmd=$(eval echo "$cmd")
 
   log "CRON: running $name"
   SERVICE_STATUS["$name"]="running"

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -322,8 +322,19 @@ DATA_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketpla
 LOG_DIR="$DATA_DIR/logs"
 mkdir -p "$LOG_DIR"
 
+# Resolve bash 4+ (required for associative arrays in ops-daemon.sh).
+# macOS ships bash 3; Homebrew installs bash 5 at /opt/homebrew/bin/bash.
+BASH_PATH="/bin/bash"
+if [[ -x /opt/homebrew/bin/bash ]]; then
+  BASH_PATH="/opt/homebrew/bin/bash"
+elif [[ -x /usr/local/bin/bash ]]; then
+  BASH_PATH="/usr/local/bin/bash"
+fi
+
 # Generate plist
 sed -e "s|__DAEMON_SCRIPT_PATH__|$DAEMON_SCRIPT|g" \
+    -e "s|__BASH_PATH__|$BASH_PATH|g" \
+    -e "s|__PLUGIN_ROOT__|$PLUGIN_ROOT|g" \
     -e "s|__LOG_DIR__|$LOG_DIR|g" \
     -e "s|__HOME__|$HOME|g" \
     "$PLIST_TEMPLATE" > "$PLIST_DEST"
@@ -883,7 +894,16 @@ PLIST_DEST="$HOME/Library/LaunchAgents/com.claude-ops.wacli-keepalive.plist"
 LOG_DIR="$HOME/.claude/plugins/data/ops-ops-marketplace/logs"
 mkdir -p "$LOG_DIR" "$HOME/Library/LaunchAgents"
 
+# Resolve bash 4+ (same logic as daemon plist)
+BASH_PATH="/bin/bash"
+if [[ -x /opt/homebrew/bin/bash ]]; then
+  BASH_PATH="/opt/homebrew/bin/bash"
+elif [[ -x /usr/local/bin/bash ]]; then
+  BASH_PATH="/usr/local/bin/bash"
+fi
+
 sed -e "s|__KEEPALIVE_SCRIPT_PATH__|$KEEPALIVE_SCRIPT|g" \
+    -e "s|__BASH_PATH__|$BASH_PATH|g" \
     -e "s|__LOG_DIR__|$LOG_DIR|g" \
     -e "s|__HOME__|$HOME|g" \
     "$PLIST_TEMPLATE" > "$PLIST_DEST"
@@ -2449,14 +2469,14 @@ fi
 echo "Services to enable: $SERVICES"
 ```
 
-Write daemon services config to `$DATA_DIR/daemon-services.json` — merge with the existing config from Step 2c, preserving `briefing-pre-warm` and `memory-extractor`, and enabling the new channel-dependent services. Each service entry should include:
-- `briefing-pre-warm`: `{ "enabled": true, "cron": "*/2 * * * *" }` — pre-warms /ops:go cache (installed in 2c)
-- `wacli-sync`: `{ "enabled": true, "interval": "continuous" }` — only if WhatsApp configured
-- `memory-extractor`: `{ "enabled": true, "cron": "*/30 * * * *" }` — every 30 min (installed in 2c)
-- `inbox-digest`: `{ "enabled": true, "cron": "0 */4 * * *" }` — every 4h
-- `store-health`: `{ "enabled": true, "cron": "0 9 * * *" }` — daily 9am, only if ecom configured
-- `competitor-intel`: `{ "enabled": true, "cron": "0 10 * * 1" }` — weekly Monday 10am
-- `message-listener`: `{ "enabled": true, "interval": "continuous" }` — only if WhatsApp or Telegram configured
+Write daemon services config to `$DATA_DIR/daemon-services.json` — merge with the existing config from Step 2c, preserving `briefing-pre-warm` and `memory-extractor`, and enabling the new channel-dependent services. **Every service MUST include a `command` field** — the daemon's `start_service()` skips any service without one. Use `${CLAUDE_PLUGIN_ROOT}` (resolved at runtime) for script paths. Each service entry should include:
+- `briefing-pre-warm`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/bin/ops-gather", "cron": "*/2 * * * *" }` — pre-warms /ops:go cache (installed in 2c)
+- `wacli-sync`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/wacli-keepalive.sh", "health_file": "~/.wacli/.health", "restart_delay": 60, "max_restarts": 10 }` — only if WhatsApp configured
+- `memory-extractor`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-memory-extractor.sh", "health_file": "~/.claude/plugins/data/ops-ops-marketplace/memories/.health", "cron": "*/30 * * * *" }` — every 30 min (installed in 2c)
+- `inbox-digest`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-cron-inbox-digest.sh", "cron": "0 */4 * * *" }` — every 4h
+- `store-health`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-cron-store-health.sh", "cron": "0 9 * * *" }` — daily 9am, only if ecom configured
+- `competitor-intel`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-cron-competitor-intel.sh", "cron": "0 10 * * 1" }` — weekly Monday 10am
+- `message-listener`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-message-listener.sh" }` — only if WhatsApp or Telegram configured
 
 After rewriting the services config, do a quick health check (foreground, <2s), then background the reload:
 


### PR DESCRIPTION
## Summary
- Plist templates resolve bash 4+ at install time (macOS ships bash 3, `declare -A` needs 4+)
- Daemon plist exports `CLAUDE_PLUGIN_ROOT` env var so `${CLAUDE_PLUGIN_ROOT}` in service commands resolves
- `start_service()` and `run_cron_service()` expand env vars in command paths
- Step 5b service definitions now include `command` fields for all services (wacli-sync, inbox-digest, competitor-intel, message-listener were missing)
- Normalize `__SCRIPTS_DIR__` → `${CLAUDE_PLUGIN_ROOT}` in default config

## Test plan
- [ ] Fresh install: all daemon services start without "no command configured, skipping"
- [ ] macOS with only `/bin/bash` (v3): daemon uses homebrew bash 5
- [ ] `wacli-sync` launches keepalive script and writes health file
- [ ] Cron services (inbox-digest, competitor-intel) fire on schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/111" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daemon service launching and launchd environment/templating; the new `eval`-based command expansion could misbehave if service `command` strings contain unexpected shell content.
> 
> **Overview**
> Ensures the macOS launchd agents run with a Bash 4+ binary by templating `__BASH_PATH__` into both daemon and keepalive plists during setup.
> 
> Standardizes daemon service commands to use `${CLAUDE_PLUGIN_ROOT}` (and exports `CLAUDE_PLUGIN_ROOT` in the daemon plist), then updates `ops-daemon.sh` to expand environment variables in `command` paths for both persistent and cron services.
> 
> Updates setup docs/steps to generate plists with the resolved bash path and to require `command` fields for all daemon-managed services so they don’t get skipped on install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db6fb1699f1ba53f05d831cbc26b3e770162c988. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced daemon installer to intelligently locate bash interpreter from multiple system locations.
  * Updated service configuration to support dynamic path resolution using environment variables.
  * Expanded setup documentation with improved configuration examples and new requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->