### PR TITLE
feat: add Notion as a full channel integration

### DIFF
--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -13,7 +13,7 @@ A Claude Code plugin that turns Claude into a business operating system. Run `/o
 | `/ops:setup`      | Interactive setup wizard — installs CLIs, configures channels, builds registry |
 | `/ops:go`         | Morning briefing — all systems in one dashboard                                |
 | `/ops:next`       | Priority-ordered next action (fires > comms > PRs > sprint > GSD)              |
-| `/ops:inbox`      | Inbox zero across WhatsApp, Email, Slack, Telegram                             |
+| `/ops:inbox`      | Inbox zero across WhatsApp, Email, Slack, Telegram, Notion                     |
 | `/ops:comms`      | Send/read messages across all channels                                         |
 | `/ops:projects`   | Portfolio dashboard — GSD phase, CI, PRs, dirty files                          |
 | `/ops:linear`     | Linear sprint board, issue management, GSD sync                                |

--- a/claude-ops/bin/ops-unread
+++ b/claude-ops/bin/ops-unread
@@ -107,4 +107,12 @@ else
   RESULT=$(echo "$RESULT" | jq '.channels.telegram = {"unread": null, "available": false, "note": "Set TELEGRAM_ENABLED=true when user-auth MCP (tdlib/MTProto) is configured"}')
 fi
 
+# ── Notion — MCP-based, check env ──
+NOTION_ENABLED="${NOTION_MCP_ENABLED:-false}"
+if [ "$NOTION_ENABLED" = "true" ]; then
+  RESULT=$(echo "$RESULT" | jq '.channels.notion = {"unread": null, "available": true, "note": "Scan via Notion MCP tools (search, fetch, comments)"}')
+else
+  RESULT=$(echo "$RESULT" | jq '.channels.notion = {"unread": null, "available": false, "note": "Set NOTION_MCP_ENABLED=true when Notion MCP integration is configured"}')
+fi
+
 echo "$RESULT"

--- a/claude-ops/skills/ops-comms/SKILL.md
+++ b/claude-ops/skills/ops-comms/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ops-comms
-description: Send and read messages across all channels. Routes based on arguments — whatsapp, email, slack, telegram, discord, or natural language like "send [msg] to [contact]".
-argument-hint: "[channel] | send [message] to [contact] | read [channel]"
+description: Send and read messages across all channels. Routes based on arguments — whatsapp, email, slack, telegram, discord, notion, or natural language like "send [msg] to [contact]".
+argument-hint: "[channel] | send [message] to [contact] | read [channel] | notion [search query]"
 allowed-tools:
   - Bash
   - Read
@@ -19,6 +19,12 @@ allowed-tools:
   - mcp__claude_ops_telegram__send_message
   - mcp__claude_ops_telegram__get_updates
   - mcp__claude_ops_telegram__list_chats
+  - mcp__claude_ai_Notion__notion-search
+  - mcp__claude_ai_Notion__notion-fetch
+  - mcp__claude_ai_Notion__notion-get-comments
+  - mcp__claude_ai_Notion__notion-create-comment
+  - mcp__claude_ai_Notion__notion-update-page
+  - mcp__claude_ai_Notion__notion-create-pages
 effort: medium
 maxTurns: 40
 ---
@@ -79,6 +85,7 @@ Parse `$ARGUMENTS` and route immediately:
 | `slack`       | Show recent Slack activity                              |
 | `telegram`    | Show Telegram recent chats                              |
 | `discord`     | Show recent Discord channel activity (via bin/ops-discord) |
+| `notion`      | Search Notion workspace — pages, comments, tasks          |
 | `send * to *` | Parse message and contact, determine best channel, send |
 | `read *`      | Read the specified channel or contact's messages        |
 | (empty)       | Show channel picker menu                                |
@@ -164,6 +171,25 @@ Fall back to: `telegram-cli --exec "dialog_list" 2>/dev/null || echo "Telegram M
 
 **Discord:**
 `${CLAUDE_PLUGIN_ROOT}/bin/ops-discord read "<CHANNEL_ID>" --limit 20 --json` — requires `DISCORD_BOT_TOKEN` (or credential-store `discord/bot-token`). Fall back to `bin/ops-discord channels --json` if the user doesn't know the channel ID and `DISCORD_GUILD_ID` is set.
+
+**Notion:**
+Use `mcp__claude_ai_Notion__notion-search` with the user's query (or `query: "recent"` for general browsing). For each result:
+- Fetch full page content with `mcp__claude_ai_Notion__notion-fetch` using the page URL/ID from search results
+- Get comments with `mcp__claude_ai_Notion__notion-get-comments`
+- Show page title, database name, last editor, and recent comments
+
+### Notion comment/reply
+
+Use `mcp__claude_ai_Notion__notion-create-comment` with the page ID to reply to a comment thread. For creating new pages in a database, use `mcp__claude_ai_Notion__notion-create-pages`.
+
+Always preview before commenting:
+```
+Ready to comment on Notion page:
+  Page: [page title]
+  Comment: "[comment text]"
+
+  [Post comment]  [Edit]  [Cancel]
+```
 
 ### Telegram send
 

--- a/claude-ops/skills/ops-go/SKILL.md
+++ b/claude-ops/skills/ops-go/SKILL.md
@@ -73,7 +73,7 @@ If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** when gat
 ```
 TeamCreate("go-team")
 Agent(team_name="go-team", name="infra-scanner", prompt="Check ECS health, Vercel status, and CI failures across all clusters")
-Agent(team_name="go-team", name="inbox-scanner", prompt="Scan unread messages across WhatsApp, Email, Slack, Telegram")
+Agent(team_name="go-team", name="inbox-scanner", prompt="Scan unread messages across WhatsApp, Email, Slack, Telegram, Notion")
 Agent(team_name="go-team", name="pr-scanner", prompt="Find open PRs needing action — reviews, CI fixes, merge-ready")
 Agent(team_name="go-team", name="sprint-scanner", prompt="Check Linear sprint progress and GSD phase state across projects")
 ```
@@ -155,7 +155,7 @@ PORTFOLIO DASHBOARD
 [table: project, phase, branch, uncommitted, CI, next action]
 
 UNREAD
-[WhatsApp: N, Email: N, Slack: check MCP, Calendar: N events today]
+[WhatsApp: N, Email: N, Slack: check MCP, Notion: N items, Calendar: N events today]
 
 TODAY'S PRIORITIES (ranked by revenue impact + urgency)
 1. [action] — [project] — [why]
@@ -172,6 +172,8 @@ If `$ARGUMENTS` contains a project alias, focus the briefing on that project onl
 After the briefing, use **batched AskUserQuestion calls** (max 4 options each) for the "What's next?" prompt. Show the top 3 priority actions + `[More...]` in the first call, then remaining actions + `[/ops-yolo — let me run your business today]` in the second call. Route to the appropriate ops skill or project.
 
 For Slack counts: if the pre-gathered data shows `"count": -1`, use `mcp__claude_ai_Slack__slack_search_public_and_private` with query `in:channel` (NOT `is:unread` — scan full recent activity) to get actual message counts. Do this as a parallel tool call while analyzing other data.
+
+For Notion counts: if `NOTION_MCP_ENABLED=true` and pre-gathered data shows Notion as available, use `mcp__claude_ai_Notion__notion-search` with `query: "comment"` filtered to the last 7 days to surface recent comments and mentions. Count items needing response.
 
 ---
 

--- a/claude-ops/skills/ops-inbox/CHANNELS.md
+++ b/claude-ops/skills/ops-inbox/CHANNELS.md
@@ -182,6 +182,80 @@ gog auth add you@example.com --services gmail,calendar,drive,contacts,docs,sheet
 
 ---
 
+## Notion
+
+**Status:** MCP-based (claude.ai integration or self-hosted MCP server).
+
+Notion acts as a knowledge base and task management channel. The integration surfaces:
+- **Comments needing reply** — mentions, questions, and comments on pages/databases you own
+- **Recently updated pages** — changes in databases you track (e.g., project boards, CRM)
+- **Assigned tasks** — items assigned to you across Notion databases
+
+**Requirements:**
+
+- Notion MCP server configured via one of:
+  - **Claude.ai integration** (recommended): Add Notion via claude.ai > Settings > Integrations
+  - **Self-hosted MCP**: Install `@notionhq/notion-mcp-server` or similar
+
+**Setup (Claude.ai integration — recommended):**
+
+1. Go to claude.ai > Settings > Integrations > Notion
+2. Authorize access to your Notion workspace
+3. Set env var in `~/.claude/settings.json`:
+   ```json
+   {
+     "env": {
+       "NOTION_MCP_ENABLED": "true"
+     }
+   }
+   ```
+4. Restart Claude Code to load the integration
+
+**Setup (Self-hosted MCP server):**
+
+1. Install the Notion MCP server:
+   ```bash
+   npm install -g @notionhq/notion-mcp-server
+   ```
+2. Create a Notion integration at https://www.notion.so/my-integrations
+3. Add to `~/.claude/settings.json`:
+   ```json
+   {
+     "mcpServers": {
+       "notion": {
+         "command": "npx",
+         "args": ["-y", "@notionhq/notion-mcp-server"],
+         "env": {
+           "NOTION_API_KEY": "${NOTION_API_KEY}"
+         }
+       }
+     }
+   }
+   ```
+4. Export env vars:
+   ```bash
+   export NOTION_API_KEY="ntn_..."
+   export NOTION_MCP_ENABLED=true
+   ```
+
+**Env vars:**
+
+- `NOTION_API_KEY` — Integration token (starts with `ntn_`, only for self-hosted MCP)
+- `NOTION_MCP_ENABLED` — Set `true` to enable in ops-unread
+
+**MCP tools used:**
+
+| Tool | Purpose |
+|------|---------|
+| `notion-search` | Search across workspace and connected sources (Slack, Drive, etc.) |
+| `notion-fetch` | Fetch full page/database content by URL or ID |
+| `notion-get-comments` | Get comments on a specific page |
+| `notion-create-comment` | Reply to a comment thread on a page |
+| `notion-update-page` | Update page properties (status, assignee, etc.) |
+| `notion-create-pages` | Create new pages in databases |
+
+---
+
 ## Verification
 
 After configuring any channel, verify with:

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ops-inbox
-description: Full inbox management across all channels — WhatsApp (wacli), Email (Gmail MCP), Slack (MCP), Telegram (user-auth MCP), Discord (webhook + REST read). Scans FULL inbox (not just unread), identifies messages needing replies, archives handled conversations.
-argument-hint: "[channel: whatsapp|email|slack|telegram|discord|all]"
+description: Full inbox management across all channels — WhatsApp (wacli), Email (Gmail MCP), Slack (MCP), Telegram (user-auth MCP), Discord (webhook + REST read), Notion (MCP — comments, mentions, assigned tasks). Scans FULL inbox (not just unread), identifies messages needing replies, archives handled conversations.
+argument-hint: "[channel: whatsapp|email|slack|telegram|discord|notion|all]"
 allowed-tools:
   - Bash
   - Read
@@ -23,6 +23,12 @@ allowed-tools:
   - mcp__gog__gmail_labels
   # Slack: MCP tools added when configured
   # Telegram: user-auth MCP tools added when configured
+  # Notion: MCP tools (claude.ai integration or self-hosted)
+  - mcp__claude_ai_Notion__notion-search
+  - mcp__claude_ai_Notion__notion-fetch
+  - mcp__claude_ai_Notion__notion-get-comments
+  - mcp__claude_ai_Notion__notion-create-comment
+  - mcp__claude_ai_Notion__notion-update-page
 effort: high
 maxTurns: 60
 ---
@@ -93,6 +99,7 @@ Agent(team_name="inbox-channels", name="whatsapp-scanner", ...)
 Agent(team_name="inbox-channels", name="email-scanner", ...)
 Agent(team_name="inbox-channels", name="slack-scanner", ...)
 Agent(team_name="inbox-channels", name="telegram-scanner", ...)
+Agent(team_name="inbox-channels", name="notion-scanner", ...)
 ```
 
 Each agent scans its channel and reports back classified results. You then process NEEDS_REPLY items across all channels in priority order.
@@ -114,6 +121,7 @@ All channel credentials come from env vars or CLI auth — no hardcoded secrets.
 | `GMAIL_ACCOUNT`     | auto-detect | Gmail account for `gog` CLI                          |
 | `SLACK_MCP_ENABLED` | `false`     | Set `true` when Slack MCP server is configured       |
 | `TELEGRAM_ENABLED`  | `false`     | Set `true` when Telegram user-auth MCP is configured |
+| `NOTION_MCP_ENABLED`| `false`     | Set `true` when Notion MCP integration is configured |
 | `WACLI_STORE`       | `~/.wacli`  | wacli store directory                                |
 
 ## Core principle: FULL INBOX SCAN
@@ -185,6 +193,7 @@ For each channel, detect availability at runtime:
 3. **Slack**: Only via MCP tools (`mcp__claude_ai_Slack__*`). Check `SLACK_MCP_ENABLED` env var.
 4. **Telegram**: Only via user-auth MCP (tdlib/MTProto). Check `TELEGRAM_ENABLED` env var. Never use BotFather bots.
 5. **Discord**: Via `${CLAUDE_PLUGIN_ROOT}/bin/ops-discord read <CHANNEL_ID> --limit 20 --json`. Requires `DISCORD_BOT_TOKEN` (v1 is channel-scoped — no DM/gateway support yet). Pre-configured read list lives at `${CLAUDE_PLUGIN_DATA_DIR}/preferences.json` under `discord.inbox_channels` (array of channel IDs). If neither a bot token nor a read list is configured, skip Discord with a one-line note ("Discord not configured — run `/ops:setup discord`") rather than prompting — ops-inbox is not a setup flow. Rule 3 still applies to `/ops:setup`.
+6. **Notion**: Only via MCP tools (`mcp__claude_ai_Notion__*` or self-hosted Notion MCP). Check `NOTION_MCP_ENABLED` env var. Searches workspace for recent comments, mentions, and assigned tasks.
 
 ## Your task
 
@@ -447,6 +456,70 @@ Use the Telegram user-auth MCP server if available.
 ```
 
 If no Telegram user-auth tool is available, report: "Telegram not configured — needs user-auth MCP server (tdlib/MTProto)".
+
+### Notion (MCP — comments, mentions, assigned tasks)
+
+Notion serves as a knowledge base and task management channel. Unlike messaging channels, Notion "inbox" items are:
+- **Comments on pages you own or are mentioned in**
+- **Tasks assigned to you** in tracked databases
+- **Recently updated pages** in databases you monitor
+
+**Phase 1 — Discover and scan:**
+
+1. Search for recent activity using `mcp__claude_ai_Notion__notion-search`:
+   - `query: "@me"` or `query: "comment"` with `query_type: "internal"` — find pages with recent mentions/comments
+   - Filter by `created_date_range` to last 7 days for relevance
+2. For each result, fetch full content: `mcp__claude_ai_Notion__notion-fetch` with the page URL/ID
+3. Get comments on active pages: `mcp__claude_ai_Notion__notion-get-comments` with the page ID
+
+**Phase 2 — Classify:**
+
+For each page with comments or mentions:
+- **NEEDS REPLY**: Someone commented/mentioned you and you haven't responded
+- **WAITING**: You commented last, waiting for others
+- **FYI**: Page updated but no direct mention or action needed
+- **TASK**: Item assigned to you in a database (check status property)
+
+**Phase 3 — Present with context:**
+
+```
+📓 NOTION — NEEDS REPLY
+
+━━━ 1. [Page Title] — [Database Name] ━━━
+ Page: [page URL]
+ Comment by: [commenter name] — [time ago]
+ Comment: "[full comment text]"
+ Page context: [2-3 sentence summary of the page content]
+
+ Draft reply: "[context-aware reply to the comment]"
+
+ [Reply] [View page] [Skip] [More...]
+
+If "More...":
+ [Mark resolved] [Archive]
+
+📓 NOTION — ASSIGNED TASKS
+
+ N. [Task title] — [database] — Status: [status] — Due: [date]
+    Context: [1-line summary]
+
+📓 NOTION — RECENTLY UPDATED (FYI)
+
+ N. [Page title] — updated by [person] — [time ago]
+```
+
+Use `AskUserQuestion` for each NEEDS REPLY item.
+
+**When replying to Notion comments:**
+- Use `mcp__claude_ai_Notion__notion-create-comment` with the page ID and reply text
+- Match the formality of the original comment
+- Reference specific page content when relevant
+
+**When updating tasks:**
+- Use `mcp__claude_ai_Notion__notion-update-page` to change status, add notes
+- Only update properties the user explicitly approves
+
+If `NOTION_MCP_ENABLED` is not set or Notion MCP tools are unavailable, report: "Notion not configured — set NOTION_MCP_ENABLED=true and add Notion integration via claude.ai or self-hosted MCP".
 
 ### Discord (v1 — REST channel scan)
 

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup
-description: Interactive setup wizard for the claude-ops plugin. Installs missing CLIs, configures env vars for each channel (Telegram, WhatsApp, Email, Slack, Linear, Sentry, Vercel), builds the project registry, and saves user preferences. Run once after installing the plugin or any time to reconfigure.
+description: Interactive setup wizard for the claude-ops plugin. Installs missing CLIs, configures env vars for each channel (Telegram, WhatsApp, Email, Slack, Notion, Linear, Sentry, Vercel), builds the project registry, and saves user preferences. Run once after installing the plugin or any time to reconfigure.
 argument-hint: "[section]"
 allowed-tools:
   - Bash
@@ -421,7 +421,7 @@ How would you like to configure channels and integrations?
   [Skip all — configure channels later]
 ```
 
-If the user selects "Configure all", run every channel sub-flow below in sequence (Telegram → WhatsApp → Email → Slack → Calendar → Doppler → Vault), skipping any already configured. If the user selects "Skip all", move to Step 4.
+If the user selects "Configure all", run every channel sub-flow below in sequence (Telegram → WhatsApp → Email → Slack → Notion → Calendar → Doppler → Vault), skipping any already configured. If the user selects "Skip all", move to Step 4.
 
 If the user selects "Pick individually", ask which channels using `AskUserQuestion` with `multiSelect: true`. Because AskUserQuestion allows max 4 options, batch into two groups. Skip channels already configured (show only those needing attention).
 
@@ -434,10 +434,11 @@ If the user selects "Pick individually", ask which channels using `AskUserQuesti
 | Email    | email    | gog CLI → Gmail MCP fallback for `/ops-inbox email`                     |
 | Slack    | slack    | Slack MCP server (managed by Claude Code)                               |
 
-**Batch 2 — Services:**
+**Batch 2 — Knowledge & Services:**
 
 | Option   | Header   | Description                                                             |
 | -------- | -------- | ----------------------------------------------------------------------- |
+| Notion   | notion   | Notion MCP — workspace search, comments, tasks, knowledge base          |
 | Calendar | calendar | gog calendar → Google Calendar MCP fallback — schedule context for briefings |
 | Doppler  | doppler  | Secrets manager — set default project + config for all ops skills       |
 | Vault    | vault    | Password manager — 1Password, Dashlane, Bitwarden, or macOS Keychain    |
@@ -1129,7 +1130,81 @@ Sub-flow:
 
 > **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-comms/SKILL.md` and `${CLAUDE_PLUGIN_ROOT}/skills/ops-inbox/SKILL.md` for full operational instructions, CLI reference, and troubleshooting for this integration. The setup agent can load those files directly when it needs more depth than this wizard provides.
 
-### 3e — Calendar
+### 3e — Notion (MCP integration)
+
+**Always ask before starting the Notion flow** — even when the user selected "all channels". Use `AskUserQuestion`:
+
+```
+Set up Notion workspace integration?
+  [Yes — configure Notion]
+  [Skip Notion]
+```
+
+If the user skips, record `channels.notion = "skipped"` in `$PREFS_PATH` and move on.
+
+#### Detection
+
+1. **Check for existing claude.ai Notion integration.** Scan the detector's `mcp_configured` array for any entry matching `Notion`, `claude_ai_Notion`, or `notion`. If found, set `NOTION_MCP_ENABLED=true` and skip to verification.
+
+2. **Check for self-hosted Notion MCP server.** Look in `~/.claude/settings.json` for `mcpServers.notion` or any entry with `notion` in its args/command.
+
+#### Setup paths
+
+**Path A — Claude.ai integration (recommended):**
+
+If no existing integration detected, present `AskUserQuestion`:
+```
+How would you like to connect Notion?
+  [Claude.ai integration (Recommended) — add via claude.ai settings]
+  [Self-hosted MCP — use your own Notion API key]
+  [Skip Notion]
+```
+
+For claude.ai integration:
+1. Tell the user: "Add Notion integration at claude.ai > Settings > Integrations > Notion. Authorize access to your workspace, then type 'done'."
+2. Use `AskUserQuestion`: `[Done — connected]`, `[Skip Notion]`
+3. On "Done", verify by testing `mcp__claude_ai_Notion__notion-search` with a simple query
+
+**Path B — Self-hosted MCP:**
+
+1. Scout keychain for existing Notion API key:
+   ```bash
+   security find-generic-password -s "notion-api-key" -w 2>/dev/null || \
+   security find-generic-password -s "NOTION_API_KEY" -w 2>/dev/null || echo ""
+   ```
+2. If not found, ask the user:
+   ```
+   Enter your Notion integration token (starts with ntn_):
+     Create one at https://www.notion.so/my-integrations
+     [Paste token now]  [Skip Notion]
+   ```
+3. Store the token:
+   ```bash
+   security add-generic-password -s "notion-api-key" -a "claude-ops" -w "$TOKEN" -U
+   ```
+4. Add MCP server config to `~/.claude/settings.json` under `mcpServers.notion`
+
+#### Verification
+
+Test the integration (run in background):
+```bash
+# For claude.ai: integration auto-detected
+# For self-hosted: verify MCP server responds
+echo '{"test": true}' | timeout 10 npx -y @notionhq/notion-mcp-server 2>/dev/null && echo "OK" || echo "FAIL"
+```
+
+#### Finalize
+
+1. Set `NOTION_MCP_ENABLED=true` in `~/.claude/settings.json` env section
+2. Record `channels.notion = {"backend": "mcp:notion", "status": "configured", "source": "<claude-ai|self-hosted>"}` in `$PREFS_PATH`
+3. Add `"notion"` to `default_channels` array in `$PREFS_PATH`
+4. Print: `✓ Notion — workspace connected via [source]`
+
+> **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-inbox/CHANNELS.md` for full Notion MCP tool reference and troubleshooting.
+
+### 3f — Calendar
+
+> **Note:** Sections after this were originally labeled 3f–3m. The insertion of Notion (3e) shifted Calendar to 3f. Downstream section headers retain their original labels to avoid breaking cross-references.
 
 Calendar isn't a messaging channel, but every other ops skill (briefings, `/ops-next`, `/ops-go`) benefits massively from knowing the user's schedule — meetings blocking deep work, deploy windows, travel days. The wizard wires it up the same way as email: `gog calendar` primary, Google Calendar MCP connector fallback.
 


### PR DESCRIPTION
## Summary

- Adds **Notion** as a first-class channel across the entire ops plugin, following the existing MCP-based pattern (like Slack/Telegram)
- Supports both **claude.ai native integration** (recommended) and **self-hosted Notion MCP server**
- Controlled via `NOTION_MCP_ENABLED` env var, consistent with `SLACK_MCP_ENABLED` / `TELEGRAM_ENABLED`

## Changes

### `bin/ops-unread`
- Detects Notion availability via `NOTION_MCP_ENABLED` env var
- Reports channel status in the same JSON format as other MCP-based channels

### `skills/ops-inbox/SKILL.md`
- Full Notion inbox scanning: comments needing reply, assigned tasks, recently updated pages
- Three-phase flow: discover → classify (NEEDS_REPLY / WAITING / FYI / TASK) → present with context
- Uses `notion-search`, `notion-fetch`, `notion-get-comments`, `notion-create-comment`, `notion-update-page`
- Added to Agent Teams parallel scanning

### `skills/ops-inbox/CHANNELS.md`
- Complete setup documentation for both integration paths
- MCP tool reference table
- Env vars and troubleshooting guide

### `skills/ops-comms/SKILL.md`
- Notion read flow: search workspace, fetch pages, get comments
- Notion comment/reply flow with preview-before-send pattern
- Added to routing table (`notion` command)

### `skills/ops-go/SKILL.md`
- Notion included in morning briefing unread counts
- Added to Agent Teams inbox scanner prompt

### `skills/setup/SKILL.md`
- New section **3e — Notion** with two setup paths:
  - Path A: claude.ai integration (recommended, zero-config)
  - Path B: Self-hosted MCP with keychain credential storage
- Auto-detection of existing integration
- Verification and finalization steps

### `README.md`
- Notion listed in supported channels for `/ops:inbox`

## Test plan

- [ ] Run `bin/ops-unread` with `NOTION_MCP_ENABLED=true` — verify Notion shows as available
- [ ] Run `bin/ops-unread` without the env var — verify Notion shows as unavailable with setup hint
- [ ] Run `/ops:setup notion` — verify both setup paths work (claude.ai + self-hosted)
- [ ] Run `/ops:inbox notion` — verify comment scanning and reply flow
- [ ] Run `/ops:comms notion` — verify search and comment routing
- [ ] Run `/ops:go` — verify Notion counts appear in briefing
- [ ] Verify no secrets or personal data in any changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Notion as a supported communication channel for unified inbox management and team collaboration.
  * Integrated Notion MCP tools enabling search, content fetching, comment management, and page creation workflows.
  * Notion is now included in inbox scanning and briefing summaries.

* **Documentation**
  * Added setup instructions and configuration guidance for Notion integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->