### PR TITLE
chore: release v1.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 25 skills, 13 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes YOLO autonomous mode with 4 C-suite agents.",
       "source": "./claude-ops",
-      "version": "1.1.1",
+      "version": "1.4.0",
       "category": "productivity",
       "screenshots": [
         "docs/screenshots/dashboard.png",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "1.2.0",
+  "version": "1.4.0",
   "description": "Business operations command center for Claude Code — 25 skills, 13 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes YOLO mode for autonomous operation.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,67 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.0] — 2026-04-15
+
+### Added
+
+- **External project support** — Non-repo projects (Shopify stores, Linear teams, Slack/Notion workspaces, custom SaaS endpoints) can now be registered in `registry.json` with `type: "external"` and appear across all dashboards, briefings, fire detection, revenue tracking, and C-suite analysis.
+- **`bin/ops-external`** — New data collector that probes external project health (Shopify Admin API, Linear GraphQL, custom health endpoints).
+- **`registry.templates/external-project.json`** — Registry template for all supported external project types.
+- **`/ops:daemon` skill** — Manage the background daemon (start, stop, restart, health check).
+- **gog CLI reference** — Comprehensive command reference added to all agent skills.
+
+### Changed
+
+- **`ops-projects`** — Portfolio dashboard now includes an EXTERNAL PROJECTS table.
+- **`ops-go`** — Morning briefing includes external project health status.
+- **`ops-fires`** — Classifies external project issues by severity (unreachable=CRITICAL, auth_expired=HIGH).
+- **`ops-revenue`** — Pulls Shopify GMV for external stores, adds SOURCE column to revenue pipeline.
+- **`ops-yolo`** — Pre-gathers external project data for all 4 C-suite agents.
+- **`project-scanner` agent** — Handles external projects in scan output.
+- **`infra-monitor` agent** — Probes external projects, fire detection rules for auth_expired/unreachable.
+- **`revenue-tracker` agent** — Queries Shopify orders API for GMV on external stores.
+- **All C-suite agents** (CEO/CTO/CFO/COO) — Factor external projects into strategic, technical, financial, and operational analysis.
+
+### Fixed
+
+- **`ops-daemon`** — Critical installer, test, and arg-parser fixes.
+- **Stale plist and wait bugs** in `ops-daemon.sh`.
+
+---
+
+## [1.3.0] — 2026-04-14
+
+### Added
+
+- **Notion integration** — Full channel support for Notion workspaces in inbox, comms, and setup flows.
+
+### Fixed
+
+- **Notion search API** — Corrected API usage, added missing tools and API fallback.
+- **Setup wizard** — Renumbered sections after Notion insertion, fixed verification command.
+
+---
+
+## [1.2.0] — 2026-04-14
+
+### Added
+
+- **Agent Teams enforcement** — All agent-spawning skills now support Agent Teams when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set.
+- **Discord integration** — `/ops:comms discord` via webhook + bot read.
+- **Docker support** — Turnkey container image + compose stack for Linux/CI.
+- **Fires-watcher daemon** — Push notification sinks (Telegram/Discord/ntfy/Pushover).
+- **`/ops:status` skill** — Lightweight integration health panel.
+- **Registry templates** — Starter templates for 4 common stacks (monorepo, Next.js SaaS, Python microservices, React Native).
+- **CI release workflow** — Auto-opens PR for version bumps + optional npm publish.
+
+### Fixed
+
+- **Daemon** — Services work out of the box on fresh install.
+- **npm publish** — Updated to use `claude-ops-plugin` package name.
+
+---
+
 ## [1.1.1] — 2026-04-14
 
 ### Added

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump all version files to 1.4.0 (package.json, plugin.json, marketplace.json)
- Backfill CHANGELOG entries for v1.2.0 and v1.3.0 (were released without notes)
- Add v1.4.0 changelog with external project support and daemon skill

## Version sync
| File | Was | Now |
|------|-----|-----|
| `claude-ops/package.json` | 1.3.0 | 1.4.0 |
| `claude-ops/.claude-plugin/plugin.json` | 1.2.0 | 1.4.0 |
| `.claude-plugin/marketplace.json` | 1.1.1 | 1.4.0 |

No code changes — version bumps and changelog only. Merge to unblock the v1.4.0 tag + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only metadata/version bumps and changelog backfill, with no runtime code changes.
> 
> **Overview**
> Releases `v1.4.0` by syncing version numbers across `marketplace.json`, `claude-ops/.claude-plugin/plugin.json`, and `claude-ops/package.json`.
> 
> Backfills `claude-ops/CHANGELOG.md` with entries for `1.2.0` and `1.3.0`, and adds the `1.4.0` notes (e.g., external project support and daemon-related updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02794ff0672d5fb1a24faad4bbaf38e7ad06c3e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->