### PR TITLE
fix: Notion integration fixes + bump to v1.3.0

### DIFF
--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/claude-ops/skills/ops-comms/SKILL.md
+++ b/claude-ops/skills/ops-comms/SKILL.md
@@ -173,10 +173,12 @@ Fall back to: `telegram-cli --exec "dialog_list" 2>/dev/null || echo "Telegram M
 `${CLAUDE_PLUGIN_ROOT}/bin/ops-discord read "<CHANNEL_ID>" --limit 20 --json` — requires `DISCORD_BOT_TOKEN` (or credential-store `discord/bot-token`). Fall back to `bin/ops-discord channels --json` if the user doesn't know the channel ID and `DISCORD_GUILD_ID` is set.
 
 **Notion:**
-Use `mcp__claude_ai_Notion__notion-search` with the user's query (or `query: "recent"` for general browsing). For each result:
+Use `mcp__claude_ai_Notion__notion-search` with the user's query (or `query: ""` sorted by `last_edited_time` for general browsing). For each result:
 - Fetch full page content with `mcp__claude_ai_Notion__notion-fetch` using the page URL/ID from search results
 - Get comments with `mcp__claude_ai_Notion__notion-get-comments`
 - Show page title, database name, last editor, and recent comments
+
+**Notion API fallback:** If MCP tools fail and `NOTION_API_KEY` is set, use `curl -s -H "Authorization: Bearer $NOTION_API_KEY" -H "Notion-Version: 2022-06-28" -X POST https://api.notion.com/v1/search -d '{"query":"<QUERY>","page_size":10}'`
 
 ### Notion comment/reply
 

--- a/claude-ops/skills/ops-go/SKILL.md
+++ b/claude-ops/skills/ops-go/SKILL.md
@@ -173,7 +173,7 @@ After the briefing, use **batched AskUserQuestion calls** (max 4 options each) f
 
 For Slack counts: if the pre-gathered data shows `"count": -1`, use `mcp__claude_ai_Slack__slack_search_public_and_private` with query `in:channel` (NOT `is:unread` — scan full recent activity) to get actual message counts. Do this as a parallel tool call while analyzing other data.
 
-For Notion counts: if `NOTION_MCP_ENABLED=true` and pre-gathered data shows Notion as available, use `mcp__claude_ai_Notion__notion-search` with `query: "comment"` filtered to the last 7 days to surface recent comments and mentions. Count items needing response.
+For Notion counts: if `NOTION_MCP_ENABLED=true` and pre-gathered data shows Notion as available, use `mcp__claude_ai_Notion__notion-search` with `query: ""` sorted by `last_edited_time` descending to surface recently active pages. Then call `mcp__claude_ai_Notion__notion-get-comments` on the top results to find comments needing response. Note: Notion search does not support date range filters — sort by recency and limit to the first 10-20 results instead.
 
 ---
 

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -29,6 +29,7 @@ allowed-tools:
   - mcp__claude_ai_Notion__notion-get-comments
   - mcp__claude_ai_Notion__notion-create-comment
   - mcp__claude_ai_Notion__notion-update-page
+  - mcp__claude_ai_Notion__notion-create-pages
 effort: high
 maxTurns: 60
 ---
@@ -467,10 +468,12 @@ Notion serves as a knowledge base and task management channel. Unlike messaging 
 **Phase 1 — Discover and scan:**
 
 1. Search for recent activity using `mcp__claude_ai_Notion__notion-search`:
-   - `query: "@me"` or `query: "comment"` with `query_type: "internal"` — find pages with recent mentions/comments
-   - Filter by `created_date_range` to last 7 days for relevance
+   - Use broad queries like `query: ""` (empty string returns recent pages) or topic-specific terms
+   - Use `filter: {"property": "object", "value": "page"}` to limit to pages (not databases)
+   - Sort by `last_edited_time` descending to surface recent activity
+   - Note: Notion search is full-text over titles/content — it does NOT support mention-based queries or date range filters
 2. For each result, fetch full content: `mcp__claude_ai_Notion__notion-fetch` with the page URL/ID
-3. Get comments on active pages: `mcp__claude_ai_Notion__notion-get-comments` with the page ID
+3. Get comments on active pages: `mcp__claude_ai_Notion__notion-get-comments` with the page ID — scan comment authors and timestamps to determine which need replies
 
 **Phase 2 — Classify:**
 
@@ -518,6 +521,15 @@ Use `AskUserQuestion` for each NEEDS REPLY item.
 **When updating tasks:**
 - Use `mcp__claude_ai_Notion__notion-update-page` to change status, add notes
 - Only update properties the user explicitly approves
+
+**API fallback (when MCP is down):**
+If Notion MCP tools fail or are unavailable but `NOTION_API_KEY` is set, fall back to direct API:
+```bash
+curl -s -H "Authorization: Bearer $NOTION_API_KEY" -H "Notion-Version: 2022-06-28" \
+  -H "Content-Type: application/json" \
+  -X POST https://api.notion.com/v1/search \
+  -d '{"sort":{"direction":"descending","timestamp":"last_edited_time"},"page_size":10}'
+```
 
 If `NOTION_MCP_ENABLED` is not set or Notion MCP tools are unavailable, report: "Notion not configured — set NOTION_MCP_ENABLED=true and add Notion integration via claude.ai or self-hosted MCP".
 

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -1188,9 +1188,13 @@ For claude.ai integration:
 
 Test the integration (run in background):
 ```bash
-# For claude.ai: integration auto-detected
-# For self-hosted: verify MCP server responds
-echo '{"test": true}' | timeout 10 npx -y @notionhq/notion-mcp-server 2>/dev/null && echo "OK" || echo "FAIL"
+# For claude.ai: integration auto-detected — test via MCP tool call
+# For self-hosted: verify API key works
+if [ -n "$NOTION_API_KEY" ]; then
+  curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $NOTION_API_KEY" -H "Notion-Version: 2022-06-28" https://api.notion.com/v1/users/me | grep -q "200" && echo "OK" || echo "FAIL"
+else
+  echo "OK — claude.ai integration (verify via MCP tool call after restart)"
+fi
 ```
 
 #### Finalize
@@ -1203,8 +1207,6 @@ echo '{"test": true}' | timeout 10 npx -y @notionhq/notion-mcp-server 2>/dev/nul
 > **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-inbox/CHANNELS.md` for full Notion MCP tool reference and troubleshooting.
 
 ### 3f — Calendar
-
-> **Note:** Sections after this were originally labeled 3f–3m. The insertion of Notion (3e) shifted Calendar to 3f. Downstream section headers retain their original labels to avoid breaking cross-references.
 
 Calendar isn't a messaging channel, but every other ops skill (briefings, `/ops-next`, `/ops-go`) benefits massively from knowing the user's schedule — meetings blocking deep work, deploy windows, travel days. The wizard wires it up the same way as email: `gog calendar` primary, Google Calendar MCP connector fallback.
 
@@ -1265,11 +1267,11 @@ Downstream skills (`/ops-go`, `/ops-next`, `/ops-fires`) read `channels.calendar
 
 > **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-go/SKILL.md` for full operational instructions, CLI reference, and troubleshooting for this integration (calendar context feeds `/ops:go` briefings). The setup agent can load that file directly when it needs more depth than this wizard provides.
 
-### 3f — Doppler (secrets management)
+### 3g — Doppler (secrets management)
 
 Doppler is a secrets manager that injects environment variables at runtime. When configured, all ops skills can query secrets via `doppler secrets get` instead of reading from dotfiles or keychain. The wizard checks presence, auth status, and default project context.
 
-#### Step 3f.1 — Presence
+#### Step 3g.1 — Presence
 
 ```bash
 command -v doppler
@@ -1297,7 +1299,7 @@ Where the OS-specific command is:
 
 Run the chosen command in the background, capture stdout/stderr, and report success/failure. If the user skips, record `secrets_manager: "none"` in `$PREFS_PATH` and end this sub-flow.
 
-#### Step 3f.2 — Auth status
+#### Step 3g.2 — Auth status
 
 Run:
 
@@ -1319,7 +1321,7 @@ Run `doppler login` via Bash tool with `run_in_background: true` (it opens a bro
 
 Never display the name or email unless they came from `doppler me` output in this session.
 
-#### Step 3f.3 — Project context
+#### Step 3g.3 — Project context
 
 If authenticated, list available projects:
 
@@ -1370,7 +1372,7 @@ Print confirmation:
 ✓ Doppler default context set: <project>/<config>
 ```
 
-#### Step 3f.4 — Document for agents
+#### Step 3g.4 — Document for agents
 
 Print this note so it's visible in the session:
 
@@ -1388,11 +1390,11 @@ Individual skills can override with --project / --config flags.
 
 > **Deep-dive:** no dedicated skill ships with Doppler — see `${CLAUDE_PLUGIN_ROOT}/docs/memories-system.md` (Runtime Context section) for how downstream skills consume the `secrets_manager` / `doppler.*` values from `$PREFS_PATH` and resolve `doppler:KEY_NAME` references at runtime. The setup agent can load that file directly when it needs more depth than this wizard provides.
 
-### 3g — Password Manager (credential vault)
+### 3h — Password Manager (credential vault)
 
 Ops agents frequently need to look up credentials (API keys, database passwords, service tokens) on your behalf. This step wires up a password manager so those queries can be automated via a standard command template stored in `$PREFS_PATH`.
 
-#### Step 3g.1 — Auto-detect installed managers
+#### Step 3h.1 — Auto-detect installed managers
 
 Run these in parallel:
 
@@ -1405,7 +1407,7 @@ security find-generic-password -s "test" 2>&1 | head -1             # macOS Keyc
 
 Parse each result to classify as `authenticated`, `needs_unlock`, `not_installed`, or `available` (Keychain is always `available`).
 
-#### Step 3g.2 — Present findings
+#### Step 3h.2 — Present findings
 
 Show only what was detected via `AskUserQuestion`. **Max 4 options per call.** Since macOS Keychain and Skip are always shown, you have room for at most 2 detected managers per call. If all 3 CLIs (1Password, Dashlane, Bitwarden) are installed, batch into two calls:
 
@@ -1434,7 +1436,7 @@ Call 2:
 
 Never show managers that aren't installed. Always show macOS Keychain and Skip. If none of the CLIs are installed, skip straight to showing just `[macOS Keychain — always available]` and `[Skip]`.
 
-#### Step 3g.3 — Configure selected manager
+#### Step 3h.3 — Configure selected manager
 
 **1Password (`op`):**
 
@@ -1506,7 +1508,7 @@ Never show managers that aren't installed. Always show macOS Keychain and Skip. 
    security find-generic-password -s "{{name}}" -w
    ```
 
-#### Step 3g.4 — Write to preferences
+#### Step 3h.4 — Write to preferences
 
 After the user selects and configures a manager, write to `$PREFS_PATH`:
 
@@ -1534,7 +1536,7 @@ Merge with the existing file (`jq '. + { ... }'`) — never overwrite. Example f
 
 If the user picks Skip, write `"password_manager": "none"` so subsequent runs don't re-prompt unless the user explicitly runs `/ops:setup vault`.
 
-#### Step 3g.5 — Document for agents
+#### Step 3h.5 — Document for agents
 
 After saving, print this note once:
 
@@ -1570,15 +1572,15 @@ Omit this line entirely if `password_manager` is `"none"` or unset.
 
 #### Invocation shortcut
 
-Add to the shortcuts table: `vault`, `password-manager`, `pm` → Step 3g
+Add to the shortcuts table: `vault`, `password-manager`, `pm` → Step 3h
 
 > **Deep-dive:** no dedicated skill ships with the password manager integration — see `${CLAUDE_PLUGIN_ROOT}/docs/memories-system.md` (Runtime Context section) for how downstream skills resolve `password_manager` + related vault references from `$PREFS_PATH`. Privacy-and-security guidance lives in this SKILL.md (keychain-only storage of API hashes/session strings, `umask 077` for bridge files). The setup agent can load that file directly when it needs more depth than this wizard provides.
 
 ---
 
-### 3h — Ecommerce (Shopify + dynamic partners)
+### 3i — Ecommerce (Shopify + dynamic partners)
 
-#### Step 3h.1 — Auto-scan for existing Shopify credentials
+#### Step 3i.1 — Auto-scan for existing Shopify credentials
 
 **Before asking for anything**, run the Universal Credential Auto-Scan for all Shopify-related vars simultaneously:
 
@@ -1623,16 +1625,16 @@ dcli password shopify --output json 2>/dev/null | jq -r '.[].url // empty' | gre
 grep -rhE 'myshopify\.com|SHOPIFY_STORE' ~/Projects/*/.env* 2>/dev/null | grep -v '^#' | head -5
 ```
 
-**Important**: Do NOT report "No Shopify credentials found" until ALL scan sources have been checked. If tokens are missing but store URLs are found (e.g. from Chrome history or Dashlane), report: `"Found Shopify store(s): <stores>. No API token found — you'll need to create one."` and skip straight to Step 3h.3 (token) with the store URL pre-filled.
+**Important**: Do NOT report "No Shopify credentials found" until ALL scan sources have been checked. If tokens are missing but store URLs are found (e.g. from Chrome history or Dashlane), report: `"Found Shopify store(s): <stores>. No API token found — you'll need to create one."` and skip straight to Step 3i.3 (token) with the store URL pre-filled.
 
 If both `store_url` and `admin_token` are already found, show:
 ```
 ✓ Shopify — already configured (<store_url>)
   [Keep existing]  [Reconfigure]
 ```
-If the user keeps existing, skip to Step 3h.4. If reconfiguring or no values found, continue.
+If the user keeps existing, skip to Step 3i.4. If reconfiguring or no values found, continue.
 
-#### Step 3h.2 — Shopify store URL
+#### Step 3i.2 — Shopify store URL
 
 If `SHOPIFY_STORE_URL` was found in the auto-scan, present it using the Universal Credential Auto-Scan prompt format. Only ask via free text if no value was found:
 ```
@@ -1643,7 +1645,7 @@ Enter your Shopify store URL:
 
 Validate the input: strip `https://`, strip trailing slash, check that the result ends with `.myshopify.com`. If invalid, ask again with a correction note.
 
-#### Step 3h.3 — Shopify Admin API token
+#### Step 3i.3 — Shopify Admin API token
 
 If `SHOPIFY_ACCESS_TOKEN`, `SHOPIFY_ADMIN_TOKEN`, or `SHOPIFY_ADMIN_API_ACCESS_TOKEN` was found in the auto-scan, present it using the Universal Credential Auto-Scan prompt format with truncated display (`shpat_508b...682e`). Only ask via free text if no value was found.
 
@@ -1693,7 +1695,7 @@ curl -s -H "X-Shopify-Access-Token: $TOKEN" \
 ```
 Expect a shop name string. If the response contains `errors` or `{"shop":null}`, show the error and ask the user to check the token scopes. Print `✓ Shopify — connected (<shop name>)`.
 
-#### Step 3h.4 — Dynamic ecommerce partners
+#### Step 3i.4 — Dynamic ecommerce partners
 
 After Shopify is configured, ask via `AskUserQuestion` (free text):
 ```
@@ -1769,7 +1771,7 @@ For any partner not in this table, always web search for current auth docs befor
 
 ---
 
-### 3i — Marketing (Klaviyo, Meta Ads, GA4, Search Console)
+### 3j — Marketing (Klaviyo, Meta Ads, GA4, Search Console)
 
 **Before showing the service selector**, run the Universal Credential Auto-Scan for all marketing vars simultaneously:
 
@@ -1871,7 +1873,7 @@ Write to `$PREFS_PATH` (merge):
 }
 ```
 
-Same Doppler-reference pattern as Step 3h — prefer `doppler:KEY_NAME` over raw tokens when Doppler is configured.
+Same Doppler-reference pattern as Step 3i — prefer `doppler:KEY_NAME` over raw tokens when Doppler is configured.
 
 #### Dynamic marketing partners
 
@@ -1883,7 +1885,7 @@ Any other marketing tools you'd like to connect?
   Type names separated by commas, or leave blank to skip.
 ```
 
-If the user provides partner names, apply the same dynamic partner loop as Step 3h.4 — for each partner:
+If the user provides partner names, apply the same dynamic partner loop as Step 3i.4 — for each partner:
 
 1. **Research credentials** via web search: `"<partner name> API authentication developer docs 2025"`
 2. **Ask for credentials** via `AskUserQuestion` with instructions sourced from the docs
@@ -1923,7 +1925,7 @@ For any partner not in this table, always web search for current auth docs befor
 
 ---
 
-### 3j — Voice (Bland AI, ElevenLabs, Groq)
+### 3k — Voice (Bland AI, ElevenLabs, Groq)
 
 **Before showing the service selector**, run the Universal Credential Auto-Scan for all voice vars simultaneously:
 
@@ -2022,7 +2024,7 @@ Same Doppler-reference pattern — prefer `doppler:KEY_NAME` over raw tokens whe
 
 ---
 
-### 3k — Revenue (Stripe + RevenueCat)
+### 3l — Revenue (Stripe + RevenueCat)
 
 **Before showing the service selector**, run the Universal Credential Auto-Scan for all revenue vars simultaneously (Rule 4 — background these):
 
@@ -2173,7 +2175,7 @@ Prefer a Doppler reference (`doppler:STRIPE_SECRET_KEY`, `doppler:REVENUECAT_API
 
 ---
 
-### 3m — Notifications (fires-watcher sinks)
+### 3n — Notifications (fires-watcher sinks)
 
 Sets up push notifications for CRITICAL/HIGH fires so the user stops having to poll `/ops:fires` manually. Gated behind the `fires-watcher` daemon service (disabled by default).
 
@@ -2279,7 +2281,7 @@ Expect `{"status": "ok", ...}` within 60 seconds.
 
 > **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/docs/notifications.md`, `${CLAUDE_PLUGIN_ROOT}/scripts/ops-fires-watcher.sh`, and `${CLAUDE_PLUGIN_ROOT}/scripts/ops-notify.sh` for sink priority rationale, debounce rules, and a troubleshooting walk-through.
 
-### 3l — Discord (webhook + optional bot)
+### 3m — Discord (webhook + optional bot)
 
 Discord is a v1 integration — webhook-based send + REST channel reads. DM + gateway support are deferred to a v2 issue. The send-side webhook also supplies the Discord notification sink consumed by `scripts/ops-notify.sh`, so configuring it here covers both `/ops:comms discord send` and ops-fires alerts.
 
@@ -2746,12 +2748,13 @@ If `$ARGUMENTS` contains a specific section name, jump straight to that section:
 | `whatsapp`, `wacli`, `whatsapp-doctor` | Step 3b |
 | `email`                                | Step 3c |
 | `slack`                                | Step 3d |
-| `calendar`, `cal`                      | Step 3e |
-| `doppler`, `secrets`                   | Step 3f |
-| `vault`, `password-manager`, `pm`      | Step 3g |
-| `ecom`, `shopify`, `store`             | Step 3h |
-| `marketing`, `klaviyo`, `ads`, `meta`, `ga4` | Step 3i |
-| `voice`, `bland`, `elevenlabs`, `tts`  | Step 3j |
+| `notion`                               | Step 3e |
+| `calendar`, `cal`                      | Step 3f |
+| `doppler`, `secrets`                   | Step 3g |
+| `vault`, `password-manager`, `pm`      | Step 3h |
+| `ecom`, `shopify`, `store`             | Step 3i |
+| `marketing`, `klaviyo`, `ads`, `meta`, `ga4` | Step 3j |
+| `voice`, `bland`, `elevenlabs`, `tts`  | Step 3k |
 | `mcp`                                  | Step 4  |
 | `registry`, `projects`                 | Step 5  |
 | `daemon`, `background`                 | Step 5b |


### PR DESCRIPTION
## Summary

- Fix invalid Notion search API parameters (`@me`, `created_date_range` don't exist in the API)
- Add `notion-create-pages` to inbox allowed-tools (was missing)
- Add curl API fallback for when Notion MCP is down (matches Sentry/Linear pattern)
- Fix broken setup verification command (was piping to npx, now uses proper API health check)
- Renumber all setup wizard sections 3e→3n after Notion insertion at 3e
- Bump version to 1.3.0

## Test plan

- [x] Verified all section cross-references resolve correctly
- [x] Verified no stale step numbers remain
- [ ] Run `/ops:inbox notion` — verify search uses valid API params
- [ ] Run `/ops:setup notion` — verify verification command works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are primarily documentation/agent-instruction updates; main risk is altered Notion query/verification behavior in ops skills if assumptions about Notion API/MCP differ from reality.
> 
> **Overview**
> Updates Notion guidance across ops skills to use valid `notion-search` inputs (drop unsupported mention/date filtering), instead relying on empty-query + `last_edited_time` sorting and then scanning comments via `notion-get-comments`.
> 
> Adds resilience when Notion MCP is unavailable by documenting a direct `curl` Notion Search API fallback, and expands Notion tool permissions in `ops-inbox` to include `mcp__claude_ai_Notion__notion-create-pages`.
> 
> Fixes `/ops:setup notion` verification to perform an actual Notion API health check, renumbers setup wizard section references after inserting Notion, and bumps `claude-ops-bin` version to `1.3.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9ff91cfa7b91e9b0dd07b1ab92faf97c4b60e57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Notion API fallback mechanism for operations when MCP tools are unavailable
  * New page creation capability in Notion integration

* **Documentation**
  * Updated Notion search procedures with refined sorting and discovery guidance
  * Enhanced comment and unread item detection workflows
  * Restructured setup wizard with renumbered configuration steps

* **Chores**
  * Released version 1.3.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->