### PR TITLE
feat(ops-merge): filter PRs by approved author logins

### DIFF
--- a/claude-ops/bin/ops-merge-scan
+++ b/claude-ops/bin/ops-merge-scan
@@ -8,6 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_DIR="${CLAUDE_PLUGIN_ROOT:-${SCRIPT_DIR}/..}"
 REGISTRY="${PLUGIN_DIR}/scripts/registry.json"
+PREFS="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
 
 # Optional: scope to a single repo
 FILTER_REPO="${1:-}"
@@ -25,6 +26,14 @@ if [ -n "$FILTER_REPO" ]; then
   REPOS="$FILTER_REPO"
 else
   REPOS=$(jq -r '[.projects[].repos[]] | unique | .[]' "$REGISTRY")
+fi
+
+# Approved PR author logins (owner + bots). Configured in preferences.json
+# under .merge_authors (array of GitHub logins, e.g. "you", "dependabot[bot]").
+# Empty / missing → keep all authors (legacy behavior).
+MERGE_AUTHORS_JSON='[]'
+if [ -f "$PREFS" ]; then
+  MERGE_AUTHORS_JSON=$(jq -c '.merge_authors // []' "$PREFS" 2>/dev/null || echo '[]')
 fi
 
 TMPDIR_OPS=$(mktemp -d)
@@ -46,35 +55,49 @@ for repo in $REPOS; do
         echo "$pr" | jq --argjson ci "$CI_JSON" '. + {statusCheckRollup: $ci.statusCheckRollup}'
       done | jq -s '.')
 
-      # Classify each PR
-      CLASSIFIED=$(echo "$ENRICHED" | jq --arg repo "$repo" '[.[] | {
-        repo: $repo,
-        number,
-        title,
-        branch: .headRefName,
-        draft: .isDraft,
-        review: .reviewDecision,
-        mergeable: .mergeable,
-        merge_state: .mergeStateStatus,
-        ci_status: (if (.statusCheckRollup | length) > 0 then
-          (if (.statusCheckRollup | map(select(.conclusion == "FAILURE")) | length) > 0 then "failing"
-           elif (.statusCheckRollup | map(select(.status != "COMPLETED")) | length) > 0 then "pending"
-           else "passing" end)
-        else "unknown" end),
-        ci_failures: [(.statusCheckRollup // [])[] | select(.conclusion == "FAILURE") | .name],
-        created: .createdAt,
-        author: .author.login,
-        classification: (
-          if .isDraft then "draft"
-          elif .mergeable == "CONFLICTING" then "needs-rebase"
-          elif (.statusCheckRollup // [] | map(select(.conclusion == "FAILURE")) | length) > 0 then "needs-ci-fix"
-          elif .reviewDecision == "CHANGES_REQUESTED" then "needs-review-response"
-          elif .mergeStateStatus == "BLOCKED" then "blocked"
-          elif .mergeable == "MERGEABLE" and .reviewDecision == "APPROVED" then "ready"
-          else "unknown" end
-        )
-      }]')
-      echo "$CLASSIFIED" > "$TMPDIR_OPS/$SAFE_NAME.json"
+      # Classify each PR.
+      # If merge_authors is configured, PRs from unlisted authors are dropped
+      # entirely — they do not belong in the operator's merge queue.
+      CLASSIFIED=$(echo "$ENRICHED" | jq \
+        --arg repo "$repo" \
+        --argjson allowed "$MERGE_AUTHORS_JSON" \
+        '[.[]
+          | (if ($allowed | length) > 0
+             then select(.author.login as $a | $allowed | any(. == $a))
+             else .
+             end)
+          | {
+            repo: $repo,
+            number,
+            title,
+            branch: .headRefName,
+            draft: .isDraft,
+            review: .reviewDecision,
+            mergeable: .mergeable,
+            merge_state: .mergeStateStatus,
+            ci_status: (if (.statusCheckRollup | length) > 0 then
+              (if (.statusCheckRollup | map(select(.conclusion == "FAILURE")) | length) > 0 then "failing"
+               elif (.statusCheckRollup | map(select(.status != "COMPLETED")) | length) > 0 then "pending"
+               else "passing" end)
+            else "unknown" end),
+            ci_failures: [(.statusCheckRollup // [])[] | select(.conclusion == "FAILURE") | .name],
+            created: .createdAt,
+            author: .author.login,
+            classification: (
+              if .isDraft then "draft"
+              elif .mergeable == "CONFLICTING" then "needs-rebase"
+              elif (.statusCheckRollup // [] | map(select(.conclusion == "FAILURE")) | length) > 0 then "needs-ci-fix"
+              elif .reviewDecision == "CHANGES_REQUESTED" then "needs-review-response"
+              elif .mergeStateStatus == "BLOCKED" then "blocked"
+              elif .mergeable == "MERGEABLE" and .reviewDecision == "APPROVED" then "ready"
+              else "unknown" end
+            )
+          }
+        ]')
+      # Only write the file if there is at least one PR left after filtering.
+      if [ "$(echo "$CLASSIFIED" | jq 'length')" != "0" ]; then
+        echo "$CLASSIFIED" > "$TMPDIR_OPS/$SAFE_NAME.json"
+      fi
     fi
   ) &
 done


### PR DESCRIPTION
## Summary
Today's `/ops:ops-merge` queue surfaced 2 PRs from a registered public repo authored by external contributors. The scanner had no author filter → external PRs pollute the operator's merge queue.

Adds an optional `merge_authors` array in `preferences.json`. When set, the scanner keeps only PRs whose `author.login` is in the list. When unset/empty, behavior is unchanged.

## Changes
- `bin/ops-merge-scan`:
  - Reads `.merge_authors` from `preferences.json` (via `$CLAUDE_PLUGIN_DATA_DIR`)
  - Applies filter during `jq` classification pipeline
  - Suppresses tmp files for repos where every PR was filtered out (no empty entries in output)

## Usage
Add to `~/.claude/plugins/data/ops-ops-marketplace/preferences.json`:
```json
{
  "merge_authors": ["your-login", "dependabot[bot]", "app/dependabot"]
}
```

## Test plan
- [x] `bash -n` passes
- [x] `tests/test-no-secrets.sh` passes 11/11
- [x] Smoke test with `merge_authors=["my-login","dependabot[bot]"]` + registry containing an external-author repo → external PRs filtered out, own PRs retained
- [x] Smoke test with `merge_authors=[]` (or unset) → all PRs returned (legacy behavior preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/133" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to PR scanning output that only narrows results when an optional config is set; minimal impact outside the merge-queue workflow.
> 
> **Overview**
> `ops-merge-scan` now optionally filters open PRs by an allowlist of GitHub author logins read from `preferences.json` (`.merge_authors`), keeping legacy behavior when the list is unset/empty.
> 
> Repos where all PRs are filtered out no longer write temp JSON files, preventing empty entries from appearing in the aggregated scan output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c3db5ff9f4c4015da30f6bfbc1a9b274e574397. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->