### PR TITLE
release: v1.8.1 — wacli keepalive cold-restart fix + marketplace version bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code \u2014 30 skills, 14 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "1.7.1",
+      "version": "1.8.1",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Business operations command center for Claude Code \u2014 30 skills, 14 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.8.1] — 2026-04-26
+
+### Fixed
+
+- **`scripts/wacli-keepalive.sh` — `refresh_wacli_cache` cold-restarted the keepalive every cache cycle.** `refresh_wacli_cache` called `release_wacli_batch` after killing `--follow` to refresh the chats/urgent caches, which removed `BATCH_MARKER`. The supervisor's exit-detect (line 567) saw the marker missing and treated the kill as a clean shutdown instead of a deliberate self-pause, breaking out of the while-loop and letting launchd cold-restart the script with a fresh bootstrap sync. Symptom: persistent `wacli sync --follow` could not stay alive longer than ~15 minutes; the daemon was effectively in a restart loop disguised as healthy backfill cycles. Fix: omit `release_wacli_batch` in `refresh_wacli_cache`, matching the deliberate behavior already documented in `periodic_backfill`. The supervisor's pre-restart `rm -f "$BATCH_MARKER"` (line 571) handles cleanup.
+- **`.claude-plugin/marketplace.json` — plugin version pin lagged `plugin.json`.** v1.8.0 bumped `claude-ops/.claude-plugin/plugin.json` but missed the version field in the marketplace manifest at the repo root, so users discovering the plugin via the marketplace still saw `1.7.1`. Now both files agree.
+
 ## [1.8.0] — 2026-04-26
 
 ### Added

--- a/claude-ops/scripts/wacli-keepalive.sh
+++ b/claude-ops/scripts/wacli-keepalive.sh
@@ -384,7 +384,12 @@ refresh_wacli_cache() {
   "$WACLI" messages search --query "urgent OR asap OR deadline OR emergency OR ASAP" --json \
     > "$WACLI_CACHE_DIR/wacli_urgent.json" 2>/dev/null || true
 
-  release_wacli_batch
+  # Intentionally omit release_wacli_batch — BATCH_MARKER stays so the
+  # supervisor's exit-detect at line 567 sees the marker and restarts
+  # --follow instead of treating the kill as a clean shutdown. This matches
+  # the deliberate behavior in periodic_backfill (see comment at line 459).
+  # Without this, refresh_wacli_cache caused the keepalive to cold-restart
+  # via launchd every time it ran, defeating persistent sync.
   log "CACHE: refreshed wacli data cache"
 }
 


### PR DESCRIPTION
## Summary

Patch release on top of v1.8.0.

### Fixed — `scripts/wacli-keepalive.sh` cold-restarted every cache cycle

`refresh_wacli_cache` called `release_wacli_batch` after killing `--follow` to refresh the chats/urgent caches, which removed `BATCH_MARKER`. The supervisor's exit-detect (line 567) saw the marker missing and treated the kill as a clean shutdown instead of a deliberate self-pause, breaking out of the while-loop and letting launchd cold-restart the script with a fresh bootstrap sync.

**Symptom:** persistent `wacli sync --follow` couldn't stay alive longer than ~15 minutes. The daemon was effectively in a restart loop disguised as healthy backfill cycles — log showed `EXIT: sync process ended — launchd will restart` every ~15-30 min, immediately after `CACHE: refreshed wacli data cache`.

**Fix:** omit `release_wacli_batch` in `refresh_wacli_cache`, matching the deliberate behavior already documented in `periodic_backfill` ("Intentionally omit release_wacli_batch — BATCH_MARKER stays so the supervisor restarts"). The supervisor's pre-restart `rm -f "$BATCH_MARKER"` (line 571) handles cleanup.

### Fixed — marketplace.json version pin lagged plugin.json

v1.8.0 bumped `claude-ops/.claude-plugin/plugin.json` but missed the version field in the marketplace manifest at the repo root, so users discovering the plugin via the marketplace listing still saw `1.7.1`. Now both files agree on `1.8.1`.

## Test plan

- [x] `bash -n scripts/wacli-keepalive.sh` — syntax OK
- [x] `tests/run-all.sh` — 9 suites, all pass
- [x] CHANGELOG entry added
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/154" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `wacli-keepalive.sh` supervisor/batch-marker logic that controls persistent sync restarts; a small mistake here could cause the daemon to stop restarting `--follow` or to loop/crash. Otherwise changes are limited to version metadata and changelog updates.
> 
> **Overview**
> Fixes `scripts/wacli-keepalive.sh` so `refresh_wacli_cache` no longer calls `release_wacli_batch`, keeping `BATCH_MARKER` set and ensuring the supervisor restarts `wacli sync --follow` instead of exiting and relying on a launchd cold restart.
> 
> Bumps plugin version to `1.8.1` in both `claude-ops/.claude-plugin/plugin.json` and the root `.claude-plugin/marketplace.json`, and adds a `1.8.1` changelog entry documenting the keepalive fix and the marketplace version alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63524c627d69b9f29f2cce76575f78b3a9940072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->