### PR TITLE
fix: resolve wacli store-lock race between launchd keepalive and ops daemon

### DIFF
--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -140,9 +140,39 @@ else:
   echo $(( $(date +%s) + interval_min ))
 }
 
+# ── Launchd ownership check ──────────────────────────────────────────────
+# Returns 0 if the launchd keepalive service for wacli is loaded and has a
+# live process.  When true, the daemon must NOT start wacli-sync itself —
+# launchd is the sole owner and handles restarts via KeepAlive=true.
+_wacli_owned_by_launchd() {
+  command -v launchctl >/dev/null 2>&1 || return 1
+  local pid_str
+  pid_str=$(launchctl list 2>/dev/null \
+    | awk '$3=="com.claude-ops.wacli-keepalive" {print $1}' || true)
+  # Service must be registered AND have a live PID (not "-")
+  if [[ -n "$pid_str" ]] && [[ "$pid_str" != "-" ]] && kill -0 "$pid_str" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
 # ── Service lifecycle ─────────────────────────────────────────────────────
 start_service() {
   local name="$1"
+
+  # ── Race-condition guard: wacli-sync ownership ──────────────────────────
+  # The launchd keepalive service (com.claude-ops.wacli-keepalive) is the
+  # sole owner of the wacli sync process.  If it is loaded and running, the
+  # daemon must not spawn a competing wacli-sync — doing so causes store-lock
+  # errors and WhatsApp disconnections.  Instead we mark the service as
+  # "delegated" and monitor health passively via the health file.
+  if [[ "$name" == "wacli-sync" ]] && _wacli_owned_by_launchd; then
+    log "START: $name — launchd keepalive is running, deferring ownership (no duplicate spawn)"
+    SERVICE_STATUS["$name"]="delegated"
+    SERVICE_LAST_HEALTH["$name"]="launchd-owned"
+    return 0
+  fi
+
   local cmd
   cmd=$(get_service_field "$name" "command")
   if [[ -z "$cmd" ]]; then
@@ -231,6 +261,14 @@ check_health() {
 
 restart_service() {
   local name="$1"
+
+  # ── Race-condition guard (mirrors start_service) ────────────────────────
+  if [[ "$name" == "wacli-sync" ]] && _wacli_owned_by_launchd; then
+    log "RESTART: $name — launchd keepalive owns this service, skipping daemon restart"
+    SERVICE_STATUS["$name"]="delegated"
+    return 0
+  fi
+
   local restart_delay max_restarts
   restart_delay=$(get_service_field "$name" "restart_delay")
   restart_delay="${restart_delay:-60}"
@@ -1240,7 +1278,19 @@ while true; do
       fi
     else
       # Persistent service: check health + restart if needed
-      if ! check_health "$svc"; then
+      # For wacli-sync delegated to launchd, re-check ownership each loop.
+      # If launchd stopped unexpectedly, the daemon can take over.
+      if [[ "$svc" == "wacli-sync" ]] && [[ "${SERVICE_STATUS[$svc]:-}" == "delegated" ]]; then
+        if _wacli_owned_by_launchd; then
+          # Still owned by launchd — just read the health file passively
+          check_health "$svc" || true
+          SERVICE_STATUS["$svc"]="delegated"
+        else
+          log "MONITOR: $svc — launchd keepalive no longer running, daemon taking ownership"
+          SERVICE_STATUS["$svc"]="dead"
+          start_service "$svc"
+        fi
+      elif ! check_health "$svc"; then
         local_status="${SERVICE_STATUS[$svc]}"
         if [[ "$local_status" != "needs_reauth" ]] && [[ "$local_status" != "max_restarts_exceeded" ]]; then
           restart_service "$svc"

--- a/claude-ops/scripts/wacli-keepalive.sh
+++ b/claude-ops/scripts/wacli-keepalive.sh
@@ -77,14 +77,46 @@ fi
 
 log "START: keepalive pid=$$ starting"
 
-# ── Step 0: Race condition prevention ───────────────────────────────────
+# ── Step 0: Race condition prevention with exponential backoff ──────────
 # Both com.claude-ops.daemon and com.claude-ops.wacli-keepalive start at boot.
 # If both try wacli sync simultaneously, one crashes on the store lock.
-# Wait briefly for any concurrent sync to claim the lock first.
-if pgrep -f "wacli sync" >/dev/null 2>&1; then
-  log "START: another wacli sync is running — waiting 15s for lock release"
-  sleep 15
-fi
+# Retry with exponential backoff instead of a single fixed wait.
+LOCK_RETRY_MAX=5
+LOCK_RETRY_DELAY=5  # seconds — doubles each attempt: 5, 10, 20, 40, 80
+_wait_for_store_lock() {
+  local attempt=0
+  local delay=$LOCK_RETRY_DELAY
+  while (( attempt < LOCK_RETRY_MAX )); do
+    # Check both running sync processes and the store lock itself
+    local has_sync=0 has_lock=0
+    pgrep -f "wacli sync" >/dev/null 2>&1 && has_sync=1
+    local doctor_json
+    doctor_json=$("$WACLI" doctor --json 2>/dev/null || echo '{}')
+    echo "$doctor_json" | grep -q '"locked":true' && has_lock=1
+
+    if [[ $has_sync -eq 0 ]] && [[ $has_lock -eq 0 ]]; then
+      return 0  # Lock is free
+    fi
+
+    log "START: store locked or another sync running (attempt $((attempt+1))/$LOCK_RETRY_MAX) — waiting ${delay}s"
+    sleep "$delay"
+    delay=$((delay * 2))
+    (( attempt++ )) || true
+  done
+
+  # Final attempt: force-kill competing processes and clear the lock
+  log "START: lock still held after $LOCK_RETRY_MAX retries — force-clearing"
+  local stale_pids
+  stale_pids=$(pgrep -f "wacli sync" 2>/dev/null || true)
+  for pid in $stale_pids; do
+    if [[ "$pid" != "$$" ]]; then
+      kill -TERM "$pid" 2>/dev/null || true
+    fi
+  done
+  sleep 2
+  return 0
+}
+_wait_for_store_lock
 
 # ── Step 1: Kill orphaned wacli sync processes ──────────────────────────
 cleanup_stale() {


### PR DESCRIPTION
## Summary

- **ops-daemon.sh**: Added `_wacli_owned_by_launchd()` guard — when the launchd keepalive service (`com.claude-ops.wacli-keepalive`) is loaded with a live PID, the daemon marks wacli-sync as `"delegated"` and skips spawning a competing process. The monitor loop re-checks ownership each cycle and takes over only if launchd stops unexpectedly.
- **wacli-keepalive.sh**: Replaced the naive 15s sleep with exponential backoff retry (5 attempts: 5s, 10s, 20s, 40s, 80s) that checks both `pgrep` and `wacli doctor --json` lock status before proceeding. Falls back to force-clearing stale locks after all retries are exhausted.

## Problem

Both the launchd keepalive service and the ops daemon tried to start/manage `wacli sync`, causing simultaneous store-lock acquisition, "store is locked" errors, and WhatsApp disconnections.

## Test plan

- [ ] Verify `launchctl list | grep wacli-keepalive` shows a live PID
- [ ] Start the ops daemon — confirm `wacli-sync` logs show "deferring ownership" instead of launching a duplicate
- [ ] Stop the launchd keepalive (`launchctl unload`) — confirm the daemon takes over within 30s
- [ ] Restart keepalive — confirm daemon yields ownership back on next monitor cycle
- [ ] Simulate a locked store — confirm keepalive retries with backoff instead of crashing immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/126" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process ownership and restart behavior for `wacli-sync` and adds more aggressive lock-handling (including terminating competing sync processes), which could affect WhatsApp connectivity if detection is wrong. Scope is limited to ops scripts but runs at boot and impacts a core background service.
> 
> **Overview**
> Prevents `ops-daemon.sh` from spawning/restarting `wacli-sync` when the launchd keepalive service `com.claude-ops.wacli-keepalive` is loaded with a live PID, marking the service as **delegated** and only taking ownership if keepalive stops.
> 
> Reworks `wacli-keepalive.sh` startup lock avoidance by replacing a fixed sleep with an exponential-backoff loop that checks both running sync processes and `wacli doctor --json` lock state, then force-terminates stale `wacli sync` processes if the lock does not clear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fe3a02b2fbdd7315cc7f1724baea95a55e6f2e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved service management to prevent conflicts when external process managers control services.
  * Enhanced synchronization lock detection with intelligent retry mechanism for improved reliability and conflict resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->