### PR TITLE
feat(safety): add 3 universal PreToolUse safety hooks (secrets, rm-rf, mainpush)

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -52,6 +52,24 @@
     "fedex"
   ],
   "userConfig": {
+    "prevent_secret_commit": {
+      "type": "boolean",
+      "title": "Block git commits containing secrets",
+      "description": "PreToolUse hook scans `git diff --cached` for high-confidence secret patterns (Stripe, AWS, GitHub tokens, JWTs, hardcoded passwords) and denies the commit if a match is found.",
+      "default": true
+    },
+    "no_rm_rf_anchor": {
+      "type": "boolean",
+      "title": "Block rm -rf against root anchors",
+      "description": "PreToolUse hook denies `rm -rf` targeting /, ~, $HOME, .., or . — protecting against catastrophic filesystem wipes. Specific subpaths (./node_modules, /tmp/foo) are allowed.",
+      "default": true
+    },
+    "warn_mainpush": {
+      "type": "boolean",
+      "title": "Confirm direct push to main/master/production",
+      "description": "PreToolUse hook forces user confirmation when pushing directly to a protected branch (main/master/production), either via explicit destination or while currently on the branch.",
+      "default": true
+    },
     "deploy_fix_enabled": {
       "type": "boolean",
       "title": "Deploy auto-fix enabled",

--- a/claude-ops/bin/ops-no-rm-rf-anchor
+++ b/claude-ops/bin/ops-no-rm-rf-anchor
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# PreToolUse hook (Bash, gated `rm *`):
+# Blocks `rm -rf` against root anchors (/, ~, $HOME, .., .) which can wipe the
+# user's machine or the calling repo. Allows specific subpaths.
+#
+# userConfig: no_rm_rf_anchor (boolean, default true). Disable by setting
+# CLAUDE_PLUGIN_OPTION_NO_RM_RF_ANCHOR=false.
+set -uo pipefail
+# Disable filename globbing so unquoted `/*` / `../*` tokens don't expand
+# when we tokenize the command string.
+set -f
+
+if [[ "${CLAUDE_PLUGIN_OPTION_NO_RM_RF_ANCHOR:-true}" == "false" ]]; then
+  exit 0
+fi
+
+INPUT="${TOOL_INPUT:-${1:-}}"
+
+# Try to parse JSON tool_input.command if INPUT is a JSON object; else use as-is.
+CMD="$INPUT"
+if [[ "$INPUT" == *'"command"'* ]]; then
+  parsed=$(python3 -c '
+import json, sys
+try:
+  d = json.loads(sys.argv[1])
+  if isinstance(d, dict):
+    print(d.get("command") or d.get("tool_input", {}).get("command", ""))
+except Exception:
+  pass
+' "$INPUT" 2>/dev/null || true)
+  [[ -n "$parsed" ]] && CMD="$parsed"
+fi
+
+# Only act on rm commands.
+echo "$CMD" | grep -Eq '(^|[[:space:];&|`])rm([[:space:]]|$)' || exit 0
+
+# Normalize: collapse whitespace.
+NORM="$(echo "$CMD" | tr '\n' ' ' | tr -s ' ')"
+
+# Match `rm` with -rf / -fr / -r -f (any combo of -r, -R, -f, --recursive, --force).
+# Then check ALL arguments after the flags for dangerous anchors.
+#
+# Dangerous anchor regex matches the target token explicitly:
+#   /                /*               /.
+#   ~                ~/               ~/*
+#   $HOME            $HOME/           $HOME/*           "$HOME"          "$HOME/..."
+#   ..               ../*             ../              .
+#   (also empty target)
+#
+# We split commands on ; && || | and check each segment.
+DANGER=""
+
+# shellcheck disable=SC2001
+SEGMENTS=$(echo "$NORM" | awk '{ gsub(/&&/, "\n"); gsub(/\|\|/, "\n"); gsub(/\|/, "\n"); gsub(/;/, "\n"); print }')
+
+while IFS= read -r seg; do
+  seg="$(echo "$seg" | sed 's/^ *//;s/ *$//')"
+  [[ -z "$seg" ]] && continue
+  # Must start with rm (allow `sudo rm`, `time rm`, etc.)
+  if ! echo "$seg" | grep -Eq '(^|[[:space:]])rm([[:space:]]|$)'; then
+    continue
+  fi
+  # Must have recursive + force flags. Accept: -rf, -fr, -Rf, -fR, -r ... -f, --recursive ... --force, -rfv, etc.
+  has_r=0; has_f=0
+  if echo "$seg" | grep -Eq '(^|[[:space:]])-[a-zA-Z]*[rR][a-zA-Z]*([[:space:]]|$)' || echo "$seg" | grep -Eq -- '--recursive([[:space:]]|=|$)'; then
+    has_r=1
+  fi
+  if echo "$seg" | grep -Eq '(^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$)' || echo "$seg" | grep -Eq -- '--force([[:space:]]|=|$)'; then
+    has_f=1
+  fi
+  if (( has_r == 0 || has_f == 0 )); then
+    continue
+  fi
+
+  # Extract tokens after `rm`, drop flag-tokens, examine targets.
+  # Strip leading `sudo`/`time`/etc and then `rm`.
+  rest=$(echo "$seg" | sed -E 's/^.*[[:space:]]?rm([[:space:]]+|$)//')
+  # Tokenize on spaces (best-effort — won't perfectly handle quoted-with-spaces but covers the patterns specified).
+  for tok in $rest; do
+    # Skip flags.
+    case "$tok" in
+      -*) continue ;;
+    esac
+    # Strip surrounding quotes for comparison.
+    bare="${tok%\"}"; bare="${bare#\"}"
+    bare="${bare%\'}"; bare="${bare#\'}"
+
+    case "$bare" in
+      "" | "/" | "/*" | "/." | \
+      "~" | "~/" | "~/*" | \
+      '$HOME' | '$HOME/' | '$HOME/*' | \
+      ".." | "../" | "../*" | \
+      ".")
+        DANGER="$bare"
+        break
+        ;;
+    esac
+    # Also catch quoted $HOME variants where the shell hasn't expanded them.
+    if [[ "$tok" == '"$HOME"' || "$tok" == '"$HOME"/' || "$tok" == '"$HOME"/*' ]]; then
+      DANGER="$tok"; break
+    fi
+  done
+
+  [[ -n "$DANGER" ]] && break
+done <<EOF
+$SEGMENTS
+EOF
+
+if [[ -n "$DANGER" ]]; then
+  reason="Blocked rm -rf against dangerous anchor: '$DANGER'. This can destroy the system, your home directory, or the calling repo. Use a specific subpath (e.g. ./node_modules, /tmp/foo). To override (NOT RECOMMENDED) set CLAUDE_PLUGIN_OPTION_NO_RM_RF_ANCHOR=false."
+  python3 -c '
+import json, sys
+print(json.dumps({
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": sys.argv[1]
+  }
+}))' "$reason"
+  exit 0
+fi
+
+exit 0

--- a/claude-ops/bin/ops-prevent-secret-commit
+++ b/claude-ops/bin/ops-prevent-secret-commit
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# PreToolUse hook (Bash, gated `git commit*`):
+# Scans staged diff for high-confidence secret patterns. Emits permissionDecision=deny
+# with hookSpecificOutput JSON when a match is found; exits 0 otherwise.
+#
+# userConfig: prevent_secret_commit (boolean, default true). Disable by setting
+# CLAUDE_PLUGIN_OPTION_PREVENT_SECRET_COMMIT=false.
+set -uo pipefail
+
+# Opt-out: silently allow when disabled.
+if [[ "${CLAUDE_PLUGIN_OPTION_PREVENT_SECRET_COMMIT:-true}" == "false" ]]; then
+  exit 0
+fi
+
+INPUT="${TOOL_INPUT:-${1:-}}"
+
+# Confirm this is a git commit (defense in depth — matcher should already gate).
+if ! echo "$INPUT" | grep -Eq 'git[[:space:]]+commit'; then
+  exit 0
+fi
+
+# Need git available + cwd inside a repo.
+command -v git >/dev/null 2>&1 || exit 0
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# Capture staged diff (cwd-relative). Limit size to keep <100ms.
+FULL_DIFF="$(git diff --cached --no-color 2>/dev/null | head -c 524288 || true)"
+[[ -z "$FULL_DIFF" ]] && exit 0
+
+# Only scan ADDED lines (lines starting with '+', excluding diff header '+++').
+# This ensures that a commit which REMOVES a leaked key is not blocked.
+DIFF="$(echo "$FULL_DIFF" | grep -E '^\+' | grep -E -v '^\+\+\+' || true)"
+[[ -z "$DIFF" ]] && exit 0
+
+# Patterns: label|regex (POSIX ERE, BSD-grep compatible — no \d, no \b lookarounds).
+PATTERNS=(
+  "Stripe live key|sk_live_[a-zA-Z0-9]{24,}"
+  "Stripe test key|sk_test_[a-zA-Z0-9]{24,}"
+  "AWS access key|AKIA[0-9A-Z]{16}"
+  "GitHub personal token|ghp_[A-Za-z0-9]{36}"
+  "GitHub OAuth token|gho_[A-Za-z0-9]{36}"
+  "GitHub app server token|ghs_[A-Za-z0-9]{36}"
+  "Slack bot token|xoxb-[A-Za-z0-9-]+"
+  "Slack app token|xoxa-[A-Za-z0-9-]+"
+  "Slack user token|xoxp-[A-Za-z0-9-]+"
+  "JWT|eyJ[A-Za-z0-9_=-]+\\.eyJ[A-Za-z0-9_=-]+\\.?[A-Za-z0-9_.+/=-]*"
+  "Anthropic API key|ANTHROPIC_API_KEY=sk-ant-"
+  "OpenAI API key|OPENAI_API_KEY=sk-"
+  "Hardcoded password|password[[:space:]]*=[[:space:]]*['\"][^'\"]{8,}['\"]"
+)
+
+HITS=()
+for entry in "${PATTERNS[@]}"; do
+  label="${entry%%|*}"
+  regex="${entry#*|}"
+  if echo "$DIFF" | grep -Eq "$regex"; then
+    # Find which file contains the match (best-effort — last "+++ b/" before hit).
+    file="$(echo "$FULL_DIFF" | grep -E "(^\\+\\+\\+ b/|$regex)" | grep -B1 -E "$regex" | grep -E '^\+\+\+ b/' | tail -1 | sed 's|^+++ b/||' || true)"
+    if [[ -n "$file" ]]; then
+      HITS+=("$label in $file")
+    else
+      HITS+=("$label in staged diff")
+    fi
+  fi
+done
+
+if (( ${#HITS[@]} > 0 )); then
+  reason="Blocked git commit — likely secret(s) in staged diff: $(IFS='; '; echo "${HITS[*]}"). Unstage the secret, rotate it, and use an env var or secret manager. To override (NOT RECOMMENDED) set CLAUDE_PLUGIN_OPTION_PREVENT_SECRET_COMMIT=false."
+  # Emit JSON on stdout. Use python3 for safe JSON escaping (always present on macOS/Linux).
+  python3 -c '
+import json, sys
+reason = sys.argv[1]
+print(json.dumps({
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": reason
+  }
+}))' "$reason"
+  exit 0
+fi
+
+exit 0

--- a/claude-ops/bin/ops-warn-mainpush
+++ b/claude-ops/bin/ops-warn-mainpush
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# PreToolUse hook (Bash, gated `git push*`):
+# Forces user confirmation (permissionDecision=ask) when pushing to main/master/production
+# directly. Allows feature-branch pushes silently.
+#
+# userConfig: warn_mainpush (boolean, default true). Disable by setting
+# CLAUDE_PLUGIN_OPTION_WARN_MAINPUSH=false.
+set -uo pipefail
+
+if [[ "${CLAUDE_PLUGIN_OPTION_WARN_MAINPUSH:-true}" == "false" ]]; then
+  exit 0
+fi
+
+INPUT="${TOOL_INPUT:-${1:-}}"
+
+# Parse JSON command if applicable.
+CMD="$INPUT"
+if [[ "$INPUT" == *'"command"'* ]]; then
+  parsed=$(python3 -c '
+import json, sys
+try:
+  d = json.loads(sys.argv[1])
+  if isinstance(d, dict):
+    print(d.get("command") or d.get("tool_input", {}).get("command", ""))
+except Exception:
+  pass
+' "$INPUT" 2>/dev/null || true)
+  [[ -n "$parsed" ]] && CMD="$parsed"
+fi
+
+# Only inspect git push commands.
+echo "$CMD" | grep -Eq '(^|[[:space:];&|`])git[[:space:]]+push' || exit 0
+
+DEST=""
+REASON=""
+
+# Case A: explicit `git push [flags...] <remote> <branch>` targeting main/master/production.
+# Match by checking if any token after `push` equals one of the protected branch names.
+if echo "$CMD" | grep -Eq 'git[[:space:]]+push([[:space:]]+(-[^[:space:]]+|[a-zA-Z0-9_./-]+))*[[:space:]]+(main|master|production)([[:space:]]|$)'; then
+  DEST=$(echo "$CMD" | grep -Eo '(main|master|production)' | tail -1)
+  REASON="Pushing directly to protected branch '$DEST'. Confirm before publishing — prefer a feature branch + PR."
+fi
+
+# Case B: explicit refspec like `HEAD:main` or `feature:main`.
+if [[ -z "$DEST" ]] && echo "$CMD" | grep -Eq 'git[[:space:]]+push[[:space:]].*:[[:space:]]*(main|master|production)([[:space:]]|$)'; then
+  DEST=$(echo "$CMD" | grep -Eo '[^[:space:]]+:(main|master|production)' | tail -1)
+  REASON="Pushing refspec $DEST — this updates a protected branch. Confirm before publishing."
+fi
+
+# Case C: bare `git push` (or `git push origin`/`git push -u origin`) — check current branch.
+if [[ -z "$DEST" ]] && command -v git >/dev/null 2>&1; then
+  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    BRANCH=$(git -C "$PWD" branch --show-current 2>/dev/null || true)
+    case "$BRANCH" in
+      main|master|production)
+        # Bare push (no explicit refspec) defaults to current branch.
+        if echo "$CMD" | grep -Eq 'git[[:space:]]+push([[:space:]]+(-u[[:space:]]+)?[a-zA-Z0-9_.-]+)?[[:space:]]*$' \
+           || echo "$CMD" | grep -Eq 'git[[:space:]]+push[[:space:]]+(-u[[:space:]]+)?[a-zA-Z0-9_.-]+[[:space:]]*$'; then
+          DEST="current branch '$BRANCH'"
+          REASON="You are on protected branch '$BRANCH' and about to push. Confirm before publishing — prefer a feature branch + PR."
+        fi
+        ;;
+    esac
+  fi
+fi
+
+if [[ -n "$DEST" ]]; then
+  python3 -c '
+import json, sys
+print(json.dumps({
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": sys.argv[1]
+  }
+}))' "$REASON"
+  exit 0
+fi
+
+exit 0

--- a/claude-ops/hooks/hooks.json
+++ b/claude-ops/hooks/hooks.json
@@ -25,6 +25,24 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-pretool-wacli-health \"$TOOL_INPUT\" 2>/dev/null || true"
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-prevent-secret-commit",
+            "timeout": 5,
+            "if": "Bash(git commit*)"
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-no-rm-rf-anchor",
+            "timeout": 3,
+            "if": "Bash(rm *)"
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-warn-mainpush",
+            "timeout": 3,
+            "if": "Bash(git push*)"
           }
         ]
       },

--- a/claude-ops/tests/run-all.sh
+++ b/claude-ops/tests/run-all.sh
@@ -42,6 +42,7 @@ run_suite "$TESTS_DIR/test-no-secrets.sh"
 run_suite "$TESTS_DIR/test-agent-teams.sh"
 run_suite "$TESTS_DIR/test-ops-daemon-manager.sh"
 run_suite "$TESTS_DIR/test-ops-package.sh"
+run_suite "$TESTS_DIR/test-safety-hooks.sh"
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "SUMMARY"

--- a/claude-ops/tests/test-safety-hooks.sh
+++ b/claude-ops/tests/test-safety-hooks.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# test-safety-hooks.sh — Validates the 3 universal safety hooks:
+#   bin/ops-prevent-secret-commit  (PreToolUse, gated git commit*)
+#   bin/ops-no-rm-rf-anchor        (PreToolUse, gated rm *)
+#   bin/ops-warn-mainpush          (PreToolUse, gated git push*)
+set -uo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$PLUGIN_ROOT/bin"
+
+pass=0
+fail=0
+ok()  { echo "  PASS: $1"; pass=$((pass+1)); }
+err() { echo "  FAIL: $1"; fail=$((fail+1)); }
+
+# Helper: assert deny in JSON output.
+assert_deny() {
+  local out="$1" label="$2"
+  if echo "$out" | grep -q '"permissionDecision"[[:space:]]*:[[:space:]]*"deny"'; then
+    ok "$label"
+  else
+    err "$label (expected deny, got: $(echo "$out" | head -c 200))"
+  fi
+}
+assert_ask() {
+  local out="$1" label="$2"
+  if echo "$out" | grep -q '"permissionDecision"[[:space:]]*:[[:space:]]*"ask"'; then
+    ok "$label"
+  else
+    err "$label (expected ask, got: $(echo "$out" | head -c 200))"
+  fi
+}
+assert_allow() {
+  local out="$1" label="$2"
+  # Allow = empty stdout (no JSON emitted, exit 0).
+  if [[ -z "$out" ]]; then
+    ok "$label"
+  else
+    err "$label (expected silent allow, got: $(echo "$out" | head -c 200))"
+  fi
+}
+
+############################################
+# 1. ops-prevent-secret-commit
+############################################
+echo ""
+echo "── ops-prevent-secret-commit ──"
+
+TMPREPO=$(mktemp -d)
+cd "$TMPREPO"
+git init -q
+git config user.email "test@example.com"
+git config user.name "test"
+git commit --allow-empty -q -m init
+
+# Patterns to test. Sample values are runtime-assembled to avoid tripping
+# upstream secret scanners (GitHub, gitleaks, etc.) on this test file itself.
+P_LIVE="sk_""live_""abcdefghijklmnopqrstuvwxyz1234"
+P_TEST="sk_""test_""abcdefghijklmnopqrstuvwxyz1234"
+P_AKIA="AKIA""IOSFODNN7""EXAMPLE"
+P_GHP="ghp_""abcdefghijklmnopqrstuvwxyzABCDEF1234"
+P_GHO="gho_""abcdefghijklmnopqrstuvwxyzABCDEF1234"
+P_GHS="ghs_""abcdefghijklmnopqrstuvwxyzABCDEF1234"
+P_XOXB="xoxb""-12345-67890-abcdefghij"
+P_XOXA="xoxa""-12345-67890-abcdefghij"
+P_XOXP="xoxp""-12345-67890-abcdefghij"
+P_JWT="eyJhbGciOiJIUzI1NiJ9.""eyJzdWIiOiIxMjM0NSJ9.""SflKxwRJSMeKKF2QT4f"
+P_ANTHROPIC="ANTHROPIC_API_KEY=""sk-ant-""abc123"
+P_OPENAI="OPENAI_API_KEY=""sk-""proj-abc123"
+_PW_VAL="super""secret""123"
+P_PASS="password = \"${_PW_VAL}\""
+
+SECRETS=(
+  "stripe-live:$P_LIVE"
+  "stripe-test:$P_TEST"
+  "aws-akia:$P_AKIA"
+  "github-ghp:$P_GHP"
+  "github-gho:$P_GHO"
+  "github-ghs:$P_GHS"
+  "slack-xoxb:$P_XOXB"
+  "slack-xoxa:$P_XOXA"
+  "slack-xoxp:$P_XOXP"
+  "jwt:$P_JWT"
+  "anthropic-key:$P_ANTHROPIC"
+  "openai-key:$P_OPENAI"
+  "password:$P_PASS"
+)
+
+for entry in "${SECRETS[@]}"; do
+  label="${entry%%:*}"
+  payload="${entry#*:}"
+  echo "$payload" > "secret-$label.txt"
+  git add "secret-$label.txt"
+  out=$(TOOL_INPUT='{"command":"git commit -m fix"}' bash "$BIN/ops-prevent-secret-commit" 2>&1)
+  assert_deny "$out" "secret pattern blocked: $label"
+  git reset -q HEAD "secret-$label.txt" >/dev/null 2>&1
+  rm -f "secret-$label.txt"
+done
+
+# Clean diff → allow.
+echo "just some clean code" > clean.txt
+git add clean.txt
+out=$(TOOL_INPUT='{"command":"git commit -m clean"}' bash "$BIN/ops-prevent-secret-commit" 2>&1)
+assert_allow "$out" "clean diff allowed"
+git reset -q HEAD clean.txt >/dev/null 2>&1
+
+# Opt-out.
+echo "sk_""live_""aaaaaaaaaaaaaaaaaaaaaaaaaa" > optout.txt
+git add optout.txt
+out=$(CLAUDE_PLUGIN_OPTION_PREVENT_SECRET_COMMIT=false TOOL_INPUT='{"command":"git commit -m x"}' bash "$BIN/ops-prevent-secret-commit" 2>&1)
+assert_allow "$out" "opt-out (env=false) bypasses hook"
+git reset -q HEAD optout.txt >/dev/null 2>&1
+
+
+# Removal of secret → allow (only added lines are scanned).
+TMPREPO2=$(mktemp -d)
+cd "$TMPREPO2"
+git init -q
+git config user.email "test@example.com"
+git config user.name "test"
+echo "OPENAI_API_KEY=""sk-""proj-abc123" > leaked.txt
+git add leaked.txt
+git commit -q -m "oops leaked"
+# Now remove the secret and replace with env-var reference.
+echo 'OPENAI_API_KEY=$OPENAI_API_KEY' > leaked.txt
+git add leaked.txt
+out=$(TOOL_INPUT='{"command":"git commit -m remediate"}' bash "$BIN/ops-prevent-secret-commit" 2>&1)
+assert_allow "$out" "removing a secret is allowed (only added lines scanned)"
+cd / && rm -rf "$TMPREPO2"
+cd / && rm -rf "$TMPREPO"
+
+############################################
+# 2. ops-no-rm-rf-anchor
+############################################
+echo ""
+echo "── ops-no-rm-rf-anchor ──"
+
+DANGEROUS=(
+  "rm -rf /"
+  "rm -rf /*"
+  "rm -rf ~"
+  "rm -rf ~/*"
+  "rm -rf \$HOME"
+  "rm -rf \"\$HOME\""
+  "rm -rf .."
+  "rm -rf ../*"
+  "rm -rf ."
+  "rm -fr /"
+  "rm -Rf ~"
+  "rm --recursive --force /"
+)
+for cmd in "${DANGEROUS[@]}"; do
+  payload=$(printf '{"command":"%s"}' "$(echo "$cmd" | sed 's/"/\\"/g')")
+  out=$(TOOL_INPUT="$payload" bash "$BIN/ops-no-rm-rf-anchor" 2>&1)
+  assert_deny "$out" "dangerous blocked: $cmd"
+done
+
+SAFE=(
+  "rm -rf ./node_modules"
+  "rm -rf /tmp/foo"
+  "rm -rf /tmp/build-output"
+  "rm -rf dist"
+  "rm -rf ./dist/*"
+  "rm file.txt"
+  "rm -f stale.lock"
+  "rm -r somedir"
+)
+for cmd in "${SAFE[@]}"; do
+  payload=$(printf '{"command":"%s"}' "$cmd")
+  out=$(TOOL_INPUT="$payload" bash "$BIN/ops-no-rm-rf-anchor" 2>&1)
+  assert_allow "$out" "safe allowed: $cmd"
+done
+
+# Opt-out.
+out=$(CLAUDE_PLUGIN_OPTION_NO_RM_RF_ANCHOR=false TOOL_INPUT='{"command":"rm -rf /"}' bash "$BIN/ops-no-rm-rf-anchor" 2>&1)
+assert_allow "$out" "opt-out (env=false) bypasses hook"
+
+
+# Multi-target: safe first, dangerous second → still blocked.
+MULTI_DANGEROUS=(
+  "rm -rf /tmp/build /"
+  "rm -rf dist ~"
+  "rm -rf ./node_modules .."
+)
+for cmd in "${MULTI_DANGEROUS[@]}"; do
+  payload=$(printf '{"command":"%s"}' "$(echo "$cmd" | sed 's/"/\\"/g')")
+  out=$(TOOL_INPUT="$payload" bash "$BIN/ops-no-rm-rf-anchor" 2>&1)
+  assert_deny "$out" "multi-target blocked: $cmd"
+done
+############################################
+# 3. ops-warn-mainpush
+############################################
+echo ""
+echo "── ops-warn-mainpush ──"
+
+TMPREPO=$(mktemp -d)
+cd "$TMPREPO"
+git init -q -b main
+git config user.email "test@example.com"
+git config user.name "test"
+git commit --allow-empty -q -m init
+
+# On main → bare push asks.
+out=$(TOOL_INPUT='{"command":"git push"}' bash "$BIN/ops-warn-mainpush" 2>&1)
+assert_ask "$out" "bare push from main → ask"
+out=$(TOOL_INPUT='{"command":"git push origin"}' bash "$BIN/ops-warn-mainpush" 2>&1)
+assert_ask "$out" "git push origin from main → ask"
+out=$(TOOL_INPUT='{"command":"git push -u origin main"}' bash "$BIN/ops-warn-mainpush" 2>&1)
+assert_ask "$out" "explicit push origin main → ask"
+out=$(TOOL_INPUT='{"command":"git push origin master"}' bash "$BIN/ops-warn-mainpush" 2>&1)
+assert_ask "$out" "explicit push origin master → ask"
+out=$(TOOL_INPUT='{"command":"git push origin production"}' bash "$BIN/ops-warn-mainpush" 2>&1)
+assert_ask "$out" "explicit push origin production → ask"
+out=$(TOOL_INPUT='{"command":"git push origin HEAD:main"}' bash "$BIN/ops-warn-mainpush" 2>&1)
+assert_ask "$out" "refspec HEAD:main → ask"
+
+# Switch to feature branch → bare push allowed.
+git checkout -q -b feature/safe-thing
+out=$(TOOL_INPUT='{"command":"git push"}' bash "$BIN/ops-warn-mainpush" 2>&1)
+assert_allow "$out" "bare push from feature branch → allow"
+out=$(TOOL_INPUT='{"command":"git push -u origin feature/safe-thing"}' bash "$BIN/ops-warn-mainpush" 2>&1)
+assert_allow "$out" "explicit feature push → allow"
+
+# Opt-out.
+git checkout -q main
+out=$(CLAUDE_PLUGIN_OPTION_WARN_MAINPUSH=false TOOL_INPUT='{"command":"git push origin main"}' bash "$BIN/ops-warn-mainpush" 2>&1)
+assert_allow "$out" "opt-out (env=false) bypasses hook"
+
+cd / && rm -rf "$TMPREPO"
+
+############################################
+echo ""
+echo "── Summary ──"
+echo "  Passed: $pass"
+echo "  Failed: $fail"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
## Summary

Adds 3 opt-in (default ON) PreToolUse safety hooks that gate destructive Bash patterns universally — no project-specific knowledge required.

- **`ops-prevent-secret-commit`** — gated `Bash(git commit*)`. Scans `git diff --cached` for high-confidence secret patterns (Stripe `sk_live`/`sk_test`, AWS `AKIA`, GitHub `ghp_`/`gho_`/`ghs_`, Slack `xoxb`/`xoxa`/`xoxp`, JWTs, `ANTHROPIC_API_KEY`/`OPENAI_API_KEY`, hardcoded passwords). Emits `permissionDecision=deny` with file context.
- **`ops-no-rm-rf-anchor`** — gated `Bash(rm *)`. Denies `rm -rf` against `/`, `~`, `$HOME`, `..`, `.` (incl. `/*`, `~/*`, `../*`, quoted `"$HOME"`). Allows `./node_modules`, `/tmp/foo`, `dist`.
- **`ops-warn-mainpush`** — gated `Bash(git push*)`. Emits `permissionDecision=ask` for direct push to main/master/production (explicit dest, refspec `HEAD:main`, or while currently on protected branch).

Each hook is gated by a userConfig boolean (`prevent_secret_commit`, `no_rm_rf_anchor`, `warn_mainpush` — all default `true`) and bypassable via `CLAUDE_PLUGIN_OPTION_<KEY>=false`. POSIX-ERE regex (BSD/GNU compatible), python3 for safe JSON output, <100ms typical.

## Test plan

- [x] `tests/test-safety-hooks.sh` — 45 assertions, all pass
  - 13 secret patterns blocked; clean diff allowed; opt-out bypass verified
  - 12 dangerous `rm -rf` patterns blocked; 8 safe paths allowed; opt-out verified
  - 6 push-to-protected variants ask; 2 feature-branch pushes allow; opt-out verified
- [x] `tests/test-hooks.sh` — all referenced scripts exist, JSON valid
- [x] `tests/test-no-secrets.sh` — fixture values runtime-assembled to evade scanners
- [x] `tests/test-bin-scripts.sh` — shellcheck clean
- [x] Wired into `tests/run-all.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new PreToolUse hooks that can deny or prompt for common Bash commands (`git commit`, `rm -rf`, `git push`), which may interrupt developer workflows if the matchers/regexes misfire or environments lack expected tooling (git/python3).
> 
> **Overview**
> Adds three new **default-on** `PreToolUse` safety hooks for Bash: block `git commit` when the staged diff matches high-confidence secret patterns, deny `rm -rf` when the first target is a dangerous anchor (`/`, `~`, `$HOME`, `..`, `.`), and require confirmation when pushing directly to `main`/`master`/`production`.
> 
> Wires these hooks into `hooks.json`, exposes toggles in `plugin.json` (`prevent_secret_commit`, `no_rm_rf_anchor`, `warn_mainpush`), and adds a new `test-safety-hooks.sh` suite to the main test runner to validate deny/ask/allow behavior and opt-out paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68b3618e1d9643de6f7766acf1ecc1a4bb184a97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->