### PR TITLE
feat(setup): account rotator OAuth init wizard

### DIFF
--- a/claude-ops/lib/credential-store.sh
+++ b/claude-ops/lib/credential-store.sh
@@ -19,7 +19,7 @@
 #   ops_cred_backend_for <service> <account>
 #
 # Direct-execution CLI (for the .mjs helper to shell out to):
-#   credential-store.sh set|get|delete|backends|backend-for ...
+#   credential-store.sh set|set-stdin|get|delete|backends|backend-for ...
 
 # ─── Re-source guard ────────────────────────────────────────────────────────
 if [[ -n "${__OPS_CREDENTIAL_STORE_SH_LOADED__:-}" ]]; then
@@ -589,6 +589,10 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     set)
       [[ $# -eq 3 ]] || { echo "usage: credential-store.sh set <service> <account> <secret>" >&2; exit 2; }
       ops_cred_set "$@" ;;
+    set-stdin)
+      [[ $# -eq 2 ]] || { echo "usage: credential-store.sh set-stdin <service> <account>" >&2; exit 2; }
+      sec="$(cat)" || sec=""
+      ops_cred_set "$1" "$2" "$sec" ;;
     get)
       [[ $# -eq 2 ]] || { echo "usage: credential-store.sh get <service> <account>" >&2; exit 2; }
       ops_cred_get "$@" ;;
@@ -605,6 +609,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 credential-store.sh — cross-OS secret storage with cascading backends
 Usage:
   credential-store.sh set         <service> <account> <secret>
+  credential-store.sh set-stdin   <service> <account>   # secret on stdin (avoids argv exposure)
   credential-store.sh get         <service> <account>
   credential-store.sh delete      <service> <account>
   credential-store.sh backends

--- a/claude-ops/lib/credential-store.sh
+++ b/claude-ops/lib/credential-store.sh
@@ -592,6 +592,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     set-stdin)
       [[ $# -eq 2 ]] || { echo "usage: credential-store.sh set-stdin <service> <account>" >&2; exit 2; }
       sec="$(cat)" || sec=""
+      [[ -n "$sec" ]] || { echo "error: empty secret on stdin (pipe the secret, e.g. echo \"tok\" | credential-store.sh set-stdin svc acct)" >&2; exit 2; }
       ops_cred_set "$1" "$2" "$sec" ;;
     get)
       [[ $# -eq 2 ]] || { echo "usage: credential-store.sh get <service> <account>" >&2; exit 2; }

--- a/claude-ops/scripts/account-rotation/config.json
+++ b/claude-ops/scripts/account-rotation/config.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "comment": "Default empty config. User overrides land at ~/.claude/plugins/data/ops-ops-marketplace/account-rotation-config.json (gitignored). Never commit real emails — Rule 0.",
+  "accounts": []
+}

--- a/claude-ops/scripts/account-rotation/setup-account.mjs
+++ b/claude-ops/scripts/account-rotation/setup-account.mjs
@@ -302,7 +302,11 @@ async function main() {
     process.exit(1);
   }
 
-  const stored = credSet('Claude-Rotation', args.accountId, JSON.stringify({ cookieName: session.name, token: session.value }));
+  const stored = credSet(
+    'Claude-Rotation',
+    args.accountId,
+    JSON.stringify({ cookieName: session.name, token: session.value }),
+  );
   if (!stored) {
     console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: 'keychain_write_failed' }));
     process.exit(1);

--- a/claude-ops/scripts/account-rotation/setup-account.mjs
+++ b/claude-ops/scripts/account-rotation/setup-account.mjs
@@ -1,0 +1,317 @@
+#!/usr/bin/env node
+// setup-account.mjs — Standalone OAuth init for a single Claude account.
+//
+// Walks a magic-link login flow against claude.ai using Playwright, extracts
+// the session token from cookies, verifies the token against api.anthropic.com,
+// and writes it to the OS keychain via lib/credential-store.sh as
+// `Claude-Rotation-<account_id>`. Does NOT touch the active rotation state.
+//
+// Usage:
+//   node setup-account.mjs --email user@example.com [--display "Personal"] \
+//                          [--plan max] [--account-id <slug>] [--no-headless]
+//
+// TODO(account-rotation-fold): when the parallel account-rotation source lands,
+// fold this file into rotate.mjs as a `--setup-account <email>` mode and call
+// the shared keychain/verification helpers from there. Until then this file is
+// callable standalone.
+
+import { spawn, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..", "..");
+const CRED_STORE = resolve(REPO_ROOT, "lib", "credential-store.sh");
+const CONFIG_USER = join(
+  homedir(),
+  ".claude",
+  "plugins",
+  "data",
+  "ops-ops-marketplace",
+  "account-rotation-config.json",
+);
+const CONFIG_REPO = resolve(__dirname, "config.json");
+const LOG_DIR = join(homedir(), ".claude", "logs", "account-rotation");
+
+function parseArgs(argv) {
+  const out = { headless: true, plan: "max" };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--email") out.email = argv[++i];
+    else if (a === "--display") out.display = argv[++i];
+    else if (a === "--plan") out.plan = argv[++i];
+    else if (a === "--account-id") out.accountId = argv[++i];
+    else if (a === "--no-headless") out.headless = false;
+    else if (a === "--gmail-poll") out.gmailPoll = true;
+    else if (a === "--help" || a === "-h") {
+      console.log(
+        "usage: setup-account.mjs --email <addr> [--display <name>] [--plan pro|max] [--account-id <slug>] [--no-headless] [--gmail-poll]",
+      );
+      process.exit(0);
+    }
+  }
+  if (!out.email) {
+    console.error("error: --email is required");
+    process.exit(2);
+  }
+  if (!out.accountId) out.accountId = slugify(out.email);
+  if (!out.display) out.display = out.email;
+  return out;
+}
+
+function slugify(s) {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function log(msg) {
+  const ts = new Date().toISOString();
+  process.stderr.write(`[setup-account ${ts}] ${msg}\n`);
+}
+
+function ensureLogDir() {
+  if (!existsSync(LOG_DIR)) mkdirSync(LOG_DIR, { recursive: true });
+}
+
+function loadConfig() {
+  const path = existsSync(CONFIG_USER) ? CONFIG_USER : CONFIG_REPO;
+  if (!existsSync(path)) return { accounts: [] };
+  try {
+    return JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return { accounts: [] };
+  }
+}
+
+function saveConfig(cfg) {
+  const path = CONFIG_USER;
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(cfg, null, 2));
+}
+
+function upsertAccount(args) {
+  const cfg = loadConfig();
+  cfg.accounts = cfg.accounts || [];
+  const existing = cfg.accounts.find((a) => a.id === args.accountId);
+  if (existing) {
+    existing.email = args.email;
+    existing.display = args.display;
+    existing.plan = args.plan;
+  } else {
+    cfg.accounts.push({
+      id: args.accountId,
+      email: args.email,
+      display: args.display,
+      plan: args.plan,
+      added: new Date().toISOString(),
+    });
+  }
+  saveConfig(cfg);
+  log(`config upserted: ${args.accountId} -> ${CONFIG_USER}`);
+}
+
+function credSet(service, account, secret) {
+  const r = spawnSync("bash", [CRED_STORE, "set", service, account, secret], {
+    input: "",
+    encoding: "utf8",
+  });
+  if (r.status !== 0) {
+    log(`credential-store set failed: ${r.stderr}`);
+    return false;
+  }
+  return true;
+}
+
+function credGet(service, account) {
+  const r = spawnSync("bash", [CRED_STORE, "get", service, account], {
+    encoding: "utf8",
+  });
+  if (r.status !== 0) return null;
+  return r.stdout.trim() || null;
+}
+
+async function ensurePlaywright() {
+  try {
+    await import("playwright");
+    return true;
+  } catch {
+    log("installing playwright (one-time)...");
+    const r = spawnSync("npm", ["install", "--no-save", "playwright"], {
+      cwd: REPO_ROOT,
+      stdio: "inherit",
+    });
+    if (r.status !== 0) {
+      log("playwright install failed");
+      return false;
+    }
+    spawnSync("npx", ["playwright", "install", "chromium"], {
+      cwd: REPO_ROOT,
+      stdio: "inherit",
+    });
+    return true;
+  }
+}
+
+async function pollGmailForMagicLink(toEmail, sinceTs) {
+  // Best-effort: use `gog` if available. Returns the link URL or null.
+  const probe = spawnSync("which", ["gog"], { encoding: "utf8" });
+  if (probe.status !== 0) {
+    log("gog CLI not installed — falling back to manual confirmation");
+    return null;
+  }
+  const deadline = Date.now() + 5 * 60 * 1000; // 5 min
+  while (Date.now() < deadline) {
+    const r = spawnSync(
+      "gog",
+      [
+        "gmail",
+        "search",
+        `to:${toEmail} from:noreply@anthropic.com after:${Math.floor(sinceTs / 1000)} subject:"sign in"`,
+        "--max",
+        "3",
+        "-j",
+        "--results-only",
+        "--no-input",
+      ],
+      { encoding: "utf8", timeout: 15000 },
+    );
+    if (r.status === 0 && r.stdout.trim()) {
+      try {
+        const threads = JSON.parse(r.stdout);
+        const first = Array.isArray(threads) ? threads[0] : null;
+        if (first?.id) {
+          const t = spawnSync(
+            "gog",
+            ["gmail", "thread", "get", first.id, "-j"],
+            { encoding: "utf8", timeout: 15000 },
+          );
+          if (t.status === 0) {
+            const m = t.stdout.match(
+              /https:\/\/claude\.ai\/(?:magic-link|verify|login)[^\s"'<>]+/,
+            );
+            if (m) return m[0];
+          }
+        }
+      } catch {}
+    }
+    await new Promise((r) => setTimeout(r, 5000));
+  }
+  return null;
+}
+
+async function runOAuth(args) {
+  const ok = await ensurePlaywright();
+  if (!ok) return null;
+  const { chromium } = await import("playwright");
+  const browser = await chromium.launch({ headless: args.headless });
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+
+  log("navigating to claude.ai/login");
+  await page.goto("https://claude.ai/login", { waitUntil: "domcontentloaded" });
+
+  log(`filling email: ${args.email}`);
+  // Selector is best-effort — Anthropic's login form may change.
+  try {
+    await page.fill('input[type="email"], input[name="email"]', args.email, {
+      timeout: 15000,
+    });
+    await page.click('button[type="submit"], button:has-text("Continue")', {
+      timeout: 5000,
+    });
+  } catch (e) {
+    log(`email entry failed: ${e.message}`);
+  }
+
+  const sinceTs = Date.now();
+  log("magic-link sent — waiting for completion...");
+  if (args.gmailPoll) {
+    const link = await pollGmailForMagicLink(args.email, sinceTs);
+    if (link) {
+      log(`got magic link from gmail — navigating`);
+      await page.goto(link, { waitUntil: "domcontentloaded" });
+    } else {
+      log("gmail poll timed out — waiting for manual click");
+    }
+  }
+
+  // Wait for the post-login app shell. 10 min ceiling for 2FA / manual click.
+  try {
+    await page.waitForURL(/claude\.ai\/(?:chats?|new|projects)/, {
+      timeout: 10 * 60 * 1000,
+    });
+  } catch (e) {
+    log(`login did not complete in time: ${e.message}`);
+    await browser.close();
+    return null;
+  }
+
+  const cookies = await ctx.cookies("https://claude.ai");
+  const session = cookies.find((c) => c.name === "sessionKey" || c.name === "__Secure-next-auth.session-token");
+  await browser.close();
+  if (!session) {
+    log("no session cookie found after login");
+    return null;
+  }
+  return session.value;
+}
+
+async function verifyToken(token) {
+  // Minimal probe — the rotation system uses this token to mint API requests
+  // via the Claude Code OAuth bridge. We just check that claude.ai accepts it.
+  try {
+    const res = await fetch("https://claude.ai/api/organizations", {
+      headers: { Cookie: `sessionKey=${token}` },
+    });
+    return res.ok;
+  } catch (e) {
+    log(`verify error: ${e.message}`);
+    return false;
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  ensureLogDir();
+  log(`starting setup for ${args.email} (id=${args.accountId}, plan=${args.plan})`);
+
+  const existingToken = credGet("Claude-Rotation", args.accountId);
+  if (existingToken) {
+    log(`keychain entry already present for ${args.accountId} — skipping OAuth`);
+    upsertAccount(args);
+    console.log(JSON.stringify({ ok: true, accountId: args.accountId, skipped: true }));
+    return;
+  }
+
+  const token = await runOAuth(args);
+  if (!token) {
+    console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: "oauth_failed" }));
+    process.exit(1);
+  }
+
+  const verified = await verifyToken(token);
+  if (!verified) {
+    console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: "verify_failed" }));
+    process.exit(1);
+  }
+
+  const stored = credSet("Claude-Rotation", args.accountId, token);
+  if (!stored) {
+    console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: "keychain_write_failed" }));
+    process.exit(1);
+  }
+
+  upsertAccount(args);
+  log(`✓ ${args.accountId} initialized`);
+  console.log(JSON.stringify({ ok: true, accountId: args.accountId, email: args.email }));
+}
+
+main().catch((e) => {
+  log(`fatal: ${e.stack || e.message}`);
+  console.log(JSON.stringify({ ok: false, error: String(e.message || e) }));
+  process.exit(1);
+});

--- a/claude-ops/scripts/account-rotation/setup-account.mjs
+++ b/claude-ops/scripts/account-rotation/setup-account.mjs
@@ -15,45 +15,45 @@
 // the shared keychain/verification helpers from there. Until then this file is
 // callable standalone.
 
-import { spawn, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { homedir } from "node:os";
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = resolve(__dirname, "..", "..");
-const CRED_STORE = resolve(REPO_ROOT, "lib", "credential-store.sh");
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const CRED_STORE = resolve(REPO_ROOT, 'lib', 'credential-store.sh');
 const CONFIG_USER = join(
   homedir(),
-  ".claude",
-  "plugins",
-  "data",
-  "ops-ops-marketplace",
-  "account-rotation-config.json",
+  '.claude',
+  'plugins',
+  'data',
+  'ops-ops-marketplace',
+  'account-rotation-config.json',
 );
-const CONFIG_REPO = resolve(__dirname, "config.json");
-const LOG_DIR = join(homedir(), ".claude", "logs", "account-rotation");
+const CONFIG_REPO = resolve(__dirname, 'config.json');
+const LOG_DIR = join(homedir(), '.claude', 'logs', 'account-rotation');
 
 function parseArgs(argv) {
-  const out = { headless: true, plan: "max" };
+  const out = { headless: true, plan: 'max' };
   for (let i = 2; i < argv.length; i++) {
     const a = argv[i];
-    if (a === "--email") out.email = argv[++i];
-    else if (a === "--display") out.display = argv[++i];
-    else if (a === "--plan") out.plan = argv[++i];
-    else if (a === "--account-id") out.accountId = argv[++i];
-    else if (a === "--no-headless") out.headless = false;
-    else if (a === "--gmail-poll") out.gmailPoll = true;
-    else if (a === "--help" || a === "-h") {
+    if (a === '--email') out.email = argv[++i];
+    else if (a === '--display') out.display = argv[++i];
+    else if (a === '--plan') out.plan = argv[++i];
+    else if (a === '--account-id') out.accountId = argv[++i];
+    else if (a === '--no-headless') out.headless = false;
+    else if (a === '--gmail-poll') out.gmailPoll = true;
+    else if (a === '--help' || a === '-h') {
       console.log(
-        "usage: setup-account.mjs --email <addr> [--display <name>] [--plan pro|max] [--account-id <slug>] [--no-headless] [--gmail-poll]",
+        'usage: setup-account.mjs --email <addr> [--display <name>] [--plan pro|max] [--account-id <slug>] [--no-headless] [--gmail-poll]',
       );
       process.exit(0);
     }
   }
   if (!out.email) {
-    console.error("error: --email is required");
+    console.error('error: --email is required');
     process.exit(2);
   }
   if (!out.accountId) out.accountId = slugify(out.email);
@@ -64,8 +64,8 @@ function parseArgs(argv) {
 function slugify(s) {
   return s
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
 function log(msg) {
@@ -81,7 +81,7 @@ function loadConfig() {
   const path = existsSync(CONFIG_USER) ? CONFIG_USER : CONFIG_REPO;
   if (!existsSync(path)) return { accounts: [] };
   try {
-    return JSON.parse(readFileSync(path, "utf8"));
+    return JSON.parse(readFileSync(path, 'utf8'));
   } catch {
     return { accounts: [] };
   }
@@ -115,9 +115,9 @@ function upsertAccount(args) {
 }
 
 function credSet(service, account, secret) {
-  const r = spawnSync("bash", [CRED_STORE, "set", service, account, secret], {
-    input: "",
-    encoding: "utf8",
+  const r = spawnSync('bash', [CRED_STORE, 'set', service, account, secret], {
+    input: '',
+    encoding: 'utf8',
   });
   if (r.status !== 0) {
     log(`credential-store set failed: ${r.stderr}`);
@@ -127,8 +127,8 @@ function credSet(service, account, secret) {
 }
 
 function credGet(service, account) {
-  const r = spawnSync("bash", [CRED_STORE, "get", service, account], {
-    encoding: "utf8",
+  const r = spawnSync('bash', [CRED_STORE, 'get', service, account], {
+    encoding: 'utf8',
   });
   if (r.status !== 0) return null;
   return r.stdout.trim() || null;
@@ -136,21 +136,21 @@ function credGet(service, account) {
 
 async function ensurePlaywright() {
   try {
-    await import("playwright");
+    await import('playwright');
     return true;
   } catch {
-    log("installing playwright (one-time)...");
-    const r = spawnSync("npm", ["install", "--no-save", "playwright"], {
+    log('installing playwright (one-time)...');
+    const r = spawnSync('npm', ['install', '--no-save', 'playwright'], {
       cwd: REPO_ROOT,
-      stdio: "inherit",
+      stdio: 'inherit',
     });
     if (r.status !== 0) {
-      log("playwright install failed");
+      log('playwright install failed');
       return false;
     }
-    spawnSync("npx", ["playwright", "install", "chromium"], {
+    spawnSync('npx', ['playwright', 'install', 'chromium'], {
       cwd: REPO_ROOT,
-      stdio: "inherit",
+      stdio: 'inherit',
     });
     return true;
   }
@@ -158,41 +158,35 @@ async function ensurePlaywright() {
 
 async function pollGmailForMagicLink(toEmail, sinceTs) {
   // Best-effort: use `gog` if available. Returns the link URL or null.
-  const probe = spawnSync("which", ["gog"], { encoding: "utf8" });
+  const probe = spawnSync('which', ['gog'], { encoding: 'utf8' });
   if (probe.status !== 0) {
-    log("gog CLI not installed — falling back to manual confirmation");
+    log('gog CLI not installed — falling back to manual confirmation');
     return null;
   }
   const deadline = Date.now() + 5 * 60 * 1000; // 5 min
   while (Date.now() < deadline) {
     const r = spawnSync(
-      "gog",
+      'gog',
       [
-        "gmail",
-        "search",
+        'gmail',
+        'search',
         `to:${toEmail} from:noreply@anthropic.com after:${Math.floor(sinceTs / 1000)} subject:"sign in"`,
-        "--max",
-        "3",
-        "-j",
-        "--results-only",
-        "--no-input",
+        '--max',
+        '3',
+        '-j',
+        '--results-only',
+        '--no-input',
       ],
-      { encoding: "utf8", timeout: 15000 },
+      { encoding: 'utf8', timeout: 15000 },
     );
     if (r.status === 0 && r.stdout.trim()) {
       try {
         const threads = JSON.parse(r.stdout);
         const first = Array.isArray(threads) ? threads[0] : null;
         if (first?.id) {
-          const t = spawnSync(
-            "gog",
-            ["gmail", "thread", "get", first.id, "-j"],
-            { encoding: "utf8", timeout: 15000 },
-          );
+          const t = spawnSync('gog', ['gmail', 'thread', 'get', first.id, '-j'], { encoding: 'utf8', timeout: 15000 });
           if (t.status === 0) {
-            const m = t.stdout.match(
-              /https:\/\/claude\.ai\/(?:magic-link|verify|login)[^\s"'<>]+/,
-            );
+            const m = t.stdout.match(/https:\/\/claude\.ai\/(?:magic-link|verify|login)[^\s"'<>]+/);
             if (m) return m[0];
           }
         }
@@ -206,13 +200,13 @@ async function pollGmailForMagicLink(toEmail, sinceTs) {
 async function runOAuth(args) {
   const ok = await ensurePlaywright();
   if (!ok) return null;
-  const { chromium } = await import("playwright");
+  const { chromium } = await import('playwright');
   const browser = await chromium.launch({ headless: args.headless });
   const ctx = await browser.newContext();
   const page = await ctx.newPage();
 
-  log("navigating to claude.ai/login");
-  await page.goto("https://claude.ai/login", { waitUntil: "domcontentloaded" });
+  log('navigating to claude.ai/login');
+  await page.goto('https://claude.ai/login', { waitUntil: 'domcontentloaded' });
 
   log(`filling email: ${args.email}`);
   // Selector is best-effort — Anthropic's login form may change.
@@ -228,14 +222,14 @@ async function runOAuth(args) {
   }
 
   const sinceTs = Date.now();
-  log("magic-link sent — waiting for completion...");
+  log('magic-link sent — waiting for completion...');
   if (args.gmailPoll) {
     const link = await pollGmailForMagicLink(args.email, sinceTs);
     if (link) {
       log(`got magic link from gmail — navigating`);
-      await page.goto(link, { waitUntil: "domcontentloaded" });
+      await page.goto(link, { waitUntil: 'domcontentloaded' });
     } else {
-      log("gmail poll timed out — waiting for manual click");
+      log('gmail poll timed out — waiting for manual click');
     }
   }
 
@@ -250,11 +244,11 @@ async function runOAuth(args) {
     return null;
   }
 
-  const cookies = await ctx.cookies("https://claude.ai");
-  const session = cookies.find((c) => c.name === "sessionKey" || c.name === "__Secure-next-auth.session-token");
+  const cookies = await ctx.cookies('https://claude.ai');
+  const session = cookies.find((c) => c.name === 'sessionKey' || c.name === '__Secure-next-auth.session-token');
   await browser.close();
   if (!session) {
-    log("no session cookie found after login");
+    log('no session cookie found after login');
     return null;
   }
   return session.value;
@@ -264,7 +258,7 @@ async function verifyToken(token) {
   // Minimal probe — the rotation system uses this token to mint API requests
   // via the Claude Code OAuth bridge. We just check that claude.ai accepts it.
   try {
-    const res = await fetch("https://claude.ai/api/organizations", {
+    const res = await fetch('https://claude.ai/api/organizations', {
       headers: { Cookie: `sessionKey=${token}` },
     });
     return res.ok;
@@ -279,7 +273,7 @@ async function main() {
   ensureLogDir();
   log(`starting setup for ${args.email} (id=${args.accountId}, plan=${args.plan})`);
 
-  const existingToken = credGet("Claude-Rotation", args.accountId);
+  const existingToken = credGet('Claude-Rotation', args.accountId);
   if (existingToken) {
     log(`keychain entry already present for ${args.accountId} — skipping OAuth`);
     upsertAccount(args);
@@ -289,19 +283,19 @@ async function main() {
 
   const token = await runOAuth(args);
   if (!token) {
-    console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: "oauth_failed" }));
+    console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: 'oauth_failed' }));
     process.exit(1);
   }
 
   const verified = await verifyToken(token);
   if (!verified) {
-    console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: "verify_failed" }));
+    console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: 'verify_failed' }));
     process.exit(1);
   }
 
-  const stored = credSet("Claude-Rotation", args.accountId, token);
+  const stored = credSet('Claude-Rotation', args.accountId, token);
   if (!stored) {
-    console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: "keychain_write_failed" }));
+    console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: 'keychain_write_failed' }));
     process.exit(1);
   }
 

--- a/claude-ops/scripts/account-rotation/setup-account.mjs
+++ b/claude-ops/scripts/account-rotation/setup-account.mjs
@@ -115,8 +115,8 @@ function upsertAccount(args) {
 }
 
 function credSet(service, account, secret) {
-  const r = spawnSync('bash', [CRED_STORE, 'set', service, account, secret], {
-    input: '',
+  const r = spawnSync('bash', [CRED_STORE, 'set-stdin', service, account], {
+    input: secret,
     encoding: 'utf8',
   });
   if (r.status !== 0) {
@@ -210,6 +210,7 @@ async function runOAuth(args) {
 
   log(`filling email: ${args.email}`);
   // Selector is best-effort — Anthropic's login form may change.
+  let emailSubmitted = true;
   try {
     await page.fill('input[type="email"], input[name="email"]', args.email, {
       timeout: 15000,
@@ -219,6 +220,13 @@ async function runOAuth(args) {
     });
   } catch (e) {
     log(`email entry failed: ${e.message}`);
+    emailSubmitted = false;
+  }
+
+  if (!emailSubmitted && args.headless) {
+    log('aborting: email step failed in headless mode (no manual recovery)');
+    await browser.close();
+    return null;
   }
 
   const sinceTs = Date.now();
@@ -251,15 +259,16 @@ async function runOAuth(args) {
     log('no session cookie found after login');
     return null;
   }
-  return session.value;
+  return { name: session.name, value: session.value };
 }
 
-async function verifyToken(token) {
+async function verifyToken(session) {
   // Minimal probe — the rotation system uses this token to mint API requests
   // via the Claude Code OAuth bridge. We just check that claude.ai accepts it.
+  const { name, value } = session;
   try {
     const res = await fetch('https://claude.ai/api/organizations', {
-      headers: { Cookie: `sessionKey=${token}` },
+      headers: { Cookie: `${name}=${value}` },
     });
     return res.ok;
   } catch (e) {
@@ -281,19 +290,19 @@ async function main() {
     return;
   }
 
-  const token = await runOAuth(args);
-  if (!token) {
+  const session = await runOAuth(args);
+  if (!session) {
     console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: 'oauth_failed' }));
     process.exit(1);
   }
 
-  const verified = await verifyToken(token);
+  const verified = await verifyToken(session);
   if (!verified) {
     console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: 'verify_failed' }));
     process.exit(1);
   }
 
-  const stored = credSet('Claude-Rotation', args.accountId, token);
+  const stored = credSet('Claude-Rotation', args.accountId, session.value);
   if (!stored) {
     console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: 'keychain_write_failed' }));
     process.exit(1);

--- a/claude-ops/scripts/account-rotation/setup-account.mjs
+++ b/claude-ops/scripts/account-rotation/setup-account.mjs
@@ -302,7 +302,7 @@ async function main() {
     process.exit(1);
   }
 
-  const stored = credSet('Claude-Rotation', args.accountId, session.value);
+  const stored = credSet('Claude-Rotation', args.accountId, JSON.stringify({ cookieName: session.name, token: session.value }));
   if (!stored) {
     console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: 'keychain_write_failed' }));
     process.exit(1);

--- a/claude-ops/scripts/account-rotation/setup-account.mjs
+++ b/claude-ops/scripts/account-rotation/setup-account.mjs
@@ -241,16 +241,44 @@ async function runOAuth(args) {
     }
   }
 
+  // Poll for 2FA indicators while waiting for the post-login app shell.
+  // This emits a log line the SKILL.md contract expects so the operator
+  // can relay a TOTP code via AskUserQuestion.
+  let twoFaLogged = false;
+  const twoFaPoll = setInterval(async () => {
+    if (twoFaLogged) return;
+    try {
+      const has2FA = await page.evaluate(() => {
+        const text = (document.body?.innerText || '').toLowerCase();
+        return (
+          text.includes('two-factor') ||
+          text.includes('2fa') ||
+          text.includes('verification code') ||
+          text.includes('authenticator') ||
+          text.includes('one-time') ||
+          !!document.querySelector('input[autocomplete="one-time-code"]')
+        );
+      });
+      if (has2FA) {
+        twoFaLogged = true;
+        log('2FA prompt detected');
+      }
+    } catch {
+      /* page may have navigated — ignore */
+    }
+  }, 3000);
   // Wait for the post-login app shell. 10 min ceiling for 2FA / manual click.
   try {
     await page.waitForURL(/claude\.ai\/(?:chats?|new|projects)/, {
       timeout: 10 * 60 * 1000,
     });
   } catch (e) {
+    clearInterval(twoFaPoll);
     log(`login did not complete in time: ${e.message}`);
     await browser.close();
     return null;
   }
+  clearInterval(twoFaPoll);
 
   const cookies = await ctx.cookies('https://claude.ai');
   const session = cookies.find((c) => c.name === 'sessionKey' || c.name === '__Secure-next-auth.session-token');

--- a/claude-ops/scripts/account-rotation/setup-account.mjs
+++ b/claude-ops/scripts/account-rotation/setup-account.mjs
@@ -10,10 +10,10 @@
 //   node setup-account.mjs --email user@example.com [--display "Personal"] \
 //                          [--plan max] [--account-id <slug>] [--no-headless]
 //
-// TODO(account-rotation-fold): when the parallel account-rotation source lands,
-// fold this file into rotate.mjs as a `--setup-account <email>` mode and call
-// the shared keychain/verification helpers from there. Until then this file is
-// callable standalone.
+// Note: when the parallel account-rotation source lands, this file should be
+// folded into rotate.mjs as a `--setup-account <email>` mode, calling shared
+// keychain/verification helpers from there. Until then this file is callable
+// standalone.
 
 import { spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
@@ -140,7 +140,7 @@ async function ensurePlaywright() {
     return true;
   } catch {
     log('installing playwright (one-time)...');
-    const r = spawnSync('npm', ['install', '--no-save', 'playwright'], {
+    const r = spawnSync('npm', ['install', '--no-save', 'playwright@^1.52.0'], {
       cwd: REPO_ROOT,
       stdio: 'inherit',
     });

--- a/claude-ops/skills/ops-rotate-setup/SKILL.md
+++ b/claude-ops/skills/ops-rotate-setup/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: ops-rotate-setup
+description: Interactive OAuth init wizard for the multi-account Claude rotator. Walks through every account in the rotation config, runs the Playwright magic-link flow for any account missing a keychain token, and writes verified tokens to `Claude-Rotation-<account_id>`. Re-runnable any time. Standalone alias of the same step inside `/ops:setup`.
+argument-hint: "[--all|--account <email>|--add]"
+allowed-tools:
+  - Bash
+  - Read
+  - AskUserQuestion
+effort: medium
+maxTurns: 25
+---
+
+## Purpose
+
+Initialize OAuth tokens for the multi-account Claude rotator system (the
+`account-rotation` daemon). For each configured account that does not already
+have a keychain entry `Claude-Rotation-<account_id>`, run the Playwright magic-
+link login flow against `claude.ai`, capture the session cookie, verify it,
+and write it to the OS keychain via `lib/credential-store.sh`.
+
+Use this skill when:
+- You ran `/ops:setup` and skipped the account-rotation step
+- You added a new Claude account and need to wire it in
+- A keychain entry was rotated/expired and needs re-init
+- You want to re-run only the OAuth portion without touching other ops config
+
+## Rules (mandatory)
+
+- **Rule 0**: Never write real emails to any committed file. Account email and
+  display name come from runtime user input only.
+- **Rule 1**: Max 4 options per `AskUserQuestion`. Paginate at 4 with
+  `[More...]` bridges when listing accounts.
+- **Rule 4**: Background by default. The Playwright OAuth flow is long-running;
+  always launch it with `run_in_background: true` and tail the log.
+- Never auto-enable `account_rotation_enabled` after init. The user flips that
+  switch from `/plugins` settings.
+
+## Step 1 — Load config
+
+```bash
+USER_CFG="$HOME/.claude/plugins/data/ops-ops-marketplace/account-rotation-config.json"
+REPO_CFG="${CLAUDE_PLUGIN_ROOT}/scripts/account-rotation/config.json"
+CFG="$([[ -f "$USER_CFG" ]] && echo "$USER_CFG" || echo "$REPO_CFG")"
+jq '.accounts // []' "$CFG"
+```
+
+If `accounts` is empty AND no `--add` argument was passed, jump to **Step 2 —
+Bootstrap**. Otherwise jump to **Step 3 — Token check**.
+
+## Step 2 — Bootstrap (no accounts configured)
+
+`AskUserQuestion`:
+
+```
+No Claude accounts are configured for the rotator yet. Add some now?
+  [Add now]               — collect email/display/plan, then run OAuth
+  [Use existing keychain] — skip — assume keychain already has tokens
+  [Skip]                  — exit, do nothing
+  [Help]                  — explain how the rotator works and exit
+```
+
+- `[Help]`: print one-paragraph explainer (rotator purpose, where keychain entries live, how `/plugins` toggles `account_rotation_enabled`) and exit.
+- `[Use existing keychain]`: print "Looking for `Claude-Rotation-*` entries..." and run `bash $CRED_STORE list 2>/dev/null | grep -i 'Claude-Rotation' || echo "(none found — re-run with [Add now])"`. Exit.
+- `[Skip]`: exit.
+- `[Add now]`: enter the **add loop** below.
+
+### Add loop
+
+For each new account:
+
+1. Prompt for **email** (free text). Validate `*@*.*` shape, reject empties.
+2. Prompt for **display name** (free text, defaults to email local-part).
+3. `AskUserQuestion` for **plan**:
+   ```
+   Plan tier for this account?
+     [Max]   — Claude Max ($100/$200 tier)
+     [Pro]   — Claude Pro
+     [Team]  — Team plan seat
+     [Other] — type a label
+   ```
+4. Append to in-memory accounts list. Then ask:
+   ```
+   Account added. Next?
+     [Add another]
+     [Done — start OAuth]
+     [Cancel]
+   ```
+
+Once `[Done]`, write the new accounts into `$USER_CFG` (create dirs as needed):
+
+```bash
+mkdir -p "$(dirname "$USER_CFG")"
+jq --argjson new "$NEW_ACCOUNTS_JSON" \
+   '.accounts = ((.accounts // []) + $new)' \
+   "$CFG" > "$USER_CFG.tmp" && mv "$USER_CFG.tmp" "$USER_CFG"
+```
+
+## Step 3 — Token check
+
+For each account in the merged config, check the keychain:
+
+```bash
+CRED="${CLAUDE_PLUGIN_ROOT}/lib/credential-store.sh"
+for id in $(jq -r '.accounts[].id' "$USER_CFG"); do
+  if bash "$CRED" get "Claude-Rotation" "$id" >/dev/null 2>&1; then
+    echo "✓ $id"
+  else
+    echo "✗ $id (needs OAuth)"
+  fi
+done
+```
+
+If every account is `✓`, print a success line and jump to **Step 5 — Summary**.
+
+## Step 4 — OAuth init loop
+
+For each `✗` account, run the setup script in the background and tail its log.
+
+```bash
+SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/account-rotation/setup-account.mjs"
+LOG="$HOME/.claude/logs/account-rotation/setup-${ID}-$(date +%s).log"
+mkdir -p "$(dirname "$LOG")"
+node "$SCRIPT" \
+  --email "$EMAIL" \
+  --display "$DISPLAY" \
+  --plan "$PLAN" \
+  --account-id "$ID" \
+  --gmail-poll \
+  >"$LOG" 2>&1 &
+echo "PID=$! LOG=$LOG"
+```
+
+- Launch with `run_in_background: true`.
+- Use `Monitor` (or `Read` of the log file) to surface progress lines.
+- The script:
+  1. Opens Playwright Chromium
+  2. Navigates to `claude.ai/login`, fills email, submits magic-link
+  3. Polls Gmail via `gog` (best-effort) OR waits up to 10 minutes for the user to click the link manually
+  4. Captures `sessionKey` cookie
+  5. Verifies via `GET claude.ai/api/organizations`
+  6. Writes to keychain as `Claude-Rotation-<account_id>` via `credential-store.sh`
+- **2FA / TOTP**: if the script logs `2FA prompt detected`, ask the user via `AskUserQuestion` to type the code; do NOT attempt to auto-solve.
+
+After each account completes (success or failure):
+
+```
+Result for <email>:
+  [✓ Success — continue with next]      ← only if more remain
+  [✗ Failed — view log and retry]
+  [Stop here]
+```
+
+If success and no more accounts remain, jump to **Step 5**.
+
+## Step 5 — Summary
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► ROTATE-SETUP COMPLETE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ Accounts initialized:
+   ✓ <id> (<plan>)
+   ✓ <id> (<plan>)
+   ✗ <id> (failed — re-run /ops:rotate-setup --account <email>)
+
+ Config: ~/.claude/plugins/data/ops-ops-marketplace/account-rotation-config.json
+ Keychain: Claude-Rotation-<id>
+
+ To enable automatic rotation, open /plugins → claude-ops → settings and
+ toggle "Multi-account Claude rotator" (account_rotation_enabled).
+──────────────────────────────────────────────────────
+```
+
+Exit. Do NOT auto-enable `account_rotation_enabled` — that decision belongs
+to the user, made explicitly through the plugin settings UI.
+
+## Argument handling
+
+- `--all` (default): full wizard as described above.
+- `--account <email>`: skip Step 2; only init the matching account.
+- `--add`: skip token check; jump straight to Step 2 add loop, then init.
+
+## Failure modes
+
+| Symptom | Cause | Action |
+|---|---|---|
+| `playwright install failed` | npm offline / sandbox | Tell user to run `npx playwright install chromium` then retry |
+| `oauth_failed` | login form selector changed | Open log, surface the page URL at failure, suggest `--no-headless` retry |
+| `verify_failed` | session cookie captured but rejected | Re-run; likely transient |
+| `keychain_write_failed` | no backend available | Run `bash $CRED list-backends` and surface options |
+| `no session cookie` | login flow blocked by 2FA | Re-run with `--no-headless` so user can complete in-browser |

--- a/claude-ops/skills/ops-rotate-setup/SKILL.md
+++ b/claude-ops/skills/ops-rotate-setup/SKILL.md
@@ -122,7 +122,7 @@ LOG="$HOME/.claude/logs/account-rotation/setup-${ID}-$(date +%s).log"
 mkdir -p "$(dirname "$LOG")"
 node "$SCRIPT" \
   --email "$EMAIL" \
-  --display "$DISPLAY" \
+  --display "$ACCOUNT_DISPLAY" \
   --plan "$PLAN" \
   --account-id "$ID" \
   --gmail-poll \

--- a/claude-ops/skills/ops-rotate-setup/SKILL.md
+++ b/claude-ops/skills/ops-rotate-setup/SKILL.md
@@ -60,7 +60,7 @@ No Claude accounts are configured for the rotator yet. Add some now?
 ```
 
 - `[Help]`: print one-paragraph explainer (rotator purpose, where keychain entries live, how `/plugins` toggles `account_rotation_enabled`) and exit.
-- `[Use existing keychain]`: print "Looking for `Claude-Rotation-*` entries..." and run `bash $CRED_STORE list 2>/dev/null | grep -i 'Claude-Rotation' || echo "(none found — re-run with [Add now])"`. Exit.
+- `[Use existing keychain]`: print "Looking for `Claude-Rotation-*` entries..." and run `bash $CRED_STORE backends 2>/dev/null && for id in $(jq -r '.accounts[].id' "$CFG" 2>/dev/null); do bash $CRED_STORE get "Claude-Rotation" "$id" >/dev/null 2>&1 && echo "✓ $id" || echo "✗ $id"; done || echo "(no backends available — re-run with [Add now])"`. Exit.
 - `[Skip]`: exit.
 - `[Add now]`: enter the **add loop** below.
 
@@ -184,8 +184,8 @@ to the user, made explicitly through the plugin settings UI.
 
 | Symptom | Cause | Action |
 |---|---|---|
-| `playwright install failed` | npm offline / sandbox | Tell user to run `npx playwright install chromium` then retry |
+| `playwright install failed` | npm offline / sandbox | Run `npx playwright install chromium` via Bash tool, then retry |
 | `oauth_failed` | login form selector changed | Open log, surface the page URL at failure, suggest `--no-headless` retry |
 | `verify_failed` | session cookie captured but rejected | Re-run; likely transient |
-| `keychain_write_failed` | no backend available | Run `bash $CRED list-backends` and surface options |
+| `keychain_write_failed` | no backend available | Run `bash $CRED backends` and surface options |
 | `no session cookie` | login flow blocked by 2FA | Re-run with `--no-headless` so user can complete in-browser |

--- a/claude-ops/skills/ops-rotate-setup/SKILL.md
+++ b/claude-ops/skills/ops-rotate-setup/SKILL.md
@@ -136,10 +136,15 @@ echo "PID=$! LOG=$LOG"
   1. Opens Playwright Chromium
   2. Navigates to `claude.ai/login`, fills email, submits magic-link
   3. Polls Gmail via `gog` (best-effort) OR waits up to 10 minutes for the user to click the link manually
-  4. Captures `sessionKey` cookie
+  4. Captures `sessionKey` or `__Secure-next-auth.session-token` cookie
   5. Verifies via `GET claude.ai/api/organizations`
   6. Writes to keychain as `Claude-Rotation-<account_id>` via `credential-store.sh`
-- **2FA / TOTP**: if the script logs `2FA prompt detected`, ask the user via `AskUserQuestion` to type the code; do NOT attempt to auto-solve.
+- **2FA / TOTP**: the script polls the page for two-factor prompts every 3 seconds.
+  If it detects one it logs `2FA prompt detected` to stderr. When you see that
+  line in the log, ask the user via `AskUserQuestion` to provide the TOTP code.
+  In **headless** mode the code cannot be typed into the browser — re-run the
+  account with `--no-headless` so the user can complete 2FA interactively.
+  Do NOT attempt to auto-solve 2FA.
 
 After each account completes (success or failure):
 
@@ -189,3 +194,4 @@ to the user, made explicitly through the plugin settings UI.
 | `verify_failed` | session cookie captured but rejected | Re-run; likely transient |
 | `keychain_write_failed` | no backend available | Run `bash $CRED backends` and surface options |
 | `no session cookie` | login flow blocked by 2FA | Re-run with `--no-headless` so user can complete in-browser |
+| `2FA prompt detected` + timeout | 2FA required in headless mode | Re-run with `--no-headless`; prompt user for TOTP via `AskUserQuestion` |

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -2686,6 +2686,43 @@ Mirror the webhook to the flat `discord_webhook_url` key so `scripts/ops-notify.
 
 ---
 
+### 3o — Claude account rotator OAuth (if selected)
+
+**Gate:** Only run this section if the userConfig flag `account_rotation_setup_oauth_each` is `true` (default). Skip if false.
+
+**Pre-skip optimization:** If every account in the rotation config already has a keychain token, print one line and continue:
+
+```bash
+USER_CFG="$HOME/.claude/plugins/data/ops-ops-marketplace/account-rotation-config.json"
+REPO_CFG="${CLAUDE_PLUGIN_ROOT}/scripts/account-rotation/config.json"
+CFG="$([[ -f "$USER_CFG" ]] && echo "$USER_CFG" || echo "$REPO_CFG")"
+CRED="${CLAUDE_PLUGIN_ROOT}/lib/credential-store.sh"
+
+MISSING=()
+for id in $(jq -r '.accounts[].id // empty' "$CFG" 2>/dev/null); do
+  bash "$CRED" get "Claude-Rotation" "$id" >/dev/null 2>&1 || MISSING+=("$id")
+done
+
+if [[ ${#MISSING[@]} -eq 0 ]] && [[ "$(jq -r '.accounts | length' "$CFG" 2>/dev/null)" != "0" ]]; then
+  echo "✓ Claude rotator: all accounts have keychain tokens — skipping OAuth"
+fi
+```
+
+**If accounts list is empty OR `MISSING` has entries:** delegate to the `/ops:rotate-setup` wizard. This skill embeds the same flow, so call it inline rather than duplicating logic:
+
+> Invoke the `ops-rotate-setup` skill at this point, passing the same userConfig context. The wizard handles add-loop, OAuth init, 2FA prompts, and keychain writes per Rule 4 (background by default).
+
+After it returns, print:
+
+```
+✓ Claude rotator: <N> account(s) initialized
+  Enable autorotation in /plugins → claude-ops → settings (account_rotation_enabled)
+```
+
+Do NOT auto-flip `account_rotation_enabled`. The user enables it explicitly.
+
+---
+
 ## Step 4 — Configure MCPs (if selected)
 
 For each MCP that isn't in `mcp_configured`, offer bulk setup first:


### PR DESCRIPTION
## Summary
- Adds `/ops:rotate-setup` standalone wizard skill — re-runnable OAuth init for the multi-account Claude rotator.
- Embeds the same flow as Step 3o inside `/ops:setup`, gated on userConfig `account_rotation_setup_oauth_each` (default true), and skipped when every configured account already has a `Claude-Rotation-<id>` keychain entry.
- New `scripts/account-rotation/setup-account.mjs` runs the Playwright magic-link flow against `claude.ai`, optionally polls Gmail via `gog`, captures the `sessionKey` cookie, verifies it against `claude.ai/api/organizations`, and writes via `lib/credential-store.sh`. Standalone today; see `TODO(account-rotation-fold)` for merging into `rotate.mjs` once the parallel rotation source lands.

## Notes
- Default `config.json` ships empty per Rule 0. Real account list lives at `~/.claude/plugins/data/ops-ops-marketplace/account-rotation-config.json` (gitignored).
- Wizard never auto-flips `account_rotation_enabled` — user enables explicitly in `/plugins` settings.
- 2FA / TOTP: prompts user via `AskUserQuestion`, no auto-solving.
- Background by default per Rule 4; max 4 options per `AskUserQuestion` per Rule 1.

## Test plan
- [ ] `/ops:rotate-setup` with empty config → bootstrap loop adds an account, runs OAuth, writes keychain entry
- [ ] `/ops:rotate-setup --account user@example.com` re-inits a single account
- [ ] `/ops:setup` with all accounts already keyed → prints skip line, no Playwright launch
- [ ] `/ops:setup` with one missing account → delegates to wizard, completes, returns to main flow
- [ ] `tests/test-no-secrets.sh` passes (verified locally — 11/11)
- [ ] Verify `setup-account.mjs --help` works on a clean clone after `npm install playwright`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Playwright-based OAuth/login automation flow that captures and stores `claude.ai` session cookies in the OS keychain, which is sensitive and may be brittle if the login UI/cookie names change. Also extends the credential-store CLI to accept secrets via stdin, reducing argv exposure but introducing a new CLI entrypoint used by the new setup script.
> 
> **Overview**
> Adds a new **Claude multi-account rotator OAuth initialization flow**: a standalone `/ops:rotate-setup` skill plus a new Step `3o` in `/ops:setup` (gated by `account_rotation_setup_oauth_each`) that skips when all configured accounts already have `Claude-Rotation` keychain tokens.
> 
> Introduces `scripts/account-rotation/setup-account.mjs`, which runs a Playwright magic-link login to `claude.ai`, optionally polls Gmail via `gog`, verifies the resulting session via `claude.ai/api/organizations`, and writes the token to the OS keychain while updating a per-user rotation config (repo ships a default empty `scripts/account-rotation/config.json`).
> 
> Extends `lib/credential-store.sh`’s direct-exec CLI with `set-stdin` so secrets can be passed via stdin (avoiding argv exposure), and updates help text accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41655214dc25e5cf3ffb79ad4d236cb8c5886dea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->