### PR TITLE
chore: bump package.json to 1.2.0

### DIFF
--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Sync package.json version with plugin.json after v1.2.0 release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only updates the `claude-ops` `package.json` version number with no functional or dependency changes.
> 
> **Overview**
> Updates `claude-ops/package.json` to bump the package version from `1.1.1` to `1.2.0` to align with the latest release metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d747ae69ffbb52fe0f0eaf1455f89a606bb835e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->