### PR TITLE
chore(telegram-server): publish to npm + official MCP registry

### DIFF
--- a/claude-ops/telegram-server/index.js
+++ b/claude-ops/telegram-server/index.js
@@ -99,7 +99,7 @@ if (CONFIGURED) {
 }
 
 // ── MCP server setup ──
-const server = new Server({ name: 'claude-ops-telegram', version: '0.2.0' }, { capabilities: { tools: {} } });
+const server = new Server({ name: 'claude-ops-telegram', version: '0.2.1' }, { capabilities: { tools: {} } });
 
 server.setRequestHandler(ListToolsRequestSchema, async () => ({
   tools: [

--- a/claude-ops/telegram-server/package.json
+++ b/claude-ops/telegram-server/package.json
@@ -10,7 +10,13 @@
     "directory": "claude-ops/telegram-server"
   },
   "homepage": "https://github.com/Lifecycle-Innovations-Limited/claude-ops/tree/main/claude-ops/telegram-server",
-  "keywords": ["mcp", "telegram", "mtproto", "claude-code", "inbox"],
+  "keywords": [
+    "mcp",
+    "telegram",
+    "mtproto",
+    "claude-code",
+    "inbox"
+  ],
   "type": "module",
   "main": "index.js",
   "bin": {

--- a/claude-ops/telegram-server/package.json
+++ b/claude-ops/telegram-server/package.json
@@ -1,7 +1,16 @@
 {
   "name": "claude-ops-telegram-server",
-  "version": "0.2.0",
+  "version": "0.2.1",
+  "mcpName": "io.github.auroracapital/claude-ops-telegram-server",
   "description": "Telegram user-auth MCP server for claude-ops plugin (personal account via MTProto, not bots)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Lifecycle-Innovations-Limited/claude-ops.git",
+    "directory": "claude-ops/telegram-server"
+  },
+  "homepage": "https://github.com/Lifecycle-Innovations-Limited/claude-ops/tree/main/claude-ops/telegram-server",
+  "keywords": ["mcp", "telegram", "mtproto", "claude-code", "inbox"],
   "type": "module",
   "main": "index.js",
   "bin": {

--- a/claude-ops/telegram-server/server.json
+++ b/claude-ops/telegram-server/server.json
@@ -33,7 +33,7 @@
         },
         {
           "name": "TELEGRAM_PHONE",
-          "description": "Your Telegram phone number in E.164 format (e.g. +14155551234).",
+          "description": "Your Telegram phone number in E.164 format (e.g. +1234567890).",
           "isRequired": true,
           "format": "string",
           "isSecret": true

--- a/claude-ops/telegram-server/server.json
+++ b/claude-ops/telegram-server/server.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.auroracapital/claude-ops-telegram-server",
+  "description": "Telegram personal-account MCP (MTProto user-auth). Read DMs, send messages, search across chats.",
+  "repository": {
+    "url": "https://github.com/Lifecycle-Innovations-Limited/claude-ops",
+    "source": "github",
+    "subfolder": "claude-ops/telegram-server"
+  },
+  "version": "0.2.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "claude-ops-telegram-server",
+      "version": "0.2.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "TELEGRAM_API_ID",
+          "description": "Numeric API ID from https://my.telegram.org/apps (create a personal app, not a bot).",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "TELEGRAM_API_HASH",
+          "description": "API hash from the same my.telegram.org/apps page.",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "TELEGRAM_PHONE",
+          "description": "Your Telegram phone number in E.164 format (e.g. +14155551234).",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": true
+        },
+        {
+          "name": "TELEGRAM_SESSION",
+          "description": "gram.js StringSession token. Generate once via: node index.js --auth (prompts for SMS code + optional 2FA). Store in your secret manager — never commit.",
+          "isRequired": true,
+          "format": "string",
+          "isSecret": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Publishes the bundled Telegram MCP server to two registries so it's discoverable outside the claude-ops plugin:

- **npm:** https://www.npmjs.com/package/claude-ops-telegram-server (v0.2.1)
- **Official MCP registry:** \`io.github.auroracapital/claude-ops-telegram-server@0.2.1\` at https://registry.modelcontextprotocol.io/

Also covers the awesome-mcp-servers entry which feeds Glama.ai via auto-indexing (PR punkpeye/awesome-mcp-servers#5113).

## Changes

- \`claude-ops/telegram-server/package.json\` — bump 0.2.0 → 0.2.1, add \`mcpName\`, \`license\`, \`repository\`, \`homepage\`, \`keywords\` (required by npm + MCP registry validators)
- \`claude-ops/telegram-server/server.json\` (new) — MCP registry manifest declaring the 4 env vars (\`TELEGRAM_API_ID\`/\`HASH\`/\`PHONE\`/\`SESSION\`), stdio transport, repo subfolder

The MCP registry validates that \`mcpName\` in the published npm package matches the \`name\` in \`server.json\`, so both are kept in sync.

## Namespace note

Used \`io.github.auroracapital/*\` (Sam's personal GitHub) instead of \`io.github.lifecycle-innovations-limited/*\` because the registry's GitHub OAuth scope only grants publish permission to visible orgs, and LIL membership is configured as private. Making org membership public would let us republish under the LIL namespace, but that's a cosmetic change for a future release — the MCP is fully functional and discoverable as-is.

## Not included

- Smithery.ai — architecturally incompatible (accepts only hosted HTTPS MCPs; this is stdio-local because the user's session string must stay on their machine)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: packaging/metadata-only changes plus a new `server.json` manifest; no runtime logic is modified. Main risk is registry/publishing validation or name/version mismatches.
> 
> **Overview**
> Bumps `claude-ops/telegram-server` to v`0.2.1` and adds npm publishing metadata (`license`, `repository`, `homepage`, `keywords`) plus an `mcpName` identifier.
> 
> Adds a new MCP registry manifest `server.json` describing the stdio package, version, repository subfolder, and required secret environment variables (`TELEGRAM_API_ID`, `TELEGRAM_API_HASH`, `TELEGRAM_PHONE`, `TELEGRAM_SESSION`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f72c51d907ef17b629d92daf2149aba07f9e670a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.2.1
  * Added package metadata and repository information
  * Introduced MCP server configuration with support for required Telegram API credentials and configuration setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->