### PR TITLE
feat: auto-discover external projects (Shopify/Linear/Slack/Notion)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code \u2014 25 skills, 13 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes YOLO autonomous mode with 4 C-suite agents.",
       "source": "./claude-ops",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "category": "productivity",
       "screenshots": [
         "docs/screenshots/dashboard.png",

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -31,7 +31,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders at **support@healify.ai**. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders at **info@lifecycleinnovations.limited**. All complaints will be reviewed and investigated promptly and fairly.
 
 ## Attribution
 

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Business operations command center for Claude Code \u2014 25 skills, 13 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes YOLO mode for autonomous operation.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **`bin/ops-discover-external`** — Auto-discovers external (non-git) projects from credentials already configured in the plugin: Shopify stores (via prefs/env), Linear teams (via `LINEAR_API_KEY`), Slack workspaces (via keychain `slack-xoxc`/`slack-xoxd`), and Notion databases (via `NOTION_API_KEY` / keychain `notion-api-key`). Emits a JSON array of ready-to-register candidates with pre-built `config` blocks. Never writes to `registry.json` itself — the setup wizard handles registration after user confirmation.
+- **Setup Step 5: "Auto-discover external projects"** — New sub-step in `skills/setup/SKILL.md` that runs `ops-discover-external` after the filesystem git-repo scan, cross-references against the existing registry, and presents only unregistered candidates via batched `AskUserQuestion` calls (≤ 4 options per call, per Rule 1).
+- **`ops-projects` external candidate surfacing** — The portfolio dashboard now runs `ops-discover-external` alongside `ops-external` and shows an "UNREGISTERED CANDIDATES" footer listing Shopify/Linear/Slack/Notion projects the user has credentials for but has not yet added to `registry.json`, with a one-line path to `/ops:setup registry`.
+- **`ops-projects` external deep-dive** — The `/ops:projects <alias>` jump-to-project view now branches on `type: external` and renders a source-specific deep-dive (Shopify order summary, Linear team issues, Slack workspace health, Notion recent edits) with actions that route to the relevant source-specific skill instead of assuming git/CI/PR context.
+
 ## [1.5.0] — 2026-04-15
 
 ### Added

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,14 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [1.6.0] — 2026-04-16
 
 ### Added
 
-- **`bin/ops-discover-external`** — Auto-discovers external (non-git) projects from credentials already configured in the plugin: Shopify stores (via prefs/env), Linear teams (via `LINEAR_API_KEY`), Slack workspaces (via keychain `slack-xoxc`/`slack-xoxd`), and Notion databases (via `NOTION_API_KEY` / keychain `notion-api-key`). Emits a JSON array of ready-to-register candidates with pre-built `config` blocks. Never writes to `registry.json` itself — the setup wizard handles registration after user confirmation.
+- **`bin/ops-discover-external`** — Auto-discovers external (non-git) projects from credentials already configured in the plugin: Shopify stores (via prefs/env), Linear teams (via `LINEAR_API_KEY`), Slack workspaces (via keychain `slack-xoxc`/`slack-xoxd`), and Notion databases (via `NOTION_API_KEY` / keychain `notion-api-key`). Emits a JSON array of ready-to-register candidates with pre-built `config` blocks. Never writes to `registry.json` itself — the setup wizard handles registration after user confirmation. Shopify candidates emit the credential key that actually supplied the token (`SHOPIFY_ADMIN_TOKEN` or `SHOPIFY_ACCESS_TOKEN`) so downstream health checks resolve correctly, and Slack lookups use account=`$USER` (matching `bin/ops-slack-autolink.mjs`) so real installations are discovered.
 - **Setup Step 5: "Auto-discover external projects"** — New sub-step in `skills/setup/SKILL.md` that runs `ops-discover-external` after the filesystem git-repo scan, cross-references against the existing registry, and presents only unregistered candidates via batched `AskUserQuestion` calls (≤ 4 options per call, per Rule 1).
 - **`ops-projects` external candidate surfacing** — The portfolio dashboard now runs `ops-discover-external` alongside `ops-external` and shows an "UNREGISTERED CANDIDATES" footer listing Shopify/Linear/Slack/Notion projects the user has credentials for but has not yet added to `registry.json`, with a one-line path to `/ops:setup registry`.
 - **`ops-projects` external deep-dive** — The `/ops:projects <alias>` jump-to-project view now branches on `type: external` and renders a source-specific deep-dive (Shopify order summary, Linear team issues, Slack workspace health, Notion recent edits) with actions that route to the relevant source-specific skill instead of assuming git/CI/PR context.
+
+### Fixed
+
+- **`CODE_OF_CONDUCT.md`** — Enforcement contact changed from a product support address to the plugin maintainer email (`info@lifecycleinnovations.limited`), matching `SECURITY.md`. Fixes Rule 0 (no personal/product-specific emails in a public repo).
 
 ## [1.5.0] — 2026-04-15
 
@@ -252,7 +256,7 @@ All notable changes to this project will be documented in this file.
 - **Telegram setup** — After authenticating via `ops-telegram-autolink.mjs`, credentials are now auto-written to the MCP config. No more manual paste into `/plugin settings`.
 - **GSD companion install** — Now installs automatically with a single "Yes" instead of telling users to run slash commands manually.
 
-## [Unreleased]
+## [Unreleased — legacy drafts]
 
 ### Added — autolink wizards for Telegram and Slack
 

--- a/claude-ops/bin/ops-discover-external
+++ b/claude-ops/bin/ops-discover-external
@@ -80,14 +80,22 @@ if want_source shopify; then
   (
     STORE_URL="$(prefs_get '.ecom.shopify.store_url')"
     TOKEN=""
+    # Track which env-var name supplied the token so the candidate config
+    # references the key the user actually has set, not a hardcoded default.
+    CRED_KEY="SHOPIFY_ADMIN_TOKEN"
 
     # Resolve token: prefs -> env fallbacks. prefs may contain a `doppler:` reference,
     # in which case we cannot dereference without running the doppler CLI — skip that case.
     PREFS_TOKEN="$(prefs_get '.ecom.shopify.admin_token')"
     if [ -n "$PREFS_TOKEN" ] && [[ "$PREFS_TOKEN" != doppler:* ]]; then
       TOKEN="$PREFS_TOKEN"
+    elif [ -n "${SHOPIFY_ADMIN_TOKEN:-}" ]; then
+      TOKEN="$SHOPIFY_ADMIN_TOKEN"
+      CRED_KEY="SHOPIFY_ADMIN_TOKEN"
+    elif [ -n "${SHOPIFY_ACCESS_TOKEN:-}" ]; then
+      TOKEN="$SHOPIFY_ACCESS_TOKEN"
+      CRED_KEY="SHOPIFY_ACCESS_TOKEN"
     fi
-    TOKEN="${TOKEN:-${SHOPIFY_ADMIN_TOKEN:-${SHOPIFY_ACCESS_TOKEN:-}}}"
     STORE_URL="${STORE_URL:-${SHOPIFY_STORE_URL:-}}"
 
     if [ -z "$STORE_URL" ] || [ -z "$TOKEN" ]; then
@@ -117,6 +125,7 @@ if want_source shopify; then
       --arg shop_name "$SHOP_NAME" \
       --arg plan "$PLAN" \
       --arg store_url "$STORE_URL" \
+      --arg cred_key "$CRED_KEY" \
       '{
         alias: $alias,
         source: "shopify",
@@ -126,7 +135,7 @@ if want_source shopify; then
           alias: $alias,
           source: "shopify",
           type: "external",
-          shopify: { store_url: $store_url, credential_key: "SHOPIFY_ADMIN_TOKEN" },
+          shopify: { store_url: $store_url, credential_key: $cred_key },
           revenue: { model: "ecommerce", stage: "active" },
           priority: 3
         }
@@ -189,9 +198,14 @@ fi
 #
 if want_source slack; then
   (
-    XOXC=$(cred_get slack-xoxc slack-xoxc || true)
-    XOXD=$(cred_get slack-xoxd slack-xoxd || true)
-    [ -z "$XOXC" ] || [ -z "$XOXD" ] && exit 0
+    # bin/ops-slack-autolink.mjs stores tokens as service=slack-xoxc|slack-xoxd,
+    # account=$USER. Older bin/ops-setup-preflight probes used the service name
+    # as the account too; try the real convention first, then fall back.
+    XOXC=$(cred_get slack-xoxc "${USER:-$(id -un)}" || true)
+    XOXD=$(cred_get slack-xoxd "${USER:-$(id -un)}" || true)
+    [ -z "$XOXC" ] && XOXC=$(cred_get slack-xoxc slack-xoxc || true)
+    [ -z "$XOXD" ] && XOXD=$(cred_get slack-xoxd slack-xoxd || true)
+    { [ -z "$XOXC" ] || [ -z "$XOXD" ]; } && exit 0
 
     RESP=$(curl -fsS --max-time 8 \
       -H "Authorization: Bearer $XOXC" \

--- a/claude-ops/bin/ops-discover-external
+++ b/claude-ops/bin/ops-discover-external
@@ -1,0 +1,360 @@
+#!/usr/bin/env bash
+# ops-discover-external — Auto-discover external (non-git) projects from configured integrations.
+#
+# Probes Shopify, Linear, Slack, and Notion using credentials already available in the environment,
+# plugin preferences, or the OS keychain. Outputs a JSON array of candidate projects that the setup
+# wizard (Step 5) can present to the user for registration in registry.json.
+#
+# The script never writes to registry.json itself — it only surfaces candidates. Secrets are
+# redacted from the output (only the credential_key name is returned, never the value).
+#
+# Output shape:
+# [
+#   {
+#     "alias":   "suggested-alias",
+#     "source":  "shopify|linear|slack|notion",
+#     "status":  "discovered|auth_expired|unreachable",
+#     "details": { ... source-specific metadata ... },
+#     "config":  { ... ready-to-merge block for registry.json .projects[] ... }
+#   }
+# ]
+#
+# Usage:
+#   ops-discover-external                # all sources, JSON to stdout
+#   ops-discover-external --source shopify  # single source
+#   ops-discover-external --pretty       # pretty-printed JSON
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+[ -r "$SCRIPT_DIR/lib/os-detect.sh" ]        && . "$SCRIPT_DIR/lib/os-detect.sh"
+[ -r "$SCRIPT_DIR/lib/credential-store.sh" ] && . "$SCRIPT_DIR/lib/credential-store.sh"
+
+PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+
+ONLY_SOURCE=""
+PRETTY=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --source) ONLY_SOURCE="$2"; shift 2 ;;
+    --pretty) PRETTY=true; shift ;;
+    -h|--help)
+      sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+cred_get() {
+  if declare -F ops_cred_get >/dev/null 2>&1; then
+    ops_cred_get "$1" "$2" 2>/dev/null || true
+  elif [ "$(uname -s)" = "Darwin" ]; then
+    security find-generic-password -s "$1" -a "$2" -w 2>/dev/null || true
+  fi
+}
+
+prefs_get() {
+  [ -f "$PREFS_PATH" ] || return 0
+  jq -r "${1} // empty" "$PREFS_PATH" 2>/dev/null
+}
+
+# Sanitize a candidate alias: lowercase, replace non-alphanum with '-', trim
+slugify() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+    | cut -c1-40
+}
+
+TMPDIR_D=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_D"' EXIT
+
+want_source() {
+  [ -z "$ONLY_SOURCE" ] || [ "$ONLY_SOURCE" = "$1" ]
+}
+
+#
+# Shopify — one candidate per configured store
+#
+if want_source shopify; then
+  (
+    STORE_URL="$(prefs_get '.ecom.shopify.store_url')"
+    TOKEN=""
+
+    # Resolve token: prefs -> env fallbacks. prefs may contain a `doppler:` reference,
+    # in which case we cannot dereference without running the doppler CLI — skip that case.
+    PREFS_TOKEN="$(prefs_get '.ecom.shopify.admin_token')"
+    if [ -n "$PREFS_TOKEN" ] && [[ "$PREFS_TOKEN" != doppler:* ]]; then
+      TOKEN="$PREFS_TOKEN"
+    fi
+    TOKEN="${TOKEN:-${SHOPIFY_ADMIN_TOKEN:-${SHOPIFY_ACCESS_TOKEN:-}}}"
+    STORE_URL="${STORE_URL:-${SHOPIFY_STORE_URL:-}}"
+
+    if [ -z "$STORE_URL" ] || [ -z "$TOKEN" ]; then
+      exit 0
+    fi
+
+    RESP=$(curl -fsS --max-time 8 \
+      -H "X-Shopify-Access-Token: $TOKEN" \
+      "https://$STORE_URL/admin/api/2024-10/shop.json" 2>/dev/null || echo "")
+
+    if [ -z "$RESP" ]; then
+      STATUS="unreachable"
+      SHOP_NAME="$STORE_URL"
+      PLAN="unknown"
+    else
+      STATUS="discovered"
+      SHOP_NAME=$(echo "$RESP" | jq -r '.shop.name // ""')
+      PLAN=$(echo "$RESP" | jq -r '.shop.plan_name // ""')
+    fi
+
+    ALIAS=$(slugify "${SHOP_NAME:-$STORE_URL}")
+    [ -z "$ALIAS" ] && ALIAS="shopify-store"
+
+    jq -n \
+      --arg alias "$ALIAS" \
+      --arg status "$STATUS" \
+      --arg shop_name "$SHOP_NAME" \
+      --arg plan "$PLAN" \
+      --arg store_url "$STORE_URL" \
+      '{
+        alias: $alias,
+        source: "shopify",
+        status: $status,
+        details: { shop_name: $shop_name, plan: $plan, store_url: $store_url },
+        config: {
+          alias: $alias,
+          source: "shopify",
+          type: "external",
+          shopify: { store_url: $store_url, credential_key: "SHOPIFY_ADMIN_TOKEN" },
+          revenue: { model: "ecommerce", stage: "active" },
+          priority: 3
+        }
+      }' > "$TMPDIR_D/shopify.json"
+  ) &
+fi
+
+#
+# Linear — one candidate per team (teams are projects)
+#
+if want_source linear; then
+  (
+    LINEAR_KEY="${LINEAR_API_KEY:-}"
+    [ -z "$LINEAR_KEY" ] && exit 0
+
+    RESP=$(curl -fsS --max-time 8 -X POST \
+      -H "Authorization: $LINEAR_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{"query":"{ teams(first: 25) { nodes { id key name issueCount } } }"}' \
+      "https://api.linear.app/graphql" 2>/dev/null || echo "")
+
+    if [ -z "$RESP" ]; then exit 0; fi
+
+    COUNT=$(echo "$RESP" | jq '.data.teams.nodes | length' 2>/dev/null || echo 0)
+    [ "$COUNT" -eq 0 ] && exit 0
+
+    for i in $(seq 0 $((COUNT - 1))); do
+      TEAM=$(echo "$RESP" | jq -c ".data.teams.nodes[$i]")
+      TEAM_KEY=$(echo "$TEAM" | jq -r '.key // ""')
+      TEAM_NAME=$(echo "$TEAM" | jq -r '.name // ""')
+      ISSUES=$(echo "$TEAM" | jq -r '.issueCount // 0')
+      [ -z "$TEAM_KEY" ] && continue
+
+      ALIAS=$(slugify "linear-$TEAM_KEY")
+
+      jq -n \
+        --arg alias "$ALIAS" \
+        --arg team_key "$TEAM_KEY" \
+        --arg team_name "$TEAM_NAME" \
+        --argjson issues "$ISSUES" \
+        '{
+          alias: $alias,
+          source: "linear",
+          status: "discovered",
+          details: { team_key: $team_key, team_name: $team_name, issue_count: $issues },
+          config: {
+            alias: $alias,
+            source: "linear",
+            type: "external",
+            linear: { team_key: $team_key },
+            priority: 5
+          }
+        }' > "$TMPDIR_D/linear-$TEAM_KEY.json"
+    done
+  ) &
+fi
+
+#
+# Slack — one candidate per workspace (from xoxc/xoxd session tokens)
+#
+if want_source slack; then
+  (
+    XOXC=$(cred_get slack-xoxc slack-xoxc || true)
+    XOXD=$(cred_get slack-xoxd slack-xoxd || true)
+    [ -z "$XOXC" ] || [ -z "$XOXD" ] && exit 0
+
+    RESP=$(curl -fsS --max-time 8 \
+      -H "Authorization: Bearer $XOXC" \
+      -b "d=$XOXD" \
+      "https://slack.com/api/auth.test" 2>/dev/null || echo "")
+
+    OK=$(echo "$RESP" | jq -r '.ok // false' 2>/dev/null)
+    if [ "$OK" != "true" ]; then
+      # Token exists but call failed — surface as auth_expired so the wizard can flag it
+      jq -n '{
+        alias: "slack-workspace",
+        source: "slack",
+        status: "auth_expired",
+        details: { note: "xoxc/xoxd tokens present but auth.test failed — re-run /ops:setup slack" },
+        config: null
+      }' > "$TMPDIR_D/slack.json"
+      exit 0
+    fi
+
+    TEAM_ID=$(echo "$RESP" | jq -r '.team_id // ""')
+    URL=$(echo "$RESP" | jq -r '.url // ""')
+    # Extract workspace slug from URL (https://yourteam.slack.com/)
+    WORKSPACE=$(echo "$URL" | sed -E 's#https?://([^.]+)\..*#\1#; s#/$##')
+    [ -z "$WORKSPACE" ] && WORKSPACE="slack-workspace"
+
+    ALIAS=$(slugify "slack-$WORKSPACE")
+
+    jq -n \
+      --arg alias "$ALIAS" \
+      --arg workspace "$WORKSPACE" \
+      --arg team_id "$TEAM_ID" \
+      --arg url "$URL" \
+      '{
+        alias: $alias,
+        source: "slack",
+        status: "discovered",
+        details: { workspace: $workspace, team_id: $team_id, url: $url },
+        config: {
+          alias: $alias,
+          source: "slack",
+          type: "external",
+          slack: { workspace: $workspace, team_id: $team_id },
+          priority: 5
+        }
+      }' > "$TMPDIR_D/slack.json"
+  ) &
+fi
+
+#
+# Notion — one candidate per database the token can see (databases = project trackers)
+#
+if want_source notion; then
+  (
+    # Prefer env, fall back to keychain; skip if neither present. claude.ai managed Notion
+    # does not expose a raw token — in that case the setup wizard handles discovery via the MCP
+    # tools (out of scope for this script).
+    NOTION_TOKEN="${NOTION_API_KEY:-}"
+    if [ -z "$NOTION_TOKEN" ]; then
+      NOTION_TOKEN=$(cred_get notion-api-key claude-ops || true)
+    fi
+    [ -z "$NOTION_TOKEN" ] && exit 0
+
+    # List databases (projects) the integration can see
+    RESP=$(curl -fsS --max-time 10 -X POST \
+      -H "Authorization: Bearer $NOTION_TOKEN" \
+      -H "Notion-Version: 2022-06-28" \
+      -H "Content-Type: application/json" \
+      -d '{"filter":{"value":"database","property":"object"},"page_size":25}' \
+      "https://api.notion.com/v1/search" 2>/dev/null || echo "")
+
+    if [ -z "$RESP" ]; then
+      # Token exists but API call failed
+      jq -n '{
+        alias: "notion-workspace",
+        source: "notion",
+        status: "auth_expired",
+        details: { note: "Notion token present but /v1/search failed — re-run /ops:setup notion" },
+        config: null
+      }' > "$TMPDIR_D/notion.json"
+      exit 0
+    fi
+
+    COUNT=$(echo "$RESP" | jq '.results | length' 2>/dev/null || echo 0)
+
+    if [ "$COUNT" -eq 0 ]; then
+      # Token works but no databases shared — still surface the workspace itself so the user
+      # can register it as a general knowledge-base project.
+      BOT_RESP=$(curl -fsS --max-time 8 \
+        -H "Authorization: Bearer $NOTION_TOKEN" \
+        -H "Notion-Version: 2022-06-28" \
+        "https://api.notion.com/v1/users/me" 2>/dev/null || echo "")
+      WORKSPACE=$(echo "$BOT_RESP" | jq -r '.bot.workspace_name // .name // "notion-workspace"')
+      ALIAS=$(slugify "notion-$WORKSPACE")
+
+      jq -n \
+        --arg alias "$ALIAS" \
+        --arg workspace "$WORKSPACE" \
+        '{
+          alias: $alias,
+          source: "notion",
+          status: "discovered",
+          details: { workspace: $workspace, note: "no databases shared with the integration" },
+          config: {
+            alias: $alias,
+            source: "notion",
+            type: "external",
+            notion: { workspace: $workspace },
+            priority: 5
+          }
+        }' > "$TMPDIR_D/notion-root.json"
+      exit 0
+    fi
+
+    for i in $(seq 0 $((COUNT - 1))); do
+      DB=$(echo "$RESP" | jq -c ".results[$i]")
+      DB_ID=$(echo "$DB" | jq -r '.id // ""')
+      TITLE=$(echo "$DB" | jq -r '.title[0].plain_text // .title[0].text.content // ""' 2>/dev/null)
+      [ -z "$DB_ID" ] && continue
+      [ -z "$TITLE" ] && TITLE="untitled-database"
+
+      ALIAS=$(slugify "notion-$TITLE")
+
+      jq -n \
+        --arg alias "$ALIAS" \
+        --arg db_id "$DB_ID" \
+        --arg title "$TITLE" \
+        '{
+          alias: $alias,
+          source: "notion",
+          status: "discovered",
+          details: { database_id: $db_id, title: $title },
+          config: {
+            alias: $alias,
+            source: "notion",
+            type: "external",
+            notion: { database_id: $db_id, title: $title },
+            priority: 5
+          }
+        }' > "$TMPDIR_D/notion-$i.json"
+    done
+  ) &
+fi
+
+wait
+
+# Assemble output array
+RESULTS=$(find "$TMPDIR_D" -maxdepth 1 -name '*.json' -type f 2>/dev/null | sort)
+if [ -z "$RESULTS" ]; then
+  echo '[]'
+  exit 0
+fi
+
+OUT="["
+first=true
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ "$first" = true ] && first=false || OUT="$OUT,"
+  OUT="$OUT$(cat "$f")"
+done <<< "$RESULTS"
+OUT="$OUT]"
+
+if [ "$PRETTY" = true ]; then
+  echo "$OUT" | jq .
+else
+  echo "$OUT" | jq -c .
+fi

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/claude-ops/skills/ops-projects/SKILL.md
+++ b/claude-ops/skills/ops-projects/SKILL.md
@@ -105,6 +105,24 @@ done | jq -s '.'
 ${CLAUDE_PLUGIN_ROOT}/bin/ops-external 2>/dev/null || echo '[]'
 ```
 
+## External-project auto-discovery (candidates not yet registered)
+
+```!
+${CLAUDE_PLUGIN_ROOT}/bin/ops-discover-external 2>/dev/null || echo '[]'
+```
+
+Cross-reference the candidates against the registry loaded above. If a candidate's `config.alias` is NOT already registered, surface it in a footer section of the dashboard so the user can register it via `/ops:setup registry`:
+
+```
+UNREGISTERED CANDIDATES (found via configured integrations)
+ SOURCE    DETAILS                            ACTION
+ ──────────────────────────────────────────────────────
+ shopify   mystore (basic plan)               /ops:setup registry
+ linear    Engineering (42 issues)            /ops:setup registry
+```
+
+Suppress this section if all candidates are already registered or the script returns `[]`.
+
 ---
 
 ## Your task
@@ -147,7 +165,9 @@ Use **batched AskUserQuestion calls** (max 4 options each) for the project selec
 
 ## Jump to project
 
-If `$ARGUMENTS` contains a project alias, show a deep-dive for that project:
+If `$ARGUMENTS` contains a project alias, look up the project in the registry and branch on `type`:
+
+### Git-backed project (default)
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -167,7 +187,33 @@ If `$ARGUMENTS` contains a project alias, show a deep-dive for that project:
  d) Check fires (/ops-fires [alias])
 ```
 
-Use AskUserQuestion after displaying either view.
+### External project (type: external, no git repo)
+
+For `source: shopify|linear|slack|notion|custom`, render a source-specific deep-dive pulled from `ops-external` + live MCP/API data — no git/CI/PR rows:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ [PROJECT] — EXTERNAL (shopify)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ Source:  shopify — mystore.myshopify.com (basic plan)
+ Status:  ✓ healthy    Revenue: ecommerce / growth
+ Recent:  [last 5 orders / Linear issues / Slack threads / Notion page edits]
+
+ Actions:
+ a) Jump to relevant tool (/ops:ecom, /ops:linear, /ops:inbox --slack, etc.)
+ b) Check fires (/ops-fires [alias])
+ c) View revenue (/ops:revenue [alias])
+ d) Back to portfolio
+```
+
+Source → action-skill map:
+- `shopify` → `/ops:ecom [alias]`
+- `linear`  → `/ops:linear [alias]`
+- `slack`   → `/ops:inbox --slack` (filter to that workspace)
+- `notion`  → `mcp__claude_ai_Notion__notion-search` or `/ops:inbox --notion`
+- `custom`  → show the `custom.url` and offer to open it via `WebFetch`
+
+Use AskUserQuestion (≤ 4 options) after displaying either view.
 
 ---
 

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -2644,6 +2644,46 @@ For each selected project, collect these fields one `AskUserQuestion` at a time:
 - `infra.platform` → select `[aws]`, `[vercel]`, `[cloudflare]`, `[other]`
 - `revenue.model` → select in batches of 4: `[saas]`, `[subscription]`, `[marketplace]`, `[More...]` then `[internal]`, `[portfolio]`, `[other]`
 
+### Auto-discover external projects
+
+A real user's portfolio is rarely just git repos. Shopify stores, Linear teams, Slack workspaces, and Notion databases are first-class projects that `ops-external` + `ops-projects` know how to surface — but only if they land in `registry.json`. This sub-step probes whatever integrations the wizard has already configured and offers discovered items for one-click registration.
+
+```!
+${CLAUDE_PLUGIN_ROOT}/bin/ops-discover-external 2>/dev/null || echo '[]'
+```
+
+The script reads Shopify creds from `$PREFS_PATH .ecom.shopify.*` + `SHOPIFY_*` env, Linear from `LINEAR_API_KEY`, Slack from keychain `slack-xoxc`/`slack-xoxd`, and Notion from `NOTION_API_KEY` / keychain `notion-api-key`. It returns an array of candidate projects, each with a ready-to-merge `config` block.
+
+**Parse the candidates** and — for each one not already present in `registry.json` (match by `config.alias` or by `source + source-specific ID`) — present it via `AskUserQuestion`. Batch at 3 candidates per call + `[More...]` to respect Rule 1 (max 4 options). Example batch:
+
+```
+Found external projects not yet in your registry (page 1 of N):
+  [Register "mystore" (shopify — basic plan, 142 products)]
+  [Register "linear-eng" (linear — Engineering, 42 open issues)]
+  [Register "notion-roadmap" (notion — Product Roadmap database)]
+  [More candidates...]
+```
+
+On the final page, the last option becomes `[None of the remaining — skip]`. Multi-select is acceptable — if you offer it, keep the `multiSelect: true` list size ≤ 4.
+
+For each **accepted** candidate, merge its `config` block straight into `registry.json .projects[]` with `jq`:
+
+```bash
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
+REG="$PLUGIN_ROOT/scripts/registry.json"
+[ -f "$REG" ] || echo '{"version":"1.0","owner":"","projects":[]}' > "$REG"
+jq --argjson new "$CONFIG_JSON" '.projects += [$new]' "$REG" > "$REG.tmp" && mv "$REG.tmp" "$REG"
+```
+
+**Status handling:**
+- `discovered` → register as-is.
+- `auth_expired` → surface a warning and route the user to `/ops:setup` for the affected channel before retrying.
+- `unreachable` → offer `[Register anyway (will show as unreachable in dashboards)]` / `[Skip]`.
+
+If the discovery script returns `[]`, print a single info line (`ℹ No external projects auto-discovered. You can add Shopify / Linear / Slack / Notion manually below.`) and continue. Never silently skip — the user must know the discovery ran.
+
+If the candidate's credential value came from an env var but the user later wants Doppler, the credential key stored in the candidate (`SHOPIFY_ADMIN_TOKEN`, etc.) is safe to replace with a `doppler:` reference later via `/ops:settings`.
+
 ### Existing registry
 
 If `registry.json` already has projects, ask first (4 options, fits in one call): `[Keep existing N projects]`, `[Add more projects]`, `[Auto-detect from existing registry]`, `[Start from scratch]`.


### PR DESCRIPTION
## Summary

- **Auto-discovery script** (`bin/ops-discover-external`) probes credentials already present in the plugin (Shopify prefs/env, Linear `LINEAR_API_KEY`, Slack keychain tokens, Notion API key) and emits candidate projects with ready-to-register `config` blocks.
- **Setup wizard Step 5** now surfaces those candidates alongside the existing filesystem git-repo scan, so users no longer have to hand-edit `registry.json` to register Shopify stores, Linear teams, Slack workspaces, or Notion databases.
- **`ops-projects` dashboard** gains a footer listing unregistered candidates + a source-specific deep-dive (shopify/linear/slack/notion/custom) that routes to the right skill instead of assuming git/CI/PR context.
- **Rule 0 drive-by:** `CODE_OF_CONDUCT.md` CoC report email changed from a product support address to the plugin maintainer email (`info@lifecycleinnovations.limited`), matching `SECURITY.md`.

Closes the gap where `bin/ops-external` + the registry schema already supported external projects but nothing populated them automatically.

## Test plan

- [x] `npm test` — passes (no-secrets scan + bash -n + node --check)
- [x] `npx prettier --check` — all formatted
- [x] Smoke: `bin/ops-discover-external --pretty` returns valid JSON with linear + notion candidates when those integrations are configured; returns `[]` with no creds
- [x] Smoke: `--source slack` / `--source shopify` exit 0 with `[]` when creds absent (no errors, no leaked values)
- [ ] Manual: run `/ops:setup registry` end-to-end on a fresh-ish machine and confirm candidates land in `registry.json` with `type: external`
- [ ] Manual: `/ops:projects` shows UNREGISTERED CANDIDATES footer when a discovered project isn't registered, and drops it once it is

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new credential-driven discovery script that calls third-party APIs (Shopify/Linear/Slack/Notion), which could affect setup reliability and error handling across environments. Changes are otherwise additive/docs-oriented with no direct registry writes in the script.
> 
> **Overview**
> Adds external-project auto-discovery to reduce manual `registry.json` edits: new `bin/ops-discover-external` probes existing Shopify/Linear/Slack/Notion credentials and emits redacted, ready-to-register candidate `config` blocks.
> 
> Updates the setup wizard (`skills/setup/SKILL.md`) to offer registration of newly discovered external candidates (batched `AskUserQuestion`, status-aware flows), and enhances `ops-projects` guidance to show an “UNREGISTERED CANDIDATES” footer plus external-project deep-dive behavior when jumping by alias.
> 
> Bumps plugin/marketplace/package versions to `1.6.0` and updates `CODE_OF_CONDUCT.md` enforcement contact email.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f95c3bef04745db8ea83f5a8bb40859608fbdf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/131" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-discovery of external projects from Shopify, Linear, Slack, and Notion integrations.
  * Display of unregistered project candidates in the portfolio dashboard with registration actions.
  * Enhanced project details view with source-specific information for external integrations.

* **Documentation**
  * Updated Code of Conduct enforcement contact information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->