### PR TITLE
feat(rules): Rule 6 — outbound comms require per-message approval

### DIFF
--- a/claude-ops/CLAUDE.md
+++ b/claude-ops/CLAUDE.md
@@ -71,6 +71,35 @@ During setup and configuration flows, NEVER silently skip a channel, service, or
 
 During `/ops:setup` and any skill's setup/configure flow, use `run_in_background: true` on **every** Bash call unless you need the result immediately for the very next decision. This includes: credential scans, CLI installs, OAuth flows, npm installs, brew installs, autolink scripts, smoke tests, keychain writes, Doppler queries, Chrome history queries. While background commands run, continue to the next independent step or ask the user the next question. Never block the conversation waiting for a command the user isn't actively waiting for.
 
+## Rule 6 — Outbound comms require per-message approval, always
+
+**NO skill in this plugin may send an outbound message — email, Slack, WhatsApp, SMS, voice call, Telegram, Discord, Resend, or any other channel — without first showing the user the full draft and receiving an explicit per-message approval.** This applies to every skill (`/ops`, `/ops-inbox`, `/ops-go`, `/ops-comms`, `/ops-yolo`, `/ops-orchestrate`, and any future skill), every surface (Bash CLI, MCP tool, direct API), and every orchestration mode (main session, subagent, daemon, cron).
+
+**The universal send gate:**
+
+1. **Stage ONE draft, show the user EVERYTHING** — to, cc, bcc, subject, full body, attachments. Not a summary. Not a line count. The full message the recipient will see.
+
+2. **Call `AskUserQuestion` for THAT ONE message** with options like `[Send]`, `[Edit]`, `[Skip]`. Wait for the user's choice. A plain-chat approval word (`ok`, `send`, `go`, `yes`, `approved`, `ship it`) is also a valid signal — but only for the single staged message.
+
+3. **Execute the send.** Then — and only then — stage the next draft.
+
+4. **Never stack.** If you have 6 replies to send, that's 6 separate draft-show-approve-send cycles. Never "approve all 6", never "I'll fire them in order", never batch.
+
+5. **Subagents are not an escape hatch.** When spawning an `Agent` with access to send-tools (`mcp__gog__gmail_send`, `mcp__whatsapp__send_message`, Bash with `gog` / `curl resend.com` / etc), the subagent's prompt MUST explicitly say *"You are read-only. Do NOT send any outbound messages. Return drafts to the orchestrator who will stage them one-by-one."* For autonomous orchestration, prefer subagents with only read/search tools (`mcp__gog__gmail_search`, `gog gmail thread get`) so they physically cannot send.
+
+6. **MCP ≡ Bash ≡ API.** `mcp__gog__gmail_send` is the same gate as `gog gmail send` (Bash) is the same gate as `curl -X POST https://api.resend.com/emails` is the same gate as `mcp__whatsapp__send_message`. Surface doesn't matter — if it produces outbound comms, it needs its own per-message approval.
+
+7. **Forbidden output patterns** — if you find yourself about to emit any of these, STOP and convert to one-at-a-time staging:
+   - "6 drafts queued — approve all?"
+   - "I'll fire them in recommended order"
+   - "Firing batch 1 of 2..."
+   - Multiple `mcp__*_send` or `gog gmail send` tool calls in the same assistant turn without intervening user approvals
+   - "I've drafted the emails autonomously — approve by number"
+
+8. **Violation log.** Any skill that violates this rule MUST be considered a bug and reported via `/ops:ops-doctor` for remediation. The user's guardrail hook (`block-outbound-comms.py` with `/tmp/.claude-send-ok` token, one-shot, 120s TTL) is a defense-in-depth layer — this rule is the primary gate and must hold even when the hook is absent.
+
+**Why this rule exists:** On 2026-04-20, the `/ops:ops` router — when given a free-form argument that didn't match a keyword route — fell through to autonomous agent behavior and fired 15 `mcp__gog__gmail_send` calls in a 3-minute burst to 6 business contacts (royalty-collection labels, publishing partners, legal counsel, intro subjects). The user was never shown individual drafts. Real relationships received un-reviewed AI emails. This cannot repeat.
+
 ## Appendix: CLI Reference (EXACT SYNTAX — never guess)
 
 ### gog (v0.12.0+)


### PR DESCRIPTION
## Summary

Adds **Rule 6** to `claude-ops/CLAUDE.md`: no skill in this plugin may send an outbound message (email, Slack, WhatsApp, SMS, voice, Resend, Telegram, Discord) without first showing the user the full draft and receiving an explicit per-message approval.

## Why

Without this rule, a free-form `/ops:ops` argument that doesn't match a hardcoded keyword route (`dash`, `go`, `inbox`, etc.) falls through to autonomous agent behavior. In that mode, nothing in the plugin contract prevents the assistant from drafting and firing multiple MCP `gmail_send` calls in a single burst — one user reported 15 MCP sends to 6 real business contacts in a 3-minute window, all without seeing individual drafts.

The existing `UserPromptSubmit` guardrail hook (`block-outbound-comms.py` with a single-use `/tmp/.claude-send-ok` token) is defense-in-depth at the user's shell layer. Rule 6 is the **primary gate inside the plugin**, so the rule holds even for users who haven't installed the hook.

## What the rule enforces

1. Stage ONE draft at a time — show full to/cc/bcc/subject/body/attachments
2. `AskUserQuestion` for THAT message (`[Send]` / `[Edit]` / `[Skip]`)
3. Send. Then stage the next.
4. **No batching, no "approve all", no "fire in recommended order"**
5. Subagents with send-tool access must be explicitly told *"you are read-only"* — prefer spawning subagents with only `gmail_search`/`gmail_thread_get` so they physically cannot send
6. **MCP ≡ Bash ≡ direct API** — the surface doesn't change the gate

Lists 5 forbidden output patterns (e.g. "6 drafts queued — approve all?") that MUST trigger a STOP-and-convert response.

## Scope

Applies to: every skill (`/ops`, `/ops-inbox`, `/ops-go`, `/ops-comms`, `/ops-yolo`, `/ops-orchestrate`, future skills), every surface (Bash CLI / MCP / direct API), every orchestration mode (main, subagent, daemon, cron).

## Test plan

- [x] `tests/test-no-secrets.sh` passes (11/11)
- [x] No functional code changed — this is a rule addition in `CLAUDE.md` that governs LLM behavior at runtime
- [ ] Manual: invoke `/ops:ops <free-form arg>` and verify the assistant stages drafts individually instead of batch-firing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only updates `CLAUDE.md` guidance and does not change runtime code; behavior impact is limited to stricter human-in-the-loop sending rules.
> 
> **Overview**
> Adds **Rule 6** to `claude-ops/CLAUDE.md`, making outbound communications (email/Slack/SMS/WhatsApp/etc.) require a *one-at-a-time* draft → full user review → explicit approval via `AskUserQuestion` → send cycle.
> 
> The rule explicitly forbids batching/queueing approvals, applies the same gate across MCP/Bash/direct-API sends, and requires subagents with send-capabilities to be prompted as read-only and return drafts for orchestrator approval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9af0948f0c5844ba154e6a58ca93089acceef306. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-message approval requirement for all outbound communications (email, Slack, WhatsApp, SMS, voice, Telegram, Discord, Resend, etc.).
  * Each message must be presented as a draft, reviewed, and individually approved before sending.
  * Batch and queued message sends are no longer supported; all messages require one-at-a-time approval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->