### PR TITLE
fix: bot-flagged bugs in ops-marketing + marketing-optimizer

### DIFF
--- a/claude-ops/agents/marketing-optimizer.md
+++ b/claude-ops/agents/marketing-optimizer.md
@@ -16,11 +16,17 @@ Read pre-gathered marketing data from the ops-marketing-dash script:
 "${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/ops-ops-marketplace}/bin/ops-marketing-dash" 2>/dev/null
 ```
 
-Parse the JSON output. Look for:
-- `meta_ads.spend`, `meta_ads.roas`, `meta_ads.purchases`, `meta_ads.campaigns[]`
-- `google_ads.spend`, `google_ads.conversions_value`, `google_ads.campaigns[]`
-- `klaviyo.attributed_revenue`
-- `ga4.revenue`, `ga4.conversions`
+Parse the JSON output. The schema emitted by `ops-marketing-dash` (v1.5+) is:
+
+- `meta` — account-level Meta Ads totals (last 7 days): `meta.spend`, `meta.impressions`, `meta.clicks`, `meta.ctr`, `meta.purchases`, `meta.purchase_value`, `meta.roas`. All values are strings. No per-campaign breakdown is pre-gathered — fetch campaigns directly via the fallback query below if you need per-campaign analysis.
+- `google_ads` — raw Google Ads `searchStream` response (array of pages). Each page has `.results[]` with `.campaign.{id,name,status}` and `.metrics.{costMicros,impressions,clicks,conversions,conversionsValue}`. Compute `google_ads.spend` as `[.[].results[]?.metrics.costMicros | tonumber] | add / 1000000` and `google_ads.conversions_value` as `[.[].results[]?.metrics.conversionsValue | tonumber] | add`.
+- `klaviyo` — `klaviyo.subscribers`, `klaviyo.last_campaign`, `klaviyo.last_campaign_status`, `klaviyo.open_rate`.
+- `ga4` — `ga4.sessions`, `ga4.users`, `ga4.conversions`, `ga4.revenue`, `ga4.cvr`.
+- `gsc` — `gsc.clicks`, `gsc.impressions`, `gsc.ctr`, `gsc.avg_position`.
+- `instagram` — `instagram.followers`, `instagram.media_count`, `instagram.reach_7d`.
+- Top-level: `blended_roas`, `health_score`, `health_status`, `date`.
+
+Any channel the user has not configured will be JSON `null` rather than an object.
 
 If ops-marketing-dash data is unavailable, pull directly:
 

--- a/claude-ops/agents/marketing-optimizer.md
+++ b/claude-ops/agents/marketing-optimizer.md
@@ -19,7 +19,9 @@ Read pre-gathered marketing data from the ops-marketing-dash script:
 Parse the JSON output. The schema emitted by `ops-marketing-dash` (v1.5+) is:
 
 - `meta` — account-level Meta Ads totals (last 7 days): `meta.spend`, `meta.impressions`, `meta.clicks`, `meta.ctr`, `meta.purchases`, `meta.purchase_value`, `meta.roas`. All values are strings. No per-campaign breakdown is pre-gathered — fetch campaigns directly via the fallback query below if you need per-campaign analysis.
-- `google_ads` — raw Google Ads `searchStream` response (array of pages). Each page has `.results[]` with `.campaign.{id,name,status}` and `.metrics.{costMicros,impressions,clicks,conversions,conversionsValue}`. Compute `google_ads.spend` as `[.[].results[]?.metrics.costMicros | tonumber] | add / 1000000` and `google_ads.conversions_value` as `[.[].results[]?.metrics.conversionsValue | tonumber] | add`.
+- `google_ads` — raw Google Ads `searchStream` response (array of pages) when configured, or `null` otherwise. Each page has `.results[]` with `.campaign.{id,name,status}` and `.metrics.{costMicros,impressions,clicks,conversions,conversionsValue}`. Derive spend and conversions_value via null-safe reductions so unconfigured / empty responses yield `0` instead of throwing:
+  - spend: `(if type=="array" then [.[].results[]?.metrics.costMicros // "0" | tonumber] | add // 0 else 0 end) / 1000000`
+  - conversions_value: `if type=="array" then [.[].results[]?.metrics.conversionsValue // "0" | tonumber] | add // 0 else 0 end`
 - `klaviyo` — `klaviyo.subscribers`, `klaviyo.last_campaign`, `klaviyo.last_campaign_status`, `klaviyo.open_rate`.
 - `ga4` — `ga4.sessions`, `ga4.users`, `ga4.conversions`, `ga4.revenue`, `ga4.cvr`.
 - `gsc` — `gsc.clicks`, `gsc.impressions`, `gsc.ctr`, `gsc.avg_position`.

--- a/claude-ops/bin/ops-marketing-dash
+++ b/claude-ops/bin/ops-marketing-dash
@@ -57,12 +57,25 @@ gather_klaviyo() {
 
   LAST_CAMPAIGN_NAME=$(echo "$CAMPAIGNS" | jq -r '.data[0].attributes.name // "none"' 2>/dev/null || echo "none")
   LAST_CAMPAIGN_STATUS=$(echo "$CAMPAIGNS" | jq -r '.data[0].attributes.status // "none"' 2>/dev/null || echo "none")
+  LAST_CAMPAIGN_ID=$(echo "$CAMPAIGNS" | jq -r '.data[0].id // empty' 2>/dev/null || echo "")
+
+  # Open rate (0.0-1.0) for last campaign — feeds marketing health score email component.
+  OPEN_RATE="0"
+  if [ -n "$LAST_CAMPAIGN_ID" ]; then
+    VALUES=$(curl -s -X POST "https://a.klaviyo.com/api/campaign-values-reports/" \
+      -H "Authorization: Klaviyo-API-Key ${KLAVIYO_KEY}" \
+      -H "revision: 2024-10-15" \
+      -H "Content-Type: application/json" \
+      -d "{\"data\":{\"type\":\"campaign-values-report\",\"attributes\":{\"statistics\":[\"open_rate\"],\"timeframe\":{\"key\":\"last_30_days\"},\"filter\":\"equals(campaign_id,\\\"${LAST_CAMPAIGN_ID}\\\")\"}}}" 2>/dev/null)
+    OPEN_RATE=$(echo "$VALUES" | jq -r '.data.attributes.results[0].statistics.open_rate // 0' 2>/dev/null || echo "0")
+  fi
 
   jq -n \
     --argjson subs "$TOTAL_SUBS" \
     --arg last_campaign "$LAST_CAMPAIGN_NAME" \
     --arg last_status "$LAST_CAMPAIGN_STATUS" \
-    '{subscribers: $subs, last_campaign: $last_campaign, last_campaign_status: $last_status}'
+    --argjson open_rate "${OPEN_RATE:-0}" \
+    '{subscribers: $subs, last_campaign: $last_campaign, last_campaign_status: $last_status, open_rate: $open_rate}'
 }
 
 # --- Meta Ads ---
@@ -251,14 +264,27 @@ gather_google_ads() {
     2>/dev/null || echo "null"
 }
 
-# Run all in parallel (subshells)
-KLAVIYO_DATA=$(gather_klaviyo) &
-META_DATA=$(gather_meta) &
-GA4_DATA=$(gather_ga4) &
-GSC_DATA=$(gather_gsc) &
-GADS_DATA=$(gather_google_ads) &
-INSTAGRAM_DATA=$(gather_instagram) &
+# Run all in parallel. VAR=$(fn) & does NOT propagate assignments to the parent
+# shell after `wait` (the assignment happens in the backgrounded subshell only),
+# so write each gatherer's stdout to a tempfile and read them back post-wait.
+# This mirrors the pattern already used in bin/ops-external and bin/ops-discover-external.
+TMPDIR_MD=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_MD"' EXIT
+
+( gather_klaviyo     > "$TMPDIR_MD/klaviyo.json"   ) &
+( gather_meta        > "$TMPDIR_MD/meta.json"      ) &
+( gather_ga4         > "$TMPDIR_MD/ga4.json"       ) &
+( gather_gsc         > "$TMPDIR_MD/gsc.json"       ) &
+( gather_google_ads  > "$TMPDIR_MD/google_ads.json") &
+( gather_instagram   > "$TMPDIR_MD/instagram.json" ) &
 wait
+
+KLAVIYO_DATA=$(cat "$TMPDIR_MD/klaviyo.json"    2>/dev/null); KLAVIYO_DATA=${KLAVIYO_DATA:-null}
+META_DATA=$(cat "$TMPDIR_MD/meta.json"          2>/dev/null); META_DATA=${META_DATA:-null}
+GA4_DATA=$(cat "$TMPDIR_MD/ga4.json"            2>/dev/null); GA4_DATA=${GA4_DATA:-null}
+GSC_DATA=$(cat "$TMPDIR_MD/gsc.json"            2>/dev/null); GSC_DATA=${GSC_DATA:-null}
+GADS_DATA=$(cat "$TMPDIR_MD/google_ads.json"    2>/dev/null); GADS_DATA=${GADS_DATA:-null}
+INSTAGRAM_DATA=$(cat "$TMPDIR_MD/instagram.json" 2>/dev/null); INSTAGRAM_DATA=${INSTAGRAM_DATA:-null}
 
 # Compute blended ROAS across Meta + Google Ads
 META_SPEND=$(echo "$META_DATA" | jq -r '.spend // "0"' 2>/dev/null || echo "0")
@@ -272,14 +298,23 @@ BLENDED_ROAS=$(awk "BEGIN { if (${TOTAL_SPEND:-0} > 0) printf \"%.2f\", ${TOTAL_
 # Compute marketing health score (0-100)
 # ROAS score (0-30)
 ROAS_SCORE=$(awk "BEGIN { r = ${BLENDED_ROAS:-0}; if (r >= 3) print 30; else if (r >= 1) print 15; else print 0 }")
-# Email open rate score — use Klaviyo data if available (0-20)
-EMAIL_SCORE=10  # default medium score if no open rate data available
-# Channel diversification (0-20): count active platforms
+# Email open rate score (0-20) — derived from Klaviyo last-campaign open rate
+# when available; falls back to 0 when we have no campaign data.
+KLAVIYO_OPEN_RATE=$(echo "$KLAVIYO_DATA" | jq -r '.open_rate // "0"' 2>/dev/null || echo "0")
+EMAIL_SCORE=$(awk "BEGIN { r = ${KLAVIYO_OPEN_RATE:-0}; if (r >= 0.25) print 20; else if (r >= 0.15) print 10; else print 0 }")
+# Channel diversification (0-20): count active platforms.
+# Compare numerically — after the tempfile fix these fields can be JSON null or
+# numeric strings like "0.00", neither of which a literal != "0" string test
+# handles correctly.
 ACTIVE_CHANNELS=0
-[ "$(echo "$META_DATA" | jq -r '.spend // "0"')" != "0" ] && ACTIVE_CHANNELS=$((ACTIVE_CHANNELS + 1))
-[ "$(echo "$GADS_SPEND_RAW" | tr -d ' ')" != "0" ] && ACTIVE_CHANNELS=$((ACTIVE_CHANNELS + 1))
-[ "$(echo "$KLAVIYO_DATA" | jq -r '.subscribers // 0')" != "0" ] && ACTIVE_CHANNELS=$((ACTIVE_CHANNELS + 1))
-[ "$(echo "$INSTAGRAM_DATA" | jq -r '.followers // 0')" != "0" ] && ACTIVE_CHANNELS=$((ACTIVE_CHANNELS + 1))
+is_positive() { awk -v v="${1:-0}" 'BEGIN { v = v + 0; exit !(v > 0) }'; }
+META_SPEND_CHECK=$(echo "$META_DATA" | jq -r '.spend // 0' 2>/dev/null || echo 0)
+KLAVIYO_SUBS_CHECK=$(echo "$KLAVIYO_DATA" | jq -r '.subscribers // 0' 2>/dev/null || echo 0)
+INSTAGRAM_FOLLOWERS_CHECK=$(echo "$INSTAGRAM_DATA" | jq -r '.followers // 0' 2>/dev/null || echo 0)
+is_positive "$META_SPEND_CHECK"          && ACTIVE_CHANNELS=$((ACTIVE_CHANNELS + 1))
+is_positive "$GADS_SPEND_RAW"            && ACTIVE_CHANNELS=$((ACTIVE_CHANNELS + 1))
+is_positive "$KLAVIYO_SUBS_CHECK"        && ACTIVE_CHANNELS=$((ACTIVE_CHANNELS + 1))
+is_positive "$INSTAGRAM_FOLLOWERS_CHECK" && ACTIVE_CHANNELS=$((ACTIVE_CHANNELS + 1))
 DIV_SCORE=$([ $ACTIVE_CHANNELS -ge 3 ] && echo 20 || ([ $ACTIVE_CHANNELS -ge 2 ] && echo 10 || echo 0))
 # GA4 CVR score (0-20)
 GA4_CVR=$(echo "$GA4_DATA" | jq -r '.cvr // "0"' 2>/dev/null || echo "0")

--- a/claude-ops/bin/ops-marketing-dash
+++ b/claude-ops/bin/ops-marketing-dash
@@ -299,9 +299,10 @@ BLENDED_ROAS=$(awk "BEGIN { if (${TOTAL_SPEND:-0} > 0) printf \"%.2f\", ${TOTAL_
 # ROAS score (0-30)
 ROAS_SCORE=$(awk "BEGIN { r = ${BLENDED_ROAS:-0}; if (r >= 3) print 30; else if (r >= 1) print 15; else print 0 }")
 # Email open rate score (0-20) — derived from Klaviyo last-campaign open rate
-# when available; falls back to 0 when we have no campaign data.
+# when available; falls back to 0 when we have no campaign data. Thresholds
+# come from SKILL.md §Marketing Health Score: >=20% → 20pt, 10-20% → 10pt.
 KLAVIYO_OPEN_RATE=$(echo "$KLAVIYO_DATA" | jq -r '.open_rate // "0"' 2>/dev/null || echo "0")
-EMAIL_SCORE=$(awk "BEGIN { r = ${KLAVIYO_OPEN_RATE:-0}; if (r >= 0.25) print 20; else if (r >= 0.15) print 10; else print 0 }")
+EMAIL_SCORE=$(awk "BEGIN { r = ${KLAVIYO_OPEN_RATE:-0}; if (r >= 0.20) print 20; else if (r >= 0.10) print 10; else print 0 }")
 # Channel diversification (0-20): count active platforms.
 # Compare numerically — after the tempfile fix these fields can be JSON null or
 # numeric strings like "0.00", neither of which a literal != "0" string test

--- a/claude-ops/skills/ops-marketing/SKILL.md
+++ b/claude-ops/skills/ops-marketing/SKILL.md
@@ -390,11 +390,22 @@ if [ -z "$IMAGE_HASH" ]; then
   exit 0
 fi
 
+# Resolve the Facebook Page ID. Meta's `object_story_spec.page_id` requires a
+# real Page ID — the ad account ID (with `act_` stripped) is NOT a Page ID and
+# the API call will fail. Require META_PAGE_ID in env or plugin prefs.
+META_PAGE_ID="${META_PAGE_ID:-$(claude plugin config get meta_page_id 2>/dev/null || echo "")}"
+if [ -z "$META_PAGE_ID" ]; then
+  echo "META_PAGE_ID is required to create an ad creative. Set it via:"
+  echo "  claude plugin config set meta_page_id <your_fb_page_id>"
+  echo "Find your Page ID at https://www.facebook.com/<your-page>/about_profile_transparency"
+  exit 0
+fi
+
 # Step 2: Create ad creative
 CREATIVE_RESP=$(curl -s -X POST "https://graph.facebook.com/v20.0/${META_ACCOUNT}/adcreatives" \
   -H "Authorization: Bearer ${META_TOKEN}" \
   -F "name=Creative for ${AD_NAME}" \
-  -F "object_story_spec={\"page_id\": \"$(echo "$META_ACCOUNT" | sed 's/act_//')\", \"link_data\": {\"image_hash\": \"${IMAGE_HASH}\", \"message\": \"${PRIMARY_TEXT}\", \"name\": \"${HEADLINE}\"}}")
+  -F "object_story_spec={\"page_id\": \"${META_PAGE_ID}\", \"link_data\": {\"image_hash\": \"${IMAGE_HASH}\", \"message\": \"${PRIMARY_TEXT}\", \"name\": \"${HEADLINE}\"}}")
 CREATIVE_ID=$(echo "$CREATIVE_RESP" | jq -r '.id // empty')
 
 if [ -z "$CREATIVE_ID" ]; then
@@ -1155,9 +1166,8 @@ fi
 
 CONTAINER=$(curl -s -X POST "https://graph.facebook.com/v21.0/${IG_ACCOUNT_ID}/media" \
   -H "Authorization: Bearer ${META_TOKEN}" \
-  -F "media_type=${MEDIA_TYPE}" \
-  -F "${URL_FIELD}=${CONTENT_URL}" \
-  -F "media_type=STORIES")
+  -F "media_type=STORIES" \
+  -F "${URL_FIELD}=${CONTENT_URL}")
 CONTAINER_ID=$(echo "$CONTAINER" | jq -r '.id // empty')
 
 if [ -z "$CONTAINER_ID" ]; then


### PR DESCRIPTION
## Summary

Fixes six unresolved bot-flagged bugs from PR #129 (v1.5 Phases 11-15).
None overlap with the ops-package work that landed as v1.6.1.

## Bugs fixed

| # | PR | Bot(s) | File:line | Root cause | Fix |
|---|----|--------|-----------|------------|-----|
| 1 | #129 | sentry CRITICAL + cursor HIGH | `claude-ops/bin/ops-marketing-dash:255-261` | `VAR=$(fn) &` assignments don't propagate past `wait` — all six channel variables were empty, which then crashed every `jq --argjson` call. | Write each gatherer to a per-channel tempfile in a `trap`-cleaned `mktemp -d`, `cat` them back post-wait. Mirrors the pattern in `bin/ops-external` and `bin/ops-discover-external`. |
| 2 | #129 | cursor LOW | `claude-ops/bin/ops-marketing-dash:275` | `EMAIL_SCORE` hard-coded to `10`, so max achievable health score was 90/100. | Added `open_rate` to `gather_klaviyo` (via Klaviyo `campaign-values-reports`) and scored it `>=0.25 → 20`, `>=0.15 → 10`, else `0`. |
| 3 | #129 | cursor MEDIUM + codex P2 | `claude-ops/bin/ops-marketing-dash:276-277` | `[ "$(...)" != "0" ]` string check broke on JSON `null` and `"0.00"`. After fix #1 these are now possible. | Added `is_positive` helper using awk numeric coercion. |
| 4 | #129 | codex P1 + sentry CRITICAL | `claude-ops/skills/ops-marketing/SKILL.md:397` | `page_id` derived by stripping `act_` from the ad account ID — Meta requires a real Facebook Page ID there, so every `adcreatives` call would fail. | Require `META_PAGE_ID` in env/prefs; bail with guidance if missing (preferred over implicit `/me/accounts` fetch on every call). |
| 5 | #129 | cursor MEDIUM + devin | `claude-ops/skills/ops-marketing/SKILL.md:1160` | `media_type` was sent twice in the IG Story container curl (IMAGE/VIDEO + STORIES). | Send `media_type=STORIES` only — IG infers IMAGE/VIDEO from the URL field. |
| 6 | #129 | codex P1 | `claude-ops/agents/marketing-optimizer.md:21` | Optimizer told agent to read `meta_ads.*` and `google_ads.spend|conversions_value|campaigns`, but the dashboard emits `meta.*` and a raw Google Ads `searchStream` response. | Documented the actual schema (verified against `bin/ops-marketing-dash` on main), including jq for deriving spend/conversions_value from the searchStream response. |

## Test plan

- [x] `bash -n claude-ops/bin/ops-marketing-dash` passes.
- [x] `cd claude-ops && npm test` passes (secrets scan + bash syntax + node --check).
- [x] `npx prettier --check 'claude-ops/**/*.{js,mjs,json}'` passes.
- [x] Dry-run `KLAVIYO_PRIVATE_KEY="" META_ADS_TOKEN="" GA4_PROPERTY_ID="" GOOGLE_SEARCH_CONSOLE_SITE="" GOOGLE_ADS_REFRESH_TOKEN="" GOOGLE_ADS_DEVELOPER_TOKEN="" bash claude-ops/bin/ops-marketing-dash` now emits a valid JSON with `null` per channel (previously crashed via `jq --argjson` on empty strings).
- [ ] With real creds, verify `klaviyo`, `meta`, `ga4`, `gsc`, `google_ads`, `instagram` blocks are populated (not `null`) and `health_score` can exceed 90 when `klaviyo.open_rate >= 0.25`.
- [ ] With `META_PAGE_ID` unset, `/ops:marketing creative ...` now prints the guidance and exits cleanly; with `META_PAGE_ID` set, the creative request sends the real Page ID.
- [ ] IG Story publish curl has exactly one `media_type` form field (STORIES).
- [ ] Run `/ops:marketing-optimizer` after the dash — optimizer keys (`meta.spend`, `meta.roas`, `meta.purchases`, `meta.purchase_value`, `google_ads.results[].metrics.*`, `klaviyo.open_rate`) line up with the dashboard JSON.

### `npm test` output

```
> claude-ops-bin@1.6.1 test
> bash tests/test-no-secrets.sh && bash -n bin/ops-* && node --check bin/*.mjs lib/*.mjs

Scanning for secrets and personal data in: /Users/<user>/Projects/claude-ops/claude-ops

  PASS: no Stripe secret keys (sk_live_) found
  PASS: no Stripe publishable keys (pk_live_) found
  PASS: no Shopify tokens (shppa_, shpca_, shpat_) found
  PASS: no Slack tokens (xoxb-, xoxp-) found
  PASS: no Google API keys (AIza) found
  PASS: no GitHub tokens (ghp_, gho_, ghs_) found
  PASS: no generic secret key patterns (gsk_) found
  PASS: no OpenAI tokens (sk-) found
  PASS: no project-specific email addresses found
  PASS: no AWS secret access keys found
  PASS: no org_ prefixed tokens (often API keys) found

---
Results: 11 passed, 0 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/135" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live marketing data collection and health scoring plus Meta/Klaviyo API request shapes, so misconfigurations or API response edge cases could change dashboard output or break creative/story publishing.
> 
> **Overview**
> Fixes `ops-marketing-dash` parallel execution so each channel gatherer reliably populates JSON (writing each gatherer output to a temp dir and reading it back after `wait`), preventing empty vars from crashing `jq --argjson` and ensuring unconfigured channels emit `null`.
> 
> Enhances marketing health scoring by adding Klaviyo last-campaign `open_rate` collection and using it for `EMAIL_SCORE`, and makes channel-activity/diversification checks numeric-safe (handles `null` and "0.00").
> 
> Corrects Meta/Instagram operational docs and commands: the marketing optimizer instructions are updated to the v1.5+ `ops-marketing-dash` schema (including null-safe Google Ads reductions), Meta creative creation now requires an explicit `META_PAGE_ID`, and the Instagram Story publish curl no longer sends duplicate `media_type` fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd3f63487659d39cf84a4ee329446641499c273. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->