### PR TITLE
feat(recap): fold multi-session digest marquee into claude-ops

### DIFF
--- a/claude-ops/hooks/hooks.json
+++ b/claude-ops/hooks/hooks.json
@@ -54,6 +54,11 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-task-reminder 2>/dev/null || true",
             "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "[ \"${CLAUDE_PLUGIN_USERCONFIG_RECAP_MARQUEE_ENABLED:-true}\" = \"true\" ] && sh ${CLAUDE_PLUGIN_ROOT}/hooks/recap-tool-activity.sh 2>/dev/null || true",
+            "timeout": 2
           }
         ]
       }
@@ -64,6 +69,11 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-post-session-cleanup 2>/dev/null || true"
+          },
+          {
+            "type": "command",
+            "command": "[ \"${CLAUDE_PLUGIN_USERCONFIG_RECAP_MARQUEE_ENABLED:-true}\" = \"true\" ] && sh ${CLAUDE_PLUGIN_ROOT}/hooks/recap-capture.sh 2>/dev/null || true",
+            "timeout": 3
           }
         ]
       }

--- a/claude-ops/hooks/hooks.json
+++ b/claude-ops/hooks/hooks.json
@@ -57,7 +57,7 @@
           },
           {
             "type": "command",
-            "command": "[ \"${CLAUDE_PLUGIN_USERCONFIG_RECAP_MARQUEE_ENABLED:-true}\" = \"true\" ] && sh ${CLAUDE_PLUGIN_ROOT}/hooks/recap-tool-activity.sh 2>/dev/null || true",
+            "command": "[ \"${CLAUDE_PLUGIN_USERCONFIG_RECAP_MARQUEE_ENABLED:-false}\" = \"true\" ] && sh ${CLAUDE_PLUGIN_ROOT}/hooks/recap-tool-activity.sh 2>/dev/null || true",
             "timeout": 2
           }
         ]
@@ -72,7 +72,7 @@
           },
           {
             "type": "command",
-            "command": "[ \"${CLAUDE_PLUGIN_USERCONFIG_RECAP_MARQUEE_ENABLED:-true}\" = \"true\" ] && sh ${CLAUDE_PLUGIN_ROOT}/hooks/recap-capture.sh 2>/dev/null || true",
+            "command": "[ \"${CLAUDE_PLUGIN_USERCONFIG_RECAP_MARQUEE_ENABLED:-false}\" = \"true\" ] && sh ${CLAUDE_PLUGIN_ROOT}/hooks/recap-capture.sh 2>/dev/null || true",
             "timeout": 3
           }
         ]

--- a/claude-ops/hooks/recap-capture.sh
+++ b/claude-ops/hooks/recap-capture.sh
@@ -9,8 +9,13 @@ transcript=$(echo "$input" | jq -r '.transcript_path // ""')
 [ -z "$transcript" ] || [ ! -f "$transcript" ] && exit 0
 
 # Walk transcript bottom-up looking for the most recent assistant turn that has
-# actual text content (not just tool_use blocks).
-last_text=$(tail -r "$transcript" 2>/dev/null | awk '
+# actual text content (not just tool_use blocks). Linux: tac; macOS BSD: tail -r.
+if command -v tac >/dev/null 2>&1; then
+  _transcript_rev_lines() { tac "$1" 2>/dev/null; }
+else
+  _transcript_rev_lines() { tail -r "$1" 2>/dev/null; }
+fi
+last_text=$(_transcript_rev_lines "$transcript" | awk '
   /"type":"assistant"/ { print; if (++n >= 30) exit }
 ' | while IFS= read -r line; do
   t=$(printf '%s' "$line" | jq -r '.message.content[]? | select(.type=="text") | .text' 2>/dev/null | tr '\n' ' ' | sed 's/  */ /g')

--- a/claude-ops/hooks/recap-capture.sh
+++ b/claude-ops/hooks/recap-capture.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Stop hook: capture a one-line recap of the last assistant turn into
+# /tmp/claude-recap-${session_id}. Read by the recap daemon to assemble the
+# multi-session digest displayed in the tmux marquee.
+input=$(cat)
+session_id=$(echo "$input" | jq -r '.session_id // ""')
+transcript=$(echo "$input" | jq -r '.transcript_path // ""')
+[ -z "$session_id" ] && exit 0
+[ -z "$transcript" ] || [ ! -f "$transcript" ] && exit 0
+
+# Walk transcript bottom-up looking for the most recent assistant turn that has
+# actual text content (not just tool_use blocks).
+last_text=$(tail -r "$transcript" 2>/dev/null | awk '
+  /"type":"assistant"/ { print; if (++n >= 30) exit }
+' | while IFS= read -r line; do
+  t=$(printf '%s' "$line" | jq -r '.message.content[]? | select(.type=="text") | .text' 2>/dev/null | tr '\n' ' ' | sed 's/  */ /g')
+  if [ -n "$t" ]; then
+    printf '%s' "$t"
+    break
+  fi
+done)
+
+if [ -z "$last_text" ]; then
+  : > "/tmp/claude-recap-${session_id}"
+  exit 0
+fi
+
+# Strip ANSI, markdown bullets, code fences; keep first 240 chars.
+clean=$(printf '%s' "$last_text" \
+  | sed -E 's/\x1B\[[0-9;]*[a-zA-Z]//g' \
+  | sed -E 's/^[ *#>`-]+//; s/`//g' \
+  | head -c 240)
+
+printf '%s' "$clean" > "/tmp/claude-recap-${session_id}"
+exit 0

--- a/claude-ops/hooks/recap-capture.sh
+++ b/claude-ops/hooks/recap-capture.sh
@@ -25,6 +25,9 @@ last_text=$(_transcript_rev_lines "$transcript" | awk '
   fi
 done)
 
+# Restrict file permissions — /tmp is world-readable on most systems
+umask 177
+
 if [ -z "$last_text" ]; then
   : > "/tmp/claude-recap-${session_id}"
   exit 0

--- a/claude-ops/hooks/recap-tool-activity.sh
+++ b/claude-ops/hooks/recap-tool-activity.sh
@@ -42,5 +42,5 @@ esac
 ts=$(date '+%H:%M:%S')
 line="[$ts] $label"
 
-[ -n "$session_id" ] && printf '%s' "$line" > "/tmp/claude-recap-${session_id}"
+[ -n "$session_id" ] && { umask 177; printf '%s' "$line" > "/tmp/claude-recap-${session_id}"; }
 exit 0

--- a/claude-ops/hooks/recap-tool-activity.sh
+++ b/claude-ops/hooks/recap-tool-activity.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# PostToolUse hook: live activity capture — fires on every tool call so the
+# tmux recap stays fresh while the agent is actively working (not only at
+# end-of-turn pauses).
+input=$(cat 2>/dev/null)
+[ -z "$input" ] && exit 0
+
+session_id=$(echo "$input" | jq -r '.session_id // ""')
+tool=$(echo "$input" | jq -r '.tool_name // ""')
+[ -z "$tool" ] && exit 0
+
+case "$tool" in
+  Bash)
+    cmd=$(echo "$input" | jq -r '.tool_input.command // ""' | head -c 80 | tr '\n' ' ')
+    label="$ $cmd"
+    ;;
+  Edit|Write)
+    f=$(echo "$input" | jq -r '.tool_input.file_path // ""')
+    label="edit ${f##*/}"
+    ;;
+  Read)
+    f=$(echo "$input" | jq -r '.tool_input.file_path // ""')
+    label="read ${f##*/}"
+    ;;
+  Grep)
+    p=$(echo "$input" | jq -r '.tool_input.pattern // ""' | head -c 40)
+    label="grep $p"
+    ;;
+  Glob)
+    p=$(echo "$input" | jq -r '.tool_input.pattern // ""' | head -c 40)
+    label="glob $p"
+    ;;
+  Agent|Task)
+    desc=$(echo "$input" | jq -r '.tool_input.description // .tool_input.prompt // ""' | head -c 60 | tr '\n' ' ')
+    label="agent $desc"
+    ;;
+  *)
+    label="$tool"
+    ;;
+esac
+
+ts=$(date '+%H:%M:%S')
+line="[$ts] $label"
+
+[ -n "$session_id" ] && printf '%s' "$line" > "/tmp/claude-recap-${session_id}"
+exit 0

--- a/claude-ops/scripts/recap/daemon.sh
+++ b/claude-ops/scripts/recap/daemon.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# Background daemon: regenerates the AI recap digest whenever any input file changes.
+# Decoupled from Claude hooks → zero impact on Claude turn latency.
+#
+# Inputs watched:
+#   /tmp/claude-recap-<sid>          (per-session, written by hooks/recap-capture.sh)
+#   /tmp/zsh-activity-<pid>.log      (shell activity from zshrc preexec, optional)
+#
+# Output: /tmp/claude-recap-digest (read by tmux marquee + scripts/recap/marquee.sh)
+#
+# Single-instance via atomic mkdir lock. Reclaims stale lock if PID is dead.
+# Log rotation: 500KB cap, keeps tail 200 lines. Universal-user safe.
+
+LOCK_DIR=/tmp/claude-recap-daemon.lock
+PID_FILE=/tmp/claude-recap-daemon.pid
+LOG=/tmp/claude-recap-daemon.log
+INTERVAL=5         # poll every 5s
+MIN_GAP=15         # min seconds between Haiku calls
+DIGEST=/tmp/claude-recap-digest
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+DIGEST_SCRIPT="${SCRIPT_DIR}/digest.sh"
+
+# Single-instance guard via atomic mkdir (race-free across parallel sessions).
+acquire_lock() {
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    echo $$ > "$PID_FILE"
+    return 0
+  fi
+  i=0
+  while [ ! -s "$PID_FILE" ] && [ "$i" -lt 5 ]; do sleep 0.1; i=$((i+1)); done
+  old=$(cat "$PID_FILE" 2>/dev/null)
+  if [ -n "$old" ] && kill -0 "$old" 2>/dev/null; then
+    return 1
+  fi
+  rm -rf "$LOCK_DIR" 2>/dev/null
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    echo $$ > "$PID_FILE"
+    return 0
+  fi
+  return 1
+}
+
+acquire_lock || exit 0
+trap 'rm -rf "$LOCK_DIR"; rm -f "$PID_FILE"; exit 0' EXIT INT TERM
+
+printf '[%s] daemon started pid=%s digest=%s\n' "$(date '+%H:%M:%S')" "$$" "$DIGEST_SCRIPT" >> "$LOG"
+
+last_run=0
+while true; do
+  newest=0
+  for f in /tmp/claude-recap-* /tmp/zsh-activity-*.log; do
+    case "$f" in
+      *digest*|*latest*|*daemon*|*pinned*) continue ;;
+    esac
+    [ -f "$f" ] || continue
+    m=$(stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo 0)
+    [ "$m" -gt "$newest" ] && newest=$m
+  done
+
+  digest_m=$(stat -f %m "$DIGEST" 2>/dev/null || stat -c %Y "$DIGEST" 2>/dev/null || echo 0)
+  now=$(date +%s)
+
+  if [ "$newest" -gt "$digest_m" ] && [ $((now - last_run)) -ge "$MIN_GAP" ]; then
+    last_run=$now
+    THROTTLE_OVERRIDE=1 sh "$DIGEST_SCRIPT" >> "$LOG" 2>&1
+  fi
+
+  log_bytes=$(stat -f %z "$LOG" 2>/dev/null || stat -c %s "$LOG" 2>/dev/null || echo 0)
+  if [ "$log_bytes" -gt 512000 ]; then
+    tail -n 200 "$LOG" > "${LOG}.tmp" && mv "${LOG}.tmp" "$LOG"
+  fi
+
+  sleep "$INTERVAL"
+done

--- a/claude-ops/scripts/recap/daemon.sh
+++ b/claude-ops/scripts/recap/daemon.sh
@@ -54,11 +54,11 @@ while true; do
       *digest*|*latest*|*daemon*|*pinned*) continue ;;
     esac
     [ -f "$f" ] || continue
-    m=$(stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo 0)
+    m=$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || echo 0)
     [ "$m" -gt "$newest" ] && newest=$m
   done
 
-  digest_m=$(stat -f %m "$DIGEST" 2>/dev/null || stat -c %Y "$DIGEST" 2>/dev/null || echo 0)
+  digest_m=$(stat -c %Y "$DIGEST" 2>/dev/null || stat -f %m "$DIGEST" 2>/dev/null || echo 0)
   now=$(date +%s)
 
   if [ "$newest" -gt "$digest_m" ] && [ $((now - last_run)) -ge "$MIN_GAP" ]; then
@@ -66,7 +66,7 @@ while true; do
     THROTTLE_OVERRIDE=1 sh "$DIGEST_SCRIPT" >> "$LOG" 2>&1
   fi
 
-  log_bytes=$(stat -f %z "$LOG" 2>/dev/null || stat -c %s "$LOG" 2>/dev/null || echo 0)
+  log_bytes=$(stat -c %s "$LOG" 2>/dev/null || stat -f %z "$LOG" 2>/dev/null || echo 0)
   if [ "$log_bytes" -gt 512000 ]; then
     tail -n 200 "$LOG" > "${LOG}.tmp" && mv "${LOG}.tmp" "$LOG"
   fi

--- a/claude-ops/scripts/recap/digest.sh
+++ b/claude-ops/scripts/recap/digest.sh
@@ -23,7 +23,7 @@ now=$(date +%s)
 
 # Block A: current per-session recaps (newest first, max 8, drop stale >2h)
 sessions=""
-for f in $(ls -t /tmp/claude-recap-* 2>/dev/null | grep -v -- '-digest$' | grep -v -- '-digest\.log$' | grep -v -- '-latest$' | grep -v -- '-pinned$' | head -8); do
+for f in $(ls -t /tmp/claude-recap-* 2>/dev/null | grep -v -- '-digest$' | grep -v -- '-digest\.log$' | grep -v -- '-latest$' | grep -v -- '-pinned$' | grep -v daemon | head -8); do
   mtime=$(stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo 0)
   age=$((now - mtime))
   [ "$age" -gt 7200 ] && continue

--- a/claude-ops/scripts/recap/digest.sh
+++ b/claude-ops/scripts/recap/digest.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# AI-generated rolling digest: summarizes the last 10 digests + current session recaps
+# + recent shell activity into one unified ticker line. 20s throttle (bypassable via
+# THROTTLE_OVERRIDE=1 — daemon.sh sets this).
+
+set -e
+DIGEST=/tmp/claude-recap-digest
+LOG=/tmp/claude-recap-digest.log
+LOCK=/tmp/claude-recap-digest.lock
+THROTTLE=20
+
+# Throttle by file age unless explicitly overridden
+if [ -z "$THROTTLE_OVERRIDE" ] && [ -f "$DIGEST" ]; then
+  age=$(($(date +%s) - $(stat -f %m "$DIGEST" 2>/dev/null || stat -c %Y "$DIGEST" 2>/dev/null || echo 0)))
+  [ "$age" -lt "$THROTTLE" ] && exit 0
+fi
+
+# Single-flight lock
+mkdir "$LOCK" 2>/dev/null || exit 0
+trap 'rmdir "$LOCK" 2>/dev/null' EXIT INT TERM
+
+now=$(date +%s)
+
+# Block A: current per-session recaps (newest first, max 8, drop stale >2h)
+sessions=""
+for f in $(ls -t /tmp/claude-recap-* 2>/dev/null | grep -v -- '-digest$' | grep -v -- '-digest\.log$' | grep -v -- '-latest$' | grep -v -- '-pinned$' | head -8); do
+  mtime=$(stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo 0)
+  age=$((now - mtime))
+  [ "$age" -gt 7200 ] && continue
+  base=$(basename "$f")
+  sid=${base#claude-recap-}
+  short=${sid#"${sid%????}"}
+  if [ "$age" -lt 60 ]; then a="${age}s"; elif [ "$age" -lt 3600 ]; then a="$((age/60))m"; else a="$((age/3600))h"; fi
+  body=$(LC_ALL=C tr -d '\n\r' < "$f" | head -c 400)
+  [ -z "$body" ] && continue
+  sessions="${sessions}- [${short}] (${a} ago): ${body}
+"
+done
+
+# Block B: last 10 prior digests (chronological)
+history=""
+if [ -f "$LOG" ]; then
+  history=$(tail -n 10 "$LOG" 2>/dev/null)
+fi
+
+# Block C: recent non-Claude zsh shell activity (last 15 cmds across live shells)
+shell_activity=""
+for sf in $(ls -t /tmp/zsh-activity-*.log 2>/dev/null | head -6); do
+  smtime=$(stat -f %m "$sf" 2>/dev/null || stat -c %Y "$sf" 2>/dev/null || echo 0)
+  [ $((now - smtime)) -gt 1800 ] && continue
+  spid=$(basename "$sf" | sed 's/zsh-activity-\(.*\)\.log/\1/')
+  recent=$(tail -n 15 "$sf" 2>/dev/null)
+  [ -n "$recent" ] && shell_activity="${shell_activity}-- shell $spid:
+${recent}
+"
+done
+
+[ -z "$sessions" ] && [ -z "$history" ] && [ -z "$shell_activity" ] && exit 0
+
+prompt="You are a newsroom ticker compressing the activity of multiple parallel Claude Code coding sessions AND the user's interactive shell sessions into ONE rolling headline.
+
+PRIOR HEADLINES (oldest → newest, each line a previous digest):
+${history:-(none)}
+
+CURRENT CLAUDE SESSION ACTIVITY (latest one-line per active session):
+${sessions:-(none)}
+
+USER SHELL ACTIVITY (raw recent commands across non-Claude zsh sessions, format: HH:MM:SS|cwd|command):
+${shell_activity:-(none)}
+
+Produce ONE single line (max 240 chars) describing the CURRENT state of work, weighted heavily toward the most-recent activity (last 1-2 headlines + current session activity + last few shell commands). DROP themes from older headlines that are no longer mentioned in current activity — assume they are resolved or no longer relevant. Only carry forward an older theme if there is concrete evidence in the current activity that it is still in flight. Translate raw shell commands into plain English (e.g., 'ssh into bastion', 'inspecting prod logs', 'running tests'). Plain English ticker style. No bullets, no quotes, no preface, no markdown."
+
+result=$(printf '%s' "$prompt" | claude -p --model haiku --no-session-persistence --output-format text 2>/dev/null | head -c 260 | LC_ALL=C tr '\n' ' ')
+
+if [ -n "$result" ]; then
+  printf '%s' "$result" > "$DIGEST"
+  printf '[%s] %s\n' "$(date '+%H:%M')" "$result" >> "$LOG"
+  tail -n 50 "$LOG" > "${LOG}.tmp" && mv "${LOG}.tmp" "$LOG"
+fi
+exit 0

--- a/claude-ops/scripts/recap/digest.sh
+++ b/claude-ops/scripts/recap/digest.sh
@@ -11,7 +11,7 @@ THROTTLE=20
 
 # Throttle by file age unless explicitly overridden
 if [ -z "$THROTTLE_OVERRIDE" ] && [ -f "$DIGEST" ]; then
-  age=$(($(date +%s) - $(stat -f %m "$DIGEST" 2>/dev/null || stat -c %Y "$DIGEST" 2>/dev/null || echo 0)))
+  age=$(($(date +%s) - $(stat -c %Y "$DIGEST" 2>/dev/null || stat -f %m "$DIGEST" 2>/dev/null || echo 0)))
   [ "$age" -lt "$THROTTLE" ] && exit 0
 fi
 
@@ -24,7 +24,7 @@ now=$(date +%s)
 # Block A: current per-session recaps (newest first, max 8, drop stale >2h)
 sessions=""
 for f in $(ls -t /tmp/claude-recap-* 2>/dev/null | grep -v -- '-digest$' | grep -v -- '-digest\.log$' | grep -v -- '-latest$' | grep -v -- '-pinned$' | grep -v daemon | head -8); do
-  mtime=$(stat -f %m "$f" 2>/dev/null || stat -c %Y "$f" 2>/dev/null || echo 0)
+  mtime=$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || echo 0)
   age=$((now - mtime))
   [ "$age" -gt 7200 ] && continue
   base=$(basename "$f")
@@ -46,7 +46,7 @@ fi
 # Block C: recent non-Claude zsh shell activity (last 15 cmds across live shells)
 shell_activity=""
 for sf in $(ls -t /tmp/zsh-activity-*.log 2>/dev/null | head -6); do
-  smtime=$(stat -f %m "$sf" 2>/dev/null || stat -c %Y "$sf" 2>/dev/null || echo 0)
+  smtime=$(stat -c %Y "$sf" 2>/dev/null || stat -f %m "$sf" 2>/dev/null || echo 0)
   [ $((now - smtime)) -gt 1800 ] && continue
   spid=$(basename "$sf" | sed 's/zsh-activity-\(.*\)\.log/\1/')
   recent=$(tail -n 15 "$sf" 2>/dev/null)

--- a/claude-ops/scripts/recap/marquee.sh
+++ b/claude-ops/scripts/recap/marquee.sh
@@ -32,11 +32,11 @@ total=$((hold_start + scroll_steps + hold_end))
 [ "$total" -lt 2 ] && total=2
 
 now=$(date +%s)
-pinned_mtime=$(stat -f %m "$PINNED" 2>/dev/null || stat -c %Y "$PINNED" 2>/dev/null || echo "$now")
+pinned_mtime=$(stat -c %Y "$PINNED" 2>/dev/null || stat -f %m "$PINNED" 2>/dev/null || echo "$now")
 elapsed=$((now - pinned_mtime))
 
 if [ "$elapsed" -ge "$total" ] && [ -f "$DIGEST" ]; then
-  digest_mtime=$(stat -f %m "$DIGEST" 2>/dev/null || stat -c %Y "$DIGEST" 2>/dev/null || echo 0)
+  digest_mtime=$(stat -c %Y "$DIGEST" 2>/dev/null || stat -f %m "$DIGEST" 2>/dev/null || echo 0)
   if [ "$digest_mtime" -gt "$pinned_mtime" ]; then
     cp "$DIGEST" "$PINNED" 2>/dev/null
     touch "$PINNED"

--- a/claude-ops/scripts/recap/marquee.sh
+++ b/claude-ops/scripts/recap/marquee.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Tmux marquee: scrolls AI digest, NEVER swaps content mid-scroll.
+# Holds the same "pinned" copy for one full scroll cycle so the user can read
+# the entire message before it refreshes with new digest content.
+
+DIGEST=/tmp/claude-recap-digest
+PINNED=/tmp/claude-recap-pinned
+
+if [ ! -f "$PINNED" ] && [ -f "$DIGEST" ]; then
+  cp "$DIGEST" "$PINNED" 2>/dev/null
+fi
+
+[ ! -f "$PINNED" ] && exit 0
+msg=$(tr -d '\n\r' < "$PINNED")
+[ -z "$msg" ] && exit 0
+
+width=$(tmux display -p '#{client_width}' 2>/dev/null || echo 80)
+viewport=$((width - 6))
+[ "$viewport" -lt 20 ] && viewport=20
+
+msg_len=${#msg}
+
+speed=6
+hold_start=1
+hold_end=1
+if [ "$msg_len" -le "$viewport" ]; then
+  scroll_steps=0
+else
+  scroll_steps=$(( (msg_len - viewport + speed - 1) / speed ))
+fi
+total=$((hold_start + scroll_steps + hold_end))
+[ "$total" -lt 2 ] && total=2
+
+now=$(date +%s)
+pinned_mtime=$(stat -f %m "$PINNED" 2>/dev/null || stat -c %Y "$PINNED" 2>/dev/null || echo "$now")
+elapsed=$((now - pinned_mtime))
+
+if [ "$elapsed" -ge "$total" ] && [ -f "$DIGEST" ]; then
+  digest_mtime=$(stat -f %m "$DIGEST" 2>/dev/null || stat -c %Y "$DIGEST" 2>/dev/null || echo 0)
+  if [ "$digest_mtime" -gt "$pinned_mtime" ]; then
+    cp "$DIGEST" "$PINNED" 2>/dev/null
+    touch "$PINNED"
+    msg=$(tr -d '\n\r' < "$PINNED")
+    msg_len=${#msg}
+    if [ "$msg_len" -le "$viewport" ]; then
+      scroll_steps=0
+    else
+      scroll_steps=$(( (msg_len - viewport + speed - 1) / speed ))
+    fi
+    total=$((hold_start + scroll_steps + hold_end))
+    [ "$total" -lt 2 ] && total=2
+    elapsed=0
+  fi
+fi
+
+phase=$((elapsed % total))
+
+if [ "$msg_len" -le "$viewport" ]; then
+  printf '%s' "$msg"
+  exit 0
+fi
+
+if [ "$phase" -lt "$hold_start" ]; then
+  offset=0
+elif [ "$phase" -lt $((hold_start + scroll_steps)) ]; then
+  offset=$(( (phase - hold_start) * speed ))
+  [ "$offset" -gt $((msg_len - viewport)) ] && offset=$((msg_len - viewport))
+else
+  offset=$((msg_len - viewport))
+fi
+
+printf '%s' "$msg" | awk -v o="$offset" -v w="$viewport" '{print substr($0, o+1, w)}'

--- a/claude-ops/skills/ops-recap/SKILL.md
+++ b/claude-ops/skills/ops-recap/SKILL.md
@@ -126,12 +126,16 @@ Walk the user through tmux integration if not already wired. Detect existing `st
 
 4. On append: insert the marquee snippet ahead of the existing setting so both render. On replace: comment out the old line and add the new one.
 
-   Snippet to append:
+   Snippet to append — expand the plugin path when writing `~/.tmux.conf` (tmux `#()` does not expand env vars):
 
-   ```
-   # claude-ops recap marquee
-   set -g status-right '#(cat /tmp/claude-recap-digest 2>/dev/null | head -c 80) #[fg=#a6e3a1]%H:%M '
-   set -g status-interval 2
+   ```bash
+   PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1)}"
+   cat >> "$TMUX_CONF" <<TMUX
+
+# claude-ops recap marquee
+set -g status-right '#('"${PLUGIN_ROOT}"'/scripts/recap/marquee.sh) #[fg=#a6e3a1]%H:%M '
+set -g status-interval 2
+TMUX
    ```
 
 5. Reload if tmux is running:

--- a/claude-ops/skills/ops-recap/SKILL.md
+++ b/claude-ops/skills/ops-recap/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: ops-recap
+description: Manage the multi-session recap marquee daemon — a background process that synthesizes a one-line digest across all parallel Claude Code sessions and shell activity, displayed in tmux status-right. Subcommands status/tail/configure/restart.
+argument-hint: "[status|tail|configure|restart]"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - AskUserQuestion
+effort: low
+maxTurns: 12
+---
+
+# OPS ► RECAP
+
+The recap marquee is a launchd-managed daemon that aggregates per-session Claude transcripts (via the `recap-capture` Stop hook) and per-tool activity (via the `recap-tool-activity` PostToolUse hook) into a single rolling headline at `/tmp/claude-recap-digest`. Tmux reads that file every refresh interval via `scripts/recap/marquee.sh` and scrolls it across `status-right`.
+
+**Files:**
+
+| Path | Role |
+|------|------|
+| `${CLAUDE_PLUGIN_ROOT}/scripts/recap/daemon.sh` | Background loop — polls inputs, calls digest.sh when stale |
+| `${CLAUDE_PLUGIN_ROOT}/scripts/recap/digest.sh` | Synthesizes one-line digest via `claude -p --model haiku` |
+| `${CLAUDE_PLUGIN_ROOT}/scripts/recap/marquee.sh` | Tmux-side scroller (called from `status-right`) |
+| `${CLAUDE_PLUGIN_ROOT}/hooks/recap-capture.sh` | Stop hook → writes `/tmp/claude-recap-<sid>` |
+| `${CLAUDE_PLUGIN_ROOT}/hooks/recap-tool-activity.sh` | PostToolUse hook → live activity per session |
+| `~/Library/LaunchAgents/com.claude-ops.recap-daemon.plist` | Launchd agent (macOS) |
+| `/tmp/claude-recap-digest` | Rolling one-liner (read by tmux + marquee.sh) |
+| `/tmp/claude-recap-daemon.log` | Daemon log (rotated at 500KB) |
+| `/tmp/claude-recap-digest.log` | Last 50 generated digests, chronological |
+
+## Subcommand: `status` (default)
+
+Print a compact health panel:
+
+```bash
+PLIST=~/Library/LaunchAgents/com.claude-ops.recap-daemon.plist
+LABEL=com.claude-ops.recap-daemon
+DIGEST=/tmp/claude-recap-digest
+DAEMON_LOG=/tmp/claude-recap-daemon.log
+
+# Plist installed?
+if [ -f "$PLIST" ]; then echo "✓ plist installed: $PLIST"; else echo "✗ plist missing"; fi
+
+# Launchd loaded?
+launchctl print "gui/$(id -u)/${LABEL}" >/dev/null 2>&1 \
+  && echo "✓ launchd loaded ($LABEL)" \
+  || echo "✗ launchd not loaded — run /ops:recap restart"
+
+# Daemon process alive?
+if [ -f /tmp/claude-recap-daemon.pid ]; then
+  pid=$(cat /tmp/claude-recap-daemon.pid)
+  kill -0 "$pid" 2>/dev/null && echo "✓ daemon alive (pid $pid)" || echo "✗ stale pid file"
+else
+  echo "✗ no pid file"
+fi
+
+# Digest freshness
+if [ -f "$DIGEST" ]; then
+  age=$(($(date +%s) - $(stat -f %m "$DIGEST" 2>/dev/null || stat -c %Y "$DIGEST" 2>/dev/null || echo 0)))
+  echo "✓ digest age: ${age}s"
+  echo "  preview: $(head -c 120 "$DIGEST")..."
+else
+  echo "✗ digest file missing — daemon may not have produced one yet"
+fi
+
+# Log size
+if [ -f "$DAEMON_LOG" ]; then
+  bytes=$(stat -f %z "$DAEMON_LOG" 2>/dev/null || stat -c %s "$DAEMON_LOG" 2>/dev/null)
+  echo "  log: $DAEMON_LOG (${bytes} bytes)"
+fi
+
+# tmux integration?
+if command -v tmux >/dev/null 2>&1; then
+  if grep -q claude-recap "$HOME/.tmux.conf" 2>/dev/null; then
+    echo "✓ tmux status-right wired"
+  else
+    echo "○ tmux installed but status-right not wired — run /ops:recap configure"
+  fi
+else
+  echo "○ tmux not installed — marquee won't display, daemon still useful for /ops:recap tail"
+fi
+```
+
+## Subcommand: `tail`
+
+Stream the rolling digest log:
+
+```bash
+echo "─── Last 20 generated digests ───"
+tail -n 20 /tmp/claude-recap-digest.log 2>/dev/null || echo "(no digest log yet)"
+echo
+echo "─── Daemon log (tail 30) ───"
+tail -n 30 /tmp/claude-recap-daemon.log 2>/dev/null || echo "(no daemon log yet)"
+```
+
+## Subcommand: `configure`
+
+Walk the user through tmux integration if not already wired. Detect existing `status-right` first to avoid clobbering.
+
+1. Check tmux availability:
+
+   ```bash
+   if ! command -v tmux >/dev/null 2>&1; then
+     echo "tmux not installed — recap daemon still runs and you can read /tmp/claude-recap-digest manually."
+     exit 0
+   fi
+   ```
+
+2. Check current `~/.tmux.conf`:
+
+   ```bash
+   TMUX_CONF="$HOME/.tmux.conf"
+   if grep -q claude-recap "$TMUX_CONF" 2>/dev/null; then
+     echo "✓ already configured."
+     exit 0
+   fi
+   existing=$(grep -E '^\s*set\s+-g\s+status-right' "$TMUX_CONF" 2>/dev/null | head -1)
+   ```
+
+3. If `existing` is non-empty, `AskUserQuestion`:
+
+   - Question: "Existing tmux status-right detected: `$existing`. Append recap marquee?"
+   - Options: `[Append (keep existing)]` `[Replace with recap-only]` `[Skip]`
+
+4. On append: insert the marquee snippet ahead of the existing setting so both render. On replace: comment out the old line and add the new one.
+
+   Snippet to append:
+
+   ```
+   # claude-ops recap marquee
+   set -g status-right '#(cat /tmp/claude-recap-digest 2>/dev/null | head -c 80) #[fg=#a6e3a1]%H:%M '
+   set -g status-interval 2
+   ```
+
+5. Reload if tmux is running:
+
+   ```bash
+   tmux info >/dev/null 2>&1 && tmux source-file "$TMUX_CONF" 2>/dev/null
+   ```
+
+## Subcommand: `restart`
+
+Reload the launchd agent without reconfiguring:
+
+```bash
+LABEL=com.claude-ops.recap-daemon
+PLIST=~/Library/LaunchAgents/com.claude-ops.recap-daemon.plist
+launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
+rm -rf /tmp/claude-recap-daemon.lock /tmp/claude-recap-daemon.pid
+launchctl bootstrap "gui/$(id -u)" "$PLIST" && echo "✓ daemon restarted"
+```
+
+## Linux / systemd alternative
+
+The launchd plist is macOS-only. Linux users can wrap `scripts/recap/daemon.sh` in a `systemd --user` unit. Minimal example (`~/.config/systemd/user/claude-recap-daemon.service`):
+
+```ini
+[Unit]
+Description=Claude Ops Recap Daemon
+After=default.target
+
+[Service]
+Type=simple
+ExecStart=/bin/sh %h/.claude/plugins/cache/ops-marketplace/ops/CURRENT/scripts/recap/daemon.sh
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=default.target
+```
+
+Then `systemctl --user daemon-reload && systemctl --user enable --now claude-recap-daemon`. The CLI subcommands above (status / tail / restart) won't auto-detect systemd — use `systemctl --user status claude-recap-daemon` directly.
+
+## Invocation
+
+`/ops:recap` (alias: shows status). Subcommand parsing:
+
+```bash
+sub="${1:-status}"
+case "$sub" in
+  status|tail|configure|restart) ;;
+  *) echo "Unknown subcommand: $sub. Try: status | tail | configure | restart"; exit 1 ;;
+esac
+```

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -555,10 +555,12 @@ PLIST_DEST="$HOME/Library/LaunchAgents/com.claude-ops.recap-daemon.plist"
 DATA_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
 LOG_DIR="$DATA_DIR/logs"
 mkdir -p "$LOG_DIR"
-
+# Resolve claude CLI bin directory (handles nvm, homebrew, system npm)
+CLAUDE_BIN_DIR=$(dirname "$(command -v claude 2>/dev/null || echo /usr/local/bin/claude)")
 sed -e "s|__DAEMON_SCRIPT_PATH__|$DAEMON_SCRIPT|g" \
     -e "s|__LOG_DIR__|$LOG_DIR|g" \
     -e "s|__HOME__|$HOME|g" \
+    -e "s|__CLAUDE_BIN_DIR__|$CLAUDE_BIN_DIR|g" \
     "$PLIST_TEMPLATE" > "$PLIST_DEST"
 
 launchctl bootout "gui/$(id -u)/com.claude-ops.recap-daemon" 2>/dev/null || true

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -512,6 +512,150 @@ Continue immediately to Step 3 — do NOT wait for the daemon to confirm startup
 
 ---
 
+## Step 2d — Recap Marquee (multi-session digest in tmux status-right)
+
+The recap marquee is a separate launchd daemon (`com.claude-ops.recap-daemon`) that synthesizes a one-line digest across all parallel Claude Code sessions and recent shell activity, then exposes it via `/tmp/claude-recap-digest` for tmux to scroll across `status-right`. Independent from the main ops daemon — it can run on its own.
+
+Skip this step entirely if `recap_marquee_enabled = false` in userConfig.
+
+### Step 2d.1 — Ask the user
+
+Use `AskUserQuestion`:
+
+```
+Enable multi-session recap marquee?
+  Background daemon synthesizes a one-line digest across all parallel Claude
+  Code sessions + recent shell commands. Display in tmux status-right.
+  [Yes — install + auto-configure]  [No — skip]  [What is this?]
+```
+
+If `What is this?`: explain (the daemon polls per-session recap files written by Stop + PostToolUse hooks, aggregates last 8 sessions + 10 prior digests + recent zsh activity into one Haiku-generated headline, refreshed every ~15s; tmux reads `/tmp/claude-recap-digest` from `status-right` and scrolls it). Then re-ask the binary question.
+
+If `No`: write `recap.enabled = false` to `$PREFS_PATH` and skip to Step 3.
+
+### Step 2d.2 — Install launchd plist (macOS only)
+
+Same platform gate as Step 2c. On Linux/WSL/Windows, print:
+
+```
+○ Recap daemon — skipped (launchd is macOS-only). Linux users: see
+  /ops:recap configure for systemd unit example.
+```
+
+On macOS, install the plist (RULE 4 — `run_in_background: true`):
+
+```bash
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1)}"
+DAEMON_SCRIPT="${PLUGIN_ROOT}/scripts/recap/daemon.sh"
+chmod +x "$DAEMON_SCRIPT" "${PLUGIN_ROOT}/scripts/recap/digest.sh" "${PLUGIN_ROOT}/scripts/recap/marquee.sh"
+chmod +x "${PLUGIN_ROOT}/hooks/recap-capture.sh" "${PLUGIN_ROOT}/hooks/recap-tool-activity.sh"
+
+PLIST_TEMPLATE="${PLUGIN_ROOT}/templates/com.claude-ops.recap-daemon.plist"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.claude-ops.recap-daemon.plist"
+DATA_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+LOG_DIR="$DATA_DIR/logs"
+mkdir -p "$LOG_DIR"
+
+sed -e "s|__DAEMON_SCRIPT_PATH__|$DAEMON_SCRIPT|g" \
+    -e "s|__LOG_DIR__|$LOG_DIR|g" \
+    -e "s|__HOME__|$HOME|g" \
+    "$PLIST_TEMPLATE" > "$PLIST_DEST"
+
+launchctl bootout "gui/$(id -u)/com.claude-ops.recap-daemon" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST_DEST"
+```
+
+### Step 2d.3 — tmux integration
+
+Detect tmux availability — skip cleanly if missing:
+
+```bash
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "○ tmux not installed — daemon installed, but no marquee surface. Daemon still useful for /ops:recap tail."
+  # write recap.enabled = true, recap.tmux_wired = false, then skip to Step 2d.5
+fi
+```
+
+If `recap_marquee_auto_configure_tmux = false`, print the snippet and skip the rest of this step (let user wire manually).
+
+If tmux is present and `recap_marquee_auto_configure_tmux = true`, ask:
+
+```
+Auto-configure tmux status-right?
+  [Yes — append to ~/.tmux.conf]  [Show me the line, I'll add manually]  [Skip]
+```
+
+On `Show me the line`, print the snippet and continue.
+
+On `Yes — append`, detect existing `status-right`:
+
+```bash
+TMUX_CONF="$HOME/.tmux.conf"
+existing=$(grep -E '^\s*set\s+-g\s+status-right' "$TMUX_CONF" 2>/dev/null | head -1)
+```
+
+If `existing` is non-empty, ask via `AskUserQuestion` (Rule 1 — exactly 4 options max):
+
+```
+Existing tmux status-right detected. How to integrate recap marquee?
+  [Replace with recap-only]  [Append (keep existing line as comment)]  [Show me, I'll edit manually]  [Skip]
+```
+
+Append the snippet (or replace, per choice):
+
+```bash
+cat >> "$TMUX_CONF" <<'TMUX'
+
+# claude-ops recap marquee — synthesizes multi-session digest into status-right
+set -g status-right '#(cat /tmp/claude-recap-digest 2>/dev/null | head -c 80) #[fg=#a6e3a1]%H:%M '
+set -g status-interval 2
+TMUX
+
+# Live-reload if tmux is currently running
+tmux info >/dev/null 2>&1 && tmux source-file "$TMUX_CONF" 2>/dev/null
+```
+
+### Step 2d.4 — Verify daemon is producing output
+
+Wait up to 60s for the daemon to write its first digest. Run in background; do NOT block the wizard:
+
+```bash
+(
+  for i in $(seq 1 12); do
+    [ -f /tmp/claude-recap-digest ] && [ -s /tmp/claude-recap-digest ] && exit 0
+    sleep 5
+  done
+  echo "WARN: recap daemon did not produce /tmp/claude-recap-digest within 60s — check /tmp/claude-recap-daemon.log" >&2
+) &
+```
+
+### Step 2d.5 — Persist preferences
+
+Write to `$PREFS_PATH`:
+
+```json
+{
+  "recap": {
+    "enabled": true,
+    "tmux_wired": true,
+    "installed_at_step": "2d",
+    "platform": "macos"
+  }
+}
+```
+
+Print:
+
+```
+✓ Recap marquee — daemon installed (com.claude-ops.recap-daemon).
+  Tmux status-right wired (or skipped per your choice).
+  Manage anytime: /ops:recap status | tail | configure | restart
+```
+
+Continue to Step 3.
+
+---
+
 ## Step 3 — Configure channels (if selected)
 
 First, offer a quick "configure everything" option before individual selection. Use `AskUserQuestion`:

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -601,13 +601,14 @@ Existing tmux status-right detected. How to integrate recap marquee?
   [Replace with recap-only]  [Append (keep existing line as comment)]  [Show me, I'll edit manually]  [Skip]
 ```
 
-Append the snippet (or replace, per choice):
+Append the snippet (or replace, per choice). Use an unquoted heredoc delimiter so `${PLUGIN_ROOT}` expands to the installed plugin path (tmux `#()` does not expand env vars):
 
 ```bash
-cat >> "$TMUX_CONF" <<'TMUX'
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1)}"
+cat >> "$TMUX_CONF" <<TMUX
 
 # claude-ops recap marquee — synthesizes multi-session digest into status-right
-set -g status-right '#(cat /tmp/claude-recap-digest 2>/dev/null | head -c 80) #[fg=#a6e3a1]%H:%M '
+set -g status-right '#('"${PLUGIN_ROOT}"'/scripts/recap/marquee.sh) #[fg=#a6e3a1]%H:%M '
 set -g status-interval 2
 TMUX
 

--- a/claude-ops/templates/com.claude-ops.recap-daemon.plist
+++ b/claude-ops/templates/com.claude-ops.recap-daemon.plist
@@ -29,7 +29,7 @@
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+        <string>__CLAUDE_BIN_DIR__:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
         <key>HOME</key>
         <string>__HOME__</string>
     </dict>

--- a/claude-ops/templates/com.claude-ops.recap-daemon.plist
+++ b/claude-ops/templates/com.claude-ops.recap-daemon.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude-ops.recap-daemon</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/sh</string>
+        <string>__DAEMON_SCRIPT_PATH__</string>
+    </array>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/recap-daemon-stdout.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/recap-daemon-stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>__HOME__</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Folds the previously personal recap-daemon (multi-session digest → tmux status-right marquee) into claude-ops as an opt-in subsystem.

- New scripts under `scripts/recap/` (daemon + digest + marquee), new hooks under `hooks/`, launchd template under `templates/`, new `/ops:recap` skill, and a new Step 2d in the setup wizard.
- Hooks are gated on `CLAUDE_PLUGIN_USERCONFIG_RECAP_MARQUEE_ENABLED` so flipping the userConfig flag silently disables the runtime — no restart needed.
- Universal-user-safe: all paths use `$HOME`, `LC_ALL=C tr` for encoding safety, log rotation at 500KB, and tmux is detected before any wiring attempt. Linux/WSL get a documented systemd alternative in the skill.
- Constraint compliance: no personal data committed (verified by `tests/test-no-secrets.sh`), max 4 options on the new `AskUserQuestion` calls, background launchd install per Rule 4.

## Files

- `claude-ops/scripts/recap/{daemon,digest,marquee}.sh`
- `claude-ops/hooks/recap-{capture,tool-activity}.sh`
- `claude-ops/templates/com.claude-ops.recap-daemon.plist`
- `claude-ops/skills/ops-recap/SKILL.md`
- `claude-ops/skills/setup/SKILL.md` — new Step 2d
- `claude-ops/hooks/hooks.json` — wires PostToolUse + Stop hooks behind the flag

## Test plan

- [ ] Fresh `/ops:setup` on macOS — accept all defaults, verify `~/Library/LaunchAgents/com.claude-ops.recap-daemon.plist` is installed and `launchctl print` shows it loaded
- [ ] `/tmp/claude-recap-digest` populated within 60s of first Claude turn
- [ ] `tmux source-file ~/.tmux.conf` after wizard — `status-right` shows scrolling digest
- [ ] `/ops:recap status` returns all green checks; `/ops:recap tail` shows recent digests
- [ ] Set `recap_marquee_enabled = false` in userConfig — hooks no-op, daemon keeps running (manual stop via `launchctl bootout`)
- [ ] Setup wizard with existing `status-right` line in `~/.tmux.conf` — confirm 4-option prompt fires before any clobber

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/161" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new hook-triggered scripts and a background `launchd` daemon that runs `claude` to generate digests; main risk is unintended overhead or noisy behavior from always-on PostToolUse/Stop hooks and new process management on macOS.
> 
> **Overview**
> Adds an *opt-in* “recap marquee” subsystem that captures per-session Claude activity and generates a rolling one-line digest for display in tmux.
> 
> Wires new `PostToolUse` and `Stop` hooks (gated by `CLAUDE_PLUGIN_USERCONFIG_RECAP_MARQUEE_ENABLED`) to write `/tmp/claude-recap-<session>` updates, and introduces `scripts/recap/{daemon,digest,marquee}.sh` to synthesize/scroll a digest at `/tmp/claude-recap-digest` via periodic Haiku calls.
> 
> Extends the setup wizard with a new Step 2d to install a macOS `launchd` agent from `templates/com.claude-ops.recap-daemon.plist` and optionally auto-wire `~/.tmux.conf`, and adds a new `/ops:recap` skill for status/tail/configure/restart workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e95019d2c318cea53e3b2f3918b43e80513db893. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->