### PR TITLE
fix: npm publish with claude-ops-plugin package name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,10 +140,10 @@ jobs:
             --body-file /tmp/bump-pr-body.md \
             || echo "PR may already exist for $BRANCH — skipping create"
 
-  # ─── 3. (Optional) Publish @claude-ops/sdk to npm ──────────────────────────
+  # ─── 3. (Optional) Publish claude-ops-plugin to npm ─────────────────────────
   # No-op when NPM_TOKEN isn't set — gates the whole job behind the secret.
-  # When the maintainer wires NPM_TOKEN into org/repo Actions secrets, this
-  # job builds and publishes the SDK package on every v* tag.
+  # Token must be a granular token with "bypass 2FA" enabled and read+write
+  # access to all packages on the claude-ops-plugin npm account.
   publish-sdk:
     needs: create-release
     runs-on: ubuntu-latest
@@ -183,11 +183,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          # SDK has its own version track; only publish when sdk/package.json
-          # contains a version that doesn't already exist on npm.
+          PKG_NAME=$(node -p "require('./package.json').name")
           PKG_VERSION=$(node -p "require('./package.json').version")
-          if npm view "@claude-ops/sdk@${PKG_VERSION}" version >/dev/null 2>&1; then
-            echo "@claude-ops/sdk@${PKG_VERSION} already on npm — skipping publish"
+          if npm view "${PKG_NAME}@${PKG_VERSION}" version >/dev/null 2>&1; then
+            echo "${PKG_NAME}@${PKG_VERSION} already on npm — skipping publish"
             exit 0
           fi
           npm publish --access public

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@claude-ops/sdk",
+  "name": "claude-ops-plugin",
   "version": "1.0.0",
   "description": "SDK and scaffolder for building claude-ops skills and agents",
   "type": "module",


### PR DESCRIPTION
Renames SDK from @claude-ops/sdk to claude-ops-plugin and updates release workflow. NPM_TOKEN secret updated.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/114" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the npm publishing workflow and package name, which can impact release automation and where artifacts are published if misconfigured. No runtime product code paths are affected.
> 
> **Overview**
> Renames the SDK npm package from `@claude-ops/sdk` to `claude-ops-plugin` in `sdk/package.json`.
> 
> Updates the release workflow’s optional npm publish job to **use the package name from `sdk/package.json`** when checking if a version already exists on npm (instead of hardcoding `@claude-ops/sdk`), and refreshes the accompanying token guidance comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6efc9b400773e0d70f13327773892539fbbabc10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->