### PR TITLE
SSH/mobile awareness + universal GSD discovery + canonical dedupe

### DIFF
--- a/claude-ops/CLAUDE.md
+++ b/claude-ops/CLAUDE.md
@@ -100,6 +100,54 @@ During `/ops:setup` and any skill's setup/configure flow, use `run_in_background
 
 **Why this rule exists:** On 2026-04-20, the `/ops:ops` router — when given a free-form argument that didn't match a keyword route — fell through to autonomous agent behavior and fired 15 `mcp__gog__gmail_send` calls in a 3-minute burst to 6 business contacts (royalty-collection labels, publishing partners, legal counsel, intro subjects). The user was never shown individual drafts. Real relationships received un-reviewed AI emails. This cannot repeat.
 
+## Rule 7 — Mobile / SSH sessions: compact text, no tables
+
+**Detection — any of these = mobile mode:**
+- `$SSH_CONNECTION`, `$SSH_CLIENT`, or `$SSH_TTY` is set (user is on a remote terminal — likely Termius/iSH on a phone, or a tmux pane on a remote host)
+- `$OPS_MOBILE=1` (explicit override)
+- `$COLUMNS` < 80 (narrow terminal regardless of cause)
+
+**When mobile mode is detected, every ops skill MUST:**
+
+1. **No tables.** Markdown tables, ASCII boxes, and multi-column ANSI dashboards wrap unreadably in a tmux pane on a phone. Use plain text lines — one fact per line.
+2. **No banners or section headers.** Skip `━━━━━` rules, `║ OPS ► … ║` boxes, ASCII art, and `──────` footers. They eat the vertical space the user doesn't have.
+3. **No emoji-prefixed status columns.** A plain `whatsapp: connected` reads cleanly; `✓ WhatsApp     connected     N chats     last sync 2m` does not.
+4. **Short answers.** Aim for 3–8 lines total. If a briefing has 20 items, summarize the top 3 + total count, not all 20.
+5. **URLs print, never `open`.** Always go through `lib/opener.sh::ops_open_url` — it auto-detects SSH/mobile and prints a copy-able URL block instead of spawning the host's opener (which would launch a browser on the SSH target the user can't see).
+6. **No ANSI colors that depend on background detection.** Termius doesn't always negotiate them; plain text wins.
+7. **`AskUserQuestion` stays normal.** Approval prompts are the one place the user IS reading carefully — don't over-truncate options. But still skip table layouts inside option descriptions.
+
+**Example — `/ops:go` desktop output:**
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► MORNING BRIEFING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+FIRES         (none)
+PRs           3 open: #N owner-a (CI red), #N owner-b, ...
+INBOX         WhatsApp 12 · Email 50 · Slack 4
+PORTFOLIO     22 projects · 3 executing · 1 blocked
+PRIORITIES
+  1. ...
+  2. ...
+```
+
+**Same content in mobile mode:**
+
+```
+no fires.
+3 open PRs — top: owner-a#N CI red.
+inbox: wa 12, mail 50, slack 4.
+portfolio: 3 active, 1 blocked.
+next: fix owner-a#N CI.
+```
+
+That's the bar. If a skill can't compress to that shape, it's too verbose for mobile.
+
+**For shell scripts and binaries** (anything in `bin/` or `scripts/`):
+- Detect via `[[ -n "$SSH_CONNECTION$SSH_CLIENT$SSH_TTY" || "$OPS_MOBILE" == "1" ]]` and switch to a compact code path.
+- For URL opening, source `lib/opener.sh` and call `ops_open_url` — never call `open`/`xdg-open` directly.
+
 ## Appendix: CLI Reference (EXACT SYNTAX — never guess)
 
 ### gog (v0.12.0+)

--- a/claude-ops/lib/opener.sh
+++ b/claude-ops/lib/opener.sh
@@ -43,6 +43,35 @@ __ops_open_log() {
   printf 'opener: using %s for %s\n' "$1" "$2" >&2
 }
 
+# ─── __ops_is_remote_session: detect SSH / mobile / headless contexts ───────
+# Returns 0 (true) when the caller is sitting at a TTY where `open URL` would
+# launch a browser the user cannot see — typically Termius/iSH over SSH, a
+# tmux pane on a remote host, or any explicit OPS_MOBILE/OPS_PRINT_URLS
+# override. In those cases ops_open_url should print the URL instead of
+# spawning the host's opener.
+#
+# Overrides:
+#   OPS_PRINT_URLS=1  → always print
+#   OPS_MOBILE=1      → always print (also shortens skill output elsewhere)
+#   OPS_FORCE_OPEN=1  → always spawn opener (debugging / explicit local use)
+__ops_is_remote_session() {
+  [[ "${OPS_PRINT_URLS:-}" == "1" ]] && return 0
+  [[ "${OPS_MOBILE:-}"     == "1" ]] && return 0
+  [[ "${OPS_FORCE_OPEN:-}" == "1" ]] && return 1
+  [[ -n "${SSH_CONNECTION:-}" || -n "${SSH_CLIENT:-}" || -n "${SSH_TTY:-}" ]] && return 0
+  return 1
+}
+
+# ─── __ops_print_url: visible, copy-able URL block for SSH / mobile users ───
+__ops_print_url() {
+  local url="$1"
+  printf '\n' >&2
+  printf '  Open this URL on your device:\n' >&2
+  printf '\n' >&2
+  printf '  %s\n' "$url" >&2
+  printf '\n' >&2
+}
+
 # ─── __ops_resolve_opener: pick a command, honoring os-detect first ─────────
 # Echoes the full opener command string, or empty if none.
 __ops_resolve_opener() {
@@ -102,6 +131,12 @@ ops_open_url() {
   if [[ ! "$url" =~ ^https?://|^mailto:|^tel: ]]; then
     echo "opener: refusing to open non-URL scheme: $url" >&2
     return 1
+  fi
+  # On SSH/mobile sessions, `open URL` would launch a browser on the SSH
+  # target instead of the user's device — print a copy-able block instead.
+  if __ops_is_remote_session; then
+    __ops_print_url "$url"
+    return 0
   fi
   ops_open "$url"
 }

--- a/claude-ops/scripts/ops-gsd-registry-sync.sh
+++ b/claude-ops/scripts/ops-gsd-registry-sync.sh
@@ -34,14 +34,111 @@ CACHE_DIR.mkdir(parents=True, exist_ok=True)
 NOW = subprocess.check_output(["date", "-u", "+%Y-%m-%dT%H:%M:%SZ"], text=True).strip()
 
 projects = []
-for base in [Path(HOME) / "Projects", Path(HOME) / "gsd-workspaces"]:
-    if not base.exists(): continue
-    source = base.name
-    for d in base.iterdir():
-        if not d.is_dir(): continue
-        planning = d / ".planning"
-        if not planning.is_dir(): continue
-        proj = d.name
+
+# ── Discover ALL .planning directories under $HOME ─────────────────────────
+# Replaces the previous hardcoded [~/Projects, ~/gsd-workspaces] scan, which
+# missed:
+#   - root-level .planning at $HOME
+#   - ad-hoc project dirs at $HOME (~/myproject/.planning)
+#   - nested multi-project workspaces (~/gsd-workspaces/X/Y/.planning)
+#   - any user-chosen layout that isn't one of the two hardcoded roots
+#
+# Honors OPS_GSD_SCAN_ROOTS (colon-separated extra paths) for non-$HOME
+# layouts. Honors OPS_GSD_SCAN_DEPTH (default 5) and excludes common noise
+# directories so the walk stays cheap.
+# Only exclude true noise — directories that cannot contain real GSD
+# projects. We deliberately do NOT exclude _archived/, tmp/, .worktrees/
+# etc. by default: archived and parked projects are still legitimate
+# portfolio entries the user may want to query. Power users can extend
+# the exclusion list via OPS_GSD_SCAN_EXCLUDE (colon-separated).
+EXCLUDE_PARTS = {
+    # Build/cache noise
+    "node_modules", ".git", ".venv", "venv", "env-py",
+    "Library", ".claude", ".Trash", ".cache", "__pycache__",
+    "dist", "build", ".next", ".nuxt", ".turbo", ".vercel",
+    # Tool config dirs that occasionally contain unrelated .planning
+    ".gemini",
+    # Git worktrees: transient clones of the same project — including them
+    # would multiply every active project by 5-30x. Power users can re-enable
+    # by passing OPS_GSD_INCLUDE_WORKTREES=1 (handled below).
+    ".worktrees",
+}
+if os.environ.get("OPS_GSD_INCLUDE_WORKTREES", "") == "1":
+    EXCLUDE_PARTS.discard(".worktrees")
+extra_excludes = os.environ.get("OPS_GSD_SCAN_EXCLUDE", "")
+if extra_excludes:
+    for part in extra_excludes.split(":"):
+        part = part.strip()
+        if part:
+            EXCLUDE_PARTS.add(part)
+try:
+    MAX_DEPTH = int(os.environ.get("OPS_GSD_SCAN_DEPTH", "5"))
+except ValueError:
+    MAX_DEPTH = 5
+
+scan_roots = [Path(HOME)]
+extra_roots = os.environ.get("OPS_GSD_SCAN_ROOTS", "")
+if extra_roots:
+    for root_str in extra_roots.split(":"):
+        root_str = root_str.strip()
+        if not root_str:
+            continue
+        rp = Path(os.path.expanduser(root_str))
+        if rp.exists() and rp.is_dir():
+            scan_roots.append(rp)
+
+planning_dirs = []
+for root in scan_roots:
+    if not root.exists():
+        continue
+    stack = [(root, 0)]
+    while stack:
+        cur, depth = stack.pop()
+        if depth > MAX_DEPTH:
+            continue
+        try:
+            entries = list(cur.iterdir())
+        except (PermissionError, OSError):
+            continue
+        for entry in entries:
+            if not entry.is_dir() or entry.is_symlink():
+                continue
+            if entry.name in EXCLUDE_PARTS:
+                continue
+            if entry.name == ".planning":
+                planning_dirs.append(entry)
+                continue  # don't descend into .planning itself
+            if depth + 1 <= MAX_DEPTH:
+                stack.append((entry, depth + 1))
+
+# De-dupe (resolve symlinks, drop duplicates) and sort for deterministic output
+seen_resolved = set()
+unique_planning = []
+for p in sorted(planning_dirs):
+    try:
+        rp = str(p.resolve())
+    except OSError:
+        rp = str(p)
+    if rp in seen_resolved:
+        continue
+    seen_resolved.add(rp)
+    unique_planning.append(p)
+
+home_path = Path(HOME)
+
+for planning in unique_planning:
+    d = planning.parent
+    if not d.is_dir():
+        continue
+    proj = d.name or "home"
+    # Source = first path segment under $HOME, or "external" for OPS_GSD_SCAN_ROOTS hits
+    try:
+        rel_parts = d.relative_to(home_path).parts
+        source = rel_parts[0] if rel_parts else "home"
+    except ValueError:
+        source = "external"
+
+    if True:  # preserve original block indentation
         handoff = planning / "HANDOFF.json"
         state = planning / "STATE.md"
         roadmap = planning / "ROADMAP.md"
@@ -100,10 +197,33 @@ for base in [Path(HOME) / "Projects", Path(HOME) / "gsd-workspaces"]:
                     milestone = line.lstrip("#").strip()[:60]
                     break
 
+        # Dedupe key: prefer git remote URL (canonical), else resolved path
+        remote_url = ""
+        if has_git:
+            try:
+                remote_url = subprocess.check_output(
+                    ["git", "-C", str(d), "remote", "get-url", "origin"],
+                    timeout=2, stderr=subprocess.DEVNULL
+                ).strip().decode() or ""
+            except: pass
+
+        # Last commit timestamp — used to pick canonical when paths collide
+        last_commit_ts = 0
+        if has_git:
+            try:
+                ts_out = subprocess.check_output(
+                    ["git", "-C", str(d), "log", "-1", "--format=%ct"],
+                    timeout=2, stderr=subprocess.DEVNULL
+                ).strip().decode()
+                last_commit_ts = int(ts_out) if ts_out else 0
+            except: pass
+
         projects.append({
             "name": proj,
             "path": str(d) + "/",
             "source": source,
+            "remote_url": remote_url,
+            "last_commit_ts": last_commit_ts,
             "phase": phase,
             "status": status,
             "milestone": milestone,
@@ -119,6 +239,38 @@ for base in [Path(HOME) / "Projects", Path(HOME) / "gsd-workspaces"]:
             "has_handoff": handoff.exists(),
             "total_phases": total_phases
         })
+
+# ── Dedupe: same git remote URL ⇒ same logical project ────────────────────
+# Multiple checkout paths (e.g. ~/healify-api and ~/Projects/healify-api,
+# or a clone in gsd-workspaces/) all map to one entry. Canonical path =
+# the one with the most recent commit; other paths land in `aliases`.
+# Projects without a git remote are deduped by resolved filesystem path
+# instead, so symlinks don't multiply entries either.
+canonical_by_key = {}
+for p in projects:
+    key = p.get("remote_url") or ""
+    if not key:
+        try:
+            key = "path:" + str(Path(p["path"].rstrip("/")).resolve())
+        except OSError:
+            key = "path:" + p["path"]
+    if key not in canonical_by_key:
+        p["aliases"] = []
+        canonical_by_key[key] = p
+        continue
+    incumbent = canonical_by_key[key]
+    challenger = p
+    # Prefer the path with the most recent commit (active checkout wins).
+    # Tie-break: shorter path (closer to $HOME, more likely "primary").
+    incumbent_score = (incumbent.get("last_commit_ts", 0), -len(incumbent["path"]))
+    challenger_score = (challenger.get("last_commit_ts", 0), -len(challenger["path"]))
+    if challenger_score > incumbent_score:
+        challenger["aliases"] = incumbent.get("aliases", []) + [incumbent["path"]]
+        canonical_by_key[key] = challenger
+    else:
+        incumbent.setdefault("aliases", []).append(challenger["path"])
+
+projects = list(canonical_by_key.values())
 
 # Sort by status priority: executing > paused > blocked > idle
 def sort_key(p):


### PR DESCRIPTION
## Summary

Three closely-related fixes for users running ops skills via SSH (Termius, tmux on remote hosts) and for users with GSD projects scattered across multiple roots.

## What changed

### 1. `lib/opener.sh` — SSH/mobile detection
- New helper `__ops_is_remote_session` checks `SSH_CONNECTION` / `SSH_CLIENT` / `SSH_TTY` plus `OPS_MOBILE` / `OPS_PRINT_URLS` overrides.
- `ops_open_url` now prints a copy-able URL block on remote sessions instead of spawning `open` on the SSH target (where the user cannot see the browser).
- `OPS_FORCE_OPEN=1` escape hatch for explicit local-open from inside an SSH session.

### 2. `CLAUDE.md` — Rule 7: mobile/SSH = compact text, no tables
- Defines the detection contract every skill must honor.
- Bans tables, banners, multi-column status lines on mobile.
- 3-8 line target for briefings; URLs always via `ops_open_url`.
- Side-by-side desktop vs mobile output examples so future skill authors know the bar.

### 3. `scripts/ops-gsd-registry-sync.sh` — universal GSD discovery + dedupe
- Replaces hardcoded `[~/Projects, ~/gsd-workspaces]` with a depth-limited walk under `\$HOME` (configurable via `OPS_GSD_SCAN_DEPTH`, default 5).
- Honors `OPS_GSD_SCAN_ROOTS` (extra colon-separated roots) and `OPS_GSD_SCAN_EXCLUDE` for power users.
- Excludes only true noise (`node_modules`, `.git`, `.venv`, `.worktrees`, build artifacts, `.gemini`); archived/tmp projects now surface so users can query them.
- `OPS_GSD_INCLUDE_WORKTREES=1` to opt into worktree clones.
- **Canonical-path dedupe**: multiple checkouts of the same git remote URL (e.g. `~/healify-api` and `~/Projects/healify-api`) collapse into one entry — the path with the most recent commit wins, other paths land in `aliases[]`. Non-git projects dedupe by resolved filesystem path so symlinks don't multiply entries.

## Why

- SSH/Termius users running `/ops:setup` would hit OAuth flows that opened browsers on the SSH target machine, invisible to the phone.
- The portfolio scanner only found projects at two hardcoded roots, missing root-level `.planning`, ad-hoc layouts, and nested workspaces.
- The same project appearing under multiple checkout paths inflated portfolio counts and split priority signals.

## Verification

```
# Before
Registry: ~30 projects (hardcoded roots only)

# After (depth-5 walk)
Registry: 53 .planning dirs found

# After dedupe (canonical via git remote URL)
Registry: 45 projects | aliases collapsed for 8 dupes
```

URL test:
```
SSH_CONNECTION=fake bash lib/opener.sh url https://example.com/oauth
# → prints "Open this URL on your device:" block, does NOT spawn `open`

OPS_FORCE_OPEN=1 bash lib/opener.sh url https://example.com
# → spawns local `open` even when SSH_CONNECTION is set
```

## Test plan

- [ ] Run `/ops:setup` over SSH — OAuth steps print URL instead of opening browser on remote
- [ ] Run `/ops:projects` — count matches `find ~ -name .planning` minus excluded noise
- [ ] Verify dedupe: a repo cloned to two locations appears once with `aliases` populated
- [ ] On phone+tmux: confirm `/ops:go` produces compact output (no tables) when `SSH_CONNECTION` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes runtime behavior in `ops_open_url` and significantly alters GSD registry scanning/output (new fields and deduping), which could affect existing workflows and consumers of `registry.json`. Changes are bounded and include explicit env-var overrides, but need verification across environments.
> 
> **Overview**
> Improves SSH/mobile usability by introducing **remote-session detection** in `lib/opener.sh` and making `ops_open_url` **print a copy-able URL block** (with `OPS_FORCE_OPEN` escape hatch) instead of launching a browser on the remote host.
> 
> Adds a new `CLAUDE.md` rule requiring **compact, no-table output** in mobile/SSH contexts and standardizing URL handling via `ops_open_url`.
> 
> Expands `ops-gsd-registry-sync.sh` to **discover `.planning` directories via a configurable depth-limited walk** (with include/exclude env vars) and **dedupe projects** by git `origin` remote (or resolved path), selecting a canonical checkout and recording other paths as `aliases` (also adding `remote_url`/`last_commit_ts` to registry entries).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c32c0fc2cd4a4d33af98230ec53f09d4d509cbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mobile mode detection with compact output formatting for remote/SSH sessions
  * Improved project discovery across the system with configurable scan locations
  * Automatic deduplication of multiple checkouts of the same repository

* **Bug Fixes**
  * URL handling now displays copyable links in remote contexts instead of attempting automatic opens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->