### PR TITLE
fix: auto-install wacli-keepalive + self-healing supervisor

### DIFF
--- a/.planning/phases/phase-10/10-01-SUMMARY.md
+++ b/.planning/phases/phase-10/10-01-SUMMARY.md
@@ -1,0 +1,119 @@
+---
+phase: 10-google-ads
+plan: "01"
+subsystem: ops-marketing
+tags: [google-ads, oauth2, credentials, setup-wizard, dashboard]
+dependency_graph:
+  requires: []
+  provides: [google-ads-credential-resolution, google-ads-token-refresh, google-ads-setup-flow, google-ads-dashboard-gather]
+  affects: [ops-marketing/SKILL.md, skills/setup/SKILL.md, bin/ops-marketing-dash]
+tech_stack:
+  added: []
+  patterns: [3-tier-credential-cascade, oauth2-refresh-token, localhost-redirect-server, parallel-gather-functions]
+key_files:
+  created: []
+  modified:
+    - claude-ops/skills/ops-marketing/SKILL.md
+    - claude-ops/skills/setup/SKILL.md
+    - claude-ops/bin/ops-marketing-dash
+decisions:
+  - "Used two-call AskUserQuestion pattern for marketing service selection to comply with Rule 1 (max 4 options)"
+  - "Kept google-ads credential resolution fully in SKILL.md (no new bin scripts) matching existing zero-dependency pattern"
+  - "gather_google_ads uses searchStream GAQL for campaign summary matching existing gather_X function pattern"
+metrics:
+  duration_minutes: 15
+  completed_date: "2026-04-15"
+  tasks_completed: 2
+  tasks_total: 2
+  files_modified: 3
+requirements_completed: [GADS-07]
+---
+
+# Phase 10 Plan 01: Google Ads Credential Foundation Summary
+
+Google Ads auth foundation wired via 3-tier credential cascade (userConfig → env → Doppler), full OAuth2 setup flow in setup wizard, and campaign pre-gather in dashboard script.
+
+## Tasks Completed
+
+| Task | Name | Commit | Files |
+|------|------|--------|-------|
+| 1 | Add Google Ads credential resolution and token refresh to SKILL.md | 2d69fca | claude-ops/skills/ops-marketing/SKILL.md |
+| 2 | Add Google Ads OAuth setup flow to setup wizard and pre-gather to dashboard script | f9c93e0 | claude-ops/skills/setup/SKILL.md, claude-ops/bin/ops-marketing-dash |
+
+## What Was Built
+
+### Task 1 — ops-marketing/SKILL.md
+
+- Added `google_ads_*` keys to Runtime Context userConfig list (6 keys)
+- Added complete `### Google Ads` credential resolution block with:
+  - 6 variables: `GADS_DEV_TOKEN`, `GADS_CLIENT_ID`, `GADS_CLIENT_SECRET`, `GADS_REFRESH_TOKEN`, `GADS_CUSTOMER_ID`, `GADS_LOGIN_CUSTOMER_ID`
+  - Doppler fallback for `REFRESH_TOKEN` and `DEV_TOKEN`
+  - Customer ID dash-stripping (`${GADS_CUSTOMER_ID//-/}`)
+  - Access token refresh via `oauth2.googleapis.com/token`
+  - `GADS_HEADERS` array with optional MCC `login-customer-id` header
+- Updated routing table entry: `google-ads, gads`
+- Added `## google-ads` section with credential and token guard checks
+- Updated `## setup` auto-scan to include `GOOGLE_ADS_*` env vars, shell profile grep pattern, Doppler filter pattern, Dashlane, keychain, and Chrome history
+- Added Google Ads setup paragraph describing the OAuth2 flow and smoke test
+
+### Task 2 — setup/SKILL.md + bin/ops-marketing-dash
+
+**setup/SKILL.md:**
+- Restructured marketing AskUserQuestion into two sequential calls to comply with Rule 1 (max 4 options) — first call: Klaviyo, Meta Ads, Google Ads, More...; second call: GA4, GSC
+- Added complete `#### Google Ads` sub-section in Step 3j with:
+  - Step A: developer token (keep/reconfigure if found in auto-scan)
+  - Step B: OAuth2 client ID + secret
+  - Step C: browser OAuth flow via localhost:8080 redirect server (`run_in_background: true`)
+  - Step D: customer ID discovery via `listAccessibleCustomers` with MCC auto-detection
+  - Step E: smoke test against `listAccessibleCustomers`
+  - Step F: save to `preferences.json` under `marketing.google_ads.*`
+- Added `google-ads`, `gads` shortcuts to routing table
+- Updated status summary line to include `google-ads`
+- Updated auto-scan block to include `GOOGLE_ADS_*` vars
+
+**bin/ops-marketing-dash:**
+- Added 6-var credential resolution block after GSC block
+- Added Doppler fallback for `GADS_REFRESH_TOKEN`
+- Added `GADS_CUSTOMER_ID` dash-stripping
+- Added `gather_google_ads()` function with:
+  - Empty credential guard (returns "null" if unconfigured)
+  - Access token refresh via OAuth2 token endpoint
+  - GAQL `searchStream` query for campaign summary (last 7 days, top 20 by spend)
+  - Optional `login-customer-id` header for MCC accounts
+- Added `GADS_DATA=$(gather_google_ads) &` to parallel execution block
+- Added `google_ads: $google_ads` to final JSON output
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+None — plan executed exactly as written.
+
+One minor adaptation: the plan's suggested `google-ads, gads` routing table entry in setup/SKILL.md was implemented as two separate backtick-wrapped values (`` `google-ads`, `gads` ``) to match the existing routing table formatting convention. This satisfies the plan's intent (both aliases route to Step 3j Google Ads).
+
+## Threat Model Compliance
+
+| Threat | Status |
+|--------|--------|
+| T-10-01: refresh_token in preferences.json | Mitigated — all token placeholders use `<YOUR_*>` format; Rule 0 enforced; no real tokens in committed files |
+| T-10-02: localhost:8080 OAuth redirect | Accepted — documented in setup flow as standard desktop OAuth pattern |
+| T-10-03: access_token in memory | Accepted — ephemeral, HTTPS only |
+| T-10-04: developer_token in curl commands | Mitigated — stored in preferences.json not source; placeholder format used in examples |
+
+## Known Stubs
+
+None — all credential resolution, token refresh, and data gather patterns are fully wired. Actual Google Ads sub-command implementations (campaigns, keywords, search terms, budget optimization) are stubbed in `## google-ads` with a note that Plans 02 and 03 define them. This is intentional per the plan design — this plan establishes auth only.
+
+## Threat Flags
+
+None — no new network endpoints or auth paths beyond what was planned.
+
+## Self-Check: PASSED
+
+- `claude-ops/skills/ops-marketing/SKILL.md` — modified, committed 2d69fca
+- `claude-ops/skills/setup/SKILL.md` — modified, committed f9c93e0
+- `claude-ops/bin/ops-marketing-dash` — modified, committed f9c93e0
+- Commit 2d69fca exists in git log
+- Commit f9c93e0 exists in git log
+- `bash -n claude-ops/bin/ops-marketing-dash` exits 0
+- `grep -c "GADS_" claude-ops/skills/ops-marketing/SKILL.md` returns 21

--- a/.planning/phases/phase-10/10-02-SUMMARY.md
+++ b/.planning/phases/phase-10/10-02-SUMMARY.md
@@ -1,0 +1,121 @@
+---
+phase: 10-google-ads
+plan: "02"
+subsystem: ops-marketing
+tags: [google-ads, gaql, searchstream, campaign-dashboard, search-terms, budget-recommendations]
+dependency_graph:
+  requires: [google-ads-credential-resolution, google-ads-token-refresh]
+  provides: [google-ads-dashboard, google-ads-search-terms-report, google-ads-budget-recommendations]
+  affects: [ops-marketing/SKILL.md]
+tech_stack:
+  added: []
+  patterns: [gaql-searchstream, micros-to-dollars-awk, division-by-zero-guards, banner-table-output]
+key_files:
+  created: []
+  modified:
+    - claude-ops/skills/ops-marketing/SKILL.md
+decisions:
+  - "Combined Tasks 1 and 2 into single SKILL.md edit since both modify the same ## google-ads section — committed atomically as Task 1 commit (116eaf8)"
+  - "Used jq @tsv + while-read pipeline for table rendering to avoid subshell output loss in bash"
+  - "Negative keyword candidates use jq select() filter inline rather than a second API call"
+  - "Impact percentage for budget recommendations uses awk to avoid integer division edge cases"
+metrics:
+  duration_minutes: 12
+  completed_date: "2026-04-15"
+  tasks_completed: 2
+  tasks_total: 2
+  files_modified: 1
+requirements_completed: [GADS-01, GADS-04, GADS-06]
+---
+
+# Phase 10 Plan 02: Google Ads Read-Only Operations Summary
+
+Three read-only Google Ads sub-commands wired via GAQL `searchStream`: campaign performance dashboard (last 7 days), Search Terms Report with negative keyword candidates (last 30 days), and budget optimization recommendations — all monetary values converted from micros to dollars with 2 decimal places.
+
+## Tasks Completed
+
+| Task | Name | Commit | Files |
+|------|------|--------|-------|
+| 1 | Implement Google Ads campaign dashboard (GADS-01) | 116eaf8 | claude-ops/skills/ops-marketing/SKILL.md |
+| 2 | Implement Search Terms Report and budget recommendations (GADS-04, GADS-06) | 116eaf8 | claude-ops/skills/ops-marketing/SKILL.md |
+
+Note: Both tasks were implemented in a single atomic edit to the `## google-ads` section and committed together as 116eaf8. No work was lost or skipped — all content for both tasks is present.
+
+## What Was Built
+
+### Sub-command Routing Table
+
+Added a routing table immediately after the credential/token-refresh guard in `## google-ads`:
+
+| Input | Action |
+|---|---|
+| (empty), dashboard, overview | Campaign dashboard — last 7 days |
+| search-terms, terms | Search Terms Report — last 30 days |
+| budget-recs, recommendations, recs | Budget recommendations from Google |
+| campaigns, manage | Plan 03 |
+| keywords, kw | Plan 03 |
+
+### Dashboard Sub-command (GADS-01)
+
+- GAQL query: `campaign`, `campaign_budget`, and `metrics.*` fields for last 7 days, top 20 by spend, status != REMOVED
+- Summary header: Total Spend, Total Conversions, Overall ROAS (computed via awk with division-by-zero guard)
+- Per-campaign table: Campaign | Status | Budget/day | Spend | Impr | Clicks | CTR | Conv | ROAS
+- All monetary values: `costMicros / 1000000` via awk `printf "%.2f"`
+- CTR: `clicks / impressions * 100` with zero-impressions guard
+- ROAS: `conversionsValue / spend` with zero-spend guard (shows "—")
+- Empty state: "No active campaigns found in the last 7 days."
+- API error: parses `.[0].error.message` and shows hint to check credentials
+
+### Search Terms Report Sub-command (GADS-04)
+
+- GAQL query: `search_term_view` resource, last 30 days, impressions > 0, top 100 by impressions
+- Status column mapping: `ADDED` → "✓ Added", `EXCLUDED` → "✗ Excluded", `NONE` → "○ New"
+- Per-term table: Search Term | Status | Campaign | Ad Group | Impr | Clicks | Cost | Conv
+- Negative keyword candidates section: inline jq `select()` filters terms where conversions == 0 AND costMicros > 1000000 (>$1 spend)
+- Empty state: "No search term data found for the last 30 days."
+- API error handling matches dashboard pattern
+
+### Budget Recommendations Sub-command (GADS-06)
+
+- GAQL query: `recommendation` resource filtered to `IN (CAMPAIGN_BUDGET, MOVE_UNUSED_BUDGET, MARGINAL_ROI_CAMPAIGN_BUDGET, FORECASTING_CAMPAIGN_BUDGET)`
+- Type column mapping: human-readable labels for all 4 recommendation types
+- Per-recommendation table: Type | Campaign | Current Budget | Recommended | Impact
+- Impact column: percentage impressions increase from `baseMetrics.impressions` to `potentialMetrics.impressions`; shows "—" if base is 0
+- Budget values from `currentBudgetAmountMicros` and `recommendedBudgetAmountMicros` converted from micros to dollars
+- Empty state: "No budget recommendations available. Google needs campaign data to generate recommendations."
+- API error handling matches dashboard pattern
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+None — plan executed exactly as written.
+
+One implementation note: Tasks 1 and 2 both target the same section of SKILL.md. Rather than writing Task 1, committing, then re-opening the file for Task 2 (which would risk diff conflicts on the exact same lines), both sub-command blocks were written in a single edit and committed as a single atomic change (116eaf8). The task commit log above attributes both tasks to this commit, which accurately represents the work done.
+
+## Threat Model Compliance
+
+| Threat | Status |
+|--------|--------|
+| T-10-05: GAQL responses contain campaign names/spend | Accepted — data stays in terminal output only |
+| T-10-06: searchStream queries on large accounts | Mitigated — LIMIT 20 on dashboard, LIMIT 100 on search terms; both applied in plan as specified |
+
+## Known Stubs
+
+None — all three sub-commands are fully wired with GAQL queries, data extraction, and output formatting. Plan 03 sub-commands (campaigns/manage, keywords/kw) are documented as "see Plan 03" in the routing table, which is intentional per the phased plan design.
+
+## Threat Flags
+
+None — no new network endpoints or auth paths beyond what was planned. All queries use the same `searchStream` endpoint already established in the threat model.
+
+## Self-Check: PASSED
+
+- `claude-ops/skills/ops-marketing/SKILL.md` — modified, committed 116eaf8
+- Commit 116eaf8 exists in git log (confirmed above)
+- `grep -q "GOOGLE ADS.*Last 7 Days"` — PASS
+- `grep -q "SEARCH TERMS REPORT"` — PASS
+- `grep -q "BUDGET RECOMMENDATIONS"` — PASS
+- `grep -c "searchStream"` returns 3 — PASS
+- `grep -q "Negative keyword candidates"` — PASS
+- `grep -q "recommendedBudgetAmountMicros"` — PASS
+- `grep -c "━━━"` returns 21 (6 banner lines from 3 sub-commands + existing banners) — PASS

--- a/.planning/phases/phase-10/10-03-SUMMARY.md
+++ b/.planning/phases/phase-10/10-03-SUMMARY.md
@@ -1,0 +1,130 @@
+---
+phase: 10-google-ads
+plan: "03"
+subsystem: ops-marketing
+tags: [google-ads, campaign-management, keyword-planner, ad-groups, mutate-api, gaql]
+dependency_graph:
+  requires: [google-ads-credential-resolution, google-ads-token-refresh, google-ads-dashboard, google-ads-search-terms-report, google-ads-budget-recommendations]
+  provides: [google-ads-campaign-management, google-ads-keyword-planner, google-ads-ad-group-management]
+  affects: [ops-marketing/SKILL.md, docs/skills-reference.md]
+tech_stack:
+  added: []
+  patterns: [campaigns-mutate, campaignBudgets-mutate, adGroups-mutate, adGroupCriteria-mutate, generateKeywordIdeas, micros-to-dollars-awk, destructive-action-confirmation]
+key_files:
+  created: []
+  modified:
+    - claude-ops/skills/ops-marketing/SKILL.md
+    - claude-ops/docs/skills-reference.md
+decisions:
+  - "New campaigns always created in PAUSED status for safety — user must explicitly enable after review"
+  - "Tasks 1 and 2 both modify SKILL.md; implemented in single edit to avoid diff conflicts, covered by single commit ddd54e5"
+  - "Budget adjustment fetches current budget resource name via searchStream before mutating — avoids needing user to know the internal resource name"
+  - "Keyword immutability note included inline with add-keyword docs to prevent confusion about why text/match-type changes require remove+recreate"
+metrics:
+  duration_minutes: 18
+  completed_date: "2026-04-15"
+  tasks_completed: 3
+  tasks_total: 3
+  files_modified: 2
+requirements_completed: [GADS-02, GADS-03, GADS-05]
+---
+
+# Phase 10 Plan 03: Google Ads Write Operations Summary
+
+Campaign management (create/pause/enable/budget), Keyword Planner (seed-to-ideas with volume/competition/bids), and ad group management (create groups, add/remove/bid-update keywords) — all wired via Google Ads REST mutate endpoints with Rule 5 confirmation guards on destructive actions.
+
+## Tasks Completed
+
+| Task | Name | Commit | Files |
+|------|------|--------|-------|
+| 1 | Implement campaign management sub-commands (GADS-02) | ddd54e5 | claude-ops/skills/ops-marketing/SKILL.md |
+| 2 | Implement Keyword Planner and ad group/keyword management (GADS-03, GADS-05) | ddd54e5 | claude-ops/skills/ops-marketing/SKILL.md |
+| 3 | Update skills reference documentation | 67c6d9a | claude-ops/docs/skills-reference.md |
+
+Note: Tasks 1 and 2 both target `## google-ads` in SKILL.md. They were written in a single atomic edit and committed together as ddd54e5 to prevent diff conflicts. All content for both tasks is present.
+
+## What Was Built
+
+### Sub-command Routing Table (updated)
+
+Replaced Plan 02 "see Plan 03" placeholder rows with final entries:
+
+| Input | Action |
+|---|---|
+| campaigns, manage | Campaign management — list, create, pause, enable, adjust budget |
+| keywords, kw, keyword-planner | Keyword Planner — discover keywords with volume and bid data |
+| ad-groups, ag | Ad group management — list, create, add/remove keywords, adjust bids |
+
+### Campaign Management Sub-section (GADS-02)
+
+- **List campaigns**: GAQL `searchStream` query selecting id, name, status, channel type, budget — output as table
+- **Create campaign** (`campaigns create`): Two-step mutate — (1) `campaignBudgets:mutate` to create budget resource, (2) `campaigns:mutate` to create campaign; always starts `PAUSED`; collects name, budget, channel type via AskUserQuestion
+- **Pause campaign** (`campaigns pause <ID>`): `campaigns:mutate` with `updateMask: "status"` → `PAUSED`; requires AskUserQuestion confirmation per Rule 5
+- **Enable campaign** (`campaigns enable <ID>`): Same mutate pattern with `ENABLED`; no confirmation needed (non-destructive)
+- **Adjust budget** (`campaigns budget <ID> <AMOUNT>`): Fetches current budget resource name via searchStream, then `campaignBudgets:mutate` with `updateMask: "amountMicros"`; requires AskUserQuestion confirmation showing old→new amounts per Rule 5
+
+### Keyword Planner Sub-section (GADS-03)
+
+- Endpoint: `:generateKeywordIdeas` (POST to customer resource)
+- Collects seed keywords via AskUserQuestion (comma-separated, split to JSON array)
+- Defaults: `languageConstants/1000` (English), `geoTargetConstants/2840` (United States); documents UK/Canada/Australia alternatives
+- Output table: Keyword | Avg Monthly Searches | Competition | Low Bid | High Bid
+- `lowTopOfPageBidMicros` and `highTopOfPageBidMicros` divided by 1,000,000 → `$X.XX`
+- Sorted by `avgMonthlySearches` descending
+- Empty state: "No keyword ideas found for these seeds. Try different or broader keywords."
+
+### Ad Group Management Sub-section (GADS-05)
+
+- **List ad groups** (`ad-groups list <CAMPAIGN_ID>`): GAQL query filtered by campaign.id, status != REMOVED
+- **Create ad group** (`ad-groups create <CAMPAIGN_ID>`): `adGroups:mutate` with `SEARCH_STANDARD` type; collects name and CPC bid via AskUserQuestion; bid converted to micros
+- **List keywords** (`ad-groups keywords <AD_GROUP_ID>`): GAQL query on `ad_group_criterion` with type = KEYWORD filter
+- **Add keyword** (`ad-groups add-keyword <AD_GROUP_ID>`): `adGroupCriteria:mutate` create; collects keyword text, match type (Broad/Phrase/Exact → BROAD/PHRASE/EXACT), optional CPC bid; uses bash conditional expansion for optional bid field
+- **Remove keyword** (`ad-groups remove-keyword <AD_GROUP_ID> <CRITERION_ID>`): `adGroupCriteria:mutate` remove with `adGroupCriteria/{AD_GROUP_ID}~{CRITERION_ID}` resource name; AskUserQuestion confirmation per Rule 5
+- **Update bid** (`ad-groups update-bid <AD_GROUP_ID> <CRITERION_ID> <BID>`): `adGroupCriteria:mutate` update with `updateMask: "cpcBidMicros"` — only field that can be changed without remove+recreate
+- Keyword immutability note documented inline: text and match type changes require remove and recreate
+
+### Skills Reference Documentation (Task 3)
+
+- Updated `/ops:marketing` description to include "Google Ads" alongside "Meta Ads"
+- Added 6 Google Ads sub-command entries with descriptions matching SKILL.md implementation
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+None — plan executed exactly as written.
+
+One implementation note: Tasks 1 and 2 both target the same `## google-ads` section of SKILL.md. Rather than writing Task 1, committing, then re-opening the file for Task 2 (which would risk diff conflicts on exactly the same lines), both sub-command blocks were written in a single edit and committed atomically as ddd54e5. The task commit log above attributes both tasks to this commit.
+
+## Threat Model Compliance
+
+| Threat | Status |
+|--------|--------|
+| T-10-07: Campaign budget mutation | Mitigated — AskUserQuestion confirmation before budget changes; new campaigns always start PAUSED |
+| T-10-08: Keyword removal | Mitigated — AskUserQuestion confirmation per Rule 5 before any remove operation |
+| T-10-09: Campaign enable without review | Accepted — enabling a paused campaign is standard; budget was already set at create time |
+| T-10-10: Excessive keyword additions | Accepted — Google Ads API has its own rate limits; plugin adds one keyword at a time |
+
+## Known Stubs
+
+None — all six sub-commands (campaigns list/create/pause/enable/budget, keyword planner, ad-groups list/create/keywords/add-keyword/remove-keyword/update-bid) are fully wired with API endpoints, data collection, and output formatting.
+
+## Threat Flags
+
+None — all mutate operations use the same `googleads.googleapis.com/v23` base URL already in the threat model. No new network endpoints or trust boundaries introduced.
+
+## Self-Check: PASSED
+
+- `claude-ops/skills/ops-marketing/SKILL.md` — modified, committed ddd54e5
+- `claude-ops/docs/skills-reference.md` — modified, committed 67c6d9a
+- `grep -c "mutate" claude-ops/skills/ops-marketing/SKILL.md` returns 10 (>= 6 required) — PASS
+- `grep "generateKeywordIdeas"` — PASS
+- `grep -c "AskUserQuestion"` returns 10 (>= 2 required) — PASS
+- `grep "google-ads" claude-ops/docs/skills-reference.md` returns 6 matches (>= 3 required) — PASS
+- `grep "campaigns:mutate"` — PASS
+- `grep "campaignBudgets:mutate"` — PASS
+- `grep "adGroups:mutate"` — PASS
+- `grep "adGroupCriteria:mutate"` — PASS
+- `grep "Keywords are immutable"` — PASS
+- `grep "languageConstants/1000"` — PASS
+- `grep "geoTargetConstants/2840"` — PASS

--- a/claude-ops/bin/ops-marketing-dash
+++ b/claude-ops/bin/ops-marketing-dash
@@ -10,6 +10,12 @@ META_TOKEN="${META_ADS_TOKEN:-$(claude plugin config get meta_ads_token 2>/dev/n
 META_ACCOUNT="${META_AD_ACCOUNT_ID:-$(claude plugin config get meta_ad_account_id 2>/dev/null || echo "")}"
 GA4_PROPERTY="${GA4_PROPERTY_ID:-$(claude plugin config get ga4_property_id 2>/dev/null || echo "")}"
 GSC_SITE="${GOOGLE_SEARCH_CONSOLE_SITE:-$(claude plugin config get google_search_console_site 2>/dev/null || echo "")}"
+GADS_DEV_TOKEN="${GOOGLE_ADS_DEVELOPER_TOKEN:-$(claude plugin config get google_ads_developer_token 2>/dev/null || echo "")}"
+GADS_CLIENT_ID="${GOOGLE_ADS_CLIENT_ID:-$(claude plugin config get google_ads_client_id 2>/dev/null || echo "")}"
+GADS_CLIENT_SECRET="${GOOGLE_ADS_CLIENT_SECRET:-$(claude plugin config get google_ads_client_secret 2>/dev/null || echo "")}"
+GADS_REFRESH_TOKEN="${GOOGLE_ADS_REFRESH_TOKEN:-$(claude plugin config get google_ads_refresh_token 2>/dev/null || echo "")}"
+GADS_CUSTOMER_ID="${GOOGLE_ADS_CUSTOMER_ID:-$(claude plugin config get google_ads_customer_id 2>/dev/null || echo "")}"
+GADS_LOGIN_CUSTOMER_ID="${GOOGLE_ADS_LOGIN_CUSTOMER_ID:-$(claude plugin config get google_ads_login_customer_id 2>/dev/null || echo "")}"
 
 # Doppler fallback
 if [ -z "$KLAVIYO_KEY" ]; then
@@ -19,6 +25,12 @@ if [ -z "$META_TOKEN" ]; then
   META_TOKEN="$(doppler secrets get META_ADS_TOKEN --plain 2>/dev/null || echo "")"
   META_ACCOUNT="$(doppler secrets get META_AD_ACCOUNT_ID --plain 2>/dev/null || echo "")"
 fi
+if [ -z "$GADS_REFRESH_TOKEN" ]; then
+  GADS_REFRESH_TOKEN="$(doppler secrets get GOOGLE_ADS_REFRESH_TOKEN --plain 2>/dev/null || echo "")"
+fi
+
+# Strip dashes from customer ID (API requires no dashes)
+GADS_CUSTOMER_ID="${GADS_CUSTOMER_ID//-/}"
 
 TODAY=$(date +%Y-%m-%d)
 
@@ -167,11 +179,39 @@ gather_gsc() {
     '{clicks: $clicks, impressions: $impressions, ctr: $ctr, avg_position: $position}'
 }
 
+# --- Google Ads ---
+gather_google_ads() {
+  if [ -z "$GADS_REFRESH_TOKEN" ] || [ -z "$GADS_DEV_TOKEN" ]; then
+    echo "null"
+    return
+  fi
+
+  # Refresh access token
+  GADS_ACCESS_TOKEN=$(curl -s -X POST https://oauth2.googleapis.com/token \
+    --data "client_id=${GADS_CLIENT_ID}&client_secret=${GADS_CLIENT_SECRET}&refresh_token=${GADS_REFRESH_TOKEN}&grant_type=refresh_token" \
+    | jq -r '.access_token // empty')
+  if [ -z "$GADS_ACCESS_TOKEN" ]; then
+    echo "null"
+    return
+  fi
+
+  # Campaign summary (last 7 days)
+  curl -s -X POST \
+    "https://googleads.googleapis.com/v23/customers/${GADS_CUSTOMER_ID}/googleAds:searchStream" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${GADS_ACCESS_TOKEN}" \
+    -H "developer-token: ${GADS_DEV_TOKEN}" \
+    ${GADS_LOGIN_CUSTOMER_ID:+-H "login-customer-id: ${GADS_LOGIN_CUSTOMER_ID}"} \
+    --data-binary '{"query": "SELECT campaign.id, campaign.name, campaign.status, metrics.cost_micros, metrics.impressions, metrics.clicks, metrics.conversions, metrics.conversions_value FROM campaign WHERE segments.date DURING LAST_7_DAYS AND campaign.status != REMOVED ORDER BY metrics.cost_micros DESC LIMIT 20"}' \
+    2>/dev/null || echo "null"
+}
+
 # Run all in parallel (subshells)
 KLAVIYO_DATA=$(gather_klaviyo) &
 META_DATA=$(gather_meta) &
 GA4_DATA=$(gather_ga4) &
 GSC_DATA=$(gather_gsc) &
+GADS_DATA=$(gather_google_ads) &
 wait
 
 # Emit unified JSON
@@ -180,5 +220,6 @@ jq -n \
   --argjson meta "$META_DATA" \
   --argjson ga4 "$GA4_DATA" \
   --argjson gsc "$GSC_DATA" \
+  --argjson google_ads "$GADS_DATA" \
   --arg date "$TODAY" \
-  '{date: $date, klaviyo: $klaviyo, meta: $meta, ga4: $ga4, gsc: $gsc}'
+  '{date: $date, klaviyo: $klaviyo, meta: $meta, ga4: $ga4, gsc: $gsc, google_ads: $google_ads}'

--- a/claude-ops/bin/wacli-health
+++ b/claude-ops/bin/wacli-health
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# wacli-health — Check wacli + keepalive health. Returns 0 if healthy, 1 if not.
+#
+# Usage: wacli-health            # exit code only
+#        wacli-health --json     # JSON output
+#        wacli-health --repair   # auto-fix if unhealthy
+#
+# Any ops skill can call this before using wacli to ensure the connection is live.
+set -euo pipefail
+
+WACLI="${WACLI_BIN:-/usr/local/bin/wacli}"
+STORE="${WACLI_STORE:-$HOME/.wacli}"
+HEALTH_FILE="$STORE/.health"
+KEEPALIVE_LABEL="com.claude-ops.wacli-keepalive"
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+JSON_MODE=0
+REPAIR_MODE=0
+for arg in "$@"; do
+  case "$arg" in
+    --json) JSON_MODE=1 ;;
+    --repair) REPAIR_MODE=1 ;;
+  esac
+done
+
+healthy=1
+issues=()
+
+# 1. Check wacli binary exists
+if ! command -v "$WACLI" &>/dev/null; then
+  healthy=0
+  issues+=("wacli binary not found at $WACLI")
+fi
+
+# 2. Check authentication
+if [[ $healthy -eq 1 ]]; then
+  doctor_out=$("$WACLI" doctor 2>&1) || true
+  if ! echo "$doctor_out" | grep -q "AUTHENTICATED.*true"; then
+    healthy=0
+    issues+=("not authenticated — QR scan required")
+  fi
+fi
+
+# 3. Check health file
+if [[ -f "$HEALTH_FILE" ]]; then
+  status=$(grep '^status=' "$HEALTH_FILE" 2>/dev/null | cut -d= -f2- || echo "unknown")
+  case "$status" in
+    connected|running|ok) ;;
+    needs_auth|needs_reauth)
+      healthy=0
+      issues+=("health file reports: $status")
+      ;;
+    paused)
+      issues+=("sync currently paused for external command")
+      ;;
+    *)
+      issues+=("health file status: $status")
+      ;;
+  esac
+  health_pid=$(grep '^pid=' "$HEALTH_FILE" 2>/dev/null | cut -d= -f2- || true)
+  if [[ -n "$health_pid" ]] && ! kill -0 "$health_pid" 2>/dev/null; then
+    healthy=0
+    issues+=("keepalive pid=$health_pid is dead")
+  fi
+else
+  healthy=0
+  issues+=("no health file — keepalive may not be running")
+fi
+
+# 4. Check launchd/systemd registration
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  pid_str=$(launchctl list 2>/dev/null | awk -v lbl="$KEEPALIVE_LABEL" '$3==lbl {print $1}' || true)
+  if [[ -z "$pid_str" ]]; then
+    healthy=0
+    issues+=("$KEEPALIVE_LABEL not registered in launchd")
+  elif [[ "$pid_str" == "-" ]]; then
+    healthy=0
+    issues+=("$KEEPALIVE_LABEL registered but not running")
+  elif ! kill -0 "$pid_str" 2>/dev/null; then
+    healthy=0
+    issues+=("$KEEPALIVE_LABEL has stale PID $pid_str")
+  fi
+elif command -v systemctl &>/dev/null; then
+  if ! systemctl --user is-active claude-ops-wacli-keepalive.service &>/dev/null; then
+    healthy=0
+    issues+=("claude-ops-wacli-keepalive.service not active")
+  fi
+fi
+
+# Output
+if [[ $JSON_MODE -eq 1 ]]; then
+  issues_json="["
+  first=1
+  for i in "${issues[@]+"${issues[@]}"}"; do
+    [[ $first -eq 0 ]] && issues_json+=","
+    first=0
+    issues_json+="\"$(echo "$i" | sed 's/"/\\"/g')\""
+  done
+  issues_json+="]"
+  echo "{\"healthy\": $([ $healthy -eq 1 ] && echo true || echo false), \"issues\": $issues_json}"
+else
+  if [[ $healthy -eq 1 ]]; then
+    echo "wacli: healthy"
+  else
+    echo "wacli: UNHEALTHY"
+    for i in "${issues[@]+"${issues[@]}"}"; do
+      echo "  - $i"
+    done
+  fi
+fi
+
+# Auto-repair if requested and unhealthy
+if [[ $REPAIR_MODE -eq 1 ]] && [[ $healthy -eq 0 ]]; then
+  echo "Attempting auto-repair..."
+  if [[ -f "$SCRIPT_DIR/scripts/ops-daemon.sh" ]]; then
+    bash "$SCRIPT_DIR/scripts/ops-daemon.sh" --install 2>&1 || true
+    echo "Reinstalled launchd/systemd services. Check again in ~15s."
+  else
+    echo "Cannot find ops-daemon.sh for repair" >&2
+  fi
+fi
+
+exit $(( 1 - healthy ))

--- a/claude-ops/bin/wacli-safe
+++ b/claude-ops/bin/wacli-safe
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# wacli-safe — Run a one-shot wacli command without store-lock conflicts.
+#
+# Pauses the persistent keepalive sync, runs the command, then lets sync resume.
+# Usage: wacli-safe send --to "+1234567890" --text "Hello"
+#        wacli-safe history backfill --chat "12345@s.whatsapp.net" --count 50
+#
+# The keepalive script watches for the pause signal file and gracefully stops
+# its persistent sync. After this script exits (or after 60s timeout), the
+# keepalive resumes automatically.
+set -euo pipefail
+
+WACLI="${WACLI_BIN:-/usr/local/bin/wacli}"
+STORE="${WACLI_STORE:-$HOME/.wacli}"
+PAUSE_SIGNAL="$STORE/.pause_sync"
+
+if [[ $# -eq 0 ]]; then
+  echo "Usage: wacli-safe <wacli-subcommand> [args...]" >&2
+  echo "  Pauses keepalive sync, runs the wacli command, then resumes sync." >&2
+  exit 1
+fi
+
+cleanup() {
+  rm -f "$PAUSE_SIGNAL"
+}
+trap cleanup EXIT INT TERM
+
+# Write pause signal with our PID + timestamp
+mkdir -p "$STORE"
+echo "$$" > "$PAUSE_SIGNAL"
+
+# Wait for keepalive to stop its sync (check every 500ms, max 10s)
+waited=0
+while pgrep -f "wacli sync --follow" >/dev/null 2>&1 && [[ $waited -lt 20 ]]; do
+  sleep 0.5
+  (( waited++ )) || true
+done
+
+if pgrep -f "wacli sync --follow" >/dev/null 2>&1; then
+  echo "warning: keepalive sync still running after 10s — proceeding anyway" >&2
+fi
+
+# Run the actual wacli command
+"$WACLI" "$@"
+exit_code=$?
+
+# Cleanup happens via trap
+exit $exit_code

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -207,11 +207,17 @@ Shopify store command center. Orders, inventory, fulfillment, analytics, and sto
 - `/ops:ecom setup` — configure Shopify API credentials
 
 ### `/ops:marketing` · `skills/ops-marketing/SKILL.md`
-Marketing analytics dashboard. Email campaigns (Klaviyo), paid ads (Meta/Google), analytics (GA4), SEO, and social media metrics.
+Marketing analytics dashboard. Email campaigns (Klaviyo), paid ads (Meta Ads, Google Ads), analytics (GA4), SEO, and social media metrics.
 - `/ops:marketing` — full dashboard
 - `/ops:marketing email` — Klaviyo campaign performance
 - `/ops:marketing ads` — Meta + Google Ads spend/ROAS
 - `/ops:marketing seo` — SEO + GA4 organic traffic
+- `/ops:marketing google-ads` — Google Ads campaign dashboard (last 7 days spend, ROAS, per-campaign breakdown)
+- `/ops:marketing google-ads search-terms` — Search Terms Report with negative keyword candidates (last 30 days)
+- `/ops:marketing google-ads budget-recs` — Budget optimization recommendations from Google
+- `/ops:marketing google-ads campaigns` — Campaign management — list, create, pause, enable, adjust budget
+- `/ops:marketing google-ads keywords` — Keyword Planner — discover keywords with volume and bid data
+- `/ops:marketing google-ads ad-groups` — Ad group management — list, create, add/remove keywords, adjust bids
 
 ### `/ops:voice` · `skills/ops-voice/SKILL.md`
 Voice channel management. Make phone calls (Bland AI), text-to-speech (ElevenLabs), transcribe audio (Whisper/Groq).

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -257,8 +257,10 @@ restart_service() {
 
   SERVICE_RESTARTS["$name"]=$(( count + 1 ))
   SERVICE_LAST_RESTART_EPOCH["$name"]=$now
-  log "RESTART: $name (attempt $((count+1))/$max_restarts) — waiting ${restart_delay}s"
+  log "RESTART: $name (attempt $((count+1))/$max_restarts) — waiting ${restart_delay}s before restart"
   stop_service "$name"
+  # Apply configured backoff synchronously before re-launching
+  sleep "$restart_delay"
   start_service "$name"
 }
 

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -285,6 +285,17 @@ write_daemon_health() {
       local pid_val
       if [[ "$pid" == "null" ]] || [[ -z "$pid" ]]; then
         pid_val="null"
+        # No PID tracked — status cannot be "running"
+        if [[ "$status" == "running" ]]; then
+          status="dead"
+          SERVICE_STATUS["$name"]="dead"
+        fi
+      elif ! kill -0 "$pid" 2>/dev/null; then
+        # PID exists in our tracking but process is dead
+        pid_val="null"
+        status="dead"
+        SERVICE_STATUS["$name"]="dead"
+        SERVICE_PIDS["$name"]=""
       else
         pid_val="$pid"
       fi
@@ -705,31 +716,57 @@ install_daemon_launchd() {
     return 1
   fi
 
-  # Substitute placeholders while copying.
-  if [[ -f "$daemon_plist_src" ]]; then
-    sed \
-      -e "s|__BASH_PATH__|$bash_path|g" \
-      -e "s|__PLUGIN_ROOT__|$plugin_root|g" \
-      -e "s|__DAEMON_SCRIPT_PATH__|$OPS_DAEMON_SCRIPT|g" \
-      -e "s|__LOG_DIR__|$LOG_DIR|g" \
-      -e "s|__HOME__|$HOME|g" \
-      "$daemon_plist_src" > "$daemon_plist_dst"
-    launchctl unload -w "$daemon_plist_dst" 2>/dev/null || true
-    launchctl load -w "$daemon_plist_dst"
-    log "INSTALL(launchd): loaded $daemon_plist_dst"
+  _install_launchd_plist "$daemon_plist_src" "$daemon_plist_dst" \
+    "$bash_path" "$plugin_root" "com.claude-ops.daemon"
+  _install_launchd_plist "$keepalive_plist_src" "$keepalive_plist_dst" \
+    "$bash_path" "$plugin_root" "com.claude-ops.wacli-keepalive"
+}
+
+# Install a single launchd plist: substitute placeholders, copy, bootstrap.
+# Args: $1=src $2=dst $3=bash_path $4=plugin_root $5=label
+_install_launchd_plist() {
+  local src="$1" dst="$2" bash_path="$3" plugin_root="$4" label="$5"
+  if [[ ! -f "$src" ]]; then
+    log "INSTALL(launchd): source plist not found: $src"
+    return 1
   fi
 
-  if [[ -f "$keepalive_plist_src" ]]; then
-    sed \
-      -e "s|__BASH_PATH__|$bash_path|g" \
-      -e "s|__PLUGIN_ROOT__|$plugin_root|g" \
-      -e "s|__KEEPALIVE_SCRIPT_PATH__|$OPS_KEEPALIVE_SCRIPT|g" \
-      -e "s|__LOG_DIR__|$LOG_DIR|g" \
-      -e "s|__HOME__|$HOME|g" \
-      "$keepalive_plist_src" > "$keepalive_plist_dst"
-    launchctl unload -w "$keepalive_plist_dst" 2>/dev/null || true
-    launchctl load -w "$keepalive_plist_dst"
-    log "INSTALL(launchd): loaded $keepalive_plist_dst"
+  # Check if already running with a live PID — skip reinstall
+  local existing_pid
+  existing_pid=$(launchctl list "$label" 2>/dev/null | awk '/PID/{print $2}' || true)
+  if [[ -z "$existing_pid" ]]; then
+    # Also try parsing the list output (format: PID\tStatus\tLabel)
+    existing_pid=$(launchctl list 2>/dev/null | awk -v lbl="$label" '$3==lbl && $1!="-" {print $1}' || true)
+  fi
+  if [[ -n "$existing_pid" ]] && kill -0 "$existing_pid" 2>/dev/null; then
+    log "INSTALL(launchd): $label already running (pid=$existing_pid) — skipping"
+    return 0
+  fi
+
+  # Substitute placeholders
+  sed \
+    -e "s|__BASH_PATH__|$bash_path|g" \
+    -e "s|__PLUGIN_ROOT__|$plugin_root|g" \
+    -e "s|__DAEMON_SCRIPT_PATH__|$OPS_DAEMON_SCRIPT|g" \
+    -e "s|__KEEPALIVE_SCRIPT_PATH__|$OPS_KEEPALIVE_SCRIPT|g" \
+    -e "s|__LOG_DIR__|$LOG_DIR|g" \
+    -e "s|__HOME__|$HOME|g" \
+    "$src" > "$dst"
+
+  # Bootstrap: prefer modern launchctl bootstrap, fallback to legacy load
+  local uid
+  uid=$(id -u)
+  local gui_domain="gui/$uid"
+
+  # Bootout first to clear stale registrations
+  launchctl bootout "$gui_domain/$label" 2>/dev/null || true
+  if launchctl bootstrap "$gui_domain" "$dst" 2>/dev/null; then
+    log "INSTALL(launchd): bootstrapped $label into $gui_domain"
+  else
+    # Fallback: legacy load (macOS <10.10 or restricted environments)
+    launchctl unload -w "$dst" 2>/dev/null || true
+    launchctl load -w "$dst"
+    log "INSTALL(launchd): loaded $label via legacy launchctl load"
   fi
 }
 
@@ -882,6 +919,139 @@ uninstall_daemon_schtasks() {
   log "UNINSTALL(schtasks): removed ClaudeOpsDaemon + ClaudeOpsWacliKeepalive"
 }
 
+# ── General self-healing supervisor for all com.claude-ops.* services ─────
+# Enumerates expected services, checks each is installed + alive, auto-repairs.
+# Called at daemon startup and periodically during the monitor loop.
+ENSURE_SERVICES_LAST_RUN=0
+ENSURE_SERVICES_INTERVAL="${ENSURE_SERVICES_INTERVAL:-300}"  # every 5 min
+
+# Expected launchd agents (macOS) / systemd units (Linux).
+# Format: "label|plist_src_basename|description"
+EXPECTED_SERVICES=(
+  "com.claude-ops.daemon|com.claude-ops.daemon.plist|ops daemon"
+  "com.claude-ops.wacli-keepalive|com.claude-ops.wacli-keepalive.plist|wacli keepalive"
+)
+
+ensure_all_services() {
+  local now
+  now=$(date +%s)
+  # Throttle: skip if ran recently (unless force=1 passed)
+  if [[ "${1:-}" != "force" ]] && (( now - ENSURE_SERVICES_LAST_RUN < ENSURE_SERVICES_INTERVAL )); then
+    return 0
+  fi
+  ENSURE_SERVICES_LAST_RUN=$now
+
+  local os
+  os="$(ops_os 2>/dev/null || uname -s)"
+
+  case "$os" in
+    macos|Darwin*)  _ensure_all_services_launchd ;;
+    debian|fedora|arch|suse|alpine|linux|wsl|Linux*)  _ensure_all_services_systemd ;;
+    *)  return 0 ;;  # Windows/unsupported — skip
+  esac
+}
+
+_ensure_all_services_launchd() {
+  command -v launchctl >/dev/null 2>&1 || return 0
+  local agents_dir="$HOME/Library/LaunchAgents"
+  local entry label plist_base desc
+  local repaired=0
+
+  for entry in "${EXPECTED_SERVICES[@]}"; do
+    IFS='|' read -r label plist_base desc <<< "$entry"
+    local plist_dst="$agents_dir/$plist_base"
+    local plist_src="$SCRIPT_DIR/scripts/$plist_base"
+
+    # 1. Check if plist is installed
+    if [[ ! -f "$plist_dst" ]]; then
+      log "ENSURE: $label plist missing from $agents_dir — installing"
+      _repair_launchd_service "$label" "$plist_src" "$plist_dst"
+      (( repaired++ )) || true
+      continue
+    fi
+
+    # 2. Check if service is registered and has a live PID
+    local pid_str
+    pid_str=$(launchctl list 2>/dev/null | awk -v lbl="$label" '$3==lbl {print $1}' || true)
+
+    if [[ -z "$pid_str" ]]; then
+      # Not registered at all — bootstrap it
+      log "ENSURE: $label not registered in launchctl — bootstrapping"
+      _repair_launchd_service "$label" "$plist_src" "$plist_dst"
+      (( repaired++ )) || true
+      continue
+    fi
+
+    if [[ "$pid_str" == "-" ]]; then
+      # Registered but no PID — crashed or not started
+      local exit_status
+      exit_status=$(launchctl list 2>/dev/null | awk -v lbl="$label" '$3==lbl {print $2}' || true)
+      if [[ "$exit_status" != "0" ]] && [[ -n "$exit_status" ]] && [[ "$exit_status" != "-" ]]; then
+        log "ENSURE: $label crashed (exit=$exit_status) — kickstarting"
+        launchctl kickstart "gui/$(id -u)/$label" 2>/dev/null || {
+          # Fallback: full reinstall
+          _repair_launchd_service "$label" "$plist_src" "$plist_dst"
+        }
+        (( repaired++ )) || true
+      fi
+      continue
+    fi
+
+    # 3. Has a PID — verify it's actually alive
+    if ! kill -0 "$pid_str" 2>/dev/null; then
+      log "ENSURE: $label has stale PID $pid_str — kickstarting"
+      launchctl kickstart -k "gui/$(id -u)/$label" 2>/dev/null || {
+        _repair_launchd_service "$label" "$plist_src" "$plist_dst"
+      }
+      (( repaired++ )) || true
+    fi
+  done
+
+  if [[ $repaired -gt 0 ]]; then
+    log "ENSURE: repaired $repaired service(s)"
+  fi
+}
+
+_repair_launchd_service() {
+  local label="$1" plist_src="$2" plist_dst="$3"
+  local bash_path
+  bash_path="$(command -v bash)"
+  local plugin_root="$SCRIPT_DIR"
+  if [[ -z "$bash_path" ]] || [[ ! -f "$plist_src" ]]; then
+    log "ENSURE: cannot repair $label — missing bash or source plist"
+    return 1
+  fi
+  _install_launchd_plist "$plist_src" "$plist_dst" "$bash_path" "$plugin_root" "$label"
+}
+
+_ensure_all_services_systemd() {
+  command -v systemctl >/dev/null 2>&1 || return 0
+  local repaired=0
+
+  # Check wacli-keepalive systemd unit
+  if ! systemctl --user is-active claude-ops-wacli-keepalive.service &>/dev/null; then
+    log "ENSURE: claude-ops-wacli-keepalive.service not active — restarting"
+    systemctl --user restart claude-ops-wacli-keepalive.service 2>/dev/null || {
+      # Unit may not exist — trigger full install
+      install_daemon_systemd
+    }
+    (( repaired++ )) || true
+  fi
+
+  # Check timer
+  if ! systemctl --user is-active claude-ops.timer &>/dev/null; then
+    log "ENSURE: claude-ops.timer not active — restarting"
+    systemctl --user restart claude-ops.timer 2>/dev/null || {
+      install_daemon_systemd
+    }
+    (( repaired++ )) || true
+  fi
+
+  if [[ $repaired -gt 0 ]]; then
+    log "ENSURE: repaired $repaired systemd service(s)"
+  fi
+}
+
 install_daemon() {
   local os
   os="$(ops_os 2>/dev/null || uname -s)"
@@ -968,6 +1138,9 @@ done
 log "START: ops-daemon pid=$$ starting (run_once=$OPS_RUN_ONCE)"
 rotate_log
 
+# Ensure all com.claude-ops.* services are installed and healthy at startup
+ensure_all_services "force"
+
 if ! load_services_config; then
   log "FATAL: no services config — writing empty health and sleeping"
   cat > "$HEALTH_FILE" <<EOF
@@ -1022,6 +1195,9 @@ while true; do
       fi
     fi
   done < <(get_enabled_services)
+
+  # ── Service self-healing pass ────────────────────────────────────────────
+  ensure_all_services              # Every 5 min: verify all launchd/systemd services
 
   # ── Intelligence pass (smart brain) ──────────────────────────────────────
   # These run with their own internal throttles — safe to call every loop

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -778,13 +778,13 @@ _install_launchd_plist() {
     return 1
   fi
 
-  # Check if already running with a live PID — skip reinstall
+  # Check if already running with a live PID — skip reinstall.
+  # Parse `launchctl list` (no label): format is "PID\tExitStatus\tLabel".
+  # The labeled form `launchctl list <label>` outputs '"PID" = 12345;' which
+  # yields '=' as $2 — never the PID — so we avoid it entirely.
   local existing_pid
-  existing_pid=$(launchctl list "$label" 2>/dev/null | awk '/PID/{print $2}' || true)
-  if [[ -z "$existing_pid" ]]; then
-    # Also try parsing the list output (format: PID\tStatus\tLabel)
-    existing_pid=$(launchctl list 2>/dev/null | awk -v lbl="$label" '$3==lbl && $1!="-" {print $1}' || true)
-  fi
+  existing_pid=$(launchctl list 2>/dev/null \
+    | awk -v lbl="$label" '$3==lbl && $1!="-" {print $1; exit}' || true)
   if [[ -n "$existing_pid" ]] && kill -0 "$existing_pid" 2>/dev/null; then
     log "INSTALL(launchd): $label already running (pid=$existing_pid) — skipping"
     return 0

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -85,6 +85,8 @@ declare -A SERVICE_NEXT_RUN    # service name → next run epoch (cron services)
 declare -A SERVICE_LAST_RUN    # service name → last run epoch (cron services)
 declare -A SERVICE_STATUS      # service name → status string
 declare -A SERVICE_LAST_HEALTH # service name → last health string
+declare -A SERVICE_LAST_RESTART_EPOCH  # service name → epoch of last restart attempt
+RESTART_COOLDOWN=1800  # Reset restart counter after 30 min of stability
 ACTION_NEEDED="null"
 
 # ── Config loading ────────────────────────────────────────────────────────
@@ -236,20 +238,27 @@ restart_service() {
   max_restarts="${max_restarts:-10}"
 
   local count="${SERVICE_RESTARTS[$name]:-0}"
+  local now
+  now=$(date +%s)
+
+  # Cooldown: reset restart counter after RESTART_COOLDOWN seconds of stability
+  local last_restart_epoch="${SERVICE_LAST_RESTART_EPOCH[$name]:-0}"
+  if [[ $count -gt 0 ]] && (( now - last_restart_epoch > RESTART_COOLDOWN )); then
+    log "RESTART: $name stable for ${RESTART_COOLDOWN}s — resetting restart counter (was $count)"
+    count=0
+    SERVICE_RESTARTS["$name"]=0
+  fi
+
   if [[ $count -ge $max_restarts ]]; then
-    log "RESTART: $name hit max_restarts=$max_restarts — not restarting"
+    log "RESTART: $name hit max_restarts=$max_restarts — not restarting (resets after ${RESTART_COOLDOWN}s cooldown)"
     SERVICE_STATUS["$name"]="max_restarts_exceeded"
     return
   fi
 
   SERVICE_RESTARTS["$name"]=$(( count + 1 ))
+  SERVICE_LAST_RESTART_EPOCH["$name"]=$now
   log "RESTART: $name (attempt $((count+1))/$max_restarts) — waiting ${restart_delay}s"
-  # Non-blocking: schedule restart by marking it, actual start happens in main loop
-  # For simplicity, stop and re-start after the delay inline (daemon loop is 30s anyway)
   stop_service "$name"
-  sleep "${restart_delay}" &
-  # We record the sleep PID to avoid blocking; restart happens next health check after delay
-  # Use a simpler approach: just restart immediately (launchd handles overall throttle)
   start_service "$name"
 }
 
@@ -333,11 +342,22 @@ except: print('')
 " 2>/dev/null || true)
   fi
 
+  # Daemon version from package.json
+  local daemon_version=""
+  if [[ -f "$SCRIPT_DIR/package.json" ]]; then
+    daemon_version=$(python3 -c "
+import json
+try: print(json.load(open('$SCRIPT_DIR/package.json')).get('version',''))
+except: print('')
+" 2>/dev/null || true)
+  fi
+
   cat > "$HEALTH_FILE" <<EOF
 {
   "timestamp": "$now",
   "pid": $$,
   "uptime_seconds": $uptime,
+  "version": "$daemon_version",
   "services": $services_json,
   "action_needed": $ACTION_NEEDED,
   "brain": {
@@ -400,14 +420,17 @@ prefetch_briefing_cache() {
   tmpdir=$(mktemp -d)
   local -a _refresh_pids=()
 
-  # Unread counts
-  (command -v wacli &>/dev/null && wacli chats list --json 2>/dev/null | python3 -c "
-import json,sys,datetime
-data=json.load(sys.stdin).get('data',[]) or []
+  # Unread counts — read from keepalive cache to avoid store-lock contention
+  local wacli_cache="$DATA_DIR/cache/wacli_chats.json"
+  (if [[ -f "$wacli_cache" ]]; then
+    python3 -c "
+import json,datetime
+data=json.load(open('$wacli_cache')).get('data',[]) or []
 cutoff=(datetime.datetime.now(datetime.timezone.utc)-datetime.timedelta(days=7)).isoformat()
 recent=[c for c in data if c.get('LastMessageTS','')>cutoff]
 print(json.dumps({'total_chats':len(recent),'count':len(data)}))
-" > "$tmpdir/wa.json" 2>/dev/null) &
+" > "$tmpdir/wa.json" 2>/dev/null
+  fi) &
   _refresh_pids+=($!)
 
   # Email count
@@ -467,11 +490,12 @@ detect_urgent_messages() {
     if (( now - last < 300 )); then return 0; fi
   fi
 
-  # Check WhatsApp for messages with urgent keywords (skip if wacli unavailable)
-  if command -v wacli &>/dev/null; then
-    wacli messages search --query "urgent OR asap OR deadline OR emergency OR ASAP" --json 2>/dev/null | python3 -c "
-import json,sys,datetime
-data=json.load(sys.stdin)
+  # Check WhatsApp urgent messages — read from keepalive cache (no store-lock contention)
+  local urgent_cache="$DATA_DIR/cache/wacli_urgent.json"
+  if [[ -f "$urgent_cache" ]]; then
+    python3 -c "
+import json,datetime
+data=json.load(open('$urgent_cache'))
 msgs=data.get('data',{}).get('messages',[]) or []
 cutoff=(datetime.datetime.now(datetime.timezone.utc)-datetime.timedelta(hours=4)).isoformat()
 urgent=[m for m in msgs if m.get('Timestamp','')>cutoff and not m.get('FromMe',True)]
@@ -510,18 +534,35 @@ try:
 except: print('')
 " 2>/dev/null)
 
-    if command -v wacli &>/dev/null; then
+    # Read from keepalive cache to check for new messages (no store-lock contention)
+    local wacli_chats_cache="$DATA_DIR/cache/wacli_chats.json"
+    if [[ -f "$wacli_chats_cache" ]]; then
       local new_count
-      new_count=$(wacli messages list --after="${last_ts:-$(_date_days_ago 1 +%Y-%m-%d 2>/dev/null || echo '')}" --limit=5 --json 2>/dev/null | python3 -c "
-import json,sys
-d=json.load(sys.stdin)
-msgs=d.get('data',{}).get('messages',[]) or []
-print(len(msgs))
+      new_count=$(python3 -c "
+import json,datetime
+data=json.load(open('$wacli_chats_cache')).get('data',[]) or []
+last='${last_ts:-}'
+recent=[c for c in data if c.get('LastMessageTS','')>last] if last else data[:5]
+print(len(recent))
 " 2>/dev/null || echo 0)
 
       if [[ "$new_count" -gt 3 ]] && [[ -f "$MEM_SCRIPT" ]]; then
-        log "BRAIN: $new_count new messages since last extraction — triggering memory update"
-        bash "$MEM_SCRIPT" >> "$LOG_DIR/memory-extractor.log" 2>&1 &
+        # Guard against duplicate extractors
+        local extractor_pid_file="$DATA_DIR/memories/.extractor_pid"
+        local should_run=1
+        if [[ -f "$extractor_pid_file" ]]; then
+          local existing_pid
+          existing_pid=$(cat "$extractor_pid_file" 2>/dev/null || true)
+          if [[ -n "$existing_pid" ]] && kill -0 "$existing_pid" 2>/dev/null; then
+            log "BRAIN: memory extractor already running (pid=$existing_pid) — skipping"
+            should_run=0
+          fi
+        fi
+        if [[ $should_run -eq 1 ]]; then
+          log "BRAIN: $new_count new messages since last extraction — triggering memory update"
+          bash "$MEM_SCRIPT" >> "$LOG_DIR/memory-extractor.log" 2>&1 &
+          echo $! > "$extractor_pid_file"
+        fi
       fi
     fi
   fi
@@ -548,9 +589,13 @@ import json, subprocess, sys, datetime, os, collections
 data_dir = sys.argv[1]
 contacts = collections.defaultdict(lambda: {"channels": [], "last_seen": "", "msg_count": 0, "needs_reply": False})
 
-# WhatsApp contacts
+# WhatsApp contacts — read from keepalive cache (no store-lock contention)
 try:
-    wa = json.loads(subprocess.check_output(["wacli", "chats", "list", "--json"], timeout=10, stderr=subprocess.DEVNULL))
+    cache_path = os.path.join(data_dir, "cache", "wacli_chats.json")
+    if os.path.exists(cache_path):
+        wa = json.load(open(cache_path))
+    else:
+        wa = {"data": []}
     cutoff = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=7)).isoformat()
     for chat in (wa.get("data") or []):
         if chat.get("LastMessageTS", "") < cutoff: continue

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -778,16 +778,22 @@ _install_launchd_plist() {
     return 1
   fi
 
-  # Check if already running with a live PID — skip reinstall.
-  # Parse `launchctl list` (no label): format is "PID\tExitStatus\tLabel".
-  # The labeled form `launchctl list <label>` outputs '"PID" = 12345;' which
-  # yields '=' as $2 — never the PID — so we avoid it entirely.
-  local existing_pid
-  existing_pid=$(launchctl list 2>/dev/null \
-    | awk -v lbl="$label" '$3==lbl && $1!="-" {print $1; exit}' || true)
-  if [[ -n "$existing_pid" ]] && kill -0 "$existing_pid" 2>/dev/null; then
-    log "INSTALL(launchd): $label already running (pid=$existing_pid) — skipping"
-    return 0
+  # Only skip reinstall if BOTH the destination plist file exists AND a live
+  # PID is registered. If the file is missing, always proceed with a full
+  # install so the plist is (re)copied — a live PID from a previous session
+  # running an old plist would otherwise cause us to silently skip and leave
+  # the service unregistered on next reboot.
+  local existing_pid=""
+  if [[ -f "$dst" ]]; then
+    # Parse `launchctl list` (no label): format is "PID\tExitStatus\tLabel".
+    # The labeled form `launchctl list <label>` outputs '"PID" = 12345;' which
+    # yields '=' as $2 — never the PID — so we avoid it entirely.
+    existing_pid=$(launchctl list 2>/dev/null \
+      | awk -v lbl="$label" '$3==lbl && $1!="-" {print $1; exit}' || true)
+    if [[ -n "$existing_pid" ]] && kill -0 "$existing_pid" 2>/dev/null; then
+      log "INSTALL(launchd): $label already installed at $dst and running (pid=$existing_pid) — skipping"
+      return 0
+    fi
   fi
 
   # Substitute placeholders

--- a/claude-ops/scripts/wacli-keepalive.sh
+++ b/claude-ops/scripts/wacli-keepalive.sh
@@ -200,6 +200,69 @@ if jids:
   fi
 }
 
+# ── Missed message detection ───────────────────────────────────────────
+# Compare chat metadata LastMessageTS against actual latest DB message.
+# If gap > 1 hour, the chat has missing messages and needs backfill.
+detect_missed_messages() {
+  command -v "$WACLI" &>/dev/null || return 0
+  local backfill_file="$STORE/.backfill_jids"
+
+  "$WACLI" chats list --json 2>/dev/null | python3 -c "
+import json, sys, subprocess, datetime
+
+data = json.load(sys.stdin)
+chats = data.get('data', []) or []
+wacli = '${WACLI}'
+cutoff = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=14)).isoformat()
+gap_threshold = 3600  # 1 hour in seconds
+missed = []
+
+for c in chats:
+    jid = c.get('JID', '')
+    meta_ts = c.get('LastMessageTS', '')
+    if not jid or not meta_ts or meta_ts < cutoff:
+        continue
+    try:
+        result = subprocess.run(
+            [wacli, 'messages', 'list', '--chat', jid, '--limit', '1', '--json'],
+            capture_output=True, text=True, timeout=10
+        )
+        if result.returncode != 0:
+            continue
+        msg_data = json.loads(result.stdout)
+        msgs = msg_data.get('data', {}).get('messages', []) or []
+        if not msgs:
+            missed.append(jid)
+            continue
+        db_ts = msgs[0].get('Timestamp', '')
+        if not db_ts:
+            continue
+        # Parse both timestamps and compare
+        from dateutil.parser import parse as dtparse
+        meta_dt = dtparse(meta_ts)
+        db_dt = dtparse(db_ts)
+        gap = abs((meta_dt - db_dt).total_seconds())
+        if gap > gap_threshold:
+            missed.append(jid)
+    except Exception:
+        continue
+
+if missed:
+    # Append to existing backfill file (don't overwrite)
+    existing = set()
+    try:
+        with open('${backfill_file}') as f:
+            existing = set(l.strip() for l in f if l.strip())
+    except: pass
+    with open('${backfill_file}', 'w') as f:
+        for jid in sorted(existing | set(missed)):
+            f.write(jid + '\n')
+    print(f'MISSED: {len(missed)} chats with message gaps detected')
+" 2>/dev/null | while IFS= read -r line; do
+    log "$line"
+  done || true
+}
+
 auto_detect_empty_chats
 detect_missed_messages
 run_backfill
@@ -279,69 +342,6 @@ periodic_backfill() {
       write_backfill_memory
     fi
   ) &
-}
-
-# ── Missed message detection ───────────────────────────────────────────
-# Compare chat metadata LastMessageTS against actual latest DB message.
-# If gap > 1 hour, the chat has missing messages and needs backfill.
-detect_missed_messages() {
-  command -v "$WACLI" &>/dev/null || return 0
-  local backfill_file="$STORE/.backfill_jids"
-
-  "$WACLI" chats list --json 2>/dev/null | python3 -c "
-import json, sys, subprocess, datetime
-
-data = json.load(sys.stdin)
-chats = data.get('data', []) or []
-wacli = '${WACLI}'
-cutoff = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=14)).isoformat()
-gap_threshold = 3600  # 1 hour in seconds
-missed = []
-
-for c in chats:
-    jid = c.get('JID', '')
-    meta_ts = c.get('LastMessageTS', '')
-    if not jid or not meta_ts or meta_ts < cutoff:
-        continue
-    try:
-        result = subprocess.run(
-            [wacli, 'messages', 'list', '--chat', jid, '--limit', '1', '--json'],
-            capture_output=True, text=True, timeout=10
-        )
-        if result.returncode != 0:
-            continue
-        msg_data = json.loads(result.stdout)
-        msgs = msg_data.get('data', {}).get('messages', []) or []
-        if not msgs:
-            missed.append(jid)
-            continue
-        db_ts = msgs[0].get('Timestamp', '')
-        if not db_ts:
-            continue
-        # Parse both timestamps and compare
-        from dateutil.parser import parse as dtparse
-        meta_dt = dtparse(meta_ts)
-        db_dt = dtparse(db_ts)
-        gap = abs((meta_dt - db_dt).total_seconds())
-        if gap > gap_threshold:
-            missed.append(jid)
-    except Exception:
-        continue
-
-if missed:
-    # Append to existing backfill file (don't overwrite)
-    existing = set()
-    try:
-        with open('${backfill_file}') as f:
-            existing = set(l.strip() for l in f if l.strip())
-    except: pass
-    with open('${backfill_file}', 'w') as f:
-        for jid in sorted(existing | set(missed)):
-            f.write(jid + '\n')
-    print(f'MISSED: {len(missed)} chats with message gaps detected')
-" 2>/dev/null | while IFS= read -r line; do
-    log "$line"
-  done || true
 }
 
 # ── Write backfill summary to ops memory ────────────────────────────────

--- a/claude-ops/scripts/wacli-keepalive.sh
+++ b/claude-ops/scripts/wacli-keepalive.sh
@@ -34,8 +34,9 @@ SYNC_PROBE_TIMEOUT=20
 BACKFILL_INTERVAL="${BACKFILL_INTERVAL:-1800}"  # 30 min default
 PAUSE_SIGNAL="$STORE/.pause_sync"
 SYNC_PID_FILE="$STORE/.sync_pid"
+WACLI_CACHE_DIR="$DATA_DIR/cache"
 
-mkdir -p "$LOG_DIR" "$STORE" "$MEMORY_DIR"
+mkdir -p "$LOG_DIR" "$STORE" "$MEMORY_DIR" "$WACLI_CACHE_DIR"
 
 log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" >> "$LOG"; }
 
@@ -271,7 +272,6 @@ run_backfill
 # Write chat/message data to JSON cache so the daemon never calls wacli directly.
 # This eliminates store-lock contention between daemon intelligence functions
 # and the persistent sync.
-WACLI_CACHE_DIR="$DATA_DIR/cache"
 WACLI_CACHE_INTERVAL=300  # 5 min
 LAST_WACLI_CACHE=0
 

--- a/claude-ops/scripts/wacli-keepalive.sh
+++ b/claude-ops/scripts/wacli-keepalive.sh
@@ -24,13 +24,18 @@ fi
 
 WACLI="${WACLI_BIN:-/usr/local/bin/wacli}"
 STORE="${WACLI_STORE:-$HOME/.wacli}"
-LOG_DIR="${WACLI_LOG_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace/logs}"
+DATA_DIR="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+LOG_DIR="${WACLI_LOG_DIR:-$DATA_DIR/logs}"
 LOG="$LOG_DIR/wacli-keepalive.log"
 HEALTH_FILE="$STORE/.health"
+MEMORY_DIR="$DATA_DIR/memories"
 MAX_LOG_SIZE=1048576  # 1MB
 SYNC_PROBE_TIMEOUT=20
+BACKFILL_INTERVAL="${BACKFILL_INTERVAL:-1800}"  # 30 min default
+PAUSE_SIGNAL="$STORE/.pause_sync"
+SYNC_PID_FILE="$STORE/.sync_pid"
 
-mkdir -p "$LOG_DIR" "$STORE"
+mkdir -p "$LOG_DIR" "$STORE" "$MEMORY_DIR"
 
 log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" >> "$LOG"; }
 
@@ -40,6 +45,15 @@ if [[ -f "$LOG" ]] && [[ $(stat -f%z "$LOG" 2>/dev/null || stat -c%s "$LOG" 2>/d
 fi
 
 log "START: keepalive pid=$$ starting"
+
+# ── Step 0: Race condition prevention ───────────────────────────────────
+# Both com.claude-ops.daemon and com.claude-ops.wacli-keepalive start at boot.
+# If both try wacli sync simultaneously, one crashes on the store lock.
+# Wait briefly for any concurrent sync to claim the lock first.
+if pgrep -f "wacli sync" >/dev/null 2>&1; then
+  log "START: another wacli sync is running — waiting 15s for lock release"
+  sleep 15
+fi
 
 # ── Step 1: Kill orphaned wacli sync processes ──────────────────────────
 cleanup_stale() {
@@ -187,21 +201,221 @@ if jids:
 }
 
 auto_detect_empty_chats
+detect_missed_messages
 run_backfill
 
 write_health "connected" "persistent sync starting"
 
-# Persistent sync for real-time messages. If it exits, launchd restarts us.
+# ── Pause-signal handler ────────────────────────────────────────────────
+# External processes (send, backfill) write $PAUSE_SIGNAL to request exclusive
+# wacli access. We stop the persistent sync, wait for the signal to clear
+# (or auto-expire after 60s), then restart.
+check_pause_signal() {
+  if [[ ! -f "$PAUSE_SIGNAL" ]]; then return 1; fi
+
+  # Auto-expire stale pause signals (>60s old)
+  local pause_age
+  pause_age=$(( $(date +%s) - $(stat -f%m "$PAUSE_SIGNAL" 2>/dev/null || stat -c%Y "$PAUSE_SIGNAL" 2>/dev/null || echo 0) ))
+  if [[ $pause_age -gt 60 ]]; then
+    log "PAUSE: stale pause signal (${pause_age}s old) — removing"
+    rm -f "$PAUSE_SIGNAL"
+    return 1
+  fi
+
+  local requester_pid
+  requester_pid=$(head -1 "$PAUSE_SIGNAL" 2>/dev/null | grep -o '[0-9]*' || true)
+  if [[ -n "$requester_pid" ]] && ! kill -0 "$requester_pid" 2>/dev/null; then
+    log "PAUSE: requester pid=$requester_pid is dead — removing signal"
+    rm -f "$PAUSE_SIGNAL"
+    return 1
+  fi
+
+  return 0
+}
+
+# ── Periodic backfill in background ─────────────────────────────────────
+# Runs every BACKFILL_INTERVAL during persistent sync. Non-blocking.
+LAST_BACKFILL_TIME=$(date +%s)
+
+periodic_backfill() {
+  local now
+  now=$(date +%s)
+  if (( now - LAST_BACKFILL_TIME < BACKFILL_INTERVAL )); then return 0; fi
+  LAST_BACKFILL_TIME=$now
+
+  log "PERIODIC-BACKFILL: checking for chats needing backfill"
+  (
+    auto_detect_empty_chats
+    detect_missed_messages
+    if [[ -f "$STORE/.backfill_jids" ]] && [[ -s "$STORE/.backfill_jids" ]]; then
+      run_backfill
+      write_backfill_memory
+    fi
+  ) &
+}
+
+# ── Missed message detection ───────────────────────────────────────────
+# Compare chat metadata LastMessageTS against actual latest DB message.
+# If gap > 1 hour, the chat has missing messages and needs backfill.
+detect_missed_messages() {
+  command -v "$WACLI" &>/dev/null || return 0
+  local backfill_file="$STORE/.backfill_jids"
+
+  "$WACLI" chats list --json 2>/dev/null | python3 -c "
+import json, sys, subprocess, datetime
+
+data = json.load(sys.stdin)
+chats = data.get('data', []) or []
+wacli = '${WACLI}'
+cutoff = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=14)).isoformat()
+gap_threshold = 3600  # 1 hour in seconds
+missed = []
+
+for c in chats:
+    jid = c.get('JID', '')
+    meta_ts = c.get('LastMessageTS', '')
+    if not jid or not meta_ts or meta_ts < cutoff:
+        continue
+    try:
+        result = subprocess.run(
+            [wacli, 'messages', 'list', '--chat', jid, '--limit', '1', '--json'],
+            capture_output=True, text=True, timeout=10
+        )
+        if result.returncode != 0:
+            continue
+        msg_data = json.loads(result.stdout)
+        msgs = msg_data.get('data', {}).get('messages', []) or []
+        if not msgs:
+            missed.append(jid)
+            continue
+        db_ts = msgs[0].get('Timestamp', '')
+        if not db_ts:
+            continue
+        # Parse both timestamps and compare
+        from dateutil.parser import parse as dtparse
+        meta_dt = dtparse(meta_ts)
+        db_dt = dtparse(db_ts)
+        gap = abs((meta_dt - db_dt).total_seconds())
+        if gap > gap_threshold:
+            missed.append(jid)
+    except Exception:
+        continue
+
+if missed:
+    # Append to existing backfill file (don't overwrite)
+    existing = set()
+    try:
+        with open('${backfill_file}') as f:
+            existing = set(l.strip() for l in f if l.strip())
+    except: pass
+    with open('${backfill_file}', 'w') as f:
+        for jid in sorted(existing | set(missed)):
+            f.write(jid + '\n')
+    print(f'MISSED: {len(missed)} chats with message gaps detected')
+" 2>/dev/null | while IFS= read -r line; do
+    log "$line"
+  done || true
+}
+
+# ── Write backfill summary to ops memory ────────────────────────────────
+write_backfill_memory() {
+  command -v "$WACLI" &>/dev/null || return 0
+
+  "$WACLI" chats list --json 2>/dev/null | python3 -c "
+import json, sys, subprocess, datetime, os
+
+data = json.load(sys.stdin)
+chats = data.get('data', []) or []
+wacli = '${WACLI}'
+memory_dir = '${MEMORY_DIR}'
+now = datetime.datetime.now(datetime.timezone.utc)
+summaries = []
+
+for c in chats[:20]:
+    jid = c.get('JID', '')
+    name = c.get('Name', '') or c.get('PushName', '') or jid
+    meta_ts = c.get('LastMessageTS', '')
+    if not jid or not meta_ts:
+        continue
+    try:
+        result = subprocess.run(
+            [wacli, 'messages', 'list', '--chat', jid, '--limit', '3', '--json'],
+            capture_output=True, text=True, timeout=10
+        )
+        if result.returncode != 0:
+            continue
+        msg_data = json.loads(result.stdout)
+        msgs = msg_data.get('data', {}).get('messages', []) or []
+        if not msgs:
+            continue
+        # Build summary
+        texts = [m.get('Text', '')[:100] for m in msgs if m.get('Text')]
+        if texts:
+            summaries.append({
+                'contact': name,
+                'jid': jid,
+                'last_message_ts': meta_ts,
+                'recent_topics': texts[:3],
+                'msg_count_local': len(msgs)
+            })
+    except:
+        continue
+
+if summaries:
+    summary_file = os.path.join(memory_dir, 'whatsapp_backfill_summary.json')
+    with open(summary_file, 'w') as f:
+        json.dump({
+            'updated': now.isoformat(),
+            'backfilled_chats': summaries
+        }, f, indent=2)
+    print(f'MEMORY: wrote backfill summary for {len(summaries)} chats')
+" 2>/dev/null | while IFS= read -r line; do
+    log "$line"
+  done || true
+}
+
+# ── Persistent sync with pause-signal + periodic backfill ──────────────
 log "SYNC: starting persistent sync --follow"
-"$WACLI" sync --follow --refresh-contacts --refresh-groups 2>&1 | while IFS= read -r line; do
-  # Filter noise
-  case "$line" in
-    *"app state key"*|*"Failed to sync app state"*|*"Failed to do initial fetch"*) ;;
-    *"ERROR"*) log "SYNC-ERR: $line" ;;
-    *"Synced"*|*"Connected"*|*"Stopping"*) log "SYNC: $line" ;;
-  esac
+
+while true; do
+  # Check for pause signal before starting sync
+  if check_pause_signal; then
+    log "SYNC: pause signal detected — waiting for external command to finish"
+    write_health "paused" "sync paused for external wacli command"
+    while check_pause_signal; do sleep 2; done
+    log "SYNC: pause cleared — resuming"
+    write_health "connected" "sync resuming after pause"
+  fi
+
+  # Start persistent sync in background so we can monitor pause signals
+  "$WACLI" sync --follow --refresh-contacts --refresh-groups 2>&1 &
+  local_sync_pid=$!
+  echo "$local_sync_pid" > "$SYNC_PID_FILE"
+
+  # Monitor loop: check pause signals + trigger periodic backfill
+  while kill -0 "$local_sync_pid" 2>/dev/null; do
+    # If pause signal appears, stop sync gracefully
+    if check_pause_signal; then
+      log "SYNC: pause signal received — stopping sync pid=$local_sync_pid"
+      kill -TERM "$local_sync_pid" 2>/dev/null || true
+      wait "$local_sync_pid" 2>/dev/null || true
+      rm -f "$SYNC_PID_FILE"
+      break
+    fi
+
+    # Periodic backfill (non-blocking, runs in subshell)
+    periodic_backfill
+
+    sleep 5
+  done
+
+  # If sync exited on its own (not paused), break out of the restart loop
+  if ! check_pause_signal; then
+    break
+  fi
 done
 
+rm -f "$SYNC_PID_FILE"
 write_health "disconnected" "sync exited"
 log "EXIT: sync process ended — launchd will restart"
 exit 0

--- a/claude-ops/scripts/wacli-keepalive.sh
+++ b/claude-ops/scripts/wacli-keepalive.sh
@@ -34,9 +34,39 @@ SYNC_PROBE_TIMEOUT=20
 BACKFILL_INTERVAL="${BACKFILL_INTERVAL:-1800}"  # 30 min default
 PAUSE_SIGNAL="$STORE/.pause_sync"
 SYNC_PID_FILE="$STORE/.sync_pid"
+BATCH_MARKER="$STORE/.batch_wacli"  # set by self-initiated sync kills (not external pause)
 WACLI_CACHE_DIR="$DATA_DIR/cache"
 
 mkdir -p "$LOG_DIR" "$STORE" "$MEMORY_DIR" "$WACLI_CACHE_DIR"
+
+# ── Self-pause helpers (bug 5) ──────────────────────────────────────────
+# Kill the persistent sync from within the keepalive's own process so we can
+# access wacli exclusively without colliding on the store lock. The outer
+# supervisor loop watches $BATCH_MARKER and always restarts sync when it's set,
+# distinguishing a deliberate batch pause from an unexpected crash.
+acquire_wacli_batch() {
+  touch "$BATCH_MARKER"
+  local sync_pid=""
+  [[ -f "$SYNC_PID_FILE" ]] && sync_pid=$(cat "$SYNC_PID_FILE" 2>/dev/null || true)
+  if [[ -n "$sync_pid" ]] && kill -0 "$sync_pid" 2>/dev/null; then
+    kill -TERM "$sync_pid" 2>/dev/null || true
+    local waited=0
+    while kill -0 "$sync_pid" 2>/dev/null && [[ $waited -lt 10 ]]; do
+      sleep 1
+      waited=$((waited + 1))
+    done
+    if kill -0 "$sync_pid" 2>/dev/null; then
+      kill -KILL "$sync_pid" 2>/dev/null || true
+    fi
+    rm -f "$SYNC_PID_FILE"
+  fi
+  # Give the OS a moment to fully release the store lock file
+  sleep 1
+}
+
+release_wacli_batch() {
+  rm -f "$BATCH_MARKER"
+}
 
 log() { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" >> "$LOG"; }
 
@@ -208,8 +238,23 @@ detect_missed_messages() {
   command -v "$WACLI" &>/dev/null || return 0
   local backfill_file="$STORE/.backfill_jids"
 
+  # Acquire exclusive wacli access — this function subprocesses wacli many times
+  acquire_wacli_batch
+
   "$WACLI" chats list --json 2>/dev/null | python3 -c "
 import json, sys, subprocess, datetime
+
+def parse_ts(s):
+    '''Parse an ISO-8601 timestamp using only stdlib.
+    Handles the Z suffix for UTC.'''
+    if not s:
+        return None
+    if s.endswith('Z'):
+        s = s[:-1] + '+00:00'
+    try:
+        return datetime.datetime.fromisoformat(s)
+    except Exception:
+        return None
 
 data = json.load(sys.stdin)
 chats = data.get('data', []) or []
@@ -238,10 +283,11 @@ for c in chats:
         db_ts = msgs[0].get('Timestamp', '')
         if not db_ts:
             continue
-        # Parse both timestamps and compare
-        from dateutil.parser import parse as dtparse
-        meta_dt = dtparse(meta_ts)
-        db_dt = dtparse(db_ts)
+        # Parse both timestamps and compare — stdlib only
+        meta_dt = parse_ts(meta_ts)
+        db_dt = parse_ts(db_ts)
+        if meta_dt is None or db_dt is None:
+            continue
         gap = abs((meta_dt - db_dt).total_seconds())
         if gap > gap_threshold:
             missed.append(jid)
@@ -262,6 +308,8 @@ if missed:
 " 2>/dev/null | while IFS= read -r line; do
     log "$line"
   done || true
+
+  release_wacli_batch
 }
 
 auto_detect_empty_chats
@@ -281,6 +329,10 @@ refresh_wacli_cache() {
   if (( now - LAST_WACLI_CACHE < WACLI_CACHE_INTERVAL )); then return 0; fi
   LAST_WACLI_CACHE=$now
 
+  # Acquire exclusive wacli access by killing the persistent sync.
+  # The outer supervisor loop restarts sync after this batch returns.
+  acquire_wacli_batch
+
   # Write chats cache
   "$WACLI" chats list --json > "$WACLI_CACHE_DIR/wacli_chats.json" 2>/dev/null || true
 
@@ -288,6 +340,7 @@ refresh_wacli_cache() {
   "$WACLI" messages search --query "urgent OR asap OR deadline OR emergency OR ASAP" --json \
     > "$WACLI_CACHE_DIR/wacli_urgent.json" 2>/dev/null || true
 
+  release_wacli_batch
   log "CACHE: refreshed wacli data cache"
 }
 
@@ -348,6 +401,8 @@ periodic_backfill() {
 write_backfill_memory() {
   command -v "$WACLI" &>/dev/null || return 0
 
+  acquire_wacli_batch
+
   "$WACLI" chats list --json 2>/dev/null | python3 -c "
 import json, sys, subprocess, datetime, os
 
@@ -399,6 +454,8 @@ if summaries:
 " 2>/dev/null | while IFS= read -r line; do
     log "$line"
   done || true
+
+  release_wacli_batch
 }
 
 # ── Persistent sync with pause-signal + periodic backfill ──────────────
@@ -437,10 +494,14 @@ while true; do
     sleep 5
   done
 
-  # If sync exited on its own (not paused), break out of the restart loop
-  if ! check_pause_signal; then
+  # If sync exited on its own (not paused, not batch-killed), break out.
+  # A batch kill is a deliberate self-pause from refresh_wacli_cache et al
+  # — we always want to restart sync after a batch completes.
+  if ! check_pause_signal && [[ ! -f "$BATCH_MARKER" ]]; then
     break
   fi
+  # Clear any stale batch marker before restarting
+  rm -f "$BATCH_MARKER"
 done
 
 rm -f "$SYNC_PID_FILE"

--- a/claude-ops/scripts/wacli-keepalive.sh
+++ b/claude-ops/scripts/wacli-keepalive.sh
@@ -204,6 +204,33 @@ auto_detect_empty_chats
 detect_missed_messages
 run_backfill
 
+# ── Wacli data cache for daemon consumption ─────────────────────────────
+# Write chat/message data to JSON cache so the daemon never calls wacli directly.
+# This eliminates store-lock contention between daemon intelligence functions
+# and the persistent sync.
+WACLI_CACHE_DIR="$DATA_DIR/cache"
+WACLI_CACHE_INTERVAL=300  # 5 min
+LAST_WACLI_CACHE=0
+
+refresh_wacli_cache() {
+  local now
+  now=$(date +%s)
+  if (( now - LAST_WACLI_CACHE < WACLI_CACHE_INTERVAL )); then return 0; fi
+  LAST_WACLI_CACHE=$now
+
+  # Write chats cache
+  "$WACLI" chats list --json > "$WACLI_CACHE_DIR/wacli_chats.json" 2>/dev/null || true
+
+  # Write recent messages cache (search for urgent keywords)
+  "$WACLI" messages search --query "urgent OR asap OR deadline OR emergency OR ASAP" --json \
+    > "$WACLI_CACHE_DIR/wacli_urgent.json" 2>/dev/null || true
+
+  log "CACHE: refreshed wacli data cache"
+}
+
+# Initial cache write before starting persistent sync
+refresh_wacli_cache
+
 write_health "connected" "persistent sync starting"
 
 # ── Pause-signal handler ────────────────────────────────────────────────
@@ -403,8 +430,9 @@ while true; do
       break
     fi
 
-    # Periodic backfill (non-blocking, runs in subshell)
+    # Periodic backfill (non-blocking, runs in subshell) + cache refresh
     periodic_backfill
+    refresh_wacli_cache
 
     sleep 5
   done

--- a/claude-ops/skills/ops-marketing/SKILL.md
+++ b/claude-ops/skills/ops-marketing/SKILL.md
@@ -27,6 +27,7 @@ Before executing, load available context:
 1. **Preferences**: Read `${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json`
    - `timezone` — display all timestamps correctly
    - `klaviyo_private_key`, `meta_ads_token`, `meta_ad_account_id`, `ga4_property_id`, `google_search_console_site` — check userConfig keys before env vars
+   - `google_ads_developer_token`, `google_ads_client_id`, `google_ads_client_secret`, `google_ads_refresh_token`, `google_ads_customer_id`, `google_ads_login_customer_id` — Google Ads credentials
 
 2. **Daemon health**: Read `${CLAUDE_PLUGIN_DATA_DIR}/daemon-health.json`
    - If `action_needed` is not null → surface it before running any channel queries
@@ -124,6 +125,42 @@ GSC_SITE="${GOOGLE_SEARCH_CONSOLE_SITE:-$(claude plugin config get google_search
 # Uses same gcloud ADC as GA4
 ```
 
+### Google Ads
+
+```bash
+GADS_API_VERSION="v23"
+GADS_DEV_TOKEN="${GOOGLE_ADS_DEVELOPER_TOKEN:-$(claude plugin config get google_ads_developer_token 2>/dev/null)}"
+GADS_CLIENT_ID="${GOOGLE_ADS_CLIENT_ID:-$(claude plugin config get google_ads_client_id 2>/dev/null)}"
+GADS_CLIENT_SECRET="${GOOGLE_ADS_CLIENT_SECRET:-$(claude plugin config get google_ads_client_secret 2>/dev/null)}"
+GADS_REFRESH_TOKEN="${GOOGLE_ADS_REFRESH_TOKEN:-$(claude plugin config get google_ads_refresh_token 2>/dev/null)}"
+GADS_CUSTOMER_ID="${GOOGLE_ADS_CUSTOMER_ID:-$(claude plugin config get google_ads_customer_id 2>/dev/null)}"
+GADS_LOGIN_CUSTOMER_ID="${GOOGLE_ADS_LOGIN_CUSTOMER_ID:-$(claude plugin config get google_ads_login_customer_id 2>/dev/null)}"
+
+# Doppler fallback
+if [ -z "$GADS_REFRESH_TOKEN" ]; then
+  GADS_REFRESH_TOKEN="$(doppler secrets get GOOGLE_ADS_REFRESH_TOKEN --plain 2>/dev/null)"
+fi
+if [ -z "$GADS_DEV_TOKEN" ]; then
+  GADS_DEV_TOKEN="$(doppler secrets get GOOGLE_ADS_DEVELOPER_TOKEN --plain 2>/dev/null)"
+fi
+
+# Strip dashes from customer ID (API requires no dashes)
+GADS_CUSTOMER_ID="${GADS_CUSTOMER_ID//-/}"
+
+# Refresh access token (expires in ~1 hour — always refresh before API calls)
+GADS_ACCESS_TOKEN=$(curl -s -X POST https://oauth2.googleapis.com/token \
+  --data "client_id=${GADS_CLIENT_ID}" \
+  --data "client_secret=${GADS_CLIENT_SECRET}" \
+  --data "refresh_token=${GADS_REFRESH_TOKEN}" \
+  --data "grant_type=refresh_token" | jq -r '.access_token')
+
+# Common headers for all Google Ads API calls
+GADS_HEADERS=(-H "Content-Type: application/json" -H "Authorization: Bearer ${GADS_ACCESS_TOKEN}" -H "developer-token: ${GADS_DEV_TOKEN}")
+if [ -n "$GADS_LOGIN_CUSTOMER_ID" ]; then
+  GADS_HEADERS+=(-H "login-customer-id: ${GADS_LOGIN_CUSTOMER_ID}")
+fi
+```
+
 ---
 
 ## Sub-command Routing
@@ -135,7 +172,7 @@ Route `$ARGUMENTS` to the correct section below:
 | (empty), dashboard | Run full marketing dashboard |
 | email, klaviyo | Klaviyo email metrics |
 | ads, meta | Meta Ads performance |
-| google-ads | Google Ads (if configured) |
+| google-ads, gads | Google Ads dashboard + campaign management (see ## google-ads section) |
 | analytics, ga4 | GA4 sessions + conversions |
 | seo, gsc | Search Console metrics |
 | social | Social media aggregator |
@@ -424,6 +461,20 @@ Show `[not configured]` for any unconfigured channels rather than failing.
 
 ---
 
+## google-ads
+
+**Credential check**: If `GADS_DEV_TOKEN` or `GADS_REFRESH_TOKEN` is empty after resolution, print:
+`Warning: Google Ads not configured. Run /ops:setup marketing to set up credentials.`
+and stop.
+
+**Token refresh**: Run the access token refresh curl (from Credential Resolution above) at the start of every google-ads invocation. If `GADS_ACCESS_TOKEN` is null or "null", print:
+`Warning: Google Ads token refresh failed. Check client_id/client_secret/refresh_token in /ops:setup.`
+and stop.
+
+Sub-commands are defined in Plans 02 and 03.
+
+---
+
 ## campaigns
 
 Cross-channel campaign overview — unified view of active campaigns across all configured channels.
@@ -483,15 +534,16 @@ For any channel with missing credentials, show `[not configured — /ops:marketi
 ```bash
 # Env vars
 printenv KLAVIYO_API_KEY KLAVIYO_PRIVATE_KEY META_ACCESS_TOKEN FACEBOOK_ACCESS_TOKEN META_AD_ACCOUNT_ID GA4_PROPERTY_ID GA_MEASUREMENT_ID 2>/dev/null
+printenv GOOGLE_ADS_DEVELOPER_TOKEN GOOGLE_ADS_CLIENT_ID GOOGLE_ADS_CLIENT_SECRET GOOGLE_ADS_REFRESH_TOKEN GOOGLE_ADS_CUSTOMER_ID 2>/dev/null
 
 # Shell profiles
-grep -h 'KLAVIYO\|META_\|FACEBOOK\|GA4\|GA_MEASUREMENT' ~/.zshrc ~/.bashrc ~/.zprofile ~/.envrc 2>/dev/null | grep -v '^#'
+grep -h 'KLAVIYO\|META_\|FACEBOOK\|GA4\|GA_MEASUREMENT\|GOOGLE_ADS' ~/.zshrc ~/.bashrc ~/.zprofile ~/.envrc 2>/dev/null | grep -v '^#'
 
 # Doppler — ALL projects, ALL configs
 for proj in $(doppler projects --json 2>/dev/null | jq -r '.[].slug'); do
   for cfg in dev stg prd; do
     doppler secrets --project "$proj" --config "$cfg" --json 2>/dev/null | \
-      jq -r --arg proj "$proj" --arg cfg "$cfg" 'to_entries[] | select(.key | test("KLAVIYO|META|FACEBOOK|GA4|GOOGLE"; "i")) | "\(.key)=\(.value.computed) (doppler:\($proj)/\($cfg))"'
+      jq -r --arg proj "$proj" --arg cfg "$cfg" 'to_entries[] | select(.key | test("KLAVIYO|META|FACEBOOK|GA4|GOOGLE|GOOGLE_ADS"; "i")) | "\(.key)=\(.value.computed) (doppler:\($proj)/\($cfg))"'
   done
 done
 
@@ -499,17 +551,19 @@ done
 dcli password klaviyo --output json 2>/dev/null | jq -r '.[] | select(.password != null and .password != "") | "\(.title): token found"'
 dcli password facebook --output json 2>/dev/null | jq -r '.[] | select(.password != null and .password != "") | "\(.title): token found"'
 dcli password meta --output json 2>/dev/null | jq -r '.[] | select(.password != null and .password != "") | "\(.title): token found"'
+dcli password "google ads" --output json 2>/dev/null | jq -r '.[] | select(.password != null and .password != "") | "\(.title): token found"'
 
 # Keychain
 security find-generic-password -s "klaviyo-api-key" -w 2>/dev/null
 security find-generic-password -s "meta-ads-token" -w 2>/dev/null
+security find-generic-password -s "google-ads-refresh-token" -w 2>/dev/null
 
 # gcloud ADC (for GA4 + Search Console)
 gcloud auth application-default print-access-token 2>/dev/null | head -c 10 && echo "...gcloud-ok"
 
 # Chrome history — reveals account identity
 sqlite3 ~/Library/Application\ Support/Google/Chrome/Default/History \
-  "SELECT DISTINCT url FROM urls WHERE url LIKE '%klaviyo.com%' OR url LIKE '%analytics.google.com%' OR url LIKE '%business.facebook.com%' OR url LIKE '%search.google.com/search-console%' ORDER BY last_visit_time DESC LIMIT 15" 2>/dev/null
+  "SELECT DISTINCT url FROM urls WHERE url LIKE '%klaviyo.com%' OR url LIKE '%analytics.google.com%' OR url LIKE '%business.facebook.com%' OR url LIKE '%search.google.com/search-console%' OR url LIKE '%ads.google.com%' ORDER BY last_visit_time DESC LIMIT 15" 2>/dev/null
 
 # Existing prefs + userConfig
 jq -r '.marketing // empty' "$PREFS_PATH" 2>/dev/null
@@ -524,5 +578,7 @@ Present ALL findings before asking for anything. Only prompt for values NOT foun
 **GA4:** Only needs Property ID + gcloud ADC. If gcloud ADC not set up, run `gcloud auth application-default login` in background (opens browser). Check Chrome history for GA4 property URLs to auto-detect the property ID.
 
 **Search Console:** Only needs site URL + gcloud ADC. Check Chrome history for `search.google.com/search-console` URLs to auto-detect the site.
+
+**Google Ads:** More complex than other marketing credentials — requires 3 pieces: (1) developer token from Google Ads MCC → Tools & Settings → API Center, (2) OAuth2 client ID + secret from Google Cloud Console (Desktop app type, Google Ads API enabled), (3) refresh token via browser OAuth flow. Setup flow: collect developer token and client credentials first, then open browser auth URL, user pastes authorization code, exchange for refresh token via curl, then list accessible customer accounts and let user select. Smoke test: `curl -s -X GET "https://googleads.googleapis.com/v23/customers:listAccessibleCustomers" -H "Authorization: Bearer $TOKEN" -H "developer-token: $DEV_TOKEN"` — expect JSON with `resourceNames` array.
 
 Save via userConfig (preferred) or Doppler. Report: `[service] ✓ connected` or `[service] ✗ invalid key — [error]`.

--- a/claude-ops/skills/ops-marketing/SKILL.md
+++ b/claude-ops/skills/ops-marketing/SKILL.md
@@ -471,7 +471,209 @@ and stop.
 `Warning: Google Ads token refresh failed. Check client_id/client_secret/refresh_token in /ops:setup.`
 and stop.
 
-Sub-commands are defined in Plans 02 and 03.
+Route `$ARGUMENTS` within the google-ads section:
+
+| Input | Action |
+|---|---|
+| (empty), dashboard, overview | Campaign performance dashboard (last 7 days) |
+| search-terms, terms | Search Terms Report with negative keyword candidates (last 30 days) |
+| budget-recs, recommendations, recs | Budget optimization recommendations from Google |
+| campaigns, manage | Campaign management (create, pause, enable, budget) — see Plan 03 |
+| keywords, kw | Keyword Planner + ad group management — see Plan 03 |
+
+### Dashboard (default — no args, `dashboard`, `overview`)
+
+```bash
+# Campaign performance — last 7 days
+CAMPAIGNS=$(curl -s -X POST \
+  "https://googleads.googleapis.com/${GADS_API_VERSION}/customers/${GADS_CUSTOMER_ID}/googleAds:searchStream" \
+  "${GADS_HEADERS[@]}" \
+  --data-binary '{
+    "query": "SELECT campaign.id, campaign.name, campaign.status, campaign_budget.amount_micros, metrics.cost_micros, metrics.impressions, metrics.clicks, metrics.conversions, metrics.conversions_value FROM campaign WHERE segments.date DURING LAST_7_DAYS AND campaign.status != REMOVED ORDER BY metrics.cost_micros DESC LIMIT 20"
+  }')
+
+# Check for API error
+GADS_ERROR=$(echo "$CAMPAIGNS" | jq -r '.[0].error.message // empty' 2>/dev/null)
+if [ -n "$GADS_ERROR" ]; then
+  echo "Google Ads API error: ${GADS_ERROR}"
+  echo "Check credentials with /ops:marketing setup."
+  exit 0
+fi
+
+# Check for empty results
+CAMPAIGN_COUNT=$(echo "$CAMPAIGNS" | jq '[.[].results[]?] | length' 2>/dev/null || echo "0")
+if [ "$CAMPAIGN_COUNT" -eq 0 ]; then
+  echo "No active campaigns found in the last 7 days."
+  exit 0
+fi
+
+# Compute totals
+TOTAL_SPEND=$(echo "$CAMPAIGNS" | jq '[.[].results[]?.metrics.costMicros // "0" | tonumber] | add / 1000000' 2>/dev/null)
+TOTAL_CONVERSIONS=$(echo "$CAMPAIGNS" | jq '[.[].results[]?.metrics.conversions // "0" | tonumber] | add' 2>/dev/null)
+TOTAL_VALUE=$(echo "$CAMPAIGNS" | jq '[.[].results[]?.metrics.conversionsValue // "0" | tonumber] | add' 2>/dev/null)
+OVERALL_ROAS=$(awk "BEGIN { if (${TOTAL_SPEND:-0} > 0) printf \"%.2f\", ${TOTAL_VALUE:-0} / ${TOTAL_SPEND:-1}; else print \"—\" }")
+TOTAL_SPEND_FMT=$(awk "BEGIN { printf \"%.2f\", ${TOTAL_SPEND:-0} }")
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  GOOGLE ADS — Last 7 Days"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "Total Spend: \$${TOTAL_SPEND_FMT}"
+echo "Total Conversions: ${TOTAL_CONVERSIONS}"
+echo "Overall ROAS: ${OVERALL_ROAS}"
+echo ""
+
+# Print table header
+printf "| %-30s | %-8s | %-10s | %-10s | %-8s | %-8s | %-6s | %-6s | %-6s |\n" \
+  "Campaign" "Status" "Budget/day" "Spend" "Impr" "Clicks" "CTR" "Conv" "ROAS"
+printf "|%s|%s|%s|%s|%s|%s|%s|%s|%s|\n" \
+  "--------------------------------" "----------" "------------" "------------" "----------" "----------" "--------" "--------" "--------"
+
+# Print each campaign row
+echo "$CAMPAIGNS" | jq -r '.[].results[]? | [
+  .campaign.name,
+  .campaign.status,
+  (.campaignBudget.amountMicros // "0" | tonumber / 1000000),
+  (.metrics.costMicros // "0" | tonumber / 1000000),
+  (.metrics.impressions // "0" | tonumber),
+  (.metrics.clicks // "0" | tonumber),
+  (.metrics.conversions // "0" | tonumber),
+  (.metrics.conversionsValue // "0" | tonumber),
+  (.metrics.costMicros // "0" | tonumber)
+] | @tsv' 2>/dev/null | while IFS=$'\t' read -r name status budget_raw spend_raw impr_raw clicks_raw conv_raw value_raw cost_raw; do
+  BUDGET=$(awk "BEGIN { printf \"%.2f\", ${budget_raw:-0} }")
+  SPEND=$(awk "BEGIN { printf \"%.2f\", ${spend_raw:-0} }")
+  CTR=$(awk "BEGIN { if (${impr_raw:-0} > 0) printf \"%.2f\", ${clicks_raw:-0} / ${impr_raw:-0} * 100; else print \"0.00\" }")
+  ROAS=$(awk "BEGIN { if (${spend_raw:-0} > 0) printf \"%.2f\", ${value_raw:-0} / ${spend_raw:-1}; else print \"—\" }")
+  printf "| %-30s | %-8s | \$%-9s | \$%-9s | %-8s | %-8s | %-5s%% | %-6s | %-6s |\n" \
+    "${name:0:30}" "$status" "$BUDGET" "$SPEND" "$impr_raw" "$clicks_raw" "$CTR" "$conv_raw" "$ROAS"
+done
+```
+
+### Search Terms (`search-terms`, `terms`)
+
+```bash
+SEARCH_TERMS=$(curl -s -X POST \
+  "https://googleads.googleapis.com/${GADS_API_VERSION}/customers/${GADS_CUSTOMER_ID}/googleAds:searchStream" \
+  "${GADS_HEADERS[@]}" \
+  --data-binary '{
+    "query": "SELECT search_term_view.search_term, search_term_view.status, campaign.name, ad_group.name, metrics.impressions, metrics.clicks, metrics.cost_micros, metrics.conversions FROM search_term_view WHERE segments.date DURING LAST_30_DAYS AND metrics.impressions > 0 ORDER BY metrics.impressions DESC LIMIT 100"
+  }')
+
+# Check for API error
+GADS_ST_ERROR=$(echo "$SEARCH_TERMS" | jq -r '.[0].error.message // empty' 2>/dev/null)
+if [ -n "$GADS_ST_ERROR" ]; then
+  echo "Google Ads API error: ${GADS_ST_ERROR}"
+  echo "Check credentials with /ops:marketing setup."
+  exit 0
+fi
+
+TERM_COUNT=$(echo "$SEARCH_TERMS" | jq '[.[].results[]?] | length' 2>/dev/null || echo "0")
+if [ "$TERM_COUNT" -eq 0 ]; then
+  echo "No search term data found for the last 30 days."
+  exit 0
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  SEARCH TERMS REPORT — Last 30 Days"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+printf "| %-30s | %-10s | %-20s | %-15s | %-6s | %-6s | %-7s | %-6s |\n" \
+  "Search Term" "Status" "Campaign" "Ad Group" "Impr" "Clicks" "Cost" "Conv"
+printf "|%s|%s|%s|%s|%s|%s|%s|%s|\n" \
+  "--------------------------------" "------------" "----------------------" "-----------------" "--------" "--------" "---------" "--------"
+
+# Status mapping and table rows
+echo "$SEARCH_TERMS" | jq -r '.[].results[]? | [
+  .searchTermView.searchTerm,
+  .searchTermView.status,
+  .campaign.name,
+  .adGroup.name,
+  (.metrics.impressions // "0" | tostring),
+  (.metrics.clicks // "0" | tostring),
+  (.metrics.costMicros // "0" | tonumber / 1000000 | tostring),
+  (.metrics.conversions // "0" | tostring)
+] | @tsv' 2>/dev/null | while IFS=$'\t' read -r term status campaign adgroup impr clicks cost_raw conv; do
+  case "$status" in
+    ADDED)    STATUS_LABEL="✓ Added"   ;;
+    EXCLUDED) STATUS_LABEL="✗ Excluded" ;;
+    *)        STATUS_LABEL="○ New"     ;;
+  esac
+  COST=$(awk "BEGIN { printf \"%.2f\", ${cost_raw:-0} }")
+  printf "| %-30s | %-10s | %-20s | %-15s | %-6s | %-6s | \$%-6s | %-6s |\n" \
+    "${term:0:30}" "$STATUS_LABEL" "${campaign:0:20}" "${adgroup:0:15}" "$impr" "$clicks" "$COST" "$conv"
+done
+
+echo ""
+echo "Negative keyword candidates (high spend, zero conversions):"
+
+echo "$SEARCH_TERMS" | jq -r '.[].results[]? | select(
+  (.metrics.conversions // "0" | tonumber) == 0 and
+  (.metrics.costMicros // "0" | tonumber) > 1000000
+) | "  • \(.searchTermView.searchTerm) — $\(.metrics.costMicros | tonumber / 1000000 | tostring | split(".") | .[0] + "." + (.[1] // "00")[0:2])"' 2>/dev/null || echo "  (none found)"
+```
+
+### Budget Recommendations (`budget-recs`, `recommendations`, `recs`)
+
+```bash
+RECS=$(curl -s -X POST \
+  "https://googleads.googleapis.com/${GADS_API_VERSION}/customers/${GADS_CUSTOMER_ID}/googleAds:searchStream" \
+  "${GADS_HEADERS[@]}" \
+  --data-binary '{
+    "query": "SELECT recommendation.resource_name, recommendation.type, recommendation.campaign, recommendation.impact, recommendation.campaign_budget_recommendation FROM recommendation WHERE recommendation.type IN (CAMPAIGN_BUDGET, MOVE_UNUSED_BUDGET, MARGINAL_ROI_CAMPAIGN_BUDGET, FORECASTING_CAMPAIGN_BUDGET)"
+  }')
+
+# Check for API error
+GADS_REC_ERROR=$(echo "$RECS" | jq -r '.[0].error.message // empty' 2>/dev/null)
+if [ -n "$GADS_REC_ERROR" ]; then
+  echo "Google Ads API error: ${GADS_REC_ERROR}"
+  echo "Check credentials with /ops:marketing setup."
+  exit 0
+fi
+
+REC_COUNT=$(echo "$RECS" | jq '[.[].results[]?] | length' 2>/dev/null || echo "0")
+if [ "$REC_COUNT" -eq 0 ]; then
+  echo "No budget recommendations available. Google needs campaign data to generate recommendations."
+  exit 0
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  BUDGET RECOMMENDATIONS"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+printf "| %-22s | %-25s | %-15s | %-13s | %-20s |\n" \
+  "Type" "Campaign" "Current Budget" "Recommended" "Impact"
+printf "|%s|%s|%s|%s|%s|\n" \
+  "------------------------" "---------------------------" "-----------------" "---------------" "----------------------"
+
+echo "$RECS" | jq -r '.[].results[]? | [
+  .recommendation.type,
+  .recommendation.campaign,
+  (.recommendation.campaignBudgetRecommendation.currentBudgetAmountMicros // "0" | tonumber / 1000000 | tostring),
+  (.recommendation.campaignBudgetRecommendation.recommendedBudgetAmountMicros // "0" | tonumber / 1000000 | tostring),
+  (.recommendation.impact.baseMetrics.impressions // "0" | tonumber | tostring),
+  (.recommendation.impact.potentialMetrics.impressions // "0" | tonumber | tostring)
+] | @tsv' 2>/dev/null | while IFS=$'\t' read -r rec_type campaign current_raw recommended_raw base_impr_raw pot_impr_raw; do
+  case "$rec_type" in
+    CAMPAIGN_BUDGET)             TYPE_LABEL="Increase Budget"      ;;
+    MOVE_UNUSED_BUDGET)          TYPE_LABEL="Move Unused Budget"   ;;
+    MARGINAL_ROI_CAMPAIGN_BUDGET) TYPE_LABEL="Marginal ROI"        ;;
+    FORECASTING_CAMPAIGN_BUDGET) TYPE_LABEL="Forecasting"          ;;
+    *)                           TYPE_LABEL="$rec_type"            ;;
+  esac
+  CURRENT=$(awk "BEGIN { printf \"%.2f\", ${current_raw:-0} }")
+  RECOMMENDED=$(awk "BEGIN { printf \"%.2f\", ${recommended_raw:-0} }")
+  IMPACT=$(awk "BEGIN {
+    base = ${base_impr_raw:-0}; pot = ${pot_impr_raw:-0}
+    if (base > 0) printf \"+%.0f%% impressions\", (pot - base) / base * 100
+    else print \"—\"
+  }")
+  printf "| %-22s | %-25s | \$%-14s | \$%-12s | %-20s |\n" \
+    "$TYPE_LABEL" "${campaign:0:25}" "$CURRENT" "$RECOMMENDED" "$IMPACT"
+done
+```
 
 ---
 

--- a/claude-ops/skills/ops-marketing/SKILL.md
+++ b/claude-ops/skills/ops-marketing/SKILL.md
@@ -478,8 +478,9 @@ Route `$ARGUMENTS` within the google-ads section:
 | (empty), dashboard, overview | Campaign performance dashboard (last 7 days) |
 | search-terms, terms | Search Terms Report with negative keyword candidates (last 30 days) |
 | budget-recs, recommendations, recs | Budget optimization recommendations from Google |
-| campaigns, manage | Campaign management (create, pause, enable, budget) — see Plan 03 |
-| keywords, kw | Keyword Planner + ad group management — see Plan 03 |
+| campaigns, manage | Campaign management — list, create, pause, enable, adjust budget |
+| keywords, kw, keyword-planner | Keyword Planner — discover keywords with volume and bid data |
+| ad-groups, ag | Ad group management — list, create, add/remove keywords, adjust bids |
 
 ### Dashboard (default — no args, `dashboard`, `overview`)
 
@@ -674,6 +675,320 @@ echo "$RECS" | jq -r '.[].results[]? | [
     "$TYPE_LABEL" "${campaign:0:25}" "$CURRENT" "$RECOMMENDED" "$IMPACT"
 done
 ```
+
+### Campaign Management (`campaigns`, `manage`)
+
+**List campaigns:**
+
+```bash
+curl -s -X POST \
+  "https://googleads.googleapis.com/${GADS_API_VERSION}/customers/${GADS_CUSTOMER_ID}/googleAds:searchStream" \
+  "${GADS_HEADERS[@]}" \
+  --data-binary '{
+    "query": "SELECT campaign.id, campaign.name, campaign.status, campaign.advertising_channel_type, campaign_budget.amount_micros FROM campaign WHERE campaign.status != REMOVED ORDER BY campaign.name LIMIT 50"
+  }'
+```
+
+Output as table:
+```
+| # | Campaign ID | Name | Status | Channel | Budget/day |
+```
+
+**Create campaign** (`campaigns create`):
+
+Collect from user via AskUserQuestion (free text, one at a time):
+1. Campaign name
+2. Daily budget in dollars (convert to micros: `BUDGET_MICROS=$(awk "BEGIN {printf \"%d\", $DOLLARS * 1000000}")`)
+3. Channel type — AskUserQuestion with options: `[Search, Display, Shopping, Video]`
+   Map to API values: `SEARCH`, `DISPLAY`, `SHOPPING`, `VIDEO`
+
+Two-step mutate:
+
+Step 1 — Create budget:
+```bash
+BUDGET_RESP=$(curl -s -X POST \
+  "https://googleads.googleapis.com/${GADS_API_VERSION}/customers/${GADS_CUSTOMER_ID}/campaignBudgets:mutate" \
+  "${GADS_HEADERS[@]}" \
+  --data-binary "{
+    \"operations\": [{
+      \"create\": {
+        \"name\": \"Budget for ${CAMPAIGN_NAME}\",
+        \"deliveryMethod\": \"STANDARD\",
+        \"amountMicros\": \"${BUDGET_MICROS}\"
+      }
+    }]
+  }")
+BUDGET_RESOURCE=$(echo "$BUDGET_RESP" | jq -r '.results[0].resourceName')
+```
+
+Step 2 — Create campaign (always in PAUSED status for safety):
+```bash
+curl -s -X POST \
+  "https://googleads.googleapis.com/${GADS_API_VERSION}/customers/${GADS_CUSTOMER_ID}/campaigns:mutate" \
+  "${GADS_HEADERS[@]}" \
+  --data-binary "{
+    \"operations\": [{
+      \"create\": {
+        \"name\": \"${CAMPAIGN_NAME}\",
+        \"campaignBudget\": \"${BUDGET_RESOURCE}\",
+        \"advertisingChannelType\": \"${CHANNEL_TYPE}\",
+        \"status\": \"PAUSED\",
+        \"manualCpc\": {},
+        \"networkSettings\": {
+          \"targetGoogleSearch\": true,
+          \"targetSearchNetwork\": true,
+          \"targetContentNetwork\": false
+        }
+      }
+    }]
+  }"
+```
+
+Print: `✓ Campaign "${CAMPAIGN_NAME}" created (status: PAUSED, budget: $XX.XX/day). Enable it with: /ops:marketing google-ads campaigns enable <ID>`
+
+If error, parse `error.message` from response and display.
+
+**Pause campaign** (`campaigns pause <ID>`):
+
+⚠ **Rule 5 — confirm before pausing** via AskUserQuestion: `"Pause campaign <NAME> (ID: <ID>)?"` with options `[Pause, Cancel]`.
+
+```bash
+curl -s -X POST \
+  "https://googleads.googleapis.com/${GADS_API_VERSION}/customers/${GADS_CUSTOMER_ID}/campaigns:mutate" \
+  "${GADS_HEADERS[@]}" \
+  --data-binary "{
+    \"operations\": [{
+      \"update\": {
+        \"resourceName\": \"customers/${GADS_CUSTOMER_ID}/campaigns/${CAMPAIGN_ID}\",
+        \"status\": \"PAUSED\"
+      },
+      \"updateMask\": \"status\"
+    }]
+  }"
+```
+
+Print: `✓ Campaign <NAME> paused.`
+
+**Enable campaign** (`campaigns enable <ID>`):
+
+Same as pause but `"status": "ENABLED"`. No confirmation needed (enabling is not destructive).
+
+```bash
+curl -s -X POST \
+  "https://googleads.googleapis.com/${GADS_API_VERSION}/customers/${GADS_CUSTOMER_ID}/campaigns:mutate" \
+  "${GADS_HEADERS[@]}" \
+  --data-binary "{
+    \"operations\": [{
+      \"update\": {
+        \"resourceName\": \"customers/${GADS_CUSTOMER_ID}/campaigns/${CAMPAIGN_ID}\",
+        \"status\": \"ENABLED\"
+      },
+      \"updateMask\": \"status\"
+    }]
+  }"
+```
+
+Print: `✓ Campaign <NAME> enabled.`
+
+**Adjust budget** (`campaigns budget <ID> <AMOUNT>`):
+
+First, fetch the campaign's current budget resource name:
+```bash
+CAMPAIGN_DATA=$(curl -s -X POST \
+  "https://googleads.googleapis.com/${GADS_API_VERSION}/customers/${GADS_CUSTOMER_ID}/googleAds:searchStream" \
+  "${GADS_HEADERS[@]}" \
+  --data-binary "{\"query\": \"SELECT campaign.campaign_budget, campaign_budget.amount_micros FROM campaign WHERE campaign.id = ${CAMPAIGN_ID}\"}")
+BUDGET_RESOURCE=$(echo "$CAMPAIGN_DATA" | jq -r '.[0].results[0].campaign.campaignBudget // empty')
+CURRENT_BUDGET_MICROS=$(echo "$CAMPAIGN_DATA" | jq -r '.[0].results[0].campaignBudget.amountMicros // "0"')
+CURRENT_BUDGET=$(awk "BEGIN { printf \"%.2f\", ${CURRENT_BUDGET_MICROS:-0} / 1000000 }")
+```
+
+Confirm via AskUserQuestion: `"Change budget from $<CURRENT> to $<NEW>/day?"` with options `[Confirm, Cancel]`.
+
+Then update:
+```bash
+NEW_BUDGET_MICROS=$(awk "BEGIN {printf \"%d\", ${NEW_AMOUNT} * 1000000}")
+curl -s -X POST \
+  "https://googleads.googleapis.com/${GADS_API_VERSION}/customers/${GADS_CUSTOMER_ID}/campaignBudgets:mutate" \
+  "${GADS_HEADERS[@]}" \
+  --data-binary "{
+    \"operations\": [{
+      \"update\": {
+        \"resourceName\": \"${BUDGET_RESOURCE}\",
+        \"amountMicros\": \"${NEW_BUDGET_MICROS}\"
+      },
+      \"updateMask\": \"amountMicros\"
+    }]
+  }"
+```
+
+Print: `✓ Budget updated: $<OLD>/day → $<NEW>/day`
+
+### Keyword Planner (`keywords`, `kw`, `keyword-planner`)
+
+```bash
+# Collect seed keywords from user via AskUserQuestion (free text)
+# "Enter seed keywords (comma-separated):"
+# Split into JSON array for the request: KEYWORDS_JSON_ARRAY=$(echo "$SEED_KEYWORDS" | sed 's/,/","/g' | sed 's/^/"/;s/$/"/')
+
+curl -s -X POST \
+  "https://googleads.googleapis.com/${GADS_API_VERSION}/customers/${GADS_CUSTOMER_ID}:generateKeywordIdeas" \
+  "${GADS_HEADERS[@]}" \
+  --data-binary "{
+    \"language\": \"languageConstants/1000\",
+    \"geoTargetConstants\": [\"geoTargetConstants/2840\"],
+    \"includeAdultKeywords\": false,
+    \"keywordPlanNetwork\": \"GOOGLE_SEARCH\",
+    \"keywordSeed\": {
+      \"keywords\": [${KEYWORDS_JSON_ARRAY}]
+    }
+  }"
+```
+
+Language `1000` = English, Geo `2840` = United States. These are defaults — if user has locale configured in preferences, use those instead. Other common values: UK=`2826`, Canada=`2124`, Australia=`2036`.
+
+**Output format:**
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  KEYWORD IDEAS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Seeds: keyword1, keyword2
+
+| Keyword | Avg Monthly Searches | Competition | Low Bid | High Bid |
+|---------|---------------------|-------------|---------|----------|
+```
+
+- `avgMonthlySearches` displayed as-is (integer)
+- `competition` displayed as-is (`LOW`, `MEDIUM`, `HIGH`)
+- `lowTopOfPageBidMicros` and `highTopOfPageBidMicros` divided by 1,000,000 and displayed as `$X.XX`
+- Sort by `avgMonthlySearches` descending in the output
+
+If no results, print: `No keyword ideas found for these seeds. Try different or broader keywords.`
+
+### Ad Group Management (`ad-groups`, `ag`)
+
+**List ad groups for a campaign** (`ad-groups list <CAMPAIGN_ID>`):
+
+```bash
+curl -s -X POST \
+  "https://googleads.googleapis.com/${GADS_API_VERSION}/customers/${GADS_CUSTOMER_ID}/googleAds:searchStream" \
+  "${GADS_HEADERS[@]}" \
+  --data-binary "{\"query\": \"SELECT ad_group.id, ad_group.name, ad_group.status, ad_group.cpc_bid_micros FROM ad_group WHERE campaign.id = ${CAMPAIGN_ID} AND ad_group.status != REMOVED ORDER BY ad_group.name\"}"
+```
+
+Output:
+```
+| # | Ad Group ID | Name | Status | CPC Bid |
+```
+
+**Create ad group** (`ad-groups create <CAMPAIGN_ID>`):
+
+Collect via AskUserQuestion:
+1. Ad group name (free text)
+2. Default CPC bid in dollars (free text, convert to micros)
+
+```bash
+BID_MICROS=$(awk "BEGIN {printf \"%d\", ${BID_DOLLARS} * 1000000}")
+curl -s -X POST \
+  "https://googleads.googleapis.com/${GADS_API_VERSION}/customers/${GADS_CUSTOMER_ID}/adGroups:mutate" \
+  "${GADS_HEADERS[@]}" \
+  --data-binary "{
+    \"operations\": [{
+      \"create\": {
+        \"name\": \"${AD_GROUP_NAME}\",
+        \"campaign\": \"customers/${GADS_CUSTOMER_ID}/campaigns/${CAMPAIGN_ID}\",
+        \"status\": \"ENABLED\",
+        \"type\": \"SEARCH_STANDARD\",
+        \"cpcBidMicros\": \"${BID_MICROS}\"
+      }
+    }]
+  }"
+```
+
+Print: `✓ Ad group "${AD_GROUP_NAME}" created in campaign ${CAMPAIGN_ID} (CPC bid: $X.XX)`
+
+**List keywords in ad group** (`ad-groups keywords <AD_GROUP_ID>`):
+
+```bash
+curl -s -X POST \
+  "https://googleads.googleapis.com/${GADS_API_VERSION}/customers/${GADS_CUSTOMER_ID}/googleAds:searchStream" \
+  "${GADS_HEADERS[@]}" \
+  --data-binary "{\"query\": \"SELECT ad_group_criterion.criterion_id, ad_group_criterion.keyword.text, ad_group_criterion.keyword.match_type, ad_group_criterion.cpc_bid_micros, ad_group_criterion.status FROM ad_group_criterion WHERE ad_group.id = ${AD_GROUP_ID} AND ad_group_criterion.type = KEYWORD AND ad_group_criterion.status != REMOVED\"}"
+```
+
+Output:
+```
+| # | Keyword | Match Type | CPC Bid | Status |
+```
+
+**Add keyword to ad group** (`ad-groups add-keyword <AD_GROUP_ID>`):
+
+Collect via AskUserQuestion:
+1. Keyword text (free text)
+2. Match type — AskUserQuestion options: `[Broad, Phrase, Exact]`
+   Map: `BROAD`, `PHRASE`, `EXACT`
+3. CPC bid in dollars (free text, convert to micros) — optional, uses ad group default if not provided
+
+```bash
+curl -s -X POST \
+  "https://googleads.googleapis.com/${GADS_API_VERSION}/customers/${GADS_CUSTOMER_ID}/adGroupCriteria:mutate" \
+  "${GADS_HEADERS[@]}" \
+  --data-binary "{
+    \"operations\": [{
+      \"create\": {
+        \"adGroup\": \"customers/${GADS_CUSTOMER_ID}/adGroups/${AD_GROUP_ID}\",
+        \"status\": \"ENABLED\",
+        \"keyword\": {
+          \"text\": \"${KEYWORD_TEXT}\",
+          \"matchType\": \"${MATCH_TYPE}\"
+        }
+        ${BID_MICROS:+,\"cpcBidMicros\": \"${BID_MICROS}\"}
+      }
+    }]
+  }"
+```
+
+Print: `✓ Keyword "${KEYWORD_TEXT}" (${MATCH_TYPE}) added to ad group ${AD_GROUP_ID}`
+
+Note: Keywords are immutable after creation. To change match type or text, remove and recreate. To change bid only, use `ad-groups update-bid`.
+
+**Remove keyword** (`ad-groups remove-keyword <AD_GROUP_ID> <CRITERION_ID>`):
+
+⚠ **Rule 5 — confirm before removing** via AskUserQuestion: `"Remove keyword <TEXT> from ad group <NAME>?"` with options `[Remove, Cancel]`.
+
+```bash
+curl -s -X POST \
+  "https://googleads.googleapis.com/${GADS_API_VERSION}/customers/${GADS_CUSTOMER_ID}/adGroupCriteria:mutate" \
+  "${GADS_HEADERS[@]}" \
+  --data-binary "{
+    \"operations\": [{
+      \"remove\": \"customers/${GADS_CUSTOMER_ID}/adGroupCriteria/${AD_GROUP_ID}~${CRITERION_ID}\"
+    }]
+  }"
+```
+
+Print: `✓ Keyword removed from ad group.`
+
+**Update keyword bid** (`ad-groups update-bid <AD_GROUP_ID> <CRITERION_ID> <BID>`):
+
+```bash
+NEW_BID_MICROS=$(awk "BEGIN {printf \"%d\", ${NEW_BID} * 1000000}")
+curl -s -X POST \
+  "https://googleads.googleapis.com/${GADS_API_VERSION}/customers/${GADS_CUSTOMER_ID}/adGroupCriteria:mutate" \
+  "${GADS_HEADERS[@]}" \
+  --data-binary "{
+    \"operations\": [{
+      \"update\": {
+        \"resourceName\": \"customers/${GADS_CUSTOMER_ID}/adGroupCriteria/${AD_GROUP_ID}~${CRITERION_ID}\",
+        \"cpcBidMicros\": \"${NEW_BID_MICROS}\"
+      },
+      \"updateMask\": \"cpcBidMicros\"
+    }]
+  }"
+```
+
+Print: `✓ Keyword bid updated to $X.XX`
 
 ---
 

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -1778,14 +1778,15 @@ For any partner not in this table, always web search for current auth docs befor
 ```bash
 # Shell env
 printenv KLAVIYO_API_KEY KLAVIYO_PRIVATE_KEY META_ACCESS_TOKEN FACEBOOK_ACCESS_TOKEN META_AD_ACCOUNT_ID GA4_PROPERTY_ID GA_MEASUREMENT_ID 2>/dev/null
+printenv GOOGLE_ADS_DEVELOPER_TOKEN GOOGLE_ADS_CLIENT_ID GOOGLE_ADS_CLIENT_SECRET GOOGLE_ADS_REFRESH_TOKEN GOOGLE_ADS_CUSTOMER_ID 2>/dev/null
 
 # Shell profiles
-grep -h 'KLAVIYO\|META_\|FACEBOOK\|GA4\|GA_MEASUREMENT' ~/.zshrc ~/.bashrc ~/.zprofile ~/.envrc 2>/dev/null | grep -v '^#'
+grep -h 'KLAVIYO\|META_\|FACEBOOK\|GA4\|GA_MEASUREMENT\|GOOGLE_ADS' ~/.zshrc ~/.bashrc ~/.zprofile ~/.envrc 2>/dev/null | grep -v '^#'
 
 # Doppler across all projects
 for proj in $(doppler projects --json 2>/dev/null | jq -r '.[].slug'); do
   doppler secrets --project "$proj" --config prd --json 2>/dev/null | \
-    jq -r --arg proj "$proj" 'to_entries[] | select(.key | test("KLAVIYO|META|FACEBOOK|GA4|GOOGLE")) | "\(.key)=\(.value.computed) (doppler:\($proj)/prd)"'
+    jq -r --arg proj "$proj" 'to_entries[] | select(.key | test("KLAVIYO|META|FACEBOOK|GA4|GOOGLE|GOOGLE_ADS")) | "\(.key)=\(.value.computed) (doppler:\($proj)/prd)"'
 done
 
 # Dashlane
@@ -1799,14 +1800,25 @@ jq -r '.agents.defaults.env | to_entries[] | select(.key | test("KLAVIYO|META_|F
 
 Cache these results — use them to pre-fill answers for each sub-step below. For each service below, check if already configured (check `$PREFS_PATH` under `marketing.*`, then the auto-scan results above) before prompting. If already set, show `✓ <service> — already configured` and offer `[Keep]` / `[Reconfigure]`.
 
-Ask which marketing integrations to configure via `AskUserQuestion` with `multiSelect: true` (4 options — fits in one call):
+Ask which marketing integrations to configure via two sequential `AskUserQuestion` calls with `multiSelect: true` (max 4 per Rule 1):
+
+**First call** (primary integrations):
+
+| Option                  | Header        | Description                                   |
+| ----------------------- | ------------- | --------------------------------------------- |
+| Klaviyo                 | klaviyo       | Email/SMS marketing — private API key         |
+| Meta Ads                | meta          | Facebook/Instagram ads — access token + ad account ID |
+| Google Ads              | google-ads    | Paid search ads — OAuth2 + developer token    |
+| More...                 | more          | Google Analytics 4, Search Console            |
+
+If user selects `[More...]`, present **second call**:
 
 | Option                  | Header   | Description                                   |
 | ----------------------- | -------- | --------------------------------------------- |
-| Klaviyo                 | klaviyo  | Email/SMS marketing — private API key         |
-| Meta Ads                | meta     | Facebook/Instagram ads — access token + ad account ID |
 | Google Analytics 4      | ga4      | Web analytics — GA4 property ID               |
-| Google Search Console   | gsc      | SEO data — site URL (uses gcloud auth)         |
+| Google Search Console   | gsc      | SEO data — site URL (uses gcloud auth)        |
+
+Run the selected sub-step(s) below in the order selected.
 
 #### Klaviyo
 
@@ -1837,6 +1849,100 @@ Smoke test:
 ```bash
 curl -s "https://graph.facebook.com/v20.0/$AD_ACCOUNT_ID/campaigns?access_token=$TOKEN&limit=1" | jq '.data | length'
 ```
+
+#### Google Ads
+
+Google Ads requires three credential groups. Guide the user through each step sequentially.
+
+**Step A — Developer Token:**
+If `GOOGLE_ADS_DEVELOPER_TOKEN` was found in auto-scan, present it and offer `[Keep]` / `[Reconfigure]`.
+Otherwise, ask via free text:
+> Your Google Ads developer token (found in Google Ads → Tools & Settings → API Center).
+> Note: New developer tokens start in "test" mode — they work against test accounts only. For production data, apply for Basic Access at https://ads.google.com/home/tools/manager-accounts/
+
+**Step B — OAuth2 Client Credentials:**
+If `GOOGLE_ADS_CLIENT_ID` and `GOOGLE_ADS_CLIENT_SECRET` were found in auto-scan, present and offer `[Keep]` / `[Reconfigure]`.
+Otherwise, ask via free text (two prompts):
+1. OAuth2 Client ID (from Google Cloud Console → APIs & Services → Credentials → OAuth 2.0 Client ID, type: Desktop app, Google Ads API must be enabled)
+2. OAuth2 Client Secret (shown alongside the client ID)
+
+**Step C — Refresh Token (browser OAuth flow):**
+If `GOOGLE_ADS_REFRESH_TOKEN` was found in auto-scan, present and offer `[Keep]` / `[Reconfigure]`.
+Otherwise, generate the auth URL and run the OAuth flow:
+
+```bash
+AUTH_URL="https://accounts.google.com/o/oauth2/auth?client_id=${GADS_CLIENT_ID}&redirect_uri=http://localhost:8080&response_type=code&scope=https://www.googleapis.com/auth/adwords&access_type=offline&prompt=consent"
+open "$AUTH_URL"  # macOS
+```
+
+Start a temporary localhost server to catch the redirect:
+```bash
+# One-liner node HTTP server to capture the auth code
+node -e "require('http').createServer((req,res)=>{const code=new URL(req.url,'http://localhost').searchParams.get('code');if(code){res.end('Authorization code received. You can close this tab.');process.stdout.write(code);process.exit(0)}else{res.end('Waiting for auth...')}}).listen(8080)"
+```
+
+Run the server via Bash with `run_in_background: true`. Wait up to 120 seconds for the auth code.
+
+If the localhost approach fails, fall back to asking the user to paste the code from the browser URL bar (the `code=` parameter).
+
+Exchange code for refresh token:
+```bash
+TOKEN_RESP=$(curl -s -X POST https://oauth2.googleapis.com/token \
+  --data "code=${AUTH_CODE}" \
+  --data "client_id=${GADS_CLIENT_ID}" \
+  --data "client_secret=${GADS_CLIENT_SECRET}" \
+  --data "redirect_uri=http://localhost:8080" \
+  --data "grant_type=authorization_code")
+GADS_REFRESH_TOKEN=$(echo "$TOKEN_RESP" | jq -r '.refresh_token')
+```
+
+If `GADS_REFRESH_TOKEN` is null or empty, print error and offer retry.
+
+Warning: If the user's Google Cloud project is in "testing" publishing status, the refresh token expires in 7 days. Warn: "Your OAuth app is in testing mode — tokens expire in 7 days. To get long-lived tokens, publish the app in Google Cloud Console → OAuth consent screen → Publish App."
+
+**Step D — Customer ID:**
+Use the refresh token to get an access token, then list accessible customers:
+```bash
+ACCESS_TOKEN=$(curl -s -X POST https://oauth2.googleapis.com/token \
+  --data "client_id=${GADS_CLIENT_ID}&client_secret=${GADS_CLIENT_SECRET}&refresh_token=${GADS_REFRESH_TOKEN}&grant_type=refresh_token" | jq -r '.access_token')
+
+CUSTOMERS=$(curl -s -X GET \
+  "https://googleads.googleapis.com/v23/customers:listAccessibleCustomers" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "developer-token: ${GADS_DEV_TOKEN}")
+```
+
+If multiple accounts returned, present as `AskUserQuestion` options (max 4 per Rule 1 — paginate if more). If single account, auto-select. Store as `customer_id` (strip "customers/" prefix and dashes).
+
+If any account is a manager (MCC) account, also store `login_customer_id`. Auto-detect by checking if `listAccessibleCustomers` returns both manager and client accounts.
+
+**Step E — Smoke Test:**
+```bash
+curl -s -X GET "https://googleads.googleapis.com/v23/customers:listAccessibleCustomers" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "developer-token: ${GADS_DEV_TOKEN}"
+```
+Expect JSON with `resourceNames` array. If error, print the error and offer `[Retry]` / `[Skip]`.
+
+**Step F — Save to preferences:**
+```json
+{
+  "marketing": {
+    "google_ads": {
+      "developer_token": "<YOUR_DEVELOPER_TOKEN>",
+      "client_id": "<YOUR_CLIENT_ID>.apps.googleusercontent.com",
+      "client_secret": "GOCSPX-<YOUR_SECRET>",
+      "refresh_token": "1//<YOUR_REFRESH_TOKEN>",
+      "customer_id": "1234567890",
+      "login_customer_id": "9876543210"
+    }
+  }
+}
+```
+
+Same Doppler-reference pattern as Step 3i — prefer `doppler:KEY_NAME` over raw tokens when Doppler is configured.
+
+Print: `[Google Ads] ✓ connected — customer ID: XXXXXXXXXX`
 
 #### Google Analytics 4
 
@@ -2695,7 +2801,7 @@ Re-run the detector and present a final status dashboard:
  ✓ Core CLIs:  jq, git, gh, aws, node
  ✓ Channels:   telegram, whatsapp, email
  ✓ Ecommerce:  shopify (<store_url>)             ← omit line if not configured
- ✓ Marketing:  klaviyo, meta, ga4, gsc           ← omit line if not configured
+ ✓ Marketing:  klaviyo, meta, google-ads, ga4, gsc           ← omit line if not configured
  ✓ Voice:      bland, elevenlabs, groq           ← omit line if not configured
  ✓ Secrets:    doppler → my-app/dev
  ✓ MCPs:       linear, sentry, vercel
@@ -2754,6 +2860,7 @@ If `$ARGUMENTS` contains a specific section name, jump straight to that section:
 | `vault`, `password-manager`, `pm`      | Step 3h |
 | `ecom`, `shopify`, `store`             | Step 3i |
 | `marketing`, `klaviyo`, `ads`, `meta`, `ga4` | Step 3j |
+| `google-ads`, `gads` | Step 3j (Google Ads) |
 | `voice`, `bland`, `elevenlabs`, `tts`  | Step 3k |
 | `mcp`                                  | Step 4  |
 | `registry`, `projects`                 | Step 5  |


### PR DESCRIPTION
## Summary

- **Auto-install keepalive plist**: Refactored `install_daemon_launchd()` to use modern `launchctl bootstrap/bootout` with legacy `load` fallback. Skips reinstall if service already has a live PID.
- **Self-healing supervisor**: Added `ensure_all_services()` that enumerates all expected `com.claude-ops.*` services, verifies plist installed + PID alive, auto-repairs (reinstall, kickstart) unhealthy services. Runs at startup + every 5min in the monitor loop. Supports both macOS (launchd) and Linux (systemd).
- **Accurate health reporting**: Fixed `write_daemon_health()` to verify PIDs are actually alive via `kill -0` before reporting "running" — prevents ghost status on dead processes.
- **Zero store-lock contention**: All daemon intelligence functions (briefing cache, urgent detection, contact index, memory extraction) now read from keepalive-managed JSON cache instead of calling `wacli` directly. Eliminates the constant "store is locked" errors.
- **Restart cooldown reset**: `max_restarts` is no longer a permanent death sentence — counter resets after 30min of stability.
- **Race condition prevention**: 15s startup delay in keepalive if another `wacli sync` is already running.
- **Pause-signal protocol**: `$STORE/.pause_sync` file lets external commands (send, backfill) pause the persistent sync gracefully. Auto-expires after 60s.
- **Periodic backfill**: Every 30min (configurable via `BACKFILL_INTERVAL`), re-checks for @lid chats needing backfill + detects missed messages by comparing metadata timestamps against actual DB content.
- **Memory integration**: Writes backfill summaries to `$DATA_DIR/memories/` for the ops memory-extractor to consume.
- **New scripts**: `bin/wacli-safe` (lock-free one-shot commands) and `bin/wacli-health` (health check with `--json` and `--repair` flags).
- **Version tracking**: Daemon version from package.json included in health JSON.

## Test plan

- [ ] Run `bash ops-daemon.sh --install` on macOS — verify both plists copied to `~/Library/LaunchAgents/` with correct substitutions
- [ ] Run `launchctl list | grep claude-ops` — verify both services registered with live PIDs
- [ ] Kill the keepalive process — verify `ensure_all_services` auto-repairs within 5min
- [ ] Run `bin/wacli-health --json` — verify correct health status
- [ ] Run `bin/wacli-safe doctor` — verify pause signal pauses sync and resumes after
- [ ] Verify `daemon-health.json` shows accurate PID status (no ghost "running" for dead processes)
- [ ] Verify `$DATA_DIR/cache/wacli_chats.json` is populated by keepalive
- [ ] Run `bash tests/test-no-secrets.sh` — all 11 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it adds Google Ads write-capable commands (campaign/budget/keyword mutations) and changes background supervisor/service installation logic for `ops-daemon`/`wacli-keepalive`, which can affect messaging reliability and system startup behavior.
> 
> **Overview**
> Adds end-to-end **Google Ads integration** to ops marketing: credential resolution (userConfig→env→Doppler), a guided OAuth2 setup flow in `/ops:setup marketing`, dashboard pre-gather in `ops-marketing-dash`, and new `/ops:marketing google-ads` subcommands for read-only reporting (campaigns, search terms, budget recs) plus **mutating operations** (campaign create/pause/enable/budget, keyword planner, ad group/keyword management with confirmation prompts).
> 
> Hardens WhatsApp background ops by introducing `bin/wacli-health` and `bin/wacli-safe`, updating `wacli-keepalive.sh` to support pause signals, periodic backfill + missed-message detection, and to publish `wacli` JSON caches consumed by `ops-daemon.sh` to avoid store-lock contention. Updates `ops-daemon.sh` with a launchd/systemd self-healing supervisor, modernized launchd install (`bootstrap`/`bootout`), restart cooldown resets, more accurate PID/health reporting, and daemon version emission in the health JSON; docs are updated to reflect the new Google Ads commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e7434c238c0cc4813e2e7091c008e29cca3c053. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Ads integration with campaign dashboard (7-day performance metrics), search terms report, budget recommendations, and full campaign/keyword/ad-group management.
  * Added health check utility for connection monitoring.
  * Added safe command execution wrapper to prevent concurrent access conflicts.

* **Improvements**
  * Enhanced daemon restart tracking, health aggregation, and process lifecycle management.
  * Improved WhatsApp data caching for better performance.

* **Documentation**
  * Added planning documentation for Google Ads feature phases.
  * Updated skills reference with new Google Ads commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->