### PR TITLE
fix(daemon): auto-upgrade plist when plugin version changes

### DIFF
--- a/claude-ops/hooks/hooks.json
+++ b/claude-ops/hooks/hooks.json
@@ -10,6 +10,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/setup.sh 2>/dev/null | grep '✗' | head -3 || true"
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/ops-daemon-manager.sh ensure-current --plugin-root ${CLAUDE_PLUGIN_ROOT} 2>/dev/null || true"
           }
         ]
       }

--- a/claude-ops/scripts/ops-daemon-manager.sh
+++ b/claude-ops/scripts/ops-daemon-manager.sh
@@ -21,7 +21,16 @@ set -euo pipefail
 
 usage() {
   cat >&2 <<EOF
-Usage: ops-daemon-manager.sh <install|upgrade|uninstall|status|restart> [options]
+Usage: ops-daemon-manager.sh <install|upgrade|ensure-current|uninstall|status|restart> [options]
+
+Subcommands:
+  install         First-time install (writes plist + loads launchd)
+  upgrade         Re-point plist at PLUGIN_ROOT + reload (always reloads)
+  ensure-current  No-op if plist already points at PLUGIN_ROOT, else upgrade
+                  (cheap + idempotent — safe to run on every SessionStart)
+  restart         Unload + reload without reconfiguring
+  uninstall       Stop + remove plist
+  status          Emit JSON snapshot
 
 Options:
   --plugin-root PATH    Override auto-detected plugin root
@@ -34,7 +43,7 @@ Environment:
 Examples:
   ops-daemon-manager.sh install
   ops-daemon-manager.sh status
-  ops-daemon-manager.sh upgrade --plugin-root \$HOME/.claude/plugins/cache/ops-marketplace/ops/1.3.0
+  ops-daemon-manager.sh ensure-current
 EOF
 }
 
@@ -280,6 +289,20 @@ cmd_upgrade() {
   esac
 }
 
+cmd_ensure_current() {
+  [[ "$OS" == "macos" ]] || exit 0
+  [[ -n "$PLUGIN_ROOT" ]] && [[ -d "$PLUGIN_ROOT/scripts" ]] || exit 0
+  [[ -f "$PLIST_DEST" ]] || exit 0
+  local current_script="$PLUGIN_ROOT/scripts/ops-daemon.sh"
+  local plist_script
+  plist_script="$(mac_plist_script_path)"
+  if [[ "$plist_script" == "$current_script" ]]; then
+    exit 0
+  fi
+  log "plist points at stale version ($plist_script); upgrading to $PLUGIN_ROOT"
+  cmd_upgrade
+}
+
 cmd_uninstall() {
   case "$OS" in
     macos)
@@ -374,10 +397,11 @@ EOF
 
 # ── Dispatch ─────────────────────────────────────────────────────────────
 case "$CMD" in
-  install)   cmd_install ;;
-  upgrade)   cmd_upgrade ;;
-  uninstall) cmd_uninstall ;;
-  restart)   cmd_restart ;;
-  status)    cmd_status ;;
-  *)         usage; exit 64 ;;
+  install)        cmd_install ;;
+  upgrade)        cmd_upgrade ;;
+  ensure-current) cmd_ensure_current ;;
+  uninstall)      cmd_uninstall ;;
+  restart)        cmd_restart ;;
+  status)         cmd_status ;;
+  *)              usage; exit 64 ;;
 esac


### PR DESCRIPTION
## Summary
- **Problem:** Plugin upgrades don't re-point the daemon's launchd plist at the new version path, so the daemon keeps running the old version until the user manually runs `ops-daemon-manager.sh upgrade`. In practice the plist ages through several releases, orphan `wacli-keepalive.sh` children accumulate, and users see wacli status mismatches that look like WhatsApp bugs.
- **Fix:** Add an idempotent `ensure-current` subcommand and wire it into SessionStart so every new Claude Code session after a plugin upgrade self-heals the plist.

## Changes
- `scripts/ops-daemon-manager.sh`:
  - New `cmd_ensure_current` — exits 0 if plist already points at `PLUGIN_ROOT`, else calls `cmd_upgrade`. macOS-only; no-op elsewhere.
  - Dispatch + usage() updated.
- `hooks/hooks.json`: third SessionStart hook that invokes `ensure-current` (stderr silenced, `|| true` so it can't break the session).

## Test plan
- [x] `bash -n` passes on the script
- [x] `python3 -m json.tool` accepts the updated `hooks.json`
- [x] `tests/test-no-secrets.sh` passes (11/11)
- [x] `ensure-current --plugin-root <current>` exits 0 as a no-op when versions already match
- [x] Reproduced the bug locally: plist was at v1.3.0 after two upgrades to v1.5.0; running `ensure-current` detected the mismatch and upgraded the plist cleanly. A fresh SessionStart with this patch would have prevented the drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, macOS-scoped operational change that mainly adds an idempotent check and invokes it on session start; primary risk is unintended restart/reload of the daemon if the plist parsing/match is wrong.
> 
> **Overview**
> Automatically self-heals macOS daemon installs after plugin upgrades by ensuring the launchd plist always points at the current `CLAUDE_PLUGIN_ROOT`.
> 
> This introduces a new `ensure-current` subcommand in `ops-daemon-manager.sh` that no-ops when the plist already references the current `ops-daemon.sh`, otherwise it triggers an `upgrade`; `hooks.json` now runs this check during `SessionStart` (stderr-silenced and non-fatal).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f25f51479641f51dda01d452d73be5ba15ce508. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/132" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
