### PR TITLE
fix(metadata): marketplace + plugin descriptions to 30 skills, 14 agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "ops",
-      "description": "Business operations command center for Claude Code \u2014 25 skills, 13 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes YOLO autonomous mode with 4 C-suite agents.",
+      "description": "Business operations command center for Claude Code \u2014 30 skills, 14 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
       "version": "1.7.0",
       "category": "productivity",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ops",
   "version": "1.7.0",
-  "description": "Business operations command center for Claude Code \u2014 25 skills, 13 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes YOLO mode for autonomous operation.",
+  "description": "Business operations command center for Claude Code \u2014 30 skills, 14 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",
     "url": "https://github.com/Lifecycle-Innovations-Limited"


### PR DESCRIPTION
## Summary

Both plugin metadata descriptions still said **25 skills, 13 agents** despite v1.7.0 shipping **30 skills, 14 agents**. Found while investigating claudemarketplaces.com auto-indexing — that site daily-crawls every public repo with `.claude-plugin/marketplace.json` and publishes the description verbatim. Without this fix, our auto-listing would show stale counts.

## Changes

- `.claude-plugin/marketplace.json` — `plugins[0].description` → 30 skills, 14 agents
- `claude-ops/.claude-plugin/plugin.json` — `description` → 30 skills, 14 agents

Also surfaces `/gtm` and `/ops:projects` in both descriptions — the two headline v1.7.0 features most likely to drive clicks in auto-indexed listings.

## Why not bump version

No runtime changes, no skill/agent additions, no behavioral differences. Pure metadata string fix. Version stays at 1.7.0.

## Test plan

- [x] JSON still valid (`jq . .claude-plugin/marketplace.json`)
- [ ] Auto-indexer picks up new description within 48h
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/144" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates descriptive strings in marketplace/plugin JSON metadata with no runtime, versioning, or behavioral changes.
> 
> **Overview**
> Updates the `ops` listing metadata in `.claude-plugin/marketplace.json` and `claude-ops/.claude-plugin/plugin.json` to reflect **30 skills / 14 agents** (instead of 25/13) and to highlight `/gtm` and `/ops:projects` plus the *4-parallel C-suite* YOLO mode in the description text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 588978afdab3867ef61436292aa90306db1518e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Expanded ops plugin from 25 to 30 skills and 13 to 14 agents.
  * Added `/gtm` go-to-market planner and `/ops:projects` portfolio dashboard capabilities.
  * Enhanced YOLO mode to include 4 parallel C-suite agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->