### PR TITLE
fix: migrate RevenueCat API from v1 to v2

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -179,7 +179,7 @@
     },
     "revenuecat_api_key": {
       "title": "RevenueCat API Key",
-      "description": "RevenueCat V1 API key for mobile subscription revenue tracking.",
+      "description": "RevenueCat API key for mobile subscription revenue tracking (V2 API).",
       "type": "string",
       "sensitive": true,
       "default": ""

--- a/claude-ops/agents/revenue-tracker.md
+++ b/claude-ops/agents/revenue-tracker.md
@@ -120,7 +120,7 @@ Only run if `REVENUECAT_API_KEY` is set AND a project ID is available (from `$RE
 
 ```bash
 curl -s -H "Authorization: Bearer $REVENUECAT_API_KEY" \
-  "https://api.revenuecat.com/v1/projects/$REVENUECAT_PROJECT_ID/metrics/overview" 2>/dev/null
+  "https://api.revenuecat.com/v2/projects/$REVENUECAT_PROJECT_ID/metrics/overview" 2>/dev/null
 ```
 
 Extract `mrr`, `revenue` (trailing 30d), `active_subscriptions`, `active_trials`.
@@ -129,7 +129,7 @@ Extract `mrr`, `revenue` (trailing 30d), `active_subscriptions`, `active_trials`
 
 ```bash
 curl -s -H "Authorization: Bearer $REVENUECAT_API_KEY" \
-  "https://api.revenuecat.com/v1/projects/$REVENUECAT_PROJECT_ID/metrics/active_subscribers" 2>/dev/null
+  "https://api.revenuecat.com/v2/projects/$REVENUECAT_PROJECT_ID/metrics/active_subscribers" 2>/dev/null
 ```
 
 ### Churn rate

--- a/claude-ops/skills/ops-settings/SKILL.md
+++ b/claude-ops/skills/ops-settings/SKILL.md
@@ -100,7 +100,7 @@ When a specific integration is selected (via argument or user pick from dashboar
 | Integration | Smoke test command |
 |-------------|-------------------|
 | Stripe | `curl -s -u "${new_key}:" https://api.stripe.com/v1/balance \| jq .object` → must be "balance" |
-| RevenueCat | `curl -s -H "Authorization: Bearer ${new_key}" "https://api.revenuecat.com/v1/subscribers/test_user" \| jq .subscriber` → non-null |
+| RevenueCat | `curl -s -H "Authorization: Bearer ${new_key}" "https://api.revenuecat.com/v2/projects" \| jq '.items \| length'` → non-zero |
 | Telegram | `node ${CLAUDE_PLUGIN_ROOT}/telegram-server/index.js --health 2>&1` → "healthy" |
 | Slack | `curl -s -H "Authorization: Bearer ${new_token}" https://slack.com/api/auth.test \| jq .ok` → true |
 | Shopify | `curl -s -H "X-Shopify-Access-Token: ${new_token}" "https://${store_url}/admin/api/2024-01/shop.json" \| jq .shop.name` → non-null |

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -2279,9 +2279,9 @@ Agent(
 
 On `[Paste RevenueCat API key manually]`:
 ```
-Enter your RevenueCat V1 API Key:
-  Find it: app.revenuecat.com → Project settings → API keys → V1 secret key
-  Format: rcb_XXX (V2)  or  legacy secret (starts with sk_)
+Enter your RevenueCat API Key:
+  Find it: app.revenuecat.com → Project settings → API keys → Secret key
+  Format: rcb_XXX (V2 secret)  or  sk_XXX (legacy secret key)
 
 Enter your RevenueCat Project ID:
   Find it in the URL: app.revenuecat.com/projects/<project_id>/...
@@ -2290,7 +2290,7 @@ Enter your RevenueCat Project ID:
 Smoke test:
 ```bash
 curl -s -H "Authorization: Bearer $REVENUECAT_API_KEY" \
-  "https://api.revenuecat.com/v1/projects/$REVENUECAT_PROJECT_ID/metrics/overview" | jq '.mrr // .object'
+  "https://api.revenuecat.com/v2/projects/$REVENUECAT_PROJECT_ID/metrics/overview" | jq '.metrics // .object'
 ```
 Expect a numeric `mrr` or an object descriptor. If the response is `{"code": 7243, ...}` (auth error), re-ask.
 


### PR DESCRIPTION
## Summary

- Updated all `api.revenuecat.com/v1/` calls to `api.revenuecat.com/v2/` across agents, skills, and plugin config
- The current secret key (`sk_xnQ...`) is a V2 key incompatible with V1 endpoints — confirmed working against `/v2/projects`
- Smoke test updated from `/v1/subscribers/test_user` to `/v2/projects` (list-based check)
- Removed "V1 API key" language from `plugin.json` and setup wizard copy

## Files changed

- `agents/revenue-tracker.md` — metrics/overview and metrics/active_subscribers endpoints
- `skills/setup/SKILL.md` — smoke test URL + credential input label
- `skills/ops-settings/SKILL.md` — key rotation smoke test
- `.claude-plugin/plugin.json` — userConfig description field

## Test plan

- [ ] `curl -s -H "Authorization: Bearer $REVENUECAT_API_KEY" "https://api.revenuecat.com/v2/projects" | jq '.items | length'` returns non-zero
- [ ] `curl -s -H "Authorization: Bearer $REVENUECAT_API_KEY" "https://api.revenuecat.com/v2/projects/$REVENUECAT_PROJECT_ID/metrics/overview"` returns `{"object":"overview_metrics",...}`
- [ ] `/ops:revenue` no longer errors on RevenueCat queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/127" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to configuration/help text and curl-based smoke-test endpoints; the main risk is broken revenue tracking if any v2 response fields differ from the documented extraction expectations.
> 
> **Overview**
> Updates RevenueCat references across the ops plugin to use the **v2 API** instead of v1, including the revenue tracker agent’s metrics curl endpoints.
> 
> Refreshes setup and ops-settings smoke tests to validate keys via `GET /v2/projects` and adjusts copy in `plugin.json` and the setup wizard to remove “V1 API key” wording and reflect v2/legacy key formats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a13623deaab2474bb9ac2f9e303549723b630e06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->