### PR TITLE
chore(release): promote to v1.6.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code \u2014 25 skills, 13 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes YOLO autonomous mode with 4 C-suite agents.",
       "source": "./claude-ops",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "category": "productivity",
       "screenshots": [
         "docs/screenshots/dashboard.png",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Business operations command center for Claude Code \u2014 25 skills, 13 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes YOLO mode for autonomous operation.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.6.2] — 2026-04-16
+
+### Fixed
+
+- **`bin/ops-marketing-dash` — empty data from background gatherers** (sentry[bot] + cursor[bot], HIGH). `VAR=$(fn) &` with `wait` only assigns inside the backgrounded subshell, so `KLAVIYO_DATA`, `META_DATA`, `GA4_DATA`, `GSC_DATA`, `GADS_DATA`, and `INSTAGRAM_DATA` were all empty after `wait`. Switched to the tempfile pattern already used in `bin/ops-external` / `bin/ops-discover-external`.
+- **`bin/ops-marketing-dash` — hardcoded `EMAIL_SCORE=10`** (cursor[bot]). Now derived from Klaviyo last-campaign `open_rate` (≥20% → 20pt, ≥10% → 10pt, else 0), matching the thresholds documented in `skills/ops-marketing/SKILL.md §Marketing Health Score`. `gather_klaviyo` now fetches campaign-values-reports for the most recent campaign.
+- **`bin/ops-marketing-dash` — active-channel count used string compare** (cursor[bot] + codex[bot]). After the tempfile fix, unconfigured gatherers emit JSON `null`, so the literal `!= "0"` test mis-counted. Replaced with a numeric `is_positive` awk helper.
+- **`skills/ops-marketing/SKILL.md` — Meta ad creative passed ad account ID as page_id** (codex[bot] P1 + sentry[bot]). Meta's `object_story_spec.page_id` requires a real FB Page ID, not `act_…`. Now requires `META_PAGE_ID` in env or plugin config with a clear error message.
+- **`skills/ops-marketing/SKILL.md` — Instagram Story publishing sent duplicate `media_type`** (cursor[bot]). Removed the duplicate form field from the Stories container `curl`.
+- **`agents/marketing-optimizer.md` — parser keys mismatched dashboard schema** (codex[bot] P1). Optimizer expected `meta_ads.*` / `google_ads.campaigns[]` / `klaviyo.attributed_revenue` but dashboard emits `meta.*` / raw `google_ads` searchStream array / no `attributed_revenue` field. Rewrote the schema reference to match what `bin/ops-marketing-dash` actually produces, with null-safe jq reductions for the Google Ads path.
+
 ## [1.6.1] — 2026-04-16
 
 ### Added

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Version bump for marketing-dash + optimizer bug fixes shipped in PR #135.

## Bumps
- `claude-ops/package.json`: 1.6.1 → 1.6.2
- `claude-ops/.claude-plugin/plugin.json`: 1.6.1 → 1.6.2
- `.claude-plugin/marketplace.json` plugins[0].version: 1.6.1 → 1.6.2

## CHANGELOG
New `## [1.6.2] — 2026-04-16` section with `### Fixed` enumerating each bot-flagged bug and the bot that flagged it.

## Test plan
- [x] `npm test` passes
- [x] prettier --check passes
- [x] jq-parse marketplace.json, confirm plugins[0].version == "1.6.2"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure release bookkeeping (version bumps + changelog text) with no runtime code changes in this PR.
> 
> **Overview**
> Promotes the plugin release to **v1.6.2** by bumping versions in `claude-ops/package.json`, `claude-ops/.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json`.
> 
> Updates `claude-ops/CHANGELOG.md` with a new `1.6.2` *Fixed* section describing marketing-related bug fixes (marketing dashboard background gatherer data capture, email score calculation, channel counting, Meta/Instagram doc corrections, and `marketing-optimizer` schema alignment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 956f2a93180383e22c9024b90f722d6350f66f39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->