### PR TITLE
chore: bump version to 1.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,9 +9,9 @@
   "plugins": [
     {
       "name": "ops",
-      "description": "Business operations command center for Claude Code — 25 skills, 13 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes YOLO autonomous mode with 4 C-suite agents.",
+      "description": "Business operations command center for Claude Code \u2014 25 skills, 13 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes YOLO autonomous mode with 4 C-suite agents.",
       "source": "./claude-ops",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "category": "productivity",
       "screenshots": [
         "docs/screenshots/dashboard.png",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ops",
-  "version": "1.4.0",
-  "description": "Business operations command center for Claude Code — 25 skills, 13 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes YOLO mode for autonomous operation.",
+  "version": "1.5.0",
+  "description": "Business operations command center for Claude Code \u2014 25 skills, 13 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes YOLO mode for autonomous operation.",
   "author": {
     "name": "Lifecycle Innovations Limited",
     "url": "https://github.com/Lifecycle-Innovations-Limited"
@@ -45,28 +45,28 @@
   "userConfig": {
     "telegram_api_id": {
       "title": "Telegram API ID",
-      "description": "Numeric API ID from https://my.telegram.org/apps. Optional — run /ops:setup telegram to auto-configure.",
+      "description": "Numeric API ID from https://my.telegram.org/apps. Optional \u2014 run /ops:setup telegram to auto-configure.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "telegram_api_hash": {
       "title": "Telegram API Hash",
-      "description": "API hash from https://my.telegram.org/apps. Optional — run /ops:setup telegram to auto-configure.",
+      "description": "API hash from https://my.telegram.org/apps. Optional \u2014 run /ops:setup telegram to auto-configure.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "telegram_phone": {
       "title": "Telegram Phone Number",
-      "description": "Your phone number in E.164 format. Optional — run /ops:setup telegram to auto-configure.",
+      "description": "Your phone number in E.164 format. Optional \u2014 run /ops:setup telegram to auto-configure.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "telegram_session": {
       "title": "Telegram Session String",
-      "description": "gram.js StringSession. Optional — run /ops:setup telegram to auto-configure.",
+      "description": "gram.js StringSession. Optional \u2014 run /ops:setup telegram to auto-configure.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -150,21 +150,21 @@
     },
     "bland_ai_api_key": {
       "title": "Bland AI API Key",
-      "description": "API key from https://app.bland.ai — used for /ops:ops-voice call",
+      "description": "API key from https://app.bland.ai \u2014 used for /ops:ops-voice call",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "elevenlabs_api_key": {
       "title": "ElevenLabs API Key",
-      "description": "API key from https://elevenlabs.io — used for /ops:ops-voice tts",
+      "description": "API key from https://elevenlabs.io \u2014 used for /ops:ops-voice tts",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "groq_api_key": {
       "title": "Groq API Key",
-      "description": "API key from https://console.groq.com — used for /ops:ops-voice transcribe (Whisper)",
+      "description": "API key from https://console.groq.com \u2014 used for /ops:ops-voice transcribe (Whisper)",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -192,7 +192,7 @@
     },
     "datadog_api_key": {
       "title": "Datadog API Key",
-      "description": "From Datadog Organization Settings > API Keys — used for /ops:monitor",
+      "description": "From Datadog Organization Settings > API Keys \u2014 used for /ops:monitor",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -206,7 +206,7 @@
     },
     "newrelic_api_key": {
       "title": "New Relic API Key",
-      "description": "User API Key from one.newrelic.com/api-keys — used for /ops:monitor",
+      "description": "User API Key from one.newrelic.com/api-keys \u2014 used for /ops:monitor",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -241,7 +241,7 @@
     },
     "pushover_user_key": {
       "title": "Pushover User Key",
-      "description": "From https://pushover.net/ — paired with pushover_app_token.",
+      "description": "From https://pushover.net/ \u2014 paired with pushover_app_token.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -255,21 +255,21 @@
     },
     "discord_bot_token": {
       "title": "Discord Bot Token",
-      "description": "Bot token from Discord Developer Portal — used for channel reads and DMs. Prefer Doppler reference.",
+      "description": "Bot token from Discord Developer Portal \u2014 used for channel reads and DMs. Prefer Doppler reference.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "discord_guild_id": {
       "title": "Discord Guild ID",
-      "description": "Server/guild ID (right-click server in Discord → Copy ID with Developer Mode enabled)",
+      "description": "Server/guild ID (right-click server in Discord \u2192 Copy ID with Developer Mode enabled)",
       "type": "string",
       "sensitive": false,
       "default": ""
     },
     "discord_default_webhook_url": {
       "title": "Discord Default Webhook URL",
-      "description": "Optional default webhook URL (https://discord.com/api/webhooks/…) for /ops:comms discord send. Shared with the ops-fires notification sink (which also reads discord_webhook_url).",
+      "description": "Optional default webhook URL (https://discord.com/api/webhooks/\u2026) for /ops:comms discord send. Shared with the ops-fires notification sink (which also reads discord_webhook_url).",
       "type": "string",
       "sensitive": true,
       "default": ""

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.5.0] — 2026-04-15
+
+### Added
+
+- **`bin/wacli-safe`** — Lock-free one-shot wacli command wrapper. Pauses keepalive sync via pause-signal protocol, runs the command, then resumes automatically.
+- **`bin/wacli-health`** — Health check script with `--json` and `--repair` flags for any ops skill to verify wacli + keepalive status.
+- **Self-healing service supervisor** — `ensure_all_services()` in ops-daemon enumerates all expected `com.claude-ops.*` launchd agents (macOS) and systemd units (Linux), verifies each is installed with a live PID, and auto-repairs (reinstall, kickstart) unhealthy services. Runs at startup + every 5min.
+- **Wacli data cache** — Keepalive writes `wacli_chats.json` and `wacli_urgent.json` to cache every 5min. Daemon intelligence functions read from cache instead of calling wacli directly, eliminating store-lock contention.
+- **Periodic backfill** — Keepalive re-checks for chats needing backfill every 30min (configurable via `BACKFILL_INTERVAL`).
+- **Missed message detection** — Compares chat metadata timestamps against actual DB content; gaps > 1 hour are auto-queued for backfill.
+- **Backfill memory integration** — Writes conversation summaries to `$DATA_DIR/memories/` for the ops memory-extractor to consume.
+- **Pause-signal protocol** — `$STORE/.pause_sync` + `$STORE/.batch_wacli` files coordinate exclusive wacli access between keepalive, daemon, and external commands.
+
+### Fixed
+
+- **Keepalive P0 crash** — `detect_missed_messages` was called before its function definition; keepalive exited with status 127 on every machine, never reaching persistent sync.
+- **Cache directory never created** — `WACLI_CACHE_DIR` was defined but not included in `mkdir -p`, causing all cache writes to silently fail.
+- **Restart delay never applied** — `restart_delay` was logged but no `sleep` happened; services restarted immediately ignoring configured backoff.
+- **Launchctl PID parsing** — `awk '/PID/{print $2}'` extracted `=` instead of the PID from `launchctl list` dictionary output; replaced with `launchctl list | awk '$3==lbl'` which parses the tabular format correctly.
+- **Plist repair early-return** — `_install_launchd_plist` returned early on live PID even when the destination plist file was missing; service would vanish on reboot. Now requires both file existence AND live PID to skip.
+- **Store-lock contention in cache refresh** — `refresh_wacli_cache`, `detect_missed_messages`, and `write_backfill_memory` all called wacli directly during persistent sync. Now use `acquire_wacli_batch` / `release_wacli_batch` to pause sync first.
+- **dateutil dependency** — Replaced third-party `dateutil.parser` with stdlib `datetime.fromisoformat` in missed-message detection.
+- **Restart counter permanent death** — `max_restarts` counter now resets after 30min of stability instead of staying dead forever.
+- **Startup race condition** — 15s delay in keepalive when another `wacli sync` is already running.
+- **Daemon version tracking** — Health JSON now includes daemon version from package.json.
+
+---
+
 ## [1.4.0] — 2026-04-15
 
 ### Added

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bumps `plugin.json`, `package.json`, `marketplace.json` to 1.5.0
- Adds v1.5.0 CHANGELOG entry covering daemon self-healing, wacli-keepalive fixes, and all 7 review bot bug fixes

Auto-generated version bump. Safe to merge — no code changes beyond version numbers and CHANGELOG.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only metadata and documentation updates (version bumps and changelog text); no runtime code paths are modified.
> 
> **Overview**
> Bumps the ops plugin/package version from `1.4.0` to `1.5.0` across `marketplace.json`, `plugin.json`, and `package.json`.
> 
> Updates metadata strings to use escaped Unicode punctuation (e.g., em-dash/ellipsis/arrow) and adds a new `1.5.0` entry to `CHANGELOG.md` describing the release’s wacli/daemon improvements and fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb6bec0cec39eb0ee3633fffb6eb4e2421b5e4f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->