### PR TITLE
feat(account-rotation): fold multi-account Claude Max rotator into plugin

### DIFF
--- a/claude-ops/config/post-merge-services.example.json
+++ b/claude-ops/config/post-merge-services.example.json
@@ -1,5 +1,8 @@
 {
   "_doc": "Service health registry for ops-deploy-monitor. Key = '<owner/repo>:<base_branch>'. Each entry: { health: <url>, version: <url> (optional, returns {commit/sha/gitSha}) }. Layered lookup: project .claude/post-merge-services.json (committed) → user ~/.claude/config/post-merge-services.json → this plugin default. Add your own services in user-level or per-project file.",
-  "your-org/your-api:dev":  { "health": "https://api-dev.example.com/health", "version": "https://api-dev.example.com/version" },
-  "your-org/your-api:main": { "health": "https://api.example.com/health",     "version": "https://api.example.com/version" }
+  "your-org/your-api:dev": {
+    "health": "https://api-dev.example.com/health",
+    "version": "https://api-dev.example.com/version"
+  },
+  "your-org/your-api:main": { "health": "https://api.example.com/health", "version": "https://api.example.com/version" }
 }

--- a/claude-ops/scripts/account-rotation/README.md
+++ b/claude-ops/scripts/account-rotation/README.md
@@ -1,0 +1,99 @@
+# Multi-Account Claude Max Rotator
+
+Optional component of the `claude-ops` plugin. Rotates between multiple Claude
+Max subscriptions as 5-hour and weekly quotas approach the cap, so an active
+session can keep working without a manual `/login`.
+
+## What it does
+
+- Watches the active Claude Code session's reported usage (5h window + 7d window).
+- When the active account approaches its cap, picks the most cooled-down account from your configured list and swaps the keychain token.
+- Falls back to a Playwright-driven browser OAuth flow when refresh tokens have expired.
+- Has an optional Claude Haiku "AI brain" that drives the browser past unexpected pages (new Google challenges, workspace re-consent, etc).
+
+## Status: opt-in, advanced
+
+This is **off by default**. It requires:
+
+1. Multiple Claude Max accounts you legitimately own.
+2. macOS (uses the system keychain + `launchd` for the background daemon).
+3. Node 20+ (already required by the plugin).
+4. Optional: Playwright (installed on first browser-fallback use), Dashlane CLI (`dcli`) for credential reads.
+
+## Enable
+
+In Claude Code settings → plugin `ops` → toggle:
+
+- `account_rotation_enabled` → `true`
+
+Then run:
+
+```
+/ops:rotate
+```
+
+The skill walks you through:
+
+1. Adding your first account (`add-account`).
+2. Capturing the current keychain token into the rotator vault (`capture`).
+3. Installing the launchd daemon from `templates/com.claude-ops.account-rotation.plist`.
+4. Verifying everything with `status`.
+
+## Config
+
+`config.json` lives in the plugin data dir (`~/.claude/plugins/data/ops/account-rotation/config.json`) and is **never committed**. The shape is documented in `config.example.json`.
+
+Each account entry:
+
+| Field                  | Required | Notes                                                                        |
+| ---------------------- | -------- | ---------------------------------------------------------------------------- |
+| `email`                | yes      | Login email for the Claude Max account.                                      |
+| `label`                | no       | Disambiguator if you have two configs for the same email (multi-org).        |
+| `orgName` / `orgUuid`  | no       | Workspace metadata for accounts in a Claude org.                             |
+| `dashlaneTokenPath`    | no       | If you store the token in Dashlane: `dl://<vault-name>/password`.            |
+| `extraUsageEnabled`    | no       | Set to `true` ONLY if the account has paid overage on. Triggers safety margin. |
+| `capacityMultiplier`   | no       | Override per-account threshold (default 1.0 = standard Max 20x quota).       |
+
+## Keychain layout
+
+- `Claude Code-credentials` (account = your OS user) — the live token Claude Code reads.
+- `Claude-Rotation-<account_id>` (account = your OS user) — vault per configured account.
+
+The `<account_id>` is the email or label, picked when you `add-account`.
+
+Override the keychain account name via `CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT` if you need to (defaults to `$USER`).
+
+## Files
+
+| File                  | Purpose                                                                |
+| --------------------- | ---------------------------------------------------------------------- |
+| `rotate.mjs`          | Main rotation logic. CLI: `--status`, `--utilization`, `--to`, `--setup`. |
+| `daemon.mjs`          | launchd-managed monitor. Polls every 15s, rotates at 80% utilization.  |
+| `ai-brain.mjs`        | Claude Haiku fallback for unexpected OAuth pages.                      |
+| `force-rotate.sh`     | Out-of-band rotation when Claude Code is unreachable.                  |
+| `config.example.json` | Schema reference. Copy to `config.json` and populate.                  |
+
+## Triggers
+
+The daemon rotates when ANY one fires:
+
+1. 5h utilization >= 80%.
+2. 7d utilization >= 80%.
+3. The plugin's `rate-limit-detector.cjs` hook writes a 429 signal file.
+4. A 401 auth-error hook fires.
+5. You run `/ops:rotate rotate-now` or `force-rotate.sh`.
+
+## Disable
+
+```
+launchctl unload ~/Library/LaunchAgents/com.claude-ops.account-rotation.plist
+```
+
+And toggle `account_rotation_enabled` off in plugin settings.
+
+## Safety notes
+
+- Passwords NEVER leave your machine. The AI brain only sees a screenshot + DOM summary; password fields are masked.
+- The daemon never touches accounts marked `disabled: true` in `config.json`.
+- Accounts with `extraUsageEnabled: true` rotate at 75% (not 80%) to avoid paid overage.
+- A 3-minute post-rotation blackout suppresses thrashing.

--- a/claude-ops/scripts/account-rotation/ai-brain.mjs
+++ b/claude-ops/scripts/account-rotation/ai-brain.mjs
@@ -1,0 +1,343 @@
+#!/usr/bin/env node
+/**
+ * AI-brain fallback for the OAuth browser driver.
+ *
+ * Runs when the hard-coded playwright flow stalls on an unexpected page
+ * (new Google challenge type, Cloudflare interstitial, unseen cookie modal,
+ * terms-acceptance wall, workspace admin re-consent, etc.). Sends a PNG
+ * screenshot + DOM summary to Claude and executes the returned action.
+ *
+ * Safety caps:
+ *   - MAX_DECISIONS per rotation      (cost + runaway guard)
+ *   - screenshot ≤ 1.5MB, DOM text ≤ 6KB in the prompt
+ *   - passwords NEVER leave the machine; fill_password uses local dcli
+ *   - abort terminates the flow; never retry on abort
+ */
+import { execFileSync } from "child_process";
+
+const API_URL = "https://api.anthropic.com/v1/messages";
+const DEFAULT_MODEL = "claude-haiku-4-5";
+const MAX_DECISIONS = 6;
+const REQUEST_TIMEOUT_MS = 30_000;
+
+// ── Resolve API key from env → Doppler → keychain ────────────────────────────
+function readCommand(argv, timeout = 4000) {
+  try {
+    return execFileSync(argv[0], argv.slice(1), {
+      timeout,
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return "";
+  }
+}
+
+function resolveApiKey() {
+  if (process.env.ANTHROPIC_API_KEY?.startsWith("sk-ant-")) {
+    return process.env.ANTHROPIC_API_KEY;
+  }
+  // Optional Doppler lookup — set CLAUDE_ROTATOR_DOPPLER_PROJECTS as a
+  // comma-separated list of "<project>:<config>" pairs (e.g. "myapp:prd,other:dev").
+  const dopplerSpec = process.env.CLAUDE_ROTATOR_DOPPLER_PROJECTS || "";
+  const dopplerTargets = dopplerSpec
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => s.split(":"))
+    .filter((p) => p.length === 2);
+  for (const [project, config] of dopplerTargets) {
+    const out = readCommand([
+      "doppler",
+      "secrets",
+      "get",
+      "ANTHROPIC_API_KEY",
+      "--project",
+      project,
+      "--config",
+      config,
+      "--plain",
+    ]);
+    if (out.startsWith("sk-ant-")) return out;
+  }
+  // macOS keychain — account name = current OS user (matches rotate.mjs convention)
+  const kcAccount = process.env.USER || process.env.LOGNAME || "claude-ops";
+  const kc = readCommand(
+    [
+      "security",
+      "find-generic-password",
+      "-s",
+      "anthropic-api-key",
+      "-a",
+      kcAccount,
+      "-w",
+    ],
+    2000,
+  );
+  if (kc.startsWith("sk-ant-")) return kc;
+  return null;
+}
+
+// ── Snapshot: screenshot + structured DOM summary ────────────────────────────
+async function snapshotPage(page) {
+  let screenshotB64 = null;
+  try {
+    const buf = await page.screenshot({
+      type: "png",
+      fullPage: false,
+      timeout: 5000,
+    });
+    if (buf && buf.length < 1_500_000) {
+      screenshotB64 = Buffer.from(buf).toString("base64");
+    }
+  } catch {}
+  let domSummary = "";
+  try {
+    domSummary = await page.evaluate(() => {
+      const visible = (el) => {
+        const r = el.getBoundingClientRect();
+        const s = getComputedStyle(el);
+        return (
+          r.width > 0 &&
+          r.height > 0 &&
+          s.visibility !== "hidden" &&
+          s.display !== "none" &&
+          parseFloat(s.opacity || "1") > 0.1
+        );
+      };
+      const sel =
+        "button, a, input, textarea, select, [role=button], [role=link], [role=checkbox], [role=radio], [role=tab], li[data-challengetype]";
+      const nodes = [...document.querySelectorAll(sel)];
+      const items = [];
+      for (const n of nodes) {
+        if (items.length >= 60) break;
+        if (!visible(n)) continue;
+        const tag = n.tagName.toLowerCase();
+        const type = n.getAttribute("type") || "";
+        const id = n.id || "";
+        const testid = n.getAttribute("data-testid") || "";
+        const name = n.getAttribute("name") || "";
+        const challenge = n.getAttribute("data-challengetype") || "";
+        const cls = (n.getAttribute("class") || "")
+          .split(/\s+/)
+          .slice(0, 2)
+          .join(".");
+        const ariaLabel = n.getAttribute("aria-label") || "";
+        const rawText =
+          type === "password"
+            ? "(password — masked)"
+            : (n.innerText || n.value || n.placeholder || ariaLabel || "").trim();
+        const txt = rawText.slice(0, 120);
+        items.push(
+          `  ${tag}${type ? "[" + type + "]" : ""}${id ? " #" + id : ""}${
+            testid ? " data-testid=" + testid : ""
+          }${name ? " name=" + name : ""}${
+            challenge ? " data-challengetype=" + challenge : ""
+          }${cls ? " ." + cls : ""} :: ${txt}`,
+        );
+      }
+      const title = (document.title || "").slice(0, 200);
+      const headings = [...document.querySelectorAll("h1, h2, h3")]
+        .slice(0, 6)
+        .map((e) => (e.innerText || "").trim())
+        .filter(Boolean)
+        .join(" | ");
+      const bodyText = (document.body?.innerText || "").slice(0, 2000);
+      return `TITLE: ${title}\nHEADINGS: ${headings}\n---INTERACTIVE ELEMENTS---\n${items.join(
+        "\n",
+      )}\n---VISIBLE TEXT (trimmed)---\n${bodyText}`;
+    });
+  } catch (e) {
+    domSummary = `[dom extraction failed: ${String(e.message || e).slice(0, 80)}]`;
+  }
+  let url = "";
+  try {
+    url = page.url();
+  } catch {}
+  if (domSummary.length > 6000)
+    domSummary = domSummary.slice(0, 6000) + "\n[truncated]";
+  return { screenshotB64, domSummary, url };
+}
+
+// ── Prompt builder ────────────────────────────────────────────────────────────
+function buildPrompt(snapshot, account, attempt, history, stallReason) {
+  const orgHint = account.orgName
+    ? `Target Claude org/workspace: ${account.orgName}`
+    : "Target Claude org/workspace: Personal (default)";
+  return [
+    "You are an automation agent driving a Chrome browser through Google OAuth and claude.ai login.",
+    `Goal: complete login as ${account.email} and reach the Claude CLI localhost callback so a refresh token is issued.`,
+    orgHint,
+    "",
+    `Stall reason: ${stallReason}`,
+    `Current URL: ${snapshot.url || "(unknown)"}`,
+    "",
+    "Page snapshot (DOM summary):",
+    snapshot.domSummary,
+    "",
+    history.length
+      ? `Previous AI-brain decisions this rotation:\n${history
+          .map((h, i) => `  ${i + 1}. ${h}`)
+          .join("\n")}`
+      : "No prior AI-brain decisions yet.",
+    "",
+    `Attempt ${attempt}/${MAX_DECISIONS}.`,
+    "",
+    "Return ONLY one JSON object. No prose, no markdown fences.",
+    'Schema: { "action": "click|fill|fill_password|goto|wait|abort", "selector"?: string, "value"?: string, "url"?: string, "reason": string }',
+    "",
+    "Rules:",
+    "- action=click: `selector` is either a precise CSS selector or the EXACT visible text of the element.",
+    "- action=fill: `selector` is a CSS selector; `value` is the literal text to type. NEVER pass a password here.",
+    "- action=fill_password: the automation will inject the stored Google password into `selector` (defaults to input[type=password]).",
+    "- action=goto: `url` is an absolute URL to navigate to (only for Claude or Google auth hosts).",
+    "- action=wait: no fields; use when the page is still loading and a re-check is the right move.",
+    "- action=abort: ONLY for dead-ends — account locked, human-only CAPTCHA, wrong account with no switch UI, subscription canceled.",
+    "- Prefer the natural next step: 'Continue', 'Next', 'Authorize', 'Allow', 'Try another way', picking the target email in an account chooser, the correct workspace in the Claude org chooser.",
+    "- NEVER click 'Don't allow', 'Cancel', 'Forget this device', 'Remove account', 'Delete', or any destructive option.",
+    "- Language-tolerant: Dutch / German / French / Spanish variants are all valid.",
+    "- reCAPTCHA/hCaptcha checkbox: try clicking once; invisible challenge → abort with reason='captcha'.",
+    "- If the page is just a spinner with no interactive elements yet, action=wait.",
+  ].join("\n");
+}
+
+function parseActionJson(text) {
+  if (!text) return null;
+  let cleaned = text.trim();
+  cleaned = cleaned
+    .replace(/^```(?:json|JSON)?\s*/i, "")
+    .replace(/```\s*$/i, "")
+    .trim();
+  const m = cleaned.match(/\{[\s\S]*\}/);
+  if (!m) return null;
+  try {
+    return JSON.parse(m[0]);
+  } catch {
+    return null;
+  }
+}
+
+// ── Public: ask Claude what to do ─────────────────────────────────────────────
+export async function askAIBrain({
+  page,
+  account,
+  history,
+  stallReason,
+  logger,
+}) {
+  const log = logger || ((m) => console.error(`[ai-brain] ${m}`));
+  const apiKey = resolveApiKey();
+  if (!apiKey) {
+    log("no ANTHROPIC_API_KEY available (env, Doppler, keychain all empty)");
+    return { action: "abort", reason: "no_api_key" };
+  }
+  const attempt = history.length + 1;
+  if (attempt > MAX_DECISIONS) {
+    return { action: "abort", reason: `decision_cap_${MAX_DECISIONS}` };
+  }
+  const snap = await snapshotPage(page);
+  const prompt = buildPrompt(snap, account, attempt, history, stallReason);
+
+  const content = [];
+  if (snap.screenshotB64) {
+    content.push({
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: "image/png",
+        data: snap.screenshotB64,
+      },
+    });
+  }
+  content.push({ type: "text", text: prompt });
+
+  const model = process.env.CLAUDE_ROTATOR_BRAIN_MODEL || DEFAULT_MODEL;
+  log(
+    `asking ${model} (attempt ${attempt}/${MAX_DECISIONS}) — stall: ${stallReason}`,
+  );
+
+  try {
+    const res = await fetch(API_URL, {
+      method: "POST",
+      headers: {
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: 400,
+        messages: [{ role: "user", content }],
+      }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const reason =
+        data?.error?.message || data?.error?.type || `http_${res.status}`;
+      log(`api error: ${String(reason).slice(0, 160)}`);
+      return {
+        action: "abort",
+        reason: `api_error: ${String(reason).slice(0, 80)}`,
+      };
+    }
+    const text = (data?.content || [])
+      .map((p) => p?.text || "")
+      .join("")
+      .trim();
+    const action = parseActionJson(text);
+    if (!action || !action.action) {
+      log(`unparseable response: ${text.slice(0, 120)}`);
+      return { action: "abort", reason: "unparseable_response" };
+    }
+    log(
+      `decided: ${action.action}${action.selector ? ` selector=${String(action.selector).slice(0, 60)}` : ""}${action.url ? ` url=${String(action.url).slice(0, 60)}` : ""} — ${String(action.reason || "").slice(0, 80)}`,
+    );
+    return action;
+  } catch (e) {
+    log(`call failed: ${String(e.message || e).slice(0, 120)}`);
+    return {
+      action: "abort",
+      reason: `call_failed: ${String(e.message || e).slice(0, 80)}`,
+    };
+  }
+}
+
+// ── Execute the returned action against the existing driver ──────────────────
+export async function executeAIAction(driver, action, { googlePassword } = {}) {
+  if (!action || !action.action) return false;
+  try {
+    switch (action.action) {
+      case "click": {
+        if (!action.selector) return false;
+        return await driver.findAndClick([action.selector]);
+      }
+      case "fill": {
+        if (!action.selector) return false;
+        return await driver.fillInput(action.selector, action.value || "");
+      }
+      case "fill_password": {
+        if (!googlePassword) return false;
+        const sel = action.selector || 'input[type="password"]';
+        return await driver.fillInput(sel, googlePassword);
+      }
+      case "goto": {
+        if (!action.url) return false;
+        await driver.goto(action.url);
+        return true;
+      }
+      case "wait": {
+        await new Promise((r) => setTimeout(r, 4000));
+        return true;
+      }
+      case "abort":
+      default:
+        return false;
+    }
+  } catch {
+    return false;
+  }
+}
+
+export const AI_BRAIN_MAX_DECISIONS = MAX_DECISIONS;

--- a/claude-ops/scripts/account-rotation/ai-brain.mjs
+++ b/claude-ops/scripts/account-rotation/ai-brain.mjs
@@ -13,10 +13,10 @@
  *   - passwords NEVER leave the machine; fill_password uses local dcli
  *   - abort terminates the flow; never retry on abort
  */
-import { execFileSync } from "child_process";
+import { execFileSync } from 'child_process';
 
-const API_URL = "https://api.anthropic.com/v1/messages";
-const DEFAULT_MODEL = "claude-haiku-4-5";
+const API_URL = 'https://api.anthropic.com/v1/messages';
+const DEFAULT_MODEL = 'claude-haiku-4-5';
 const MAX_DECISIONS = 6;
 const REQUEST_TIMEOUT_MS = 30_000;
 
@@ -25,57 +25,46 @@ function readCommand(argv, timeout = 4000) {
   try {
     return execFileSync(argv[0], argv.slice(1), {
       timeout,
-      stdio: ["ignore", "pipe", "ignore"],
+      stdio: ['ignore', 'pipe', 'ignore'],
     })
       .toString()
       .trim();
   } catch {
-    return "";
+    return '';
   }
 }
 
 function resolveApiKey() {
-  if (process.env.ANTHROPIC_API_KEY?.startsWith("sk-ant-")) {
+  if (process.env.ANTHROPIC_API_KEY?.startsWith('sk-ant-')) {
     return process.env.ANTHROPIC_API_KEY;
   }
   // Optional Doppler lookup — set CLAUDE_ROTATOR_DOPPLER_PROJECTS as a
   // comma-separated list of "<project>:<config>" pairs (e.g. "myapp:prd,other:dev").
-  const dopplerSpec = process.env.CLAUDE_ROTATOR_DOPPLER_PROJECTS || "";
+  const dopplerSpec = process.env.CLAUDE_ROTATOR_DOPPLER_PROJECTS || '';
   const dopplerTargets = dopplerSpec
-    .split(",")
+    .split(',')
     .map((s) => s.trim())
     .filter(Boolean)
-    .map((s) => s.split(":"))
+    .map((s) => s.split(':'))
     .filter((p) => p.length === 2);
   for (const [project, config] of dopplerTargets) {
     const out = readCommand([
-      "doppler",
-      "secrets",
-      "get",
-      "ANTHROPIC_API_KEY",
-      "--project",
+      'doppler',
+      'secrets',
+      'get',
+      'ANTHROPIC_API_KEY',
+      '--project',
       project,
-      "--config",
+      '--config',
       config,
-      "--plain",
+      '--plain',
     ]);
-    if (out.startsWith("sk-ant-")) return out;
+    if (out.startsWith('sk-ant-')) return out;
   }
   // macOS keychain — account name = current OS user (matches rotate.mjs convention)
-  const kcAccount = process.env.USER || process.env.LOGNAME || "claude-ops";
-  const kc = readCommand(
-    [
-      "security",
-      "find-generic-password",
-      "-s",
-      "anthropic-api-key",
-      "-a",
-      kcAccount,
-      "-w",
-    ],
-    2000,
-  );
-  if (kc.startsWith("sk-ant-")) return kc;
+  const kcAccount = process.env.USER || process.env.LOGNAME || 'claude-ops';
+  const kc = readCommand(['security', 'find-generic-password', '-s', 'anthropic-api-key', '-a', kcAccount, '-w'], 2000);
+  if (kc.startsWith('sk-ant-')) return kc;
   return null;
 }
 
@@ -84,15 +73,15 @@ async function snapshotPage(page) {
   let screenshotB64 = null;
   try {
     const buf = await page.screenshot({
-      type: "png",
+      type: 'png',
       fullPage: false,
       timeout: 5000,
     });
     if (buf && buf.length < 1_500_000) {
-      screenshotB64 = Buffer.from(buf).toString("base64");
+      screenshotB64 = Buffer.from(buf).toString('base64');
     }
   } catch {}
-  let domSummary = "";
+  let domSummary = '';
   try {
     domSummary = await page.evaluate(() => {
       const visible = (el) => {
@@ -101,62 +90,58 @@ async function snapshotPage(page) {
         return (
           r.width > 0 &&
           r.height > 0 &&
-          s.visibility !== "hidden" &&
-          s.display !== "none" &&
-          parseFloat(s.opacity || "1") > 0.1
+          s.visibility !== 'hidden' &&
+          s.display !== 'none' &&
+          parseFloat(s.opacity || '1') > 0.1
         );
       };
       const sel =
-        "button, a, input, textarea, select, [role=button], [role=link], [role=checkbox], [role=radio], [role=tab], li[data-challengetype]";
+        'button, a, input, textarea, select, [role=button], [role=link], [role=checkbox], [role=radio], [role=tab], li[data-challengetype]';
       const nodes = [...document.querySelectorAll(sel)];
       const items = [];
       for (const n of nodes) {
         if (items.length >= 60) break;
         if (!visible(n)) continue;
         const tag = n.tagName.toLowerCase();
-        const type = n.getAttribute("type") || "";
-        const id = n.id || "";
-        const testid = n.getAttribute("data-testid") || "";
-        const name = n.getAttribute("name") || "";
-        const challenge = n.getAttribute("data-challengetype") || "";
-        const cls = (n.getAttribute("class") || "")
-          .split(/\s+/)
-          .slice(0, 2)
-          .join(".");
-        const ariaLabel = n.getAttribute("aria-label") || "";
+        const type = n.getAttribute('type') || '';
+        const id = n.id || '';
+        const testid = n.getAttribute('data-testid') || '';
+        const name = n.getAttribute('name') || '';
+        const challenge = n.getAttribute('data-challengetype') || '';
+        const cls = (n.getAttribute('class') || '').split(/\s+/).slice(0, 2).join('.');
+        const ariaLabel = n.getAttribute('aria-label') || '';
         const rawText =
-          type === "password"
-            ? "(password — masked)"
-            : (n.innerText || n.value || n.placeholder || ariaLabel || "").trim();
+          type === 'password'
+            ? '(password — masked)'
+            : (n.innerText || n.value || n.placeholder || ariaLabel || '').trim();
         const txt = rawText.slice(0, 120);
         items.push(
-          `  ${tag}${type ? "[" + type + "]" : ""}${id ? " #" + id : ""}${
-            testid ? " data-testid=" + testid : ""
-          }${name ? " name=" + name : ""}${
-            challenge ? " data-challengetype=" + challenge : ""
-          }${cls ? " ." + cls : ""} :: ${txt}`,
+          `  ${tag}${type ? '[' + type + ']' : ''}${id ? ' #' + id : ''}${
+            testid ? ' data-testid=' + testid : ''
+          }${name ? ' name=' + name : ''}${
+            challenge ? ' data-challengetype=' + challenge : ''
+          }${cls ? ' .' + cls : ''} :: ${txt}`,
         );
       }
-      const title = (document.title || "").slice(0, 200);
-      const headings = [...document.querySelectorAll("h1, h2, h3")]
+      const title = (document.title || '').slice(0, 200);
+      const headings = [...document.querySelectorAll('h1, h2, h3')]
         .slice(0, 6)
-        .map((e) => (e.innerText || "").trim())
+        .map((e) => (e.innerText || '').trim())
         .filter(Boolean)
-        .join(" | ");
-      const bodyText = (document.body?.innerText || "").slice(0, 2000);
+        .join(' | ');
+      const bodyText = (document.body?.innerText || '').slice(0, 2000);
       return `TITLE: ${title}\nHEADINGS: ${headings}\n---INTERACTIVE ELEMENTS---\n${items.join(
-        "\n",
+        '\n',
       )}\n---VISIBLE TEXT (trimmed)---\n${bodyText}`;
     });
   } catch (e) {
     domSummary = `[dom extraction failed: ${String(e.message || e).slice(0, 80)}]`;
   }
-  let url = "";
+  let url = '';
   try {
     url = page.url();
   } catch {}
-  if (domSummary.length > 6000)
-    domSummary = domSummary.slice(0, 6000) + "\n[truncated]";
+  if (domSummary.length > 6000) domSummary = domSummary.slice(0, 6000) + '\n[truncated]';
   return { screenshotB64, domSummary, url };
 }
 
@@ -164,50 +149,48 @@ async function snapshotPage(page) {
 function buildPrompt(snapshot, account, attempt, history, stallReason) {
   const orgHint = account.orgName
     ? `Target Claude org/workspace: ${account.orgName}`
-    : "Target Claude org/workspace: Personal (default)";
+    : 'Target Claude org/workspace: Personal (default)';
   return [
-    "You are an automation agent driving a Chrome browser through Google OAuth and claude.ai login.",
+    'You are an automation agent driving a Chrome browser through Google OAuth and claude.ai login.',
     `Goal: complete login as ${account.email} and reach the Claude CLI localhost callback so a refresh token is issued.`,
     orgHint,
-    "",
+    '',
     `Stall reason: ${stallReason}`,
-    `Current URL: ${snapshot.url || "(unknown)"}`,
-    "",
-    "Page snapshot (DOM summary):",
+    `Current URL: ${snapshot.url || '(unknown)'}`,
+    '',
+    'Page snapshot (DOM summary):',
     snapshot.domSummary,
-    "",
+    '',
     history.length
-      ? `Previous AI-brain decisions this rotation:\n${history
-          .map((h, i) => `  ${i + 1}. ${h}`)
-          .join("\n")}`
-      : "No prior AI-brain decisions yet.",
-    "",
+      ? `Previous AI-brain decisions this rotation:\n${history.map((h, i) => `  ${i + 1}. ${h}`).join('\n')}`
+      : 'No prior AI-brain decisions yet.',
+    '',
     `Attempt ${attempt}/${MAX_DECISIONS}.`,
-    "",
-    "Return ONLY one JSON object. No prose, no markdown fences.",
+    '',
+    'Return ONLY one JSON object. No prose, no markdown fences.',
     'Schema: { "action": "click|fill|fill_password|goto|wait|abort", "selector"?: string, "value"?: string, "url"?: string, "reason": string }',
-    "",
-    "Rules:",
-    "- action=click: `selector` is either a precise CSS selector or the EXACT visible text of the element.",
-    "- action=fill: `selector` is a CSS selector; `value` is the literal text to type. NEVER pass a password here.",
-    "- action=fill_password: the automation will inject the stored Google password into `selector` (defaults to input[type=password]).",
-    "- action=goto: `url` is an absolute URL to navigate to (only for Claude or Google auth hosts).",
-    "- action=wait: no fields; use when the page is still loading and a re-check is the right move.",
-    "- action=abort: ONLY for dead-ends — account locked, human-only CAPTCHA, wrong account with no switch UI, subscription canceled.",
+    '',
+    'Rules:',
+    '- action=click: `selector` is either a precise CSS selector or the EXACT visible text of the element.',
+    '- action=fill: `selector` is a CSS selector; `value` is the literal text to type. NEVER pass a password here.',
+    '- action=fill_password: the automation will inject the stored Google password into `selector` (defaults to input[type=password]).',
+    '- action=goto: `url` is an absolute URL to navigate to (only for Claude or Google auth hosts).',
+    '- action=wait: no fields; use when the page is still loading and a re-check is the right move.',
+    '- action=abort: ONLY for dead-ends — account locked, human-only CAPTCHA, wrong account with no switch UI, subscription canceled.',
     "- Prefer the natural next step: 'Continue', 'Next', 'Authorize', 'Allow', 'Try another way', picking the target email in an account chooser, the correct workspace in the Claude org chooser.",
     "- NEVER click 'Don't allow', 'Cancel', 'Forget this device', 'Remove account', 'Delete', or any destructive option.",
-    "- Language-tolerant: Dutch / German / French / Spanish variants are all valid.",
+    '- Language-tolerant: Dutch / German / French / Spanish variants are all valid.',
     "- reCAPTCHA/hCaptcha checkbox: try clicking once; invisible challenge → abort with reason='captcha'.",
-    "- If the page is just a spinner with no interactive elements yet, action=wait.",
-  ].join("\n");
+    '- If the page is just a spinner with no interactive elements yet, action=wait.',
+  ].join('\n');
 }
 
 function parseActionJson(text) {
   if (!text) return null;
   let cleaned = text.trim();
   cleaned = cleaned
-    .replace(/^```(?:json|JSON)?\s*/i, "")
-    .replace(/```\s*$/i, "")
+    .replace(/^```(?:json|JSON)?\s*/i, '')
+    .replace(/```\s*$/i, '')
     .trim();
   const m = cleaned.match(/\{[\s\S]*\}/);
   if (!m) return null;
@@ -219,22 +202,16 @@ function parseActionJson(text) {
 }
 
 // ── Public: ask Claude what to do ─────────────────────────────────────────────
-export async function askAIBrain({
-  page,
-  account,
-  history,
-  stallReason,
-  logger,
-}) {
+export async function askAIBrain({ page, account, history, stallReason, logger }) {
   const log = logger || ((m) => console.error(`[ai-brain] ${m}`));
   const apiKey = resolveApiKey();
   if (!apiKey) {
-    log("no ANTHROPIC_API_KEY available (env, Doppler, keychain all empty)");
-    return { action: "abort", reason: "no_api_key" };
+    log('no ANTHROPIC_API_KEY available (env, Doppler, keychain all empty)');
+    return { action: 'abort', reason: 'no_api_key' };
   }
   const attempt = history.length + 1;
   if (attempt > MAX_DECISIONS) {
-    return { action: "abort", reason: `decision_cap_${MAX_DECISIONS}` };
+    return { action: 'abort', reason: `decision_cap_${MAX_DECISIONS}` };
   }
   const snap = await snapshotPage(page);
   const prompt = buildPrompt(snap, account, attempt, history, stallReason);
@@ -242,63 +219,60 @@ export async function askAIBrain({
   const content = [];
   if (snap.screenshotB64) {
     content.push({
-      type: "image",
+      type: 'image',
       source: {
-        type: "base64",
-        media_type: "image/png",
+        type: 'base64',
+        media_type: 'image/png',
         data: snap.screenshotB64,
       },
     });
   }
-  content.push({ type: "text", text: prompt });
+  content.push({ type: 'text', text: prompt });
 
   const model = process.env.CLAUDE_ROTATOR_BRAIN_MODEL || DEFAULT_MODEL;
-  log(
-    `asking ${model} (attempt ${attempt}/${MAX_DECISIONS}) — stall: ${stallReason}`,
-  );
+  log(`asking ${model} (attempt ${attempt}/${MAX_DECISIONS}) — stall: ${stallReason}`);
 
   try {
     const res = await fetch(API_URL, {
-      method: "POST",
+      method: 'POST',
       headers: {
-        "x-api-key": apiKey,
-        "anthropic-version": "2023-06-01",
-        "content-type": "application/json",
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
       },
       body: JSON.stringify({
         model,
         max_tokens: 400,
-        messages: [{ role: "user", content }],
+        messages: [{ role: 'user', content }],
       }),
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
     const data = await res.json().catch(() => ({}));
     if (!res.ok) {
-      const reason =
-        data?.error?.message || data?.error?.type || `http_${res.status}`;
+      const reason = data?.error?.message || data?.error?.type || `http_${res.status}`;
       log(`api error: ${String(reason).slice(0, 160)}`);
       return {
-        action: "abort",
+        action: 'abort',
         reason: `api_error: ${String(reason).slice(0, 80)}`,
       };
     }
     const text = (data?.content || [])
-      .map((p) => p?.text || "")
-      .join("")
+      .map((p) => p?.text || '')
+      .join('')
       .trim();
     const action = parseActionJson(text);
     if (!action || !action.action) {
       log(`unparseable response: ${text.slice(0, 120)}`);
-      return { action: "abort", reason: "unparseable_response" };
+      return { action: 'abort', reason: 'unparseable_response' };
     }
     log(
-      `decided: ${action.action}${action.selector ? ` selector=${String(action.selector).slice(0, 60)}` : ""}${action.url ? ` url=${String(action.url).slice(0, 60)}` : ""} — ${String(action.reason || "").slice(0, 80)}`,
+      `decided: ${action.action}${action.selector ? ` selector=${String(action.selector).slice(0, 60)}` : ''}${action.url ? ` url=${String(action.url).slice(0, 60)}` : ''} — ${String(action.reason || '').slice(0, 80)}`,
     );
     return action;
   } catch (e) {
     log(`call failed: ${String(e.message || e).slice(0, 120)}`);
     return {
-      action: "abort",
+      action: 'abort',
       reason: `call_failed: ${String(e.message || e).slice(0, 80)}`,
     };
   }
@@ -309,29 +283,39 @@ export async function executeAIAction(driver, action, { googlePassword } = {}) {
   if (!action || !action.action) return false;
   try {
     switch (action.action) {
-      case "click": {
+      case 'click': {
         if (!action.selector) return false;
         return await driver.findAndClick([action.selector]);
       }
-      case "fill": {
+      case 'fill': {
         if (!action.selector) return false;
-        return await driver.fillInput(action.selector, action.value || "");
+        return await driver.fillInput(action.selector, action.value || '');
       }
-      case "fill_password": {
+      case 'fill_password': {
         if (!googlePassword) return false;
         const sel = action.selector || 'input[type="password"]';
         return await driver.fillInput(sel, googlePassword);
       }
-      case "goto": {
+      case 'goto': {
         if (!action.url) return false;
+        // Code-level URL allowlist — prompt constraints alone are insufficient
+        const allowedHosts = ['claude.ai', 'accounts.google.com', 'myaccount.google.com', 'login.microsoftonline.com'];
+        try {
+          const host = new URL(action.url).hostname;
+          if (!allowedHosts.some((d) => host === d || host.endsWith('.' + d))) {
+            return false;
+          }
+        } catch {
+          return false;
+        }
         await driver.goto(action.url);
         return true;
       }
-      case "wait": {
+      case 'wait': {
         await new Promise((r) => setTimeout(r, 4000));
         return true;
       }
-      case "abort":
+      case 'abort':
       default:
         return false;
     }

--- a/claude-ops/scripts/account-rotation/config.example.json
+++ b/claude-ops/scripts/account-rotation/config.example.json
@@ -1,0 +1,27 @@
+{
+  "_comment": "Copy to config.json and add your Claude Max accounts. The rotator does NOT ship with any accounts — you opt in by populating this file via /ops:rotate add-account or by editing it directly. See README.md for details.",
+  "accounts": [],
+  "_account_schema_example": {
+    "email": "user@example.com",
+    "label": "optional-disambiguator",
+    "orgName": "Optional Workspace Name",
+    "orgUuid": "optional-workspace-uuid",
+    "dashlaneTokenPath": "dl://claude-max-user@example.com/password",
+    "dashlaneGooglePath": null,
+    "extraUsageEnabled": false,
+    "capacityMultiplier": 1.0
+  },
+  "rateLimits": {
+    "tokensPerWindow": 220000,
+    "windowHours": 5,
+    "messagesPerWindow": 900,
+    "weeklyCapMultiplier": 1.0,
+    "extraUsageSafetyMargin": 0.75,
+    "note": "Max 20x defaults: ~220K tokens / ~900 messages per 5h window. extraUsageSafetyMargin: accounts with paid overage enabled rotate at 75% of their threshold to avoid incurring charges."
+  },
+  "toolUseThreshold": 800,
+  "maxHoursPerAccount": 4,
+  "autoRotate": true,
+  "refreshSession": false,
+  "notifyOnRotation": true
+}

--- a/claude-ops/scripts/account-rotation/config.example.json
+++ b/claude-ops/scripts/account-rotation/config.example.json
@@ -8,6 +8,7 @@
     "orgUuid": "optional-workspace-uuid",
     "dashlaneTokenPath": "dl://claude-max-user@example.com/password",
     "dashlaneGooglePath": null,
+    "googleSmsPhone": "+1234567890",
     "extraUsageEnabled": false,
     "capacityMultiplier": 1.0
   },

--- a/claude-ops/scripts/account-rotation/daemon.mjs
+++ b/claude-ops/scripts/account-rotation/daemon.mjs
@@ -27,7 +27,7 @@ import {
 } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import { execSync, execFileSync, spawn } from "child_process";
+import { execSync, execFileSync, spawn, spawnSync } from "child_process";
 import { tmpdir } from "os";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -161,10 +161,19 @@ function readStoredToken(account) {
 
 function readActiveKeychainToken() {
   try {
-    const out = execSync(
-      'security find-generic-password -s "Claude Code-credentials" -g 2>&1',
-      { timeout: 5000 },
-    ).toString();
+    const r = spawnSync(
+      "security",
+      [
+        "find-generic-password",
+        "-s",
+        "Claude Code-credentials",
+        "-a",
+        KEYCHAIN_ACCOUNT,
+        "-g",
+      ],
+      { encoding: "utf8", timeout: 5000 },
+    );
+    const out = `${r.stdout || ""}${r.stderr || ""}`;
     const m = out.match(/^password: "?(.*?)"?$/m);
     return m ? m[1].replace(/\\"/g, '"') : null;
   } catch {
@@ -562,15 +571,11 @@ async function doRotation(reason) {
   }
 }
 
-// ── Dynamic token refresh ────────────────────────────────────────────────────
-// Instead of a fixed hourly launchd job refreshing all accounts, refresh
-// on-demand: when utilization is climbing (50%+), pre-refresh candidate
-// accounts so they're ready for rotation. Also refresh any token within
-// 1h of expiry regardless of utilization.
+// ── Token refresh (vault entries) ───────────────────────────────────────────
+// In-place refresh via OAuth; invoked from shouldRotate / findValidRotationTarget.
 
 const TOKEN_ENDPOINT = "https://platform.claude.com/v1/oauth/token";
 const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
-const REFRESH_URGENCY_MS = 1 * 3_600_000; // Refresh if <1h remaining
 
 function parseTokenExpiry(tokenJson) {
   try {
@@ -636,41 +641,14 @@ async function refreshSingleToken(account) {
   }
 }
 
-async function dynamicRefresh(config, state) {
-  const now = Date.now();
-  const real = readRealUtilization();
-  const pct5h = real?.five_hour?.pct || 0;
-
-  for (const account of config.accounts) {
-    const key = accountKey(account);
-    if (key === state.activeAccount) continue; // Don't refresh active account mid-session
-
-    const tokenJson = readStoredToken(account);
-    if (!tokenJson) continue;
-    const expiry = parseTokenExpiry(tokenJson);
-    const remaining = expiry - now;
-
-    // Refresh if: token expiring within 1h, OR utilization >50% and token <3h
-    const urgent = remaining > 0 && remaining < REFRESH_URGENCY_MS;
-    const preemptive =
-      pct5h >= 50 && remaining > 0 && remaining < 3 * 3_600_000;
-
-    if (urgent || preemptive) {
-      await refreshSingleToken(account);
-      await sleep(2000); // Don't hammer the token endpoint
-    }
-  }
-}
-
 // ── Main loop ─────────────────────────────────────────────────────────────────
 
 async function mainLoop() {
-  log("Daemon started (v3 — dynamic refresh, no hourly launchd)");
-  notify("Claude Rotation Daemon", "Monitoring usage — dynamic refresh");
+  log("Daemon started (v3 — on-demand token refresh)");
+  notify("Claude Rotation Daemon", "Monitoring usage — on-demand refresh");
 
   let lastRotatedAt = 0; // track when we last rotated
   let lastStatusLog = 0; // periodic status logging
-  let lastRefreshCheck = 0; // dynamic refresh check
   let lastDriftCheck = 0; // cheap vault-based drift detection
 
   while (true) {

--- a/claude-ops/scripts/account-rotation/daemon.mjs
+++ b/claude-ops/scripts/account-rotation/daemon.mjs
@@ -1,0 +1,854 @@
+#!/usr/bin/env node
+/**
+ * Claude Account Rotation Daemon
+ *
+ * Runs in background, monitors:
+ *   1. Tool use count (from usage-tracker.js hook)
+ *   2. Time per account (maxHoursPerAccount)
+ *   3. Rate limit errors (watches Claude Code stderr / log patterns)
+ *   4. Token expiry
+ *
+ * Auto-rotates to the most cooled-down account when any threshold is hit.
+ *
+ * Usage:
+ *   node daemon.mjs           # Run in foreground
+ *   node daemon.mjs --bg      # Daemonize
+ *   node daemon.mjs --stop    # Stop running daemon
+ *   node daemon.mjs --status  # Show daemon status
+ */
+
+import {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  unlinkSync,
+  appendFileSync,
+  statSync,
+} from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { execSync, spawn } from "child_process";
+import { tmpdir } from "os";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CONFIG_PATH = join(__dirname, "config.json");
+const STATE_PATH = join(__dirname, "state.json");
+const LOG_PATH = join(__dirname, "rotation.log");
+const PID_FILE = join(__dirname, ".daemon.pid");
+const ROTATE_SCRIPT = join(__dirname, "rotate.mjs");
+
+// Keychain account name — must match rotate.mjs convention.
+const KEYCHAIN_ACCOUNT =
+  process.env.CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT ||
+  process.env.USER ||
+  process.env.LOGNAME ||
+  "claude-ops";
+
+const POLL_INTERVAL = 15_000; // Check every 15s — fast enough to catch hook-triggered 429 signals (fireAt = now+15s)
+const RATE_LIMIT_COOLDOWN = 10_000; // 10s after rate limit before rotating
+const POST_ROTATION_BLACKOUT = 180_000; // 3min after rotation: ignore ALL triggers
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const MAX_LOG_SIZE = 50_000; // 50KB — ~500 lines, enough for debugging
+function log(msg) {
+  const line = `[${new Date().toISOString()}] [daemon] ${msg}`;
+  console.error(line);
+  try {
+    appendFileSync(LOG_PATH, line + "\n");
+    // Truncate: keep last half when exceeding max
+    try {
+      const { size } = statSync(LOG_PATH);
+      if (size > MAX_LOG_SIZE) {
+        const content = readFileSync(LOG_PATH, "utf8");
+        const lines = content.split("\n");
+        writeFileSync(
+          LOG_PATH,
+          lines.slice(Math.floor(lines.length / 2)).join("\n"),
+        );
+      }
+    } catch {}
+  } catch {}
+}
+
+function notify(title, msg) {
+  try {
+    execSync(
+      `osascript -e 'display notification "${msg.replace(/"/g, '\\"')}" with title "${title}"'`,
+    );
+  } catch {}
+}
+
+function readConfig() {
+  return JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
+}
+function readState() {
+  try {
+    return JSON.parse(readFileSync(STATE_PATH, "utf8"));
+  } catch {
+    return {
+      activeAccount: null,
+      accounts: {},
+      toolUses: 0,
+      totalRotations: 0,
+    };
+  }
+}
+
+// ── Account cooldown tracking ───────────────────────────────────────────────
+// Each account's state.accounts[key].lastUtilization has { pct, reset, ts }.
+// `reset` is epoch seconds for when the 5h window resets. If reset > now, the
+// account is still cooling down. rotate.mjs queries all accounts via the
+// Anthropic API and populates this data at rotation time.
+
+function accountCooldownStatus(state) {
+  const now = Date.now();
+  const summary = [];
+  for (const [key, acct] of Object.entries(state.accounts || {})) {
+    const util = acct.lastUtilization;
+    if (!util) {
+      summary.push(`  ${key}: unknown`);
+      continue;
+    }
+    const resetMs = util.reset ? util.reset * 1000 : 0;
+    const fresh = resetMs && resetMs < now;
+    const pct = util.pct ?? "?";
+    if (fresh) {
+      summary.push(
+        `  ${key}: READY (reset ${Math.round((now - resetMs) / 60_000)}min ago, was ${pct}%)`,
+      );
+    } else if (resetMs) {
+      summary.push(
+        `  ${key}: COOLING (${pct}%, resets in ${Math.round((resetMs - now) / 60_000)}min)`,
+      );
+    } else {
+      summary.push(`  ${key}: ${pct}% (no reset info)`);
+    }
+  }
+  return summary.join("\n");
+}
+
+function accountKey(a) {
+  return a.label || a.email;
+}
+
+function tokenExpired(json) {
+  try {
+    const exp = JSON.parse(json)?.claudeAiOauth?.expiresAt;
+    if (!exp) return false;
+    // Expired or expiring within 5 minutes
+    return Date.now() > exp - 5 * 60_000;
+  } catch {
+    return false;
+  }
+}
+
+function readStoredToken(account) {
+  const svc = `Claude-Rotation-${accountKey(account)}`;
+  try {
+    const out = execSync(
+      `security find-generic-password -s "${svc}" -a "${KEYCHAIN_ACCOUNT}" -g 2>&1`,
+      { timeout: 5000 },
+    ).toString();
+    const m = out.match(/^password: "?(.*?)"?$/m);
+    return m ? m[1].replace(/\\"/g, '"') : null;
+  } catch {
+    return null;
+  }
+}
+
+function readActiveKeychainToken() {
+  try {
+    const out = execSync(
+      'security find-generic-password -s "Claude Code-credentials" -g 2>&1',
+      { timeout: 5000 },
+    ).toString();
+    const m = out.match(/^password: "?(.*?)"?$/m);
+    return m ? m[1].replace(/\\"/g, '"') : null;
+  } catch {
+    return null;
+  }
+}
+
+function tokenAccessKey(json) {
+  try {
+    return JSON.parse(json)?.claudeAiOauth?.accessToken || null;
+  } catch {
+    return null;
+  }
+}
+
+// First try: cheap vault-token comparison (zero network). Works briefly after
+// a rotation. Falls back to /api/oauth/profile (1 cheap API call) when Claude
+// Code has refreshed its own token and the live no longer matches any vault.
+async function detectLiveAccountFromVault(config) {
+  const liveTok = tokenAccessKey(readActiveKeychainToken());
+  if (!liveTok) return null;
+  for (const a of config.accounts) {
+    const vaultTok = tokenAccessKey(readStoredToken(a));
+    if (vaultTok && vaultTok === liveTok) return accountKey(a);
+  }
+  // Vault miss — query profile to get the actual email
+  try {
+    const res = await fetch("https://api.anthropic.com/api/oauth/profile", {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${liveTok}`,
+        "anthropic-beta": "oauth-2025-04-20",
+      },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    const body = await res.json();
+    const liveEmail = body?.account?.email?.toLowerCase();
+    if (!liveEmail) return null;
+    // Map email → account key (handle multi-org accounts via label)
+    const matches = config.accounts.filter(
+      (a) => a.email.toLowerCase() === liveEmail,
+    );
+    if (matches.length === 1) return accountKey(matches[0]);
+    if (matches.length > 1) {
+      // Multiple labels for same email (e.g. heartfeldt-personal vs -team).
+      // Use orgName from profile to disambiguate.
+      const orgName = body?.organization?.name?.toLowerCase() || "";
+      const byOrg = matches.find((a) =>
+        (a.orgName || "").toLowerCase() === orgName,
+      );
+      if (byOrg) return accountKey(byOrg);
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Real utilization from Anthropic (via statusline export) ──────────────────
+
+const RATE_LIMITS_FILE = join(__dirname, ".rate-limits.json");
+const UTILIZATION_ROTATE_THRESHOLD = 80; // Rotate at 80% — with 8+ concurrent sessions burning tokens fast, 95% was too late (hit 100% between statusline updates)
+
+function readRealUtilization() {
+  try {
+    if (!existsSync(RATE_LIMITS_FILE)) return null;
+    const data = JSON.parse(readFileSync(RATE_LIMITS_FILE, "utf8"));
+    const age = Date.now() - data.ts * 1000;
+    if (age > 5 * 60_000) return null; // Stale (>5min) — session may be dead
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+// ── Rate limit detection ─────────────────────────────────────────────────────
+
+function checkRateLimited() {
+  // Method 1: Real Anthropic utilization from statusline (primary signal)
+  const real = readRealUtilization();
+  if (real) {
+    const pct5h = real.five_hour?.pct || 0;
+    const pct7d = real.seven_day?.pct || 0;
+    if (pct5h >= UTILIZATION_ROTATE_THRESHOLD) {
+      return {
+        limited: true,
+        reason: `5h utilization ${pct5h.toFixed(1)}% >= ${UTILIZATION_ROTATE_THRESHOLD}%`,
+        utilization: real,
+      };
+    }
+    // 7d weekly cap — also rotate at 80% (was 95%, but Claude itself surfaces
+    // the warning at ~75%, so 95% is too late and the active session sees
+    // "you've used X% of your weekly limit" before the daemon acts).
+    if (pct7d >= UTILIZATION_ROTATE_THRESHOLD) {
+      return {
+        limited: true,
+        reason: `7d utilization ${pct7d.toFixed(1)}% >= ${UTILIZATION_ROTATE_THRESHOLD}%`,
+        utilization: real,
+      };
+    }
+  }
+
+  // Method 2: Explicit 429 signal from rate-limit-detector.cjs hook.
+  // The hook writes a signal file with `fireAt` (now+15s) when it detects a
+  // real 429 response. We honor the delay to give the user time to see the
+  // error and let the rotation complete before they retry.
+  try {
+    const rateLimitFile = join(tmpdir(), "claude-rate-limited.json");
+    if (existsSync(rateLimitFile)) {
+      const data = JSON.parse(readFileSync(rateLimitFile, "utf8"));
+      const fireAt = data.fireAt || 0;
+      const age = Date.now() - new Date(data.timestamp).getTime();
+      if (age > 5 * 60_000) {
+        // Stale — discard
+        unlinkSync(rateLimitFile);
+      } else if (Date.now() >= fireAt) {
+        // Delay elapsed — trigger rotation and consume the signal
+        unlinkSync(rateLimitFile);
+        return {
+          limited: true,
+          reason: `429 signal: ${(data.reason || "rate_limit").substring(0, 120)}`,
+        };
+      }
+      // else: signal fresh but delay not elapsed — wait for next poll
+    }
+  } catch {}
+
+  return { limited: false };
+}
+
+// ── Should we rotate? ─────────────────────────────────────────────────────────
+
+function getActiveAccount(config, activeKey) {
+  return config.accounts.find((a) => accountKey(a) === activeKey) || null;
+}
+
+const AUTH_ERROR_FILE = join(tmpdir(), "claude-auth-error.json");
+
+async function shouldRotate(config, state) {
+  // 1. Real utilization from statusline (PRIMARY signal for rotation)
+  const rl = checkRateLimited();
+  if (rl.limited) return { should: true, reason: `Rate limited: ${rl.reason}` };
+
+  // 2. Auth error signal (401) from PostToolUseFailure hook
+  try {
+    if (existsSync(AUTH_ERROR_FILE)) {
+      const sig = JSON.parse(readFileSync(AUTH_ERROR_FILE, "utf8"));
+      const age = Date.now() - new Date(sig.timestamp).getTime();
+      if (age < 5 * 60_000) {
+        unlinkSync(AUTH_ERROR_FILE);
+        log(`401 auth error detected: ${sig.reason || "unknown"}`);
+        return {
+          should: true,
+          reason: `Auth error (401): ${sig.reason || "invalid credentials"}`,
+        };
+      }
+      unlinkSync(AUTH_ERROR_FILE); // Stale
+    }
+  } catch {}
+
+  // 3. Token expiring — try refresh first, only rotate if refresh fails
+  const account = getActiveAccount(config, state.activeAccount);
+  if (account) {
+    const token = readStoredToken(account);
+    if (token && tokenExpired(token)) {
+      // Try refreshing the active token in-place before rotating
+      log(
+        "[active-refresh] Active token expiring — attempting in-place refresh",
+      );
+      const refreshed = await refreshSingleToken(account);
+      if (refreshed) {
+        // Also update the active keychain so running sessions pick it up on next /login
+        try {
+          const freshToken = readStoredToken(account);
+          if (freshToken) {
+            const svc = "Claude Code-credentials";
+            const escaped = freshToken.replace(/"/g, '\\"');
+            execSync(
+              `security add-generic-password -U -s "${svc}" -a "${KEYCHAIN_ACCOUNT}" -w "${escaped}"`,
+              { timeout: 5000 },
+            );
+            log(
+              "[active-refresh] Active keychain updated — sessions will auto-recover",
+            );
+          }
+        } catch (err) {
+          log(
+            `[active-refresh] Keychain update failed: ${err.message?.substring(0, 60)}`,
+          );
+        }
+        return { should: false }; // Refreshed in-place, no rotation needed
+      }
+      log("[active-refresh] Refresh failed — triggering rotation");
+      return { should: true, reason: "Token expired and refresh failed" };
+    }
+  }
+
+  return { should: false };
+}
+
+// ── Execute rotation ──────────────────────────────────────────────────────────
+
+// Fetch live 5h/7d utilization for one account (no cache). Returns
+// {pct5h, pct7d} or null on failure. Cheap — single GET, 4s timeout.
+async function queryLiveUtilization(account) {
+  try {
+    const tokenJson = readStoredToken(account);
+    if (!tokenJson) return null;
+    const accessToken = JSON.parse(tokenJson)?.claudeAiOauth?.accessToken;
+    if (!accessToken) return null;
+    const res = await fetch("https://api.anthropic.com/api/oauth/usage", {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "anthropic-beta": "oauth-2025-04-20",
+      },
+      signal: AbortSignal.timeout(4000),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return {
+      pct5h: data?.five_hour?.utilization || 0,
+      pct7d: data?.seven_day?.utilization || 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function findValidRotationTarget(config, state) {
+  const now = Date.now();
+  const activeKey = state.activeAccount;
+  const SAFE_UTIL_5H_PCT = 70; // 5h window is what we rotate around — strict
+  const SAFE_UTIL_7D_PCT = 95; // 7d resets weekly — only hard-skip if truly capped
+
+  // Build candidate list: all accounts except the active one AND disabled ones.
+  const candidates = config.accounts.filter(
+    (a) => accountKey(a) !== activeKey && a.disabled !== true,
+  );
+
+  // Sort by cached util (best-guess ordering before live query). Treat
+  // missing reset as "unknown utilization" — DON'T treat null reset as
+  // "ready" (lic had reset:null + pct:0 and got picked while live was 100%).
+  candidates.sort((a, b) => {
+    const aUtil = state.accounts?.[accountKey(a)]?.lastUtilization;
+    const bUtil = state.accounts?.[accountKey(b)]?.lastUtilization;
+    const aResetMs = aUtil?.reset ? aUtil.reset * 1000 : 0;
+    const bResetMs = bUtil?.reset ? bUtil.reset * 1000 : 0;
+    // Account is "ready" only if it has a known reset time AND that's passed
+    const aReady = aResetMs > 0 && aResetMs < now;
+    const bReady = bResetMs > 0 && bResetMs < now;
+    if (aReady !== bReady) return aReady ? -1 : 1;
+    return (aUtil?.pct || 0) - (bUtil?.pct || 0);
+  });
+
+  for (const account of candidates) {
+    const key = accountKey(account);
+    const tokenJson = readStoredToken(account);
+
+    if (!tokenJson) {
+      log(`[pre-rotate] ${key}: no token in keychain — skipping`);
+      continue;
+    }
+
+    const expiry = parseTokenExpiry(tokenJson);
+    const isExpired = expiry > 0 && now > expiry - 5 * 60_000;
+
+    if (isExpired) {
+      log(`[pre-rotate] ${key}: token expired/expiring — attempting refresh`);
+      const refreshed = await refreshSingleToken(account);
+      if (!refreshed) {
+        log(`[pre-rotate] ${key}: refresh FAILED — skipping`);
+        continue;
+      }
+      log(`[pre-rotate] ${key}: refresh succeeded`);
+    } else {
+      log(
+        `[pre-rotate] ${key}: token valid (${((expiry - now) / 3_600_000).toFixed(1)}h remaining)`,
+      );
+    }
+
+    // Live util check — never rotate to a high-utilization account.
+    // The cached snapshot may be stale (e.g. lic had pct:0 but live was 100%).
+    const live = await queryLiveUtilization(account);
+    if (live) {
+      const max = Math.max(live.pct5h, live.pct7d);
+      const tooHot5h = live.pct5h >= SAFE_UTIL_5H_PCT;
+      const tooHot7d = live.pct7d >= SAFE_UTIL_7D_PCT;
+      if (tooHot5h || tooHot7d) {
+        const reason = tooHot5h
+          ? `5h ${live.pct5h.toFixed(0)}% >= ${SAFE_UTIL_5H_PCT}%`
+          : `7d ${live.pct7d.toFixed(0)}% >= ${SAFE_UTIL_7D_PCT}%`;
+        log(
+          `[pre-rotate] ${key}: live util 5h=${live.pct5h.toFixed(0)}% 7d=${live.pct7d.toFixed(0)}% — skipping (${reason})`,
+        );
+        // Also update cached util so future picks see the truth
+        if (!state.accounts) state.accounts = {};
+        if (!state.accounts[key]) state.accounts[key] = {};
+        state.accounts[key].lastUtilization = {
+          pct: max,
+          reset: null,
+          ts: now,
+        };
+        continue;
+      }
+      log(
+        `[pre-rotate] ${key}: live util 5h=${live.pct5h.toFixed(0)}% 7d=${live.pct7d.toFixed(0)}% — OK`,
+      );
+    } else {
+      log(`[pre-rotate] ${key}: live util query failed — accepting anyway`);
+    }
+
+    return account;
+  }
+
+  return null; // No valid candidate found
+}
+
+async function doRotation(reason) {
+  const lockFile = join(__dirname, ".rotating");
+  // Lock format written by rotate.mjs: `<ISO timestamp>\n<pid>`. If the holder
+  // PID is still alive, skip — don't race even if the wall-clock is ancient
+  // (browser OAuth flows can legitimately run several minutes).
+  const LOCK_HARD_CEILING_MS = 15 * 60_000;
+  if (existsSync(lockFile)) {
+    try {
+      const raw = readFileSync(lockFile, "utf8").trim();
+      const [tsStr, pidStr] = raw.split(/\s+/);
+      const age = Date.now() - new Date(tsStr).getTime();
+      const pid = parseInt(pidStr || "", 10);
+      let holderAlive = false;
+      if (Number.isFinite(pid) && pid > 0) {
+        try {
+          process.kill(pid, 0);
+          holderAlive = true;
+        } catch {}
+      }
+      if (holderAlive && age < LOCK_HARD_CEILING_MS) {
+        log(`Rotation already in progress (holder PID ${pid}, ${Math.round(age / 1000)}s) — skipping`);
+        return;
+      }
+      if (!holderAlive) log(`Stale lock (PID ${pid || "?"} dead) — proceeding`);
+      else log(`Lock exceeded hard ceiling (${Math.round(age / 60_000)}min) — proceeding`);
+    } catch {
+      // Unparseable lock — treat as stale
+    }
+  }
+
+  log(`AUTO-ROTATING: ${reason}`);
+
+  // Pre-rotation: find a candidate with a valid (non-expired) token
+  const config = readConfig();
+  const state = readState();
+  const target = await findValidRotationTarget(config, state);
+
+  if (!target) {
+    log("ROTATION ABORTED: no candidate has a valid or refreshable token");
+    notify(
+      "Account Rotation",
+      "ABORTED — all candidate tokens expired/invalid",
+    );
+    return;
+  }
+
+  const targetKey = accountKey(target);
+  log(
+    `Target account: ${targetKey} — token validated, proceeding with rotation`,
+  );
+  notify("Claude Account Rotation", `Auto-rotating to ${targetKey}: ${reason}`);
+
+  try {
+    // --no-browser: no Chrome, no API calls (works when rate limited)
+    // --to: daemon controls which account to rotate to (pre-validated token)
+    // NO --session: keychain swap only. Running sessions can't accept /login mid-work.
+    // When sessions hit the wall they show "not logged in" — user runs /login → instant
+    // success because the fresh token is already in the keychain.
+    // --session: inject /login into running sessions (safe — keychain token is pre-validated)
+    const result = execSync(
+      `node "${ROTATE_SCRIPT}" --no-browser --session --to "${targetKey}" 2>&1`,
+      {
+        cwd: __dirname,
+        timeout: 300_000, // 5min — session restart takes ~15s per session × up to 8 sessions
+        env: { ...process.env, NODE_NO_WARNINGS: "1" },
+      },
+    ).toString();
+    log(`Rotation result: ${result.substring(0, 200)}`);
+  } catch (err) {
+    log(`Rotation failed: ${err.message}`);
+    notify(
+      "Account Rotation",
+      `Auto-rotation failed: ${err.message.substring(0, 60)}`,
+    );
+  }
+}
+
+// ── Auto-sync: detect if live auth drifted from state ────────────────────────
+
+function syncDriftedState(state, config, lastRotatedAt = 0) {
+  // After a rotation, `claude auth status` still returns the OLD session's email
+  // until the user restarts Claude Code. Don't undo the rotation by "correcting"
+  // state back to the stale live email — wait for the blackout to pass.
+  // Use the shared state.lastRotation (written by rotate.mjs) so duplicate daemon
+  // instances both respect the blackout, even if one of them didn't do the rotation.
+  const stateLastRotation = state.lastRotation
+    ? new Date(state.lastRotation).getTime()
+    : 0;
+  const effectiveLastRotation = Math.max(lastRotatedAt, stateLastRotation);
+  if (
+    effectiveLastRotation &&
+    Date.now() - effectiveLastRotation < POST_ROTATION_BLACKOUT
+  )
+    return false;
+
+  try {
+    const liveAuth = execSync("claude auth status 2>&1", {
+      timeout: 5_000,
+    }).toString();
+    const liveEmail = JSON.parse(liveAuth)?.email;
+    if (!liveEmail) return false;
+
+    const liveKey = config.accounts.find((a) => a.email === liveEmail);
+    if (!liveKey) return false;
+
+    const liveAccountKey = accountKey(liveKey);
+    if (state.activeAccount !== liveAccountKey) {
+      log(
+        `⚠️ DRIFT DETECTED: state says ${state.activeAccount || "none"}, live auth is ${liveAccountKey} — syncing state`,
+      );
+      state.activeAccount = liveAccountKey;
+      writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+      return true; // Drift was corrected
+    }
+  } catch {}
+  return false;
+}
+
+// ── Dynamic token refresh ────────────────────────────────────────────────────
+// Instead of a fixed hourly launchd job refreshing all accounts, refresh
+// on-demand: when utilization is climbing (50%+), pre-refresh candidate
+// accounts so they're ready for rotation. Also refresh any token within
+// 1h of expiry regardless of utilization.
+
+const TOKEN_ENDPOINT = "https://platform.claude.com/v1/oauth/token";
+const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const REFRESH_URGENCY_MS = 1 * 3_600_000; // Refresh if <1h remaining
+
+function parseTokenExpiry(tokenJson) {
+  try {
+    return JSON.parse(tokenJson)?.claudeAiOauth?.expiresAt || 0;
+  } catch {
+    return 0;
+  }
+}
+
+function parseRefreshToken(tokenJson) {
+  try {
+    return JSON.parse(tokenJson)?.claudeAiOauth?.refreshToken || null;
+  } catch {
+    return null;
+  }
+}
+
+async function refreshSingleToken(account) {
+  const key = accountKey(account);
+  const tokenJson = readStoredToken(account);
+  if (!tokenJson) return false;
+
+  const refreshToken = parseRefreshToken(tokenJson);
+  if (!refreshToken) return false;
+
+  try {
+    const res = await fetch(TOKEN_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: OAUTH_CLIENT_ID,
+      }),
+    });
+    const body = await res.json();
+    if (!res.ok || !body.access_token) return false;
+
+    const parsed = JSON.parse(tokenJson);
+    parsed.claudeAiOauth.accessToken = body.access_token;
+    if (body.refresh_token)
+      parsed.claudeAiOauth.refreshToken = body.refresh_token;
+    parsed.claudeAiOauth.expiresAt = body.expires_in
+      ? Date.now() + body.expires_in * 1000
+      : Date.now() + 8 * 3_600_000;
+
+    // Save back to vault
+    const svc = `Claude-Rotation-${key}`;
+    const escaped = JSON.stringify(parsed).replace(/"/g, '\\"');
+    execSync(
+      `security add-generic-password -U -s "${svc}" -a "${KEYCHAIN_ACCOUNT}" -w "${escaped}"`,
+      { timeout: 5000 },
+    );
+    log(
+      `[refresh] ${key}: refreshed (${((parsed.claudeAiOauth.expiresAt - Date.now()) / 3_600_000).toFixed(1)}h remaining)`,
+    );
+    return true;
+  } catch (err) {
+    log(`[refresh] ${key}: failed — ${err.message?.substring(0, 60)}`);
+    return false;
+  }
+}
+
+async function dynamicRefresh(config, state) {
+  const now = Date.now();
+  const real = readRealUtilization();
+  const pct5h = real?.five_hour?.pct || 0;
+
+  for (const account of config.accounts) {
+    const key = accountKey(account);
+    if (key === state.activeAccount) continue; // Don't refresh active account mid-session
+
+    const tokenJson = readStoredToken(account);
+    if (!tokenJson) continue;
+    const expiry = parseTokenExpiry(tokenJson);
+    const remaining = expiry - now;
+
+    // Refresh if: token expiring within 1h, OR utilization >50% and token <3h
+    const urgent = remaining > 0 && remaining < REFRESH_URGENCY_MS;
+    const preemptive =
+      pct5h >= 50 && remaining > 0 && remaining < 3 * 3_600_000;
+
+    if (urgent || preemptive) {
+      await refreshSingleToken(account);
+      await sleep(2000); // Don't hammer the token endpoint
+    }
+  }
+}
+
+// ── Main loop ─────────────────────────────────────────────────────────────────
+
+async function mainLoop() {
+  log("Daemon started (v3 — dynamic refresh, no hourly launchd)");
+  notify("Claude Rotation Daemon", "Monitoring usage — dynamic refresh");
+
+  let lastRotatedAt = 0; // track when we last rotated
+  let lastStatusLog = 0; // periodic status logging
+  let lastRefreshCheck = 0; // dynamic refresh check
+  let lastDriftCheck = 0; // cheap vault-based drift detection
+
+  while (true) {
+    try {
+      const config = readConfig();
+      if (!config.autoRotate) {
+        await sleep(POLL_INTERVAL);
+        continue;
+      }
+
+      const state = readState();
+
+      // Periodic status log (every 5 min) — shows cooldown state for all accounts
+      if (Date.now() - lastStatusLog > 300_000) {
+        log(`Account cooldown status:\n${accountCooldownStatus(state)}`);
+        lastStatusLog = Date.now();
+      }
+
+      // Drift detection — every 2 min, find the actual live account.
+      // 1) Cheap vault-token compare first (zero network).
+      // 2) Fall back to /api/oauth/profile when Claude Code has refreshed
+      //    its own token and the live no longer matches any vault.
+      // Self-heals when state.json disagrees with the actual active account
+      // (crashed rotation, manual /login, leftover lock).
+      if (Date.now() - lastDriftCheck > 120_000) {
+        lastDriftCheck = Date.now();
+        const stateLastRotation2 = state.lastRotation
+          ? new Date(state.lastRotation).getTime()
+          : 0;
+        const inBlackoutDrift =
+          stateLastRotation2 &&
+          Date.now() - stateLastRotation2 < POST_ROTATION_BLACKOUT;
+        if (!inBlackoutDrift) {
+          const liveKey = await detectLiveAccountFromVault(config);
+          if (liveKey && liveKey !== state.activeAccount) {
+            log(
+              `⚠️ DRIFT: state=${state.activeAccount || "none"} but keychain=${liveKey} — syncing state.json`,
+            );
+            state.activeAccount = liveKey;
+            writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+          }
+        }
+      }
+
+      // Dynamic token refresh disabled — only refresh when the active account
+      // actually needs rotation (shouldRotate handles in-place refresh, and
+      // findValidRotationTarget refreshes candidates lazily). Avoids keychain
+      // churn that was disconnecting HTTP MCP sessions every 5 min.
+
+      const { should, reason } = await shouldRotate(config, state);
+
+      // Post-rotation blackout: ALL rotation triggers are suppressed for 90s
+      // after any rotation. `claude auth status` returns stale data during this
+      // window, which causes drift detection → re-rotation thrashing loops.
+      const stateLastRotation = readState().lastRotation
+        ? new Date(readState().lastRotation).getTime()
+        : 0;
+      const effectiveLastRotated = Math.max(lastRotatedAt, stateLastRotation);
+      const inBlackout =
+        effectiveLastRotated &&
+        Date.now() - effectiveLastRotated < POST_ROTATION_BLACKOUT;
+
+      if (should && inBlackout) {
+        const remaining = Math.ceil(
+          (POST_ROTATION_BLACKOUT - (Date.now() - effectiveLastRotated)) / 1000,
+        );
+        log(
+          `Post-rotation blackout: ignoring "${reason}" for ${remaining}s more`,
+        );
+      } else if (should) {
+        await doRotation(reason);
+        lastRotatedAt = Date.now();
+        await sleep(RATE_LIMIT_COOLDOWN);
+      }
+    } catch (err) {
+      log(`Daemon error: ${err.message}`);
+    }
+
+    await sleep(POLL_INTERVAL);
+  }
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+
+if (args.includes("--stop")) {
+  if (existsSync(PID_FILE)) {
+    const pid = readFileSync(PID_FILE, "utf8").trim();
+    try {
+      process.kill(parseInt(pid));
+      log(`Stopped daemon (PID ${pid})`);
+    } catch {}
+    try {
+      unlinkSync(PID_FILE);
+    } catch {}
+    console.log(`Daemon stopped (PID ${pid})`);
+  } else {
+    console.log("No daemon running");
+  }
+} else if (args.includes("--status")) {
+  if (existsSync(PID_FILE)) {
+    const pid = readFileSync(PID_FILE, "utf8").trim();
+    try {
+      process.kill(parseInt(pid), 0); // Check if alive
+      console.log(`Daemon running (PID ${pid})`);
+    } catch {
+      console.log("Daemon PID file exists but process is dead");
+      unlinkSync(PID_FILE);
+    }
+  } else {
+    console.log("Daemon not running");
+  }
+} else if (args.includes("--bg")) {
+  // Daemonize
+  const child = spawn("node", [join(__dirname, "daemon.mjs")], {
+    cwd: __dirname,
+    detached: true,
+    stdio: "ignore",
+    env: { ...process.env, NODE_NO_WARNINGS: "1" },
+  });
+  child.unref();
+  writeFileSync(PID_FILE, String(child.pid));
+  console.log(`Daemon started in background (PID ${child.pid})`);
+  console.log(
+    `Monitoring: tool uses (${readConfig().toolUseThreshold}), hours (${readConfig().maxHoursPerAccount}h), rate limits, token expiry`,
+  );
+  console.log(`Log: ${LOG_PATH}`);
+} else {
+  // Foreground
+  writeFileSync(PID_FILE, String(process.pid));
+  process.on("SIGINT", () => {
+    try {
+      unlinkSync(PID_FILE);
+    } catch {}
+    process.exit(0);
+  });
+  process.on("SIGTERM", () => {
+    try {
+      unlinkSync(PID_FILE);
+    } catch {}
+    process.exit(0);
+  });
+  await mainLoop();
+}

--- a/claude-ops/scripts/account-rotation/daemon.mjs
+++ b/claude-ops/scripts/account-rotation/daemon.mjs
@@ -31,18 +31,15 @@ import { execSync, execFileSync, spawn, spawnSync } from "child_process";
 import { tmpdir } from "os";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const CONFIG_PATH = join(__dirname, "config.json");
-const STATE_PATH = join(__dirname, "state.json");
-const LOG_PATH = join(__dirname, "rotation.log");
-const PID_FILE = join(__dirname, ".daemon.pid");
-const ROTATE_SCRIPT = join(__dirname, "rotate.mjs");
+const CONFIG_PATH = join(__dirname, 'config.json');
+const STATE_PATH = join(__dirname, 'state.json');
+const LOG_PATH = join(__dirname, 'rotation.log');
+const PID_FILE = join(__dirname, '.daemon.pid');
+const ROTATE_SCRIPT = join(__dirname, 'rotate.mjs');
 
 // Keychain account name — must match rotate.mjs convention.
 const KEYCHAIN_ACCOUNT =
-  process.env.CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT ||
-  process.env.USER ||
-  process.env.LOGNAME ||
-  "claude-ops";
+  process.env.CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT || process.env.USER || process.env.LOGNAME || 'claude-ops';
 
 const POLL_INTERVAL = 15_000; // Check every 15s — fast enough to catch hook-triggered 429 signals (fireAt = now+15s)
 const RATE_LIMIT_COOLDOWN = 10_000; // 10s after rate limit before rotating
@@ -55,17 +52,14 @@ function log(msg) {
   const line = `[${new Date().toISOString()}] [daemon] ${msg}`;
   console.error(line);
   try {
-    appendFileSync(LOG_PATH, line + "\n");
+    appendFileSync(LOG_PATH, line + '\n');
     // Truncate: keep last half when exceeding max
     try {
       const { size } = statSync(LOG_PATH);
       if (size > MAX_LOG_SIZE) {
-        const content = readFileSync(LOG_PATH, "utf8");
-        const lines = content.split("\n");
-        writeFileSync(
-          LOG_PATH,
-          lines.slice(Math.floor(lines.length / 2)).join("\n"),
-        );
+        const content = readFileSync(LOG_PATH, 'utf8');
+        const lines = content.split('\n');
+        writeFileSync(LOG_PATH, lines.slice(Math.floor(lines.length / 2)).join('\n'));
       }
     } catch {}
   } catch {}
@@ -74,19 +68,23 @@ function log(msg) {
 function notify(title, msg) {
   try {
     // Use execFileSync to avoid shell interpretation of quotes in title/msg
-    execFileSync("osascript", [
-      "-e",
-      `display notification "${msg.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}" with title "${title.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`,
-    ], { timeout: 5000 });
+    execFileSync(
+      'osascript',
+      [
+        '-e',
+        `display notification "${msg.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}" with title "${title.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`,
+      ],
+      { timeout: 5000 },
+    );
   } catch {}
 }
 
 function readConfig() {
-  return JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
+  return JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
 }
 function readState() {
   try {
-    return JSON.parse(readFileSync(STATE_PATH, "utf8"));
+    return JSON.parse(readFileSync(STATE_PATH, 'utf8'));
   } catch {
     return {
       activeAccount: null,
@@ -114,20 +112,16 @@ function accountCooldownStatus(state) {
     }
     const resetMs = util.reset ? util.reset * 1000 : 0;
     const fresh = resetMs && resetMs < now;
-    const pct = util.pct ?? "?";
+    const pct = util.pct ?? '?';
     if (fresh) {
-      summary.push(
-        `  ${key}: READY (reset ${Math.round((now - resetMs) / 60_000)}min ago, was ${pct}%)`,
-      );
+      summary.push(`  ${key}: READY (reset ${Math.round((now - resetMs) / 60_000)}min ago, was ${pct}%)`);
     } else if (resetMs) {
-      summary.push(
-        `  ${key}: COOLING (${pct}%, resets in ${Math.round((resetMs - now) / 60_000)}min)`,
-      );
+      summary.push(`  ${key}: COOLING (${pct}%, resets in ${Math.round((resetMs - now) / 60_000)}min)`);
     } else {
       summary.push(`  ${key}: ${pct}% (no reset info)`);
     }
   }
-  return summary.join("\n");
+  return summary.join('\n');
 }
 
 function accountKey(a) {
@@ -148,10 +142,11 @@ function tokenExpired(json) {
 function readStoredToken(account) {
   const svc = `Claude-Rotation-${accountKey(account)}`;
   try {
-    const out = execSync(
-      `security find-generic-password -s "${svc}" -a "${KEYCHAIN_ACCOUNT}" -g 2>&1`,
-      { timeout: 5000 },
-    ).toString();
+    const result = spawnSync('security', ['find-generic-password', '-s', svc, '-a', KEYCHAIN_ACCOUNT, '-g'], {
+      timeout: 5000,
+      encoding: 'utf8',
+    });
+    const out = (result.stdout || '') + (result.stderr || '');
     const m = out.match(/^password: "?(.*?)"?$/m);
     return m ? m[1].replace(/\\"/g, '"') : null;
   } catch {
@@ -201,11 +196,11 @@ async function detectLiveAccountFromVault(config) {
   }
   // Vault miss — query profile to get the actual email
   try {
-    const res = await fetch("https://api.anthropic.com/api/oauth/profile", {
-      method: "GET",
+    const res = await fetch('https://api.anthropic.com/api/oauth/profile', {
+      method: 'GET',
       headers: {
         Authorization: `Bearer ${liveTok}`,
-        "anthropic-beta": "oauth-2025-04-20",
+        'anthropic-beta': 'oauth-2025-04-20',
       },
       signal: AbortSignal.timeout(5000),
     });
@@ -214,17 +209,13 @@ async function detectLiveAccountFromVault(config) {
     const liveEmail = body?.account?.email?.toLowerCase();
     if (!liveEmail) return null;
     // Map email → account key (handle multi-org accounts via label)
-    const matches = config.accounts.filter(
-      (a) => a.email.toLowerCase() === liveEmail,
-    );
+    const matches = config.accounts.filter((a) => a.email.toLowerCase() === liveEmail);
     if (matches.length === 1) return accountKey(matches[0]);
     if (matches.length > 1) {
       // Multiple labels for same email (e.g. user-personal vs -team).
       // Use orgName from profile to disambiguate.
-      const orgName = body?.organization?.name?.toLowerCase() || "";
-      const byOrg = matches.find((a) =>
-        (a.orgName || "").toLowerCase() === orgName,
-      );
+      const orgName = body?.organization?.name?.toLowerCase() || '';
+      const byOrg = matches.find((a) => (a.orgName || '').toLowerCase() === orgName);
       if (byOrg) return accountKey(byOrg);
     }
     return null;
@@ -235,13 +226,13 @@ async function detectLiveAccountFromVault(config) {
 
 // ── Real utilization from Anthropic (via statusline export) ──────────────────
 
-const RATE_LIMITS_FILE = join(__dirname, ".rate-limits.json");
+const RATE_LIMITS_FILE = join(__dirname, '.rate-limits.json');
 const UTILIZATION_ROTATE_THRESHOLD = 80; // Rotate at 80% — with 8+ concurrent sessions burning tokens fast, 95% was too late (hit 100% between statusline updates)
 
 function readRealUtilization() {
   try {
     if (!existsSync(RATE_LIMITS_FILE)) return null;
-    const data = JSON.parse(readFileSync(RATE_LIMITS_FILE, "utf8"));
+    const data = JSON.parse(readFileSync(RATE_LIMITS_FILE, 'utf8'));
     const age = Date.now() - data.ts * 1000;
     if (age > 5 * 60_000) return null; // Stale (>5min) — session may be dead
     return data;
@@ -282,9 +273,9 @@ function checkRateLimited() {
   // real 429 response. We honor the delay to give the user time to see the
   // error and let the rotation complete before they retry.
   try {
-    const rateLimitFile = join(tmpdir(), "claude-rate-limited.json");
+    const rateLimitFile = join(tmpdir(), 'claude-rate-limited.json');
     if (existsSync(rateLimitFile)) {
-      const data = JSON.parse(readFileSync(rateLimitFile, "utf8"));
+      const data = JSON.parse(readFileSync(rateLimitFile, 'utf8'));
       const fireAt = data.fireAt || 0;
       const age = Date.now() - new Date(data.timestamp).getTime();
       if (age > 5 * 60_000) {
@@ -295,7 +286,7 @@ function checkRateLimited() {
         unlinkSync(rateLimitFile);
         return {
           limited: true,
-          reason: `429 signal: ${(data.reason || "rate_limit").substring(0, 120)}`,
+          reason: `429 signal: ${(data.reason || 'rate_limit').substring(0, 120)}`,
         };
       }
       // else: signal fresh but delay not elapsed — wait for next poll
@@ -311,7 +302,7 @@ function getActiveAccount(config, activeKey) {
   return config.accounts.find((a) => accountKey(a) === activeKey) || null;
 }
 
-const AUTH_ERROR_FILE = join(tmpdir(), "claude-auth-error.json");
+const AUTH_ERROR_FILE = join(tmpdir(), 'claude-auth-error.json');
 
 async function shouldRotate(config, state) {
   // 1. Real utilization from statusline (PRIMARY signal for rotation)
@@ -321,14 +312,14 @@ async function shouldRotate(config, state) {
   // 2. Auth error signal (401) from PostToolUseFailure hook
   try {
     if (existsSync(AUTH_ERROR_FILE)) {
-      const sig = JSON.parse(readFileSync(AUTH_ERROR_FILE, "utf8"));
+      const sig = JSON.parse(readFileSync(AUTH_ERROR_FILE, 'utf8'));
       const age = Date.now() - new Date(sig.timestamp).getTime();
       if (age < 5 * 60_000) {
         unlinkSync(AUTH_ERROR_FILE);
-        log(`401 auth error detected: ${sig.reason || "unknown"}`);
+        log(`401 auth error detected: ${sig.reason || 'unknown'}`);
         return {
           should: true,
-          reason: `Auth error (401): ${sig.reason || "invalid credentials"}`,
+          reason: `Auth error (401): ${sig.reason || 'invalid credentials'}`,
         };
       }
       unlinkSync(AUTH_ERROR_FILE); // Stale
@@ -341,34 +332,28 @@ async function shouldRotate(config, state) {
     const token = readStoredToken(account);
     if (token && tokenExpired(token)) {
       // Try refreshing the active token in-place before rotating
-      log(
-        "[active-refresh] Active token expiring — attempting in-place refresh",
-      );
+      log('[active-refresh] Active token expiring — attempting in-place refresh');
       const refreshed = await refreshSingleToken(account);
       if (refreshed) {
         // Also update the active keychain so running sessions pick it up on next /login
         try {
           const freshToken = readStoredToken(account);
           if (freshToken) {
-            const svc = "Claude Code-credentials";
-            const escaped = freshToken.replace(/"/g, '\\"');
-            execSync(
-              `security add-generic-password -U -s "${svc}" -a "${KEYCHAIN_ACCOUNT}" -w "${escaped}"`,
+            const svc = 'Claude Code-credentials';
+            execFileSync(
+              'security',
+              ['add-generic-password', '-U', '-s', svc, '-a', KEYCHAIN_ACCOUNT, '-w', freshToken],
               { timeout: 5000 },
             );
-            log(
-              "[active-refresh] Active keychain updated — sessions will auto-recover",
-            );
+            log('[active-refresh] Active keychain updated — sessions will auto-recover');
           }
         } catch (err) {
-          log(
-            `[active-refresh] Keychain update failed: ${err.message?.substring(0, 60)}`,
-          );
+          log(`[active-refresh] Keychain update failed: ${err.message?.substring(0, 60)}`);
         }
         return { should: false }; // Refreshed in-place, no rotation needed
       }
-      log("[active-refresh] Refresh failed — triggering rotation");
-      return { should: true, reason: "Token expired and refresh failed" };
+      log('[active-refresh] Refresh failed — triggering rotation');
+      return { should: true, reason: 'Token expired and refresh failed' };
     }
   }
 
@@ -385,11 +370,11 @@ async function queryLiveUtilization(account) {
     if (!tokenJson) return null;
     const accessToken = JSON.parse(tokenJson)?.claudeAiOauth?.accessToken;
     if (!accessToken) return null;
-    const res = await fetch("https://api.anthropic.com/api/oauth/usage", {
-      method: "GET",
+    const res = await fetch('https://api.anthropic.com/api/oauth/usage', {
+      method: 'GET',
       headers: {
         Authorization: `Bearer ${accessToken}`,
-        "anthropic-beta": "oauth-2025-04-20",
+        'anthropic-beta': 'oauth-2025-04-20',
       },
       signal: AbortSignal.timeout(4000),
     });
@@ -411,9 +396,7 @@ async function findValidRotationTarget(config, state) {
   const SAFE_UTIL_7D_PCT = 95; // 7d resets weekly — only hard-skip if truly capped
 
   // Build candidate list: all accounts except the active one AND disabled ones.
-  const candidates = config.accounts.filter(
-    (a) => accountKey(a) !== activeKey && a.disabled !== true,
-  );
+  const candidates = config.accounts.filter((a) => accountKey(a) !== activeKey && a.disabled !== true);
 
   // Sort by cached util (best-guess ordering before live query). Treat
   // missing reset as "unknown utilization" — DON'T treat null reset as
@@ -451,9 +434,7 @@ async function findValidRotationTarget(config, state) {
       }
       log(`[pre-rotate] ${key}: refresh succeeded`);
     } else {
-      log(
-        `[pre-rotate] ${key}: token valid (${((expiry - now) / 3_600_000).toFixed(1)}h remaining)`,
-      );
+      log(`[pre-rotate] ${key}: token valid (${((expiry - now) / 3_600_000).toFixed(1)}h remaining)`);
     }
 
     // Live util check — never rotate to a high-utilization account.
@@ -480,9 +461,7 @@ async function findValidRotationTarget(config, state) {
         };
         continue;
       }
-      log(
-        `[pre-rotate] ${key}: live util 5h=${live.pct5h.toFixed(0)}% 7d=${live.pct7d.toFixed(0)}% — OK`,
-      );
+      log(`[pre-rotate] ${key}: live util 5h=${live.pct5h.toFixed(0)}% 7d=${live.pct7d.toFixed(0)}% — OK`);
     } else {
       log(`[pre-rotate] ${key}: live util query failed — accepting anyway`);
     }
@@ -494,17 +473,17 @@ async function findValidRotationTarget(config, state) {
 }
 
 async function doRotation(reason) {
-  const lockFile = join(__dirname, ".rotating");
+  const lockFile = join(__dirname, '.rotating');
   // Lock format written by rotate.mjs: `<ISO timestamp>\n<pid>`. If the holder
   // PID is still alive, skip — don't race even if the wall-clock is ancient
   // (browser OAuth flows can legitimately run several minutes).
   const LOCK_HARD_CEILING_MS = 15 * 60_000;
   if (existsSync(lockFile)) {
     try {
-      const raw = readFileSync(lockFile, "utf8").trim();
+      const raw = readFileSync(lockFile, 'utf8').trim();
       const [tsStr, pidStr] = raw.split(/\s+/);
       const age = Date.now() - new Date(tsStr).getTime();
-      const pid = parseInt(pidStr || "", 10);
+      const pid = parseInt(pidStr || '', 10);
       let holderAlive = false;
       if (Number.isFinite(pid) && pid > 0) {
         try {
@@ -516,7 +495,7 @@ async function doRotation(reason) {
         log(`Rotation already in progress (holder PID ${pid}, ${Math.round(age / 1000)}s) — skipping`);
         return;
       }
-      if (!holderAlive) log(`Stale lock (PID ${pid || "?"} dead) — proceeding`);
+      if (!holderAlive) log(`Stale lock (PID ${pid || '?'} dead) — proceeding`);
       else log(`Lock exceeded hard ceiling (${Math.round(age / 60_000)}min) — proceeding`);
     } catch {
       // Unparseable lock — treat as stale
@@ -531,19 +510,14 @@ async function doRotation(reason) {
   const target = await findValidRotationTarget(config, state);
 
   if (!target) {
-    log("ROTATION ABORTED: no candidate has a valid or refreshable token");
-    notify(
-      "Account Rotation",
-      "ABORTED — all candidate tokens expired/invalid",
-    );
+    log('ROTATION ABORTED: no candidate has a valid or refreshable token');
+    notify('Account Rotation', 'ABORTED — all candidate tokens expired/invalid');
     return;
   }
 
   const targetKey = accountKey(target);
-  log(
-    `Target account: ${targetKey} — token validated, proceeding with rotation`,
-  );
-  notify("Claude Account Rotation", `Auto-rotating to ${targetKey}: ${reason}`);
+  log(`Target account: ${targetKey} — token validated, proceeding with rotation`);
+  notify('Claude Account Rotation', `Auto-rotating to ${targetKey}: ${reason}`);
 
   try {
     // --no-browser: no Chrome, no API calls (works when rate limited)
@@ -552,22 +526,15 @@ async function doRotation(reason) {
     // When sessions hit the wall they show "not logged in" — user runs /login → instant
     // success because the fresh token is already in the keychain.
     // --session: inject /login into running sessions (safe — keychain token is pre-validated)
-    const result = execFileSync(
-      process.execPath,
-      [ROTATE_SCRIPT, "--no-browser", "--session", "--to", targetKey],
-      {
-        cwd: __dirname,
-        timeout: 300_000, // 5min — session restart takes ~15s per session × up to 8 sessions
-        env: { ...process.env, NODE_NO_WARNINGS: "1" },
-      },
-    ).toString();
+    const result = execFileSync(process.execPath, [ROTATE_SCRIPT, '--no-browser', '--session', '--to', targetKey], {
+      cwd: __dirname,
+      timeout: 300_000, // 5min — session restart takes ~15s per session × up to 8 sessions
+      env: { ...process.env, NODE_NO_WARNINGS: '1' },
+    }).toString();
     log(`Rotation result: ${result.substring(0, 200)}`);
   } catch (err) {
     log(`Rotation failed: ${err.message}`);
-    notify(
-      "Account Rotation",
-      `Auto-rotation failed: ${err.message.substring(0, 60)}`,
-    );
+    notify('Account Rotation', `Auto-rotation failed: ${err.message.substring(0, 60)}`);
   }
 }
 
@@ -603,10 +570,10 @@ async function refreshSingleToken(account) {
 
   try {
     const res = await fetch(TOKEN_ENDPOINT, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        grant_type: "refresh_token",
+        grant_type: 'refresh_token',
         refresh_token: refreshToken,
         client_id: OAUTH_CLIENT_ID,
       }),
@@ -616,21 +583,17 @@ async function refreshSingleToken(account) {
 
     const parsed = JSON.parse(tokenJson);
     parsed.claudeAiOauth.accessToken = body.access_token;
-    if (body.refresh_token)
-      parsed.claudeAiOauth.refreshToken = body.refresh_token;
-    parsed.claudeAiOauth.expiresAt = body.expires_in
-      ? Date.now() + body.expires_in * 1000
-      : Date.now() + 8 * 3_600_000;
+    if (body.refresh_token) parsed.claudeAiOauth.refreshToken = body.refresh_token;
+    parsed.claudeAiOauth.expiresAt = body.expires_in ? Date.now() + body.expires_in * 1000 : Date.now() + 8 * 3_600_000;
 
     // Save back to vault
     const svc = `Claude-Rotation-${key}`;
     // Use execFileSync to avoid shell-escaping issues with JSON tokens
-    execFileSync("security", [
-      "add-generic-password", "-U",
-      "-s", svc,
-      "-a", KEYCHAIN_ACCOUNT,
-      "-w", JSON.stringify(parsed),
-    ], { timeout: 5000 });
+    execFileSync(
+      'security',
+      ['add-generic-password', '-U', '-s', svc, '-a', KEYCHAIN_ACCOUNT, '-w', JSON.stringify(parsed)],
+      { timeout: 5000 },
+    );
     log(
       `[refresh] ${key}: refreshed (${((parsed.claudeAiOauth.expiresAt - Date.now()) / 3_600_000).toFixed(1)}h remaining)`,
     );
@@ -675,18 +638,12 @@ async function mainLoop() {
       // (crashed rotation, manual /login, leftover lock).
       if (Date.now() - lastDriftCheck > 120_000) {
         lastDriftCheck = Date.now();
-        const stateLastRotation2 = state.lastRotation
-          ? new Date(state.lastRotation).getTime()
-          : 0;
-        const inBlackoutDrift =
-          stateLastRotation2 &&
-          Date.now() - stateLastRotation2 < POST_ROTATION_BLACKOUT;
+        const stateLastRotation2 = state.lastRotation ? new Date(state.lastRotation).getTime() : 0;
+        const inBlackoutDrift = stateLastRotation2 && Date.now() - stateLastRotation2 < POST_ROTATION_BLACKOUT;
         if (!inBlackoutDrift) {
           const liveKey = await detectLiveAccountFromVault(config);
           if (liveKey && liveKey !== state.activeAccount) {
-            log(
-              `⚠️ DRIFT: state=${state.activeAccount || "none"} but keychain=${liveKey} — syncing state.json`,
-            );
+            log(`⚠️ DRIFT: state=${state.activeAccount || 'none'} but keychain=${liveKey} — syncing state.json`);
             state.activeAccount = liveKey;
             writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
           }
@@ -703,21 +660,13 @@ async function mainLoop() {
       // Post-rotation blackout: ALL rotation triggers are suppressed for 90s
       // after any rotation. `claude auth status` returns stale data during this
       // window, which causes drift detection → re-rotation thrashing loops.
-      const stateLastRotation = state.lastRotation
-        ? new Date(state.lastRotation).getTime()
-        : 0;
+      const stateLastRotation = state.lastRotation ? new Date(state.lastRotation).getTime() : 0;
       const effectiveLastRotated = Math.max(lastRotatedAt, stateLastRotation);
-      const inBlackout =
-        effectiveLastRotated &&
-        Date.now() - effectiveLastRotated < POST_ROTATION_BLACKOUT;
+      const inBlackout = effectiveLastRotated && Date.now() - effectiveLastRotated < POST_ROTATION_BLACKOUT;
 
       if (should && inBlackout) {
-        const remaining = Math.ceil(
-          (POST_ROTATION_BLACKOUT - (Date.now() - effectiveLastRotated)) / 1000,
-        );
-        log(
-          `Post-rotation blackout: ignoring "${reason}" for ${remaining}s more`,
-        );
+        const remaining = Math.ceil((POST_ROTATION_BLACKOUT - (Date.now() - effectiveLastRotated)) / 1000);
+        log(`Post-rotation blackout: ignoring "${reason}" for ${remaining}s more`);
       } else if (should) {
         await doRotation(reason);
         lastRotatedAt = Date.now();
@@ -735,9 +684,9 @@ async function mainLoop() {
 
 const args = process.argv.slice(2);
 
-if (args.includes("--stop")) {
+if (args.includes('--stop')) {
   if (existsSync(PID_FILE)) {
-    const pid = readFileSync(PID_FILE, "utf8").trim();
+    const pid = readFileSync(PID_FILE, 'utf8').trim();
     try {
       process.kill(parseInt(pid));
       log(`Stopped daemon (PID ${pid})`);
@@ -747,28 +696,28 @@ if (args.includes("--stop")) {
     } catch {}
     console.log(`Daemon stopped (PID ${pid})`);
   } else {
-    console.log("No daemon running");
+    console.log('No daemon running');
   }
-} else if (args.includes("--status")) {
+} else if (args.includes('--status')) {
   if (existsSync(PID_FILE)) {
-    const pid = readFileSync(PID_FILE, "utf8").trim();
+    const pid = readFileSync(PID_FILE, 'utf8').trim();
     try {
       process.kill(parseInt(pid), 0); // Check if alive
       console.log(`Daemon running (PID ${pid})`);
     } catch {
-      console.log("Daemon PID file exists but process is dead");
+      console.log('Daemon PID file exists but process is dead');
       unlinkSync(PID_FILE);
     }
   } else {
-    console.log("Daemon not running");
+    console.log('Daemon not running');
   }
-} else if (args.includes("--bg")) {
+} else if (args.includes('--bg')) {
   // Daemonize
-  const child = spawn("node", [join(__dirname, "daemon.mjs")], {
+  const child = spawn('node', [join(__dirname, 'daemon.mjs')], {
     cwd: __dirname,
     detached: true,
-    stdio: "ignore",
-    env: { ...process.env, NODE_NO_WARNINGS: "1" },
+    stdio: 'ignore',
+    env: { ...process.env, NODE_NO_WARNINGS: '1' },
   });
   child.unref();
   writeFileSync(PID_FILE, String(child.pid));
@@ -780,13 +729,13 @@ if (args.includes("--stop")) {
 } else {
   // Foreground
   writeFileSync(PID_FILE, String(process.pid));
-  process.on("SIGINT", () => {
+  process.on('SIGINT', () => {
     try {
       unlinkSync(PID_FILE);
     } catch {}
     process.exit(0);
   });
-  process.on("SIGTERM", () => {
+  process.on('SIGTERM', () => {
     try {
       unlinkSync(PID_FILE);
     } catch {}

--- a/claude-ops/scripts/account-rotation/daemon.mjs
+++ b/claude-ops/scripts/account-rotation/daemon.mjs
@@ -17,18 +17,11 @@
  *   node daemon.mjs --status  # Show daemon status
  */
 
-import {
-  readFileSync,
-  writeFileSync,
-  existsSync,
-  unlinkSync,
-  appendFileSync,
-  statSync,
-} from "fs";
-import { join, dirname } from "path";
-import { fileURLToPath } from "url";
-import { execSync, execFileSync, spawn, spawnSync } from "child_process";
-import { tmpdir } from "os";
+import { readFileSync, writeFileSync, existsSync, unlinkSync, appendFileSync, statSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { execSync, execFileSync, spawn, spawnSync } from 'child_process';
+import { tmpdir } from 'os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CONFIG_PATH = join(__dirname, 'config.json');
@@ -157,18 +150,11 @@ function readStoredToken(account) {
 function readActiveKeychainToken() {
   try {
     const r = spawnSync(
-      "security",
-      [
-        "find-generic-password",
-        "-s",
-        "Claude Code-credentials",
-        "-a",
-        KEYCHAIN_ACCOUNT,
-        "-g",
-      ],
-      { encoding: "utf8", timeout: 5000 },
+      'security',
+      ['find-generic-password', '-s', 'Claude Code-credentials', '-a', KEYCHAIN_ACCOUNT, '-g'],
+      { encoding: 'utf8', timeout: 5000 },
     );
-    const out = `${r.stdout || ""}${r.stderr || ""}`;
+    const out = `${r.stdout || ''}${r.stderr || ''}`;
     const m = out.match(/^password: "?(.*?)"?$/m);
     return m ? m[1].replace(/\\"/g, '"') : null;
   } catch {
@@ -541,8 +527,8 @@ async function doRotation(reason) {
 // ── Token refresh (vault entries) ───────────────────────────────────────────
 // In-place refresh via OAuth; invoked from shouldRotate / findValidRotationTarget.
 
-const TOKEN_ENDPOINT = "https://platform.claude.com/v1/oauth/token";
-const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
+const TOKEN_ENDPOINT = 'https://platform.claude.com/v1/oauth/token';
+const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
 
 function parseTokenExpiry(tokenJson) {
   try {
@@ -607,8 +593,8 @@ async function refreshSingleToken(account) {
 // ── Main loop ─────────────────────────────────────────────────────────────────
 
 async function mainLoop() {
-  log("Daemon started (v3 — on-demand token refresh)");
-  notify("Claude Rotation Daemon", "Monitoring usage — on-demand refresh");
+  log('Daemon started (v3 — on-demand token refresh)');
+  notify('Claude Rotation Daemon', 'Monitoring usage — on-demand refresh');
 
   let lastRotatedAt = 0; // track when we last rotated
   let lastStatusLog = 0; // periodic status logging

--- a/claude-ops/scripts/account-rotation/daemon.mjs
+++ b/claude-ops/scripts/account-rotation/daemon.mjs
@@ -559,47 +559,6 @@ async function doRotation(reason) {
   }
 }
 
-// ── Auto-sync: detect if live auth drifted from state ────────────────────────
-
-function syncDriftedState(state, config, lastRotatedAt = 0) {
-  // After a rotation, `claude auth status` still returns the OLD session's email
-  // until the user restarts Claude Code. Don't undo the rotation by "correcting"
-  // state back to the stale live email — wait for the blackout to pass.
-  // Use the shared state.lastRotation (written by rotate.mjs) so duplicate daemon
-  // instances both respect the blackout, even if one of them didn't do the rotation.
-  const stateLastRotation = state.lastRotation
-    ? new Date(state.lastRotation).getTime()
-    : 0;
-  const effectiveLastRotation = Math.max(lastRotatedAt, stateLastRotation);
-  if (
-    effectiveLastRotation &&
-    Date.now() - effectiveLastRotation < POST_ROTATION_BLACKOUT
-  )
-    return false;
-
-  try {
-    const liveAuth = execSync("claude auth status 2>&1", {
-      timeout: 5_000,
-    }).toString();
-    const liveEmail = JSON.parse(liveAuth)?.email;
-    if (!liveEmail) return false;
-
-    const liveKey = config.accounts.find((a) => a.email === liveEmail);
-    if (!liveKey) return false;
-
-    const liveAccountKey = accountKey(liveKey);
-    if (state.activeAccount !== liveAccountKey) {
-      log(
-        `⚠️ DRIFT DETECTED: state says ${state.activeAccount || "none"}, live auth is ${liveAccountKey} — syncing state`,
-      );
-      state.activeAccount = liveAccountKey;
-      writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
-      return true; // Drift was corrected
-    }
-  } catch {}
-  return false;
-}
-
 // ── Dynamic token refresh ────────────────────────────────────────────────────
 // Instead of a fixed hourly launchd job refreshing all accounts, refresh
 // on-demand: when utilization is climbing (50%+), pre-refresh candidate
@@ -761,8 +720,9 @@ async function mainLoop() {
       // Post-rotation blackout: ALL rotation triggers are suppressed for 90s
       // after any rotation. `claude auth status` returns stale data during this
       // window, which causes drift detection → re-rotation thrashing loops.
-      const stateLastRotation = readState().lastRotation
-        ? new Date(readState().lastRotation).getTime()
+      const stateForBlackout = readState();
+      const stateLastRotation = stateForBlackout.lastRotation
+        ? new Date(stateForBlackout.lastRotation).getTime()
         : 0;
       const effectiveLastRotated = Math.max(lastRotatedAt, stateLastRotation);
       const inBlackout =

--- a/claude-ops/scripts/account-rotation/daemon.mjs
+++ b/claude-ops/scripts/account-rotation/daemon.mjs
@@ -27,7 +27,7 @@ import {
 } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import { execSync, spawn } from "child_process";
+import { execSync, execFileSync, spawn } from "child_process";
 import { tmpdir } from "os";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -73,9 +73,11 @@ function log(msg) {
 
 function notify(title, msg) {
   try {
-    execSync(
-      `osascript -e 'display notification "${msg.replace(/"/g, '\\"')}" with title "${title}"'`,
-    );
+    // Use execFileSync to avoid shell interpretation of quotes in title/msg
+    execFileSync("osascript", [
+      "-e",
+      `display notification "${msg.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}" with title "${title.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`,
+    ], { timeout: 5000 });
   } catch {}
 }
 
@@ -208,7 +210,7 @@ async function detectLiveAccountFromVault(config) {
     );
     if (matches.length === 1) return accountKey(matches[0]);
     if (matches.length > 1) {
-      // Multiple labels for same email (e.g. heartfeldt-personal vs -team).
+      // Multiple labels for same email (e.g. user-personal vs -team).
       // Use orgName from profile to disambiguate.
       const orgName = body?.organization?.name?.toLowerCase() || "";
       const byOrg = matches.find((a) =>
@@ -541,8 +543,9 @@ async function doRotation(reason) {
     // When sessions hit the wall they show "not logged in" — user runs /login → instant
     // success because the fresh token is already in the keychain.
     // --session: inject /login into running sessions (safe — keychain token is pre-validated)
-    const result = execSync(
-      `node "${ROTATE_SCRIPT}" --no-browser --session --to "${targetKey}" 2>&1`,
+    const result = execFileSync(
+      process.execPath,
+      [ROTATE_SCRIPT, "--no-browser", "--session", "--to", targetKey],
       {
         cwd: __dirname,
         timeout: 300_000, // 5min — session restart takes ~15s per session × up to 8 sessions
@@ -616,11 +619,13 @@ async function refreshSingleToken(account) {
 
     // Save back to vault
     const svc = `Claude-Rotation-${key}`;
-    const escaped = JSON.stringify(parsed).replace(/"/g, '\\"');
-    execSync(
-      `security add-generic-password -U -s "${svc}" -a "${KEYCHAIN_ACCOUNT}" -w "${escaped}"`,
-      { timeout: 5000 },
-    );
+    // Use execFileSync to avoid shell-escaping issues with JSON tokens
+    execFileSync("security", [
+      "add-generic-password", "-U",
+      "-s", svc,
+      "-a", KEYCHAIN_ACCOUNT,
+      "-w", JSON.stringify(parsed),
+    ], { timeout: 5000 });
     log(
       `[refresh] ${key}: refreshed (${((parsed.claudeAiOauth.expiresAt - Date.now()) / 3_600_000).toFixed(1)}h remaining)`,
     );
@@ -720,9 +725,8 @@ async function mainLoop() {
       // Post-rotation blackout: ALL rotation triggers are suppressed for 90s
       // after any rotation. `claude auth status` returns stale data during this
       // window, which causes drift detection → re-rotation thrashing loops.
-      const stateForBlackout = readState();
-      const stateLastRotation = stateForBlackout.lastRotation
-        ? new Date(stateForBlackout.lastRotation).getTime()
+      const stateLastRotation = state.lastRotation
+        ? new Date(state.lastRotation).getTime()
         : 0;
       const effectiveLastRotated = Math.max(lastRotatedAt, stateLastRotation);
       const inBlackout =

--- a/claude-ops/scripts/account-rotation/force-rotate.sh
+++ b/claude-ops/scripts/account-rotation/force-rotate.sh
@@ -43,7 +43,7 @@
 #
 # Recovery from stuck state:
 #   pkill -9 -f "rotate\.mjs"
-#   rm -f ~/.claude/scripts/account-rotation/.rotating
+#   rm -f ~/.claude/plugins/data/ops/account-rotation/.rotating
 #   launchctl kickstart -k gui/$(id -u)/com.claude-ops.account-rotation
 #
 # Behavior: --force kills any stuck competing rotate.mjs and bypasses the lock.
@@ -52,7 +52,9 @@
 # by a watchdog so the rotation can never hang indefinitely.
 
 set -u
-DIR="$HOME/.claude/scripts/account-rotation"
+DEFAULT_ROT_DIR="${HOME}/.claude/plugins/data/ops/account-rotation"
+DIR="${CLAUDE_ROTATION_DATA_DIR:-${CLAUDE_PLUGIN_DATA_DIR:-${HOME}/.claude/plugins/data/ops}/account-rotation}"
+[ -d "$DIR" ] || DIR="$DEFAULT_ROT_DIR"
 WATCHDOG_SECONDS="${FORCE_ROTATE_TIMEOUT:-360}"
 
 echo "🔄 Force-rotating Claude account..."

--- a/claude-ops/scripts/account-rotation/force-rotate.sh
+++ b/claude-ops/scripts/account-rotation/force-rotate.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# Force-rotate Claude account from OUTSIDE Claude Code
+# Run this when you've hit the limit and can't reach the CLI
+# Usage: $CLAUDE_PLUGIN_ROOT/scripts/account-rotation/force-rotate.sh [target-email]
+#
+# Also available as: force-rotate (shell alias)
+# Magic-link variant: rotate-magic = node rotate.mjs --magic-link --force --to <email>
+#
+# === ROTATION SYSTEM OVERVIEW ===
+# Files in this directory:
+#   rotate.mjs        - main rotation logic, holds .rotating lock (PID-tagged)
+#   daemon.mjs        - launchd-managed monitor (com.claude-ops.account-rotation)
+#   ai-brain.mjs      - Haiku fallback for stuck OAuth pages
+#   state.json        - activeAccount, lastRotation, per-account util snapshots
+#   config.json       - account list, autoRotate toggle
+#   .rotating         - lock file: <ISO ts>\n<pid>; auto-broken if PID dead or >15min
+#   .rate-limits.json - written by ~/.claude/statusline-command.sh, read by daemon
+#
+# Auto-rotation triggers (any one fires):
+#   1. Daemon poll      : 5h pct >= 80% OR 7d pct >= 80%
+#   2. Statusline fire  : 5h OR 7d >= 90% (opens new Terminal with rotate-magic)
+#   3. 429 from API     : rate-limit-detector.cjs writes /tmp/claude-rate-limited.json
+#   4. 401 auth error   : PostToolUse hook writes /tmp/claude-auth-error.json
+#   5. Manual           : this script, or `node rotate.mjs --to <email>`
+#
+# Drift detection (daemon, every 2min, NO network call):
+#   Compares live "Claude Code-credentials" keychain accessToken against each
+#   "Claude-Rotation-<key>" vault token. If state.activeAccount disagrees with
+#   the actual live account, state.json is auto-corrected. Skipped during the
+#   3-min post-rotation blackout to avoid undoing fresh rotations.
+#
+# Magic-link safety:
+#   - Decodes <base64-email> from claude.ai/magic-link#<hex>:<b64> URLs and
+#     skips any link whose target email != requested account. Prevents picking
+#     up stale links from prior rotation calls (subject is identical for all).
+#   - Rejects emails older than the poll start (5s clock skew tolerance).
+#
+# OAuth stall handling:
+#   - Authorize button: 6 attempts × 5s = 30s, then escalates to ai-brain
+#   - General URL stall: 2 stagnant steps -> ai-brain
+#   - ai-brain (Haiku) pulls API key from env -> Doppler -> keychain
+#   - Max 6 ai-brain decisions per rotation
+#
+# Recovery from stuck state:
+#   pkill -9 -f "rotate\.mjs"
+#   rm -f ~/.claude/scripts/account-rotation/.rotating
+#   launchctl kickstart -k gui/$(id -u)/com.claude-ops.account-rotation
+#
+# Behavior: --force kills any stuck competing rotate.mjs and bypasses the lock.
+# We try the fast --no-browser path first (works when refresh tokens are valid);
+# if that fails we fall back to the full browser OAuth flow. Both are guarded
+# by a watchdog so the rotation can never hang indefinitely.
+
+set -u
+DIR="$HOME/.claude/scripts/account-rotation"
+WATCHDOG_SECONDS="${FORCE_ROTATE_TIMEOUT:-360}"
+
+echo "🔄 Force-rotating Claude account..."
+
+# Pre-flight: clear stale lock if its PID is dead. rotate.mjs --force does this
+# too, but doing it here keeps the watchdog timer accurate.
+if [ -f "$DIR/.rotating" ]; then
+  LOCK_PID=$(tail -1 "$DIR/.rotating" 2>/dev/null | tr -d '[:space:]')
+  if [ -n "$LOCK_PID" ] && ! kill -0 "$LOCK_PID" 2>/dev/null; then
+    echo "↻  Clearing stale lock (PID $LOCK_PID dead)"
+    rm -f "$DIR/.rotating"
+  fi
+fi
+
+# Pre-flight: ensure daemon is running. If launchd reports not loaded, kickstart.
+if ! launchctl list 2>/dev/null | grep -q com.claude-ops.account-rotation; then
+  echo "↻  Daemon not loaded — loading"
+  launchctl load "$HOME/Library/LaunchAgents/com.claude-ops.account-rotation.plist" 2>/dev/null
+fi
+
+# Pre-flight: detect drift between state.json and live keychain (informational —
+# the daemon also auto-corrects every 2min, but this surfaces it during manual
+# rotation). Don't block on failure; just log.
+{
+  LIVE_TOK=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null | python3 -c "import sys,json; print(json.loads(sys.stdin.read()).get('claudeAiOauth',{}).get('accessToken',''))" 2>/dev/null)
+  STATE_ACCT=$(python3 -c "import json; print(json.load(open('$DIR/state.json')).get('activeAccount',''))" 2>/dev/null)
+  if [ -n "$LIVE_TOK" ] && [ -n "$STATE_ACCT" ]; then
+    LIVE_ACCT=$(curl -s -m 4 -H "Authorization: Bearer $LIVE_TOK" -H "anthropic-beta: oauth-2025-04-20" https://api.anthropic.com/api/oauth/profile 2>/dev/null | python3 -c "import sys,json; print(json.loads(sys.stdin.read()).get('account',{}).get('email',''))" 2>/dev/null)
+    if [ -n "$LIVE_ACCT" ] && [ "$LIVE_ACCT" != "$STATE_ACCT" ] && [ "${STATE_ACCT}" != "${LIVE_ACCT%@*}-personal" ] && [ "${STATE_ACCT}" != "${LIVE_ACCT%@*}-team" ]; then
+      echo "⚠  Drift: state=$STATE_ACCT live=$LIVE_ACCT (daemon will auto-correct, or rotate.mjs will reconcile on swap)"
+    fi
+  fi
+} 2>/dev/null
+
+TARGET_ARG=()
+if [ $# -ge 1 ] && [ -n "${1:-}" ]; then
+  TARGET_ARG=(--to "$1")
+fi
+
+run_with_watchdog() {
+  # Runs a command in the background with a hard kill after $WATCHDOG_SECONDS.
+  # Returns the command's exit code, or 124 if the watchdog fired.
+  local cmd_pid wd_pid rc
+  "$@" &
+  cmd_pid=$!
+  ( sleep "$WATCHDOG_SECONDS"; kill -9 "$cmd_pid" 2>/dev/null ) &
+  wd_pid=$!
+  wait "$cmd_pid" 2>/dev/null
+  rc=$?
+  # Stop the watchdog (may already be dead)
+  kill "$wd_pid" 2>/dev/null
+  wait "$wd_pid" 2>/dev/null
+  # If watchdog killed the cmd, wait returns 137; surface as 124 (timeout)
+  if [ "$rc" -eq 137 ]; then
+    echo "⏱  Watchdog fired after ${WATCHDOG_SECONDS}s — killed stuck rotate.mjs" >&2
+    pgrep -f "chrome-beta-automation" | xargs -r kill -9 2>/dev/null
+    return 124
+  fi
+  return "$rc"
+}
+
+# Fast path: refresh-token rotation, no browser. Works whenever a candidate
+# account has a non-expired refresh token — which is the common case.
+echo "→ Trying fast path (--no-browser --force)..."
+if run_with_watchdog node "$DIR/rotate.mjs" --force --no-browser --session ${TARGET_ARG[@]+"${TARGET_ARG[@]}"}; then
+  FAST_OK=1
+else
+  FAST_OK=0
+  echo "⚠  Fast path failed — falling back to browser OAuth"
+  run_with_watchdog node "$DIR/rotate.mjs" --force --session ${TARGET_ARG[@]+"${TARGET_ARG[@]}"}
+fi
+
+# Show new status
+echo ""
+node "$DIR/rotate.mjs" --status 2>&1 | head -40
+
+# macOS notification
+osascript -e 'display notification "Account rotated — restart Claude Code session" with title "Claude Rotation"' 2>/dev/null
+
+echo ""
+if [ "$FAST_OK" -eq 1 ]; then
+  echo "✅ Done (fast path). Start a new Claude Code session to use the fresh account."
+else
+  echo "✅ Done (browser fallback). Start a new Claude Code session to use the fresh account."
+fi
+echo "   (Running sessions may still use the old token — exit and re-enter)"

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -41,6 +41,7 @@ import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 import { execSync, execFileSync, spawn } from "child_process";
 import { tmpdir } from "os";
+import { createHmac } from "node:crypto";
 import { askAIBrain, executeAIAction, AI_BRAIN_MAX_DECISIONS } from "./ai-brain.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -546,7 +547,7 @@ function fetchGooglePassword(account) {
 // Generate a TOTP code from a base32 secret using the Node crypto module.
 // Used when an account has 2FA and we have the secret in dcli.
 function generateTOTP(base32Secret) {
-  const crypto = require("crypto");
+  // Uses top-level ESM import: createHmac from "node:crypto"
   // Decode base32
   const base32chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
   const clean = base32Secret.replace(/\s/g, "").toUpperCase();
@@ -567,7 +568,7 @@ function generateTOTP(base32Secret) {
   const buf = Buffer.alloc(8);
   buf.writeBigUInt64BE(BigInt(counter));
 
-  const hmac = crypto.createHmac("sha1", key).update(buf).digest();
+  const hmac = createHmac("sha1", key).update(buf).digest();
   const offset = hmac[hmac.length - 1] & 0x0f;
   const code =
     ((hmac[offset] & 0x7f) << 24) |
@@ -2169,7 +2170,7 @@ async function runAuthFlow(driver, account) {
             // so the OAuth flow can complete (org chooser → authorize → callback)
             if (driver._authUrl) {
               // For multi-org accounts (same email, multiple workspaces like
-              // heartfeldt-personal vs heartfeldt-team), force an explicit org
+              // user-personal vs user-team), force an explicit org
               // pick BEFORE hitting /oauth/authorize. Otherwise claude.ai uses
               // the "last active" org silently, and both sibling vaults end up
               // holding the same org's token.
@@ -2854,7 +2855,7 @@ async function rotate(targetEmail, opts = {}) {
       }
       if (liveEmail) {
         // For multi-entry emails (same email under multiple config entries,
-        // e.g. heartfeldt-personal + heartfeldt-team), prefer the entry whose
+        // e.g. user-personal + user-team), prefer the entry whose
         // orgUuid matches live. Fall back to first email match.
         let liveAccount = null;
         if (liveOrgUuid) {
@@ -3018,7 +3019,7 @@ async function rotate(targetEmail, opts = {}) {
   );
 
   // Org-match check: for accounts where label != email (multi-org under same
-  // email, like heartfeldt-personal vs heartfeldt-team), confirm the live
+  // email, like user-personal vs user-team), confirm the live
   // /oauth/profile returns the expected organization. Drift here means the
   // OAuth flow landed on the wrong org picker — the stored token will be
   // usable but will double-count capacity with the sibling account.

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -1,0 +1,3567 @@
+#!/usr/bin/env node
+/**
+ * Claude Max Account Rotation — dcli + keychain + Kapture
+ *
+ * PRIMARY PATH (fast, ~1s, no browser):
+ *   dcli read token → write to keychain "Claude Code-credentials" → done
+ *
+ * FALLBACK (token missing/expired) — browser automation cascade:
+ *   1. Kapture MCP  (ws://localhost:61822 — your real Chrome, all Google sessions)
+ *   2. Playwright   (persistent context)
+ *   3. Chrome JXA   (AppleScript, needs "Allow JS from Apple Events")
+ *   4. Manual       (opens URL, notifies user)
+ *
+ * Usage:
+ *   node rotate.mjs                           # auto-rotate to longest-idle account
+ *   node rotate.mjs --to <email>              # rotate to specific account
+ *   node rotate.mjs --status                  # show state
+ *   node rotate.mjs --utilization             # live 5h/7d utilization per account
+ *   node rotate.mjs --audit-billing           # 🔴/🟢 per-account extra_usage (overage billing) audit
+ *   node rotate.mjs --setup                   # manual: claude auth login per account (interactive)
+ *   node rotate.mjs --setup --auto            # AUTOMATED: magic-link + browser cascade, all configured accounts end-to-end
+ *   node rotate.mjs --setup --auto --skip-valid  # skip accounts whose vault token is still alive
+ *   node rotate.mjs --setup --only=<key>      # only re-capture one account (e.g. --only=user@example.com)
+ *   node rotate.mjs --capture                 # save current active token (print for Dashlane)
+ *   node rotate.mjs --session                 # also send /login to running iTerm2 session
+ *   node rotate.mjs --magic-link --to <email> # re-auth via email magic link (no Google OAuth)
+ *   node rotate.mjs --allow-extra-usage       # BYPASS extra_usage billing guard (opt-in only)
+ */
+
+import {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  unlinkSync,
+  appendFileSync,
+  chmodSync,
+  readdirSync,
+  renameSync,
+} from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+import { execSync, execFileSync, spawn } from "child_process";
+import { tmpdir } from "os";
+import { askAIBrain, executeAIAction, AI_BRAIN_MAX_DECISIONS } from "./ai-brain.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CONFIG_PATH = join(__dirname, "config.json");
+const STATE_PATH = join(__dirname, "state.json");
+const LOCK_PATH = join(__dirname, ".rotating");
+const LOG_PATH = join(__dirname, "rotation.log");
+
+const KEYCHAIN_SERVICE = "Claude Code-credentials";
+// Use the OS username so multiple users on the same Mac don't collide on
+// keychain entries. Override with CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT if needed.
+const KEYCHAIN_ACCOUNT =
+  process.env.CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT ||
+  process.env.USER ||
+  process.env.LOGNAME ||
+  "claude-ops";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── Bootstrap: verify dependencies ───────────────────────────────────────────
+// The only browser driver is Playwright-over-CDP to Chrome or Chrome Beta
+// (never Comet — reserved for user, never Chromium — bundled browser banned).
+function ensureMCPServersAndTools() {
+  const actions = [];
+  const earlyLog = (m) => {
+    try {
+      console.error(`[bootstrap] ${m}`);
+    } catch {}
+  };
+
+  // 1. Chrome or Chrome Beta binary (Comet is off-limits)
+  const realChromes = [
+    "/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta",
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  ];
+  const foundChrome = realChromes.find((p) => existsSync(p));
+  if (foundChrome) {
+    actions.push(`chrome-binary: ${foundChrome.split("/").pop()}`);
+  } else {
+    actions.push("chrome-binary: WARNING — no Chrome/Chrome Beta found");
+  }
+
+  // 2. Chrome CDP port 9222 — probe (driver will launch Chrome if needed)
+  try {
+    execSync(`curl -sf http://localhost:9222/json/version >/dev/null 2>&1`, {
+      timeout: 1500,
+    });
+    actions.push("chrome-cdp: reachable on :9222");
+  } catch {
+    actions.push("chrome-cdp: not reachable (driver will launch Chrome)");
+  }
+
+  // 3. dcli (Dashlane) — required for primary token path
+  try {
+    execSync(`command -v dcli >/dev/null 2>&1`, { timeout: 1000 });
+    actions.push("dcli: available");
+  } catch {
+    actions.push("dcli: MISSING — primary token path will fail");
+  }
+
+  // 4. security (macOS keychain) — required for token writes
+  try {
+    execSync(`command -v security >/dev/null 2>&1`, { timeout: 1000 });
+  } catch {
+    actions.push("security(1): MISSING — keychain writes will fail");
+  }
+
+  for (const a of actions) earlyLog(a);
+}
+
+// Unconditional warmup: every rotate.mjs run starts its MCP servers + tools FIRST.
+// Skip only for --help (where nothing runs downstream).
+if (
+  !process.argv.slice(2).includes("--help") &&
+  !process.argv.slice(2).includes("--no-browser")
+) {
+  ensureMCPServersAndTools();
+}
+
+// ── Utilities ────────────────────────────────────────────────────────────────
+
+function log(msg) {
+  const line = `[${new Date().toISOString()}] ${msg}`;
+  console.error(line);
+  try {
+    appendFileSync(LOG_PATH, line + "\n");
+  } catch {}
+}
+
+function notify(title, msg) {
+  try {
+    execSync(
+      `osascript -e 'display notification "${msg.replace(/"/g, '\\"')}" with title "${title}"'`,
+    );
+  } catch {}
+}
+
+function readConfig() {
+  return JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
+}
+function readState() {
+  try {
+    return JSON.parse(readFileSync(STATE_PATH, "utf8"));
+  } catch {
+    return {
+      activeAccount: null,
+      accounts: {},
+      toolUses: 0,
+      totalRotations: 0,
+    };
+  }
+}
+function writeState(s, dryRun = false) {
+  if (dryRun) {
+    log("[DRY-RUN] Would write state");
+    return;
+  }
+  const tmp = STATE_PATH + ".tmp." + process.pid;
+  writeFileSync(tmp, JSON.stringify(s, null, 2));
+  renameSync(tmp, STATE_PATH);
+}
+
+// Lock format: `<ISO timestamp>\n<pid>` — PID lets us detect dead holders
+// regardless of wall-clock age (browser OAuth can legitimately run >30s).
+const LOCK_MAX_AGE_MS = 15 * 60_000; // hard ceiling; browser OAuth can take minutes
+function readLock() {
+  try {
+    const raw = readFileSync(LOCK_PATH, "utf8").trim();
+    const [ts, pidStr] = raw.split(/\s+/);
+    const pid = parseInt(pidStr || "", 10);
+    const when = new Date(ts).getTime();
+    return {
+      when: Number.isFinite(when) ? when : 0,
+      pid: Number.isFinite(pid) ? pid : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+function lockHolderAlive(pid) {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+function acquireLock() {
+  if (existsSync(LOCK_PATH)) {
+    const info = readLock();
+    if (info && lockHolderAlive(info.pid)) {
+      const age = Date.now() - info.when;
+      if (age < LOCK_MAX_AGE_MS) {
+        log(`Rotation in progress (holder PID ${info.pid}, ${Math.round(age / 1000)}s old)`);
+        return false;
+      }
+      log(`Lock held by PID ${info.pid} but >${Math.round(LOCK_MAX_AGE_MS / 60_000)}min old — breaking`);
+    } else if (info) {
+      log(`Stale lock (PID ${info.pid || "?"} not running) — breaking`);
+    }
+  }
+  writeFileSync(LOCK_PATH, `${new Date().toISOString()}\n${process.pid}`);
+  return true;
+}
+function releaseLock() {
+  try {
+    // Only release if we still own it
+    const info = readLock();
+    if (!info || info.pid === process.pid) unlinkSync(LOCK_PATH);
+  } catch {}
+}
+
+function accountKey(a) {
+  return a.label || a.email;
+}
+
+// ── Live utilization query ────────────────────────────────────────────────────
+
+// Query all accounts in parallel — best-effort, uses cached fallback.
+// Staggered + retry-on-429 to avoid rate-limiting the /oauth/usage endpoint,
+// especially right after a token refresh when Anthropic briefly throttles.
+async function queryAllUtilization(config) {
+  async function queryAccount(a) {
+    try {
+      const tokenJson = readStoredToken(a);
+      if (!tokenJson) return null;
+      const parsed = JSON.parse(tokenJson);
+      const accessToken = parsed?.claudeAiOauth?.accessToken;
+      if (!accessToken) return null;
+
+      const headers = {
+        Authorization: `Bearer ${accessToken}`,
+        "anthropic-beta": "oauth-2025-04-20",
+        "Content-Type": "application/json",
+      };
+
+      async function fetchWithRetry(url, attempt = 0) {
+        const res = await fetch(url, {
+          method: "GET",
+          headers,
+          signal: AbortSignal.timeout(5000),
+        });
+        // Retry once on 429 — happens transiently right after token refresh
+        // or when multiple accounts query in parallel
+        if (res.status === 429 && attempt < 2) {
+          await new Promise((r) => setTimeout(r, 1500 * (attempt + 1)));
+          return fetchWithRetry(url, attempt + 1);
+        }
+        return res;
+      }
+
+      const [usageRes, profileRes] = await Promise.all([
+        fetchWithRetry("https://api.anthropic.com/api/oauth/usage"),
+        fetchWithRetry("https://api.anthropic.com/api/oauth/profile"),
+      ]);
+
+      if (!usageRes.ok) return null;
+      const data = await usageRes.json();
+      let extraUsageEnabled = null;
+      let billingType = null;
+      let subscriptionStatus = null;
+      if (profileRes.ok) {
+        const prof = await profileRes.json();
+        extraUsageEnabled = prof?.organization?.has_extra_usage_enabled ?? null;
+        billingType = prof?.organization?.billing_type ?? null;
+        subscriptionStatus = prof?.organization?.subscription_status ?? null;
+      }
+      return {
+        five_hour_pct:
+          Math.round((data.five_hour?.utilization ?? 0) * 100) / 100,
+        seven_day_pct:
+          Math.round((data.seven_day?.utilization ?? 0) * 100) / 100,
+        resets_at_5h: data.five_hour?.resets_at || null,
+        resets_at_7d: data.seven_day?.resets_at || null,
+        extra_usage_enabled: extraUsageEnabled,
+        billing_type: billingType,
+        subscription_status: subscriptionStatus,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  // Stagger account queries by 150ms to avoid bursting /oauth/usage endpoint,
+  // which otherwise 429s on ~5-7 parallel requests from the same IP.
+  const results = await Promise.allSettled(
+    config.accounts
+      .filter((a) => a.disabled !== true)
+      .map(async (a, idx) => {
+        if (idx > 0) await new Promise((r) => setTimeout(r, 150 * idx));
+        return { key: accountKey(a), util: await queryAccount(a) };
+      }),
+  );
+  const map = {};
+  for (const r of results) {
+    if (r.status === "fulfilled" && r.value.util) {
+      map[r.value.key] = r.value.util;
+    }
+  }
+  return map;
+}
+
+// liveUtil: optional map from queryAllUtilization() — key → { five_hour_pct, ... }
+function pickNextAccount(config, state, liveUtil = {}, opts = {}) {
+  const activeKey = state.activeAccount;
+  const windowMs = (config.rateLimits?.windowHours || 5) * 3_600_000;
+  const now = Date.now();
+
+  // Hard block: account has Anthropic-side extra-usage (pay-per-use overage) enabled.
+  // Rotating to such an account risks credit-card charges when the weekly cap is hit.
+  // Override with opts.allowExtraUsage=true (CLI flag --allow-extra-usage) only when
+  // the user has explicitly opted in for this run.
+  const allowExtraUsage = opts.allowExtraUsage === true;
+  function hasExtraUsageEnabled(a) {
+    const key = accountKey(a);
+    const live = liveUtil[key];
+    return live && live.extra_usage_enabled === true;
+  }
+
+  // Check if an account's quota window has been exhausted (local tool-use tracking)
+  function isExhausted(a) {
+    const key = accountKey(a);
+    const acct = state.accounts[key];
+    if (!acct?.windowStart) return false;
+    const windowAge = now - new Date(acct.windowStart).getTime();
+    if (windowAge >= windowMs) return false;
+    const capacity = a.capacityMultiplier ?? 1.0;
+    const maxUses = Math.floor(config.toolUseThreshold * capacity);
+    return (acct.windowToolUses || 0) >= maxUses;
+  }
+
+  // Get best available utilization for an account:
+  //   1. Live API data (freshest)
+  //   2. Snapshot from last rotation away (stale but better than nothing)
+  //   3. null (unknown)
+  function getUtil5h(a) {
+    const key = accountKey(a);
+
+    // 1. Live
+    if (liveUtil[key] != null) return liveUtil[key].five_hour_pct;
+
+    // 2. Snapshot stored in state
+    const acct = state.accounts[key];
+    if (!acct?.lastUtilization) return null;
+    const { pct, reset, ts } = acct.lastUtilization;
+    if (!ts) return null;
+    const resetMs = reset * 1000;
+    if (resetMs && resetMs < now) return 0; // Window reset — account is fresh
+    if (now - ts > 6 * 3_600_000) return null; // Too stale
+    return pct ?? null;
+  }
+
+  // 7-day weekly cap utilization. Live only — no snapshot fallback because
+  // 7d resets are slow and stale data is misleading.
+  function getUtil7d(a) {
+    const key = accountKey(a);
+    if (liveUtil[key] != null && liveUtil[key].seven_day_pct != null) {
+      return liveUtil[key].seven_day_pct;
+    }
+    return null;
+  }
+
+  // Score: max of (5h, 7d) — an account is only viable if BOTH windows have
+  // headroom. Unknown util → 50 (neutral). Lower is better.
+  function score(a) {
+    const u5 = getUtil5h(a);
+    const u7 = getUtil7d(a);
+    if (u5 === null && u7 === null) return 50;
+    return Math.max(u5 ?? 0, u7 ?? 0);
+  }
+
+  // Log + hard-exclude accounts with extra_usage enabled (pay-per-use overage billing).
+  // These are the accounts that silently charge your credit card when the weekly cap
+  // is exceeded. Unless --allow-extra-usage was passed, we refuse to rotate to them.
+  const extraUsageAccounts = config.accounts.filter(hasExtraUsageEnabled);
+  if (extraUsageAccounts.length > 0) {
+    log(
+      `⚠  EXTRA USAGE ENABLED on ${extraUsageAccounts.length} account(s): ${extraUsageAccounts
+        .map((a) => accountKey(a))
+        .join(
+          ", ",
+        )} — these can incur overage charges. Disable at console.anthropic.com/settings/billing.`,
+    );
+  }
+
+  const excludeKey = (a) =>
+    a.disabled === true ||
+    accountKey(a) === activeKey ||
+    (!allowExtraUsage && hasExtraUsageEnabled(a));
+
+  // Separate normal and low-priority, excluding current active + extra-usage accounts
+  const normal = config.accounts.filter(
+    (a) => a.priority !== "low" && !excludeKey(a),
+  );
+  const low = config.accounts.filter(
+    (a) => a.priority === "low" && !excludeKey(a),
+  );
+
+  const UTIL_HARD_BLOCK = 90; // Skip accounts at/above this util% if possible
+
+  for (const pool of [normal, low]) {
+    const fresh = pool.filter((a) => !isExhausted(a));
+    const exhausted = pool.filter((a) => isExhausted(a));
+
+    for (const candidates of [fresh, exhausted]) {
+      const viable = candidates.filter((a) => score(a) < UTIL_HARD_BLOCK);
+      const blocked = candidates.filter((a) => score(a) >= UTIL_HARD_BLOCK);
+      const sorted = [...viable].sort((a, b) => score(a) - score(b));
+      const pool2 = sorted.length
+        ? sorted
+        : [...blocked].sort((a, b) => score(a) - score(b));
+
+      if (pool2.length > 0) {
+        const best = pool2[0];
+        const u5 = getUtil5h(best);
+        const u7 = getUtil7d(best);
+        const src = liveUtil[accountKey(best)]
+          ? "live"
+          : state.accounts[accountKey(best)]?.lastUtilization
+            ? "cached"
+            : "unknown";
+        const utilStr = ` 5h=${u5 ?? "?"}% 7d=${u7 ?? "?"}% [${src}]`;
+        if (score(best) >= UTIL_HARD_BLOCK) {
+          log(
+            `WARNING: All candidates near limit — rotating to ${accountKey(best)}${utilStr}`,
+          );
+        } else {
+          log(`Picked ${accountKey(best)}${utilStr}`);
+        }
+        return best;
+      }
+    }
+  }
+  return null;
+}
+
+// ── Keychain ─────────────────────────────────────────────────────────────────
+
+function readKeychain(svc = KEYCHAIN_SERVICE, acct = KEYCHAIN_ACCOUNT) {
+  const out = execSync(
+    `security find-generic-password -s "${svc}" -a "${acct}" -g 2>&1`,
+    { timeout: 5000 },
+  ).toString();
+  const m = out.match(/^password: "?(.*?)"?$/m);
+  if (!m) throw new Error(`No keychain entry ${svc}/${acct}`);
+  return m[1].replace(/\\"/g, '"');
+}
+
+function writeKeychain(json, svc = KEYCHAIN_SERVICE, acct = KEYCHAIN_ACCOUNT) {
+  try {
+    execSync(
+      `security delete-generic-password -s "${svc}" -a "${acct}" 2>/dev/null`,
+    );
+  } catch {}
+  execSync(
+    `security add-generic-password -s "${svc}" -a "${acct}" -w ${JSON.stringify(json)}`,
+    { timeout: 5000 },
+  );
+}
+
+function tokenExpired(json) {
+  try {
+    const exp = JSON.parse(json)?.claudeAiOauth?.expiresAt;
+    return exp ? Date.now() > exp : false;
+  } catch {
+    return false;
+  }
+}
+
+// ── Token vault (local keychain entries per account) ─────────────────────────
+
+const TOKEN_PREFIX = "Claude-Rotation";
+
+function tokenService(account) {
+  return `${TOKEN_PREFIX}-${accountKey(account)}`;
+}
+
+function readStoredToken(account) {
+  try {
+    return readKeychain(tokenService(account));
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredToken(account, json) {
+  writeKeychain(json, tokenService(account));
+}
+
+function hasStoredToken(account) {
+  try {
+    readKeychain(tokenService(account));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Fetches Google password AND (optional) TOTP secret from dcli by querying
+// all google.com credentials and matching on email.
+// Returns { password, otpSecret } or null.
+function fetchGoogleCreds(account) {
+  try {
+    const json = execSync(`dcli password -o json google.com 2>/dev/null`, {
+      timeout: 15_000,
+    }).toString();
+    const creds = JSON.parse(json);
+    // Find credential whose email matches account.email
+    const match = creds.find(
+      (c) => (c.email || "").toLowerCase() === account.email.toLowerCase(),
+    );
+    if (!match) return null;
+    return {
+      password: match.password || null,
+      otpSecret: match.otpSecret || null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// Legacy alias — returns only password for backwards compat with existing call sites
+function fetchGooglePassword(account) {
+  // Legacy path: honor explicit dashlaneGooglePath if set
+  if (account.dashlaneGooglePath) {
+    try {
+      return execSync(`dcli read "${account.dashlaneGooglePath}" 2>/dev/null`, {
+        timeout: 10_000,
+      })
+        .toString()
+        .trim();
+    } catch {
+      return null;
+    }
+  }
+  // New path: query by email
+  const creds = fetchGoogleCreds(account);
+  return creds?.password || null;
+}
+
+// Generate a TOTP code from a base32 secret using the Node crypto module.
+// Used when an account has 2FA and we have the secret in dcli.
+function generateTOTP(base32Secret) {
+  const crypto = require("crypto");
+  // Decode base32
+  const base32chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+  const clean = base32Secret.replace(/\s/g, "").toUpperCase();
+  let bits = "";
+  for (const c of clean) {
+    const i = base32chars.indexOf(c);
+    if (i === -1) continue;
+    bits += i.toString(2).padStart(5, "0");
+  }
+  const bytes = [];
+  for (let i = 0; i + 8 <= bits.length; i += 8) {
+    bytes.push(parseInt(bits.substring(i, i + 8), 2));
+  }
+  const key = Buffer.from(bytes);
+
+  // TOTP counter: 30-second intervals since epoch
+  const counter = Math.floor(Date.now() / 1000 / 30);
+  const buf = Buffer.alloc(8);
+  buf.writeBigUInt64BE(BigInt(counter));
+
+  const hmac = crypto.createHmac("sha1", key).update(buf).digest();
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  const code =
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff);
+  return (code % 1_000_000).toString().padStart(6, "0");
+}
+
+// Read the latest SMS verification code from Messages.app for the Google 2FA number.
+// Returns a 6-digit code string or null.
+// Read latest SMS verification code from Messages.app.
+// Modern iMessages store text in `attributedBody` (NSKeyedArchiver blob), not `text`.
+// We hex-dump both and extract G-XXXXXX or a 6-digit code.
+function readLatestSMSCode({ maxAgeSec = 300 } = {}) {
+  try {
+    const db = join(process.env.HOME || "", "Library/Messages/chat.db");
+    if (!existsSync(db)) return null;
+    // Apple timestamp = seconds since 2001-01-01, stored as nanoseconds
+    const cutoffAppleNs =
+      (Math.floor(Date.now() / 1000) - 978307200 - maxAgeSec) * 1_000_000_000;
+    const sql = `SELECT hex(attributedBody), text FROM message WHERE date > ${cutoffAppleNs} AND service IN ('SMS','iMessage') ORDER BY date DESC LIMIT 10;`;
+    const rows = execSync(`sqlite3 "${db}" "${sql}"`, { timeout: 5000 })
+      .toString()
+      .split("\n")
+      .filter(Boolean);
+    for (const row of rows) {
+      const [hex, text] = row.split("|");
+      // Plain text column (older macOS)
+      if (text) {
+        const m = text.match(/G-(\d{6})/) || text.match(/\b(\d{6})\b/);
+        if (m) return m[1];
+      }
+      // attributedBody blob — decode as latin-1 and regex-match
+      if (hex && hex.length > 20) {
+        const decoded = Buffer.from(hex, "hex").toString("latin1");
+        const m =
+          decoded.match(/G-(\d{6})/) ||
+          decoded.match(/(\d{6})\s+is your (?:Google )?verification code/);
+        if (m) return m[1];
+      }
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+// ── PRIMARY: local keychain token swap ───────────────────────────────────────
+
+async function swapToken(account) {
+  const token = readStoredToken(account);
+  if (!token) {
+    log("[primary] No stored token — need browser fallback");
+    return false;
+  }
+  if (tokenExpired(token)) {
+    log("[primary] Token expired — need browser fallback");
+    return false;
+  }
+  log(`[primary] Swapping active keychain for ${accountKey(account)}...`);
+
+  // Preserve mcpOAuth from current active token (Figma, Shake etc.)
+  // so MCP connectors don't break on account swap
+  try {
+    const current = readKeychain();
+    const currentParsed = JSON.parse(current);
+    const newParsed = JSON.parse(token);
+    if (
+      currentParsed.mcpOAuth &&
+      Object.keys(currentParsed.mcpOAuth).length > 0
+    ) {
+      // Merge: keep current mcpOAuth, only swap claudeAiOauth
+      newParsed.mcpOAuth = { ...newParsed.mcpOAuth, ...currentParsed.mcpOAuth };
+      writeKeychain(JSON.stringify(newParsed));
+      log("[primary] Preserved mcpOAuth from previous session");
+      return true;
+    }
+  } catch {}
+
+  writeKeychain(token);
+  return true;
+}
+
+// Save current active token back to the account's vault entry
+// Strips mcpOAuth so vault tokens are clean (mcpOAuth merged at swap time)
+function saveCurrentToken(account) {
+  try {
+    const token = readKeychain();
+    if (token.includes("claudeAiOauth")) {
+      // Store only claudeAiOauth, not mcpOAuth (that's session-specific)
+      try {
+        const parsed = JSON.parse(token);
+        const clean = { claudeAiOauth: parsed.claudeAiOauth, mcpOAuth: {} };
+        writeStoredToken(account, JSON.stringify(clean));
+      } catch {
+        writeStoredToken(account, token);
+      }
+      log(`Saved token to vault: ${tokenService(account)}`);
+      return true;
+    }
+  } catch (e) {
+    log(`Save token failed: ${e.message}`);
+  }
+  return false;
+}
+
+// ── Browser driver cascade ────────────────────────────────────────────────────
+
+// Driver cascade — Playwright only by default.
+// Kapture/Chrome-JXA/Manual are disabled because they may touch Comet (user's browser)
+// or depend on whatever is frontmost. Set CLAUDE_ROTATION_ENABLE_FALLBACKS=1 to enable.
+const _fallbacksEnabled = process.env.CLAUDE_ROTATION_ENABLE_FALLBACKS === "1";
+const DRIVER_CASCADE = [
+  ["playwright", makePlaywrightDriver], // CDP to Chrome/Chrome Beta with real profile
+  ...(_fallbacksEnabled
+    ? [
+        ["kapture", makeKaptureDriver],
+        ["chrome-jxa", makeChromeJXADriver],
+        ["manual", makeManualDriver],
+      ]
+    : []),
+];
+
+async function getBrowserDriver(skip = new Set()) {
+  for (const [name, factory] of DRIVER_CASCADE) {
+    if (skip.has(name)) continue;
+    try {
+      const d = await factory();
+      log(`Browser driver: ${name}`);
+      d._driverName = name;
+      return d;
+    } catch (err) {
+      log(`Driver [${name}] unavailable: ${err.message}`);
+    }
+  }
+  throw new Error("All browser drivers failed");
+}
+
+// ─── Driver 1: Kapture MCP (WebSocket → real Chrome, all Google sessions) ────
+
+async function makeKaptureDriver() {
+  const { default: WebSocket } = await import("ws");
+
+  // Auto-start Kapture server if not running
+  let ws;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      ws = await new Promise((resolve, reject) => {
+        const socket = new WebSocket("ws://localhost:61822/mcp");
+        const timer = setTimeout(() => {
+          socket.terminate();
+          reject(new Error("timeout"));
+        }, 4000);
+        socket.once("open", () => {
+          clearTimeout(timer);
+          resolve(socket);
+        });
+        socket.once("error", (e) => {
+          clearTimeout(timer);
+          reject(e);
+        });
+      });
+      break;
+    } catch {
+      if (attempt === 0) {
+        log("Kapture not running — starting server...");
+        spawn("npx", ["kapture-mcp"], {
+          detached: true,
+          stdio: "ignore",
+        }).unref();
+        await sleep(3000);
+      }
+    }
+  }
+  if (!ws) throw new Error("Kapture unavailable");
+
+  // JSON-RPC over WebSocket
+  let msgId = 0;
+  const pending = new Map();
+
+  ws.on("message", (data) => {
+    try {
+      const msg = JSON.parse(data.toString());
+      if (msg.id !== undefined && pending.has(msg.id)) {
+        const { resolve, reject } = pending.get(msg.id);
+        pending.delete(msg.id);
+        msg.error
+          ? reject(new Error(msg.error.message || JSON.stringify(msg.error)))
+          : resolve(msg.result);
+      }
+    } catch {}
+  });
+
+  function rpc(method, params = {}) {
+    return new Promise((resolve, reject) => {
+      const id = ++msgId;
+      pending.set(id, { resolve, reject });
+      ws.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+      const t = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`RPC timeout: ${method}`));
+      }, 30_000);
+      const origResolve = pending.get(id)?.resolve;
+      if (origResolve) {
+        pending.set(id, {
+          resolve: (v) => {
+            clearTimeout(t);
+            resolve(v);
+          },
+          reject: (e) => {
+            clearTimeout(t);
+            reject(e);
+          },
+        });
+      }
+    });
+  }
+
+  function tool(name, args = {}) {
+    return rpc("tools/call", { name, arguments: args });
+  }
+
+  // MCP handshake
+  await rpc("initialize", {
+    protocolVersion: "2024-11-05",
+    capabilities: {},
+    clientInfo: { name: "claude-rotation", version: "1.0" },
+  });
+  ws.send(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+      params: {},
+    }),
+  );
+
+  // Get existing tab or open new one
+  let tabId;
+  try {
+    const tabsResult = await tool("list_tabs", {});
+    const text = extractText(tabsResult);
+    log(`Kapture tabs: ${text.substring(0, 200)}`);
+    // Parse first tab ID from format: "Tab ID: abc123" or "id: abc123" or "(abc123)"
+    const m =
+      text.match(/[Tt]ab\s+[Ii][Dd][:\s]+([a-zA-Z0-9_-]+)/) ||
+      text.match(/\bid[:\s]+([a-zA-Z0-9_-]+)/) ||
+      text.match(/\(([a-zA-Z0-9_-]{6,})\)/);
+    tabId = m?.[1];
+  } catch {}
+
+  if (!tabId) {
+    // Open new tab
+    const result = await tool("new_tab", { browser: "chrome" });
+    const text = extractText(result);
+    const m =
+      text.match(/[Tt]ab\s+[Ii][Dd][:\s]+([a-zA-Z0-9_-]+)/) ||
+      text.match(/([a-zA-Z0-9_-]{8,})/);
+    tabId = m?.[1] || "tab1";
+    await sleep(2000);
+  }
+
+  log(`Kapture using tab: ${tabId}`);
+
+  return {
+    name: "kapture",
+    _tabId: tabId,
+    async goto(url) {
+      await tool("navigate", { tabId, url, timeout: 30_000 });
+      await sleep(2500);
+    },
+    async currentUrl() {
+      try {
+        const r = await tool("tab_detail", { tabId });
+        const text = extractText(r);
+        const m =
+          text.match(/[Uu][Rr][Ll][:\s]+(\S+)/) ||
+          text.match(/https?:\/\/[^\s"',]+/);
+        return m?.[1] || m?.[0] || "";
+      } catch {
+        return "";
+      }
+    },
+    async findAndClick(texts) {
+      for (const t of texts) {
+        // CSS selector? Try that first — most reliable.
+        const isCss =
+          /^[\[#.]/.test(t) ||
+          t.includes("data-testid") ||
+          t.includes("[type=");
+        if (isCss) {
+          try {
+            await tool("click", { tabId, selector: t });
+            log(`[kapture] clicked via CSS: ${t}`);
+            return true;
+          } catch {}
+          continue;
+        }
+        const clean = t
+          .replace(/button:has-text\("?([^"]+)"?\)/g, "$1")
+          .replace(/['"]/g, "")
+          .trim();
+        const escaped = clean.replace(/'/g, "\\'");
+        const xpaths = [
+          `//button[.//*[contains(normalize-space(.),'${escaped}')] or contains(normalize-space(.),'${escaped}')]`,
+          `//a[.//*[contains(normalize-space(.),'${escaped}')] or contains(normalize-space(.),'${escaped}')]`,
+          `//*[@role='button' and (.//*[contains(normalize-space(.),'${escaped}')] or contains(normalize-space(.),'${escaped}'))]`,
+          `//*[@aria-label='${escaped}' or contains(@aria-label,'${escaped}')]`,
+          `//*[normalize-space(text())='${escaped}']`,
+          `//*[contains(normalize-space(text()),'${escaped}')]`,
+          `//*[@data-identifier='${escaped}']`,
+          `//*[@placeholder='${escaped}']`,
+        ];
+        for (const xpath of xpaths) {
+          try {
+            await tool("click", { tabId, xpath });
+            log(`[kapture] clicked via xpath: ${xpath.substring(0, 80)}`);
+            return true;
+          } catch {}
+        }
+      }
+      return false;
+    },
+    async fillInput(sel, val) {
+      if (!val) return false;
+      try {
+        await tool("fill", { tabId, selector: sel, value: val });
+        return true;
+      } catch {}
+      // XPath fallback
+      try {
+        const xpath = `//*[self::input or self::textarea][@type='${sel.includes("password") ? "password" : "email"}']`;
+        await tool("fill", { tabId, xpath, value: val });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    async screenshot(path) {
+      try {
+        const r = await tool("screenshot", {
+          tabId,
+          format: "png",
+          scale: 0.5,
+        });
+        const content = r?.content?.[0];
+        if (content?.type === "image" && content.data) {
+          writeFileSync(path, Buffer.from(content.data, "base64"));
+        }
+      } catch {}
+    },
+    async readPageText() {
+      try {
+        const r = await tool("dom", { tabId });
+        return extractText(r);
+      } catch {
+        return "";
+      }
+    },
+    // Poll list_tabs for a new tab that appears after a Google OAuth click.
+    // Returns a new driver bound to the popup's tab ID.
+    async waitForPopup(timeoutMs = 15_000) {
+      // Snapshot current tabs
+      const snapshotTabs = async () => {
+        try {
+          const r = await tool("list_tabs", {});
+          const text = extractText(r);
+          // Parse all tab IDs from the response
+          const ids = [];
+          const re =
+            /[Tt]ab\s+[Ii][Dd][:\s]+([a-zA-Z0-9_-]+)|\(([a-zA-Z0-9_-]{6,})\)|"id"\s*:\s*"([a-zA-Z0-9_-]+)"/g;
+          let m;
+          while ((m = re.exec(text)) !== null) {
+            const id = m[1] || m[2] || m[3];
+            if (id) ids.push(id);
+          }
+          return new Set(ids);
+        } catch {
+          return new Set();
+        }
+      };
+
+      const before = await snapshotTabs();
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        await sleep(1000);
+        const after = await snapshotTabs();
+        const newTabs = [...after].filter(
+          (id) => !before.has(id) && id !== tabId,
+        );
+        if (newTabs.length > 0) {
+          const popupTabId = newTabs[0];
+          log(`Popup detected, switching to tab: ${popupTabId}`);
+          // Return a minimal driver bound to the popup tab
+          return {
+            name: "kapture-popup",
+            _tabId: popupTabId,
+            async goto(url) {
+              await tool("navigate", {
+                tabId: popupTabId,
+                url,
+                timeout: 30_000,
+              });
+              await sleep(2500);
+            },
+            async currentUrl() {
+              try {
+                const r = await tool("tab_detail", { tabId: popupTabId });
+                const text = extractText(r);
+                const m =
+                  text.match(/[Uu][Rr][Ll][:\s]+(\S+)/) ||
+                  text.match(/https?:\/\/[^\s"',]+/);
+                return m?.[1] || m?.[0] || "";
+              } catch {
+                return "";
+              }
+            },
+            async findAndClick(texts) {
+              for (const t of texts) {
+                const clean = t
+                  .replace(/button:has-text\("?([^"]+)"?\)/g, "$1")
+                  .replace(/['"]/g, "")
+                  .trim();
+                const xpaths = [
+                  `//*[normalize-space(text())='${clean}']`,
+                  `//*[contains(normalize-space(text()),'${clean}')]`,
+                  `//*[@data-identifier='${clean}']`,
+                  `//*[@placeholder='${clean}']`,
+                ];
+                for (const xpath of xpaths) {
+                  try {
+                    await tool("click", { tabId: popupTabId, xpath });
+                    return true;
+                  } catch {}
+                }
+              }
+              return false;
+            },
+            async fillInput(sel, val) {
+              if (!val) return false;
+              try {
+                await tool("fill", {
+                  tabId: popupTabId,
+                  selector: sel,
+                  value: val,
+                });
+                return true;
+              } catch {}
+              return false;
+            },
+            async waitForEvent() {
+              return null;
+            },
+            async close() {},
+          };
+        }
+      }
+      log("No popup appeared within timeout");
+      return null;
+    },
+    async close() {
+      ws.close();
+    },
+  };
+}
+
+// Helper: extract text from MCP tool result
+function extractText(result) {
+  if (!result) return "";
+  if (typeof result === "string") return result;
+  const content = result.content || result;
+  if (Array.isArray(content)) {
+    return content.map((c) => c.text || c.data || "").join("\n");
+  }
+  return JSON.stringify(result);
+}
+
+// ─── Driver 2: Playwright attached to REAL Chrome via CDP ───────────────────
+// Attaches to the user's real Chrome/Comet profile (with all Google logins).
+// Strategy:
+//   1. If CDP is already up on :9222 → attach directly
+//   2. Else: gracefully quit Chrome, relaunch with CDP + the real user profile
+//   3. NEVER uses bundled Chromium, NEVER uses a separate profile dir
+//
+// The real user profile has all Google accounts signed in, so claude.ai's
+// OAuth account picker shows all of them.
+
+// Chrome Beta ONLY — dedicated automation browser.
+// Uses an ISOLATED profile (not linked to Chrome Beta's default). Starts empty;
+// rotation logs into Google accounts from scratch using dcli passwords + TOTP.
+// Comet = user's browser (never touch). Chrome = user's browser (never touch).
+const REAL_BROWSERS = [
+  {
+    name: "Google Chrome Beta",
+    bin: "/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta",
+    profile: join(__dirname, ".chrome-beta-automation"),
+    appName: "Google Chrome Beta",
+  },
+];
+
+// Ensure an isolated automation profile directory exists.
+// We use a FRESH profile with NO pre-logged accounts — rotation logs in from
+// scratch using dcli credentials + TOTP/SMS each time. This is cleaner than
+// trying to share Chrome's profile (cookie encryption is keychain-bound).
+function ensureSymlinkedProfile(browser) {
+  const auto = browser.profile;
+  if (!existsSync(auto)) {
+    execSync(`mkdir -p "${auto}"`, { timeout: 2000 });
+  }
+  // Persistent profile — it keeps cookies between runs so subsequent rotations
+  // can reuse existing logins. First run per account: full login flow.
+  // Subsequent runs: Google session cookies are still fresh, chooser shows
+  // the accounts, we just click to select.
+}
+const CDP_PORT = 9222;
+
+function findRealBrowser({ preferNotRunning = true } = {}) {
+  const existing = REAL_BROWSERS.filter((b) => existsSync(b.bin));
+  if (preferNotRunning) {
+    // Prefer a browser that isn't currently running (avoid disrupting user's session)
+    const notRunning = existing.find((b) => !isAppRunning(b.appName));
+    if (notRunning) return notRunning;
+  }
+  return existing[0] || null;
+}
+
+async function tryConnectCDP(chromium) {
+  try {
+    const browser = await chromium.connectOverCDP(
+      `http://localhost:${CDP_PORT}`,
+    );
+    const contexts = browser.contexts();
+    const ctx = contexts[0] || (await browser.newContext());
+    const page = ctx.pages()[0] || (await ctx.newPage());
+    log(`[playwright] Attached to running Chrome via CDP :${CDP_PORT}`);
+    return { browser, ctx, page };
+  } catch {
+    return null;
+  }
+}
+
+function isAppRunning(appName) {
+  try {
+    execSync(`pgrep -f "${appName.replace(/ /g, ".")}" > /dev/null 2>&1`, {
+      timeout: 2000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function gracefullyQuitApp(appName) {
+  try {
+    execSync(
+      `osascript -e 'tell application "${appName}" to quit' 2>/dev/null`,
+      { timeout: 8000 },
+    );
+    // Wait up to 5s for it to actually quit
+    for (let i = 0; i < 10; i++) {
+      if (!isAppRunning(appName)) return true;
+      execSync("sleep 0.5");
+    }
+  } catch {}
+  return false;
+}
+
+async function makePlaywrightDriver() {
+  const { chromium } = await import("playwright");
+
+  // 1. Try attaching to already-running Chrome on CDP
+  let attached = await tryConnectCDP(chromium);
+  let weSpawnedChrome = false;
+  let spawnedProfile = null;
+
+  if (!attached) {
+    const browser = findRealBrowser();
+    if (!browser)
+      throw new Error("No Comet / Chrome Beta / Chrome binary found");
+
+    // 2. Ensure symlinked profile exists (Chrome CDP requires non-default user-data-dir)
+    ensureSymlinkedProfile(browser);
+
+    // 3. Quit any running Chrome Beta that might be holding the real profile
+    //    (the symlinked profile shares Cookies/LoginData files with the real one).
+    if (isAppRunning(browser.appName)) {
+      log(
+        `[playwright] ${browser.name} running — quitting to release profile files...`,
+      );
+      gracefullyQuitApp(browser.appName);
+      await sleep(1500);
+      // Force kill if still alive
+      try {
+        execSync(`pkill -f "${browser.appName}.app/Contents/MacOS"`);
+      } catch {}
+      await sleep(500);
+    }
+
+    // 4. Launch visible (NOT headless — Cloudflare blocks headless Chrome)
+    //    Positioned off-screen + 1x1 size so the window is effectively invisible
+    //    even on multi-monitor / retina setups where 3000,3000 clamps onto a display.
+    log(
+      `[playwright] Launching ${browser.name} hidden (1x1 off-screen) with CDP :${CDP_PORT}...`,
+    );
+    spawn(
+      browser.bin,
+      [
+        `--remote-debugging-port=${CDP_PORT}`,
+        `--user-data-dir=${browser.profile}`,
+        "--no-first-run",
+        "--no-default-browser-check",
+        "--disable-blink-features=AutomationControlled",
+        "--disable-background-networking",
+        "--disable-component-update",
+        "--disable-default-apps",
+        "--disable-sync",
+        "--disable-notifications",
+        "--window-position=9000,9000",
+        "--window-size=1,1",
+      ],
+      { detached: true, stdio: "ignore" },
+    ).unref();
+    weSpawnedChrome = true;
+    spawnedProfile = browser.profile;
+
+    // 4. Poll CDP until it comes up
+    for (let i = 0; i < 30; i++) {
+      await sleep(500);
+      attached = await tryConnectCDP(chromium);
+      if (attached) break;
+    }
+    if (!attached)
+      throw new Error(`CDP didn't come up on :${CDP_PORT} within 15s`);
+  }
+
+  const { browser: pwBrowser, ctx, page } = attached;
+  return buildPageDriver(
+    "playwright",
+    page,
+    async () => {
+      try {
+        await pwBrowser.close();
+      } catch {}
+      // Kill Chrome Beta if WE spawned it — don't leave zombie Chromes
+      if (weSpawnedChrome && spawnedProfile) {
+        try {
+          execSync(`pkill -f "${spawnedProfile}"`, { timeout: 5000 });
+        } catch {}
+      }
+    },
+    ctx,
+  );
+}
+
+// ─── Driver 3: Chrome JXA ────────────────────────────────────────────────────
+
+async function makeChromeJXADriver() {
+  const test = execSync(
+    `osascript -l JavaScript -e '
+    var chrome = Application("Google Chrome");
+    "ok:" + chrome.windows[0].activeTab().url();
+  '`,
+    { timeout: 5000 },
+  )
+    .toString()
+    .trim();
+  if (!test.startsWith("ok:")) throw new Error("Chrome JXA test failed");
+
+  function jxaJs(js) {
+    return execSync(
+      `osascript -l JavaScript -e '
+      var chrome = Application("Google Chrome");
+      chrome.windows[0].activeTab().execute({javascript: ${JSON.stringify(js)}});
+    '`,
+      { timeout: 10_000 },
+    )
+      .toString()
+      .trim();
+  }
+
+  return {
+    name: "chrome-jxa",
+    async goto(url) {
+      // Do NOT activate Chrome — focus-steal would interrupt the user's work.
+      // URL assignment alone is enough to drive navigation via JXA.
+      execSync(`osascript -l JavaScript -e '
+        var c = Application("Google Chrome");
+        c.windows[0].activeTab().url = ${JSON.stringify(url)};
+      '`);
+      await sleep(3000);
+    },
+    async currentUrl() {
+      return execSync(`osascript -l JavaScript -e '
+        Application("Google Chrome").windows[0].activeTab().url();
+      '`)
+        .toString()
+        .trim();
+    },
+    async findAndClick(texts) {
+      for (const t of texts) {
+        const clean = t
+          .replace(/button:has-text\("?([^"]+)"?\)/g, "$1")
+          .replace(/['"]/g, "")
+          .trim();
+        try {
+          const r = jxaJs(
+            `(function(){var els=document.querySelectorAll('button,a,[role=button],input[type=submit]');` +
+              `for(var e of els){if((e.textContent||e.value||'').trim().toLowerCase().includes('${clean.toLowerCase()}')){e.click();return'ok';}}return'miss';})()`,
+          );
+          if (r === "ok") return true;
+        } catch {}
+      }
+      return false;
+    },
+    async fillInput(sel, val) {
+      if (!val) return false;
+      try {
+        jxaJs(
+          `(function(){var e=document.querySelector('${sel}');if(e){e.value='${val.replace(/'/g, "\\'")}';e.dispatchEvent(new Event('input',{bubbles:true}));e.dispatchEvent(new Event('change',{bubbles:true}));}})()`,
+        );
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    async screenshot(path) {
+      try {
+        execSync(`screencapture -x "${path}"`);
+      } catch {}
+    },
+    async waitForPopup() {
+      return null;
+    },
+    async close() {},
+  };
+}
+
+// ─── Driver 4: Manual ────────────────────────────────────────────────────────
+
+async function makeManualDriver() {
+  return {
+    name: "manual",
+    async goto(url) {
+      execSync(`open "${url}"`);
+      notify("Account Rotation", "Complete Google sign-in → click Allow");
+    },
+    async currentUrl() {
+      return "";
+    },
+    async findAndClick() {
+      return false;
+    },
+    async fillInput() {
+      return false;
+    },
+    async screenshot() {},
+    async waitForPopup() {
+      return null;
+    },
+    async close() {},
+  };
+}
+
+// ─── Playwright page → driver adapter ────────────────────────────────────────
+
+function buildPageDriver(name, page, closeFn, ctx) {
+  return {
+    name,
+    // Raw refs — exposed so the AI-brain fallback can screenshot / evaluate
+    // against the same page the flow is driving.
+    _page: page,
+    _ctx: ctx,
+    async goto(url) {
+      await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30_000 });
+      await page
+        .waitForLoadState?.("networkidle", { timeout: 10_000 })
+        .catch(() => {});
+    },
+    async currentUrl() {
+      return page.url();
+    },
+    async findAndClick(texts) {
+      for (const t of texts) {
+        // If it looks like a CSS selector (starts with [, #, ., or contains data-testid), use directly
+        const isCss =
+          /^[\[#.]/.test(t) ||
+          t.includes("data-testid") ||
+          t.includes("[type=");
+        if (isCss) {
+          try {
+            const loc = page.locator(t).first();
+            if (await loc.isVisible({ timeout: 2000 }).catch(() => false)) {
+              await loc.click({ timeout: 5000 });
+              return true;
+            }
+          } catch {}
+          continue;
+        }
+        // Otherwise treat as text — broad matcher covering buttons, links, list items,
+        // and ARIA roles (Google 2FA pages use <li> for options, not <button>)
+        const clean = t
+          .replace(/button:has-text\("?([^"]+)"?\)/g, "$1")
+          .replace(/['"]/g, "")
+          .trim();
+        try {
+          // Try each element type individually so we don't get strict-mode violations
+          const selectors = [
+            `button:has-text("${clean}")`,
+            `a:has-text("${clean}")`,
+            `[role=button]:has-text("${clean}")`,
+            `[role=link]:has-text("${clean}")`,
+            `li:has-text("${clean}")`,
+            `div[data-challengetype]:has-text("${clean}")`,
+          ];
+          for (const sel of selectors) {
+            const loc = page.locator(sel).first();
+            if (await loc.isVisible({ timeout: 500 }).catch(() => false)) {
+              await loc.click({ timeout: 5000 });
+              return true;
+            }
+          }
+        } catch {}
+      }
+      return false;
+    },
+    async fillInput(sel, val) {
+      if (!val) return false;
+      try {
+        if (page.fill) {
+          // Short explicit timeout — Playwright's default is 30s, which
+          // causes a single iteration to hang for 30-60s when the selector
+          // doesn't exist on the current page (e.g. generic fallback on a
+          // page that's really a 2FA challenge). 3s is plenty for a real
+          // input; missing inputs should fail fast so the loop can move on.
+          await page.fill(sel, val, { timeout: 3000 });
+          return true;
+        }
+        await page.type(sel, val, { delay: 40, timeout: 3000 });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    async screenshot(path) {
+      try {
+        await page.screenshot({ path });
+      } catch {}
+    },
+    async readPageText() {
+      try {
+        return await page.evaluate(() => document.body?.innerText || "");
+      } catch {
+        return "";
+      }
+    },
+    async waitForPopup(timeout = 10_000) {
+      return ctx
+        ? ctx.waitForEvent("page", { timeout }).catch(() => null)
+        : null;
+    },
+    async close() {
+      await closeFn();
+    },
+  };
+}
+
+// ── Magic link Gmail polling ─────────────────────────────────────────────────
+
+/**
+ * Poll Gmail via `gog` CLI for a Claude magic link email.
+ * Returns the login URL from the email body, or null if not found within timeout.
+ */
+// Decode the target email embedded in a Claude magic-link URL.
+// Format: https://claude.ai/magic-link#<hex>:<base64-email>
+function magicLinkTargetEmail(url) {
+  try {
+    const hash = url.split("#")[1] || "";
+    const b64 = hash.split(":")[1] || "";
+    if (!b64) return null;
+    return Buffer.from(b64, "base64").toString("utf-8").trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+async function pollGmailForMagicLink(accountEmail, maxWaitMs = 120_000) {
+  const startTime = Date.now();
+  // Anchor to "now" so we never accept a magic-link email older than this call.
+  const requestedAt = Math.floor(Date.now() / 1000);
+  const targetLower = accountEmail.toLowerCase();
+  log(
+    `[magic-link] Polling Gmail for login email to ${accountEmail} (max ${maxWaitMs / 1000}s)...`,
+  );
+
+  // Track skipped (stale/wrong-target) thread IDs so we don't re-evaluate them every poll
+  const seenSkip = new Set();
+
+  while (Date.now() - startTime < maxWaitMs) {
+    try {
+      // Pull up to 10 recent matches so a stale top-result doesn't block us.
+      const searchResult = execFileSync(
+        "gog",
+        [
+          "gmail",
+          "search",
+          'subject:"Secure link to log in to Claude" newer_than:5m',
+          "--max",
+          "10",
+          "-j",
+        ],
+        { timeout: 15_000, stdio: ["ignore", "pipe", "pipe"] },
+      )
+        .toString()
+        .trim();
+
+      const parsedSearch = JSON.parse(searchResult);
+      const list = Array.isArray(parsedSearch)
+        ? parsedSearch
+        : parsedSearch.threads || parsedSearch.results || [];
+
+      for (const item of list) {
+        const threadIdRaw = item.id || item.threadId;
+        if (!threadIdRaw) continue;
+        // Sanitize: Gmail IDs are alphanumeric. Reject anything else.
+        if (!/^[A-Za-z0-9_-]+$/.test(threadIdRaw)) continue;
+        if (seenSkip.has(threadIdRaw)) continue;
+
+        const threadJson = execFileSync(
+          "gog",
+          ["gmail", "read", threadIdRaw, "-j"],
+          { timeout: 15_000, stdio: ["ignore", "pipe", "pipe"] },
+        ).toString();
+
+        const parsed = JSON.parse(threadJson);
+        const messages = parsed?.thread?.messages || [];
+
+        // Reject any message older than our requestedAt (stale link from prior call)
+        const msgTimes = messages
+          .map((m) => parseInt(m.internalDate || "0", 10) / 1000)
+          .filter((t) => t > 0);
+        const newestMsg = msgTimes.length ? Math.max(...msgTimes) : 0;
+        if (newestMsg && newestMsg < requestedAt - 5) {
+          seenSkip.add(threadIdRaw);
+          continue;
+        }
+
+        const decodedBodies = [];
+        const walkParts = (part) => {
+          const data = part?.body?.data;
+          if (data) {
+            try {
+              decodedBodies.push(
+                Buffer.from(data, "base64url").toString("utf-8"),
+              );
+            } catch {}
+          }
+          for (const p of part?.parts || []) walkParts(p);
+        };
+        for (const msg of messages) walkParts(msg.payload);
+        const fullBody = decodedBodies.join("\n");
+
+        const linkPatterns = [
+          /https:\/\/claude\.ai\/magic-link#[^\s"'<>)}\]]+/,
+          /https:\/\/claude\.ai\/api\/auth\/verify[^\s"'<>)}\]]+/,
+          /https:\/\/claude\.ai\/login\/verify[^\s"'<>)}\]]+/,
+          /https:\/\/claude\.ai\/auth\/verify[^\s"'<>)}\]]+/,
+          /https:\/\/claude\.ai\/[^\s"'<>)}\]]*(?:verify|confirm|magic-link|login\?code)[^\s"'<>)}\]]*/,
+        ];
+
+        let url = null;
+        for (const pattern of linkPatterns) {
+          const m = fullBody.match(pattern);
+          if (m) {
+            url = m[0];
+            break;
+          }
+        }
+
+        if (!url) {
+          const codeMatch = fullBody.match(/\b(\d{6,8})\b/);
+          if (codeMatch) {
+            log(`[magic-link] Found login code: ${codeMatch[1]}`);
+            return `code:${codeMatch[1]}`;
+          }
+          seenSkip.add(threadIdRaw);
+          continue;
+        }
+
+        // Validate the embedded target email matches our account.
+        // Without this, polling can grab a stale magic-link from a prior call
+        // (subject is identical for every account) and rotate to the wrong one.
+        const linkTarget = magicLinkTargetEmail(url);
+        if (linkTarget && linkTarget !== targetLower) {
+          log(
+            `[magic-link] Skipping stale link for ${linkTarget} (waiting for ${targetLower})`,
+          );
+          seenSkip.add(threadIdRaw);
+          continue;
+        }
+
+        log(
+          `[magic-link] Found login link: ${url.substring(0, 100)}...`,
+        );
+        return url;
+      }
+    } catch (err) {
+      const stderr = err.stderr ? err.stderr.toString().trim() : "";
+      log(`[magic-link] Gmail poll error: ${err.message}${stderr ? " | stderr: " + stderr : ""}`);
+    }
+    await sleep(5000);
+  }
+  log(`[magic-link] Timed out waiting for magic link email for ${accountEmail}`);
+  return null;
+}
+
+// ── Auth flow (driver-agnostic) ───────────────────────────────────────────────
+
+async function runAuthFlow(driver, account) {
+  const creds = fetchGoogleCreds(account) || {};
+  const googlePassword = creds.password || fetchGooglePassword(account);
+  const googleOtpSecret = creds.otpSecret || null;
+  if (googlePassword)
+    log(
+      `dcli Google password available for ${account.email}${googleOtpSecret ? " (+TOTP)" : ""}`,
+    );
+  const PHONE_NUMBER = "+31614446458";
+
+  // AI-brain stall detector: when the URL doesn't advance for N consecutive
+  // steps, hand the page to Claude to decide what to do. Kept separate from
+  // the hard-coded URL branches below — the branches stay fast + free for the
+  // common case; Claude only fires on genuinely unseen pages.
+  //
+  // Threshold is low (2) because each iteration's findAndClick/fillInput
+  // retries can take 20-60s on a page with nothing to match — we want Claude
+  // to intervene on the second stagnant step, not the fourth.
+  let lastStallUrl = "";
+  let stallCount = 0;
+  const STALL_THRESHOLD = 2;
+  const aiBrainHistory = [];
+  const aiBrainEnabled =
+    driver._page &&
+    process.env.CLAUDE_ROTATOR_DISABLE_AI_BRAIN !== "1";
+
+  for (let step = 0; step < 20; step++) {
+    await sleep(2500);
+    const url = await driver.currentUrl().catch(() => "");
+    log(`Step ${step} [${driver.name}]: ${url.substring(0, 100)}`);
+
+    // Stall check — run BEFORE the URL pattern dispatcher so an unknown
+    // challenge page gets escalated to the AI brain. Skip on the very first
+    // step (no history yet) and skip inside the manual driver.
+    if (aiBrainEnabled && step > 0 && driver.name !== "manual") {
+      if (url && url === lastStallUrl) {
+        stallCount++;
+      } else {
+        stallCount = 0;
+      }
+      lastStallUrl = url;
+      if (
+        stallCount >= STALL_THRESHOLD &&
+        aiBrainHistory.length < AI_BRAIN_MAX_DECISIONS
+      ) {
+        const stallReason = `url stagnant for ${stallCount} steps: ${url.substring(0, 100)}`;
+        log(`[ai-brain] STALL DETECTED — ${stallReason}`);
+        const action = await askAIBrain({
+          page: driver._page,
+          account,
+          history: aiBrainHistory,
+          stallReason,
+          logger: (m) => log(`[ai-brain] ${m}`),
+        });
+        aiBrainHistory.push(
+          `${action.action}${action.selector ? `(${String(action.selector).slice(0, 40)})` : ""} — ${String(action.reason || "").slice(0, 60)}`,
+        );
+        if (action.action === "abort") {
+          log(
+            `[ai-brain] aborted — reason: ${action.reason}. Returning to caller.`,
+          );
+          return false;
+        }
+        const ok = await executeAIAction(driver, action, { googlePassword });
+        log(`[ai-brain] executed ${action.action}: ${ok ? "ok" : "no-op"}`);
+        stallCount = 0;
+        await sleep(3000);
+        continue;
+      }
+    }
+
+    // Success: redirected to localhost callback (check hostname, not query string)
+    try {
+      const parsed = new URL(url);
+      if (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1") {
+        log("Auth callback reached (localhost) — success");
+        return true;
+      }
+    } catch {}
+
+    // Success: landed on platform.claude.com success page
+    if (url.includes("/oauth/code/success")) {
+      log("Auth success page reached");
+      return true;
+    }
+
+    // Anthropic fallback redirect — extract code and replay to CLI's localhost
+    if (url.includes("/oauth/code/callback") && url.includes("code=")) {
+      log(
+        "Auth callback reached (platform.claude.com) — replaying to localhost",
+      );
+      const codeMatch = url.match(/[?&]code=([^&]+)/);
+      const stateMatch = url.match(/[?&]state=([^&]+)/);
+      if (codeMatch && driver._localhostPort) {
+        const replayUrl = `http://localhost:${driver._localhostPort}/callback?code=${codeMatch[1]}${stateMatch ? "&state=" + stateMatch[1] : ""}`;
+        try {
+          execSync(`curl -s "${replayUrl}" -o /dev/null`, { timeout: 5000 });
+        } catch {}
+      }
+      return true;
+    }
+    if (driver.name === "manual") {
+      await sleep(12_000);
+      continue;
+    }
+
+    // Google 2FA: push notification to phone (/challenge/dp) — can't automate, must switch
+    if (url.includes("accounts.google.com") && url.includes("challenge/dp")) {
+      log(`Push-notification 2FA detected — clicking "Try another way"`);
+      const clicked = await driver.findAndClick([
+        "Try another way",
+        "Probeer een andere manier",
+      ]);
+      if (!clicked) {
+        log(`Could not find "Try another way" button`);
+        return false;
+      }
+      await sleep(4000);
+      continue;
+    }
+
+    // Google passkey challenge (/challenge/pk/presend, /challenge/pk/verify).
+    // No hardware key available — bail out via "Try another way".
+    if (url.includes("accounts.google.com") && url.includes("/challenge/pk")) {
+      log(`Passkey challenge detected — clicking "Try another way"`);
+      const clicked = await driver.findAndClick([
+        "Try another way",
+        "Try another method",
+        "Use password instead",
+        "Use your password instead",
+        "Probeer een andere manier",
+        "Gebruik wachtwoord",
+        'button:has-text("Try another way")',
+        'button:has-text("Use password")',
+        '[jsname="QkNstf"]',
+      ]);
+      if (!clicked) {
+        log(`Passkey: "Try another way" not clickable — AI-brain will escalate`);
+      } else {
+        await sleep(4000);
+      }
+      continue;
+    }
+
+    // Google 2FA: method selection page (/challenge/selection)
+    // Google orders options differently per account. Confirmed via CDP on
+    // a live "Too many failed attempts" selection page:
+    //   - data-challengetype="1"  → "Enter your password"
+    //   - data-challengetype="9"  → "Get a verification code" (SMS)
+    //   - data-challengetype="53" → "Use your passkey" / "Try another way"
+    //   - data-challengetype="6"  → TOTP authenticator app
+    // Preference: password (we have it via dcli) > TOTP (we have the secret)
+    //           > SMS (requires a phone) > passkey (no hardware).
+    if (
+      url.includes("accounts.google.com") &&
+      url.includes("challenge/selection")
+    ) {
+      log(`On 2FA selection page — prefer password, then TOTP, then SMS`);
+      const selectors = [];
+      if (googlePassword)
+        selectors.push(
+          'div[data-challengetype="1"]',
+          'li:has-text("Enter your password")',
+          "Enter your password",
+          "Wachtwoord invoeren",
+        );
+      if (googleOtpSecret)
+        selectors.push(
+          'div[data-challengetype="6"]',
+          'li:has-text("Google Authenticator")',
+          "Google Authenticator",
+          "Authenticator app",
+        );
+      selectors.push(
+        'div[data-challengetype="9"]',
+        'li:has-text("Get a verification code")',
+        "Get a verification code",
+        "Text message",
+      );
+      const clicked = await driver.findAndClick(selectors);
+      if (clicked) {
+        await sleep(5000);
+        continue;
+      }
+      log(`No preferred method found on selection page — AI-brain will escalate`);
+      continue; // don't hard-abort; let stall detector route to AI-brain
+    }
+
+    // Google 2FA: TOTP code entry
+    if (url.includes("accounts.google.com") && url.includes("challenge/totp")) {
+      if (googleOtpSecret) {
+        const code = generateTOTP(googleOtpSecret);
+        log(`Entering TOTP code from dcli secret`);
+        await driver.fillInput(
+          'input[type="tel"], input[name=totpPin], #totpPin',
+          code,
+        );
+        await sleep(500);
+        await driver.findAndClick(["Next", "#totpNext button", "Verify"]);
+        await sleep(3000);
+        continue;
+      }
+      log(`No TOTP secret — trying alternate verification`);
+      await driver.findAndClick(["Try another way"]);
+      await sleep(2000);
+      continue;
+    }
+
+    // Google 2FA: SMS phone collect (/challenge/ipp/collect) — enter phone, click Send
+    if (
+      url.includes("accounts.google.com") &&
+      url.includes("challenge/ipp/collect")
+    ) {
+      log(`SMS phone collect — entering ${PHONE_NUMBER} and clicking Send`);
+      await driver.fillInput('#phoneNumberId, input[type="tel"]', PHONE_NUMBER);
+      await sleep(500);
+      await driver.findAndClick(["Send", "Next", "Verstuur"]);
+      await sleep(4000);
+      continue;
+    }
+
+    // Google 2FA: SMS code verify (/challenge/ipp/verify or /challenge/sms)
+    if (
+      url.includes("accounts.google.com") &&
+      (url.includes("challenge/ipp/verify") || url.includes("challenge/sms"))
+    ) {
+      log(`Waiting for SMS code from Messages.app (up to 60s)...`);
+      let smsCode = null;
+      for (let waitI = 0; waitI < 12; waitI++) {
+        await sleep(5000);
+        smsCode = readLatestSMSCode({ maxAgeSec: 180 });
+        if (smsCode) break;
+      }
+      if (!smsCode) {
+        log(`Failed to retrieve SMS code — aborting`);
+        return false;
+      }
+      log(`Got SMS code: ${smsCode}`);
+      await driver.fillInput(
+        '#idvPin, input[name="Pin"], input[type="tel"]',
+        smsCode,
+      );
+      await sleep(500);
+      await driver.findAndClick(["Next", "Verify"]);
+      await sleep(4000);
+      continue;
+    }
+
+    // Google consent page (/signin/oauth/id or /signin/oauth/consent) — click Continue
+    if (
+      url.includes("accounts.google.com") &&
+      (url.includes("/signin/oauth/id") ||
+        url.includes("/signin/oauth/consent") ||
+        url.includes("/signin/oauth/legacy"))
+    ) {
+      log(`Google OAuth consent — clicking Continue`);
+      // Workspace accounts show a scope list with a Continue button at the bottom;
+      // sometimes it's disabled until the user scrolls. Try direct click first, then fall through.
+      const clicked = await driver.findAndClick([
+        'button[jsname="LgbsSe"]:has-text("Continue")',
+        'button[jsname="LgbsSe"]:has-text("Allow")',
+        'button[jsname="LgbsSe"]:has-text("Approve")',
+        'button:has-text("Continue")',
+        'button:has-text("Allow")',
+        'button:has-text("Approve")',
+        'button:has-text("Confirm")',
+        'button:has-text("Doorgaan")',
+        'button:has-text("Toestaan")',
+        '[role="button"]:has-text("Continue")',
+        '[role="button"]:has-text("Allow")',
+        '[role="button"]:has-text("Approve")',
+        "Continue",
+        "Allow",
+        "Approve",
+        "Confirm",
+        "Doorgaan",
+        "Toestaan",
+      ]);
+      if (!clicked) {
+        log(`Continue button not found on consent page — waiting and retrying`);
+      }
+      await sleep(3000);
+      continue;
+    }
+
+    // Google account chooser — click the target account
+    if (url.includes("accounts.google.com")) {
+      // Detect "Signed out" next to the target account (needs re-login)
+      let targetSignedOut = false;
+      if (driver.readPageText) {
+        try {
+          const txt = (await driver.readPageText()).toLowerCase();
+          const emailIdx = txt.indexOf(account.email.toLowerCase());
+          if (emailIdx >= 0) {
+            const nearby = txt.substring(emailIdx, emailIdx + 200);
+            targetSignedOut = nearby.includes("signed out");
+          }
+        } catch {}
+      }
+
+      const picked = await driver.findAndClick([
+        account.email,
+        `data-identifier="${account.email}"`,
+      ]);
+      if (picked && targetSignedOut && googlePassword) {
+        // Account was signed out — click picked it, now password prompt will appear
+        log(
+          `Account ${account.email} was signed out — password flow will handle`,
+        );
+      }
+      if (!picked) {
+        // Not in list — add manually
+        await driver.findAndClick(["Use another account", "Add account"]);
+        await sleep(2000);
+        await driver.fillInput(
+          'input[type="email"], #identifierId',
+          account.email,
+        );
+        await sleep(500);
+        await driver.findAndClick(["Next", "#identifierNext button"]);
+        await sleep(2000);
+        if (googlePassword) {
+          await driver.fillInput('input[type="password"]', googlePassword);
+          await sleep(500);
+          await driver.findAndClick(["Next", "#passwordNext button"]);
+        }
+      }
+      continue;
+    }
+
+    // Google password prompt (standalone page, no account chooser)
+    if (url.includes("accounts.google.com") && url.includes("challenge/pwd")) {
+      if (googlePassword) {
+        await driver.fillInput('input[type="password"]', googlePassword);
+        await sleep(500);
+        await driver.findAndClick(["Next", "#passwordNext button"]);
+        continue;
+      }
+    }
+
+    // Claude organization/workspace chooser (Workspace accounts on a custom domain)
+    // Shown between Google OAuth return and /oauth/authorize. Pick Personal unless
+    // the account metadata specifies a team/organization name.
+    // URL match is intentionally broad — claude.ai has renamed the chooser route
+    // several times (select-organization, onboarding/organization, workspaces,
+    // choose-workspace). Also triggers on page-text heuristic for routes we miss.
+    const isOrgChooserUrl =
+      url.includes("claude.ai") &&
+      (url.includes("select-organization") ||
+        url.includes("/onboarding/organization") ||
+        url.includes("choose-organization") ||
+        url.includes("select-workspace") ||
+        url.includes("choose-workspace") ||
+        url.includes("workspaces") ||
+        url.includes("select-account") ||
+        url.includes("switch-org"));
+    let isOrgChooserByText = false;
+    if (!isOrgChooserUrl && url.includes("claude.ai") && driver.readPageText) {
+      try {
+        const t = (await driver.readPageText()).toLowerCase();
+        isOrgChooserByText =
+          (t.includes("choose an organization") ||
+            t.includes("select an organization") ||
+            t.includes("choose a workspace") ||
+            t.includes("select a workspace") ||
+            t.includes("which organization")) &&
+          (t.includes("personal") || t.includes("organization"));
+      } catch {}
+    }
+    if (isOrgChooserUrl || isOrgChooserByText) {
+      const orgLabel = account.organization || account.orgName || "Personal";
+      log(
+        `Claude organization chooser (${isOrgChooserByText ? "via page-text" : "via URL"}) — selecting "${orgLabel}"`,
+      );
+      // Dump all visible button/link labels so we can see the real workspace
+      // names claude.ai is showing (vs what's configured as orgName).
+      if (driver.readPageText) {
+        try {
+          const t = await driver.readPageText();
+          const labels = [
+            ...new Set(
+              (t || "")
+                .split("\n")
+                .map((l) => l.trim())
+                .filter((l) => l.length > 0 && l.length < 80),
+            ),
+          ].slice(0, 40);
+          log(`[org-chooser] Visible lines: ${JSON.stringify(labels)}`);
+        } catch {}
+      }
+      const picked = await driver.findAndClick([
+        `button:has-text("${orgLabel}")`,
+        `[role="button"]:has-text("${orgLabel}")`,
+        `text="${orgLabel}"`,
+        orgLabel,
+        // Only fall back to "Personal" / "Continue" if the configured label
+        // is itself Personal — never silently default a team account to Personal.
+        ...(orgLabel === "Personal" ? ["Personal", "Continue"] : []),
+      ]);
+      if (!picked) {
+        log(
+          `No organization button matched "${orgLabel}" — the account may land on the wrong org`,
+        );
+      }
+      await sleep(3000);
+      continue;
+    }
+
+    // Claude OAuth consent page — MUST check account BEFORE clicking Authorize.
+    // Match by pathname only — URL params (like redirect_uri=...callback) would
+    // false-match a substring check on the full URL.
+    let oauthPath = "";
+    try {
+      oauthPath = new URL(url).pathname;
+    } catch {}
+    if (
+      oauthPath.includes("/oauth/authorize") ||
+      (oauthPath.endsWith("/authorize") && url.includes("claude"))
+    ) {
+      // Step 1: Read page to verify "Logged in as <correct email>"
+      let pageText = "";
+      if (driver.readPageText) {
+        try {
+          pageText = (await driver.readPageText()).toLowerCase();
+        } catch {}
+      }
+
+      const hasCorrectAccount =
+        pageText && pageText.includes(account.email.toLowerCase());
+      const hasAnyOtherEmail =
+        pageText &&
+        /[\w.+-]+@[\w.-]+\.\w+/.test(pageText) &&
+        !hasCorrectAccount;
+
+      // If we can't read the page OR we see the wrong account, force switch
+      if (!pageText || hasAnyOtherEmail) {
+        log(
+          `Page text: ${pageText ? "wrong account" : "unreadable"} — clicking Switch account / Logout`,
+        );
+        const switched = await driver.findAndClick([
+          "Switch account",
+          "Log out",
+          "Logout",
+          "Sign out",
+          "Use another account",
+        ]);
+        if (switched) {
+          await sleep(3000);
+          continue;
+        }
+        // Couldn't find switch button — the page may already be the account chooser
+        // Try clicking the email we want directly
+        const picked = await driver.findAndClick([account.email]);
+        if (picked) {
+          await sleep(3000);
+          continue;
+        }
+        // Last resort: log and click authorize anyway (may fail)
+        log(`WARNING: Could not verify account — clicking Authorize blind`);
+      } else if (hasCorrectAccount) {
+        log(`Correct account confirmed: ${account.email}`);
+      }
+
+      // Step 2: Click Authorize — wait for button to become enabled (up to 30s)
+      let authorized = false;
+      for (let wait = 0; wait < 6; wait++) {
+        if (
+          await driver.findAndClick(["Authorize", "Allow", "Approve", "Accept"])
+        ) {
+          log("Clicked Authorize");
+          authorized = true;
+          break;
+        }
+        // Button might exist but be disabled — wait for page to finish loading
+        log(
+          `Authorize button not clickable — waiting (attempt ${wait + 1}/6)...`,
+        );
+        await sleep(5000);
+      }
+      if (authorized) {
+        await sleep(4000);
+        continue;
+      }
+      log(
+        "Authorize button still not clickable after 30s — escalating to ai-brain",
+      );
+      // Fast-path ai-brain escalation: don't wait for stall detector to catch up
+      // on the next loop iter. The page is stuck on OAuth authorize and Haiku
+      // can usually pick the right org/continue button immediately.
+      if (aiBrainEnabled && aiBrainHistory.length < AI_BRAIN_MAX_DECISIONS) {
+        const action = await askAIBrain({
+          page: driver._page,
+          account,
+          history: aiBrainHistory,
+          stallReason: `authorize button not clickable on ${url.substring(0, 100)}`,
+          logger: (m) => log(`[ai-brain] ${m}`),
+        });
+        aiBrainHistory.push(
+          `${action.action}${action.selector ? `(${String(action.selector).slice(0, 40)})` : ""} — ${String(action.reason || "").slice(0, 60)}`,
+        );
+        if (action.action !== "abort") {
+          const ok = await executeAIAction(driver, action, { googlePassword });
+          log(`[ai-brain] executed ${action.action}: ${ok ? "ok" : "no-op"}`);
+          stallCount = 0;
+          await sleep(3000);
+          continue;
+        }
+        log(`[ai-brain] aborted — reason: ${action.reason}`);
+      }
+      await sleep(3000);
+      continue;
+    }
+
+    // Dismiss cookie consent banner if present (blocks clicks on everything else)
+    if (url.includes("claude.ai")) {
+      await driver.findAndClick([
+        '[data-testid="consent-reject"]',
+        '[data-testid="consent-accept"]',
+        "Reject All Cookies",
+        "Accept All Cookies",
+      ]);
+      await sleep(500);
+    }
+
+    // Claude.ai login → Magic link path (when account.useMagicLink is set)
+    // The email input is always visible on /login — no button click needed first.
+    if (account.useMagicLink && url.includes("claude.ai/login")) {
+      // Fill the email input directly
+      const filled = await driver.fillInput(
+        '[data-testid="email"], #email, input[type="email"]',
+        account.email,
+      );
+      if (filled) {
+        log(`[magic-link] Filled email: ${account.email}`);
+        await sleep(500);
+        // Click the "Continue with email" submit button (data-testid="continue")
+        const submitted = await driver.findAndClick([
+          '[data-testid="continue"]',
+          'button[type="submit"]:has-text("Continue with email")',
+          'button:has-text("Continue with email")',
+        ]);
+        if (submitted) {
+          log(`[magic-link] Submitted email — magic link should be sent`);
+          await sleep(3000);
+
+          // Poll Gmail for the magic link
+          const magicLink = await pollGmailForMagicLink(account.email);
+          if (magicLink) {
+            if (magicLink.startsWith("code:")) {
+              const code = magicLink.replace("code:", "");
+              log(`[magic-link] Entering verification code: ${code}`);
+              await driver.fillInput(
+                'input[type="text"], input[type="number"], input[name="code"], input[placeholder*="code" i]',
+                code,
+              );
+              await driver.findAndClick([
+                "Continue",
+                "Verify",
+                "Submit",
+                'button[type="submit"]',
+              ]);
+            } else {
+              log(`[magic-link] Navigating to login link`);
+              await driver.goto(magicLink);
+            }
+            await sleep(4000);
+            // After magic link login, session is now valid — re-navigate to authUrl
+            // so the OAuth flow can complete (org chooser → authorize → callback)
+            if (driver._authUrl) {
+              // For multi-org accounts (same email, multiple workspaces like
+              // heartfeldt-personal vs heartfeldt-team), force an explicit org
+              // pick BEFORE hitting /oauth/authorize. Otherwise claude.ai uses
+              // the "last active" org silently, and both sibling vaults end up
+              // holding the same org's token.
+              const isMultiOrg =
+                account.label &&
+                account.orgName &&
+                account.orgName.toLowerCase() !==
+                  account.email.toLowerCase();
+              if (isMultiOrg) {
+                log(
+                  `[magic-link] Multi-org account — forcing org pick for "${account.orgName}" via claude.ai/home detour`,
+                );
+                try {
+                  await driver.goto("https://claude.ai/home");
+                } catch {}
+                await sleep(3500);
+                // Try to click the configured orgName if a chooser is showing.
+                // The broadened org-chooser logic in the main loop will also
+                // pick this up on the next iteration, but an immediate attempt
+                // here short-circuits silently-skipped cases.
+                const picked = await driver.findAndClick([
+                  `button:has-text("${account.orgName}")`,
+                  `[role="button"]:has-text("${account.orgName}")`,
+                  `text="${account.orgName}"`,
+                  account.orgName,
+                ]);
+                if (picked) {
+                  log(
+                    `[magic-link] Pre-selected org "${account.orgName}" before OAuth`,
+                  );
+                  await sleep(2500);
+                } else {
+                  log(
+                    `[magic-link] No immediate match for "${account.orgName}" — will rely on org-chooser loop / ai-brain`,
+                  );
+                }
+              }
+              log(`[magic-link] Re-navigating to OAuth authorize URL`);
+              try {
+                await driver.goto(driver._authUrl);
+              } catch {}
+              await sleep(3000);
+            }
+            continue;
+          }
+          log(
+            `[magic-link] No magic link found in Gmail — falling through to Google OAuth`,
+          );
+        }
+      }
+    }
+
+    // Claude.ai login → Continue with Google (button has data-testid="login-with-google")
+    const popupP = driver.waitForPopup
+      ? driver.waitForPopup(15_000)
+      : Promise.resolve(null);
+    if (
+      await driver.findAndClick([
+        '[data-testid="login-with-google"]',
+        "Continue with Google",
+        "Sign in with Google",
+      ])
+    ) {
+      const popup = await popupP;
+      if (popup) {
+        // Kapture popup is already a full driver; Playwright returns a raw Page
+        const pd = popup.name
+          ? popup
+          : buildPageDriver(driver.name + "-popup", popup, () => {}, null);
+        await runAuthFlow(pd, account);
+        if (popup.waitForEvent) {
+          await popup
+            .waitForEvent("close", { timeout: 30_000 })
+            .catch(() => {});
+        }
+      }
+      continue;
+    }
+
+    // Email input
+    if (
+      await driver.fillInput(
+        '#identifierId, input[type="email"]',
+        account.email,
+      )
+    ) {
+      await driver.findAndClick(["Next", "#identifierNext button"]);
+    }
+  }
+
+  // Loop exhausted — final AI-brain attempt before giving up. Some flows
+  // legitimately exceed 20 steps (multi-factor + workspace chooser + consent),
+  // so give Claude up to its remaining decision budget to unstick us.
+  if (aiBrainEnabled && aiBrainHistory.length < AI_BRAIN_MAX_DECISIONS) {
+    const url = await driver.currentUrl().catch(() => "");
+    log(`[ai-brain] loop exhausted — final rescue attempt`);
+    for (
+      let rescue = 0;
+      rescue < AI_BRAIN_MAX_DECISIONS - aiBrainHistory.length && rescue < 3;
+      rescue++
+    ) {
+      const action = await askAIBrain({
+        page: driver._page,
+        account,
+        history: aiBrainHistory,
+        stallReason: `loop exhausted at ${url.substring(0, 80)} (rescue ${rescue + 1})`,
+        logger: (m) => log(`[ai-brain] ${m}`),
+      });
+      aiBrainHistory.push(
+        `${action.action}${action.selector ? `(${String(action.selector).slice(0, 40)})` : ""} — ${String(action.reason || "").slice(0, 60)}`,
+      );
+      if (action.action === "abort") break;
+      await executeAIAction(driver, action, { googlePassword });
+      await sleep(4000);
+      // Re-check success conditions after each rescue action
+      const newUrl = await driver.currentUrl().catch(() => "");
+      try {
+        const parsed = new URL(newUrl);
+        if (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1") {
+          log("[ai-brain] rescue SUCCEEDED — localhost callback reached");
+          return true;
+        }
+      } catch {}
+      if (newUrl.includes("/oauth/code/success")) {
+        log("[ai-brain] rescue SUCCEEDED — claude.ai success page");
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+// ── Browser OAuth fallback ────────────────────────────────────────────────────
+
+async function browserOAuthFallback(account) {
+  log(`[fallback] Browser OAuth for ${account.email}...`);
+
+  const pid = process.pid;
+  const capScript = join(tmpdir(), `claude-url-cap-${pid}.sh`);
+  const urlFile = join(tmpdir(), `claude-auth-url-${pid}.txt`);
+  writeFileSync(capScript, `#!/bin/bash\necho "$1" > "${urlFile}"\n`);
+  chmodSync(capScript, 0o755);
+
+  const proc = spawn("claude", ["auth", "login", "--email", account.email], {
+    env: { ...process.env, BROWSER: capScript },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+
+  // BROWSER script gets the URL with localhost redirect (what we want).
+  // stderr gets a fallback URL with platform.claude.com redirect (don't use that).
+  // Prefer the file-captured URL — wait up to 15s for it, then fall back to stdout.
+  let authUrl = null;
+  for (let i = 0; i < 30; i++) {
+    await sleep(500);
+    if (existsSync(urlFile)) {
+      const u = readFileSync(urlFile, "utf8").trim();
+      try {
+        unlinkSync(urlFile);
+      } catch {}
+      if (u.startsWith("http")) {
+        authUrl = u;
+        break;
+      }
+    }
+  }
+  if (!authUrl) {
+    // Fallback: parse from stderr (has platform.claude.com redirect, but still works)
+    authUrl = await new Promise((resolve) => {
+      const scan = (d) => {
+        const m = d.toString().match(/https?:\/\/[^\s\])"'\n]+/);
+        if (m) resolve(m[0]);
+      };
+      proc.stdout.on("data", scan);
+      proc.stderr.on("data", scan);
+      setTimeout(() => resolve(null), 15_000);
+    });
+  }
+  try {
+    unlinkSync(capScript);
+  } catch {}
+
+  if (!authUrl) {
+    proc.kill();
+    return false;
+  }
+  log(`Auth URL captured: ${authUrl.substring(0, 80)}...`);
+
+  // Extract localhost port from redirect_uri in the auth URL for code replay
+  const portMatch = authUrl.match(
+    /redirect_uri=http%3A%2F%2Flocalhost%3A(\d+)/,
+  );
+  const localhostPort = portMatch ? portMatch[1] : null;
+  log(`Localhost callback port: ${localhostPort || "unknown"}`);
+
+  // Cascade: try each driver in order until one completes the OAuth flow.
+  // A driver "fails" if runAuthFlow returns false (URL never reaches localhost callback).
+  const failed = new Set();
+  let success = false;
+
+  while (!success) {
+    let driver;
+    try {
+      driver = await getBrowserDriver(failed);
+    } catch (err) {
+      log(`Cascade exhausted: ${err.message}`);
+      break;
+    }
+    driver._localhostPort = localhostPort;
+    driver._authUrl = authUrl;
+
+    try {
+      log(`[${driver._driverName}] Logging out existing claude.ai session...`);
+      try {
+        await driver.goto("https://claude.ai/api/auth/logout");
+      } catch {}
+      await sleep(1500);
+      try {
+        await driver.goto("https://claude.ai/logout");
+      } catch {}
+      await sleep(1500);
+
+      // Page may have been destroyed by logout redirect — try navigating,
+      // and if the page is dead, get a fresh driver (new tab)
+      try {
+        await driver.goto(authUrl);
+      } catch (navErr) {
+        log(
+          `[${driver._driverName}] Page died after logout (${navErr.message}) — getting fresh driver`,
+        );
+        try {
+          await driver.close();
+        } catch {}
+        try {
+          driver = await getBrowserDriver(failed);
+          driver._localhostPort = localhostPort;
+          await driver.goto(authUrl);
+        } catch (freshErr) {
+          log(
+            `[${driver._driverName}] Fresh driver also failed: ${freshErr.message}`,
+          );
+          failed.add(driver._driverName || "unknown");
+          continue;
+        }
+      }
+      success = await runAuthFlow(driver, account);
+
+      if (!success) {
+        log(
+          `[${driver._driverName}] runAuthFlow returned false — trying next driver`,
+        );
+        failed.add(driver._driverName);
+        continue;
+      }
+
+      // Wait for claude auth login process to finish writing the keychain
+      await new Promise((r) => {
+        const t = setTimeout(() => {
+          proc.kill();
+          r();
+        }, 30_000);
+        proc.on("exit", () => {
+          clearTimeout(t);
+          r();
+        });
+        if (proc.exitCode !== null) {
+          clearTimeout(t);
+          r();
+        }
+      });
+    } catch (err) {
+      log(`[${driver._driverName}] threw: ${err.message}`);
+      failed.add(driver._driverName);
+    } finally {
+      try {
+        await driver.close();
+      } catch {}
+    }
+  }
+
+  return success;
+}
+
+// ── Session restart via tmux ─────────────────────────────────────────────────
+
+function findClaudeSessions() {
+  const sessions = [];
+  try {
+    const psOut = execSync(
+      `ps -eo pid,tty,args | grep -E '[c]laude.*--dangerously' | grep -v 'mcp ' | grep -v '\\-p '`,
+      { timeout: 5000 },
+    )
+      .toString()
+      .trim();
+    if (!psOut) return sessions;
+
+    const ttyMap = {};
+    try {
+      const paneOut = execSync(
+        `tmux list-panes -a -F '#{pane_tty}|#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null`,
+        { timeout: 3000 },
+      )
+        .toString()
+        .trim();
+      for (const line of paneOut.split("\n")) {
+        const [tty, pane] = line.split("|");
+        if (tty && pane) ttyMap[tty] = pane;
+      }
+    } catch {}
+
+    for (const line of psOut.split("\n")) {
+      const match = line.trim().match(/^(\d+)\s+(ttys?\d+)\s+(.+)$/);
+      if (!match) continue;
+      const [, pid, ttyShort, args] = match;
+      const tty = `/dev/${ttyShort}`;
+      const resumeMatch = args.match(/--resume\s+(\S+)/);
+      const resumeId = resumeMatch ? resumeMatch[1] : null;
+      const pane = ttyMap[tty] || null;
+      sessions.push({ pid: parseInt(pid), tty, pane, resumeId, args });
+    }
+  } catch (e) {
+    log(
+      `[session] Failed to enumerate sessions: ${e.message.substring(0, 80)}`,
+    );
+  }
+  return sessions;
+}
+
+function sendKeysToPane(pane, txt) {
+  if (!pane) return false;
+  try {
+    execSync(
+      `tmux send-keys -t ${JSON.stringify(pane)} ${JSON.stringify(txt)} C-m 2>/dev/null`,
+      { timeout: 3000 },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sendKeysToITerm(tty, txt) {
+  // Send text to an iTerm2 session matched by its TTY device path.
+  // IMPORTANT: Use `tell s to write text cmd` — the `write text "..." in s`
+  // form fails with -1723 ("Can't get ... in s. Access not allowed.") because
+  // AppleScript parses the `in s` clause as an accessor lookup, not a target.
+  const escaped = txt.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  const script = `
+tell application "iTerm2"
+  repeat with w in windows
+    repeat with t in tabs of w
+      repeat with s in sessions of t
+        if tty of s is "${tty}" then
+          tell s to write text "${escaped}"
+          return "ok"
+        end if
+      end repeat
+    end repeat
+  end repeat
+  return "not_found"
+end tell`;
+  try {
+    const result = execSync(
+      `osascript -e '${script.replace(/'/g, "'\"'\"'")}'`,
+      { timeout: 5000 },
+    )
+      .toString()
+      .trim();
+    return result === "ok";
+  } catch {
+    return false;
+  }
+}
+
+// Walk up the process tree from `pid` and return the terminal app that owns
+// the session (e.g. "Ghostty", "iTerm2", "Terminal", "Alacritty", "WezTerm")
+// or "unknown" if none matched. Used to gate AppleScript injection to
+// terminals we know actually support it without launching a new app.
+function detectTerminalForPid(pid) {
+  try {
+    const out = execSync(`ps -eo pid,ppid,comm`, { timeout: 3000 })
+      .toString()
+      .trim();
+    const byPid = new Map();
+    for (const line of out.split("\n").slice(1)) {
+      const m = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/);
+      if (m) byPid.set(parseInt(m[1]), { ppid: parseInt(m[2]), comm: m[3] });
+    }
+    let cur = parseInt(pid);
+    for (let i = 0; i < 40 && cur > 1; i++) {
+      const entry = byPid.get(cur);
+      if (!entry) break;
+      const c = entry.comm.toLowerCase();
+      if (c.includes("ghostty")) return "Ghostty";
+      if (c.includes("iterm2") || c.includes("iterm")) return "iTerm2";
+      if (c.includes("terminal.app") || /\/terminal$/.test(c)) return "Terminal";
+      if (c.includes("alacritty")) return "Alacritty";
+      if (c.includes("wezterm")) return "WezTerm";
+      if (c.includes("kitty")) return "kitty";
+      cur = entry.ppid;
+    }
+  } catch {}
+  return "unknown";
+}
+
+async function refreshRunningSession(rotatedAccount = null, noBrowser = false) {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const sessions = findClaudeSessions();
+
+  if (sessions.length === 0) {
+    log("[session] No running Claude Code sessions found");
+    return;
+  }
+
+  // Tag each session with its owning terminal app. We only have a reliable
+  // AppleScript injection path for tmux + iTerm2. For Ghostty/Terminal/others,
+  // writing to the raw TTY shows as OUTPUT (garbles the live display) and
+  // `tell application "iTerm2"` would spuriously *launch* iTerm2 — so we skip.
+  for (const s of sessions) {
+    if (!s.pane && s.pid) s.terminal = detectTerminalForPid(s.pid);
+  }
+
+  const sendKeys = (s, txt) => {
+    if (s.pane) return sendKeysToPane(s.pane, txt);
+    if (s.terminal === "iTerm2" && s.tty)
+      return sendKeysToITerm(s.tty, txt);
+    // Ghostty, Terminal.app, Alacritty, WezTerm, kitty, unknown: skip.
+    // Raw TTY write would render "/login" as on-screen output text, not
+    // stdin — corrupting the session without triggering the re-auth.
+    return false;
+  };
+
+  // Reachable = tmux pane OR known-good terminal (iTerm2). Everyone else
+  // is logged + skipped so we never pop a visual window or garble Ghostty.
+  const reachable = sessions.filter(
+    (s) => s.pane || (s.terminal === "iTerm2" && s.tty),
+  );
+  const skipped = sessions.filter(
+    (s) => !s.pane && s.terminal && s.terminal !== "iTerm2",
+  );
+  for (const s of skipped) {
+    log(
+      `[session] Skipping PID ${s.pid} (${s.terminal}) — no safe inject path; token-refresh daemon keeps keys fresh so restart isn't required`,
+    );
+  }
+  if (reachable.length === 0) {
+    log(
+      `[session] Found ${sessions.length} sessions but none have a reachable TTY`,
+    );
+    return;
+  }
+
+  log(`[session] Injecting /login into ${reachable.length} session(s):`);
+  for (const s of reachable) {
+    log(`  PID ${s.pid} ${s.pane ? "pane=" + s.pane : "tty=" + s.tty}`);
+  }
+
+  // Keychain was already swapped to the fresh account's valid token.
+  // /login re-reads the keychain → picks up the new token → "Login successful" instantly.
+  // No /exit, no process restart, no OAuth browser flow needed (token is already valid).
+  // Stagger slightly to avoid all sessions hitting the API at the exact same millisecond.
+  for (const s of reachable) {
+    if (sendKeys(s, "/login")) {
+      log(`[session] Sent /login to PID ${s.pid} (${s.pane || s.tty})`);
+    } else {
+      log(
+        `[session] Failed to inject /login to PID ${s.pid} (${s.pane || s.tty})`,
+      );
+    }
+    await sleep(500); // 500ms stagger between sessions
+  }
+
+  // If Claude relaunches trigger an OAuth browser window (token expired mid-rotation),
+  // reuse the same browser driver that handles the initial auth flow.
+  // Skipped in --no-browser mode (daemon) — token refresh daemon keeps tokens fresh,
+  // so this fallback should never be needed from automatic rotations.
+  if (!noBrowser) {
+    try {
+      await sleep(2000);
+      const driver = await getBrowserDriver(new Set()).catch(() => null);
+      if (driver) {
+        const url = await driver.currentUrl().catch(() => "");
+        if (
+          url &&
+          (url.includes("oauth") ||
+            url.includes("authorize") ||
+            url.includes("claude.ai/login"))
+        ) {
+          log(
+            `[session] Detected post-restart OAuth page (${url.substring(0, 60)}) — driving flow`,
+          );
+          if (rotatedAccount) await runAuthFlow(driver, rotatedAccount);
+        }
+        try {
+          await driver.close?.();
+        } catch {}
+      }
+    } catch (e) {
+      log(
+        `[session] Post-restart browser check skipped: ${e.message.substring(0, 60)}`,
+      );
+    }
+  }
+
+  log(`[session] Restart complete: ${reachable.length} session(s) cycled`);
+}
+
+// ── Main rotation ─────────────────────────────────────────────────────────────
+
+async function rotate(targetEmail, opts = {}) {
+  const config = readConfig();
+  const state = readState();
+  const dryRun = opts.dryRun || false;
+
+  if (!targetEmail) {
+    // Query live utilization for all accounts before picking — best-effort, ~2s
+    log("Querying live utilization for all accounts...");
+    const liveUtil = await queryAllUtilization(config);
+    const utilSummary = Object.entries(liveUtil)
+      .map(([k, v]) => `${k}:5h=${v.five_hour_pct}%/7d=${v.seven_day_pct}%`)
+      .join(", ");
+    if (utilSummary) log(`Live util: ${utilSummary}`);
+    // Snapshot live data into state for future daemon decisions
+    for (const [key, util] of Object.entries(liveUtil)) {
+      state.accounts[key] = state.accounts[key] || {};
+      state.accounts[key].lastUtilization = {
+        pct: util.five_hour_pct,
+        reset: util.resets_at_5h
+          ? Math.floor(new Date(util.resets_at_5h).getTime() / 1000)
+          : null,
+        ts: Date.now(),
+      };
+    }
+    const next = pickNextAccount(config, state, liveUtil, {
+      allowExtraUsage: opts.allowExtraUsage === true,
+    });
+    if (!next) {
+      log("No account available (all excluded — extra_usage enabled?)");
+      return false;
+    }
+    targetEmail = accountKey(next);
+  }
+
+  // Hard safety gate: even when the user passes --to <email> explicitly,
+  // refuse to activate a Max account where the Anthropic org has
+  // has_extra_usage_enabled=true (overage billing). Requires --allow-extra-usage
+  // to bypass.
+  try {
+    if (!opts.allowExtraUsage) {
+      const target = config.accounts.find(
+        (a) => accountKey(a) === targetEmail || a.email === targetEmail,
+      );
+      if (target) {
+        const tokenJson = readStoredToken(target);
+        if (tokenJson) {
+          const parsed = JSON.parse(tokenJson);
+          const accessToken = parsed?.claudeAiOauth?.accessToken;
+          if (accessToken) {
+            const res = await fetch(
+              "https://api.anthropic.com/api/oauth/profile",
+              {
+                method: "GET",
+                headers: {
+                  Authorization: `Bearer ${accessToken}`,
+                  "anthropic-beta": "oauth-2025-04-20",
+                  "Content-Type": "application/json",
+                },
+                signal: AbortSignal.timeout(5000),
+              },
+            );
+            if (res.ok) {
+              const prof = await res.json();
+              const euEnabled =
+                prof?.organization?.has_extra_usage_enabled === true;
+              if (euEnabled) {
+                log(
+                  `REFUSED: target ${targetEmail} has extra_usage enabled (pay-per-use). Pass --allow-extra-usage to override.`,
+                );
+                notify(
+                  "Rotation BLOCKED",
+                  `${targetEmail}: extra_usage enabled — would risk credit-card overage. Disable at console.anthropic.com/settings/billing`,
+                );
+                return false;
+              }
+            }
+          }
+        }
+      }
+    }
+  } catch (e) {
+    log(`Extra-usage preflight error (non-fatal): ${e.message?.slice(0, 80)}`);
+  }
+
+  // Find by label first, then by email
+  const account =
+    config.accounts.find((a) => accountKey(a) === targetEmail) ||
+    config.accounts.find((a) => a.email === targetEmail);
+  if (!account) {
+    log(`Account ${targetEmail} not in config`);
+    return false;
+  }
+  if (opts.magicLink) account.useMagicLink = true;
+  const key = accountKey(account);
+
+  log(
+    `=== ROTATING: ${state.activeAccount || "none"} → ${key} (${account.email}) ===`,
+  );
+  notify("Claude Account Rotation", `Switching to ${key}...`);
+
+  // Clear statsig cache to prevent device-level rate limit stickiness (anthropics/claude-code#12786)
+  try {
+    const statsigDir = join(process.env.HOME || "", ".claude", "statsig");
+    if (existsSync(statsigDir)) {
+      const files = readdirSync(statsigDir).filter((f) =>
+        f.startsWith("statsig.cached.evaluations."),
+      );
+      for (const f of files) {
+        try {
+          unlinkSync(join(statsigDir, f));
+        } catch {}
+      }
+      if (files.length > 0)
+        log(
+          `Cleared ${files.length} statsig cache files (device-level stickiness fix)`,
+        );
+    }
+  } catch {}
+
+  // Save outgoing token to the vault slot matching the active account.
+  // In --no-browser mode (daemon), skip the `claude auth status` call — it
+  // hits the Anthropic API and fails when we're already rate limited.
+  // Trust state.activeAccount instead.
+  if (opts.noBrowser) {
+    const trackedAccount = config.accounts.find(
+      (a) => accountKey(a) === state.activeAccount,
+    );
+    if (trackedAccount) {
+      if (!dryRun) saveCurrentToken(trackedAccount);
+      log(
+        `[no-browser] Saved outgoing token for tracked ${accountKey(trackedAccount)}`,
+      );
+    } else {
+      log(`[no-browser] No tracked active account — skipping outgoing save`);
+    }
+  } else
+    try {
+      // Identify the live keychain account AUTHORITATIVELY via direct
+      // /oauth/profile call, not `claude auth status` — the CLI caches
+      // stale email/org from the last session and lies when the keychain
+      // has been swapped out from under it. Trusting it corrupts vaults.
+      const liveTokenJson = (() => {
+        try {
+          return readKeychain();
+        } catch {
+          return null;
+        }
+      })();
+      let liveEmail = null;
+      let liveOrgUuid = null;
+      if (liveTokenJson) {
+        try {
+          const liveAccessToken =
+            JSON.parse(liveTokenJson)?.claudeAiOauth?.accessToken;
+          if (liveAccessToken) {
+            const res = await fetch(
+              "https://api.anthropic.com/api/oauth/profile",
+              {
+                method: "GET",
+                headers: {
+                  Authorization: `Bearer ${liveAccessToken}`,
+                  "anthropic-beta": "oauth-2025-04-20",
+                },
+                signal: AbortSignal.timeout(5000),
+              },
+            );
+            if (res.ok) {
+              const prof = await res.json();
+              liveEmail = prof?.account?.email || null;
+              liveOrgUuid = prof?.organization?.uuid || null;
+            }
+          }
+        } catch {}
+      }
+      if (liveEmail) {
+        // For multi-entry emails (same email under multiple config entries,
+        // e.g. heartfeldt-personal + heartfeldt-team), prefer the entry whose
+        // orgUuid matches live. Fall back to first email match.
+        let liveAccount = null;
+        if (liveOrgUuid) {
+          liveAccount = config.accounts.find(
+            (a) => a.email === liveEmail && a.orgUuid === liveOrgUuid,
+          );
+        }
+        if (!liveAccount) {
+          liveAccount = config.accounts.find((a) => a.email === liveEmail);
+        }
+        if (liveAccount) {
+          if (!dryRun) saveCurrentToken(liveAccount);
+          log(
+            `${dryRun ? "[DRY-RUN] Would save" : "Saved"} outgoing token for LIVE account ${accountKey(liveAccount)} (was tracked as ${state.activeAccount || "none"})`,
+          );
+          // Keep state in sync with reality
+          if (state.activeAccount !== accountKey(liveAccount)) {
+            log(
+              `State drift corrected: activeAccount ${state.activeAccount} → ${accountKey(liveAccount)}`,
+            );
+            state.activeAccount = accountKey(liveAccount);
+          }
+        } else {
+          log(
+            `WARNING: live account ${liveEmail} not in config — skipping outgoing save`,
+          );
+        }
+      }
+    } catch (e) {
+      log(`Could not determine live account: ${e.message.substring(0, 80)}`);
+    }
+
+  // Snapshot outgoing account's utilization before clearing the rate-limits file.
+  // This lets pickNextAccount avoid rotating back to an exhausted account.
+  try {
+    const rlPath = join(__dirname, ".rate-limits.json");
+    if (existsSync(rlPath)) {
+      const rl = JSON.parse(readFileSync(rlPath, "utf8"));
+      const outKey = state.activeAccount;
+      if (outKey && rl.five_hour) {
+        state.accounts[outKey] = state.accounts[outKey] || {};
+        state.accounts[outKey].lastUtilization = {
+          pct: rl.five_hour.pct,
+          reset: rl.five_hour.reset,
+          ts: Date.now(),
+        };
+        log(
+          `Snapshotted utilization for ${outKey}: 5h=${rl.five_hour.pct}% (resets ${new Date(rl.five_hour.reset * 1000).toISOString()})`,
+        );
+      }
+    }
+  } catch {}
+
+  // Clear stale rate limits file so daemon doesn't use old account's utilization
+  if (!dryRun) {
+    try {
+      unlinkSync(join(__dirname, ".rate-limits.json"));
+    } catch {}
+  } else {
+    log("[DRY-RUN] Would clear .rate-limits.json");
+  }
+
+  let ok;
+  if (dryRun) {
+    log("[DRY-RUN] Would swap token via swapToken()");
+    ok = true;
+  } else {
+    ok = await swapToken(account);
+    if (!ok && !opts.noBrowser) {
+      ok = await browserOAuthFallback(account);
+    } else if (!ok) {
+      log(
+        "[no-browser] Token swap failed — skipping browser fallback (daemon mode)",
+      );
+    }
+  }
+
+  if (!ok) {
+    log("Rotation failed");
+    notify("Account Rotation", `FAILED for ${targetEmail}`);
+    return false;
+  }
+
+  // POST-SWAP BILLING SAFETY CHECK
+  // The fresh token is now in the active keychain. Query /api/oauth/profile to
+  // verify has_extra_usage_enabled=false. If true, revert the swap by restoring
+  // the previous account's token — this prevents silent credit-card overages.
+  if (!opts.allowExtraUsage && !dryRun) {
+    try {
+      const freshJson = readKeychain();
+      const fresh = JSON.parse(freshJson);
+      const freshToken = fresh?.claudeAiOauth?.accessToken;
+      if (freshToken) {
+        const res = await fetch("https://api.anthropic.com/api/oauth/profile", {
+          method: "GET",
+          headers: {
+            Authorization: `Bearer ${freshToken}`,
+            "anthropic-beta": "oauth-2025-04-20",
+            "Content-Type": "application/json",
+          },
+          signal: AbortSignal.timeout(5000),
+        });
+        if (res.ok) {
+          const prof = await res.json();
+          const euOn =
+            prof?.organization?.has_extra_usage_enabled === true;
+          if (euOn) {
+            log(
+              `POST-SWAP BLOCK: ${targetEmail} has extra_usage=ON (overage billing). Reverting swap.`,
+            );
+            notify(
+              "Rotation REVERTED",
+              `${targetEmail}: extra_usage enabled — charges would hit your card. Rollback in progress.`,
+            );
+            // Revert: restore previous account's stored token to active slot
+            const prevKey = state.activeAccount;
+            const prevAccount = prevKey
+              ? config.accounts.find((a) => accountKey(a) === prevKey)
+              : null;
+            if (prevAccount) {
+              const prevToken = readStoredToken(prevAccount);
+              if (prevToken) {
+                writeKeychain(prevToken);
+                log(`Reverted keychain to previous account ${prevKey}`);
+              }
+            }
+            return false;
+          }
+        } else {
+          log(
+            `POST-SWAP profile check returned ${res.status} — unable to verify extra_usage; proceeding (fail-open for transient errors)`,
+          );
+        }
+      }
+    } catch (e) {
+      log(
+        `POST-SWAP billing check error (non-fatal): ${e.message?.slice(0, 80)}`,
+      );
+    }
+  }
+
+  // Verify by reading back what's now in the active keychain
+  let verified = false;
+  try {
+    const active = readKeychain();
+    const stored = readStoredToken(account);
+    // Token swap: verify the active keychain matches what we wrote.
+    // Guard against empty `stored` — substring("", 20, 80) === "" and
+    // active.includes("") is always true, which would spuriously verify.
+    if (stored && stored.length > 80 && active.includes(stored.substring(20, 80))) verified = true;
+    // Browser fallback: verify via CLI (skip in --no-browser mode — API may be rate limited)
+    if (!verified && !opts.noBrowser) {
+      const out = execSync("claude auth status 2>&1", {
+        timeout: 10_000,
+      }).toString();
+      verified = out.includes(account.email);
+    }
+  } catch {}
+  log(
+    `Rotation ${verified ? "VERIFIED" : "UNVERIFIED"}: ${key} (${account.email})`,
+  );
+
+  // Org-match check: for accounts where label != email (multi-org under same
+  // email, like heartfeldt-personal vs heartfeldt-team), confirm the live
+  // /oauth/profile returns the expected organization. Drift here means the
+  // OAuth flow landed on the wrong org picker — the stored token will be
+  // usable but will double-count capacity with the sibling account.
+  // Fail-open: only log — don't unverify, because the token is still valid.
+  if (verified && account.orgName && account.label && !opts.noBrowser) {
+    try {
+      const liveTok = readKeychain();
+      const accessToken = JSON.parse(liveTok)?.claudeAiOauth?.accessToken;
+      if (accessToken) {
+        const res = await fetch(
+          "https://api.anthropic.com/api/oauth/profile",
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              "anthropic-beta": "oauth-2025-04-20",
+            },
+            signal: AbortSignal.timeout(5000),
+          },
+        );
+        if (res.ok) {
+          const prof = await res.json();
+          const liveOrg = prof?.organization?.name || "";
+          if (liveOrg && liveOrg !== account.orgName) {
+            log(
+              `⚠  ORG MISMATCH: ${key} expected "${account.orgName}" but live is "${liveOrg}" — OAuth org picker likely landed on wrong workspace. Token still saved but will share quota with sibling account under same email.`,
+            );
+          } else if (liveOrg) {
+            log(`Org match confirmed: ${liveOrg}`);
+          }
+        }
+      }
+    } catch (e) {
+      log(`Org-match check skipped: ${e.message?.slice(0, 80)}`);
+    }
+  }
+
+  // Trigger token refresh via `claude auth status` — skipped in --no-browser mode
+  // because the API is likely rate limited when the daemon triggers a rotation.
+  // Claude Code's own 30s keychain re-read will pick up the new token.
+  if (verified && !opts.noBrowser) {
+    try {
+      execSync("claude auth status 2>&1", { timeout: 10_000 });
+      log("Token refresh triggered via auth status");
+    } catch {}
+  }
+
+  // Save verified (and possibly refreshed) token to vault for future fast swaps
+  if (verified && !dryRun) saveCurrentToken(account);
+  if (verified && dryRun) log("[DRY-RUN] Would save verified token to vault");
+
+  // Update state — track cumulative window usage per account
+  const now = new Date().toISOString();
+  const windowMs = (config.rateLimits?.windowHours || 5) * 3_600_000;
+  if (state.activeAccount) {
+    const prev = (state.accounts[state.activeAccount] =
+      state.accounts[state.activeAccount] || {});
+    prev.lastActive = now;
+    // Accumulate tool uses into the account's window total
+    const windowAge = prev.windowStart
+      ? Date.now() - new Date(prev.windowStart).getTime()
+      : Infinity;
+    if (windowAge >= windowMs) {
+      // Window expired — reset
+      prev.windowStart = prev.switchedAt || now;
+      prev.windowToolUses = state.toolUses || 0;
+    } else {
+      prev.windowToolUses = (prev.windowToolUses || 0) + (state.toolUses || 0);
+    }
+  }
+  // Initialize or carry over window data for target account
+  const target = (state.accounts[key] = {
+    ...(state.accounts[key] || {}),
+    switchedAt: now,
+    messagesSinceSwitch: 0,
+  });
+  const targetWindowAge = target.windowStart
+    ? Date.now() - new Date(target.windowStart).getTime()
+    : Infinity;
+  if (targetWindowAge >= windowMs) {
+    // Window expired — fresh start
+    target.windowStart = now;
+    target.windowToolUses = 0;
+  }
+  // else: keep existing window data (cumulative uses carry over)
+  state.activeAccount = key;
+  state.toolUses = 0;
+  state.lastRotation = now;
+  state.totalRotations = (state.totalRotations || 0) + 1;
+  writeState(state, dryRun);
+
+  notify("Claude Account Rotation", `${verified ? "✓" : "⚠"} Now using ${key}`);
+
+  if (opts.session) {
+    if (dryRun) {
+      log(
+        "[DRY-RUN] Would restart running Claude sessions with --continue and send resume prompt",
+      );
+    } else {
+      await refreshRunningSession(account, opts.noBrowser);
+    }
+  }
+  return verified;
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+async function setup() {
+  const config = readConfig();
+  const argv = process.argv.slice(2);
+  const filter = argv.find((a) => a.startsWith("--only="))?.slice(7);
+  const autoMode = argv.includes("--auto");
+  const magicLinkMode = autoMode || argv.includes("--magic-link");
+  const skipDone = argv.includes("--skip-valid");
+  const accounts = (filter
+    ? config.accounts.filter(
+        (a) => accountKey(a) === filter || a.email === filter,
+      )
+    : config.accounts
+  ).filter((a) => {
+    if (a.disabled === true && !filter) {
+      console.log(`⏭  Skipping ${accountKey(a)}: disabled (${a.disabledReason || "no reason given"})`);
+      return false;
+    }
+    return true;
+  });
+
+  console.log("\n=== Claude Account Rotation — Setup ===\n");
+  if (autoMode) {
+    console.log(
+      `🤖 AUTO MODE — browser driver cascade + magic-link polling via gog/Gmail`,
+    );
+    console.log(
+      `   Sequential processing (~60-120s per account). Logs → rotation.log.\n`,
+    );
+  }
+  console.log(
+    `Re-capturing ${accounts.length} account(s). For each: OAuth → verify → save to vault.\n`,
+  );
+
+  const results = [];
+  for (const account of accounts) {
+    const key = accountKey(account);
+    console.log(`\n── ${key} (${account.email}) ──`);
+
+    // --skip-valid: skip accounts whose stored vault token is still good
+    if (skipDone) {
+      try {
+        const existing = readStoredToken(account);
+        if (existing && !tokenExpired(existing)) {
+          const p = JSON.parse(existing);
+          const t = p?.claudeAiOauth?.accessToken;
+          if (t) {
+            const res = await fetch(
+              "https://api.anthropic.com/api/oauth/profile",
+              {
+                method: "GET",
+                headers: {
+                  Authorization: `Bearer ${t}`,
+                  "anthropic-beta": "oauth-2025-04-20",
+                  "Content-Type": "application/json",
+                },
+                signal: AbortSignal.timeout(4000),
+              },
+            );
+            if (res.ok) {
+              console.log(
+                `⏭  Skipped: vault token still valid (--skip-valid).`,
+              );
+              results.push({ key, ok: true, skipped: true });
+              continue;
+            }
+          }
+        }
+      } catch {}
+    }
+
+    let oauthOk = true;
+    if (magicLinkMode) {
+      // Fully automated: claude auth login subprocess + browser driver cascade
+      // + magic-link email polling. No terminal interaction required.
+      account.useMagicLink = true;
+      console.log(
+        `[auto] Automated OAuth — magic-link email to ${account.email} (routed to Gmail)...`,
+      );
+      try {
+        oauthOk = await browserOAuthFallback(account);
+      } catch (e) {
+        console.error(
+          `❌ Automation threw: ${String(e.message || e).slice(0, 120)}`,
+        );
+        oauthOk = false;
+      }
+      if (!oauthOk) {
+        console.error(
+          `❌ ${key}: auto OAuth failed. Retry manually: node rotate.mjs --setup --only=${key}`,
+        );
+        results.push({ key, ok: false, reason: "auto-oauth-failed" });
+        continue;
+      }
+    } else {
+      console.log(
+        "Opening browser for OAuth. Complete the Google login, then come back here.",
+      );
+      const child = spawn(
+        "claude",
+        ["auth", "login", "--email", account.email],
+        {
+          stdio: "inherit",
+        },
+      );
+      await new Promise((r) => child.on("exit", r));
+    }
+
+    // Verify the login succeeded and matches the expected account
+    try {
+      const status = JSON.parse(
+        execSync("claude auth status 2>&1", { timeout: 10_000 }).toString(),
+      );
+      if (status.email !== account.email) {
+        console.error(
+          `\n❌ MISMATCH: expected ${account.email}, got ${status.email}. Skipping save.`,
+        );
+        results.push({ key, ok: false, reason: `mismatch:${status.email}` });
+        continue;
+      }
+      console.log(`✅ Verified: ${status.email}`);
+      // Save to vault (strip mcpOAuth to keep vault clean)
+      const token = readKeychain();
+      try {
+        const parsed = JSON.parse(token);
+        const clean = { claudeAiOauth: parsed.claudeAiOauth, mcpOAuth: {} };
+        writeStoredToken(account, JSON.stringify(clean));
+      } catch {
+        writeStoredToken(account, token);
+      }
+      console.log(`✅ Saved to vault: ${tokenService(account)}`);
+      results.push({ key, ok: true });
+    } catch (e) {
+      console.error(`❌ Error: ${e.message}`);
+      results.push({
+        key,
+        ok: false,
+        reason: String(e.message || e).slice(0, 80),
+      });
+    }
+  }
+
+  // Summary
+  console.log(`\n=== Setup complete ===`);
+  const okCount = results.filter((r) => r.ok).length;
+  const failCount = results.length - okCount;
+  for (const r of results) {
+    const icon = r.ok ? (r.skipped ? "⏭ " : "✅") : "❌";
+    console.log(`  ${icon} ${r.key}${r.reason ? `  (${r.reason})` : ""}`);
+  }
+  console.log(
+    `\n${okCount}/${results.length} captured${failCount ? `, ${failCount} failed` : ""}.`,
+  );
+
+  // Post-setup billing audit (auto mode) — surfaces accounts with extra_usage on
+  if (autoMode && okCount > 0) {
+    console.log(`\n=== Billing audit (post-setup) ===\n`);
+    const liveUtil = await queryAllUtilization(readConfig());
+    let risky = 0;
+    let unknown = 0;
+    for (const a of config.accounts) {
+      const k = accountKey(a);
+      if (a.disabled === true) {
+        console.log(`  ⏸  ${k}: DISABLED — skipped`);
+        continue;
+      }
+      const u = liveUtil[k];
+      if (!u) {
+        console.log(`  ⚠  ${k}: token invalid/expired — cannot audit`);
+        unknown++;
+        continue;
+      }
+      if (u.extra_usage_enabled === true) {
+        console.log(`  🔴 ${k}: EXTRA_USAGE=ON — overage billing ACTIVE`);
+        risky++;
+      } else if (u.extra_usage_enabled === false) {
+        console.log(
+          `  🟢 ${k}: extra_usage=off  5h=${u.five_hour_pct}% 7d=${u.seven_day_pct}%`,
+        );
+      } else {
+        console.log(`  ⚠  ${k}: extra_usage=unknown`);
+        unknown++;
+      }
+    }
+    if (risky > 0) {
+      console.log(
+        `\n🚨 ${risky} account(s) have extra_usage ON. Disable at:\n   https://console.anthropic.com/settings/billing`,
+      );
+    } else if (unknown === 0) {
+      console.log(`\n✅ All auditable accounts have extra_usage=off.`);
+    }
+  }
+  console.log(
+    `\nSetup done. Run \`node rotate.mjs --audit-billing\` anytime to re-check.\n`,
+  );
+}
+
+// ── Status ────────────────────────────────────────────────────────────────────
+
+function showStatus() {
+  const config = readConfig();
+  const state = readState();
+  let liveEmail = null;
+  try {
+    const m = execSync("claude auth status 2>&1", { timeout: 10_000 })
+      .toString()
+      .match(/"email":\s*"([^"]+)"/);
+    if (m) liveEmail = m[1];
+  } catch {}
+
+  const since = (d) => {
+    if (!d) return "never";
+    const s = Math.floor((Date.now() - new Date(d).getTime()) / 1000);
+    if (s < 60) return `${s}s ago`;
+    if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+    if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
+    return `${Math.floor(s / 86400)}d ago`;
+  };
+
+  // Read real utilization if available
+  let realUtil = null;
+  try {
+    const rlFile = join(__dirname, ".rate-limits.json");
+    if (existsSync(rlFile)) {
+      const rl = JSON.parse(readFileSync(rlFile, "utf8"));
+      const age = Date.now() - rl.ts * 1000;
+      if (age < 5 * 60_000) realUtil = rl;
+    }
+  } catch {}
+
+  // Determine if the mismatch is expected (rotation just ran, session hasn't reloaded)
+  const recentRotation = state.lastRotation
+    ? Date.now() - new Date(state.lastRotation).getTime() < 90_000
+    : false;
+  const mismatch =
+    liveEmail &&
+    state.activeAccount &&
+    !state.activeAccount.startsWith(liveEmail) &&
+    !liveEmail.startsWith(state.activeAccount);
+  const liveNote =
+    mismatch && recentRotation
+      ? " (stale session — restart Claude Code to apply)"
+      : "";
+
+  console.log("\n=== Claude Account Rotation ===\n");
+  console.log(`Live auth:       ${liveEmail || "unknown"}${liveNote}`);
+  console.log(`Tracked active:  ${state.activeAccount || "unknown"}`);
+  console.log(
+    `Tool uses:       ${state.toolUses || 0} / ${config.toolUseThreshold}`,
+  );
+  if (realUtil) {
+    console.log(
+      `Real utilization: 5h=${realUtil.five_hour?.pct?.toFixed(1) || "?"}%  7d=${realUtil.seven_day?.pct?.toFixed(1) || "?"}%`,
+    );
+    if (realUtil.five_hour?.reset) {
+      const resetIn = Math.max(
+        0,
+        realUtil.five_hour.reset - Math.floor(Date.now() / 1000),
+      );
+      const hrs = Math.floor(resetIn / 3600);
+      const mins = Math.floor((resetIn % 3600) / 60);
+      console.log(`5h resets in:    ${hrs}h${mins}m`);
+    }
+  }
+  console.log(`Total rotations: ${state.totalRotations || 0}`);
+  console.log(`Last rotation:   ${since(state.lastRotation)}\n`);
+  console.log("Accounts:");
+  for (const a of config.accounts) {
+    const key = accountKey(a);
+    const s = state.accounts[key] || {};
+    const active = key === state.activeAccount ? " ◀ ACTIVE" : "";
+    const prio = a.priority === "low" ? " (low priority)" : "";
+    const tokenOk = hasStoredToken(a) ? "✓ token stored" : "✗ no token";
+    const label = a.label ? ` [${a.label}]` : "";
+    const windowInfo = s.windowToolUses
+      ? ` | window: ${s.windowToolUses} uses`
+      : "";
+    console.log(`  ${a.email}${label}${active}${prio}`);
+    console.log(`    Keychain:    ${tokenOk}`);
+    console.log(`    Last active: ${since(s.lastActive)}${windowInfo}`);
+  }
+  console.log("");
+}
+
+// ── --capture: print current token for Dashlane ───────────────────────────────
+
+function captureCmd() {
+  const state = readState();
+  const config = readConfig();
+  const activeKey = state.activeAccount;
+  const account =
+    config.accounts.find((a) => accountKey(a) === activeKey) ||
+    config.accounts.find((a) => a.email === activeKey);
+  if (!account) {
+    console.error(`Active account ${activeKey} not in config`);
+    process.exit(1);
+  }
+
+  try {
+    const token = readKeychain();
+    if (!token.includes("claudeAiOauth")) {
+      console.error("No valid OAuth token in active keychain");
+      process.exit(1);
+    }
+    writeStoredToken(account, token);
+    console.log(
+      `✓ Token captured and saved to keychain: ${tokenService(account)}`,
+    );
+    console.log(
+      `  Account: ${account.email}${account.label ? " [" + account.label + "]" : ""}`,
+    );
+  } catch (e) {
+    console.error(e.message);
+    process.exit(1);
+  }
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+
+if (args.includes("--setup")) {
+  await setup();
+} else if (args.includes("--utilization")) {
+  // Live utilization query for all accounts
+  const config = readConfig();
+  const state = readState();
+  console.log("\nQuerying live utilization for all accounts...\n");
+  const liveUtil = await queryAllUtilization(config);
+  for (const a of config.accounts) {
+    const key = accountKey(a);
+    if (a.disabled === true) {
+      console.log(`  ⏸  ${key}: DISABLED — ${a.disabledReason || "no reason given"}`);
+      continue;
+    }
+    const active = state.activeAccount === key ? " ◀ ACTIVE" : "";
+    const u = liveUtil[key];
+    if (!u) {
+      console.log(`  ${key}: ❌ query failed${active}`);
+      continue;
+    }
+    const s5 = u.five_hour_pct;
+    const s7 = u.seven_day_pct;
+    const worst = Math.max(s5 ?? 0, s7 ?? 0);
+    const icon = worst >= 90 ? "🔴" : worst >= 70 ? "🟡" : "🟢";
+    const reset5 = u.resets_at_5h
+      ? `resets ${new Date(u.resets_at_5h).toLocaleTimeString()}`
+      : "no reset";
+    const euIcon =
+      u.extra_usage_enabled === true
+        ? " 💳 EXTRA_USAGE_ON"
+        : u.extra_usage_enabled === false
+          ? ""
+          : " (eu?)";
+    console.log(
+      `  ${icon} ${key}: 5h=${s5}% 7d=${s7}%  (${reset5})${euIcon}${active}`,
+    );
+  }
+  console.log("");
+} else if (args.includes("--audit-billing")) {
+  // Per-account billing audit — prints extra_usage state + any risk flags
+  const config = readConfig();
+  const state = readState();
+  console.log("\nAuditing billing state for all accounts...\n");
+  const liveUtil = await queryAllUtilization(config);
+  let risky = 0;
+  let unknown = 0;
+  for (const a of config.accounts) {
+    const key = accountKey(a);
+    if (a.disabled === true) {
+      console.log(`  ⏸  ${key}: DISABLED — ${a.disabledReason || "no reason given"}`);
+      continue;
+    }
+    const active = state.activeAccount === key ? " ◀ ACTIVE" : "";
+    const u = liveUtil[key];
+    if (!u) {
+      console.log(
+        `  ⚠  ${key}: token invalid/expired — cannot audit${active}`,
+      );
+      unknown++;
+      continue;
+    }
+    const eu = u.extra_usage_enabled;
+    const bt = u.billing_type ?? "?";
+    const ss = u.subscription_status ?? "?";
+    if (eu === true) {
+      console.log(
+        `  🔴 ${key}: EXTRA_USAGE=ON billing=${bt} status=${ss}${active}  ← overage billing ACTIVE`,
+      );
+      risky++;
+    } else if (eu === false) {
+      console.log(
+        `  🟢 ${key}: extra_usage=off billing=${bt} status=${ss}${active}`,
+      );
+    } else {
+      console.log(`  ⚠  ${key}: extra_usage=unknown billing=${bt}${active}`);
+      unknown++;
+    }
+  }
+  console.log("");
+  console.log(
+    `Summary: ${risky} risky, ${unknown} unknown, ${config.accounts.length - risky - unknown} safe`,
+  );
+  if (risky > 0) {
+    console.log(
+      `\n⚠  Disable extra_usage at https://console.anthropic.com/settings/billing for each risky account.`,
+    );
+  }
+  console.log("");
+} else if (args.includes("--status")) {
+  showStatus();
+} else if (args.includes("--capture")) {
+  captureCmd();
+} else {
+  const toIdx = args.indexOf("--to");
+  const target = toIdx !== -1 ? args[toIdx + 1] : null;
+  const session = args.includes("--session");
+  const noBrowser = args.includes("--no-browser");
+  const force = args.includes("--force");
+  const dryRun = args.includes("--dry-run");
+  const magicLink = args.includes("--magic-link");
+  const allowExtraUsage = args.includes("--allow-extra-usage");
+  if (dryRun) log("DRY RUN MODE — no changes will be made");
+  if (force) {
+    log("Force mode — bypassing lock and killing any competing rotations");
+    // Kill other rotate.mjs processes (not this one)
+    try {
+      execSync(
+        `pgrep -f 'node.*rotate.mjs' | grep -v ${process.pid} | xargs -r kill -9 2>/dev/null`,
+      );
+    } catch {}
+    try {
+      unlinkSync(LOCK_PATH);
+    } catch {}
+  }
+  if (!dryRun && !acquireLock()) {
+    console.error("Rotation in progress.");
+    process.exit(1);
+  }
+  try {
+    const ok = await rotate(target, {
+      session,
+      noBrowser,
+      dryRun,
+      magicLink,
+      allowExtraUsage,
+    });
+    process.exit(ok ? 0 : 1);
+  } catch (err) {
+    log(`FATAL: ${err.message}`);
+    notify("Account Rotation", `FAILED: ${err.message}`);
+    process.exit(1);
+  } finally {
+    releaseLock();
+  }
+}

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -36,28 +36,25 @@ import {
   chmodSync,
   readdirSync,
   renameSync,
-} from "fs";
-import { join, dirname } from "path";
-import { fileURLToPath } from "url";
-import { execSync, execFileSync, spawn } from "child_process";
-import { tmpdir } from "os";
-import { createHmac } from "node:crypto";
-import { askAIBrain, executeAIAction, AI_BRAIN_MAX_DECISIONS } from "./ai-brain.mjs";
+} from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { execSync, execFileSync, spawnSync, spawn } from 'child_process';
+import { tmpdir } from 'os';
+import { createHmac } from 'node:crypto';
+import { askAIBrain, executeAIAction, AI_BRAIN_MAX_DECISIONS } from './ai-brain.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const CONFIG_PATH = join(__dirname, "config.json");
-const STATE_PATH = join(__dirname, "state.json");
-const LOCK_PATH = join(__dirname, ".rotating");
-const LOG_PATH = join(__dirname, "rotation.log");
+const CONFIG_PATH = join(__dirname, 'config.json');
+const STATE_PATH = join(__dirname, 'state.json');
+const LOCK_PATH = join(__dirname, '.rotating');
+const LOG_PATH = join(__dirname, 'rotation.log');
 
-const KEYCHAIN_SERVICE = "Claude Code-credentials";
+const KEYCHAIN_SERVICE = 'Claude Code-credentials';
 // Use the OS username so multiple users on the same Mac don't collide on
 // keychain entries. Override with CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT if needed.
 const KEYCHAIN_ACCOUNT =
-  process.env.CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT ||
-  process.env.USER ||
-  process.env.LOGNAME ||
-  "claude-ops";
+  process.env.CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT || process.env.USER || process.env.LOGNAME || 'claude-ops';
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -74,14 +71,14 @@ function ensureMCPServersAndTools() {
 
   // 1. Chrome or Chrome Beta binary (Comet is off-limits)
   const realChromes = [
-    "/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta",
-    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    '/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta',
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
   ];
   const foundChrome = realChromes.find((p) => existsSync(p));
   if (foundChrome) {
-    actions.push(`chrome-binary: ${foundChrome.split("/").pop()}`);
+    actions.push(`chrome-binary: ${foundChrome.split('/').pop()}`);
   } else {
-    actions.push("chrome-binary: WARNING — no Chrome/Chrome Beta found");
+    actions.push('chrome-binary: WARNING — no Chrome/Chrome Beta found');
   }
 
   // 2. Chrome CDP port 9222 — probe (driver will launch Chrome if needed)
@@ -89,24 +86,24 @@ function ensureMCPServersAndTools() {
     execSync(`curl -sf http://localhost:9222/json/version >/dev/null 2>&1`, {
       timeout: 1500,
     });
-    actions.push("chrome-cdp: reachable on :9222");
+    actions.push('chrome-cdp: reachable on :9222');
   } catch {
-    actions.push("chrome-cdp: not reachable (driver will launch Chrome)");
+    actions.push('chrome-cdp: not reachable (driver will launch Chrome)');
   }
 
   // 3. dcli (Dashlane) — required for primary token path
   try {
     execSync(`command -v dcli >/dev/null 2>&1`, { timeout: 1000 });
-    actions.push("dcli: available");
+    actions.push('dcli: available');
   } catch {
-    actions.push("dcli: MISSING — primary token path will fail");
+    actions.push('dcli: MISSING — primary token path will fail');
   }
 
   // 4. security (macOS keychain) — required for token writes
   try {
     execSync(`command -v security >/dev/null 2>&1`, { timeout: 1000 });
   } catch {
-    actions.push("security(1): MISSING — keychain writes will fail");
+    actions.push('security(1): MISSING — keychain writes will fail');
   }
 
   for (const a of actions) earlyLog(a);
@@ -114,10 +111,7 @@ function ensureMCPServersAndTools() {
 
 // Unconditional warmup: every rotate.mjs run starts its MCP servers + tools FIRST.
 // Skip only for --help (where nothing runs downstream).
-if (
-  !process.argv.slice(2).includes("--help") &&
-  !process.argv.slice(2).includes("--no-browser")
-) {
+if (!process.argv.slice(2).includes('--help') && !process.argv.slice(2).includes('--no-browser')) {
   ensureMCPServersAndTools();
 }
 
@@ -127,24 +121,22 @@ function log(msg) {
   const line = `[${new Date().toISOString()}] ${msg}`;
   console.error(line);
   try {
-    appendFileSync(LOG_PATH, line + "\n");
+    appendFileSync(LOG_PATH, line + '\n');
   } catch {}
 }
 
 function notify(title, msg) {
   try {
-    execSync(
-      `osascript -e 'display notification "${msg.replace(/"/g, '\\"')}" with title "${title}"'`,
-    );
+    execSync(`osascript -e 'display notification "${msg.replace(/"/g, '\\"')}" with title "${title}"'`);
   } catch {}
 }
 
 function readConfig() {
-  return JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
+  return JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
 }
 function readState() {
   try {
-    return JSON.parse(readFileSync(STATE_PATH, "utf8"));
+    return JSON.parse(readFileSync(STATE_PATH, 'utf8'));
   } catch {
     return {
       activeAccount: null,
@@ -156,10 +148,10 @@ function readState() {
 }
 function writeState(s, dryRun = false) {
   if (dryRun) {
-    log("[DRY-RUN] Would write state");
+    log('[DRY-RUN] Would write state');
     return;
   }
-  const tmp = STATE_PATH + ".tmp." + process.pid;
+  const tmp = STATE_PATH + '.tmp.' + process.pid;
   writeFileSync(tmp, JSON.stringify(s, null, 2));
   renameSync(tmp, STATE_PATH);
 }
@@ -169,9 +161,9 @@ function writeState(s, dryRun = false) {
 const LOCK_MAX_AGE_MS = 15 * 60_000; // hard ceiling; browser OAuth can take minutes
 function readLock() {
   try {
-    const raw = readFileSync(LOCK_PATH, "utf8").trim();
+    const raw = readFileSync(LOCK_PATH, 'utf8').trim();
     const [ts, pidStr] = raw.split(/\s+/);
-    const pid = parseInt(pidStr || "", 10);
+    const pid = parseInt(pidStr || '', 10);
     const when = new Date(ts).getTime();
     return {
       when: Number.isFinite(when) ? when : 0,
@@ -201,7 +193,7 @@ function acquireLock() {
       }
       log(`Lock held by PID ${info.pid} but >${Math.round(LOCK_MAX_AGE_MS / 60_000)}min old — breaking`);
     } else if (info) {
-      log(`Stale lock (PID ${info.pid || "?"} not running) — breaking`);
+      log(`Stale lock (PID ${info.pid || '?'} not running) — breaking`);
     }
   }
   writeFileSync(LOCK_PATH, `${new Date().toISOString()}\n${process.pid}`);
@@ -235,13 +227,13 @@ async function queryAllUtilization(config) {
 
       const headers = {
         Authorization: `Bearer ${accessToken}`,
-        "anthropic-beta": "oauth-2025-04-20",
-        "Content-Type": "application/json",
+        'anthropic-beta': 'oauth-2025-04-20',
+        'Content-Type': 'application/json',
       };
 
       async function fetchWithRetry(url, attempt = 0) {
         const res = await fetch(url, {
-          method: "GET",
+          method: 'GET',
           headers,
           signal: AbortSignal.timeout(5000),
         });
@@ -255,8 +247,8 @@ async function queryAllUtilization(config) {
       }
 
       const [usageRes, profileRes] = await Promise.all([
-        fetchWithRetry("https://api.anthropic.com/api/oauth/usage"),
-        fetchWithRetry("https://api.anthropic.com/api/oauth/profile"),
+        fetchWithRetry('https://api.anthropic.com/api/oauth/usage'),
+        fetchWithRetry('https://api.anthropic.com/api/oauth/profile'),
       ]);
 
       if (!usageRes.ok) return null;
@@ -271,10 +263,8 @@ async function queryAllUtilization(config) {
         subscriptionStatus = prof?.organization?.subscription_status ?? null;
       }
       return {
-        five_hour_pct:
-          Math.round((data.five_hour?.utilization ?? 0) * 100) / 100,
-        seven_day_pct:
-          Math.round((data.seven_day?.utilization ?? 0) * 100) / 100,
+        five_hour_pct: Math.round((data.five_hour?.utilization ?? 0) * 100) / 100,
+        seven_day_pct: Math.round((data.seven_day?.utilization ?? 0) * 100) / 100,
         resets_at_5h: data.five_hour?.resets_at || null,
         resets_at_7d: data.seven_day?.resets_at || null,
         extra_usage_enabled: extraUsageEnabled,
@@ -298,7 +288,7 @@ async function queryAllUtilization(config) {
   );
   const map = {};
   for (const r of results) {
-    if (r.status === "fulfilled" && r.value.util) {
+    if (r.status === 'fulfilled' && r.value.util) {
       map[r.value.key] = r.value.util;
     }
   }
@@ -382,24 +372,16 @@ function pickNextAccount(config, state, liveUtil = {}, opts = {}) {
     log(
       `⚠  EXTRA USAGE ENABLED on ${extraUsageAccounts.length} account(s): ${extraUsageAccounts
         .map((a) => accountKey(a))
-        .join(
-          ", ",
-        )} — these can incur overage charges. Disable at console.anthropic.com/settings/billing.`,
+        .join(', ')} — these can incur overage charges. Disable at console.anthropic.com/settings/billing.`,
     );
   }
 
   const excludeKey = (a) =>
-    a.disabled === true ||
-    accountKey(a) === activeKey ||
-    (!allowExtraUsage && hasExtraUsageEnabled(a));
+    a.disabled === true || accountKey(a) === activeKey || (!allowExtraUsage && hasExtraUsageEnabled(a));
 
   // Separate normal and low-priority, excluding current active + extra-usage accounts
-  const normal = config.accounts.filter(
-    (a) => a.priority !== "low" && !excludeKey(a),
-  );
-  const low = config.accounts.filter(
-    (a) => a.priority === "low" && !excludeKey(a),
-  );
+  const normal = config.accounts.filter((a) => a.priority !== 'low' && !excludeKey(a));
+  const low = config.accounts.filter((a) => a.priority === 'low' && !excludeKey(a));
 
   const UTIL_HARD_BLOCK = 90; // Skip accounts at/above this util% if possible
 
@@ -411,24 +393,20 @@ function pickNextAccount(config, state, liveUtil = {}, opts = {}) {
       const viable = candidates.filter((a) => score(a) < UTIL_HARD_BLOCK);
       const blocked = candidates.filter((a) => score(a) >= UTIL_HARD_BLOCK);
       const sorted = [...viable].sort((a, b) => score(a) - score(b));
-      const pool2 = sorted.length
-        ? sorted
-        : [...blocked].sort((a, b) => score(a) - score(b));
+      const pool2 = sorted.length ? sorted : [...blocked].sort((a, b) => score(a) - score(b));
 
       if (pool2.length > 0) {
         const best = pool2[0];
         const u5 = getUtil5h(best);
         const u7 = getUtil7d(best);
         const src = liveUtil[accountKey(best)]
-          ? "live"
+          ? 'live'
           : state.accounts[accountKey(best)]?.lastUtilization
-            ? "cached"
-            : "unknown";
-        const utilStr = ` 5h=${u5 ?? "?"}% 7d=${u7 ?? "?"}% [${src}]`;
+            ? 'cached'
+            : 'unknown';
+        const utilStr = ` 5h=${u5 ?? '?'}% 7d=${u7 ?? '?'}% [${src}]`;
         if (score(best) >= UTIL_HARD_BLOCK) {
-          log(
-            `WARNING: All candidates near limit — rotating to ${accountKey(best)}${utilStr}`,
-          );
+          log(`WARNING: All candidates near limit — rotating to ${accountKey(best)}${utilStr}`);
         } else {
           log(`Picked ${accountKey(best)}${utilStr}`);
         }
@@ -442,10 +420,11 @@ function pickNextAccount(config, state, liveUtil = {}, opts = {}) {
 // ── Keychain ─────────────────────────────────────────────────────────────────
 
 function readKeychain(svc = KEYCHAIN_SERVICE, acct = KEYCHAIN_ACCOUNT) {
-  const out = execSync(
-    `security find-generic-password -s "${svc}" -a "${acct}" -g 2>&1`,
-    { timeout: 5000 },
-  ).toString();
+  const result = spawnSync('security', ['find-generic-password', '-s', svc, '-a', acct, '-g'], {
+    timeout: 5000,
+    encoding: 'utf8',
+  });
+  const out = (result.stdout || '') + (result.stderr || '');
   const m = out.match(/^password: "?(.*?)"?$/m);
   if (!m) throw new Error(`No keychain entry ${svc}/${acct}`);
   return m[1].replace(/\\"/g, '"');
@@ -453,14 +432,11 @@ function readKeychain(svc = KEYCHAIN_SERVICE, acct = KEYCHAIN_ACCOUNT) {
 
 function writeKeychain(json, svc = KEYCHAIN_SERVICE, acct = KEYCHAIN_ACCOUNT) {
   try {
-    execSync(
-      `security delete-generic-password -s "${svc}" -a "${acct}" 2>/dev/null`,
-    );
+    execFileSync('security', ['delete-generic-password', '-s', svc, '-a', acct], {
+      stdio: 'ignore',
+    });
   } catch {}
-  execSync(
-    `security add-generic-password -s "${svc}" -a "${acct}" -w ${JSON.stringify(json)}`,
-    { timeout: 5000 },
-  );
+  execFileSync('security', ['add-generic-password', '-s', svc, '-a', acct, '-w', json], { timeout: 5000 });
 }
 
 function tokenExpired(json) {
@@ -476,7 +452,7 @@ function tokenExpired(json) {
 
 // ── Token vault (local keychain entries per account) ─────────────────────────
 
-const TOKEN_PREFIX = "Claude-Rotation";
+const TOKEN_PREFIX = 'Claude-Rotation';
 
 function tokenService(account) {
   return `${TOKEN_PREFIX}-${accountKey(account)}`;
@@ -513,9 +489,7 @@ function fetchGoogleCreds(account) {
     }).toString();
     const creds = JSON.parse(json);
     // Find credential whose email matches account.email
-    const match = creds.find(
-      (c) => (c.email || "").toLowerCase() === account.email.toLowerCase(),
-    );
+    const match = creds.find((c) => (c.email || '').toLowerCase() === account.email.toLowerCase());
     if (!match) return null;
     return {
       password: match.password || null,
@@ -532,7 +506,7 @@ function fetchGooglePassword(account) {
   // Legacy path: honor explicit dashlaneGooglePath if set
   if (account.dashlaneGooglePath) {
     try {
-      return execSync(`dcli read "${account.dashlaneGooglePath}" 2>/dev/null`, {
+      return execFileSync('dcli', ['read', account.dashlaneGooglePath], {
         timeout: 10_000,
       })
         .toString()
@@ -551,13 +525,13 @@ function fetchGooglePassword(account) {
 function generateTOTP(base32Secret) {
   // Uses top-level ESM import: createHmac from "node:crypto"
   // Decode base32
-  const base32chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
-  const clean = base32Secret.replace(/\s/g, "").toUpperCase();
-  let bits = "";
+  const base32chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  const clean = base32Secret.replace(/\s/g, '').toUpperCase();
+  let bits = '';
   for (const c of clean) {
     const i = base32chars.indexOf(c);
     if (i === -1) continue;
-    bits += i.toString(2).padStart(5, "0");
+    bits += i.toString(2).padStart(5, '0');
   }
   const bytes = [];
   for (let i = 0; i + 8 <= bits.length; i += 8) {
@@ -570,14 +544,14 @@ function generateTOTP(base32Secret) {
   const buf = Buffer.alloc(8);
   buf.writeBigUInt64BE(BigInt(counter));
 
-  const hmac = createHmac("sha1", key).update(buf).digest();
+  const hmac = createHmac('sha1', key).update(buf).digest();
   const offset = hmac[hmac.length - 1] & 0x0f;
   const code =
     ((hmac[offset] & 0x7f) << 24) |
     ((hmac[offset + 1] & 0xff) << 16) |
     ((hmac[offset + 2] & 0xff) << 8) |
     (hmac[offset + 3] & 0xff);
-  return (code % 1_000_000).toString().padStart(6, "0");
+  return (code % 1_000_000).toString().padStart(6, '0');
 }
 
 // Read the latest SMS verification code from Messages.app for the Google 2FA number.
@@ -587,18 +561,14 @@ function generateTOTP(base32Secret) {
 // We hex-dump both and extract G-XXXXXX or a 6-digit code.
 function readLatestSMSCode({ maxAgeSec = 300 } = {}) {
   try {
-    const db = join(process.env.HOME || "", "Library/Messages/chat.db");
+    const db = join(process.env.HOME || '', 'Library/Messages/chat.db');
     if (!existsSync(db)) return null;
     // Apple timestamp = seconds since 2001-01-01, stored as nanoseconds
-    const cutoffAppleNs =
-      (Math.floor(Date.now() / 1000) - 978307200 - maxAgeSec) * 1_000_000_000;
+    const cutoffAppleNs = (Math.floor(Date.now() / 1000) - 978307200 - maxAgeSec) * 1_000_000_000;
     const sql = `SELECT hex(attributedBody), text FROM message WHERE date > ${cutoffAppleNs} AND service IN ('SMS','iMessage') ORDER BY date DESC LIMIT 10;`;
-    const rows = execSync(`sqlite3 "${db}" "${sql}"`, { timeout: 5000 })
-      .toString()
-      .split("\n")
-      .filter(Boolean);
+    const rows = execSync(`sqlite3 "${db}" "${sql}"`, { timeout: 5000 }).toString().split('\n').filter(Boolean);
     for (const row of rows) {
-      const [hex, text] = row.split("|");
+      const [hex, text] = row.split('|');
       // Plain text column (older macOS)
       if (text) {
         const m = text.match(/G-(\d{6})/) || text.match(/\b(\d{6})\b/);
@@ -606,10 +576,8 @@ function readLatestSMSCode({ maxAgeSec = 300 } = {}) {
       }
       // attributedBody blob — decode as latin-1 and regex-match
       if (hex && hex.length > 20) {
-        const decoded = Buffer.from(hex, "hex").toString("latin1");
-        const m =
-          decoded.match(/G-(\d{6})/) ||
-          decoded.match(/(\d{6})\s+is your (?:Google )?verification code/);
+        const decoded = Buffer.from(hex, 'hex').toString('latin1');
+        const m = decoded.match(/G-(\d{6})/) || decoded.match(/(\d{6})\s+is your (?:Google )?verification code/);
         if (m) return m[1];
       }
     }
@@ -624,11 +592,11 @@ function readLatestSMSCode({ maxAgeSec = 300 } = {}) {
 async function swapToken(account) {
   const token = readStoredToken(account);
   if (!token) {
-    log("[primary] No stored token — need browser fallback");
+    log('[primary] No stored token — need browser fallback');
     return false;
   }
   if (tokenExpired(token)) {
-    log("[primary] Token expired — need browser fallback");
+    log('[primary] Token expired — need browser fallback');
     return false;
   }
   log(`[primary] Swapping active keychain for ${accountKey(account)}...`);
@@ -639,14 +607,11 @@ async function swapToken(account) {
     const current = readKeychain();
     const currentParsed = JSON.parse(current);
     const newParsed = JSON.parse(token);
-    if (
-      currentParsed.mcpOAuth &&
-      Object.keys(currentParsed.mcpOAuth).length > 0
-    ) {
+    if (currentParsed.mcpOAuth && Object.keys(currentParsed.mcpOAuth).length > 0) {
       // Merge: keep current mcpOAuth, only swap claudeAiOauth
       newParsed.mcpOAuth = { ...newParsed.mcpOAuth, ...currentParsed.mcpOAuth };
       writeKeychain(JSON.stringify(newParsed));
-      log("[primary] Preserved mcpOAuth from previous session");
+      log('[primary] Preserved mcpOAuth from previous session');
       return true;
     }
   } catch {}
@@ -660,7 +625,7 @@ async function swapToken(account) {
 function saveCurrentToken(account) {
   try {
     const token = readKeychain();
-    if (token.includes("claudeAiOauth")) {
+    if (token.includes('claudeAiOauth')) {
       // Store only claudeAiOauth, not mcpOAuth (that's session-specific)
       try {
         const parsed = JSON.parse(token);
@@ -683,14 +648,14 @@ function saveCurrentToken(account) {
 // Driver cascade — Playwright only by default.
 // Kapture/Chrome-JXA/Manual are disabled because they may touch Comet (user's browser)
 // or depend on whatever is frontmost. Set CLAUDE_ROTATION_ENABLE_FALLBACKS=1 to enable.
-const _fallbacksEnabled = process.env.CLAUDE_ROTATION_ENABLE_FALLBACKS === "1";
+const _fallbacksEnabled = process.env.CLAUDE_ROTATION_ENABLE_FALLBACKS === '1';
 const DRIVER_CASCADE = [
-  ["playwright", makePlaywrightDriver], // CDP to Chrome/Chrome Beta with real profile
+  ['playwright', makePlaywrightDriver], // CDP to Chrome/Chrome Beta with real profile
   ...(_fallbacksEnabled
     ? [
-        ["kapture", makeKaptureDriver],
-        ["chrome-jxa", makeChromeJXADriver],
-        ["manual", makeManualDriver],
+        ['kapture', makeKaptureDriver],
+        ['chrome-jxa', makeChromeJXADriver],
+        ['manual', makeManualDriver],
       ]
     : []),
 ];
@@ -707,29 +672,29 @@ async function getBrowserDriver(skip = new Set()) {
       log(`Driver [${name}] unavailable: ${err.message}`);
     }
   }
-  throw new Error("All browser drivers failed");
+  throw new Error('All browser drivers failed');
 }
 
 // ─── Driver 1: Kapture MCP (WebSocket → real Chrome, all Google sessions) ────
 
 async function makeKaptureDriver() {
-  const { default: WebSocket } = await import("ws");
+  const { default: WebSocket } = await import('ws');
 
   // Auto-start Kapture server if not running
   let ws;
   for (let attempt = 0; attempt < 2; attempt++) {
     try {
       ws = await new Promise((resolve, reject) => {
-        const socket = new WebSocket("ws://localhost:61822/mcp");
+        const socket = new WebSocket('ws://localhost:61822/mcp');
         const timer = setTimeout(() => {
           socket.terminate();
-          reject(new Error("timeout"));
+          reject(new Error('timeout'));
         }, 4000);
-        socket.once("open", () => {
+        socket.once('open', () => {
           clearTimeout(timer);
           resolve(socket);
         });
-        socket.once("error", (e) => {
+        socket.once('error', (e) => {
           clearTimeout(timer);
           reject(e);
         });
@@ -737,30 +702,28 @@ async function makeKaptureDriver() {
       break;
     } catch {
       if (attempt === 0) {
-        log("Kapture not running — starting server...");
-        spawn("npx", ["kapture-mcp"], {
+        log('Kapture not running — starting server...');
+        spawn('npx', ['kapture-mcp'], {
           detached: true,
-          stdio: "ignore",
+          stdio: 'ignore',
         }).unref();
         await sleep(3000);
       }
     }
   }
-  if (!ws) throw new Error("Kapture unavailable");
+  if (!ws) throw new Error('Kapture unavailable');
 
   // JSON-RPC over WebSocket
   let msgId = 0;
   const pending = new Map();
 
-  ws.on("message", (data) => {
+  ws.on('message', (data) => {
     try {
       const msg = JSON.parse(data.toString());
       if (msg.id !== undefined && pending.has(msg.id)) {
         const { resolve, reject } = pending.get(msg.id);
         pending.delete(msg.id);
-        msg.error
-          ? reject(new Error(msg.error.message || JSON.stringify(msg.error)))
-          : resolve(msg.result);
+        msg.error ? reject(new Error(msg.error.message || JSON.stringify(msg.error))) : resolve(msg.result);
       }
     } catch {}
   });
@@ -769,7 +732,7 @@ async function makeKaptureDriver() {
     return new Promise((resolve, reject) => {
       const id = ++msgId;
       pending.set(id, { resolve, reject });
-      ws.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+      ws.send(JSON.stringify({ jsonrpc: '2.0', id, method, params }));
       const t = setTimeout(() => {
         pending.delete(id);
         reject(new Error(`RPC timeout: ${method}`));
@@ -791,19 +754,19 @@ async function makeKaptureDriver() {
   }
 
   function tool(name, args = {}) {
-    return rpc("tools/call", { name, arguments: args });
+    return rpc('tools/call', { name, arguments: args });
   }
 
   // MCP handshake
-  await rpc("initialize", {
-    protocolVersion: "2024-11-05",
+  await rpc('initialize', {
+    protocolVersion: '2024-11-05',
     capabilities: {},
-    clientInfo: { name: "claude-rotation", version: "1.0" },
+    clientInfo: { name: 'claude-rotation', version: '1.0' },
   });
   ws.send(
     JSON.stringify({
-      jsonrpc: "2.0",
-      method: "notifications/initialized",
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
       params: {},
     }),
   );
@@ -811,7 +774,7 @@ async function makeKaptureDriver() {
   // Get existing tab or open new one
   let tabId;
   try {
-    const tabsResult = await tool("list_tabs", {});
+    const tabsResult = await tool('list_tabs', {});
     const text = extractText(tabsResult);
     log(`Kapture tabs: ${text.substring(0, 200)}`);
     // Parse first tab ID from format: "Tab ID: abc123" or "id: abc123" or "(abc123)"
@@ -824,54 +787,47 @@ async function makeKaptureDriver() {
 
   if (!tabId) {
     // Open new tab
-    const result = await tool("new_tab", { browser: "chrome" });
+    const result = await tool('new_tab', { browser: 'chrome' });
     const text = extractText(result);
-    const m =
-      text.match(/[Tt]ab\s+[Ii][Dd][:\s]+([a-zA-Z0-9_-]+)/) ||
-      text.match(/([a-zA-Z0-9_-]{8,})/);
-    tabId = m?.[1] || "tab1";
+    const m = text.match(/[Tt]ab\s+[Ii][Dd][:\s]+([a-zA-Z0-9_-]+)/) || text.match(/([a-zA-Z0-9_-]{8,})/);
+    tabId = m?.[1] || 'tab1';
     await sleep(2000);
   }
 
   log(`Kapture using tab: ${tabId}`);
 
   return {
-    name: "kapture",
+    name: 'kapture',
     _tabId: tabId,
     async goto(url) {
-      await tool("navigate", { tabId, url, timeout: 30_000 });
+      await tool('navigate', { tabId, url, timeout: 30_000 });
       await sleep(2500);
     },
     async currentUrl() {
       try {
-        const r = await tool("tab_detail", { tabId });
+        const r = await tool('tab_detail', { tabId });
         const text = extractText(r);
-        const m =
-          text.match(/[Uu][Rr][Ll][:\s]+(\S+)/) ||
-          text.match(/https?:\/\/[^\s"',]+/);
-        return m?.[1] || m?.[0] || "";
+        const m = text.match(/[Uu][Rr][Ll][:\s]+(\S+)/) || text.match(/https?:\/\/[^\s"',]+/);
+        return m?.[1] || m?.[0] || '';
       } catch {
-        return "";
+        return '';
       }
     },
     async findAndClick(texts) {
       for (const t of texts) {
         // CSS selector? Try that first — most reliable.
-        const isCss =
-          /^[\[#.]/.test(t) ||
-          t.includes("data-testid") ||
-          t.includes("[type=");
+        const isCss = /^[\[#.]/.test(t) || t.includes('data-testid') || t.includes('[type=');
         if (isCss) {
           try {
-            await tool("click", { tabId, selector: t });
+            await tool('click', { tabId, selector: t });
             log(`[kapture] clicked via CSS: ${t}`);
             return true;
           } catch {}
           continue;
         }
         const clean = t
-          .replace(/button:has-text\("?([^"]+)"?\)/g, "$1")
-          .replace(/['"]/g, "")
+          .replace(/button:has-text\("?([^"]+)"?\)/g, '$1')
+          .replace(/['"]/g, '')
           .trim();
         const escaped = clean.replace(/'/g, "\\'");
         const xpaths = [
@@ -886,7 +842,7 @@ async function makeKaptureDriver() {
         ];
         for (const xpath of xpaths) {
           try {
-            await tool("click", { tabId, xpath });
+            await tool('click', { tabId, xpath });
             log(`[kapture] clicked via xpath: ${xpath.substring(0, 80)}`);
             return true;
           } catch {}
@@ -897,13 +853,13 @@ async function makeKaptureDriver() {
     async fillInput(sel, val) {
       if (!val) return false;
       try {
-        await tool("fill", { tabId, selector: sel, value: val });
+        await tool('fill', { tabId, selector: sel, value: val });
         return true;
       } catch {}
       // XPath fallback
       try {
-        const xpath = `//*[self::input or self::textarea][@type='${sel.includes("password") ? "password" : "email"}']`;
-        await tool("fill", { tabId, xpath, value: val });
+        const xpath = `//*[self::input or self::textarea][@type='${sel.includes('password') ? 'password' : 'email'}']`;
+        await tool('fill', { tabId, xpath, value: val });
         return true;
       } catch {
         return false;
@@ -911,23 +867,23 @@ async function makeKaptureDriver() {
     },
     async screenshot(path) {
       try {
-        const r = await tool("screenshot", {
+        const r = await tool('screenshot', {
           tabId,
-          format: "png",
+          format: 'png',
           scale: 0.5,
         });
         const content = r?.content?.[0];
-        if (content?.type === "image" && content.data) {
-          writeFileSync(path, Buffer.from(content.data, "base64"));
+        if (content?.type === 'image' && content.data) {
+          writeFileSync(path, Buffer.from(content.data, 'base64'));
         }
       } catch {}
     },
     async readPageText() {
       try {
-        const r = await tool("dom", { tabId });
+        const r = await tool('dom', { tabId });
         return extractText(r);
       } catch {
-        return "";
+        return '';
       }
     },
     // Poll list_tabs for a new tab that appears after a Google OAuth click.
@@ -936,12 +892,11 @@ async function makeKaptureDriver() {
       // Snapshot current tabs
       const snapshotTabs = async () => {
         try {
-          const r = await tool("list_tabs", {});
+          const r = await tool('list_tabs', {});
           const text = extractText(r);
           // Parse all tab IDs from the response
           const ids = [];
-          const re =
-            /[Tt]ab\s+[Ii][Dd][:\s]+([a-zA-Z0-9_-]+)|\(([a-zA-Z0-9_-]{6,})\)|"id"\s*:\s*"([a-zA-Z0-9_-]+)"/g;
+          const re = /[Tt]ab\s+[Ii][Dd][:\s]+([a-zA-Z0-9_-]+)|\(([a-zA-Z0-9_-]{6,})\)|"id"\s*:\s*"([a-zA-Z0-9_-]+)"/g;
           let m;
           while ((m = re.exec(text)) !== null) {
             const id = m[1] || m[2] || m[3];
@@ -958,18 +913,16 @@ async function makeKaptureDriver() {
       while (Date.now() < deadline) {
         await sleep(1000);
         const after = await snapshotTabs();
-        const newTabs = [...after].filter(
-          (id) => !before.has(id) && id !== tabId,
-        );
+        const newTabs = [...after].filter((id) => !before.has(id) && id !== tabId);
         if (newTabs.length > 0) {
           const popupTabId = newTabs[0];
           log(`Popup detected, switching to tab: ${popupTabId}`);
           // Return a minimal driver bound to the popup tab
           return {
-            name: "kapture-popup",
+            name: 'kapture-popup',
             _tabId: popupTabId,
             async goto(url) {
-              await tool("navigate", {
+              await tool('navigate', {
                 tabId: popupTabId,
                 url,
                 timeout: 30_000,
@@ -978,21 +931,19 @@ async function makeKaptureDriver() {
             },
             async currentUrl() {
               try {
-                const r = await tool("tab_detail", { tabId: popupTabId });
+                const r = await tool('tab_detail', { tabId: popupTabId });
                 const text = extractText(r);
-                const m =
-                  text.match(/[Uu][Rr][Ll][:\s]+(\S+)/) ||
-                  text.match(/https?:\/\/[^\s"',]+/);
-                return m?.[1] || m?.[0] || "";
+                const m = text.match(/[Uu][Rr][Ll][:\s]+(\S+)/) || text.match(/https?:\/\/[^\s"',]+/);
+                return m?.[1] || m?.[0] || '';
               } catch {
-                return "";
+                return '';
               }
             },
             async findAndClick(texts) {
               for (const t of texts) {
                 const clean = t
-                  .replace(/button:has-text\("?([^"]+)"?\)/g, "$1")
-                  .replace(/['"]/g, "")
+                  .replace(/button:has-text\("?([^"]+)"?\)/g, '$1')
+                  .replace(/['"]/g, '')
                   .trim();
                 const xpaths = [
                   `//*[normalize-space(text())='${clean}']`,
@@ -1002,7 +953,7 @@ async function makeKaptureDriver() {
                 ];
                 for (const xpath of xpaths) {
                   try {
-                    await tool("click", { tabId: popupTabId, xpath });
+                    await tool('click', { tabId: popupTabId, xpath });
                     return true;
                   } catch {}
                 }
@@ -1012,7 +963,7 @@ async function makeKaptureDriver() {
             async fillInput(sel, val) {
               if (!val) return false;
               try {
-                await tool("fill", {
+                await tool('fill', {
                   tabId: popupTabId,
                   selector: sel,
                   value: val,
@@ -1028,7 +979,7 @@ async function makeKaptureDriver() {
           };
         }
       }
-      log("No popup appeared within timeout");
+      log('No popup appeared within timeout');
       return null;
     },
     async close() {
@@ -1039,11 +990,11 @@ async function makeKaptureDriver() {
 
 // Helper: extract text from MCP tool result
 function extractText(result) {
-  if (!result) return "";
-  if (typeof result === "string") return result;
+  if (!result) return '';
+  if (typeof result === 'string') return result;
   const content = result.content || result;
   if (Array.isArray(content)) {
-    return content.map((c) => c.text || c.data || "").join("\n");
+    return content.map((c) => c.text || c.data || '').join('\n');
   }
   return JSON.stringify(result);
 }
@@ -1064,10 +1015,10 @@ function extractText(result) {
 // Comet = user's browser (never touch). Chrome = user's browser (never touch).
 const REAL_BROWSERS = [
   {
-    name: "Google Chrome Beta",
-    bin: "/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta",
-    profile: join(__dirname, ".chrome-beta-automation"),
-    appName: "Google Chrome Beta",
+    name: 'Google Chrome Beta',
+    bin: '/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta',
+    profile: join(__dirname, '.chrome-beta-automation'),
+    appName: 'Google Chrome Beta',
   },
 ];
 
@@ -1099,9 +1050,7 @@ function findRealBrowser({ preferNotRunning = true } = {}) {
 
 async function tryConnectCDP(chromium) {
   try {
-    const browser = await chromium.connectOverCDP(
-      `http://localhost:${CDP_PORT}`,
-    );
+    const browser = await chromium.connectOverCDP(`http://localhost:${CDP_PORT}`);
     const contexts = browser.contexts();
     const ctx = contexts[0] || (await browser.newContext());
     const page = ctx.pages()[0] || (await ctx.newPage());
@@ -1114,7 +1063,7 @@ async function tryConnectCDP(chromium) {
 
 function isAppRunning(appName) {
   try {
-    execSync(`pgrep -f "${appName.replace(/ /g, ".")}" > /dev/null 2>&1`, {
+    execSync(`pgrep -f "${appName.replace(/ /g, '.')}" > /dev/null 2>&1`, {
       timeout: 2000,
     });
     return true;
@@ -1125,21 +1074,18 @@ function isAppRunning(appName) {
 
 function gracefullyQuitApp(appName) {
   try {
-    execSync(
-      `osascript -e 'tell application "${appName}" to quit' 2>/dev/null`,
-      { timeout: 8000 },
-    );
+    execSync(`osascript -e 'tell application "${appName}" to quit' 2>/dev/null`, { timeout: 8000 });
     // Wait up to 5s for it to actually quit
     for (let i = 0; i < 10; i++) {
       if (!isAppRunning(appName)) return true;
-      execSync("sleep 0.5");
+      execSync('sleep 0.5');
     }
   } catch {}
   return false;
 }
 
 async function makePlaywrightDriver() {
-  const { chromium } = await import("playwright");
+  const { chromium } = await import('playwright');
 
   // 1. Try attaching to already-running Chrome on CDP
   let attached = await tryConnectCDP(chromium);
@@ -1148,8 +1094,7 @@ async function makePlaywrightDriver() {
 
   if (!attached) {
     const browser = findRealBrowser();
-    if (!browser)
-      throw new Error("No Comet / Chrome Beta / Chrome binary found");
+    if (!browser) throw new Error('No Comet / Chrome Beta / Chrome binary found');
 
     // 2. Ensure symlinked profile exists (Chrome CDP requires non-default user-data-dir)
     ensureSymlinkedProfile(browser);
@@ -1157,9 +1102,7 @@ async function makePlaywrightDriver() {
     // 3. Quit any running Chrome Beta that might be holding the real profile
     //    (the symlinked profile shares Cookies/LoginData files with the real one).
     if (isAppRunning(browser.appName)) {
-      log(
-        `[playwright] ${browser.name} running — quitting to release profile files...`,
-      );
+      log(`[playwright] ${browser.name} running — quitting to release profile files...`);
       gracefullyQuitApp(browser.appName);
       await sleep(1500);
       // Force kill if still alive
@@ -1172,26 +1115,24 @@ async function makePlaywrightDriver() {
     // 4. Launch visible (NOT headless — Cloudflare blocks headless Chrome)
     //    Positioned off-screen + 1x1 size so the window is effectively invisible
     //    even on multi-monitor / retina setups where 3000,3000 clamps onto a display.
-    log(
-      `[playwright] Launching ${browser.name} hidden (1x1 off-screen) with CDP :${CDP_PORT}...`,
-    );
+    log(`[playwright] Launching ${browser.name} hidden (1x1 off-screen) with CDP :${CDP_PORT}...`);
     spawn(
       browser.bin,
       [
         `--remote-debugging-port=${CDP_PORT}`,
         `--user-data-dir=${browser.profile}`,
-        "--no-first-run",
-        "--no-default-browser-check",
-        "--disable-blink-features=AutomationControlled",
-        "--disable-background-networking",
-        "--disable-component-update",
-        "--disable-default-apps",
-        "--disable-sync",
-        "--disable-notifications",
-        "--window-position=9000,9000",
-        "--window-size=1,1",
+        '--no-first-run',
+        '--no-default-browser-check',
+        '--disable-blink-features=AutomationControlled',
+        '--disable-background-networking',
+        '--disable-component-update',
+        '--disable-default-apps',
+        '--disable-sync',
+        '--disable-notifications',
+        '--window-position=9000,9000',
+        '--window-size=1,1',
       ],
-      { detached: true, stdio: "ignore" },
+      { detached: true, stdio: 'ignore' },
     ).unref();
     weSpawnedChrome = true;
     spawnedProfile = browser.profile;
@@ -1202,13 +1143,12 @@ async function makePlaywrightDriver() {
       attached = await tryConnectCDP(chromium);
       if (attached) break;
     }
-    if (!attached)
-      throw new Error(`CDP didn't come up on :${CDP_PORT} within 15s`);
+    if (!attached) throw new Error(`CDP didn't come up on :${CDP_PORT} within 15s`);
   }
 
   const { browser: pwBrowser, ctx, page } = attached;
   return buildPageDriver(
-    "playwright",
+    'playwright',
     page,
     async () => {
       try {
@@ -1237,7 +1177,7 @@ async function makeChromeJXADriver() {
   )
     .toString()
     .trim();
-  if (!test.startsWith("ok:")) throw new Error("Chrome JXA test failed");
+  if (!test.startsWith('ok:')) throw new Error('Chrome JXA test failed');
 
   function jxaJs(js) {
     return execSync(
@@ -1252,7 +1192,7 @@ async function makeChromeJXADriver() {
   }
 
   return {
-    name: "chrome-jxa",
+    name: 'chrome-jxa',
     async goto(url) {
       // Do NOT activate Chrome — focus-steal would interrupt the user's work.
       // URL assignment alone is enough to drive navigation via JXA.
@@ -1272,15 +1212,15 @@ async function makeChromeJXADriver() {
     async findAndClick(texts) {
       for (const t of texts) {
         const clean = t
-          .replace(/button:has-text\("?([^"]+)"?\)/g, "$1")
-          .replace(/['"]/g, "")
+          .replace(/button:has-text\("?([^"]+)"?\)/g, '$1')
+          .replace(/['"]/g, '')
           .trim();
         try {
           const r = jxaJs(
             `(function(){var els=document.querySelectorAll('button,a,[role=button],input[type=submit]');` +
               `for(var e of els){if((e.textContent||e.value||'').trim().toLowerCase().includes('${clean.toLowerCase()}')){e.click();return'ok';}}return'miss';})()`,
           );
-          if (r === "ok") return true;
+          if (r === 'ok') return true;
         } catch {}
       }
       return false;
@@ -1312,13 +1252,13 @@ async function makeChromeJXADriver() {
 
 async function makeManualDriver() {
   return {
-    name: "manual",
+    name: 'manual',
     async goto(url) {
       execSync(`open "${url}"`);
-      notify("Account Rotation", "Complete Google sign-in → click Allow");
+      notify('Account Rotation', 'Complete Google sign-in → click Allow');
     },
     async currentUrl() {
-      return "";
+      return '';
     },
     async findAndClick() {
       return false;
@@ -1344,10 +1284,8 @@ function buildPageDriver(name, page, closeFn, ctx) {
     _page: page,
     _ctx: ctx,
     async goto(url) {
-      await page.goto(url, { waitUntil: "domcontentloaded", timeout: 30_000 });
-      await page
-        .waitForLoadState?.("networkidle", { timeout: 10_000 })
-        .catch(() => {});
+      await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+      await page.waitForLoadState?.('networkidle', { timeout: 10_000 }).catch(() => {});
     },
     async currentUrl() {
       return page.url();
@@ -1355,10 +1293,7 @@ function buildPageDriver(name, page, closeFn, ctx) {
     async findAndClick(texts) {
       for (const t of texts) {
         // If it looks like a CSS selector (starts with [, #, ., or contains data-testid), use directly
-        const isCss =
-          /^[\[#.]/.test(t) ||
-          t.includes("data-testid") ||
-          t.includes("[type=");
+        const isCss = /^[\[#.]/.test(t) || t.includes('data-testid') || t.includes('[type=');
         if (isCss) {
           try {
             const loc = page.locator(t).first();
@@ -1372,8 +1307,8 @@ function buildPageDriver(name, page, closeFn, ctx) {
         // Otherwise treat as text — broad matcher covering buttons, links, list items,
         // and ARIA roles (Google 2FA pages use <li> for options, not <button>)
         const clean = t
-          .replace(/button:has-text\("?([^"]+)"?\)/g, "$1")
-          .replace(/['"]/g, "")
+          .replace(/button:has-text\("?([^"]+)"?\)/g, '$1')
+          .replace(/['"]/g, '')
           .trim();
         try {
           // Try each element type individually so we don't get strict-mode violations
@@ -1421,15 +1356,13 @@ function buildPageDriver(name, page, closeFn, ctx) {
     },
     async readPageText() {
       try {
-        return await page.evaluate(() => document.body?.innerText || "");
+        return await page.evaluate(() => document.body?.innerText || '');
       } catch {
-        return "";
+        return '';
       }
     },
     async waitForPopup(timeout = 10_000) {
-      return ctx
-        ? ctx.waitForEvent("page", { timeout }).catch(() => null)
-        : null;
+      return ctx ? ctx.waitForEvent('page', { timeout }).catch(() => null) : null;
     },
     async close() {
       await closeFn();
@@ -1447,10 +1380,10 @@ function buildPageDriver(name, page, closeFn, ctx) {
 // Format: https://claude.ai/magic-link#<hex>:<base64-email>
 function magicLinkTargetEmail(url) {
   try {
-    const hash = url.split("#")[1] || "";
-    const b64 = hash.split(":")[1] || "";
+    const hash = url.split('#')[1] || '';
+    const b64 = hash.split(':')[1] || '';
     if (!b64) return null;
-    return Buffer.from(b64, "base64").toString("utf-8").trim().toLowerCase();
+    return Buffer.from(b64, 'base64').toString('utf-8').trim().toLowerCase();
   } catch {
     return null;
   }
@@ -1461,9 +1394,7 @@ async function pollGmailForMagicLink(accountEmail, maxWaitMs = 120_000) {
   // Anchor to "now" so we never accept a magic-link email older than this call.
   const requestedAt = Math.floor(Date.now() / 1000);
   const targetLower = accountEmail.toLowerCase();
-  log(
-    `[magic-link] Polling Gmail for login email to ${accountEmail} (max ${maxWaitMs / 1000}s)...`,
-  );
+  log(`[magic-link] Polling Gmail for login email to ${accountEmail} (max ${maxWaitMs / 1000}s)...`);
 
   // Track skipped (stale/wrong-target) thread IDs so we don't re-evaluate them every poll
   const seenSkip = new Set();
@@ -1472,24 +1403,15 @@ async function pollGmailForMagicLink(accountEmail, maxWaitMs = 120_000) {
     try {
       // Pull up to 10 recent matches so a stale top-result doesn't block us.
       const searchResult = execFileSync(
-        "gog",
-        [
-          "gmail",
-          "search",
-          'subject:"Secure link to log in to Claude" newer_than:5m',
-          "--max",
-          "10",
-          "-j",
-        ],
-        { timeout: 15_000, stdio: ["ignore", "pipe", "pipe"] },
+        'gog',
+        ['gmail', 'search', 'subject:"Secure link to log in to Claude" newer_than:5m', '--max', '10', '-j'],
+        { timeout: 15_000, stdio: ['ignore', 'pipe', 'pipe'] },
       )
         .toString()
         .trim();
 
       const parsedSearch = JSON.parse(searchResult);
-      const list = Array.isArray(parsedSearch)
-        ? parsedSearch
-        : parsedSearch.threads || parsedSearch.results || [];
+      const list = Array.isArray(parsedSearch) ? parsedSearch : parsedSearch.threads || parsedSearch.results || [];
 
       for (const item of list) {
         const threadIdRaw = item.id || item.threadId;
@@ -1498,19 +1420,16 @@ async function pollGmailForMagicLink(accountEmail, maxWaitMs = 120_000) {
         if (!/^[A-Za-z0-9_-]+$/.test(threadIdRaw)) continue;
         if (seenSkip.has(threadIdRaw)) continue;
 
-        const threadJson = execFileSync(
-          "gog",
-          ["gmail", "read", threadIdRaw, "-j"],
-          { timeout: 15_000, stdio: ["ignore", "pipe", "pipe"] },
-        ).toString();
+        const threadJson = execFileSync('gog', ['gmail', 'read', threadIdRaw, '-j'], {
+          timeout: 15_000,
+          stdio: ['ignore', 'pipe', 'pipe'],
+        }).toString();
 
         const parsed = JSON.parse(threadJson);
         const messages = parsed?.thread?.messages || [];
 
         // Reject any message older than our requestedAt (stale link from prior call)
-        const msgTimes = messages
-          .map((m) => parseInt(m.internalDate || "0", 10) / 1000)
-          .filter((t) => t > 0);
+        const msgTimes = messages.map((m) => parseInt(m.internalDate || '0', 10) / 1000).filter((t) => t > 0);
         const newestMsg = msgTimes.length ? Math.max(...msgTimes) : 0;
         if (newestMsg && newestMsg < requestedAt - 5) {
           seenSkip.add(threadIdRaw);
@@ -1522,15 +1441,13 @@ async function pollGmailForMagicLink(accountEmail, maxWaitMs = 120_000) {
           const data = part?.body?.data;
           if (data) {
             try {
-              decodedBodies.push(
-                Buffer.from(data, "base64url").toString("utf-8"),
-              );
+              decodedBodies.push(Buffer.from(data, 'base64url').toString('utf-8'));
             } catch {}
           }
           for (const p of part?.parts || []) walkParts(p);
         };
         for (const msg of messages) walkParts(msg.payload);
-        const fullBody = decodedBodies.join("\n");
+        const fullBody = decodedBodies.join('\n');
 
         const linkPatterns = [
           /https:\/\/claude\.ai\/magic-link#[^\s"'<>)}\]]+/,
@@ -1564,21 +1481,17 @@ async function pollGmailForMagicLink(accountEmail, maxWaitMs = 120_000) {
         // (subject is identical for every account) and rotate to the wrong one.
         const linkTarget = magicLinkTargetEmail(url);
         if (linkTarget && linkTarget !== targetLower) {
-          log(
-            `[magic-link] Skipping stale link for ${linkTarget} (waiting for ${targetLower})`,
-          );
+          log(`[magic-link] Skipping stale link for ${linkTarget} (waiting for ${targetLower})`);
           seenSkip.add(threadIdRaw);
           continue;
         }
 
-        log(
-          `[magic-link] Found login link: ${url.substring(0, 100)}...`,
-        );
+        log(`[magic-link] Found login link: ${url.substring(0, 100)}...`);
         return url;
       }
     } catch (err) {
-      const stderr = err.stderr ? err.stderr.toString().trim() : "";
-      log(`[magic-link] Gmail poll error: ${err.message}${stderr ? " | stderr: " + stderr : ""}`);
+      const stderr = err.stderr ? err.stderr.toString().trim() : '';
+      log(`[magic-link] Gmail poll error: ${err.message}${stderr ? ' | stderr: ' + stderr : ''}`);
     }
     await sleep(5000);
   }
@@ -1593,14 +1506,11 @@ async function runAuthFlow(driver, account) {
   const googlePassword = creds.password || fetchGooglePassword(account);
   const googleOtpSecret = creds.otpSecret || null;
   const googleSmsPhone =
-    (process.env.CLAUDE_ROTATION_GOOGLE_SMS_PHONE || "").trim() ||
-    (account.googleSmsPhone || "").trim() ||
-    (creds.phone || "").trim() ||
+    (process.env.CLAUDE_ROTATION_GOOGLE_SMS_PHONE || '').trim() ||
+    (account.googleSmsPhone || '').trim() ||
+    (creds.phone || '').trim() ||
     null;
-  if (googlePassword)
-    log(
-      `dcli Google password available for ${account.email}${googleOtpSecret ? " (+TOTP)" : ""}`,
-    );
+  if (googlePassword) log(`dcli Google password available for ${account.email}${googleOtpSecret ? ' (+TOTP)' : ''}`);
 
   // AI-brain stall detector: when the URL doesn't advance for N consecutive
   // steps, hand the page to Claude to decide what to do. Kept separate from
@@ -1610,33 +1520,28 @@ async function runAuthFlow(driver, account) {
   // Threshold is low (2) because each iteration's findAndClick/fillInput
   // retries can take 20-60s on a page with nothing to match — we want Claude
   // to intervene on the second stagnant step, not the fourth.
-  let lastStallUrl = "";
+  let lastStallUrl = '';
   let stallCount = 0;
   const STALL_THRESHOLD = 2;
   const aiBrainHistory = [];
-  const aiBrainEnabled =
-    driver._page &&
-    process.env.CLAUDE_ROTATOR_DISABLE_AI_BRAIN !== "1";
+  const aiBrainEnabled = driver._page && process.env.CLAUDE_ROTATOR_DISABLE_AI_BRAIN !== '1';
 
   for (let step = 0; step < 20; step++) {
     await sleep(2500);
-    const url = await driver.currentUrl().catch(() => "");
+    const url = await driver.currentUrl().catch(() => '');
     log(`Step ${step} [${driver.name}]: ${url.substring(0, 100)}`);
 
     // Stall check — run BEFORE the URL pattern dispatcher so an unknown
     // challenge page gets escalated to the AI brain. Skip on the very first
     // step (no history yet) and skip inside the manual driver.
-    if (aiBrainEnabled && step > 0 && driver.name !== "manual") {
+    if (aiBrainEnabled && step > 0 && driver.name !== 'manual') {
       if (url && url === lastStallUrl) {
         stallCount++;
       } else {
         stallCount = 0;
       }
       lastStallUrl = url;
-      if (
-        stallCount >= STALL_THRESHOLD &&
-        aiBrainHistory.length < AI_BRAIN_MAX_DECISIONS
-      ) {
+      if (stallCount >= STALL_THRESHOLD && aiBrainHistory.length < AI_BRAIN_MAX_DECISIONS) {
         const stallReason = `url stagnant for ${stallCount} steps: ${url.substring(0, 100)}`;
         log(`[ai-brain] STALL DETECTED — ${stallReason}`);
         const action = await askAIBrain({
@@ -1647,16 +1552,14 @@ async function runAuthFlow(driver, account) {
           logger: (m) => log(`[ai-brain] ${m}`),
         });
         aiBrainHistory.push(
-          `${action.action}${action.selector ? `(${String(action.selector).slice(0, 40)})` : ""} — ${String(action.reason || "").slice(0, 60)}`,
+          `${action.action}${action.selector ? `(${String(action.selector).slice(0, 40)})` : ''} — ${String(action.reason || '').slice(0, 60)}`,
         );
-        if (action.action === "abort") {
-          log(
-            `[ai-brain] aborted — reason: ${action.reason}. Returning to caller.`,
-          );
+        if (action.action === 'abort') {
+          log(`[ai-brain] aborted — reason: ${action.reason}. Returning to caller.`);
           return false;
         }
         const ok = await executeAIAction(driver, action, { googlePassword });
-        log(`[ai-brain] executed ${action.action}: ${ok ? "ok" : "no-op"}`);
+        log(`[ai-brain] executed ${action.action}: ${ok ? 'ok' : 'no-op'}`);
         stallCount = 0;
         await sleep(3000);
         continue;
@@ -1666,45 +1569,40 @@ async function runAuthFlow(driver, account) {
     // Success: redirected to localhost callback (check hostname, not query string)
     try {
       const parsed = new URL(url);
-      if (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1") {
-        log("Auth callback reached (localhost) — success");
+      if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
+        log('Auth callback reached (localhost) — success');
         return true;
       }
     } catch {}
 
     // Success: landed on platform.claude.com success page
-    if (url.includes("/oauth/code/success")) {
-      log("Auth success page reached");
+    if (url.includes('/oauth/code/success')) {
+      log('Auth success page reached');
       return true;
     }
 
     // Anthropic fallback redirect — extract code and replay to CLI's localhost
-    if (url.includes("/oauth/code/callback") && url.includes("code=")) {
-      log(
-        "Auth callback reached (platform.claude.com) — replaying to localhost",
-      );
+    if (url.includes('/oauth/code/callback') && url.includes('code=')) {
+      log('Auth callback reached (platform.claude.com) — replaying to localhost');
       const codeMatch = url.match(/[?&]code=([^&]+)/);
       const stateMatch = url.match(/[?&]state=([^&]+)/);
       if (codeMatch && driver._localhostPort) {
-        const replayUrl = `http://localhost:${driver._localhostPort}/callback?code=${codeMatch[1]}${stateMatch ? "&state=" + stateMatch[1] : ""}`;
+        const replayUrl = `http://localhost:${driver._localhostPort}/callback?code=${codeMatch[1]}${stateMatch ? '&state=' + stateMatch[1] : ''}`;
         try {
           execSync(`curl -s "${replayUrl}" -o /dev/null`, { timeout: 5000 });
         } catch {}
       }
       return true;
     }
-    if (driver.name === "manual") {
+    if (driver.name === 'manual') {
       await sleep(12_000);
       continue;
     }
 
     // Google 2FA: push notification to phone (/challenge/dp) — can't automate, must switch
-    if (url.includes("accounts.google.com") && url.includes("challenge/dp")) {
+    if (url.includes('accounts.google.com') && url.includes('challenge/dp')) {
       log(`Push-notification 2FA detected — clicking "Try another way"`);
-      const clicked = await driver.findAndClick([
-        "Try another way",
-        "Probeer een andere manier",
-      ]);
+      const clicked = await driver.findAndClick(['Try another way', 'Probeer een andere manier']);
       if (!clicked) {
         log(`Could not find "Try another way" button`);
         return false;
@@ -1715,15 +1613,15 @@ async function runAuthFlow(driver, account) {
 
     // Google passkey challenge (/challenge/pk/presend, /challenge/pk/verify).
     // No hardware key available — bail out via "Try another way".
-    if (url.includes("accounts.google.com") && url.includes("/challenge/pk")) {
+    if (url.includes('accounts.google.com') && url.includes('/challenge/pk')) {
       log(`Passkey challenge detected — clicking "Try another way"`);
       const clicked = await driver.findAndClick([
-        "Try another way",
-        "Try another method",
-        "Use password instead",
-        "Use your password instead",
-        "Probeer een andere manier",
-        "Gebruik wachtwoord",
+        'Try another way',
+        'Try another method',
+        'Use password instead',
+        'Use your password instead',
+        'Probeer een andere manier',
+        'Gebruik wachtwoord',
         'button:has-text("Try another way")',
         'button:has-text("Use password")',
         '[jsname="QkNstf"]',
@@ -1745,31 +1643,28 @@ async function runAuthFlow(driver, account) {
     //   - data-challengetype="6"  → TOTP authenticator app
     // Preference: password (we have it via dcli) > TOTP (we have the secret)
     //           > SMS (requires a phone) > passkey (no hardware).
-    if (
-      url.includes("accounts.google.com") &&
-      url.includes("challenge/selection")
-    ) {
+    if (url.includes('accounts.google.com') && url.includes('challenge/selection')) {
       log(`On 2FA selection page — prefer password, then TOTP, then SMS`);
       const selectors = [];
       if (googlePassword)
         selectors.push(
           'div[data-challengetype="1"]',
           'li:has-text("Enter your password")',
-          "Enter your password",
-          "Wachtwoord invoeren",
+          'Enter your password',
+          'Wachtwoord invoeren',
         );
       if (googleOtpSecret)
         selectors.push(
           'div[data-challengetype="6"]',
           'li:has-text("Google Authenticator")',
-          "Google Authenticator",
-          "Authenticator app",
+          'Google Authenticator',
+          'Authenticator app',
         );
       selectors.push(
         'div[data-challengetype="9"]',
         'li:has-text("Get a verification code")',
-        "Get a verification code",
-        "Text message",
+        'Get a verification code',
+        'Text message',
       );
       const clicked = await driver.findAndClick(selectors);
       if (clicked) {
@@ -1781,30 +1676,24 @@ async function runAuthFlow(driver, account) {
     }
 
     // Google 2FA: TOTP code entry
-    if (url.includes("accounts.google.com") && url.includes("challenge/totp")) {
+    if (url.includes('accounts.google.com') && url.includes('challenge/totp')) {
       if (googleOtpSecret) {
         const code = generateTOTP(googleOtpSecret);
         log(`Entering TOTP code from dcli secret`);
-        await driver.fillInput(
-          'input[type="tel"], input[name=totpPin], #totpPin',
-          code,
-        );
+        await driver.fillInput('input[type="tel"], input[name=totpPin], #totpPin', code);
         await sleep(500);
-        await driver.findAndClick(["Next", "#totpNext button", "Verify"]);
+        await driver.findAndClick(['Next', '#totpNext button', 'Verify']);
         await sleep(3000);
         continue;
       }
       log(`No TOTP secret — trying alternate verification`);
-      await driver.findAndClick(["Try another way"]);
+      await driver.findAndClick(['Try another way']);
       await sleep(2000);
       continue;
     }
 
     // Google 2FA: SMS phone collect (/challenge/ipp/collect) — enter phone, click Send
-    if (
-      url.includes("accounts.google.com") &&
-      url.includes("challenge/ipp/collect")
-    ) {
+    if (url.includes('accounts.google.com') && url.includes('challenge/ipp/collect')) {
       if (!googleSmsPhone) {
         log(
           `SMS phone collect page — no phone (set CLAUDE_ROTATION_GOOGLE_SMS_PHONE, account.googleSmsPhone, or dcli phone on google.com cred)`,
@@ -1812,20 +1701,17 @@ async function runAuthFlow(driver, account) {
         return false;
       }
       log(`SMS phone collect — entering configured number and clicking Send`);
-      await driver.fillInput(
-        '#phoneNumberId, input[type="tel"]',
-        googleSmsPhone,
-      );
+      await driver.fillInput('#phoneNumberId, input[type="tel"]', googleSmsPhone);
       await sleep(500);
-      await driver.findAndClick(["Send", "Next", "Verstuur"]);
+      await driver.findAndClick(['Send', 'Next', 'Verstuur']);
       await sleep(4000);
       continue;
     }
 
     // Google 2FA: SMS code verify (/challenge/ipp/verify or /challenge/sms)
     if (
-      url.includes("accounts.google.com") &&
-      (url.includes("challenge/ipp/verify") || url.includes("challenge/sms"))
+      url.includes('accounts.google.com') &&
+      (url.includes('challenge/ipp/verify') || url.includes('challenge/sms'))
     ) {
       log(`Waiting for SMS code from Messages.app (up to 60s)...`);
       let smsCode = null;
@@ -1839,22 +1725,19 @@ async function runAuthFlow(driver, account) {
         return false;
       }
       log(`Got SMS code: ${smsCode}`);
-      await driver.fillInput(
-        '#idvPin, input[name="Pin"], input[type="tel"]',
-        smsCode,
-      );
+      await driver.fillInput('#idvPin, input[name="Pin"], input[type="tel"]', smsCode);
       await sleep(500);
-      await driver.findAndClick(["Next", "Verify"]);
+      await driver.findAndClick(['Next', 'Verify']);
       await sleep(4000);
       continue;
     }
 
     // Google consent page (/signin/oauth/id or /signin/oauth/consent) — click Continue
     if (
-      url.includes("accounts.google.com") &&
-      (url.includes("/signin/oauth/id") ||
-        url.includes("/signin/oauth/consent") ||
-        url.includes("/signin/oauth/legacy"))
+      url.includes('accounts.google.com') &&
+      (url.includes('/signin/oauth/id') ||
+        url.includes('/signin/oauth/consent') ||
+        url.includes('/signin/oauth/legacy'))
     ) {
       log(`Google OAuth consent — clicking Continue`);
       // Workspace accounts show a scope list with a Continue button at the bottom;
@@ -1872,12 +1755,12 @@ async function runAuthFlow(driver, account) {
         '[role="button"]:has-text("Continue")',
         '[role="button"]:has-text("Allow")',
         '[role="button"]:has-text("Approve")',
-        "Continue",
-        "Allow",
-        "Approve",
-        "Confirm",
-        "Doorgaan",
-        "Toestaan",
+        'Continue',
+        'Allow',
+        'Approve',
+        'Confirm',
+        'Doorgaan',
+        'Toestaan',
       ]);
       if (!clicked) {
         log(`Continue button not found on consent page — waiting and retrying`);
@@ -1888,17 +1771,17 @@ async function runAuthFlow(driver, account) {
 
     // Google password prompt (standalone /challenge/pwd — must run BEFORE the
     // broad accounts.google.com account-chooser branch below).
-    if (url.includes("accounts.google.com") && url.includes("challenge/pwd")) {
+    if (url.includes('accounts.google.com') && url.includes('challenge/pwd')) {
       if (googlePassword) {
         await driver.fillInput('input[type="password"]', googlePassword);
         await sleep(500);
-        await driver.findAndClick(["Next", "#passwordNext button"]);
+        await driver.findAndClick(['Next', '#passwordNext button']);
         continue;
       }
     }
 
     // Google account chooser — click the target account
-    if (url.includes("accounts.google.com")) {
+    if (url.includes('accounts.google.com')) {
       // Detect "Signed out" next to the target account (needs re-login)
       let targetSignedOut = false;
       if (driver.readPageText) {
@@ -1907,36 +1790,28 @@ async function runAuthFlow(driver, account) {
           const emailIdx = txt.indexOf(account.email.toLowerCase());
           if (emailIdx >= 0) {
             const nearby = txt.substring(emailIdx, emailIdx + 200);
-            targetSignedOut = nearby.includes("signed out");
+            targetSignedOut = nearby.includes('signed out');
           }
         } catch {}
       }
 
-      const picked = await driver.findAndClick([
-        account.email,
-        `data-identifier="${account.email}"`,
-      ]);
+      const picked = await driver.findAndClick([account.email, `data-identifier="${account.email}"`]);
       if (picked && targetSignedOut && googlePassword) {
         // Account was signed out — click picked it, now password prompt will appear
-        log(
-          `Account ${account.email} was signed out — password flow will handle`,
-        );
+        log(`Account ${account.email} was signed out — password flow will handle`);
       }
       if (!picked) {
         // Not in list — add manually
-        await driver.findAndClick(["Use another account", "Add account"]);
+        await driver.findAndClick(['Use another account', 'Add account']);
         await sleep(2000);
-        await driver.fillInput(
-          'input[type="email"], #identifierId',
-          account.email,
-        );
+        await driver.fillInput('input[type="email"], #identifierId', account.email);
         await sleep(500);
-        await driver.findAndClick(["Next", "#identifierNext button"]);
+        await driver.findAndClick(['Next', '#identifierNext button']);
         await sleep(2000);
         if (googlePassword) {
           await driver.fillInput('input[type="password"]', googlePassword);
           await sleep(500);
-          await driver.findAndClick(["Next", "#passwordNext button"]);
+          await driver.findAndClick(['Next', '#passwordNext button']);
         }
       }
       continue;
@@ -1949,32 +1824,32 @@ async function runAuthFlow(driver, account) {
     // several times (select-organization, onboarding/organization, workspaces,
     // choose-workspace). Also triggers on page-text heuristic for routes we miss.
     const isOrgChooserUrl =
-      url.includes("claude.ai") &&
-      (url.includes("select-organization") ||
-        url.includes("/onboarding/organization") ||
-        url.includes("choose-organization") ||
-        url.includes("select-workspace") ||
-        url.includes("choose-workspace") ||
-        url.includes("workspaces") ||
-        url.includes("select-account") ||
-        url.includes("switch-org"));
+      url.includes('claude.ai') &&
+      (url.includes('select-organization') ||
+        url.includes('/onboarding/organization') ||
+        url.includes('choose-organization') ||
+        url.includes('select-workspace') ||
+        url.includes('choose-workspace') ||
+        url.includes('workspaces') ||
+        url.includes('select-account') ||
+        url.includes('switch-org'));
     let isOrgChooserByText = false;
-    if (!isOrgChooserUrl && url.includes("claude.ai") && driver.readPageText) {
+    if (!isOrgChooserUrl && url.includes('claude.ai') && driver.readPageText) {
       try {
         const t = (await driver.readPageText()).toLowerCase();
         isOrgChooserByText =
-          (t.includes("choose an organization") ||
-            t.includes("select an organization") ||
-            t.includes("choose a workspace") ||
-            t.includes("select a workspace") ||
-            t.includes("which organization")) &&
-          (t.includes("personal") || t.includes("organization"));
+          (t.includes('choose an organization') ||
+            t.includes('select an organization') ||
+            t.includes('choose a workspace') ||
+            t.includes('select a workspace') ||
+            t.includes('which organization')) &&
+          (t.includes('personal') || t.includes('organization'));
       } catch {}
     }
     if (isOrgChooserUrl || isOrgChooserByText) {
-      const orgLabel = account.organization || account.orgName || "Personal";
+      const orgLabel = account.organization || account.orgName || 'Personal';
       log(
-        `Claude organization chooser (${isOrgChooserByText ? "via page-text" : "via URL"}) — selecting "${orgLabel}"`,
+        `Claude organization chooser (${isOrgChooserByText ? 'via page-text' : 'via URL'}) — selecting "${orgLabel}"`,
       );
       // Dump all visible button/link labels so we can see the real workspace
       // names claude.ai is showing (vs what's configured as orgName).
@@ -1983,8 +1858,8 @@ async function runAuthFlow(driver, account) {
           const t = await driver.readPageText();
           const labels = [
             ...new Set(
-              (t || "")
-                .split("\n")
+              (t || '')
+                .split('\n')
                 .map((l) => l.trim())
                 .filter((l) => l.length > 0 && l.length < 80),
             ),
@@ -1999,12 +1874,10 @@ async function runAuthFlow(driver, account) {
         orgLabel,
         // Only fall back to "Personal" / "Continue" if the configured label
         // is itself Personal — never silently default a team account to Personal.
-        ...(orgLabel === "Personal" ? ["Personal", "Continue"] : []),
+        ...(orgLabel === 'Personal' ? ['Personal', 'Continue'] : []),
       ]);
       if (!picked) {
-        log(
-          `No organization button matched "${orgLabel}" — the account may land on the wrong org`,
-        );
+        log(`No organization button matched "${orgLabel}" — the account may land on the wrong org`);
       }
       await sleep(3000);
       continue;
@@ -2013,40 +1886,31 @@ async function runAuthFlow(driver, account) {
     // Claude OAuth consent page — MUST check account BEFORE clicking Authorize.
     // Match by pathname only — URL params (like redirect_uri=...callback) would
     // false-match a substring check on the full URL.
-    let oauthPath = "";
+    let oauthPath = '';
     try {
       oauthPath = new URL(url).pathname;
     } catch {}
-    if (
-      oauthPath.includes("/oauth/authorize") ||
-      (oauthPath.endsWith("/authorize") && url.includes("claude"))
-    ) {
+    if (oauthPath.includes('/oauth/authorize') || (oauthPath.endsWith('/authorize') && url.includes('claude'))) {
       // Step 1: Read page to verify "Logged in as <correct email>"
-      let pageText = "";
+      let pageText = '';
       if (driver.readPageText) {
         try {
           pageText = (await driver.readPageText()).toLowerCase();
         } catch {}
       }
 
-      const hasCorrectAccount =
-        pageText && pageText.includes(account.email.toLowerCase());
-      const hasAnyOtherEmail =
-        pageText &&
-        /[\w.+-]+@[\w.-]+\.\w+/.test(pageText) &&
-        !hasCorrectAccount;
+      const hasCorrectAccount = pageText && pageText.includes(account.email.toLowerCase());
+      const hasAnyOtherEmail = pageText && /[\w.+-]+@[\w.-]+\.\w+/.test(pageText) && !hasCorrectAccount;
 
       // If we can't read the page OR we see the wrong account, force switch
       if (!pageText || hasAnyOtherEmail) {
-        log(
-          `Page text: ${pageText ? "wrong account" : "unreadable"} — clicking Switch account / Logout`,
-        );
+        log(`Page text: ${pageText ? 'wrong account' : 'unreadable'} — clicking Switch account / Logout`);
         const switched = await driver.findAndClick([
-          "Switch account",
-          "Log out",
-          "Logout",
-          "Sign out",
-          "Use another account",
+          'Switch account',
+          'Log out',
+          'Logout',
+          'Sign out',
+          'Use another account',
         ]);
         if (switched) {
           await sleep(3000);
@@ -2068,26 +1932,20 @@ async function runAuthFlow(driver, account) {
       // Step 2: Click Authorize — wait for button to become enabled (up to 30s)
       let authorized = false;
       for (let wait = 0; wait < 6; wait++) {
-        if (
-          await driver.findAndClick(["Authorize", "Allow", "Approve", "Accept"])
-        ) {
-          log("Clicked Authorize");
+        if (await driver.findAndClick(['Authorize', 'Allow', 'Approve', 'Accept'])) {
+          log('Clicked Authorize');
           authorized = true;
           break;
         }
         // Button might exist but be disabled — wait for page to finish loading
-        log(
-          `Authorize button not clickable — waiting (attempt ${wait + 1}/6)...`,
-        );
+        log(`Authorize button not clickable — waiting (attempt ${wait + 1}/6)...`);
         await sleep(5000);
       }
       if (authorized) {
         await sleep(4000);
         continue;
       }
-      log(
-        "Authorize button still not clickable after 30s — escalating to ai-brain",
-      );
+      log('Authorize button still not clickable after 30s — escalating to ai-brain');
       // Fast-path ai-brain escalation: don't wait for stall detector to catch up
       // on the next loop iter. The page is stuck on OAuth authorize and Haiku
       // can usually pick the right org/continue button immediately.
@@ -2100,11 +1958,11 @@ async function runAuthFlow(driver, account) {
           logger: (m) => log(`[ai-brain] ${m}`),
         });
         aiBrainHistory.push(
-          `${action.action}${action.selector ? `(${String(action.selector).slice(0, 40)})` : ""} — ${String(action.reason || "").slice(0, 60)}`,
+          `${action.action}${action.selector ? `(${String(action.selector).slice(0, 40)})` : ''} — ${String(action.reason || '').slice(0, 60)}`,
         );
-        if (action.action !== "abort") {
+        if (action.action !== 'abort') {
           const ok = await executeAIAction(driver, action, { googlePassword });
-          log(`[ai-brain] executed ${action.action}: ${ok ? "ok" : "no-op"}`);
+          log(`[ai-brain] executed ${action.action}: ${ok ? 'ok' : 'no-op'}`);
           stallCount = 0;
           await sleep(3000);
           continue;
@@ -2116,24 +1974,21 @@ async function runAuthFlow(driver, account) {
     }
 
     // Dismiss cookie consent banner if present (blocks clicks on everything else)
-    if (url.includes("claude.ai")) {
+    if (url.includes('claude.ai')) {
       await driver.findAndClick([
         '[data-testid="consent-reject"]',
         '[data-testid="consent-accept"]',
-        "Reject All Cookies",
-        "Accept All Cookies",
+        'Reject All Cookies',
+        'Accept All Cookies',
       ]);
       await sleep(500);
     }
 
     // Claude.ai login → Magic link path (when account.useMagicLink is set)
     // The email input is always visible on /login — no button click needed first.
-    if (account.useMagicLink && url.includes("claude.ai/login")) {
+    if (account.useMagicLink && url.includes('claude.ai/login')) {
       // Fill the email input directly
-      const filled = await driver.fillInput(
-        '[data-testid="email"], #email, input[type="email"]',
-        account.email,
-      );
+      const filled = await driver.fillInput('[data-testid="email"], #email, input[type="email"]', account.email);
       if (filled) {
         log(`[magic-link] Filled email: ${account.email}`);
         await sleep(500);
@@ -2150,19 +2005,14 @@ async function runAuthFlow(driver, account) {
           // Poll Gmail for the magic link
           const magicLink = await pollGmailForMagicLink(account.email);
           if (magicLink) {
-            if (magicLink.startsWith("code:")) {
-              const code = magicLink.replace("code:", "");
+            if (magicLink.startsWith('code:')) {
+              const code = magicLink.replace('code:', '');
               log(`[magic-link] Entering verification code: ${code}`);
               await driver.fillInput(
                 'input[type="text"], input[type="number"], input[name="code"], input[placeholder*="code" i]',
                 code,
               );
-              await driver.findAndClick([
-                "Continue",
-                "Verify",
-                "Submit",
-                'button[type="submit"]',
-              ]);
+              await driver.findAndClick(['Continue', 'Verify', 'Submit', 'button[type="submit"]']);
             } else {
               log(`[magic-link] Navigating to login link`);
               await driver.goto(magicLink);
@@ -2177,16 +2027,13 @@ async function runAuthFlow(driver, account) {
               // the "last active" org silently, and both sibling vaults end up
               // holding the same org's token.
               const isMultiOrg =
-                account.label &&
-                account.orgName &&
-                account.orgName.toLowerCase() !==
-                  account.email.toLowerCase();
+                account.label && account.orgName && account.orgName.toLowerCase() !== account.email.toLowerCase();
               if (isMultiOrg) {
                 log(
                   `[magic-link] Multi-org account — forcing org pick for "${account.orgName}" via claude.ai/home detour`,
                 );
                 try {
-                  await driver.goto("https://claude.ai/home");
+                  await driver.goto('https://claude.ai/home');
                 } catch {}
                 await sleep(3500);
                 // Try to click the configured orgName if a chooser is showing.
@@ -2200,9 +2047,7 @@ async function runAuthFlow(driver, account) {
                   account.orgName,
                 ]);
                 if (picked) {
-                  log(
-                    `[magic-link] Pre-selected org "${account.orgName}" before OAuth`,
-                  );
+                  log(`[magic-link] Pre-selected org "${account.orgName}" before OAuth`);
                   await sleep(2500);
                 } else {
                   log(
@@ -2218,48 +2063,31 @@ async function runAuthFlow(driver, account) {
             }
             continue;
           }
-          log(
-            `[magic-link] No magic link found in Gmail — falling through to Google OAuth`,
-          );
+          log(`[magic-link] No magic link found in Gmail — falling through to Google OAuth`);
         }
       }
     }
 
     // Claude.ai login → Continue with Google (button has data-testid="login-with-google")
-    const popupP = driver.waitForPopup
-      ? driver.waitForPopup(15_000)
-      : Promise.resolve(null);
+    const popupP = driver.waitForPopup ? driver.waitForPopup(15_000) : Promise.resolve(null);
     if (
-      await driver.findAndClick([
-        '[data-testid="login-with-google"]',
-        "Continue with Google",
-        "Sign in with Google",
-      ])
+      await driver.findAndClick(['[data-testid="login-with-google"]', 'Continue with Google', 'Sign in with Google'])
     ) {
       const popup = await popupP;
       if (popup) {
         // Kapture popup is already a full driver; Playwright returns a raw Page
-        const pd = popup.name
-          ? popup
-          : buildPageDriver(driver.name + "-popup", popup, () => {}, null);
+        const pd = popup.name ? popup : buildPageDriver(driver.name + '-popup', popup, () => {}, null);
         await runAuthFlow(pd, account);
         if (popup.waitForEvent) {
-          await popup
-            .waitForEvent("close", { timeout: 30_000 })
-            .catch(() => {});
+          await popup.waitForEvent('close', { timeout: 30_000 }).catch(() => {});
         }
       }
       continue;
     }
 
     // Email input
-    if (
-      await driver.fillInput(
-        '#identifierId, input[type="email"]',
-        account.email,
-      )
-    ) {
-      await driver.findAndClick(["Next", "#identifierNext button"]);
+    if (await driver.fillInput('#identifierId, input[type="email"]', account.email)) {
+      await driver.findAndClick(['Next', '#identifierNext button']);
     }
   }
 
@@ -2267,13 +2095,9 @@ async function runAuthFlow(driver, account) {
   // legitimately exceed 20 steps (multi-factor + workspace chooser + consent),
   // so give Claude up to its remaining decision budget to unstick us.
   if (aiBrainEnabled && aiBrainHistory.length < AI_BRAIN_MAX_DECISIONS) {
-    const url = await driver.currentUrl().catch(() => "");
+    const url = await driver.currentUrl().catch(() => '');
     log(`[ai-brain] loop exhausted — final rescue attempt`);
-    for (
-      let rescue = 0;
-      rescue < AI_BRAIN_MAX_DECISIONS - aiBrainHistory.length && rescue < 3;
-      rescue++
-    ) {
+    for (let rescue = 0; rescue < AI_BRAIN_MAX_DECISIONS - aiBrainHistory.length && rescue < 3; rescue++) {
       const action = await askAIBrain({
         page: driver._page,
         account,
@@ -2282,22 +2106,22 @@ async function runAuthFlow(driver, account) {
         logger: (m) => log(`[ai-brain] ${m}`),
       });
       aiBrainHistory.push(
-        `${action.action}${action.selector ? `(${String(action.selector).slice(0, 40)})` : ""} — ${String(action.reason || "").slice(0, 60)}`,
+        `${action.action}${action.selector ? `(${String(action.selector).slice(0, 40)})` : ''} — ${String(action.reason || '').slice(0, 60)}`,
       );
-      if (action.action === "abort") break;
+      if (action.action === 'abort') break;
       await executeAIAction(driver, action, { googlePassword });
       await sleep(4000);
       // Re-check success conditions after each rescue action
-      const newUrl = await driver.currentUrl().catch(() => "");
+      const newUrl = await driver.currentUrl().catch(() => '');
       try {
         const parsed = new URL(newUrl);
-        if (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1") {
-          log("[ai-brain] rescue SUCCEEDED — localhost callback reached");
+        if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
+          log('[ai-brain] rescue SUCCEEDED — localhost callback reached');
           return true;
         }
       } catch {}
-      if (newUrl.includes("/oauth/code/success")) {
-        log("[ai-brain] rescue SUCCEEDED — claude.ai success page");
+      if (newUrl.includes('/oauth/code/success')) {
+        log('[ai-brain] rescue SUCCEEDED — claude.ai success page');
         return true;
       }
     }
@@ -2316,9 +2140,9 @@ async function browserOAuthFallback(account) {
   writeFileSync(capScript, `#!/bin/bash\necho "$1" > "${urlFile}"\n`);
   chmodSync(capScript, 0o755);
 
-  const proc = spawn("claude", ["auth", "login", "--email", account.email], {
+  const proc = spawn('claude', ['auth', 'login', '--email', account.email], {
     env: { ...process.env, BROWSER: capScript },
-    stdio: ["pipe", "pipe", "pipe"],
+    stdio: ['pipe', 'pipe', 'pipe'],
   });
 
   // BROWSER script gets the URL with localhost redirect (what we want).
@@ -2328,11 +2152,11 @@ async function browserOAuthFallback(account) {
   for (let i = 0; i < 30; i++) {
     await sleep(500);
     if (existsSync(urlFile)) {
-      const u = readFileSync(urlFile, "utf8").trim();
+      const u = readFileSync(urlFile, 'utf8').trim();
       try {
         unlinkSync(urlFile);
       } catch {}
-      if (u.startsWith("http")) {
+      if (u.startsWith('http')) {
         authUrl = u;
         break;
       }
@@ -2345,8 +2169,8 @@ async function browserOAuthFallback(account) {
         const m = d.toString().match(/https?:\/\/[^\s\])"'\n]+/);
         if (m) resolve(m[0]);
       };
-      proc.stdout.on("data", scan);
-      proc.stderr.on("data", scan);
+      proc.stdout.on('data', scan);
+      proc.stderr.on('data', scan);
       setTimeout(() => resolve(null), 15_000);
     });
   }
@@ -2361,11 +2185,9 @@ async function browserOAuthFallback(account) {
   log(`Auth URL captured: ${authUrl.substring(0, 80)}...`);
 
   // Extract localhost port from redirect_uri in the auth URL for code replay
-  const portMatch = authUrl.match(
-    /redirect_uri=http%3A%2F%2Flocalhost%3A(\d+)/,
-  );
+  const portMatch = authUrl.match(/redirect_uri=http%3A%2F%2Flocalhost%3A(\d+)/);
   const localhostPort = portMatch ? portMatch[1] : null;
-  log(`Localhost callback port: ${localhostPort || "unknown"}`);
+  log(`Localhost callback port: ${localhostPort || 'unknown'}`);
 
   // Cascade: try each driver in order until one completes the OAuth flow.
   // A driver "fails" if runAuthFlow returns false (URL never reaches localhost callback).
@@ -2386,11 +2208,11 @@ async function browserOAuthFallback(account) {
     try {
       log(`[${driver._driverName}] Logging out existing claude.ai session...`);
       try {
-        await driver.goto("https://claude.ai/api/auth/logout");
+        await driver.goto('https://claude.ai/api/auth/logout');
       } catch {}
       await sleep(1500);
       try {
-        await driver.goto("https://claude.ai/logout");
+        await driver.goto('https://claude.ai/logout');
       } catch {}
       await sleep(1500);
 
@@ -2399,9 +2221,7 @@ async function browserOAuthFallback(account) {
       try {
         await driver.goto(authUrl);
       } catch (navErr) {
-        log(
-          `[${driver._driverName}] Page died after logout (${navErr.message}) — getting fresh driver`,
-        );
+        log(`[${driver._driverName}] Page died after logout (${navErr.message}) — getting fresh driver`);
         try {
           await driver.close();
         } catch {}
@@ -2410,19 +2230,15 @@ async function browserOAuthFallback(account) {
           driver._localhostPort = localhostPort;
           await driver.goto(authUrl);
         } catch (freshErr) {
-          log(
-            `[${driver._driverName}] Fresh driver also failed: ${freshErr.message}`,
-          );
-          failed.add(driver._driverName || "unknown");
+          log(`[${driver._driverName}] Fresh driver also failed: ${freshErr.message}`);
+          failed.add(driver._driverName || 'unknown');
           continue;
         }
       }
       success = await runAuthFlow(driver, account);
 
       if (!success) {
-        log(
-          `[${driver._driverName}] runAuthFlow returned false — trying next driver`,
-        );
+        log(`[${driver._driverName}] runAuthFlow returned false — trying next driver`);
         failed.add(driver._driverName);
         continue;
       }
@@ -2433,7 +2249,7 @@ async function browserOAuthFallback(account) {
           proc.kill();
           r();
         }, 30_000);
-        proc.on("exit", () => {
+        proc.on('exit', () => {
           clearTimeout(t);
           r();
         });
@@ -2476,13 +2292,13 @@ function findClaudeSessions() {
       )
         .toString()
         .trim();
-      for (const line of paneOut.split("\n")) {
-        const [tty, pane] = line.split("|");
+      for (const line of paneOut.split('\n')) {
+        const [tty, pane] = line.split('|');
         if (tty && pane) ttyMap[tty] = pane;
       }
     } catch {}
 
-    for (const line of psOut.split("\n")) {
+    for (const line of psOut.split('\n')) {
       const match = line.trim().match(/^(\d+)\s+(ttys?\d+)\s+(.+)$/);
       if (!match) continue;
       const [, pid, ttyShort, args] = match;
@@ -2493,9 +2309,7 @@ function findClaudeSessions() {
       sessions.push({ pid: parseInt(pid), tty, pane, resumeId, args });
     }
   } catch (e) {
-    log(
-      `[session] Failed to enumerate sessions: ${e.message.substring(0, 80)}`,
-    );
+    log(`[session] Failed to enumerate sessions: ${e.message.substring(0, 80)}`);
   }
   return sessions;
 }
@@ -2503,10 +2317,7 @@ function findClaudeSessions() {
 function sendKeysToPane(pane, txt) {
   if (!pane) return false;
   try {
-    execSync(
-      `tmux send-keys -t ${JSON.stringify(pane)} ${JSON.stringify(txt)} C-m 2>/dev/null`,
-      { timeout: 3000 },
-    );
+    execSync(`tmux send-keys -t ${JSON.stringify(pane)} ${JSON.stringify(txt)} C-m 2>/dev/null`, { timeout: 3000 });
     return true;
   } catch {
     return false;
@@ -2518,7 +2329,7 @@ function sendKeysToITerm(tty, txt) {
   // IMPORTANT: Use `tell s to write text cmd` — the `write text "..." in s`
   // form fails with -1723 ("Can't get ... in s. Access not allowed.") because
   // AppleScript parses the `in s` clause as an accessor lookup, not a target.
-  const escaped = txt.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  const escaped = txt.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
   const script = `
 tell application "iTerm2"
   repeat with w in windows
@@ -2534,13 +2345,10 @@ tell application "iTerm2"
   return "not_found"
 end tell`;
   try {
-    const result = execSync(
-      `osascript -e '${script.replace(/'/g, "'\"'\"'")}'`,
-      { timeout: 5000 },
-    )
+    const result = execSync(`osascript -e '${script.replace(/'/g, "'\"'\"'")}'`, { timeout: 5000 })
       .toString()
       .trim();
-    return result === "ok";
+    return result === 'ok';
   } catch {
     return false;
   }
@@ -2552,11 +2360,9 @@ end tell`;
 // terminals we know actually support it without launching a new app.
 function detectTerminalForPid(pid) {
   try {
-    const out = execSync(`ps -eo pid,ppid,comm`, { timeout: 3000 })
-      .toString()
-      .trim();
+    const out = execSync(`ps -eo pid,ppid,comm`, { timeout: 3000 }).toString().trim();
     const byPid = new Map();
-    for (const line of out.split("\n").slice(1)) {
+    for (const line of out.split('\n').slice(1)) {
       const m = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/);
       if (m) byPid.set(parseInt(m[1]), { ppid: parseInt(m[2]), comm: m[3] });
     }
@@ -2565,16 +2371,16 @@ function detectTerminalForPid(pid) {
       const entry = byPid.get(cur);
       if (!entry) break;
       const c = entry.comm.toLowerCase();
-      if (c.includes("ghostty")) return "Ghostty";
-      if (c.includes("iterm2") || c.includes("iterm")) return "iTerm2";
-      if (c.includes("terminal.app") || /\/terminal$/.test(c)) return "Terminal";
-      if (c.includes("alacritty")) return "Alacritty";
-      if (c.includes("wezterm")) return "WezTerm";
-      if (c.includes("kitty")) return "kitty";
+      if (c.includes('ghostty')) return 'Ghostty';
+      if (c.includes('iterm2') || c.includes('iterm')) return 'iTerm2';
+      if (c.includes('terminal.app') || /\/terminal$/.test(c)) return 'Terminal';
+      if (c.includes('alacritty')) return 'Alacritty';
+      if (c.includes('wezterm')) return 'WezTerm';
+      if (c.includes('kitty')) return 'kitty';
       cur = entry.ppid;
     }
   } catch {}
-  return "unknown";
+  return 'unknown';
 }
 
 async function refreshRunningSession(rotatedAccount = null, noBrowser = false) {
@@ -2582,7 +2388,7 @@ async function refreshRunningSession(rotatedAccount = null, noBrowser = false) {
   const sessions = findClaudeSessions();
 
   if (sessions.length === 0) {
-    log("[session] No running Claude Code sessions found");
+    log('[session] No running Claude Code sessions found');
     return;
   }
 
@@ -2596,8 +2402,7 @@ async function refreshRunningSession(rotatedAccount = null, noBrowser = false) {
 
   const sendKeys = (s, txt) => {
     if (s.pane) return sendKeysToPane(s.pane, txt);
-    if (s.terminal === "iTerm2" && s.tty)
-      return sendKeysToITerm(s.tty, txt);
+    if (s.terminal === 'iTerm2' && s.tty) return sendKeysToITerm(s.tty, txt);
     // Ghostty, Terminal.app, Alacritty, WezTerm, kitty, unknown: skip.
     // Raw TTY write would render "/login" as on-screen output text, not
     // stdin — corrupting the session without triggering the re-auth.
@@ -2606,27 +2411,21 @@ async function refreshRunningSession(rotatedAccount = null, noBrowser = false) {
 
   // Reachable = tmux pane OR known-good terminal (iTerm2). Everyone else
   // is logged + skipped so we never pop a visual window or garble Ghostty.
-  const reachable = sessions.filter(
-    (s) => s.pane || (s.terminal === "iTerm2" && s.tty),
-  );
-  const skipped = sessions.filter(
-    (s) => !s.pane && s.terminal && s.terminal !== "iTerm2",
-  );
+  const reachable = sessions.filter((s) => s.pane || (s.terminal === 'iTerm2' && s.tty));
+  const skipped = sessions.filter((s) => !s.pane && s.terminal && s.terminal !== 'iTerm2');
   for (const s of skipped) {
     log(
       `[session] Skipping PID ${s.pid} (${s.terminal}) — no safe inject path; token-refresh daemon keeps keys fresh so restart isn't required`,
     );
   }
   if (reachable.length === 0) {
-    log(
-      `[session] Found ${sessions.length} sessions but none have a reachable TTY`,
-    );
+    log(`[session] Found ${sessions.length} sessions but none have a reachable TTY`);
     return;
   }
 
   log(`[session] Injecting /login into ${reachable.length} session(s):`);
   for (const s of reachable) {
-    log(`  PID ${s.pid} ${s.pane ? "pane=" + s.pane : "tty=" + s.tty}`);
+    log(`  PID ${s.pid} ${s.pane ? 'pane=' + s.pane : 'tty=' + s.tty}`);
   }
 
   // Keychain was already swapped to the fresh account's valid token.
@@ -2634,12 +2433,10 @@ async function refreshRunningSession(rotatedAccount = null, noBrowser = false) {
   // No /exit, no process restart, no OAuth browser flow needed (token is already valid).
   // Stagger slightly to avoid all sessions hitting the API at the exact same millisecond.
   for (const s of reachable) {
-    if (sendKeys(s, "/login")) {
+    if (sendKeys(s, '/login')) {
       log(`[session] Sent /login to PID ${s.pid} (${s.pane || s.tty})`);
     } else {
-      log(
-        `[session] Failed to inject /login to PID ${s.pid} (${s.pane || s.tty})`,
-      );
+      log(`[session] Failed to inject /login to PID ${s.pid} (${s.pane || s.tty})`);
     }
     await sleep(500); // 500ms stagger between sessions
   }
@@ -2653,16 +2450,9 @@ async function refreshRunningSession(rotatedAccount = null, noBrowser = false) {
       await sleep(2000);
       const driver = await getBrowserDriver(new Set()).catch(() => null);
       if (driver) {
-        const url = await driver.currentUrl().catch(() => "");
-        if (
-          url &&
-          (url.includes("oauth") ||
-            url.includes("authorize") ||
-            url.includes("claude.ai/login"))
-        ) {
-          log(
-            `[session] Detected post-restart OAuth page (${url.substring(0, 60)}) — driving flow`,
-          );
+        const url = await driver.currentUrl().catch(() => '');
+        if (url && (url.includes('oauth') || url.includes('authorize') || url.includes('claude.ai/login'))) {
+          log(`[session] Detected post-restart OAuth page (${url.substring(0, 60)}) — driving flow`);
           if (rotatedAccount) await runAuthFlow(driver, rotatedAccount);
         }
         try {
@@ -2670,9 +2460,7 @@ async function refreshRunningSession(rotatedAccount = null, noBrowser = false) {
         } catch {}
       }
     } catch (e) {
-      log(
-        `[session] Post-restart browser check skipped: ${e.message.substring(0, 60)}`,
-      );
+      log(`[session] Post-restart browser check skipped: ${e.message.substring(0, 60)}`);
     }
   }
 
@@ -2688,20 +2476,18 @@ async function rotate(targetEmail, opts = {}) {
 
   if (!targetEmail) {
     // Query live utilization for all accounts before picking — best-effort, ~2s
-    log("Querying live utilization for all accounts...");
+    log('Querying live utilization for all accounts...');
     const liveUtil = await queryAllUtilization(config);
     const utilSummary = Object.entries(liveUtil)
       .map(([k, v]) => `${k}:5h=${v.five_hour_pct}%/7d=${v.seven_day_pct}%`)
-      .join(", ");
+      .join(', ');
     if (utilSummary) log(`Live util: ${utilSummary}`);
     // Snapshot live data into state for future daemon decisions
     for (const [key, util] of Object.entries(liveUtil)) {
       state.accounts[key] = state.accounts[key] || {};
       state.accounts[key].lastUtilization = {
         pct: util.five_hour_pct,
-        reset: util.resets_at_5h
-          ? Math.floor(new Date(util.resets_at_5h).getTime() / 1000)
-          : null,
+        reset: util.resets_at_5h ? Math.floor(new Date(util.resets_at_5h).getTime() / 1000) : null,
         ts: Date.now(),
       };
     }
@@ -2709,7 +2495,7 @@ async function rotate(targetEmail, opts = {}) {
       allowExtraUsage: opts.allowExtraUsage === true,
     });
     if (!next) {
-      log("No account available (all excluded — extra_usage enabled?)");
+      log('No account available (all excluded — extra_usage enabled?)');
       return false;
     }
     targetEmail = accountKey(next);
@@ -2721,37 +2507,31 @@ async function rotate(targetEmail, opts = {}) {
   // to bypass.
   try {
     if (!opts.allowExtraUsage) {
-      const target = config.accounts.find(
-        (a) => accountKey(a) === targetEmail || a.email === targetEmail,
-      );
+      const target = config.accounts.find((a) => accountKey(a) === targetEmail || a.email === targetEmail);
       if (target) {
         const tokenJson = readStoredToken(target);
         if (tokenJson) {
           const parsed = JSON.parse(tokenJson);
           const accessToken = parsed?.claudeAiOauth?.accessToken;
           if (accessToken) {
-            const res = await fetch(
-              "https://api.anthropic.com/api/oauth/profile",
-              {
-                method: "GET",
-                headers: {
-                  Authorization: `Bearer ${accessToken}`,
-                  "anthropic-beta": "oauth-2025-04-20",
-                  "Content-Type": "application/json",
-                },
-                signal: AbortSignal.timeout(5000),
+            const res = await fetch('https://api.anthropic.com/api/oauth/profile', {
+              method: 'GET',
+              headers: {
+                Authorization: `Bearer ${accessToken}`,
+                'anthropic-beta': 'oauth-2025-04-20',
+                'Content-Type': 'application/json',
               },
-            );
+              signal: AbortSignal.timeout(5000),
+            });
             if (res.ok) {
               const prof = await res.json();
-              const euEnabled =
-                prof?.organization?.has_extra_usage_enabled === true;
+              const euEnabled = prof?.organization?.has_extra_usage_enabled === true;
               if (euEnabled) {
                 log(
                   `REFUSED: target ${targetEmail} has extra_usage enabled (pay-per-use). Pass --allow-extra-usage to override.`,
                 );
                 notify(
-                  "Rotation BLOCKED",
+                  'Rotation BLOCKED',
                   `${targetEmail}: extra_usage enabled — would risk credit-card overage. Disable at console.anthropic.com/settings/billing`,
                 );
                 return false;
@@ -2767,8 +2547,7 @@ async function rotate(targetEmail, opts = {}) {
 
   // Find by label first, then by email
   const account =
-    config.accounts.find((a) => accountKey(a) === targetEmail) ||
-    config.accounts.find((a) => a.email === targetEmail);
+    config.accounts.find((a) => accountKey(a) === targetEmail) || config.accounts.find((a) => a.email === targetEmail);
   if (!account) {
     log(`Account ${targetEmail} not in config`);
     return false;
@@ -2776,27 +2555,20 @@ async function rotate(targetEmail, opts = {}) {
   if (opts.magicLink) account.useMagicLink = true;
   const key = accountKey(account);
 
-  log(
-    `=== ROTATING: ${state.activeAccount || "none"} → ${key} (${account.email}) ===`,
-  );
-  notify("Claude Account Rotation", `Switching to ${key}...`);
+  log(`=== ROTATING: ${state.activeAccount || 'none'} → ${key} (${account.email}) ===`);
+  notify('Claude Account Rotation', `Switching to ${key}...`);
 
   // Clear statsig cache to prevent device-level rate limit stickiness (anthropics/claude-code#12786)
   try {
-    const statsigDir = join(process.env.HOME || "", ".claude", "statsig");
+    const statsigDir = join(process.env.HOME || '', '.claude', 'statsig');
     if (existsSync(statsigDir)) {
-      const files = readdirSync(statsigDir).filter((f) =>
-        f.startsWith("statsig.cached.evaluations."),
-      );
+      const files = readdirSync(statsigDir).filter((f) => f.startsWith('statsig.cached.evaluations.'));
       for (const f of files) {
         try {
           unlinkSync(join(statsigDir, f));
         } catch {}
       }
-      if (files.length > 0)
-        log(
-          `Cleared ${files.length} statsig cache files (device-level stickiness fix)`,
-        );
+      if (files.length > 0) log(`Cleared ${files.length} statsig cache files (device-level stickiness fix)`);
     }
   } catch {}
 
@@ -2805,14 +2577,10 @@ async function rotate(targetEmail, opts = {}) {
   // hits the Anthropic API and fails when we're already rate limited.
   // Trust state.activeAccount instead.
   if (opts.noBrowser) {
-    const trackedAccount = config.accounts.find(
-      (a) => accountKey(a) === state.activeAccount,
-    );
+    const trackedAccount = config.accounts.find((a) => accountKey(a) === state.activeAccount);
     if (trackedAccount) {
       if (!dryRun) saveCurrentToken(trackedAccount);
-      log(
-        `[no-browser] Saved outgoing token for tracked ${accountKey(trackedAccount)}`,
-      );
+      log(`[no-browser] Saved outgoing token for tracked ${accountKey(trackedAccount)}`);
     } else {
       log(`[no-browser] No tracked active account — skipping outgoing save`);
     }
@@ -2833,20 +2601,16 @@ async function rotate(targetEmail, opts = {}) {
       let liveOrgUuid = null;
       if (liveTokenJson) {
         try {
-          const liveAccessToken =
-            JSON.parse(liveTokenJson)?.claudeAiOauth?.accessToken;
+          const liveAccessToken = JSON.parse(liveTokenJson)?.claudeAiOauth?.accessToken;
           if (liveAccessToken) {
-            const res = await fetch(
-              "https://api.anthropic.com/api/oauth/profile",
-              {
-                method: "GET",
-                headers: {
-                  Authorization: `Bearer ${liveAccessToken}`,
-                  "anthropic-beta": "oauth-2025-04-20",
-                },
-                signal: AbortSignal.timeout(5000),
+            const res = await fetch('https://api.anthropic.com/api/oauth/profile', {
+              method: 'GET',
+              headers: {
+                Authorization: `Bearer ${liveAccessToken}`,
+                'anthropic-beta': 'oauth-2025-04-20',
               },
-            );
+              signal: AbortSignal.timeout(5000),
+            });
             if (res.ok) {
               const prof = await res.json();
               liveEmail = prof?.account?.email || null;
@@ -2861,9 +2625,7 @@ async function rotate(targetEmail, opts = {}) {
         // orgUuid matches live. Fall back to first email match.
         let liveAccount = null;
         if (liveOrgUuid) {
-          liveAccount = config.accounts.find(
-            (a) => a.email === liveEmail && a.orgUuid === liveOrgUuid,
-          );
+          liveAccount = config.accounts.find((a) => a.email === liveEmail && a.orgUuid === liveOrgUuid);
         }
         if (!liveAccount) {
           liveAccount = config.accounts.find((a) => a.email === liveEmail);
@@ -2871,19 +2633,15 @@ async function rotate(targetEmail, opts = {}) {
         if (liveAccount) {
           if (!dryRun) saveCurrentToken(liveAccount);
           log(
-            `${dryRun ? "[DRY-RUN] Would save" : "Saved"} outgoing token for LIVE account ${accountKey(liveAccount)} (was tracked as ${state.activeAccount || "none"})`,
+            `${dryRun ? '[DRY-RUN] Would save' : 'Saved'} outgoing token for LIVE account ${accountKey(liveAccount)} (was tracked as ${state.activeAccount || 'none'})`,
           );
           // Keep state in sync with reality
           if (state.activeAccount !== accountKey(liveAccount)) {
-            log(
-              `State drift corrected: activeAccount ${state.activeAccount} → ${accountKey(liveAccount)}`,
-            );
+            log(`State drift corrected: activeAccount ${state.activeAccount} → ${accountKey(liveAccount)}`);
             state.activeAccount = accountKey(liveAccount);
           }
         } else {
-          log(
-            `WARNING: live account ${liveEmail} not in config — skipping outgoing save`,
-          );
+          log(`WARNING: live account ${liveEmail} not in config — skipping outgoing save`);
         }
       }
     } catch (e) {
@@ -2893,9 +2651,9 @@ async function rotate(targetEmail, opts = {}) {
   // Snapshot outgoing account's utilization before clearing the rate-limits file.
   // This lets pickNextAccount avoid rotating back to an exhausted account.
   try {
-    const rlPath = join(__dirname, ".rate-limits.json");
+    const rlPath = join(__dirname, '.rate-limits.json');
     if (existsSync(rlPath)) {
-      const rl = JSON.parse(readFileSync(rlPath, "utf8"));
+      const rl = JSON.parse(readFileSync(rlPath, 'utf8'));
       const outKey = state.activeAccount;
       if (outKey && rl.five_hour) {
         state.accounts[outKey] = state.accounts[outKey] || {};
@@ -2914,30 +2672,28 @@ async function rotate(targetEmail, opts = {}) {
   // Clear stale rate limits file so daemon doesn't use old account's utilization
   if (!dryRun) {
     try {
-      unlinkSync(join(__dirname, ".rate-limits.json"));
+      unlinkSync(join(__dirname, '.rate-limits.json'));
     } catch {}
   } else {
-    log("[DRY-RUN] Would clear .rate-limits.json");
+    log('[DRY-RUN] Would clear .rate-limits.json');
   }
 
   let ok;
   if (dryRun) {
-    log("[DRY-RUN] Would swap token via swapToken()");
+    log('[DRY-RUN] Would swap token via swapToken()');
     ok = true;
   } else {
     ok = await swapToken(account);
     if (!ok && !opts.noBrowser) {
       ok = await browserOAuthFallback(account);
     } else if (!ok) {
-      log(
-        "[no-browser] Token swap failed — skipping browser fallback (daemon mode)",
-      );
+      log('[no-browser] Token swap failed — skipping browser fallback (daemon mode)');
     }
   }
 
   if (!ok) {
-    log("Rotation failed");
-    notify("Account Rotation", `FAILED for ${targetEmail}`);
+    log('Rotation failed');
+    notify('Account Rotation', `FAILED for ${targetEmail}`);
     return false;
   }
 
@@ -2951,32 +2707,27 @@ async function rotate(targetEmail, opts = {}) {
       const fresh = JSON.parse(freshJson);
       const freshToken = fresh?.claudeAiOauth?.accessToken;
       if (freshToken) {
-        const res = await fetch("https://api.anthropic.com/api/oauth/profile", {
-          method: "GET",
+        const res = await fetch('https://api.anthropic.com/api/oauth/profile', {
+          method: 'GET',
           headers: {
             Authorization: `Bearer ${freshToken}`,
-            "anthropic-beta": "oauth-2025-04-20",
-            "Content-Type": "application/json",
+            'anthropic-beta': 'oauth-2025-04-20',
+            'Content-Type': 'application/json',
           },
           signal: AbortSignal.timeout(5000),
         });
         if (res.ok) {
           const prof = await res.json();
-          const euOn =
-            prof?.organization?.has_extra_usage_enabled === true;
+          const euOn = prof?.organization?.has_extra_usage_enabled === true;
           if (euOn) {
-            log(
-              `POST-SWAP BLOCK: ${targetEmail} has extra_usage=ON (overage billing). Reverting swap.`,
-            );
+            log(`POST-SWAP BLOCK: ${targetEmail} has extra_usage=ON (overage billing). Reverting swap.`);
             notify(
-              "Rotation REVERTED",
+              'Rotation REVERTED',
               `${targetEmail}: extra_usage enabled — charges would hit your card. Rollback in progress.`,
             );
             // Revert: restore previous account's stored token to active slot
             const prevKey = state.activeAccount;
-            const prevAccount = prevKey
-              ? config.accounts.find((a) => accountKey(a) === prevKey)
-              : null;
+            const prevAccount = prevKey ? config.accounts.find((a) => accountKey(a) === prevKey) : null;
             if (prevAccount) {
               const prevToken = readStoredToken(prevAccount);
               if (prevToken) {
@@ -2993,9 +2744,7 @@ async function rotate(targetEmail, opts = {}) {
         }
       }
     } catch (e) {
-      log(
-        `POST-SWAP billing check error (non-fatal): ${e.message?.slice(0, 80)}`,
-      );
+      log(`POST-SWAP billing check error (non-fatal): ${e.message?.slice(0, 80)}`);
     }
   }
 
@@ -3010,15 +2759,13 @@ async function rotate(targetEmail, opts = {}) {
     if (stored && stored.length > 80 && active.includes(stored.substring(20, 80))) verified = true;
     // Browser fallback: verify via CLI (skip in --no-browser mode — API may be rate limited)
     if (!verified && !opts.noBrowser) {
-      const out = execSync("claude auth status 2>&1", {
+      const out = execSync('claude auth status 2>&1', {
         timeout: 10_000,
       }).toString();
       verified = out.includes(account.email);
     }
   } catch {}
-  log(
-    `Rotation ${verified ? "VERIFIED" : "UNVERIFIED"}: ${key} (${account.email})`,
-  );
+  log(`Rotation ${verified ? 'VERIFIED' : 'UNVERIFIED'}: ${key} (${account.email})`);
 
   // Org-match check: for accounts where label != email (multi-org under same
   // email, like user-personal vs user-team), confirm the live
@@ -3031,19 +2778,16 @@ async function rotate(targetEmail, opts = {}) {
       const liveTok = readKeychain();
       const accessToken = JSON.parse(liveTok)?.claudeAiOauth?.accessToken;
       if (accessToken) {
-        const res = await fetch(
-          "https://api.anthropic.com/api/oauth/profile",
-          {
-            headers: {
-              Authorization: `Bearer ${accessToken}`,
-              "anthropic-beta": "oauth-2025-04-20",
-            },
-            signal: AbortSignal.timeout(5000),
+        const res = await fetch('https://api.anthropic.com/api/oauth/profile', {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'anthropic-beta': 'oauth-2025-04-20',
           },
-        );
+          signal: AbortSignal.timeout(5000),
+        });
         if (res.ok) {
           const prof = await res.json();
-          const liveOrg = prof?.organization?.name || "";
+          const liveOrg = prof?.organization?.name || '';
           if (liveOrg && liveOrg !== account.orgName) {
             log(
               `⚠  ORG MISMATCH: ${key} expected "${account.orgName}" but live is "${liveOrg}" — OAuth org picker likely landed on wrong workspace. Token still saved but will share quota with sibling account under same email.`,
@@ -3063,26 +2807,23 @@ async function rotate(targetEmail, opts = {}) {
   // Claude Code's own 30s keychain re-read will pick up the new token.
   if (verified && !opts.noBrowser) {
     try {
-      execSync("claude auth status 2>&1", { timeout: 10_000 });
-      log("Token refresh triggered via auth status");
+      execSync('claude auth status 2>&1', { timeout: 10_000 });
+      log('Token refresh triggered via auth status');
     } catch {}
   }
 
   // Save verified (and possibly refreshed) token to vault for future fast swaps
   if (verified && !dryRun) saveCurrentToken(account);
-  if (verified && dryRun) log("[DRY-RUN] Would save verified token to vault");
+  if (verified && dryRun) log('[DRY-RUN] Would save verified token to vault');
 
   // Update state — track cumulative window usage per account
   const now = new Date().toISOString();
   const windowMs = (config.rateLimits?.windowHours || 5) * 3_600_000;
   if (state.activeAccount) {
-    const prev = (state.accounts[state.activeAccount] =
-      state.accounts[state.activeAccount] || {});
+    const prev = (state.accounts[state.activeAccount] = state.accounts[state.activeAccount] || {});
     prev.lastActive = now;
     // Accumulate tool uses into the account's window total
-    const windowAge = prev.windowStart
-      ? Date.now() - new Date(prev.windowStart).getTime()
-      : Infinity;
+    const windowAge = prev.windowStart ? Date.now() - new Date(prev.windowStart).getTime() : Infinity;
     if (windowAge >= windowMs) {
       // Window expired — reset
       prev.windowStart = prev.switchedAt || now;
@@ -3097,9 +2838,7 @@ async function rotate(targetEmail, opts = {}) {
     switchedAt: now,
     messagesSinceSwitch: 0,
   });
-  const targetWindowAge = target.windowStart
-    ? Date.now() - new Date(target.windowStart).getTime()
-    : Infinity;
+  const targetWindowAge = target.windowStart ? Date.now() - new Date(target.windowStart).getTime() : Infinity;
   if (targetWindowAge >= windowMs) {
     // Window expired — fresh start
     target.windowStart = now;
@@ -3112,13 +2851,11 @@ async function rotate(targetEmail, opts = {}) {
   state.totalRotations = (state.totalRotations || 0) + 1;
   writeState(state, dryRun);
 
-  notify("Claude Account Rotation", `${verified ? "✓" : "⚠"} Now using ${key}`);
+  notify('Claude Account Rotation', `${verified ? '✓' : '⚠'} Now using ${key}`);
 
   if (opts.session) {
     if (dryRun) {
-      log(
-        "[DRY-RUN] Would restart running Claude sessions with --continue and send resume prompt",
-      );
+      log('[DRY-RUN] Would restart running Claude sessions with --continue and send resume prompt');
     } else {
       await refreshRunningSession(account, opts.noBrowser);
     }
@@ -3131,35 +2868,26 @@ async function rotate(targetEmail, opts = {}) {
 async function setup() {
   const config = readConfig();
   const argv = process.argv.slice(2);
-  const filter = argv.find((a) => a.startsWith("--only="))?.slice(7);
-  const autoMode = argv.includes("--auto");
-  const magicLinkMode = autoMode || argv.includes("--magic-link");
-  const skipDone = argv.includes("--skip-valid");
-  const accounts = (filter
-    ? config.accounts.filter(
-        (a) => accountKey(a) === filter || a.email === filter,
-      )
-    : config.accounts
+  const filter = argv.find((a) => a.startsWith('--only='))?.slice(7);
+  const autoMode = argv.includes('--auto');
+  const magicLinkMode = autoMode || argv.includes('--magic-link');
+  const skipDone = argv.includes('--skip-valid');
+  const accounts = (
+    filter ? config.accounts.filter((a) => accountKey(a) === filter || a.email === filter) : config.accounts
   ).filter((a) => {
     if (a.disabled === true && !filter) {
-      console.log(`⏭  Skipping ${accountKey(a)}: disabled (${a.disabledReason || "no reason given"})`);
+      console.log(`⏭  Skipping ${accountKey(a)}: disabled (${a.disabledReason || 'no reason given'})`);
       return false;
     }
     return true;
   });
 
-  console.log("\n=== Claude Account Rotation — Setup ===\n");
+  console.log('\n=== Claude Account Rotation — Setup ===\n');
   if (autoMode) {
-    console.log(
-      `🤖 AUTO MODE — browser driver cascade + magic-link polling via gog/Gmail`,
-    );
-    console.log(
-      `   Sequential processing (~60-120s per account). Logs → rotation.log.\n`,
-    );
+    console.log(`🤖 AUTO MODE — browser driver cascade + magic-link polling via gog/Gmail`);
+    console.log(`   Sequential processing (~60-120s per account). Logs → rotation.log.\n`);
   }
-  console.log(
-    `Re-capturing ${accounts.length} account(s). For each: OAuth → verify → save to vault.\n`,
-  );
+  console.log(`Re-capturing ${accounts.length} account(s). For each: OAuth → verify → save to vault.\n`);
 
   const results = [];
   for (const account of accounts) {
@@ -3174,22 +2902,17 @@ async function setup() {
           const p = JSON.parse(existing);
           const t = p?.claudeAiOauth?.accessToken;
           if (t) {
-            const res = await fetch(
-              "https://api.anthropic.com/api/oauth/profile",
-              {
-                method: "GET",
-                headers: {
-                  Authorization: `Bearer ${t}`,
-                  "anthropic-beta": "oauth-2025-04-20",
-                  "Content-Type": "application/json",
-                },
-                signal: AbortSignal.timeout(4000),
+            const res = await fetch('https://api.anthropic.com/api/oauth/profile', {
+              method: 'GET',
+              headers: {
+                Authorization: `Bearer ${t}`,
+                'anthropic-beta': 'oauth-2025-04-20',
+                'Content-Type': 'application/json',
               },
-            );
+              signal: AbortSignal.timeout(4000),
+            });
             if (res.ok) {
-              console.log(
-                `⏭  Skipped: vault token still valid (--skip-valid).`,
-              );
+              console.log(`⏭  Skipped: vault token still valid (--skip-valid).`);
               results.push({ key, ok: true, skipped: true });
               continue;
             }
@@ -3203,47 +2926,31 @@ async function setup() {
       // Fully automated: claude auth login subprocess + browser driver cascade
       // + magic-link email polling. No terminal interaction required.
       account.useMagicLink = true;
-      console.log(
-        `[auto] Automated OAuth — magic-link email to ${account.email} (routed to Gmail)...`,
-      );
+      console.log(`[auto] Automated OAuth — magic-link email to ${account.email} (routed to Gmail)...`);
       try {
         oauthOk = await browserOAuthFallback(account);
       } catch (e) {
-        console.error(
-          `❌ Automation threw: ${String(e.message || e).slice(0, 120)}`,
-        );
+        console.error(`❌ Automation threw: ${String(e.message || e).slice(0, 120)}`);
         oauthOk = false;
       }
       if (!oauthOk) {
-        console.error(
-          `❌ ${key}: auto OAuth failed. Retry manually: node rotate.mjs --setup --only=${key}`,
-        );
-        results.push({ key, ok: false, reason: "auto-oauth-failed" });
+        console.error(`❌ ${key}: auto OAuth failed. Retry manually: node rotate.mjs --setup --only=${key}`);
+        results.push({ key, ok: false, reason: 'auto-oauth-failed' });
         continue;
       }
     } else {
-      console.log(
-        "Opening browser for OAuth. Complete the Google login, then come back here.",
-      );
-      const child = spawn(
-        "claude",
-        ["auth", "login", "--email", account.email],
-        {
-          stdio: "inherit",
-        },
-      );
-      await new Promise((r) => child.on("exit", r));
+      console.log('Opening browser for OAuth. Complete the Google login, then come back here.');
+      const child = spawn('claude', ['auth', 'login', '--email', account.email], {
+        stdio: 'inherit',
+      });
+      await new Promise((r) => child.on('exit', r));
     }
 
     // Verify the login succeeded and matches the expected account
     try {
-      const status = JSON.parse(
-        execSync("claude auth status 2>&1", { timeout: 10_000 }).toString(),
-      );
+      const status = JSON.parse(execSync('claude auth status 2>&1', { timeout: 10_000 }).toString());
       if (status.email !== account.email) {
-        console.error(
-          `\n❌ MISMATCH: expected ${account.email}, got ${status.email}. Skipping save.`,
-        );
+        console.error(`\n❌ MISMATCH: expected ${account.email}, got ${status.email}. Skipping save.`);
         results.push({ key, ok: false, reason: `mismatch:${status.email}` });
         continue;
       }
@@ -3274,12 +2981,10 @@ async function setup() {
   const okCount = results.filter((r) => r.ok).length;
   const failCount = results.length - okCount;
   for (const r of results) {
-    const icon = r.ok ? (r.skipped ? "⏭ " : "✅") : "❌";
-    console.log(`  ${icon} ${r.key}${r.reason ? `  (${r.reason})` : ""}`);
+    const icon = r.ok ? (r.skipped ? '⏭ ' : '✅') : '❌';
+    console.log(`  ${icon} ${r.key}${r.reason ? `  (${r.reason})` : ''}`);
   }
-  console.log(
-    `\n${okCount}/${results.length} captured${failCount ? `, ${failCount} failed` : ""}.`,
-  );
+  console.log(`\n${okCount}/${results.length} captured${failCount ? `, ${failCount} failed` : ''}.`);
 
   // Post-setup billing audit (auto mode) — surfaces accounts with extra_usage on
   if (autoMode && okCount > 0) {
@@ -3303,9 +3008,7 @@ async function setup() {
         console.log(`  🔴 ${k}: EXTRA_USAGE=ON — overage billing ACTIVE`);
         risky++;
       } else if (u.extra_usage_enabled === false) {
-        console.log(
-          `  🟢 ${k}: extra_usage=off  5h=${u.five_hour_pct}% 7d=${u.seven_day_pct}%`,
-        );
+        console.log(`  🟢 ${k}: extra_usage=off  5h=${u.five_hour_pct}% 7d=${u.seven_day_pct}%`);
       } else {
         console.log(`  ⚠  ${k}: extra_usage=unknown`);
         unknown++;
@@ -3319,9 +3022,7 @@ async function setup() {
       console.log(`\n✅ All auditable accounts have extra_usage=off.`);
     }
   }
-  console.log(
-    `\nSetup done. Run \`node rotate.mjs --audit-billing\` anytime to re-check.\n`,
-  );
+  console.log(`\nSetup done. Run \`node rotate.mjs --audit-billing\` anytime to re-check.\n`);
 }
 
 // ── Status ────────────────────────────────────────────────────────────────────
@@ -3331,14 +3032,14 @@ function showStatus() {
   const state = readState();
   let liveEmail = null;
   try {
-    const m = execSync("claude auth status 2>&1", { timeout: 10_000 })
+    const m = execSync('claude auth status 2>&1', { timeout: 10_000 })
       .toString()
       .match(/"email":\s*"([^"]+)"/);
     if (m) liveEmail = m[1];
   } catch {}
 
   const since = (d) => {
-    if (!d) return "never";
+    if (!d) return 'never';
     const s = Math.floor((Date.now() - new Date(d).getTime()) / 1000);
     if (s < 60) return `${s}s ago`;
     if (s < 3600) return `${Math.floor(s / 60)}m ago`;
@@ -3349,43 +3050,33 @@ function showStatus() {
   // Read real utilization if available
   let realUtil = null;
   try {
-    const rlFile = join(__dirname, ".rate-limits.json");
+    const rlFile = join(__dirname, '.rate-limits.json');
     if (existsSync(rlFile)) {
-      const rl = JSON.parse(readFileSync(rlFile, "utf8"));
+      const rl = JSON.parse(readFileSync(rlFile, 'utf8'));
       const age = Date.now() - rl.ts * 1000;
       if (age < 5 * 60_000) realUtil = rl;
     }
   } catch {}
 
   // Determine if the mismatch is expected (rotation just ran, session hasn't reloaded)
-  const recentRotation = state.lastRotation
-    ? Date.now() - new Date(state.lastRotation).getTime() < 90_000
-    : false;
+  const recentRotation = state.lastRotation ? Date.now() - new Date(state.lastRotation).getTime() < 90_000 : false;
   const mismatch =
     liveEmail &&
     state.activeAccount &&
     !state.activeAccount.startsWith(liveEmail) &&
     !liveEmail.startsWith(state.activeAccount);
-  const liveNote =
-    mismatch && recentRotation
-      ? " (stale session — restart Claude Code to apply)"
-      : "";
+  const liveNote = mismatch && recentRotation ? ' (stale session — restart Claude Code to apply)' : '';
 
-  console.log("\n=== Claude Account Rotation ===\n");
-  console.log(`Live auth:       ${liveEmail || "unknown"}${liveNote}`);
-  console.log(`Tracked active:  ${state.activeAccount || "unknown"}`);
-  console.log(
-    `Tool uses:       ${state.toolUses || 0} / ${config.toolUseThreshold}`,
-  );
+  console.log('\n=== Claude Account Rotation ===\n');
+  console.log(`Live auth:       ${liveEmail || 'unknown'}${liveNote}`);
+  console.log(`Tracked active:  ${state.activeAccount || 'unknown'}`);
+  console.log(`Tool uses:       ${state.toolUses || 0} / ${config.toolUseThreshold}`);
   if (realUtil) {
     console.log(
-      `Real utilization: 5h=${realUtil.five_hour?.pct?.toFixed(1) || "?"}%  7d=${realUtil.seven_day?.pct?.toFixed(1) || "?"}%`,
+      `Real utilization: 5h=${realUtil.five_hour?.pct?.toFixed(1) || '?'}%  7d=${realUtil.seven_day?.pct?.toFixed(1) || '?'}%`,
     );
     if (realUtil.five_hour?.reset) {
-      const resetIn = Math.max(
-        0,
-        realUtil.five_hour.reset - Math.floor(Date.now() / 1000),
-      );
+      const resetIn = Math.max(0, realUtil.five_hour.reset - Math.floor(Date.now() / 1000));
       const hrs = Math.floor(resetIn / 3600);
       const mins = Math.floor((resetIn % 3600) / 60);
       console.log(`5h resets in:    ${hrs}h${mins}m`);
@@ -3393,22 +3084,20 @@ function showStatus() {
   }
   console.log(`Total rotations: ${state.totalRotations || 0}`);
   console.log(`Last rotation:   ${since(state.lastRotation)}\n`);
-  console.log("Accounts:");
+  console.log('Accounts:');
   for (const a of config.accounts) {
     const key = accountKey(a);
     const s = state.accounts[key] || {};
-    const active = key === state.activeAccount ? " ◀ ACTIVE" : "";
-    const prio = a.priority === "low" ? " (low priority)" : "";
-    const tokenOk = hasStoredToken(a) ? "✓ token stored" : "✗ no token";
-    const label = a.label ? ` [${a.label}]` : "";
-    const windowInfo = s.windowToolUses
-      ? ` | window: ${s.windowToolUses} uses`
-      : "";
+    const active = key === state.activeAccount ? ' ◀ ACTIVE' : '';
+    const prio = a.priority === 'low' ? ' (low priority)' : '';
+    const tokenOk = hasStoredToken(a) ? '✓ token stored' : '✗ no token';
+    const label = a.label ? ` [${a.label}]` : '';
+    const windowInfo = s.windowToolUses ? ` | window: ${s.windowToolUses} uses` : '';
     console.log(`  ${a.email}${label}${active}${prio}`);
     console.log(`    Keychain:    ${tokenOk}`);
     console.log(`    Last active: ${since(s.lastActive)}${windowInfo}`);
   }
-  console.log("");
+  console.log('');
 }
 
 // ── --capture: print current token for Dashlane ───────────────────────────────
@@ -3419,9 +3108,7 @@ function captureCmd(targetEmail = null) {
   let account;
   if (targetEmail) {
     const needle = String(targetEmail).trim().toLowerCase();
-    account = config.accounts.find(
-      (a) => a.email.toLowerCase() === needle,
-    );
+    account = config.accounts.find((a) => a.email.toLowerCase() === needle);
     if (!account) {
       console.error(`No account in config matching --to ${targetEmail}`);
       process.exit(1);
@@ -3429,8 +3116,7 @@ function captureCmd(targetEmail = null) {
   } else {
     const activeKey = state.activeAccount;
     account =
-      config.accounts.find((a) => accountKey(a) === activeKey) ||
-      config.accounts.find((a) => a.email === activeKey);
+      config.accounts.find((a) => accountKey(a) === activeKey) || config.accounts.find((a) => a.email === activeKey);
     if (!account) {
       console.error(`Active account ${activeKey} not in config`);
       process.exit(1);
@@ -3439,17 +3125,13 @@ function captureCmd(targetEmail = null) {
 
   try {
     const token = readKeychain();
-    if (!token.includes("claudeAiOauth")) {
-      console.error("No valid OAuth token in active keychain");
+    if (!token.includes('claudeAiOauth')) {
+      console.error('No valid OAuth token in active keychain');
       process.exit(1);
     }
     writeStoredToken(account, token);
-    console.log(
-      `✓ Token captured and saved to keychain: ${tokenService(account)}`,
-    );
-    console.log(
-      `  Account: ${account.email}${account.label ? " [" + account.label + "]" : ""}`,
-    );
+    console.log(`✓ Token captured and saved to keychain: ${tokenService(account)}`);
+    console.log(`  Account: ${account.email}${account.label ? ' [' + account.label + ']' : ''}`);
   } catch (e) {
     console.error(e.message);
     process.exit(1);
@@ -3460,21 +3142,21 @@ function captureCmd(targetEmail = null) {
 
 const args = process.argv.slice(2);
 
-if (args.includes("--setup")) {
+if (args.includes('--setup')) {
   await setup();
-} else if (args.includes("--utilization")) {
+} else if (args.includes('--utilization')) {
   // Live utilization query for all accounts
   const config = readConfig();
   const state = readState();
-  console.log("\nQuerying live utilization for all accounts...\n");
+  console.log('\nQuerying live utilization for all accounts...\n');
   const liveUtil = await queryAllUtilization(config);
   for (const a of config.accounts) {
     const key = accountKey(a);
     if (a.disabled === true) {
-      console.log(`  ⏸  ${key}: DISABLED — ${a.disabledReason || "no reason given"}`);
+      console.log(`  ⏸  ${key}: DISABLED — ${a.disabledReason || 'no reason given'}`);
       continue;
     }
-    const active = state.activeAccount === key ? " ◀ ACTIVE" : "";
+    const active = state.activeAccount === key ? ' ◀ ACTIVE' : '';
     const u = liveUtil[key];
     if (!u) {
       console.log(`  ${key}: ❌ query failed${active}`);
@@ -3483,102 +3165,81 @@ if (args.includes("--setup")) {
     const s5 = u.five_hour_pct;
     const s7 = u.seven_day_pct;
     const worst = Math.max(s5 ?? 0, s7 ?? 0);
-    const icon = worst >= 90 ? "🔴" : worst >= 70 ? "🟡" : "🟢";
-    const reset5 = u.resets_at_5h
-      ? `resets ${new Date(u.resets_at_5h).toLocaleTimeString()}`
-      : "no reset";
+    const icon = worst >= 90 ? '🔴' : worst >= 70 ? '🟡' : '🟢';
+    const reset5 = u.resets_at_5h ? `resets ${new Date(u.resets_at_5h).toLocaleTimeString()}` : 'no reset';
     const euIcon =
-      u.extra_usage_enabled === true
-        ? " 💳 EXTRA_USAGE_ON"
-        : u.extra_usage_enabled === false
-          ? ""
-          : " (eu?)";
-    console.log(
-      `  ${icon} ${key}: 5h=${s5}% 7d=${s7}%  (${reset5})${euIcon}${active}`,
-    );
+      u.extra_usage_enabled === true ? ' 💳 EXTRA_USAGE_ON' : u.extra_usage_enabled === false ? '' : ' (eu?)';
+    console.log(`  ${icon} ${key}: 5h=${s5}% 7d=${s7}%  (${reset5})${euIcon}${active}`);
   }
-  console.log("");
-} else if (args.includes("--audit-billing")) {
+  console.log('');
+} else if (args.includes('--audit-billing')) {
   // Per-account billing audit — prints extra_usage state + any risk flags
   const config = readConfig();
   const state = readState();
-  console.log("\nAuditing billing state for all accounts...\n");
+  console.log('\nAuditing billing state for all accounts...\n');
   const liveUtil = await queryAllUtilization(config);
   let risky = 0;
   let unknown = 0;
   for (const a of config.accounts) {
     const key = accountKey(a);
     if (a.disabled === true) {
-      console.log(`  ⏸  ${key}: DISABLED — ${a.disabledReason || "no reason given"}`);
+      console.log(`  ⏸  ${key}: DISABLED — ${a.disabledReason || 'no reason given'}`);
       continue;
     }
-    const active = state.activeAccount === key ? " ◀ ACTIVE" : "";
+    const active = state.activeAccount === key ? ' ◀ ACTIVE' : '';
     const u = liveUtil[key];
     if (!u) {
-      console.log(
-        `  ⚠  ${key}: token invalid/expired — cannot audit${active}`,
-      );
+      console.log(`  ⚠  ${key}: token invalid/expired — cannot audit${active}`);
       unknown++;
       continue;
     }
     const eu = u.extra_usage_enabled;
-    const bt = u.billing_type ?? "?";
-    const ss = u.subscription_status ?? "?";
+    const bt = u.billing_type ?? '?';
+    const ss = u.subscription_status ?? '?';
     if (eu === true) {
-      console.log(
-        `  🔴 ${key}: EXTRA_USAGE=ON billing=${bt} status=${ss}${active}  ← overage billing ACTIVE`,
-      );
+      console.log(`  🔴 ${key}: EXTRA_USAGE=ON billing=${bt} status=${ss}${active}  ← overage billing ACTIVE`);
       risky++;
     } else if (eu === false) {
-      console.log(
-        `  🟢 ${key}: extra_usage=off billing=${bt} status=${ss}${active}`,
-      );
+      console.log(`  🟢 ${key}: extra_usage=off billing=${bt} status=${ss}${active}`);
     } else {
       console.log(`  ⚠  ${key}: extra_usage=unknown billing=${bt}${active}`);
       unknown++;
     }
   }
-  console.log("");
-  console.log(
-    `Summary: ${risky} risky, ${unknown} unknown, ${config.accounts.length - risky - unknown} safe`,
-  );
+  console.log('');
+  console.log(`Summary: ${risky} risky, ${unknown} unknown, ${config.accounts.length - risky - unknown} safe`);
   if (risky > 0) {
-    console.log(
-      `\n⚠  Disable extra_usage at https://console.anthropic.com/settings/billing for each risky account.`,
-    );
+    console.log(`\n⚠  Disable extra_usage at https://console.anthropic.com/settings/billing for each risky account.`);
   }
-  console.log("");
-} else if (args.includes("--status")) {
+  console.log('');
+} else if (args.includes('--status')) {
   showStatus();
-} else if (args.includes("--capture")) {
-  const capToIdx = args.indexOf("--to");
-  const captureTo =
-    capToIdx !== -1 && args[capToIdx + 1] ? args[capToIdx + 1] : null;
+} else if (args.includes('--capture')) {
+  const capToIdx = args.indexOf('--to');
+  const captureTo = capToIdx !== -1 && args[capToIdx + 1] ? args[capToIdx + 1] : null;
   captureCmd(captureTo);
 } else {
-  const toIdx = args.indexOf("--to");
+  const toIdx = args.indexOf('--to');
   const target = toIdx !== -1 ? args[toIdx + 1] : null;
-  const session = args.includes("--session");
-  const noBrowser = args.includes("--no-browser");
-  const force = args.includes("--force");
-  const dryRun = args.includes("--dry-run");
-  const magicLink = args.includes("--magic-link");
-  const allowExtraUsage = args.includes("--allow-extra-usage");
-  if (dryRun) log("DRY RUN MODE — no changes will be made");
+  const session = args.includes('--session');
+  const noBrowser = args.includes('--no-browser');
+  const force = args.includes('--force');
+  const dryRun = args.includes('--dry-run');
+  const magicLink = args.includes('--magic-link');
+  const allowExtraUsage = args.includes('--allow-extra-usage');
+  if (dryRun) log('DRY RUN MODE — no changes will be made');
   if (force) {
-    log("Force mode — bypassing lock and killing any competing rotations");
+    log('Force mode — bypassing lock and killing any competing rotations');
     // Kill other rotate.mjs processes (not this one)
     try {
-      execSync(
-        `pgrep -f 'node.*rotate.mjs' | grep -v ${process.pid} | xargs -r kill -9 2>/dev/null`,
-      );
+      execSync(`pgrep -f 'node.*rotate.mjs' | grep -v ${process.pid} | xargs -r kill -9 2>/dev/null`);
     } catch {}
     try {
       unlinkSync(LOCK_PATH);
     } catch {}
   }
   if (!dryRun && !acquireLock()) {
-    console.error("Rotation in progress.");
+    console.error('Rotation in progress.');
     process.exit(1);
   }
   try {
@@ -3592,7 +3253,7 @@ if (args.includes("--setup")) {
     process.exit(ok ? 0 : 1);
   } catch (err) {
     log(`FATAL: ${err.message}`);
-    notify("Account Rotation", `FAILED: ${err.message}`);
+    notify('Account Rotation', `FAILED: ${err.message}`);
     process.exit(1);
   } finally {
     releaseLock();

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -466,7 +466,9 @@ function writeKeychain(json, svc = KEYCHAIN_SERVICE, acct = KEYCHAIN_ACCOUNT) {
 function tokenExpired(json) {
   try {
     const exp = JSON.parse(json)?.claudeAiOauth?.expiresAt;
-    return exp ? Date.now() > exp : false;
+    if (!exp) return false;
+    // Match daemon.mjs: treat as expired within 5 minutes of expiry
+    return Date.now() > exp - 5 * 60_000;
   } catch {
     return false;
   }

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -517,6 +517,7 @@ function fetchGoogleCreds(account) {
     return {
       password: match.password || null,
       otpSecret: match.otpSecret || null,
+      phone: match.phone || match.phoneNumber || null,
     };
   } catch {
     return null;
@@ -1588,11 +1589,15 @@ async function runAuthFlow(driver, account) {
   const creds = fetchGoogleCreds(account) || {};
   const googlePassword = creds.password || fetchGooglePassword(account);
   const googleOtpSecret = creds.otpSecret || null;
+  const googleSmsPhone =
+    (process.env.CLAUDE_ROTATION_GOOGLE_SMS_PHONE || "").trim() ||
+    (account.googleSmsPhone || "").trim() ||
+    (creds.phone || "").trim() ||
+    null;
   if (googlePassword)
     log(
       `dcli Google password available for ${account.email}${googleOtpSecret ? " (+TOTP)" : ""}`,
     );
-  const PHONE_NUMBER = "+31614446458";
 
   // AI-brain stall detector: when the URL doesn't advance for N consecutive
   // steps, hand the page to Claude to decide what to do. Kept separate from
@@ -1797,8 +1802,17 @@ async function runAuthFlow(driver, account) {
       url.includes("accounts.google.com") &&
       url.includes("challenge/ipp/collect")
     ) {
-      log(`SMS phone collect — entering ${PHONE_NUMBER} and clicking Send`);
-      await driver.fillInput('#phoneNumberId, input[type="tel"]', PHONE_NUMBER);
+      if (!googleSmsPhone) {
+        log(
+          `SMS phone collect page — no phone (set CLAUDE_ROTATION_GOOGLE_SMS_PHONE, account.googleSmsPhone, or dcli phone on google.com cred)`,
+        );
+        return false;
+      }
+      log(`SMS phone collect — entering configured number and clicking Send`);
+      await driver.fillInput(
+        '#phoneNumberId, input[type="tel"]',
+        googleSmsPhone,
+      );
       await sleep(500);
       await driver.findAndClick(["Send", "Next", "Verstuur"]);
       await sleep(4000);
@@ -1869,6 +1883,17 @@ async function runAuthFlow(driver, account) {
       continue;
     }
 
+    // Google password prompt (standalone /challenge/pwd — must run BEFORE the
+    // broad accounts.google.com account-chooser branch below).
+    if (url.includes("accounts.google.com") && url.includes("challenge/pwd")) {
+      if (googlePassword) {
+        await driver.fillInput('input[type="password"]', googlePassword);
+        await sleep(500);
+        await driver.findAndClick(["Next", "#passwordNext button"]);
+        continue;
+      }
+    }
+
     // Google account chooser — click the target account
     if (url.includes("accounts.google.com")) {
       // Detect "Signed out" next to the target account (needs re-login)
@@ -1912,16 +1937,6 @@ async function runAuthFlow(driver, account) {
         }
       }
       continue;
-    }
-
-    // Google password prompt (standalone page, no account chooser)
-    if (url.includes("accounts.google.com") && url.includes("challenge/pwd")) {
-      if (googlePassword) {
-        await driver.fillInput('input[type="password"]', googlePassword);
-        await sleep(500);
-        await driver.findAndClick(["Next", "#passwordNext button"]);
-        continue;
-      }
     }
 
     // Claude organization/workspace chooser (Workspace accounts on a custom domain)
@@ -3395,16 +3410,28 @@ function showStatus() {
 
 // ── --capture: print current token for Dashlane ───────────────────────────────
 
-function captureCmd() {
+function captureCmd(targetEmail = null) {
   const state = readState();
   const config = readConfig();
-  const activeKey = state.activeAccount;
-  const account =
-    config.accounts.find((a) => accountKey(a) === activeKey) ||
-    config.accounts.find((a) => a.email === activeKey);
-  if (!account) {
-    console.error(`Active account ${activeKey} not in config`);
-    process.exit(1);
+  let account;
+  if (targetEmail) {
+    const needle = String(targetEmail).trim().toLowerCase();
+    account = config.accounts.find(
+      (a) => a.email.toLowerCase() === needle,
+    );
+    if (!account) {
+      console.error(`No account in config matching --to ${targetEmail}`);
+      process.exit(1);
+    }
+  } else {
+    const activeKey = state.activeAccount;
+    account =
+      config.accounts.find((a) => accountKey(a) === activeKey) ||
+      config.accounts.find((a) => a.email === activeKey);
+    if (!account) {
+      console.error(`Active account ${activeKey} not in config`);
+      process.exit(1);
+    }
   }
 
   try {
@@ -3521,7 +3548,10 @@ if (args.includes("--setup")) {
 } else if (args.includes("--status")) {
   showStatus();
 } else if (args.includes("--capture")) {
-  captureCmd();
+  const capToIdx = args.indexOf("--to");
+  const captureTo =
+    capToIdx !== -1 && args[capToIdx + 1] ? args[capToIdx + 1] : null;
+  captureCmd(captureTo);
 } else {
   const toIdx = args.indexOf("--to");
   const target = toIdx !== -1 ? args[toIdx + 1] : null;

--- a/claude-ops/skills/ops-rotate/SKILL.md
+++ b/claude-ops/skills/ops-rotate/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: ops-rotate
+description: Multi-account Claude Max rotator. Status, manual rotation, account list, add-account wizard. Requires account_rotation_enabled=true in plugin settings.
+argument-hint: "[status|rotate-now|list|add-account]"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - AskUserQuestion
+effort: low
+maxTurns: 25
+---
+
+# OPS ► ROTATE
+
+Manage the optional multi-account Claude Max rotator. Off by default — flip
+`account_rotation_enabled` in plugin settings to use it.
+
+## Subcommands
+
+| `$ARGUMENTS`   | Action                                                           |
+| -------------- | ---------------------------------------------------------------- |
+| (none) or `status` | Show current account, 5h%/7d%, total rotations, daemon health |
+| `rotate-now`   | Force rotation to the most-cooled candidate (or `--to <email>`) |
+| `list`         | List every configured account with token state + last util     |
+| `add-account`  | Interactive wizard: collect email, OAuth into rotator vault    |
+
+## Pre-flight (every invocation)
+
+1. Read `account_rotation_enabled` from plugin preferences. If false, tell the user how to enable and exit.
+2. Resolve paths:
+   - `ROT_DIR=${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops}/account-rotation`
+   - `ROT_SRC=${CLAUDE_PLUGIN_ROOT}/scripts/account-rotation`
+3. If `$ROT_DIR` doesn't exist yet, mirror the runtime layout:
+   ```
+   mkdir -p "$ROT_DIR"
+   cp "$ROT_SRC/config.example.json" "$ROT_DIR/config.json"  # only if missing
+   ```
+4. Verify Node 20+: `node --version`. If missing, fail fast with install hint.
+
+## status (default)
+
+Run:
+
+```
+node "$ROT_SRC/rotate.mjs" --status
+node "$ROT_SRC/rotate.mjs" --utilization 2>/dev/null | head -40
+launchctl list 2>/dev/null | grep com.claude-ops.account-rotation || echo "daemon: not loaded"
+```
+
+Render a compact panel:
+
+```
+ROTATOR STATUS
+  Active account : <email>
+  5h utilization : 42% (resets in 1h 23m)
+  7d utilization : 18%
+  Total rotations: 14
+  Daemon         : ✓ running (PID 12345)  |  ✗ not loaded
+  Configured     : 4 accounts (3 with valid tokens, 1 expired)
+```
+
+## rotate-now
+
+If user passed an explicit target email (`/ops:rotate rotate-now user@example.com`), pass `--to "<email>"`. Otherwise let `rotate.mjs` pick the most-cooled.
+
+```
+bash "$ROT_SRC/force-rotate.sh" "${TARGET_EMAIL:-}"
+```
+
+Show the trailing status output. Remind the user that running Claude Code sessions hold their own access token until next `/login` or until they exit and re-enter.
+
+## list
+
+```
+node "$ROT_SRC/rotate.mjs" --status 2>/dev/null
+```
+
+Then for each account in `$ROT_DIR/config.json`, render one row:
+
+```
+  [✓] user@example.com           5h 12%   token valid 6.4h  (active)
+  [✓] backup@example.com         5h 87%   token valid 3.1h
+  [✗] expired@example.com        ── ──    token expired 2d ago
+  [○] new@example.com            ── ──    no token captured
+```
+
+If any row is `[○]` or `[✗]`, suggest running `/ops:rotate add-account` for that email.
+
+## add-account (interactive)
+
+This is the only mutating subcommand. Walk the user through:
+
+1. **Collect email.** `AskUserQuestion`: "Email of the Claude Max account to add?" (free text via `Edit` to config — the skill must NOT capture sensitive data through chat options; just ask for the email).
+2. **Optional metadata.** Ask if it's a Workspace account (`AskUserQuestion`: `[Personal]`, `[Workspace]`, `[Skip]`). If Workspace, prompt for `orgName` (free text) — `orgUuid` is auto-discovered later.
+3. **Append to config.** Read `$ROT_DIR/config.json`, append the new account entry to `accounts[]`, write back. Use the schema from `config.example.json._account_schema_example`.
+4. **Capture token.** Two paths via `AskUserQuestion`:
+   - `[Use current Claude Code login]` — runs `node "$ROT_SRC/rotate.mjs" --capture --to <email>` to copy the live `Claude Code-credentials` token into the rotator vault.
+   - `[Run OAuth in browser now]` — runs `node "$ROT_SRC/rotate.mjs" --setup --only=<email>` (background-friendly; opens Chrome).
+   - `[Skip — I'll capture later]`.
+5. **Daemon install (one-time).** If launchd doesn't show `com.claude-ops.account-rotation`, ask `[Install + start daemon]` / `[Skip]`. On install:
+   ```
+   sed "s|\${HOME}|$HOME|g" "${CLAUDE_PLUGIN_ROOT}/templates/com.claude-ops.account-rotation.plist" > ~/Library/LaunchAgents/com.claude-ops.account-rotation.plist
+   launchctl load ~/Library/LaunchAgents/com.claude-ops.account-rotation.plist
+   ```
+   Mirror `daemon.mjs` + friends to `$ROT_DIR` if not already symlinked:
+   ```
+   for f in rotate.mjs daemon.mjs ai-brain.mjs force-rotate.sh; do
+     [ -e "$ROT_DIR/$f" ] || ln -s "$ROT_SRC/$f" "$ROT_DIR/$f"
+   done
+   ```
+6. **Verify.** Run `status` subcommand inline.
+
+## Optional npm dep
+
+`rotate.mjs` uses Playwright only for the browser fallback. It is declared as
+an optional dep in the plugin's `package.json`. If a browser fallback is needed
+and Playwright is missing, the skill should offer:
+
+```
+npm install --prefix "$CLAUDE_PLUGIN_ROOT" --no-save playwright
+npx --prefix "$CLAUDE_PLUGIN_ROOT" playwright install chromium
+```
+
+## Hard rules
+
+- This skill is **read-mostly**. Only `add-account` mutates `config.json`, and only after the user explicitly confirmed the email.
+- Never echo refresh tokens or access tokens to chat output.
+- Never auto-edit `config.json` outside `add-account` — token rotation is the daemon's job, not the skill's.
+- If `account_rotation_enabled` is false, refuse to run subcommands and instead explain the toggle.
+- If multiple OS users share the Mac, surface `CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT` as the override env var.

--- a/claude-ops/templates/com.claude-ops.account-rotation.plist
+++ b/claude-ops/templates/com.claude-ops.account-rotation.plist
@@ -21,8 +21,9 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>/usr/local/bin/node</string>
-    <string>${HOME}/.claude/plugins/data/ops/account-rotation/daemon.mjs</string>
+    <string>/bin/sh</string>
+    <string>-c</string>
+    <string>exec "$(command -v node)" "${HOME}/.claude/plugins/data/ops/account-rotation/daemon.mjs"</string>
   </array>
 
   <key>WorkingDirectory</key>

--- a/claude-ops/templates/com.claude-ops.account-rotation.plist
+++ b/claude-ops/templates/com.claude-ops.account-rotation.plist
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Multi-account Claude Max rotation daemon (claude-ops plugin).
+
+  This file is a TEMPLATE. The setup wizard substitutes ${HOME} and installs
+  the rendered copy to ~/Library/LaunchAgents/com.claude-ops.account-rotation.plist
+  before running:
+
+    launchctl load ~/Library/LaunchAgents/com.claude-ops.account-rotation.plist
+
+  To uninstall:
+
+    launchctl unload ~/Library/LaunchAgents/com.claude-ops.account-rotation.plist
+    rm ~/Library/LaunchAgents/com.claude-ops.account-rotation.plist
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.claude-ops.account-rotation</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/node</string>
+    <string>${HOME}/.claude/plugins/data/ops/account-rotation/daemon.mjs</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>${HOME}/.claude/plugins/data/ops/account-rotation</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>NODE_NO_WARNINGS</key>
+    <string>1</string>
+    <key>HOME</key>
+    <string>${HOME}</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+    <key>Crashed</key>
+    <true/>
+  </dict>
+
+  <key>ThrottleInterval</key>
+  <integer>30</integer>
+
+  <key>StandardOutPath</key>
+  <string>${HOME}/.claude/plugins/data/ops/account-rotation/daemon-launchd.log</string>
+  <key>StandardErrorPath</key>
+  <string>${HOME}/.claude/plugins/data/ops/account-rotation/daemon-launchd.log</string>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- Adds an opt-in **multi-account Claude Max rotator** as a first-class subsystem of the `ops` plugin.
- Off by default — gated by the existing `account_rotation_enabled` userConfig toggle.
- Ships with `/ops:rotate` slash command (status / rotate-now / list / add-account).

## What's included

| File | Purpose |
| --- | --- |
| `scripts/account-rotation/rotate.mjs` | Main rotation logic: dcli + keychain primary path; Playwright/Chrome JXA browser cascade fallback. |
| `scripts/account-rotation/daemon.mjs` | launchd-managed monitor. Polls every 15s, rotates at 80% utilization (5h or 7d). |
| `scripts/account-rotation/ai-brain.mjs` | Claude Haiku fallback that drives the browser past unexpected OAuth pages. Max 6 decisions, password fields masked. |
| `scripts/account-rotation/force-rotate.sh` | Out-of-band rotation when Claude Code itself is unreachable. |
| `scripts/account-rotation/config.example.json` | Schema reference. Empty `accounts[]` — user populates via `/ops:rotate add-account`. |
| `scripts/account-rotation/README.md` | Install / enable / disable / safety notes. |
| `templates/com.claude-ops.account-rotation.plist` | launchd plist with `${HOME}` placeholder. |
| `skills/ops-rotate/SKILL.md` | `/ops:rotate` slash command. |

## Public-repo sanitization (vs private source)

- `KEYCHAIN_ACCOUNT` now derives from `$USER` (override: `CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT`). No baked-in macOS username — multiple users on the same Mac don't collide.
- `ai-brain.mjs` Doppler project list comes from `CLAUDE_ROTATOR_DOPPLER_PROJECTS` env var (`project:config,project:config`). No project names baked in.
- launchd label is `com.claude-ops.account-rotation` (was a personal label in the original).
- All references to the original owner's emails / orgs / paths removed.
- **No state files copied** — only code.
- `tests/test-no-secrets.sh` passes.

## Notes

- `playwright` is already declared in `package.json` dependencies (used by other plugin scripts), so no `package.json` change was needed.
- The `add-account` wizard step in `/ops:rotate` is the only place that mutates `config.json`; the daemon never touches the config.
- This PR does **not** touch `/ops:setup` — wiring the OAuth-each setup loop into the main wizard is left for a follow-up.

## Test plan

- [x] `node --check` on `rotate.mjs`, `daemon.mjs`, `ai-brain.mjs`
- [x] `bash -n` on `force-rotate.sh`
- [x] `tests/test-no-secrets.sh` — 11/11 PASS
- [x] `npm test` — passes
- [ ] Manual: install plist, run `/ops:rotate status` on a fresh machine
- [ ] Manual: `/ops:rotate add-account` end-to-end with a real account

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it adds new automation that reads/writes macOS keychain credentials, performs OAuth flows (including AI-assisted browser actions), and runs a background `launchd` daemon that can change active authentication state automatically.
> 
> **Overview**
> Adds an **opt-in multi-account Claude Max rotator** to the `ops` plugin, including a `launchd` daemon that monitors 5h/7d utilization and rotates accounts by swapping the live `Claude Code-credentials` keychain token.
> 
> Introduces new rotation tooling (`rotate.mjs`, `daemon.mjs`, `force-rotate.sh`) with safeguards like PID-based rotation locks, cooldown/blackout logic, live utilization checks, and token refresh handling, plus a billing safety gate to avoid rotating onto accounts with overage billing enabled unless explicitly overridden.
> 
> Adds a Playwright-based OAuth browser fallback and an optional Haiku-powered `ai-brain.mjs` to recover from unexpected login/consent pages, along with user-facing docs (`README.md`, `config.example.json`), a `/ops:rotate` skill spec, and a `com.claude-ops.account-rotation.plist` template for daemon installation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9109034ea14a5ca878d0728d6df02b96d0c77fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->