### PR TITLE
release: v1.8.0 — superpowers integration + wacli --follow protection

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Business operations command center for Claude Code \u2014 30 skills, 14 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.8.0] — 2026-04-26
+
+### Added
+
+- **Superpowers integration across `/ops:ops-merge`, `/ops:ops-orchestrate`, `/ops:ops-triage`.** Each skill now invokes specific `superpowers:*` skills at well-defined checkpoints to enforce stronger guardrails:
+  - `ops-merge` calls `superpowers:verification-before-completion` + `superpowers:finishing-a-development-branch` before the final merge decision (after fixer reports green) so nothing ships half-done.
+  - `ops-orchestrate` calls `superpowers:dispatching-parallel-agents` when launching 2+ parallel teammates per wave, enforcing file-ownership boundaries and task-independence checks.
+  - `ops-triage` calls `superpowers:systematic-debugging` during root-cause investigation so fix agents target the real defect, not the symptom.
+- **`/ops:setup` Step 2b.5 — installs the `superpowers` plugin.** Mirrors the existing GSD install step: detects whether `superpowers` is already present, prompts the user, runs `claude plugin marketplace add obra/superpowers-marketplace && claude plugin install superpowers@superpowers-marketplace`, and falls back to a direct `git clone` of the marketplace if the `claude` CLI is unavailable. Skipping is fine — the superpower checkpoints become no-ops without it.
+
+### Fixed
+
+- **`bin/ops-autofix` — `wacli-health` killed the legitimate `wacli sync --follow` daemon every run.** The auto-fix unconditionally killed any process holding the wacli store lock, despite a comment promising a `>2 min` age check that was never implemented. `wacli sync --follow` legitimately holds the lock for its entire lifetime to stream live messages, so every `/ops:ops-doctor` invocation cold-restarted the keepalive and broke message reception. The fix:
+  - Skips the kill outright when the lock holder's command matches `wacli sync --follow`.
+  - Implements the >2 min age check the comment promised, parsing `ps etime` formats `SS`, `MM:SS`, `HH:MM:SS`, and `DD-HH:MM:SS`.
+  - Logs cmd + age when killing for traceability, and logs skips with a reason (young vs `--follow`) instead of silently passing through.
+
 ## [1.7.0] — 2026-04-18
 
 ### Added

--- a/claude-ops/bin/ops-autofix
+++ b/claude-ops/bin/ops-autofix
@@ -193,13 +193,35 @@ fix_channel_health() {
     WA_LOCK=$(echo "$DOCTOR" | jq -r '.data.lock_held // false' 2>/dev/null)
 
     if [ "$WA_AUTH" = "true" ]; then
-      # Kill stale lock if held >2 min
+      # Kill stale lock if held >2 min — but never kill the legitimate
+      # persistent `wacli sync --follow` daemon (it holds the lock for its
+      # entire lifetime by design; that's not "stale").
       if [ "$WA_LOCK" = "true" ]; then
         LOCK_PID=$(echo "$DOCTOR" | jq -r '.data.lock_info' 2>/dev/null | grep -oE 'pid=[0-9]+' | cut -d= -f2)
         if [ -n "$LOCK_PID" ] && kill -0 "$LOCK_PID" 2>/dev/null; then
-          log_fix "wacli-health: killed stale lock holder (pid=$LOCK_PID)"
-          kill "$LOCK_PID" 2>/dev/null; sleep 2
-          kill -0 "$LOCK_PID" 2>/dev/null && kill -9 "$LOCK_PID" 2>/dev/null
+          LOCK_CMD=$(ps -p "$LOCK_PID" -o command= 2>/dev/null || echo "")
+          LOCK_ETIME=$(ps -p "$LOCK_PID" -o etime= 2>/dev/null | tr -d ' ')
+          # Skip if it's the persistent --follow daemon
+          if echo "$LOCK_CMD" | grep -q "wacli sync --follow"; then
+            log_skip "wacli-health: lock held by persistent --follow daemon (pid=$LOCK_PID) — leaving alone"
+          else
+            # Parse etime to seconds. Formats: SS, MM:SS, HH:MM:SS, DD-HH:MM:SS
+            LOCK_AGE=$(echo "$LOCK_ETIME" | awk -F'[-:]' '{
+              n=NF; s=0
+              if (n==1) s=$1
+              else if (n==2) s=$1*60+$2
+              else if (n==3) s=$1*3600+$2*60+$3
+              else if (n==4) s=$1*86400+$2*3600+$3*60+$4
+              print s
+            }')
+            if [ -n "$LOCK_AGE" ] && [ "$LOCK_AGE" -gt 120 ]; then
+              log_fix "wacli-health: killed stale lock holder (pid=$LOCK_PID, age=${LOCK_AGE}s, cmd=$LOCK_CMD)"
+              kill "$LOCK_PID" 2>/dev/null; sleep 2
+              kill -0 "$LOCK_PID" 2>/dev/null && kill -9 "$LOCK_PID" 2>/dev/null
+            else
+              log_skip "wacli-health: lock holder pid=$LOCK_PID is young (${LOCK_AGE}s) — not stale"
+            fi
+          fi
         fi
       fi
 

--- a/claude-ops/skills/ops-merge/SKILL.md
+++ b/claude-ops/skills/ops-merge/SKILL.md
@@ -282,6 +282,16 @@ Main sync: N repos synced (dev → main → dev)
 
 ---
 
+## Superpowers Integration
+
+During this command's execution, invoke the following superpower skills at the specified checkpoint:
+
+- **Checkpoint:** Before the final merge decision for each PR in Phase 2 and Phase 5 (after fixer reports green).
+- **Skills:** `superpowers:verification-before-completion` + `superpowers:finishing-a-development-branch`
+- **Why:** Verification-before-completion forces evidence (CI green, tests pass) before the merge call; finishing-a-development-branch structures the merge/cleanup choice so nothing ships half-done.
+
+---
+
 ## Safety Rails (NEVER violate)
 
 - **NEVER force-push to main/master**

--- a/claude-ops/skills/ops-orchestrate/SKILL.md
+++ b/claude-ops/skills/ops-orchestrate/SKILL.md
@@ -340,6 +340,14 @@ SendMessage(to="mobile-worker", content="API endpoint ready. New: POST /v2/users
 3. When api-worker completes schema → `SendMessage` to consumer with the new types/endpoint
 4. Consumer proceeds with full context — no re-dispatch needed
 
+### Superpowers Integration
+
+During this command's execution, invoke the following superpower skill at the specified checkpoint:
+
+- **Checkpoint:** When dispatching 2+ parallel subagents/teammates to independent tasks at the start of each wave (Phase 3).
+- **Skill:** `superpowers:dispatching-parallel-agents`
+- **Why:** Enforces file-ownership boundaries and task-independence checks so concurrent agents don't overwrite each other or serialize hidden dependencies.
+
 ### Wave execution — NEVER idle
 
 ```

--- a/claude-ops/skills/ops-triage/SKILL.md
+++ b/claude-ops/skills/ops-triage/SKILL.md
@@ -195,6 +195,16 @@ AskUserQuestion call 2 (only if "More..."):
 
 ---
 
+## Superpowers Integration
+
+During this command's execution, invoke the following superpower skill at the specified checkpoint:
+
+- **Checkpoint:** When diagnosing an active issue before proposing a fix (root-cause investigation during Phase 2 cross-reference or Phase 4 agent dispatch brief).
+- **Skill:** `superpowers:systematic-debugging`
+- **Why:** Enforces hypothesis-driven root-cause analysis so fix agents target the real defect, not the symptom.
+
+---
+
 ## Dispatch fix agent
 
 When dispatching for an issue, spawn an Agent using `agents/triage-agent.md` with:

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -342,6 +342,51 @@ Skipped GSD. Install later with: /plugin marketplace add gsd-build/get-shit-done
 
 ---
 
+## Step 2b.5 — Superpowers (optional, recommended)
+
+Several ops skills (`/ops:ops-merge`, `/ops:ops-orchestrate`, `/ops:ops-triage`) integrate with `superpowers:*` skills at key checkpoints — verification-before-completion, finishing-a-development-branch, dispatching-parallel-agents, systematic-debugging. Without superpowers installed, those checkpoints are no-ops; with it, they enforce stronger guardrails on merges, multi-agent dispatch, and root-cause analysis.
+
+Check if superpowers is already installed:
+
+```bash
+find ~/.claude/plugins -path "*/superpowers/skills/using-superpowers" -type d 2>/dev/null | head -1 | grep -q . && echo "installed" || echo "not_installed"
+```
+
+If not installed, ask via `AskUserQuestion`:
+
+```
+Superpowers adds verification, dispatch, and debugging guardrails to ops skills.
+
+  [Install Superpowers (latest)] [Skip — I'll add it later]
+```
+
+On install, run the commands directly:
+
+```bash
+claude plugin marketplace add obra/superpowers-marketplace 2>/dev/null && \
+claude plugin install superpowers@superpowers-marketplace 2>/dev/null
+```
+
+Fallback if `claude` CLI is not on PATH:
+
+```bash
+SP_MARKETPLACE_DIR="$HOME/.claude/plugins/marketplaces/superpowers-marketplace"
+if [ ! -d "$SP_MARKETPLACE_DIR" ]; then
+  git clone https://github.com/obra/superpowers-marketplace.git "$SP_MARKETPLACE_DIR" 2>/dev/null
+fi
+```
+
+Report success/failure. Record `plugins.superpowers = "installed"` in `$PREFS_PATH`.
+
+If they skip:
+
+```
+Skipped Superpowers. Ops skills will run without superpower checkpoints.
+Install later with: /plugin marketplace add obra/superpowers-marketplace
+```
+
+---
+
 ## Step 2c — Background Daemon (early install, pre-warm caches)
 
 **Why install the daemon this early?** Running the daemon in parallel with the rest of setup lets it start pre-warming the briefing cache (`ops-gather` results for infra/git/PRs/CI), so by the time the user reaches Step 7 and runs `/ops:go`, the briefing is already cached and loads in under 3 seconds instead of 10. Channel-dependent services (wacli-sync, message-listener, inbox-digest, store-health) are added later in Step 5b once their channels are configured.


### PR DESCRIPTION
## Summary

Bump to **v1.8.0**. Two changes:

### Added — Superpowers integration

Three ops skills now invoke `superpowers:*` skills at well-defined checkpoints:

- **`/ops:ops-merge`** → `superpowers:verification-before-completion` + `superpowers:finishing-a-development-branch` before each final merge decision (after the fixer reports green). Forces evidence-based merging and a structured cleanup choice.
- **`/ops:ops-orchestrate`** → `superpowers:dispatching-parallel-agents` when launching 2+ parallel teammates per wave. Enforces file-ownership boundaries and task-independence checks.
- **`/ops:ops-triage`** → `superpowers:systematic-debugging` during root-cause investigation. Makes fix agents target the real defect, not the symptom.

`/ops:setup` Step 2b.5 now installs `superpowers` (mirrors the existing GSD install step). Skipping is fine — without superpowers, those checkpoints become no-ops.

### Fixed — `bin/ops-autofix` killed the persistent `wacli sync --follow` daemon

The `wacli-health` auto-fix unconditionally killed any process holding the wacli store lock, despite a comment promising a `>2 min` age check that was never implemented. `wacli sync --follow` legitimately holds the lock for its entire lifetime to stream live messages, so every `/ops:ops-doctor` invocation cold-restarted the keepalive and broke message reception.

- Skips kill outright when the lock holder's command matches `wacli sync --follow`.
- Implements the >2 min age check the comment promised, parsing `ps etime` formats `SS`, `MM:SS`, `HH:MM:SS`, `DD-HH:MM:SS`.
- Logs cmd + age when killing for traceability, and logs skips with a reason (young vs `--follow`) instead of silently passing through.

## Test plan

- [x] `tests/run-all.sh` — 9 suites, all pass
- [x] `tests/test-no-secrets.sh` — 11 passed, 0 failed
- [x] `bash -n bin/ops-autofix` — syntax OK
- [x] Live dry-run with `--follow` running: correctly skipped with "lock held by persistent --follow daemon"
- [x] Live dry-run with young backfill holding lock: correctly skipped with "is young (8s) — not stale"

Closes the autofix PR (#fix/autofix-wacli-follow-protection — folded into this release).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/153" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches operational automation: `bin/ops-autofix` process-kill logic is changed and could impact WhatsApp recovery behavior if `ps` parsing or lock detection differs across environments; the rest is documentation/setup flow changes.
> 
> **Overview**
> Bumps the plugin version to `1.8.0` and documents a new release in `CHANGELOG.md`.
> 
> Adds *Superpowers* guardrail checkpoints to `/ops:ops-merge`, `/ops:ops-orchestrate`, and `/ops:ops-triage`, and extends `/ops:setup` with an optional Step 2b.5 to detect/install the `superpowers` plugin (with a `claude` CLI path and a git-clone fallback).
> 
> Fixes `bin/ops-autofix` WhatsApp `wacli-health` repair logic to **avoid killing** the legitimate `wacli sync --follow` lock holder and to only kill other lock holders when their process age exceeds 2 minutes, with improved skip/kill logging for traceability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1acfe0bebeba2dfe4fabfbac8e8ae3b794b819d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release 1.8.0

* **New Features**
  * Added Superpowers guardrails to merge, orchestrate, and triage workflows for enhanced operational safety checkpoints.
  * Added Superpowers plugin installation option to the setup wizard.

* **Bug Fixes**
  * Improved lock remediation with smarter process detection—no longer terminates certain persistent processes; uses age-based criteria for termination decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->