### PR TITLE
feat(setup): deploy auto-fix wizard + /ops:deploy-fix skill

### DIFF
--- a/claude-ops/skills/ops-deploy-fix/SKILL.md
+++ b/claude-ops/skills/ops-deploy-fix/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: ops-deploy-fix
 description: Inspect and control the deploy/build auto-fix subsystem. Use for `/ops:deploy-fix status` (last monitor runs, fixer dispatches, locks, hourly budget), `/ops:deploy-fix tail` (follow latest fixer log), `/ops:deploy-fix configure` (re-run the wizard), and `/ops:deploy-fix test` (synthetic dry-run through the pipeline). Trigger when the user mentions deploy auto-fix, post-merge monitor, build fixer, fix budget, fix-agent log, or asks why a deploy didn't get auto-fixed.
+allowed-tools:
+  - Bash
+  - Read
+  - AskUserQuestion
+  - Skill
 ---
 
 # /ops:deploy-fix — Auto-fix subsystem control surface

--- a/claude-ops/skills/ops-deploy-fix/SKILL.md
+++ b/claude-ops/skills/ops-deploy-fix/SKILL.md
@@ -90,7 +90,7 @@ jq -r '{
 
 # Monitor runs — last 5 across all repos
 ls -t "$LOGS"/monitor-*.log 2>/dev/null | head -5 | while read f; do
-  printf '%s  %s\n' "$(stat -f '%Sm' -t '%FT%RZ' "$f")" "$(basename "$f")"
+  printf '%s  %s\n' "$(stat -f '%Sm' -t '%FT%RZ' "$f" 2>/dev/null || stat --format='%y' "$f" 2>/dev/null | awk '{print $1"T"$2"Z"}')" "$(basename "$f")"
 done
 
 # Fixer dispatches — last 5
@@ -98,7 +98,7 @@ ls -t "$LOGS"/fix-*.log 2>/dev/null | head -5 | while read f; do
   pid_file="$STATE/lock-$(basename "$f" | sed 's/^fix-//; s/-[0-9]*\.log$//')"
   status="done"
   [ -f "$pid_file" ] && kill -0 "$(cat "$pid_file")" 2>/dev/null && status="in-flight"
-  printf '%s  %s  %s\n' "$(stat -f '%Sm' -t '%FT%RZ' "$f")" "$status" "$(basename "$f")"
+  printf '%s  %s  %s\n' "$(stat -f '%Sm' -t '%FT%RZ' "$f" 2>/dev/null || stat --format='%y' "$f" 2>/dev/null | awk '{print $1"T"$2"Z"}')" "$status" "$(basename "$f")"
 done
 
 # Active locks
@@ -221,7 +221,7 @@ Steps:
    - Skipping the actual `claude -p ...` dispatch in `dispatch_fix_agent`
    - Writing a `would-dispatch-<id>-<ts>.log` to `$LOGS_DIR` instead
    - Still incrementing the budget counter (so the test exercises the cap)
-   - Still firing `notify` so the user sees the channel ping
+   - Logging `[DRY-RUN] would notify <channel>` instead of firing real `notify` (no actual outbound messages during test — Rule 6)
 
    *If the trigger scripts don't yet support `--synthetic` / `OPS_DEPLOY_FIX_DRY_RUN`, surface that as a known TODO in the output and degrade to "would-have-dispatched" log-only.*
 

--- a/claude-ops/skills/ops-deploy-fix/SKILL.md
+++ b/claude-ops/skills/ops-deploy-fix/SKILL.md
@@ -1,0 +1,248 @@
+---
+name: ops-deploy-fix
+description: Inspect and control the deploy/build auto-fix subsystem. Use for `/ops:deploy-fix status` (last monitor runs, fixer dispatches, locks, hourly budget), `/ops:deploy-fix tail` (follow latest fixer log), `/ops:deploy-fix configure` (re-run the wizard), and `/ops:deploy-fix test` (synthetic dry-run through the pipeline). Trigger when the user mentions deploy auto-fix, post-merge monitor, build fixer, fix budget, fix-agent log, or asks why a deploy didn't get auto-fixed.
+---
+
+# /ops:deploy-fix — Auto-fix subsystem control surface
+
+This skill is the operator console for the post-merge + build-failure auto-fix loop installed by `/ops:setup` Step 6.5a. The underlying daemons, hooks, and prompts live in `${CLAUDE_PLUGIN_ROOT}/scripts/`, `${CLAUDE_PLUGIN_ROOT}/hooks/`, and `${CLAUDE_PLUGIN_ROOT}/prompts/`. State lives in `~/.claude/state/ops-deploy-fix/`. Logs live in `~/.claude/logs/ops-deploy-fix/`.
+
+**Plugin rules apply (see `claude-ops/CLAUDE.md`).** In particular:
+- Rule 0 — never echo personal data (slugs are fine, but redact tokens, webhooks, emails)
+- Rule 1 — max 4 options per `AskUserQuestion`
+- Rule 4 — background by default during `configure`
+- Rule 5 — destructive ops (clearing locks, wiping state) require explicit per-action confirmation
+- Rule 6 — this skill never sends outbound comms; if a future flow needs to, use the universal send gate
+
+## Arguments
+
+The first positional argument selects the subcommand. If absent, present:
+
+```
+/ops:deploy-fix — what do you want to do?
+  [status]
+  [tail]
+  [configure]
+  [test]
+```
+
+Subcommands:
+
+| Subcommand   | Purpose                                                                  |
+| ------------ | ------------------------------------------------------------------------ |
+| `status`     | Dashboard of recent monitor runs, fixer dispatches, locks, budget        |
+| `tail`       | Follow the latest fixer log live                                         |
+| `configure`  | Re-run the wizard from `/ops:setup` Step 6.5a                            |
+| `test`       | Send a synthetic failure through the pipeline (dry-run, no real fix)     |
+
+---
+
+## Subcommand: `status`
+
+Print a compact dashboard. Read all data via Bash; favor parallel reads.
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► DEPLOY-FIX STATUS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ Master switch:    <on|off>          (deploy_fix_enabled)
+ Auto-dispatch:    <on|off>          (auto_dispatch_fixer)
+ Danger flag:      <on|off>          (allow_dangerous)
+ Budget cap:       <N>/hour/repo     (max_fixes_per_hour)
+ Notify channel:   <macos|ntfy|discord|none>
+ Fix model:        <haiku|sonnet|opus>
+
+ Last 5 monitor runs:
+   2026-04-26T08:14Z  owner/repo-a:dev   merge-watch         deploy-success
+   2026-04-26T08:11Z  owner/repo-b:main  build-watch         transient → rerun
+   ...
+
+ Last 5 fixer dispatches:
+   2026-04-26T08:09Z  owner/repo-b:main  build-fix.md   in-flight   pid 41123
+   2026-04-26T07:42Z  owner/repo-a:dev   deploy-fix.md  done        log:fix-...log
+
+ Active locks:
+   owner/repo-b:main:build  pid=41123 (alive)
+
+ Hourly budget remaining (this hour, <YYYYMMDD-HH>):
+   owner/repo-a   2 / 3
+   owner/repo-b   1 / 3
+──────────────────────────────────────────────────────
+```
+
+**Data sources:**
+
+```bash
+PREFS=~/.claude/plugins/data/ops-ops-marketplace/preferences.json
+STATE=~/.claude/state/ops-deploy-fix
+LOGS=~/.claude/logs/ops-deploy-fix
+
+# Config snapshot (all keys read with defaults from plugin.json userConfig)
+jq -r '{
+  deploy_fix_enabled, auto_dispatch_fixer, allow_dangerous,
+  max_fixes_per_hour, notify_channel, fix_model
+}' "$PREFS" 2>/dev/null
+
+# Monitor runs — last 5 across all repos
+ls -t "$LOGS"/monitor-*.log 2>/dev/null | head -5 | while read f; do
+  printf '%s  %s\n' "$(stat -f '%Sm' -t '%FT%RZ' "$f")" "$(basename "$f")"
+done
+
+# Fixer dispatches — last 5
+ls -t "$LOGS"/fix-*.log 2>/dev/null | head -5 | while read f; do
+  pid_file="$STATE/lock-$(basename "$f" | sed 's/^fix-//; s/-[0-9]*\.log$//')"
+  status="done"
+  [ -f "$pid_file" ] && kill -0 "$(cat "$pid_file")" 2>/dev/null && status="in-flight"
+  printf '%s  %s  %s\n' "$(stat -f '%Sm' -t '%FT%RZ' "$f")" "$status" "$(basename "$f")"
+done
+
+# Active locks
+for f in "$STATE"/lock-*; do
+  [ -f "$f" ] || continue
+  pid=$(cat "$f")
+  if kill -0 "$pid" 2>/dev/null; then
+    echo "$(basename "$f" | sed 's/^lock-//')  pid=$pid (alive)"
+  fi
+done
+
+# Hourly budget — read all budget files for current hour
+hour=$(date +%Y%m%d-%H)
+cap=$(jq -r '.max_fixes_per_hour // 3' "$PREFS")
+for f in "$STATE"/budget-*-"$hour"; do
+  [ -f "$f" ] || continue
+  slug=$(basename "$f" | sed "s/^budget-//; s/-$hour\$//")
+  used=$(cat "$f")
+  echo "$slug  $((cap - used)) / $cap"
+done
+```
+
+After the dashboard, if any lock is older than the configured `watcher_timeout_seconds`, surface a `⚠️ Stale lock:` line and offer:
+
+```
+Stale lock detected for <repo>. Action?
+  [Inspect log]
+  [Clear lock (Rule 5 — destructive)]
+  [Leave it]
+  [Skip]
+```
+
+Only on `Clear lock` should you delete the file (per-action confirmation per Rule 5).
+
+---
+
+## Subcommand: `tail`
+
+Tail the most-recent fixer log. Resolve via `ls -t`:
+
+```bash
+LATEST=$(ls -t ~/.claude/logs/ops-deploy-fix/fix-*.log 2>/dev/null | head -1)
+if [ -z "$LATEST" ]; then
+  echo "No fixer logs yet. Trigger one with /ops:deploy-fix test or wait for a real failure."
+  exit 0
+fi
+echo "▸ Tailing $LATEST (Ctrl-C to stop)"
+tail -f "$LATEST"
+```
+
+Run via Bash with `run_in_background: true` and a long timeout so the user can read the stream as it grows. Print the resolved log path and the spawned shell PID up-front so the user knows what's running.
+
+If a second positional arg `--lines N` is passed, do `tail -n N -f`. If `--no-follow`, drop `-f`.
+
+---
+
+## Subcommand: `configure`
+
+Re-run the wizard from `/ops:setup` Step 6.5a, plus optionally 6.5b/c/d. Implementation: route into the `setup` skill with section filter.
+
+Flow:
+
+1. Read current state from `$PREFS_PATH`. Print compact summary (same fields as `status`, no logs).
+2. Ask:
+   ```
+   What do you want to reconfigure?
+     [Deploy auto-fix wizard (6.5a)]
+     [Recap marquee (6.5b)]
+     [Task* reminder (6.5c)]
+     [Account rotation toggle (6.5d)]
+   ```
+3. Execute the corresponding sub-flow inline by following Step 6.5 of `skills/setup/SKILL.md` — same questions, same persistence, same Rule-3 "never silently skip" semantics.
+4. After persistence, print:
+   ```
+   ✓ Reconfigured. Daemons & hooks pick up the new prefs on the next event — no restart required.
+   ```
+
+Use `run_in_background: true` (Rule 4) for any CLI install / brew / curl / `tmux source-file` triggered along the way.
+
+---
+
+## Subcommand: `test`
+
+Synthetic dry-run through the pipeline. **No real fix dispatch — no agent runs.** Confirms wiring: hooks fire → monitor classifies → notify channel pings → state files written → would-dispatch path logged.
+
+Steps:
+
+1. Pre-flight check:
+   ```bash
+   PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+   [ -z "$PLUGIN_ROOT" ] && PLUGIN_ROOT=$(find ~/.claude -type d -name claude-ops 2>/dev/null | head -1)
+   COMMON="$PLUGIN_ROOT/scripts/lib/deploy-fix-common.sh"
+   [ -f "$COMMON" ] || { echo "✗ deploy-fix-common.sh missing — re-install the plugin"; exit 1; }
+   ```
+
+2. Ask:
+   ```
+   What should the synthetic failure look like?
+     [Build failure (npm run build:* exit 1)]
+     [Deploy workflow failure (gh actions check_run)]
+     [Health check failure (curl /health 503)]
+     [Version mismatch (served SHA != merged SHA)]
+   ```
+
+3. Generate a fake event payload matching the chosen kind. Set env var `OPS_DEPLOY_FIX_DRY_RUN=1` and invoke the relevant trigger script:
+
+   ```bash
+   export OPS_DEPLOY_FIX_DRY_RUN=1
+   export OPS_DEPLOY_FIX_TEST_REPO="your-org/your-repo"   # placeholder per Rule 0
+   export OPS_DEPLOY_FIX_TEST_BASE="dev"
+   case "$kind" in
+     build)   bash "$PLUGIN_ROOT/bin/ops-deploy-fix-build-trigger" --synthetic ;;
+     deploy)  bash "$PLUGIN_ROOT/bin/ops-deploy-fix-merge-trigger" --synthetic ;;
+     health)  bash "$PLUGIN_ROOT/scripts/ops-deploy-monitor.sh" --synthetic-health ;;
+     version) bash "$PLUGIN_ROOT/scripts/ops-deploy-monitor.sh" --synthetic-version ;;
+   esac
+   ```
+
+   Trigger scripts must honor `OPS_DEPLOY_FIX_DRY_RUN=1` by:
+   - Skipping the actual `claude -p ...` dispatch in `dispatch_fix_agent`
+   - Writing a `would-dispatch-<id>-<ts>.log` to `$LOGS_DIR` instead
+   - Still incrementing the budget counter (so the test exercises the cap)
+   - Still firing `notify` so the user sees the channel ping
+
+   *If the trigger scripts don't yet support `--synthetic` / `OPS_DEPLOY_FIX_DRY_RUN`, surface that as a known TODO in the output and degrade to "would-have-dispatched" log-only.*
+
+4. Print the resulting `would-dispatch-*.log` path and a one-line classification result (transient? dedup-hit? budget-exhausted? would-dispatch-template=`<file>`).
+
+5. Offer:
+   ```
+   Test complete. Next?
+     [Tail the would-dispatch log]
+     [Run another test]
+     [Show status dashboard]
+     [Done]
+   ```
+
+---
+
+## Failure modes / hand-offs
+
+- **No prefs file** → tell the user to run `/ops:setup` (or `/ops:deploy-fix configure`) first.
+- **`claude` CLI missing** (status / test) → instruct via output, do not auto-install.
+- **`jq` missing** → run `brew install jq` in background (Rule 4) and retry.
+- **Stale lock detection** → see `status` flow above, requires Rule-5 confirmation to clear.
+- **Notify channel mis-set** (e.g. `discord` selected but no webhook) → on `status`, surface as `⚠️ notify_channel=discord but no webhook URL configured` and offer `[Reconfigure now]`.
+
+## Files this skill reads / writes
+
+- Read-only: `~/.claude/plugins/data/ops-ops-marketplace/preferences.json`, `~/.claude/state/ops-deploy-fix/*`, `~/.claude/logs/ops-deploy-fix/*`, `${CLAUDE_PLUGIN_ROOT}/scripts/lib/deploy-fix-common.sh`, `${CLAUDE_PLUGIN_ROOT}/prompts/{build-fix,deploy-fix}.md`
+- Write (with explicit confirmation only): lock files in `~/.claude/state/ops-deploy-fix/lock-*` (clear on stale)
+- Write (via `configure` subcommand): the prefs file, via the merge pattern in Step 6.5

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -223,7 +223,7 @@ How would you like to run setup?
 
 If the user selects "Set up everything", select ALL sections across all batches and run them in order (Step 2 → 2b → 2c → 3 → 4 → 5 → 5b → 6 → 6.5 → 7), skipping any already fully configured. Within each step, use the "Configure all" fast-path where available.
 
-If the user selects "Re-run a specific section", show a single `AskUserQuestion` listing the section names (cli, daemon, channels, mcp, registry, prefs, deploy-fix, env, ecom, mktg, voice, revenue) — paginated 4 per page per Rule 1 — and jump directly to that step. The `deploy-fix` section routes to Step 6.5.
+If the user selects "Re-run a specific section", use sequential `AskUserQuestion` calls (paginated 4 options per page per Rule 1) to let the user pick from the section names (cli, daemon, channels, mcp, registry, prefs, deploy-fix, env, ecom, mktg, voice, revenue), then jump directly to that step. The `deploy-fix` section routes to Step 6.5.
 
 If the user selects "Pick sections", proceed with the batched selection below.
 
@@ -3104,11 +3104,10 @@ Persist `notify_channel` ∈ `macos|ntfy|discord|none`.
   ```
   Discord webhook URL?
     [Paste webhook URL]
-    [Reuse existing channel webhook (discord_webhook_url)]
     [Skip — downgrade to no notifications]
   ```
 
-  On paste, write `discord_default_webhook_url` (sensitive). On reuse, copy `discord_webhook_url` → `discord_default_webhook_url` so the deploy-fix sink finds it. On skip, downgrade `notify_channel` to `none`.
+  On paste, write `discord_default_webhook_url` (sensitive). On skip, downgrade `notify_channel` to `none`.
 
 - `macos` selected → background-check `command -v terminal-notifier` (Rule 4). If missing, run `brew install terminal-notifier` with `run_in_background: true` and continue.
 
@@ -3175,7 +3174,7 @@ jq '. + {
   ntfy_topic: "<topic>",
   discord_default_webhook_url: "<url>",
   deploy_fix: { configured_at: "<ISO timestamp>", wizard_version: 1 }
-}' "$PREFS_FILE" > /tmp/p.$$ && mv /tmp/p.$$ "$PREFS_FILE"
+}' "$PREFS_PATH" > /tmp/p.$$ && mv /tmp/p.$$ "$PREFS_PATH"
 ```
 
 Omit any key whose value is empty/unset. Use `lib/credential-store` for sensitive values rather than plaintext.
@@ -3231,7 +3230,7 @@ Enable multi-account Claude rotator?
 Persist `account_rotation_enabled` (bool). On `Yes`, print:
 
 ```
-✓ Account rotation toggle enabled. Run /ops:setup --section account-rotation later to wire OAuth per account.
+✓ Account rotation toggle enabled. Run /ops:setup --section deploy-fix later to wire OAuth per account.
 ```
 
 ### 6.5 — completion print
@@ -3334,6 +3333,7 @@ If `$ARGUMENTS` contains a specific section name, jump straight to that section:
 | `daemon`, `background`                 | Step 5b |
 | `prefs`, `preferences`                 | Step 6  |
 | `env`, `shell`                         | Step 7  |
+| `deploy-fix`, `auto-fix`               | Step 6.5|
 
 Empty argument → full wizard from Step 0.
 

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -221,9 +221,9 @@ How would you like to run setup?
   [Re-run a specific section — I know what I need]
 ```
 
-If the user selects "Set up everything", select ALL sections across all batches and run them in order (Step 2 → 2b → 2c → 3 → 4 → 5 → 5b → 6 → 7), skipping any already fully configured. Within each step, use the "Configure all" fast-path where available.
+If the user selects "Set up everything", select ALL sections across all batches and run them in order (Step 2 → 2b → 2c → 3 → 4 → 5 → 5b → 6 → 6.5 → 7), skipping any already fully configured. Within each step, use the "Configure all" fast-path where available.
 
-If the user selects "Re-run a specific section", show a single `AskUserQuestion` listing the section names (cli, daemon, channels, mcp, registry, prefs, env, ecom, mktg, voice, revenue) and jump directly to that step.
+If the user selects "Re-run a specific section", show a single `AskUserQuestion` listing the section names (cli, daemon, channels, mcp, registry, prefs, deploy-fix, env, ecom, mktg, voice, revenue) — paginated 4 per page per Rule 1 — and jump directly to that step. The `deploy-fix` section routes to Step 6.5.
 
 If the user selects "Pick sections", proceed with the batched selection below.
 
@@ -255,6 +255,15 @@ Use `AskUserQuestion` with `multiSelect: true`. Offer **only sections that need 
 | Configure marketing | mktg     | Set Klaviyo, Meta Ads, GA4, Search Console keys               |
 | Configure voice     | voice    | Set Bland AI, ElevenLabs, Groq API keys                       |
 | Configure revenue   | revenue  | Set Stripe + RevenueCat keys for live MRR tracking            |
+
+**Batch 4 — Auto-fix subsystem + auxiliary daemons:**
+
+| Option              | Header      | Description                                                       |
+| ------------------- | ----------- | ----------------------------------------------------------------- |
+| Deploy auto-fix     | deploy-fix  | Configure post-merge + build-failure auto-fix (Step 6.5a)         |
+| Recap marquee       | marquee     | tmux digest of parallel Claude sessions (Step 6.5b)               |
+| Task* reminder      | task-rem    | PostToolUse nudge to use TaskCreate/TaskUpdate (Step 6.5c)        |
+| Account rotation    | rotator     | Multi-account Claude rotator toggle (Step 6.5d)                   |
 
 Present each batch as a separate `AskUserQuestion` call. Skip batches where all items are already green. Collect all selections across batches and run each selected section in order.
 
@@ -2994,6 +3003,249 @@ Write to `$PREFS_PATH`:
 ```
 
 If the file already exists, **merge** — don't overwrite. Read with `jq`, apply updates with `jq '. + { ... }'`, write back.
+
+---
+
+## Step 6.5 — Auto-fix subsystem + auxiliary daemons (if selected)
+
+This step configures four subsystems that ship with the plugin but stay opt-in: the deploy/build auto-fix loop, the recap marquee (tmux digest), the periodic Task* tool reminder, and the multi-account Claude rotator. All settings persist into `$PREFS_PATH` under the same keys declared in `.claude-plugin/plugin.json` `userConfig`, so the running daemons and hooks pick them up immediately.
+
+**Re-run guard (Rule 3 compliant).** Before each sub-flow, check `$PREFS_PATH` for an existing block. If found, show current state and ask:
+
+```
+Deploy auto-fix is already configured. What now?
+  [Keep current settings]
+  [Re-run wizard]
+  [Show full config]
+  [Skip]
+```
+
+Only continue into the wizard on `Re-run wizard`. Same pattern for `recap_marquee_enabled`, `task_reminder_enabled`, and `account_rotation_enabled`.
+
+All `jq` writes use the merge pattern from Step 6: read → `jq '. + { ... }'` → write to a temp file → `mv`. Never overwrite the file.
+
+### 6.5a — Deploy auto-fix wizard
+
+**Step A1 — master switch** (`AskUserQuestion`, 4 options — Rule 1):
+
+```
+Enable deploy auto-fix?
+  [Yes — full autonomy (monitor + dispatch fixer)]
+  [Yes — notify only, no agent dispatch]
+  [Skip]
+  [Configure later]
+```
+
+Mapping:
+- `Yes — full autonomy` → `deploy_fix_enabled=true`, `auto_dispatch_fixer=true`
+- `Yes — notify only` → `deploy_fix_enabled=true`, `auto_dispatch_fixer=false`
+- `Skip` → `deploy_fix_enabled=false`, persist and jump to 6.5b
+- `Configure later` → record `deploy_fix.deferred=true` and jump to 6.5b
+
+**Step A2 — behavior toggles** (only when enabled). `AskUserQuestion` `multiSelect: true`, exactly 4 options:
+
+```
+Which auto-fix behaviors should run? (multi-select)
+  [monitor_post_merge — watch deploy after PR merge]
+  [monitor_build_failures — auto-fix local `npm run build:*` failures]
+  [audit_health_after_deploy — curl /health after deploy]
+  [verify_served_commit — check served SHA matches merged SHA]
+```
+
+Persist each as a top-level boolean key. Unchecked = `false`.
+
+**Step A3 — danger flag:**
+
+```
+Allow fixer to skip permission prompts (true unattended autonomy)?
+  [Yes — pass --dangerously-skip-permissions]
+  [No — safer, may prompt mid-fix]
+  [Skip]
+```
+
+Persist `allow_dangerous` (true/false). `Skip` → leave default (`false`).
+
+**Step A4 — hourly budget:**
+
+```
+Per-repo hourly fix budget?
+  [1 — conservative]
+  [3 — default]
+  [5]
+  [10 — aggressive]
+```
+
+Persist `max_fixes_per_hour` (integer).
+
+**Step A5 — notification channel:**
+
+```
+Notification channel for failures?
+  [macOS — terminal-notifier]
+  [ntfy.sh — phone push]
+  [Discord webhook]
+  [None]
+```
+
+Persist `notify_channel` ∈ `macos|ntfy|discord|none`.
+
+**Step A6 — channel credentials** (Rule 3 — never silently skip):
+
+- `ntfy` selected and `ntfy_topic` empty in prefs → ask for topic. The topic name is public (not sensitive). If user picks `Skip`, downgrade `notify_channel` to `none` and tell them why.
+
+  ```
+  ntfy.sh topic name?
+    [Paste topic]
+    [Skip — downgrade to no notifications]
+  ```
+
+- `discord` selected and no `discord_default_webhook_url` AND no `discord_webhook_url` in prefs → ask for webhook URL with `sensitive: true`:
+
+  ```
+  Discord webhook URL?
+    [Paste webhook URL]
+    [Reuse existing channel webhook (discord_webhook_url)]
+    [Skip — downgrade to no notifications]
+  ```
+
+  On paste, write `discord_default_webhook_url` (sensitive). On reuse, copy `discord_webhook_url` → `discord_default_webhook_url` so the deploy-fix sink finds it. On skip, downgrade `notify_channel` to `none`.
+
+- `macos` selected → background-check `command -v terminal-notifier` (Rule 4). If missing, run `brew install terminal-notifier` with `run_in_background: true` and continue.
+
+Use the `lib/credential-store.{sh,mjs}` helpers when persisting sensitive values so they land in the keychain instead of plaintext prefs.
+
+**Step A7 — registry seeding:**
+
+```
+Seed service registry from your repos?
+  [Yes — scan ~/Projects + ~ for git repos]
+  [No — I'll edit ~/.claude/config/post-merge-services.json by hand]
+  [Skip]
+```
+
+If yes, run in background (Rule 4):
+
+```bash
+find ~/Projects ~ -maxdepth 3 -type d -name .git 2>/dev/null \
+  | xargs -I{} dirname {} \
+  | while read repo; do
+      slug=$(cd "$repo" && gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)
+      [ -n "$slug" ] && echo "$slug|$repo"
+    done > /tmp/ops-deploy-fix-detected.$$
+```
+
+Read the detected slugs, dedupe, then prompt the user **paginated 4 at a time per `AskUserQuestion`** (Rule 1) for the health URL of each repo's `:dev` and `:main` bases.
+
+Per-repo prompt:
+
+```
+Health URL for <slug>:dev? (leave blank to skip)
+  [Paste URL]
+  [Reuse last pattern — apply *-dev → * for :main]
+  [Skip this repo]
+  [Skip remaining repos]
+```
+
+For each accepted entry, append to `~/.claude/config/post-merge-services.json` (create file if missing) using the merge pattern:
+
+```bash
+mkdir -p ~/.claude/config
+[ -f ~/.claude/config/post-merge-services.json ] || echo '{}' > ~/.claude/config/post-merge-services.json
+jq --arg k "$slug:dev" --arg h "$health_url" --arg v "$version_url" \
+  '. + { ($k): { health: $h, version: $v } }' \
+  ~/.claude/config/post-merge-services.json > /tmp/reg.$$ \
+  && mv /tmp/reg.$$ ~/.claude/config/post-merge-services.json
+```
+
+Tell the user the count written and the file path.
+
+**Step A8 — persist the deploy-fix block:**
+
+```bash
+jq '. + {
+  deploy_fix_enabled: <bool>,
+  monitor_post_merge: <bool>,
+  monitor_build_failures: <bool>,
+  audit_health_after_deploy: <bool>,
+  verify_served_commit: <bool>,
+  auto_dispatch_fixer: <bool>,
+  allow_dangerous: <bool>,
+  max_fixes_per_hour: <int>,
+  notify_channel: "<channel>",
+  ntfy_topic: "<topic>",
+  discord_default_webhook_url: "<url>",
+  deploy_fix: { configured_at: "<ISO timestamp>", wizard_version: 1 }
+}' "$PREFS_FILE" > /tmp/p.$$ && mv /tmp/p.$$ "$PREFS_FILE"
+```
+
+Omit any key whose value is empty/unset. Use `lib/credential-store` for sensitive values rather than plaintext.
+
+### 6.5b — Recap marquee (tmux digest)
+
+```
+Enable recap marquee daemon? (one-line digest of all parallel Claude sessions in tmux status-right)
+  [Yes — auto-configure ~/.tmux.conf]
+  [Yes — toggle on, don't touch tmux.conf]
+  [No]
+  [Skip]
+```
+
+- `Yes — auto-configure` → `recap_marquee_enabled=true`, `recap_marquee_auto_configure_tmux=true`. In background (Rule 4): grep `~/.tmux.conf` for `ops-recap-marquee`. If absent, append the source line and run `tmux source-file ~/.tmux.conf` (only if `tmux info` succeeds — i.e. server is running).
+- `Yes — no tmux change` → `recap_marquee_enabled=true`, `recap_marquee_auto_configure_tmux=false`.
+- `No` → both keys `false`.
+- `Skip` → leave defaults, mark `recap_marquee.deferred=true`.
+
+### 6.5c — Periodic Task* tool reminder
+
+```
+Enable Task* tool reminder hook?
+  [Yes — default threshold (10 calls)]
+  [Yes — custom threshold]
+  [No — disable hook]
+  [Skip]
+```
+
+If `custom threshold`, follow up:
+
+```
+Reminder threshold (tool calls without a Task*)?
+  [5]
+  [10]
+  [20]
+  [50]
+```
+
+Persist `task_reminder_enabled` (bool) and `task_reminder_threshold` (int).
+
+### 6.5d — Account rotation toggle (toggle only)
+
+The full multi-account OAuth wizard is a separate task — this step only flips the master toggle.
+
+```
+Enable multi-account Claude rotator?
+  [Yes — enable toggle, OAuth wizard later]
+  [No]
+  [Skip]
+```
+
+Persist `account_rotation_enabled` (bool). On `Yes`, print:
+
+```
+✓ Account rotation toggle enabled. Run /ops:setup --section account-rotation later to wire OAuth per account.
+```
+
+### 6.5 — completion print
+
+After all four sub-flows, print:
+
+```
+✓ Deploy auto-fix:    <on/off>  (autonomy=<full|notify|off>, budget=<N>/hr, notify=<channel>)
+✓ Recap marquee:      <on/off>  (tmux=<auto|manual>)
+✓ Task reminder:      <on/off>  (threshold=<N>)
+✓ Account rotation:   <on/off>  (OAuth wizard pending)
+```
+
+Then continue to Step 7.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds Step 6.5 to `/ops:setup` (`skills/setup/SKILL.md`) that walks the user through configuring the deploy/build auto-fix subsystem: master switch, behavior multi-select, danger flag, hourly budget, notify channel + per-channel creds, and registry seeding from `~/Projects` + `~`. Also covers recap marquee (with auto-tmux), Task* reminder + threshold, and the account-rotation toggle (OAuth wizard deferred to a follow-up).
- All settings persist into `~/.claude/plugins/data/ops-ops-marketplace/preferences.json` using the existing merge pattern, under the same keys declared in `.claude-plugin/plugin.json` `userConfig` (`deploy_fix_enabled`, `monitor_post_merge`, `monitor_build_failures`, `audit_health_after_deploy`, `verify_served_commit`, `auto_dispatch_fixer`, `allow_dangerous`, `max_fixes_per_hour`, `notify_channel`, `recap_marquee_enabled`, `recap_marquee_auto_configure_tmux`, `task_reminder_enabled`, `task_reminder_threshold`, `account_rotation_enabled`).
- Adds a new dedicated `skills/ops-deploy-fix/SKILL.md` exposing four subcommands: `status` (last 5 monitor runs / fixer dispatches / active locks / hourly budget remaining), `tail` (follow latest fixer log), `configure` (re-run the wizard inline), `test` (synthetic dry-run through the pipeline via `OPS_DEPLOY_FIX_DRY_RUN=1`).
- Wires Step 6.5 into Step 1's section selector (new Batch 4) and the orchestration order (`Step 2 → 2b → 2c → 3 → 4 → 5 → 5b → 6 → 6.5 → 7`).

## Plugin rules respected
- Rule 0 — no personal data; placeholder slugs only
- Rule 1 — every `AskUserQuestion` ≤4 options; multi-select likewise; registry seeding paginated 4-per-page
- Rule 2 — wizard runs CLI installs (brew, tmux source) itself, never delegates to user
- Rule 3 — re-run guard surfaces `[Keep / Re-run / Show / Skip]`; notify-channel cred prompts surface `[Paste / Reuse / Skip]` instead of silently skipping
- Rule 4 — registry scan, terminal-notifier install, tmux source-file all `run_in_background: true`
- Rule 5 — clearing stale fixer locks requires per-action confirmation
- Rule 6 — skill never sends outbound comms; explicit note in SKILL.md

## Test plan
- [ ] Run `/ops:setup` → reaches Step 6.5 → all four sub-flows complete → prefs file contains new keys
- [ ] Re-run `/ops:setup` → re-run guard surfaces `[Keep / Re-run / Show / Skip]`
- [ ] `/ops:deploy-fix status` → dashboard renders even with empty state dirs
- [ ] `/ops:deploy-fix tail` → resolves latest log or prints helpful empty-state hint
- [ ] `/ops:deploy-fix configure` → routes back into Step 6.5 sub-flows
- [ ] `/ops:deploy-fix test` → synthetic event respects `OPS_DEPLOY_FIX_DRY_RUN=1` (note: trigger scripts may need follow-up patch to honor flag)
- [ ] `tests/test-no-secrets.sh` passes (verified locally: 11/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/160" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new setup flow that configures an autonomous deploy/build auto-fix subsystem (including danger flag, dispatch/budget controls, and notification credentials), which can materially change post-merge behavior if enabled. Risk is limited to configuration/orchestration docs but touches operational automation and lock/budget handling.
> 
> **Overview**
> Adds a new **Step 6.5** to `/ops:setup` that guides users through enabling and configuring the deploy/build auto-fix loop (behavior toggles, unattended autonomy `allow_dangerous`, hourly fix budget, notification channel + credential prompts, and optional service-registry seeding), plus related opt-in helpers (recap marquee tmux integration, Task* reminder threshold, and account-rotation toggle).
> 
> Introduces a new `/ops:deploy-fix` skill with subcommands for **status** (recent monitor/fixer activity, locks, remaining budget + stale lock remediation), **tail** (follow latest fixer log), **configure** (re-run the new Step 6.5 flows), and **test** (synthetic dry-run path using `OPS_DEPLOY_FIX_DRY_RUN`).
> 
> Updates the setup section selector/orchestration to include the new `deploy-fix` section and ensure it runs in the main setup order before shell env export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3da6af4f88828e7189af67d4397c8989a43dcbd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->