### PR TITLE
feat: Agent Teams compliance across all skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,23 +89,23 @@ All 22 skills, grouped by category:
 
 ```mermaid
 flowchart TD
-    U[User] --> O[/ops]
-    O --> D[Dashboard]
-    D --> Daily[Daily Ops]
-    D --> Eng[Project & Eng]
-    D --> Biz[Business]
-    D --> Auto[Automation]
-    Daily --> go[/ops:go]
-    Daily --> inbox[/ops:inbox]
-    Daily --> merge[/ops:merge]
-    Eng --> projects[/ops:projects]
-    Eng --> linear[/ops:linear]
-    Eng --> fires[/ops:fires]
-    Biz --> revenue[/ops:revenue]
-    Biz --> ecom[/ops:ecom]
-    Biz --> marketing[/ops:marketing]
-    Auto --> yolo[/ops:yolo]
-    Auto --> orchestrate[/ops:orchestrate]
+    U["User"] --> O["/ops"]
+    O --> D["Dashboard"]
+    D --> Daily["Daily Ops"]
+    D --> Eng["Project & Eng"]
+    D --> Biz["Business"]
+    D --> Auto["Automation"]
+    Daily --> go["/ops:go"]
+    Daily --> inbox["/ops:inbox"]
+    Daily --> merge["/ops:merge"]
+    Eng --> projects["/ops:projects"]
+    Eng --> linear["/ops:linear"]
+    Eng --> fires["/ops:fires"]
+    Biz --> revenue["/ops:revenue"]
+    Biz --> ecom["/ops:ecom"]
+    Biz --> marketing["/ops:marketing"]
+    Auto --> yolo["/ops:yolo"]
+    Auto --> orchestrate["/ops:orchestrate"]
 ```
 
 ---
@@ -198,6 +198,46 @@ claude-ops/                        ← marketplace root (this repo, this README)
     ├── tests/                     # bash validation · test-no-secrets.sh
     └── .mcp.json                  # MCP server declarations
 ```
+
+---
+
+## Agent Teams
+
+Every ops skill that spawns agents supports [Claude Code Agent Teams](https://docs.anthropic.com/en/docs/claude-code) — a coordination layer where agents share context, report progress, and accept mid-flight steering.
+
+**Enable:** Set `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in your environment.
+
+**How it works:** When the flag is set, skills create a named team and dispatch agents into it. Agents within a team can share findings (e.g., an inbox agent discovers a Slack message referencing an email thread, so the email agent prioritizes it) and you can steer priorities via `SendMessage`.
+
+```
+TeamCreate("fire-fixers")
+Agent(team_name="fire-fixers", name="fix-ecs", ...)
+Agent(team_name="fire-fixers", name="fix-ci", ...)
+SendMessage(to="fix-ecs", content="This is P0, prioritize over CI")
+```
+
+**Without the flag:** Skills fall back to standard fire-and-forget subagents — still parallel, but no coordination or steering.
+
+| Skill | Team name | Agents |
+|-------|-----------|--------|
+| `/ops:go` | `go-team` | infra-scanner, inbox-scanner, pr-scanner, sprint-scanner |
+| `/ops:inbox` | `inbox-channels` | whatsapp-scanner, email-scanner, slack-scanner, telegram-scanner |
+| `/ops:merge` | `merge-fixers` | fixer-[repo] per failing PR |
+| `/ops:fires` | `fire-fixers` | fix-[service] per active incident |
+| `/ops:triage` | `triage-fixers` | fix-[issue-id] per active issue |
+| `/ops:yolo` | `yolo-csuite` | ceo, cto, cfo, coo |
+| `/ops:orchestrate` | `orchestrate-team` | per-project agents (hybrid auto-select) |
+| `/ops:monitor` | `monitor-probes` | datadog-probe, newrelic-probe, otel-probe |
+| `/ops:doctor` | `doctor-fixers` | fix-manifest, fix-permissions, fix-registry |
+| `/ops:marketing` | `marketing-team` | email-metrics, ads-metrics, analytics-metrics, seo-metrics |
+| `/ops:ecom` | `ecom-team` | orders-scanner, inventory-scanner, fulfillment-scanner |
+| `/ops:deploy` | `deploy-team` | ecs-checker, vercel-checker, ci-checker |
+| `/ops:projects` | `projects-team` | project-[alias] per registered project |
+| `/ops:dash` | `dash-team` | infra-loader, comms-loader, projects-loader, business-loader |
+| `/ops:next` | `next-team` | fires-checker, comms-checker, prs-checker, sprint-checker |
+| `setup` | `setup-hunters` | hunt-[service] per credential deep hunt |
+
+**Compliance enforced by CI:** `tests/test-agent-teams.sh` audits every skill for Agent Teams support — any skill with `Agent` in its allowed-tools must have `TeamCreate`/`SendMessage`, a documentation section, the feature flag check, and a fallback path.
 
 ---
 

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Business operations command center for Claude Code — 25 skills, 13 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes YOLO mode for autonomous operation.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/skills/ops-dash/SKILL.md
+++ b/claude-ops/skills/ops-dash/SKILL.md
@@ -9,6 +9,8 @@ allowed-tools:
   - Glob
   - Skill
   - Agent
+  - TeamCreate
+  - SendMessage
   - AskUserQuestion
   - CronCreate
   - CronList
@@ -46,6 +48,24 @@ Before rendering, load available context:
 The bin script reads `preferences.json` and `daemon-health.json` internally. The skill reads these files separately to check for warnings before invoking the script.
 
 ---
+
+## Agent Teams support
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** when loading dashboard data in parallel. This enables:
+- Agents share context and can coordinate mid-flight
+- You can steer priorities in real-time
+- Agents report progress as they complete
+
+**Team setup** (only when flag is enabled):
+```
+TeamCreate("dash-team")
+Agent(team_name="dash-team", name="infra-loader", prompt="Gather ECS health, Vercel status, and CI pipeline state")
+Agent(team_name="dash-team", name="comms-loader", prompt="Gather unread counts across all configured channels")
+Agent(team_name="dash-team", name="projects-loader", prompt="Gather GSD phase, git status, and PRs for all projects")
+Agent(team_name="dash-team", name="business-loader", prompt="Gather revenue, Linear sprint, and fire alerts")
+```
+
+If the flag is NOT set, use standard fire-and-forget subagents.
 
 ## Render dashboard instantly
 

--- a/claude-ops/skills/ops-deploy/SKILL.md
+++ b/claude-ops/skills/ops-deploy/SKILL.md
@@ -9,6 +9,8 @@ allowed-tools:
   - Glob
   - Skill
   - Agent
+  - TeamCreate
+  - SendMessage
   - AskUserQuestion
   - TaskCreate
   - TaskUpdate
@@ -64,6 +66,23 @@ Before executing, load available context:
 | `gh run watch <run-id> --repo <repo>` | Stream CI run | Live output (use with Monitor) |
 
 ---
+
+## Agent Teams support
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** when checking deploy platforms in parallel. This enables:
+- Agents share context and can coordinate mid-flight
+- You can steer priorities in real-time
+- Agents report progress as they complete
+
+**Team setup** (only when flag is enabled):
+```
+TeamCreate("deploy-team")
+Agent(team_name="deploy-team", name="ecs-checker", prompt="List all ECS clusters and describe service health, running/desired counts")
+Agent(team_name="deploy-team", name="vercel-checker", prompt="List Vercel projects and recent deployments with status")
+Agent(team_name="deploy-team", name="ci-checker", prompt="Check GitHub Actions runs across all registered repos for failures")
+```
+
+If the flag is NOT set, use standard fire-and-forget subagents.
 
 ## Phase 1 — Gather deploy data in parallel
 

--- a/claude-ops/skills/ops-doctor/SKILL.md
+++ b/claude-ops/skills/ops-doctor/SKILL.md
@@ -11,6 +11,8 @@ allowed-tools:
   - AskUserQuestion
   - WebSearch
   - WebFetch
+  - TeamCreate
+  - SendMessage
 effort: medium
 maxTurns: 30
 ---
@@ -83,6 +85,23 @@ Parse the JSON output. Display a summary:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
+## Agent Teams support
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** when multiple independent fix categories are identified (e.g., manifest issues + permission issues + registry issues). This enables:
+- Fix agents work in parallel on different issue categories without stepping on each other
+- You can prioritize: "fix manifest errors first, then permissions"
+- Agents share context so a manifest fix can inform the registry repair
+
+**Team setup** (only when flag is enabled, multiple issue categories):
+```
+TeamCreate("doctor-fixers")
+Agent(team_name="doctor-fixers", name="fix-manifest", subagent_type="ops:doctor-agent", ...)
+Agent(team_name="doctor-fixers", name="fix-permissions", subagent_type="ops:doctor-agent", ...)
+Agent(team_name="doctor-fixers", name="fix-registry", subagent_type="ops:doctor-agent", ...)
+```
+
+If the flag is NOT set or only one issue category exists, use a single `doctor-agent` subagent.
+
 ## Phase 2 — Decision
 
 If `$ARGUMENTS` contains `--check-only`: stop here, display results only.
@@ -91,7 +110,7 @@ If there are **errors or warnings**:
 
 Display: "Found [N] issues. Spawning doctor agent to auto-fix..."
 
-Then spawn the doctor agent:
+Then spawn the doctor agent (or Agent Team — see above):
 
 ```
 Agent({

--- a/claude-ops/skills/ops-ecom/SKILL.md
+++ b/claude-ops/skills/ops-ecom/SKILL.md
@@ -9,6 +9,8 @@ allowed-tools:
   - Grep
   - Glob
   - Agent
+  - TeamCreate
+  - SendMessage
   - AskUserQuestion
   - WebFetch
   - WebSearch
@@ -53,6 +55,24 @@ Before executing, load available context:
 | `https://api.shipbob.com/1.0/shipment?Status=Processing&PageSize=20` | GET | Pending shipments |
 
 **Auth header**: `Authorization: Bearer ${SHIPBOB_TOKEN}`
+
+## Agent Teams support
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** when probing store data in parallel. This enables:
+- Agents share context and can coordinate mid-flight
+- You can steer priorities in real-time
+- Agents report progress as they complete
+
+**Team setup** (only when flag is enabled):
+```
+TeamCreate("ecom-team")
+Agent(team_name="ecom-team", name="orders-scanner", prompt="Fetch recent orders, compute revenue for today/7d/30d")
+Agent(team_name="ecom-team", name="inventory-scanner", prompt="Fetch all products, flag low stock and out-of-stock items")
+Agent(team_name="ecom-team", name="fulfillment-scanner", prompt="Fetch unfulfilled orders and ShipBob shipment status")
+Agent(team_name="ecom-team", name="analytics-scanner", prompt="Compute revenue analytics, AOV, and top products for 30d")
+```
+
+If the flag is NOT set, use standard fire-and-forget subagents.
 
 ## Phase 1 — Resolve credentials
 

--- a/claude-ops/skills/ops-go/SKILL.md
+++ b/claude-ops/skills/ops-go/SKILL.md
@@ -9,6 +9,8 @@ allowed-tools:
   - Glob
   - Skill
   - Agent
+  - TeamCreate
+  - SendMessage
   - AskUserQuestion
   - TaskCreate
   - TaskUpdate
@@ -59,6 +61,24 @@ Before executing, load available context:
 | `gog gmail search -j --results-only --no-input --max 30 "in:inbox"` | Search inbox | JSON array of threads |
 
 ---
+
+## Agent Teams support
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** when gathering briefing data in parallel. This enables:
+- Agents share context and can coordinate mid-flight
+- You can steer priorities in real-time
+- Agents report progress as they complete
+
+**Team setup** (only when flag is enabled):
+```
+TeamCreate("go-team")
+Agent(team_name="go-team", name="infra-scanner", prompt="Check ECS health, Vercel status, and CI failures across all clusters")
+Agent(team_name="go-team", name="inbox-scanner", prompt="Scan unread messages across WhatsApp, Email, Slack, Telegram")
+Agent(team_name="go-team", name="pr-scanner", prompt="Find open PRs needing action — reviews, CI fixes, merge-ready")
+Agent(team_name="go-team", name="sprint-scanner", prompt="Check Linear sprint progress and GSD phase state across projects")
+```
+
+If the flag is NOT set, use standard fire-and-forget subagents.
 
 ## Pre-gathered data
 

--- a/claude-ops/skills/ops-marketing/SKILL.md
+++ b/claude-ops/skills/ops-marketing/SKILL.md
@@ -9,6 +9,8 @@ allowed-tools:
   - Grep
   - Glob
   - Agent
+  - TeamCreate
+  - SendMessage
   - AskUserQuestion
   - WebFetch
   - WebSearch
@@ -69,6 +71,24 @@ Before executing, load available context:
 | `https://searchconsole.googleapis.com/webmasters/v3/sites/${GSC_SITE_ENCODED}/searchAnalytics/query` | POST | Search performance data |
 
 **Auth**: Same gcloud ADC token as GA4
+
+## Agent Teams support
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** when gathering channel data in parallel. This enables:
+- Agents share context and can coordinate mid-flight
+- You can steer priorities in real-time
+- Agents report progress as they complete
+
+**Team setup** (only when flag is enabled):
+```
+TeamCreate("marketing-team")
+Agent(team_name="marketing-team", name="email-metrics", prompt="Pull Klaviyo subscriber counts, campaign stats, and flow metrics")
+Agent(team_name="marketing-team", name="ads-metrics", prompt="Pull Meta Ads spend, ROAS, and campaign breakdown")
+Agent(team_name="marketing-team", name="analytics-metrics", prompt="Pull GA4 sessions, conversions, and traffic sources")
+Agent(team_name="marketing-team", name="seo-metrics", prompt="Pull Search Console clicks, impressions, and top queries")
+```
+
+If the flag is NOT set, use standard fire-and-forget subagents.
 
 ## Credential Resolution
 

--- a/claude-ops/skills/ops-monitor/SKILL.md
+++ b/claude-ops/skills/ops-monitor/SKILL.md
@@ -7,6 +7,8 @@ allowed-tools:
   - Read
   - Agent
   - AskUserQuestion
+  - TeamCreate
+  - SendMessage
 effort: low
 maxTurns: 20
 ---
@@ -62,6 +64,23 @@ Run smoke test after saving:
 - **OTEL**: `curl -sf "$OTEL_ENDPOINT/healthz"` → expect HTTP 200
 
 Report ✅ or ❌ with status for each backend.
+
+## Agent Teams support
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** when querying multiple backends simultaneously. This enables:
+- Backend probes run in parallel with shared context (e.g., Datadog agent detects latency spike → OTEL agent can correlate with traces)
+- You can steer: "focus on Datadog alerts first, then cross-reference with New Relic"
+- Real-time progress: agents report per-backend as results arrive
+
+**Team setup** (only when flag is enabled, multiple backends configured):
+```
+TeamCreate("monitor-probes")
+Agent(team_name="monitor-probes", name="datadog-probe", subagent_type="ops:monitor-agent", ...)
+Agent(team_name="monitor-probes", name="newrelic-probe", subagent_type="ops:monitor-agent", ...)
+Agent(team_name="monitor-probes", name="otel-probe", subagent_type="ops:monitor-agent", ...)
+```
+
+If the flag is NOT set or only one backend is configured, use a single `monitor-agent` subagent.
 
 ## Default health check (no flags)
 

--- a/claude-ops/skills/ops-next/SKILL.md
+++ b/claude-ops/skills/ops-next/SKILL.md
@@ -9,6 +9,8 @@ allowed-tools:
   - Glob
   - Skill
   - Agent
+  - TeamCreate
+  - SendMessage
   - AskUserQuestion
   - TaskCreate
   - TaskUpdate
@@ -38,6 +40,24 @@ Before advising, load:
 | `gh pr list --state open --json number,title,statusCheckRollup,reviewDecision` | Open PRs with CI/review status | JSON array |
 
 ---
+
+## Agent Teams support
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** when gathering priority data in parallel. This enables:
+- Agents share context and can coordinate mid-flight
+- You can steer priorities in real-time
+- Agents report progress as they complete
+
+**Team setup** (only when flag is enabled):
+```
+TeamCreate("next-team")
+Agent(team_name="next-team", name="fires-checker", prompt="Check infra health and CI for production fires")
+Agent(team_name="next-team", name="comms-checker", prompt="Check unread messages across all channels")
+Agent(team_name="next-team", name="prs-checker", prompt="Find PRs ready to merge — CI green, reviews approved")
+Agent(team_name="next-team", name="sprint-checker", prompt="Check Linear sprint for highest-priority in-progress issues")
+```
+
+If the flag is NOT set, use standard fire-and-forget subagents.
 
 ## Pre-gathered data
 

--- a/claude-ops/skills/ops-projects/SKILL.md
+++ b/claude-ops/skills/ops-projects/SKILL.md
@@ -9,6 +9,8 @@ allowed-tools:
   - Glob
   - Skill
   - Agent
+  - TeamCreate
+  - SendMessage
   - AskUserQuestion
   - TaskCreate
   - TaskUpdate
@@ -41,6 +43,22 @@ Before rendering, load:
 | `gh issue list --repo <repo> --json number,title,labels,state` | Issues | JSON array |
 
 ---
+
+## Agent Teams support
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** when scanning projects in parallel. This enables:
+- Agents share context and can coordinate mid-flight
+- You can steer priorities in real-time
+- Agents report progress as they complete
+
+**Team setup** (only when flag is enabled):
+```
+TeamCreate("projects-team")
+# Spawn one agent per registered project for parallel scanning
+Agent(team_name="projects-team", name="project-<alias>", prompt="Scan <path> for git status, GSD phase, CI, and open PRs")
+```
+
+If the flag is NOT set, use standard fire-and-forget subagents.
 
 ## Pre-gathered git status
 

--- a/claude-ops/skills/ops/SKILL.md
+++ b/claude-ops/skills/ops/SKILL.md
@@ -9,6 +9,8 @@ allowed-tools:
   - Glob
   - Skill
   - Agent
+  - TeamCreate
+  - SendMessage
 effort: medium
 maxTurns: 20
 ---
@@ -52,6 +54,24 @@ Route `$ARGUMENTS` to the correct ops skill:
 | orchestrate, subagents, agents, dispatch, run | `/ops:ops-orchestrate $ARGUMENTS` |
 
 If `$ARGUMENTS` is empty, launch the interactive dashboard: invoke `/ops:ops-dash` directly.
+
+## Agent Teams support
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** when building dashboard sections in parallel. This enables:
+- Agents share context and can coordinate mid-flight
+- You can steer priorities in real-time
+- Agents report progress as they complete
+
+**Team setup** (only when flag is enabled):
+```
+TeamCreate("ops-team")
+Agent(team_name="ops-team", name="daily-ops", prompt="Gather fires, inbox, and unread comms status")
+Agent(team_name="ops-team", name="engineering", prompt="Gather PRs, CI status, and deploy state")
+Agent(team_name="ops-team", name="business", prompt="Gather revenue, Linear sprint, and project progress")
+Agent(team_name="ops-team", name="automation", prompt="Check cron jobs, daemon health, and scheduled tasks")
+```
+
+If the flag is NOT set, use standard fire-and-forget subagents.
 
 ## CLI/API Reference
 

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -9,6 +9,8 @@ allowed-tools:
   - Edit
   - AskUserQuestion
   - Agent
+  - TeamCreate
+  - SendMessage
 effort: high
 maxTurns: 80
 ---
@@ -53,6 +55,27 @@ Every Bash tool call MUST include a short `description` parameter (5-10 words, e
   - **`${CLAUDE_PLUGIN_ROOT}/.mcp.json`** — only to add `${user_config.*}` placeholders, never hardcoded tokens.
   - The user's shell profile (`~/.zshrc` etc.) — append-only, never rewrite.
 - At the top of every wizard step, make sure `$PREFS_PATH`'s parent directory exists: `mkdir -p "$(dirname "$PREFS_PATH")"`. Claude Code creates `~/.claude/plugins/data/ops-ops-marketplace/` on plugin install but don't assume.
+
+---
+
+## Agent Teams support
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** when multiple "Deep hunt" credential agents are needed simultaneously. This enables:
+- Credential scouts run in parallel across Doppler, keychains, browser profiles, and password managers
+- Agents share findings (e.g., Doppler agent finds a partial config → keychain agent knows to skip that service)
+- You can steer mid-hunt: "found the Telegram token, stop hunting for that one"
+
+**Team setup** (only when flag is enabled, multiple deep hunts triggered):
+```
+TeamCreate("setup-hunters")
+Agent(team_name="setup-hunters", name="hunt-telegram", model="haiku", ...)
+Agent(team_name="setup-hunters", name="hunt-sentry", model="haiku", ...)
+Agent(team_name="setup-hunters", name="hunt-shopify", model="haiku", ...)
+```
+
+Each agent reports back its findings. Merge results and present to the user for confirmation.
+
+If the flag is NOT set, use independent fire-and-forget subagents with `run_in_background: true`.
 
 ---
 

--- a/claude-ops/tests/run-all.sh
+++ b/claude-ops/tests/run-all.sh
@@ -39,6 +39,7 @@ run_suite "$TESTS_DIR/test-hooks.sh"
 run_suite "$TESTS_DIR/test-template.sh"
 run_suite "$TESTS_DIR/test-claude-md.sh"
 run_suite "$TESTS_DIR/test-no-secrets.sh"
+run_suite "$TESTS_DIR/test-agent-teams.sh"
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "SUMMARY"

--- a/claude-ops/tests/test-agent-teams.sh
+++ b/claude-ops/tests/test-agent-teams.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# test-agent-teams.sh — Ensures every skill that spawns agents has Agent Teams support
+#
+# Policy: Any SKILL.md that references Agent() or subagent spawning MUST also have:
+#   1. "TeamCreate" and "SendMessage" in allowed-tools
+#   2. An "## Agent Teams support" section in the body
+#   3. A conditional check for CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+#
+# Skills that ONLY run shell scripts (no Agent tool) are exempt.
+
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILLS_DIR="$PLUGIN_ROOT/skills"
+
+pass=0
+fail=0
+skip=0
+
+ok()   { echo "  PASS: $1"; pass=$((pass+1)); }
+err()  { echo "  FAIL: $1"; fail=$((fail+1)); }
+skp()  { echo "  SKIP: $1"; skip=$((skip+1)); }
+
+skill_files=()
+while IFS= read -r -d '' f; do
+  skill_files+=("$f")
+done < <(find "$SKILLS_DIR" -name "SKILL.md" -print0 2>/dev/null)
+
+if [[ ${#skill_files[@]} -eq 0 ]]; then
+  echo "FAIL: No SKILL.md files found in $SKILLS_DIR"
+  exit 1
+fi
+
+echo "Agent Teams compliance audit — ${#skill_files[@]} skills"
+echo ""
+
+for skill_file in "${skill_files[@]}"; do
+  rel="${skill_file#$PLUGIN_ROOT/}"
+  skill_name=$(basename "$(dirname "$skill_file")")
+
+  # Extract frontmatter
+  frontmatter=$(awk '/^---/{c++; if(c==2)exit} c==1' "$skill_file")
+
+  # Check if this skill declares Agent in allowed-tools (authoritative signal)
+  has_agent_tool=false
+  if echo "$frontmatter" | grep -qE "^\s+-\s+Agent\b"; then
+    has_agent_tool=true
+  fi
+
+  # Check if body has actual Agent() invocation patterns (not just prose mentions)
+  has_agent_invocation=false
+  if grep -qE "Agent\(\{|Agent\(team_name|subagent_type:" "$skill_file" 2>/dev/null; then
+    has_agent_invocation=true
+  fi
+
+  # Only flag skills that ACTUALLY use the Agent tool (in allowed-tools or with invocation patterns)
+  # Prose mentions like "spawn a doctor agent" or "subagents" in descriptions don't count
+  if [[ "$has_agent_tool" == "false" && "$has_agent_invocation" == "false" ]]; then
+    skp "$skill_name — no agent usage"
+    continue
+  fi
+
+  echo "Checking: $rel"
+
+  # 1. TeamCreate in allowed-tools
+  if echo "$frontmatter" | grep -qE "^\s+-\s+TeamCreate"; then
+    ok "TeamCreate in allowed-tools"
+  else
+    err "$skill_name: missing 'TeamCreate' in allowed-tools"
+  fi
+
+  # 2. SendMessage in allowed-tools
+  if echo "$frontmatter" | grep -qE "^\s+-\s+SendMessage"; then
+    ok "SendMessage in allowed-tools"
+  else
+    err "$skill_name: missing 'SendMessage' in allowed-tools"
+  fi
+
+  # 3. Agent Teams support section (accepts "## Agent Teams support" or "## Agent Teams" or subsection variants)
+  if grep -qE "^#{2,3} .*(Agent Teams|Teams support)" "$skill_file" 2>/dev/null; then
+    ok "has Agent Teams documentation section"
+  else
+    err "$skill_name: missing '## Agent Teams support' section"
+  fi
+
+  # 4. Feature flag check
+  if grep -q "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" "$skill_file" 2>/dev/null; then
+    ok "checks CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS flag"
+  else
+    err "$skill_name: missing CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS flag check"
+  fi
+
+  # 5. TeamCreate() call in body
+  if grep -qE "TeamCreate\(" "$skill_file" 2>/dev/null; then
+    ok "has TeamCreate() usage example"
+  else
+    err "$skill_name: missing TeamCreate() usage example in body"
+  fi
+
+  # 6. Fallback to standard subagents when flag is off
+  if grep -qiE "(flag is NOT set|flag is not enabled|not set.*subagent|fallback|fire-and-forget)" "$skill_file" 2>/dev/null; then
+    ok "documents fallback when flag is off"
+  else
+    err "$skill_name: missing fallback documentation for when flag is off"
+  fi
+
+  echo ""
+done
+
+echo "---"
+echo "Results: $pass passed, $fail failed, $skip skipped"
+echo ""
+
+if (( fail > 0 )); then
+  echo "To fix: add Agent Teams support sections to failing skills."
+  echo "Template: see skills/ops-fires/SKILL.md for reference."
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- Every ops skill with `Agent` in allowed-tools now has full Agent Teams support (`TeamCreate`/`SendMessage`, documentation section, feature flag check, fallback path)
- New `tests/test-agent-teams.sh` audit script enforces compliance — added to `run-all.sh`
- Fixed Mermaid rendering in README (quoted `/ops` labels)
- New `## Agent Teams` section in README with full table of 16 team names and agent roles
- Version bump 1.1.1 → 1.2.0

## Skills updated (12)
setup, ops, ops-monitor, ops-doctor, ops-marketing, ops-next, ops-projects, ops-ecom, ops-deploy, ops-dash, ops-go + README

## Test plan
- [x] `test-agent-teams.sh` passes (102 passed, 0 failed, 9 skipped)
- [x] `test-no-secrets.sh` passes (11 passed, 0 failed)
- [ ] Mermaid diagram renders on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/112" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation/frontmatter updates plus a new CI audit script; runtime risk is limited to expanded `allowed-tools` permissions for affected skills.
> 
> **Overview**
> Adds **Agent Teams compliance** across skills that spawn agents by extending `allowed-tools` with `TeamCreate`/`SendMessage` and documenting the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` feature-flagged team/fallback behavior in each updated `SKILL.md`.
> 
> Introduces a new CI audit (`tests/test-agent-teams.sh`) and wires it into `tests/run-all.sh` to fail builds when agent-using skills lack the required TeamCreate/SendMessage/docs/flag/fallback patterns.
> 
> Updates `README.md` with an Agent Teams section/table and fixes Mermaid rendering by quoting node labels, and bumps plugin version to `1.2.0` in `plugin.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b923f75d03061afc9739d4b9239107c6f642f3ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->