### PR TITLE
chore(release): promote to v1.6.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code \u2014 25 skills, 13 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes YOLO autonomous mode with 4 C-suite agents.",
       "source": "./claude-ops",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "category": "productivity",
       "screenshots": [
         "docs/screenshots/dashboard.png",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Business operations command center for Claude Code \u2014 25 skills, 13 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes YOLO mode for autonomous operation.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.1] — 2026-04-16
+
+### Added
+
+- **`ops-package` carrier-agnostic shipping skill** — Unified `/ops:package ship|label|track|list|carriers` entrypoint routing to 7 carrier adapters. Each adapter lives in `skills/ops-package/lib/carriers/<carrier>.sh` and shares common helpers (address parsing, credential resolution, label storage) in `lib/common.sh`.
+  - **VERIFIED (live API tested)**: MyParcel.nl (api.myparcel.nl v1.1), Sendcloud (Panel API v3).
+  - **UNVERIFIED (modelled from vendor docs, live account pending)**: DHL NL (My DHL Parcel Swagger), PostNL (Send API v2.2), DPD (eSolutions REST), UPS (v2403 Ship/Track REST), FedEx (Ship v1 + Track v1 REST). Adapters tagged `# UNVERIFIED - pending live test with account` in source; payloads may need adjustment against live accounts.
+
+### Fixed
+
+- **MyParcel NL insured shipments force `only_recipient:true` + `signature:true`** — MyParcel's own API contract requires both flags when `insurance > 0` for NL domestic shipments; omitting them returns a 422. Flagged by coderabbitai (Major).
+- **`mktemp` temp files leaked on `curl` failure** — Under `set -e`, a failed `curl` short-circuited label flows before `rm -f` ran, leaving stale PDFs in `$TMPDIR`. Fixed in myparcel, dhl, dpd, sendcloud label flows via `trap 'rm -f "$tmp"' RETURN` (scoped to the function, cleared on success path before `save_label_pdf` takes ownership). Flagged by sentry[bot] and chatgpt-codex-connector (P1).
+- **OAuth token cache written world-readable in `/tmp`** — `mktemp` inherits the ambient umask; on default systems that's 0644. Added `umask 077` before creating token cache files so only the owner can read them. Flagged by cursor[bot] (Medium).
+- **`myparcel_list` recipient concatenation NPE on missing name/city** — `jq` join of `.recipient.name` + `.recipient.city` crashed when either field was absent. Added `// empty` fallbacks. Flagged by cursor[bot] (Low).
+- **Dead code: `consume_carrier_flag` and `list_configured_carriers`** — Unused helper functions in `ops-package.sh` removed. Flagged by cursor[bot] (Low).
+- **`--carrier` without value crashed under `set -u`** — `CARRIER="$2"` expanded to unbound-variable error when user ran `ops-package.sh --carrier` with nothing after it. Now guards with `"${2:-}"` and exits 64 with a usage message. Flagged by devin-ai-integration[bot].
+- **MyParcel `Authorization` header scheme capitalization** — Changed `basic` to `Basic` to match RFC 7235 convention and MyParcel vendor docs (scheme matching is case-insensitive per spec but explicit casing avoids edge-case proxies). Flagged by coderabbitai (Minor).
+- **MyParcel list page size** — Bumped default from 10 to 30 to match the API's documented page size and reduce pagination chatter on the typical user's recent-shipment view. Flagged by chatgpt-codex-connector (P2).
+
 ## [1.6.0] — 2026-04-16
 
 ### Added

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/claude-ops/skills/ops-package/lib/carriers/dhl.sh
+++ b/claude-ops/skills/ops-package/lib/carriers/dhl.sh
@@ -123,17 +123,18 @@ dhl_label() {
   local auth; auth=$(dhl_auth_header)
 
   local tmp; tmp=$(mktemp)
+  trap 'rm -f "$tmp"' RETURN
   curl -sS -H "$auth" -H "$UA_HEADER" \
     -H "Accept: application/pdf" \
     -o "$tmp" \
     "$DHL_BASE_URL/labels/${id}?format=PDF&printerType=A4"
 
   if file "$tmp" 2>/dev/null | grep -qi "PDF"; then
+    trap - RETURN
     save_label_pdf "dhl" "$id" "$tmp"
   else
     echo "dhl label: unexpected non-PDF response:" >&2
     cat "$tmp" >&2 2>/dev/null || true
-    rm -f "$tmp"
     return 1
   fi
 }

--- a/claude-ops/skills/ops-package/lib/carriers/dpd.sh
+++ b/claude-ops/skills/ops-package/lib/carriers/dpd.sh
@@ -139,15 +139,16 @@ dpd_label() {
   local base; base=$(_dpd_base_url)
 
   local tmp; tmp=$(mktemp)
+  trap 'rm -f "$tmp"' RETURN
   curl -sS -H "$auth" -H "$UA_HEADER" -H "Accept: application/pdf" \
     -o "$tmp" \
     "$base/v1/parcellabelnumber/${id}?paperFormat=A4"
   if file "$tmp" 2>/dev/null | grep -qi "PDF"; then
+    trap - RETURN
     save_label_pdf "dpd" "$id" "$tmp"
   else
     echo "dpd label: unexpected non-PDF response:" >&2
     cat "$tmp" >&2 2>/dev/null || true
-    rm -f "$tmp"
     return 1
   fi
 }

--- a/claude-ops/skills/ops-package/lib/carriers/myparcel.sh
+++ b/claude-ops/skills/ops-package/lib/carriers/myparcel.sh
@@ -11,7 +11,7 @@ myparcel_auth_header() {
   local k; k=$(resolve_env "MYPARCEL_API_KEY" "myparcel_api_key") || \
     die_missing_creds "MyParcel.nl" "MYPARCEL_API_KEY" "https://developer.myparcel.nl/api-reference/"
   local b64; b64=$(printf '%s' "$k" | base64 | tr -d '\n')
-  printf 'Authorization: basic %s' "$b64"
+  printf 'Authorization: Basic %s' "$b64"
 }
 
 myparcel_ship() {
@@ -120,19 +120,20 @@ myparcel_label() {
 
   local tmp_body tmp_headers
   tmp_body=$(mktemp); tmp_headers=$(mktemp)
-  trap 'rm -f "$tmp_body" "$tmp_headers"' EXIT
+  trap 'rm -f "$tmp_body" "$tmp_headers"' RETURN
   curl -sS -D "$tmp_headers" -o "$tmp_body" \
     -H "$auth" -H "$UA_HEADER" -H "Accept: application/pdf" \
     "$MYPARCEL_BASE_URL/shipment_labels/${id}?format=A4&positions=1"
 
   local ctype
   ctype=$(awk -F': *' 'tolower($1)=="content-type"{print tolower($2)}' "$tmp_headers" | tr -d '\r' | tail -1)
-  rm -f "$tmp_headers"
 
   if [[ "$ctype" == application/pdf* ]]; then
+    trap - RETURN
+    rm -f "$tmp_headers"
     save_label_pdf "myparcel" "$id" "$tmp_body"
   else
-    local body; body=$(cat "$tmp_body"); rm -f "$tmp_body"
+    local body; body=$(cat "$tmp_body")
     local pay_url
     pay_url=$(printf '%s' "$body" | jq -r '.data.payment_instructions.payment_url // empty' 2>/dev/null)
     if [ -n "$pay_url" ]; then

--- a/claude-ops/skills/ops-package/lib/carriers/sendcloud.sh
+++ b/claude-ops/skills/ops-package/lib/carriers/sendcloud.sh
@@ -100,7 +100,9 @@ sendcloud_label() {
   fi
 
   local tmp; tmp=$(mktemp)
+  trap 'rm -f "$tmp"' RETURN
   curl -sS -H "$auth" -H "$UA_HEADER" -o "$tmp" "$pdf_url"
+  trap - RETURN
   save_label_pdf "sendcloud" "$id" "$tmp"
 }
 

--- a/claude-ops/skills/ops-package/ops-package.sh
+++ b/claude-ops/skills/ops-package/ops-package.sh
@@ -113,7 +113,14 @@ cmd_carriers() {
 ARGS=()
 while [ $# -gt 0 ]; do
   case "$1" in
-    --carrier) CARRIER="$2"; shift 2 ;;
+    --carrier)
+      CARRIER="${2:-}"
+      if [ -z "$CARRIER" ]; then
+        echo "ops-package.sh: --carrier requires a value (e.g. --carrier myparcel)" >&2
+        exit 64
+      fi
+      shift 2
+      ;;
     *) ARGS+=("$1"); shift ;;
   esac
 done


### PR DESCRIPTION
## Summary

- Ships `ops-package` carrier-agnostic shipping skill (7 carriers: MyParcel + Sendcloud VERIFIED; DHL, PostNL, DPD, UPS, FedEx UNVERIFIED — pending live accounts).
- Lands post-#130 bot-flagged fixes (140cf55): `mktemp` cleanup via `RETURN` traps across dhl/dpd/sendcloud/myparcel label flows, `--carrier` guard under `set -u`, `Authorization` scheme casing.
- Bumps version 1.6.0 → 1.6.1 across `claude-ops/package.json`, `claude-ops/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and the `CHANGELOG.md` entry.

## Test plan

- [x] `tests/test-no-secrets.sh` passes
- [x] `bash -n` on all ops-package shells passes
- [x] `node --check` on all `.mjs` passes
- [x] `npx prettier --check` passes
- [x] CI green on feat/ops-package-myparcel (run 24522029367)

Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/134" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shipping label generation and credential/token handling paths; while changes are mostly defensive, they affect live API interactions and file/permission behaviors for multiple carriers.
> 
> **Overview**
> Bumps the plugin/runtime versions to `1.6.1` across marketplace and package manifests, and adds a `1.6.1` `CHANGELOG` entry documenting the new `ops-package` carrier-agnostic shipping skill.
> 
> Hardens `ops-package` carrier adapters and router: ensures temp label files are always cleaned up on failed `curl` via function-scoped `RETURN` traps, tightens token cache creation permissions via `umask 077`, fixes MyParcel auth header scheme casing and insured-shipment flag requirements, and makes `--carrier` parsing fail fast with a clear usage error when no value is provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d273076c3acf591bab984ab4d0f532ef57e5286. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->