### PR TITLE
feat: external project support in all dashboards

### DIFF
--- a/claude-ops/agents/infra-monitor.md
+++ b/claude-ops/agents/infra-monitor.md
@@ -43,6 +43,9 @@ export AWS_DEFAULT_REGION="$REGION"
 # 4. Registry (optional — drives project-scoped deep scans)
 REGISTRY="${CLAUDE_PLUGIN_ROOT}/scripts/registry.json"
 [ -f "$REGISTRY" ] || REGISTRY="${CLAUDE_PLUGIN_ROOT}/scripts/registry.example.json"
+
+# 5. External projects (non-repo — Shopify, Linear, Slack, Notion, custom)
+EXTERNAL_JSON=$("${CLAUDE_PLUGIN_ROOT}/bin/ops-external" 2>/dev/null || echo '[]')
 ```
 
 ## Service discovery
@@ -388,6 +391,14 @@ done
     ]
   },
   "ci": { "recent_runs": [] },
+  "external_projects": [
+    {
+      "alias": "[alias]",
+      "source": "shopify|linear|slack|notion|custom",
+      "status": "healthy|auth_expired|unreachable|degraded|not_configured|discovered",
+      "details": {}
+    }
+  ],
   "anomalies": [
     {
       "severity": "critical|high|medium|low",
@@ -413,6 +424,7 @@ Flag as `critical` if:
 - CloudWatch alarm count in ALARM state > 0 on a resource marked critical in registry
 - Vercel deployment state == "ERROR" on production
 - CI conclusion == "failure" on `main` or `dev` branch
+- External project status == "unreachable" (service may be down)
 
 Flag as `high` if:
 
@@ -425,6 +437,7 @@ Flag as `high` if:
 - RDS pending maintenance actions present
 - Vercel deployment state == "ERROR" on preview
 - CI failure on feature branch with open PR
+- External project status == "auth_expired" (credential rotation needed)
 
 Flag as `medium` if:
 

--- a/claude-ops/agents/project-scanner.md
+++ b/claude-ops/agents/project-scanner.md
@@ -28,9 +28,17 @@ Load the project registry:
 cat "${CLAUDE_PLUGIN_ROOT}/scripts/registry.json" 2>/dev/null || echo '{}'
 ```
 
-For each project in the registry, run these checks in parallel:
+For each project in the registry, run these checks in parallel.
 
-### Per-project git checks
+**Important**: Projects with `"type": "external"` have no local paths or git repos. For these, run the external health check instead:
+
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/ops-external 2>/dev/null || echo '[]'
+```
+
+Include external projects in the output under the same `projects[]` array with `"source"` set to their type (shopify/linear/slack/notion/custom) and git/PR fields set to `null`.
+
+### Per-project git checks (repo-based projects only)
 
 ```bash
 PROJECT_PATH="[expanded path]"
@@ -97,13 +105,28 @@ gh pr list --repo "$REPO" --state open \
         }
       ],
       "health": "clean|dirty|behind|ahead|stale"
+    },
+    {
+      "alias": "[alias]",
+      "name": "[name]",
+      "source": "shopify|linear|slack|notion|custom",
+      "type": "external",
+      "git": null,
+      "gsd": null,
+      "prs": null,
+      "external_status": "healthy|auth_expired|unreachable|degraded|not_configured|discovered",
+      "external_details": {},
+      "health": "healthy|degraded|unreachable|auth_expired|not_configured"
     }
   ],
   "summary": {
     "total_projects": 0,
+    "total_repo_projects": 0,
+    "total_external_projects": 0,
     "dirty": 0,
     "ready_to_merge_prs": 0,
-    "stale_branches": 0
+    "stale_branches": 0,
+    "external_unhealthy": 0
   }
 }
 ```

--- a/claude-ops/agents/revenue-tracker.md
+++ b/claude-ops/agents/revenue-tracker.md
@@ -181,6 +181,25 @@ aws ce get-anomalies \
   --output json 2>/dev/null || echo '{"Anomalies": []}'
 ```
 
+### Shopify revenue (external projects)
+
+Check registry for external Shopify projects and pull their revenue data:
+
+```bash
+SHOPIFY_PROJECTS=$(jq -c '[.projects[] | select(.source == "shopify")]' "${CLAUDE_PLUGIN_ROOT}/scripts/registry.json" 2>/dev/null)
+```
+
+For each Shopify project with valid credentials, query recent orders:
+
+```bash
+STORE_URL="[from project.shopify.store_url]"
+TOKEN="[from env var named in project.shopify.credential_key]"
+curl -s -H "X-Shopify-Access-Token: $TOKEN" \
+  "https://$STORE_URL/admin/api/2024-10/orders.json?status=any&created_at_min=$(date -v-30d +%Y-%m-%dT00:00:00Z 2>/dev/null)&limit=250" 2>/dev/null
+```
+
+Sum `orders[].total_price` for trailing 30d GMV. Include in `revenue.breakdown.shopify_gmv`.
+
 ### Project registry (revenue metadata — fallback)
 
 ```bash
@@ -188,7 +207,7 @@ cat "${CLAUDE_PLUGIN_ROOT}/scripts/registry.json" 2>/dev/null | \
   jq '[.projects[] | {alias, name, revenue_stage: (.revenue_stage // "pre-revenue"), mrr: (.mrr // 0), arr: (.arr // 0)}]'
 ```
 
-Use this only if BOTH `STRIPE_SECRET_KEY` and `REVENUECAT_API_KEY` are unset. In that case populate `revenue.mrr` as the sum of `registry.json` project `mrr` values and set `mrr_source: "registry.json"`.
+Use this only if BOTH `STRIPE_SECRET_KEY` and `REVENUECAT_API_KEY` are unset and no Shopify projects are configured. In that case populate `revenue.mrr` as the sum of `registry.json` project `mrr` values and set `mrr_source: "registry.json"`.
 
 ---
 

--- a/claude-ops/agents/yolo-ceo.md
+++ b/claude-ops/agents/yolo-ceo.md
@@ -30,7 +30,9 @@ You are ONE OF FOUR parallel analysis agents (CEO, CTO, CFO, COO). You each run 
 
 ## Data available
 
-The calling skill (`/ops:yolo`) has pre-gathered all data and passed it as context: infrastructure health, git/PR/CI state, unread messages, AWS costs, project registry, GSD state. Plus any contact memories loaded via Runtime Context. Analyze from a strategic CEO lens — you are not the CTO, CFO, or COO.
+The calling skill (`/ops:yolo`) has pre-gathered all data and passed it as context: infrastructure health, git/PR/CI state, unread messages, AWS costs, project registry, GSD state, and **external project health** (Shopify stores, Linear teams, Slack workspaces, Notion, custom services). Plus any contact memories loaded via Runtime Context. Analyze from a strategic CEO lens — you are not the CTO, CFO, or COO.
+
+**External projects**: These are non-repo projects discovered from the registry (type=external). They include Shopify stores (ecommerce revenue), Linear teams (engineering org), Slack/Notion workspaces (team collaboration), and custom SaaS endpoints. Factor their health, revenue contribution, and strategic importance into your analysis just like repo-based projects.
 
 ## Your mandate
 

--- a/claude-ops/agents/yolo-cfo.md
+++ b/claude-ops/agents/yolo-cfo.md
@@ -20,7 +20,9 @@ You are the CFO. You follow the money. You have no patience for engineering work
 
 ## Data available
 
-The calling skill has pre-gathered AWS cost data, project revenue stages, and registry data. Analyze it all.
+The calling skill has pre-gathered AWS cost data, project revenue stages, registry data, and **external project health** (Shopify stores with revenue data, Linear teams, Slack/Notion workspaces, custom services). Analyze it all.
+
+**External projects**: Factor Shopify GMV and external SaaS revenue into the financial picture. Flag external projects with auth_expired credentials as revenue risk (especially Shopify stores). Include external service costs in the total burn rate analysis.
 
 ## Your mandate
 

--- a/claude-ops/agents/yolo-coo.md
+++ b/claude-ops/agents/yolo-coo.md
@@ -23,7 +23,9 @@ You are the COO. You see what everyone else misses — the things that don't get
 
 ## Data available
 
-The calling skill has pre-gathered git status, PR state, CI status, Linear data, and project state. You also have direct access to dig deeper.
+The calling skill has pre-gathered git status, PR state, CI status, Linear data, project state, and **external project health** (Shopify stores, Linear teams, Slack/Notion workspaces, custom services). You also have direct access to dig deeper.
+
+**External projects**: Include non-repo projects in your operational analysis. Check for auth_expired credentials, unreachable services, and misconfigured integrations. These are operational blind spots that often fall through the cracks.
 
 ## Your mandate
 

--- a/claude-ops/agents/yolo-cto.md
+++ b/claude-ops/agents/yolo-cto.md
@@ -91,6 +91,9 @@ REGISTRY="${CLAUDE_PLUGIN_ROOT}/scripts/registry.json"
 [ -f "$REGISTRY" ] || REGISTRY="${CLAUDE_PLUGIN_ROOT}/scripts/registry.example.json"
 PROJECT_PATHS=$(jq -r '.projects[] | select(.gsd == true) | .paths[]' "$REGISTRY" 2>/dev/null | while read p; do printf '%s\n' "${p/#\~/$HOME}"; done)
 
+# External projects (non-repo: Shopify, Linear, Slack, Notion, custom)
+EXTERNAL_JSON=$("${CLAUDE_PLUGIN_ROOT}/bin/ops-external" 2>/dev/null || echo '[]')
+
 # Find TODOs and hacks across all registered projects
 echo "$PROJECT_PATHS" | xargs -I{} grep -r "TODO\|FIXME\|HACK\|temp\|hardcoded" {} \
   --include="*.ts" --include="*.py" --include="*.js" --include="*.tsx" \

--- a/claude-ops/bin/ops-external
+++ b/claude-ops/bin/ops-external
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# ops-external — Health status for non-git (external) projects → JSON
+# Checks Shopify stores, Linear teams, Slack workspaces, Notion, custom endpoints
+# Reads from registry.json, outputs compact JSON for skill injection
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REGISTRY="${SCRIPT_DIR}/../scripts/registry.json"
+
+if [ ! -f "$REGISTRY" ]; then
+  echo '[]' && exit 0
+fi
+
+# Extract external projects (type=external or source is set without paths/repos)
+EXTERNAL=$(jq -c '[.projects[] | select(.type == "external" or (.source != null and .source != "git"))]' "$REGISTRY" 2>/dev/null)
+
+if [ "$EXTERNAL" = "[]" ] || [ -z "$EXTERNAL" ]; then
+  echo '[]' && exit 0
+fi
+
+TMPDIR_OPS=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_OPS"' EXIT
+
+COUNT=$(echo "$EXTERNAL" | jq 'length')
+
+for i in $(seq 0 $((COUNT - 1))); do
+  PROJECT=$(echo "$EXTERNAL" | jq -c ".[$i]")
+  ALIAS=$(echo "$PROJECT" | jq -r '.alias')
+  SOURCE=$(echo "$PROJECT" | jq -r '.source // "unknown"')
+
+  (
+    STATUS="unknown"
+    DETAILS="{}"
+
+    case "$SOURCE" in
+      shopify)
+        STORE_URL=$(echo "$PROJECT" | jq -r '.shopify.store_url // empty')
+        CRED_KEY=$(echo "$PROJECT" | jq -r '.shopify.credential_key // "SHOPIFY_TOKEN"')
+        TOKEN="${!CRED_KEY:-}"
+
+        if [ -n "$TOKEN" ] && [ -n "$STORE_URL" ]; then
+          RESP=$(curl -s -w "\n%{http_code}" \
+            -H "X-Shopify-Access-Token: $TOKEN" \
+            "https://$STORE_URL/admin/api/2024-10/shop.json" 2>/dev/null || echo -e "\n000")
+          HTTP_CODE=$(echo "$RESP" | tail -1)
+          BODY=$(echo "$RESP" | sed '$d')
+
+          if [ "$HTTP_CODE" = "200" ]; then
+            STATUS="healthy"
+            SHOP_NAME=$(echo "$BODY" | jq -r '.shop.name // "unknown"' 2>/dev/null)
+            PLAN=$(echo "$BODY" | jq -r '.shop.plan_name // "unknown"' 2>/dev/null)
+            DETAILS=$(jq -n --arg n "$SHOP_NAME" --arg p "$PLAN" '{shop_name:$n,plan:$p}')
+          elif [ "$HTTP_CODE" = "401" ]; then
+            STATUS="auth_expired"
+          else
+            STATUS="unreachable"
+          fi
+        else
+          STATUS="not_configured"
+        fi
+        ;;
+
+      linear)
+        TEAM_KEY=$(echo "$PROJECT" | jq -r '.linear.team_key // empty')
+        LINEAR_KEY="${LINEAR_API_KEY:-}"
+
+        if [ -n "$LINEAR_KEY" ] && [ -n "$TEAM_KEY" ]; then
+          RESP=$(curl -s -w "\n%{http_code}" -X POST \
+            -H "Authorization: $LINEAR_KEY" \
+            -H "Content-Type: application/json" \
+            -d "{\"query\":\"{ team(id: \\\"$TEAM_KEY\\\") { name issueCount } }\"}" \
+            "https://api.linear.app/graphql" 2>/dev/null || echo -e "\n000")
+          HTTP_CODE=$(echo "$RESP" | tail -1)
+          BODY=$(echo "$RESP" | sed '$d')
+
+          if [ "$HTTP_CODE" = "200" ]; then
+            ERRORS=$(echo "$BODY" | jq '.errors' 2>/dev/null)
+            if [ "$ERRORS" = "null" ] || [ -z "$ERRORS" ]; then
+              STATUS="healthy"
+              TEAM_NAME=$(echo "$BODY" | jq -r '.data.team.name // "unknown"' 2>/dev/null)
+              ISSUES=$(echo "$BODY" | jq -r '.data.team.issueCount // 0' 2>/dev/null)
+              DETAILS=$(jq -n --arg n "$TEAM_NAME" --arg c "$ISSUES" '{team_name:$n,issue_count:($c|tonumber)}')
+            else
+              STATUS="error"
+            fi
+          else
+            STATUS="unreachable"
+          fi
+        else
+          STATUS="not_configured"
+        fi
+        ;;
+
+      slack)
+        # Slack health is checked via MCP — just mark as discovered
+        WORKSPACE=$(echo "$PROJECT" | jq -r '.slack.workspace // "unknown"')
+        STATUS="discovered"
+        DETAILS=$(jq -n --arg w "$WORKSPACE" '{workspace:$w,note:"use Slack MCP for details"}')
+        ;;
+
+      notion)
+        # Notion health is checked via MCP — just mark as discovered
+        WORKSPACE=$(echo "$PROJECT" | jq -r '.notion.workspace // "unknown"')
+        STATUS="discovered"
+        DETAILS=$(jq -n --arg w "$WORKSPACE" '{workspace:$w,note:"use Notion MCP for details"}')
+        ;;
+
+      custom)
+        HEALTH_URL=$(echo "$PROJECT" | jq -r '.custom.health_endpoint // empty')
+        CRED_KEY=$(echo "$PROJECT" | jq -r '.custom.credential_key // empty')
+        TOKEN="${CRED_KEY:+${!CRED_KEY:-}}"
+
+        if [ -n "$HEALTH_URL" ]; then
+          AUTH_HEADER=""
+          [ -n "$TOKEN" ] && AUTH_HEADER="-H \"Authorization: Bearer $TOKEN\""
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" $AUTH_HEADER "$HEALTH_URL" 2>/dev/null || echo "000")
+
+          if [ "$HTTP_CODE" = "200" ]; then
+            STATUS="healthy"
+          elif [ "$HTTP_CODE" = "401" ] || [ "$HTTP_CODE" = "403" ]; then
+            STATUS="auth_expired"
+          else
+            STATUS="degraded"
+          fi
+          DETAILS=$(jq -n --arg u "$HEALTH_URL" --arg c "$HTTP_CODE" '{health_url:$u,http_status:$c}')
+        else
+          STATUS="not_configured"
+        fi
+        ;;
+
+      *)
+        STATUS="unknown_source"
+        ;;
+    esac
+
+    REVENUE_STAGE=$(echo "$PROJECT" | jq -r '.revenue.stage // "unknown"')
+    REVENUE_MODEL=$(echo "$PROJECT" | jq -r '.revenue.model // "unknown"')
+    PRIORITY=$(echo "$PROJECT" | jq -r '.priority // 99')
+
+    jq -n \
+      --arg a "$ALIAS" --arg s "$SOURCE" --arg st "$STATUS" \
+      --arg rs "$REVENUE_STAGE" --arg rm "$REVENUE_MODEL" --arg p "$PRIORITY" \
+      --argjson d "$DETAILS" \
+      '{alias:$a,source:$s,status:$st,revenue_stage:$rs,revenue_model:$rm,priority:($p|tonumber),details:$d}' \
+      > "$TMPDIR_OPS/$ALIAS.json"
+  ) &
+done
+wait
+
+# Assemble array
+echo -n '['
+first=true
+for f in "$TMPDIR_OPS"/*.json; do
+  [ ! -f "$f" ] && continue
+  [ "$first" = true ] && first=false || echo -n ','
+  cat "$f"
+done
+echo ']'

--- a/claude-ops/scripts/registry.example.json
+++ b/claude-ops/scripts/registry.example.json
@@ -3,38 +3,35 @@
   "owner": "Your Name",
   "projects": [
     {
-      "alias": "example-project",
-      "paths": ["~/Projects/example-project"],
-      "repos": ["your-github-org/example-project"],
-      "org": "your-github-org",
+      "alias": "my-app",
+      "paths": ["~/Projects/my-app"],
+      "repos": ["your-org/my-app"],
+      "org": "your-org",
       "type": "monorepo",
       "infra": {
         "platform": "vercel"
       },
-      "revenue": {
-        "model": "saas",
-        "stage": "pre-launch",
-        "target_date": "2026-12-31"
-      },
+      "revenue": { "model": "saas", "stage": "pre-launch" },
       "gsd": true,
       "priority": 1
     },
     {
-      "alias": "example-multi-repo",
-      "paths": ["~/Projects/example-api", "~/Projects/example-web", "~/Projects/example-mobile"],
-      "repos": ["your-github-org/example-api", "your-github-org/example-web", "your-github-org/example-mobile"],
-      "org": "your-github-org",
-      "type": "multi-repo",
-      "infra": {
-        "ecs_clusters": ["example-production", "example-staging"],
-        "platform": "aws"
+      "alias": "my-store",
+      "source": "shopify",
+      "type": "external",
+      "shopify": {
+        "store_url": "yourstore.myshopify.com",
+        "credential_key": "SHOPIFY_TOKEN"
       },
-      "revenue": {
-        "model": "subscription",
-        "stage": "growth"
-      },
-      "gsd": true,
-      "priority": 2
+      "revenue": { "model": "ecommerce", "stage": "growth" },
+      "priority": 3
+    },
+    {
+      "alias": "eng-team",
+      "source": "linear",
+      "type": "external",
+      "linear": { "team_key": "ENG" },
+      "priority": 5
     }
   ]
 }

--- a/claude-ops/scripts/registry.templates/external-project.json
+++ b/claude-ops/scripts/registry.templates/external-project.json
@@ -1,0 +1,62 @@
+{
+  "version": "1.0",
+  "owner": "owner",
+  "projects": [
+    {
+      "alias": "my-shopify-store",
+      "source": "shopify",
+      "type": "external",
+      "shopify": {
+        "store_url": "yourstore.myshopify.com",
+        "credential_key": "SHOPIFY_TOKEN"
+      },
+      "revenue": {
+        "model": "ecommerce",
+        "stage": "growth"
+      },
+      "priority": 3
+    },
+    {
+      "alias": "team-linear",
+      "source": "linear",
+      "type": "external",
+      "linear": {
+        "team_key": "ENG"
+      },
+      "priority": 5
+    },
+    {
+      "alias": "company-slack",
+      "source": "slack",
+      "type": "external",
+      "slack": {
+        "workspace": "your-workspace"
+      },
+      "priority": 5
+    },
+    {
+      "alias": "docs-notion",
+      "source": "notion",
+      "type": "external",
+      "notion": {
+        "workspace": "your-workspace"
+      },
+      "priority": 5
+    },
+    {
+      "alias": "custom-saas",
+      "source": "custom",
+      "type": "external",
+      "custom": {
+        "url": "https://app.example.com",
+        "health_endpoint": "https://app.example.com/api/health",
+        "credential_key": "CUSTOM_API_KEY"
+      },
+      "revenue": {
+        "model": "saas",
+        "stage": "pre-launch"
+      },
+      "priority": 4
+    }
+  ]
+}

--- a/claude-ops/skills/ops-fires/SKILL.md
+++ b/claude-ops/skills/ops-fires/SKILL.md
@@ -95,14 +95,21 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ops-infra 2>/dev/null || echo '{"clusters":[],"error":
 ${CLAUDE_PLUGIN_ROOT}/bin/ops-ci 2>/dev/null || echo '[]'
 ```
 
+## External projects health
+
+```!
+${CLAUDE_PLUGIN_ROOT}/bin/ops-external 2>/dev/null || echo '[]'
+```
+
 ## Your task
 
-Analyze the pre-gathered data. Then run parallel checks:
+Analyze the pre-gathered data — including external projects. Then run parallel checks:
 
 1. **ECS health** — parse infra data for unhealthy services, stopped tasks, failed deployments.
 2. **Sentry** — if Sentry MCP is connected, query recent unresolved errors. Otherwise note it's unavailable.
 3. **CI** — parse CI data for failing pipelines, broken main/dev branches.
 4. **GitHub Actions** — `gh run list --limit 20 --json status,conclusion,name,headBranch,createdAt 2>/dev/null`
+5. **External projects** — parse ops-external data. Flag `auth_expired` as HIGH (credential rotation needed), `unreachable`/`degraded` as MEDIUM, `not_configured` as LOW.
 
 Classify each issue by severity:
 
@@ -139,6 +146,9 @@ CI STATUS
 
 SENTRY (top errors, 24h)
 [error] [count] [first seen] [project]
+
+EXTERNAL PROJECTS
+[alias] [source] [status] [details — e.g. auth_expired, unreachable]
 
 ──────────────────────────────────────────────────────
 ```

--- a/claude-ops/skills/ops-go/SKILL.md
+++ b/claude-ops/skills/ops-go/SKILL.md
@@ -128,6 +128,12 @@ for d in $(jq -r '.projects[] | select(.gsd == true) | .paths[]' "${CLAUDE_PLUGI
 done
 ```
 
+### External Projects (non-repo)
+
+```!
+${CLAUDE_PLUGIN_ROOT}/bin/ops-external 2>/dev/null || echo '[]'
+```
+
 ### Calendar (today)
 
 ```!
@@ -153,6 +159,9 @@ PRs NEEDING ACTION
 
 PORTFOLIO DASHBOARD
 [table: project, phase, branch, uncommitted, CI, next action]
+
+EXTERNAL PROJECTS
+[table: alias, source, status, details — from ops-external data]
 
 UNREAD
 [WhatsApp: N, Email: N, Slack: check MCP, Notion: N items, Calendar: N events today]

--- a/claude-ops/skills/ops-projects/SKILL.md
+++ b/claude-ops/skills/ops-projects/SKILL.md
@@ -99,11 +99,17 @@ for d in $(jq -r '.projects[] | select(.gsd == true) | .paths[]' "${CLAUDE_PLUGI
 done | jq -s '.'
 ```
 
+## External projects (non-repo)
+
+```!
+${CLAUDE_PLUGIN_ROOT}/bin/ops-external 2>/dev/null || echo '[]'
+```
+
 ---
 
 ## Your task
 
-Parse all pre-gathered data and render the portfolio dashboard.
+Parse all pre-gathered data — including external projects — and render the portfolio dashboard.
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -114,6 +120,14 @@ Parse all pre-gathered data and render the portfolio dashboard.
  ────────────────────────────────────────────────────────────────
  example-app   7.2        feature/auth    3      ✓     finish auth tests
  example-api   5.0        dev             0      ✗     fix CI (unit tests)
+ ...
+
+EXTERNAL PROJECTS
+ ALIAS         SOURCE     STATUS     DETAILS
+ ────────────────────────────────────────────────────────────────
+ my-store      shopify    ✓ healthy  My Store (basic plan)
+ eng-team      linear     ✓ healthy  Engineering (42 issues)
+ company-slack slack      ● discovered  your-workspace
  ...
 
 OPEN PRs

--- a/claude-ops/skills/ops-revenue/SKILL.md
+++ b/claude-ops/skills/ops-revenue/SKILL.md
@@ -91,8 +91,26 @@ aws ce get-cost-forecast \
 ### Project registry (revenue stage)
 
 ```bash
-cat "${CLAUDE_PLUGIN_ROOT}/scripts/registry.json" 2>/dev/null | jq '[.projects[] | {alias, name, stage: (.revenue_stage // "pre-revenue"), mrr: (.mrr // 0)}]'
+cat "${CLAUDE_PLUGIN_ROOT}/scripts/registry.json" 2>/dev/null | jq '[.projects[] | {alias, name, stage: (.revenue_stage // .revenue.stage // "pre-revenue"), mrr: (.mrr // 0), source: (.source // "git"), type: (.type // "repo")}]'
 ```
+
+### External project revenue (Shopify, custom SaaS)
+
+```!
+${CLAUDE_PLUGIN_ROOT}/bin/ops-external 2>/dev/null || echo '[]'
+```
+
+For Shopify projects showing `status: "healthy"`, pull GMV via Shopify Admin API:
+
+```bash
+# For each Shopify project in registry with valid credentials:
+STORE_URL="[from project.shopify.store_url]"
+TOKEN="[from env var named in project.shopify.credential_key]"
+curl -s -H "X-Shopify-Access-Token: $TOKEN" \
+  "https://$STORE_URL/admin/api/2024-10/orders.json?status=any&created_at_min=$(date -v-30d +%Y-%m-%dT00:00:00Z 2>/dev/null)&limit=250" 2>/dev/null
+```
+
+Include Shopify GMV in the revenue pipeline table with source=shopify.
 
 ---
 
@@ -120,12 +138,15 @@ CREDITS
  Burn rate at current:   [N months remaining]
 
 REVENUE PIPELINE
- PROJECT        STAGE           MRR      STATUS
- ────────────────────────────────────────────────
- [project]      [stage]         $[X]     [status]
+ PROJECT        SOURCE     STAGE           MRR/GMV    STATUS
+ ──────────────────────────────────────────────────────────────
+ [project]      git        [stage]         $[X]       [status]
+ [project]      shopify    [stage]         $[X] GMV   [status]
+ [project]      custom     [stage]         $[X]       [status]
  ...
- ────────────────────────────────────────────────
- TOTAL MRR                      $[X]
+ ──────────────────────────────────────────────────────────────
+ TOTAL MRR                                 $[X]
+ TOTAL SHOPIFY GMV (30d)                   $[X]
 
 RUNWAY ESTIMATE
  Monthly burn (AWS):  $[X]

--- a/claude-ops/skills/ops-yolo/SKILL.md
+++ b/claude-ops/skills/ops-yolo/SKILL.md
@@ -114,6 +114,10 @@ cat "${CLAUDE_PLUGIN_ROOT}/scripts/registry.json" 2>/dev/null || echo '{}'
 ```
 
 ```!
+${CLAUDE_PLUGIN_ROOT}/bin/ops-external 2>/dev/null || echo '[]'
+```
+
+```!
 for d in $(jq -r '.projects[] | select(.gsd == true) | .paths[]' "${CLAUDE_PLUGIN_ROOT}/scripts/registry.json" 2>/dev/null); do
   expanded="${d/#\~/$HOME}"
   [ -f "$expanded/.planning/STATE.md" ] && echo "=== $(basename $expanded) ===" && cat "$expanded/.planning/STATE.md" && echo "---"


### PR DESCRIPTION
## Summary
- Non-repo projects (Shopify stores, Linear teams, Slack/Notion workspaces, custom SaaS) can now be registered in `registry.json` with `type: "external"` and appear across all briefings, dashboards, and analyses
- New `bin/ops-external` data collector probes each source type (Shopify Admin API, Linear GraphQL, custom health endpoints) and returns structured JSON
- All 5 dashboard skills and 6 agents updated to consume and render external project data alongside repo-based projects

## Changes
| Area | Files | What |
|------|-------|------|
| Data collection | `bin/ops-external` (new) | Probes Shopify, Linear, Slack, Notion, custom endpoints |
| Registry | `registry.example.json`, `registry.templates/external-project.json` (new) | Schema extension + examples |
| Skills | `ops-projects`, `ops-go`, `ops-fires`, `ops-revenue`, `ops-yolo` | Pre-gather + render external projects |
| Agents | `project-scanner`, `infra-monitor`, `revenue-tracker`, `yolo-ceo/cto/cfo/coo` | Include external projects in analysis |

## Registry schema addition
```json
{
  "alias": "my-store",
  "source": "shopify",
  "type": "external",
  "shopify": { "store_url": "yourstore.myshopify.com", "credential_key": "SHOPIFY_TOKEN" },
  "revenue": { "model": "ecommerce", "stage": "growth" },
  "priority": 3
}
```

Supported sources: `shopify`, `linear`, `slack`, `notion`, `custom`

## Test plan
- [ ] Run `bin/ops-external` with no external projects in registry → returns `[]`
- [ ] Add a Shopify project to registry with valid token → returns healthy status
- [ ] Add a Linear project with valid API key → returns team name + issue count
- [ ] Run `/ops:ops-projects` → EXTERNAL PROJECTS table appears
- [ ] Run `/ops:ops-fires` → auth_expired external projects flagged as HIGH
- [ ] Run `/ops:ops-revenue` → Shopify GMV included in revenue pipeline
- [ ] Run `tests/test-no-secrets.sh` → all checks pass (no personal data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `ops-external` collector that calls third-party APIs (Shopify/Linear/custom endpoints) and threads its output through multiple dashboards/agents, increasing integration and credential-handling surface area. Failures should degrade gracefully, but behavior now depends on external services and registry schema correctness.
> 
> **Overview**
> Adds first-class support for *external (non-repo) projects* in the ops suite by introducing `bin/ops-external`, which reads `registry.json` and probes Shopify, Linear, Slack/Notion (discovered), and custom health endpoints to emit a normalized health JSON payload.
> 
> Plumbs this external-project data into existing agents and skills (`infra-monitor`, `project-scanner`, `/ops-fires`, `/ops-go`, `/ops-projects`, `/ops-revenue`, `/ops-yolo`), extending their output schemas/tables and severity rules to flag `auth_expired`/`unreachable` external statuses.
> 
> Extends revenue workflows to optionally pull trailing-30d Shopify GMV and updates registry examples/templates to document the new `type: "external"` entries and fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcf1a7ee5a843e67ecb36b9678cfe1199b7a6f59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for monitoring external projects (Shopify stores, Linear teams, Slack/Notion workspaces, custom SaaS services) alongside repository projects across all dashboards and agents
  * External project health status now integrated into agent decision-making and strategic analysis
  * Added Shopify revenue tracking to financial reporting, displaying revenue alongside traditional metrics
  * Enhanced risk detection for authentication failures and unreachable external services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->