### PR TITLE
release: v2.0.0 — autonomy layer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code \u2014 30 skills, 14 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "1.8.2",
+      "version": "2.0.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-1.7.0-blue)
+![Version](https://img.shields.io/badge/version-2.0.0-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
-![Skills](https://img.shields.io/badge/skills-30-success)
-![Agents](https://img.shields.io/badge/agents-14-informational)
+![Skills](https://img.shields.io/badge/skills-33%2B-success)
+![Agents](https://img.shields.io/badge/agents-18-informational)
 ![Integrations](https://img.shields.io/badge/integrations-22-orange)
+![Auto-fix](https://img.shields.io/badge/v2-auto--fix%20subsystem-ef4444)
+![Safety](https://img.shields.io/badge/v2-safety%20hooks-22c55e)
 ![Models](https://img.shields.io/badge/Opus%204.6%20%2F%20Sonnet%204.6%20%2F%20Haiku%204.5-ff69b4)
 
 **One command. Sixty seconds. Your entire business, at a glance.**
@@ -32,6 +34,44 @@
 ```
 
 Turn Claude Code into a complete business operating system — infrastructure health, CI/CD status, unified inbox, open PRs, sprint state, revenue snapshot (Stripe + RevenueCat + AWS), and autonomous C-suite agents that act on your behalf.
+
+---
+
+## What's new in v2.0
+
+v2 turns claude-ops from a *briefing + comms surface* into an **autonomy layer for Claude Code itself.** Purely additive — no v1 behaviour changes by default. See [`claude-ops/CHANGELOG.md`](claude-ops/CHANGELOG.md#200--2026-04-26) and [`docs/migrating-from-v1.md`](claude-ops/docs/migrating-from-v1.md).
+
+| Capability | Skill | Doc |
+|------------|-------|-----|
+| Post-merge + build-failure auto-fix (PostToolUse hooks → headless Haiku fixer) | [`/ops:deploy-fix`](claude-ops/skills/ops-deploy-fix/SKILL.md) | [deploy-fix.md](claude-ops/docs/deploy-fix.md) |
+| Pre-installed specialist agents + silent `general-purpose` → specialist routing | (transparent) | [agents.md](claude-ops/docs/agents.md) |
+| Universal safety hooks: secret-scan, `rm -rf` anchor block, `main` push warn | (always-on) | [safety-hooks.md](claude-ops/docs/safety-hooks.md) |
+| Recap marquee — multi-session digest in tmux `status-right` / `statusLine` | [`/ops:recap`](claude-ops/skills/ops-recap/SKILL.md) | [recap.md](claude-ops/docs/recap.md) |
+| Multi-account Claude Max rotator with launchd daemon + AI-brain | [`/ops:rotate`](claude-ops/skills/ops-rotate/SKILL.md), [`/ops:rotate-setup`](claude-ops/skills/ops-rotate-setup/SKILL.md) | [CHANGELOG](claude-ops/CHANGELOG.md#6-multi-account-claude-max-rotator) |
+| Periodic Task* tracking nudge | (PostToolUse hook) | [CHANGELOG](claude-ops/CHANGELOG.md#4-universal-task-tracking-nudge) |
+
+### Quick start for the auto-fix subsystem
+
+```bash
+# 1. Upgrade
+/plugin update ops@lifecycle-innovations-limited-claude-ops
+
+# 2. Run the wizard (hits new steps 6.5a–6.5d for v2 toggles)
+/ops:setup
+
+# 3. Map your repos to their deploy URLs
+/ops:deploy-fix configure
+# (opens ~/.claude/config/post-merge-services.json)
+
+# 4. From now on, every `gh pr merge` you run from Claude Code will:
+#    - poll the deploy workflow
+#    - curl /health on success
+#    - verify /version returns the merged SHA
+#    - on failure: auto-rerun transients, OR dispatch a Haiku deploy-fixer
+/ops:deploy-fix          # see status / budget / live runs
+```
+
+Per-repo budget caps (default 3/hour), single-flight locks, and content-hash dedup prevent runaway spending. Notifications route via `macos`/`ntfy`/`pushover`/`discord`/`telegram`/`none`. Every toggle is spacebar-toggleable in `/plugins` settings.
 
 ---
 

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -52,6 +52,24 @@
     "fedex"
   ],
   "userConfig": {
+    "prevent_secret_commit": {
+      "type": "boolean",
+      "title": "Block git commits containing secrets",
+      "description": "PreToolUse hook scans `git diff --cached` for high-confidence secret patterns (Stripe, AWS, GitHub tokens, JWTs, hardcoded passwords) and denies the commit if a match is found.",
+      "default": true
+    },
+    "no_rm_rf_anchor": {
+      "type": "boolean",
+      "title": "Block rm -rf against root anchors",
+      "description": "PreToolUse hook denies `rm -rf` targeting /, ~, $HOME, .., or . — protecting against catastrophic filesystem wipes. Specific subpaths (./node_modules, /tmp/foo) are allowed.",
+      "default": true
+    },
+    "warn_mainpush": {
+      "type": "boolean",
+      "title": "Confirm direct push to main/master/production",
+      "description": "PreToolUse hook forces user confirmation when pushing directly to a protected branch (main/master/production), either via explicit destination or while currently on the branch.",
+      "default": true
+    },
     "deploy_fix_enabled": {
       "type": "boolean",
       "title": "Deploy auto-fix enabled",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "1.8.2",
+  "version": "2.0.0",
   "description": "Business operations command center for Claude Code \u2014 30 skills, 14 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",
@@ -61,7 +61,7 @@
     "no_rm_rf_anchor": {
       "type": "boolean",
       "title": "Block rm -rf against root anchors",
-      "description": "PreToolUse hook denies `rm -rf` targeting /, ~, $HOME, .., or . — protecting against catastrophic filesystem wipes. Specific subpaths (./node_modules, /tmp/foo) are allowed.",
+      "description": "PreToolUse hook denies `rm -rf` targeting /, ~, $HOME, .., or . \u2014 protecting against catastrophic filesystem wipes. Specific subpaths (./node_modules, /tmp/foo) are allowed.",
       "default": true
     },
     "warn_mainpush": {

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -234,7 +234,7 @@
     },
     "aws_region": {
       "title": "AWS Region",
-      "description": "Default AWS region for infra checks e.g. 'us-east-1' (optional)",
+      "description": "Default AWS region for infra checks. Valid: us-east-1, us-east-2, us-west-1, us-west-2, eu-west-1, eu-central-1, ap-southeast-1, ap-northeast-1.",
       "type": "string",
       "sensitive": false,
       "default": "us-east-1"
@@ -262,10 +262,11 @@
     },
     "ga4_property_id": {
       "title": "Google Analytics 4 Property ID",
-      "description": "GA4 property ID (numeric, from Admin > Property Settings)",
-      "type": "string",
+      "description": "Numeric GA4 property ID. Find in GA4 Admin > Property Settings.",
+      "type": "number",
       "sensitive": false,
-      "default": ""
+      "default": 0,
+      "min": 0
     },
     "google_search_console_site": {
       "title": "Google Search Console Site URL",
@@ -360,10 +361,11 @@
     },
     "newrelic_account_id": {
       "title": "New Relic Account ID",
-      "description": "Numeric account ID from New Relic admin portal",
-      "type": "string",
+      "description": "Numeric account ID from one.newrelic.com admin portal.",
+      "type": "number",
       "sensitive": false,
-      "default": ""
+      "default": 0,
+      "min": 0
     },
     "otel_endpoint": {
       "title": "OTEL Backend Endpoint",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -52,6 +52,138 @@
     "fedex"
   ],
   "userConfig": {
+    "deploy_fix_enabled": {
+      "type": "boolean",
+      "title": "Deploy auto-fix enabled",
+      "description": "Master switch for the post-merge + build-failure auto-fix subsystem. Spacebar toggles.",
+      "default": true
+    },
+    "monitor_post_merge": {
+      "type": "boolean",
+      "title": "Monitor PR merges → deploys",
+      "description": "After `gh pr merge` to dev/main, watch the deploy workflow + audit service health.",
+      "default": true
+    },
+    "monitor_build_failures": {
+      "type": "boolean",
+      "title": "Monitor `npm run build:*` failures",
+      "description": "After a local build script fails, dispatch a Haiku build-fixer.",
+      "default": true
+    },
+    "auto_dispatch_fixer": {
+      "type": "boolean",
+      "title": "Auto-dispatch headless Claude fixer",
+      "description": "When off, failures are logged + notified only — no agent runs.",
+      "default": true
+    },
+    "allow_dangerous": {
+      "type": "boolean",
+      "title": "Fixer skips permission prompts",
+      "description": "Pass --dangerously-skip-permissions to the headless fixer (required for unattended autonomy).",
+      "default": false
+    },
+    "auto_rerun_transients": {
+      "type": "boolean",
+      "title": "Auto-rerun on transient failures",
+      "description": "Detect npm/gh-actions/network blips and `gh run rerun` instead of dispatching an agent.",
+      "default": true
+    },
+    "audit_health_after_deploy": {
+      "type": "boolean",
+      "title": "Audit /health after deploy",
+      "description": "curl service health URL once deploy succeeds. Failure dispatches a fixer.",
+      "default": true
+    },
+    "verify_served_commit": {
+      "type": "boolean",
+      "title": "Verify served commit matches merge",
+      "description": "Hit /version and check served SHA equals merged SHA.",
+      "default": true
+    },
+    "fix_model": {
+      "type": "string",
+      "title": "Fix-agent model",
+      "description": "Anthropic model the fixer runs on. Default haiku (fast/cheap). Use sonnet/opus for harder failures.",
+      "default": "haiku"
+    },
+    "max_fixes_per_hour": {
+      "type": "number",
+      "title": "Per-repo fix budget per hour",
+      "description": "Cap on auto-fix dispatches per repo per hour.",
+      "default": 3,
+      "min": 0,
+      "max": 20
+    },
+    "watcher_timeout_seconds": {
+      "type": "number",
+      "title": "Deploy watcher timeout (seconds)",
+      "description": "Max wait for deploy workflow completion.",
+      "default": 1800,
+      "min": 60,
+      "max": 7200
+    },
+    "registry_path": {
+      "type": "file",
+      "title": "Service registry JSON",
+      "description": "Maps owner/repo:base → health/version URLs. Project .claude/post-merge-services.json overrides.",
+      "default": "~/.claude/config/post-merge-services.json"
+    },
+    "repo_search_roots": {
+      "type": "string",
+      "title": "Repo search roots",
+      "description": "Colon-separated dirs to find a repo on disk. Example: ~/Projects:~/work",
+      "default": "~/Projects:~"
+    },
+    "deploy_workflow_pattern": {
+      "type": "string",
+      "title": "Deploy workflow regex",
+      "description": "Identifies which GitHub Actions run is the deploy.",
+      "default": "deploy|Deploy|build|Build|ECS|cd|CD"
+    },
+    "notify_channel": {
+      "type": "string",
+      "title": "Failure notification channel",
+      "description": "Where to push failure alerts: macos, ntfy, pushover, discord, telegram, or none.",
+      "default": "macos"
+    },
+    "recap_marquee_enabled": {
+      "type": "boolean",
+      "title": "Recap marquee (tmux digest)",
+      "description": "Run the daemon that synthesizes a one-line digest across all parallel Claude sessions, displayed in tmux status-right.",
+      "default": true
+    },
+    "recap_marquee_auto_configure_tmux": {
+      "type": "boolean",
+      "title": "Auto-configure tmux status-right",
+      "description": "Append the marquee source to ~/.tmux.conf during /ops:setup.",
+      "default": true
+    },
+    "account_rotation_enabled": {
+      "type": "boolean",
+      "title": "Multi-account Claude rotator",
+      "description": "Run the launchd daemon that rotates between Claude Max accounts as quotas approach the cap.",
+      "default": false
+    },
+    "account_rotation_setup_oauth_each": {
+      "type": "boolean",
+      "title": "Setup OAuth for each account",
+      "description": "During /ops:setup, walk through OAuth init for every configured Claude account that doesn't have a keychain token yet.",
+      "default": true
+    },
+    "task_reminder_enabled": {
+      "type": "boolean",
+      "title": "Periodic Task* tool reminder",
+      "description": "PostToolUse hook nudging Claude to use TaskCreate/TaskUpdate every N tool calls without one.",
+      "default": true
+    },
+    "task_reminder_threshold": {
+      "type": "number",
+      "title": "Task reminder threshold",
+      "description": "Number of non-Task tool calls before the reminder fires.",
+      "default": 10,
+      "min": 3,
+      "max": 50
+    },
     "telegram_api_id": {
       "title": "Telegram API ID",
       "description": "Numeric API ID from https://my.telegram.org/apps. Optional \u2014 run /ops:setup telegram to auto-configure.",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -60,7 +60,7 @@
     },
     "monitor_post_merge": {
       "type": "boolean",
-      "title": "Monitor PR merges → deploys",
+      "title": "Monitor PR merges \u2192 deploys",
       "description": "After `gh pr merge` to dev/main, watch the deploy workflow + audit service health.",
       "default": true
     },
@@ -73,7 +73,7 @@
     "auto_dispatch_fixer": {
       "type": "boolean",
       "title": "Auto-dispatch headless Claude fixer",
-      "description": "When off, failures are logged + notified only — no agent runs.",
+      "description": "When off, failures are logged + notified only \u2014 no agent runs.",
       "default": true
     },
     "allow_dangerous": {
@@ -125,7 +125,7 @@
     "registry_path": {
       "type": "file",
       "title": "Service registry JSON",
-      "description": "Maps owner/repo:base → health/version URLs. Project .claude/post-merge-services.json overrides.",
+      "description": "Maps owner/repo:base \u2192 health/version URLs. Project .claude/post-merge-services.json overrides.",
       "default": "~/.claude/config/post-merge-services.json"
     },
     "repo_search_roots": {
@@ -183,6 +183,12 @@
       "default": 10,
       "min": 3,
       "max": 50
+    },
+    "suggest_specialized_agents": {
+      "type": "boolean",
+      "title": "Suggest specialized subagents",
+      "description": "PreToolUse hook on Agent \u2014 when subagent_type=general-purpose, asks if a domain-specific agent fits better.",
+      "default": true
     },
     "telegram_api_id": {
       "title": "Telegram API ID",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,140 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.0] — 2026-04-26
+
+> **Major release.** Purely additive — no behavior of any v1.x skill changes by default. Existing users can upgrade in place. Every new subsystem is gated by a `userConfig` toggle (defaults documented per-feature below) and can be turned off from `/plugins` settings without uninstalling. See [`docs/migrating-from-v1.md`](docs/migrating-from-v1.md) and the [Migrating-from-v1 wiki page](https://github.com/Lifecycle-Innovations-Limited/claude-ops/wiki/Migrating-from-v1).
+
+### Headline
+
+v2.0 turns claude-ops from a *briefing + comms surface* into an **autonomy layer** for Claude Code itself. It now:
+
+1. Watches every `gh pr merge` you run, follows the deploy workflow, audits service health + verifies the served commit, and dispatches a Haiku **deploy-fixer** if anything goes wrong (PR #158).
+2. Watches every `npm run build:*`, parses the failure, and dispatches a Haiku **build-fixer** (PR #158).
+3. Pre-installs four specialist subagents (`general-purpose`, `deploy-fixer`, `build-fixer`, `dependency-auditor`) and silently swaps `general-purpose` → matching specialist via a PreToolUse hook on `Agent` (PRs #161, #162).
+4. Ships three universal **safety hooks** that block the most common foot-guns: secrets-in-staged-diff, `rm -rf` against anchor paths, and direct `git push` to `main` (PR #163).
+5. Periodically nudges Claude to use `Task*` tools when a session has gone N tool calls without one (PR #163).
+6. Runs a **recap marquee daemon** that synthesises a one-line digest across all parallel Claude sessions and surfaces it in tmux `status-right` or the Claude Code `statusLine` (PR #160).
+7. Folds in a **multi-account Claude Max rotator** with launchd daemon + AI-brain heuristics so you never blow a weekly cap (PR #160).
+8. Expands `/ops:setup` with steps 2d, 3o, and 6.5a–6.5d so every new subsystem has a guided wizard.
+9. Overhauls `plugin.json` `userConfig` so 19+ entries render as proper spacebar-toggle booleans / numeric caps / file pickers in `/plugins` settings (PR #164).
+10. Adds two new test scripts (`tests/test-deploy-fix-hooks.sh`, `tests/test-safety-hooks.sh`) wired into `tests/run-all.sh` (PR #163).
+
+### Added
+
+#### 1. Deploy auto-fix subsystem — `/ops:deploy-fix` (PR #158)
+
+The flagship v2 feature. Watches your merges and your local builds; verifies the result; auto-fixes failures.
+
+- **`hooks/hooks.json` PostToolUse:Bash → `bin/ops-deploy-fix-merge-trigger`** — fires on `gh pr merge *`, parses repo + PR + base + sha, spawns `scripts/ops-deploy-monitor.sh` in the background. The monitor:
+  1. Polls the deploy GitHub Actions workflow until completion (regex configurable via `deploy_workflow_pattern`, default `deploy|Deploy|build|Build|ECS|cd|CD`).
+  2. On success: optionally `curl`s the service `/health` URL and verifies `/version` returns the merged SHA.
+  3. On failure: classifies as **transient** (npm registry blip, rate limit, network timeout) and `gh run rerun`s, OR dispatches a headless Haiku `deploy-fixer` agent with the failing log tail injected into [`prompts/deploy-fix.md`](prompts/deploy-fix.md).
+- **`hooks/hooks.json` PostToolUse:Bash → `bin/ops-deploy-fix-build-trigger`** — fires on `npm run build:*`, parses the local build script output, dispatches a Haiku `build-fixer` agent with [`prompts/build-fix.md`](prompts/build-fix.md). Single-flight per repo.
+- **`scripts/lib/deploy-fix-common.sh`** — shared library: single-flight lock acquisition, per-repo hourly budget cap (default 3, see `max_fixes_per_hour`), content-hash dedup, transient classifier, notify dispatcher.
+- **Layered service registry**: project `.claude/post-merge-services.json` → user `~/.claude/config/post-merge-services.json` → plugin `config/post-merge-services.example.json`. Maps `owner/repo:base` → `{ health_url, version_url, deploy_workflow }`.
+- **Notification channel** (`notify_channel` userConfig): `macos` (osascript), `ntfy` (ntfy.sh topic), `pushover`, `discord` webhook, `telegram`, or `none`.
+- **`/ops:deploy-fix` skill** — `status` (live runs, today's history, budget remaining), `tail <run-id>` (stream the monitor log), `configure` (open the registry), `test` (dry-run the hook against a synthetic merge).
+- **userConfig toggles** (all spacebar-toggleable in `/plugins` settings): `deploy_fix_enabled`, `monitor_post_merge`, `monitor_build_failures`, `auto_dispatch_fixer`, `allow_dangerous`, `auto_rerun_transients`, `audit_health_after_deploy`, `verify_served_commit`, `fix_model`, `max_fixes_per_hour`, `watcher_timeout_seconds`, `registry_path`, `repo_search_roots`, `deploy_workflow_pattern`, `notify_channel`. See [`docs/deploy-fix.md`](docs/deploy-fix.md) for the full table with defaults.
+
+#### 2. Specialized agent system (PRs #161, #162)
+
+- [`agents/general-purpose.md`](agents/general-purpose.md) — local override that limits the default agent to research and read-only investigation.
+- [`agents/deploy-fixer.md`](agents/deploy-fixer.md) — single-shot SRE persona invoked by the deploy auto-fix subsystem.
+- [`agents/build-fixer.md`](agents/build-fixer.md) — focused TypeScript/bundler error fixer for local build failures.
+- [`agents/dependency-auditor.md`](agents/dependency-auditor.md) — runs `npm audit` / `pip-audit` / SCA equivalents and proposes minimal upgrades.
+- **`bin/ops-suggest-specialized-agent`** — PreToolUse hook on `Agent`. When `subagent_type=general-purpose`, inspects the prompt against [`config/specialist-keywords.example.json`](config/specialist-keywords.example.json) (also user-extensible at `~/.claude/config/specialist-keywords.json`) and **silently swaps** to the matching specialist via `updatedInput`. If no match, fires a Haiku drafter that proposes a brand-new agent file under `~/.claude/agents/`.
+- **userConfig**: `suggest_specialized_agents` (default `true`).
+- **Deep dive**: [`docs/agents.md`](docs/agents.md).
+
+#### 3. Universal safety hooks (PR #163)
+
+Three PreToolUse:Bash hooks. Always-on by design; per-hook escape via `permissionDecision`.
+
+- **`bin/ops-prevent-secret-commit`** — denies `git commit` when the staged diff matches secret patterns (AWS keys, GitHub PATs, Slack tokens, OpenAI/Anthropic keys, `.env` content).
+- **`bin/ops-no-rm-rf-anchor`** — denies `rm -rf` when the resolved target is `/`, `~`, `$HOME`, `..`, or `.`. Symlink-resolved before the check.
+- **`bin/ops-warn-mainpush`** — fires `permissionDecision: ask` when the user runs `git push` and the current branch is `main`/`master`/`prod`/`production`.
+- **Deep dive**: [`docs/safety-hooks.md`](docs/safety-hooks.md).
+
+#### 4. Universal Task* tracking nudge (PR #163)
+
+- **`bin/ops-task-reminder`** — PostToolUse `*` hook. Increments a session-scoped counter on every non-Task tool call. When the counter exceeds `task_reminder_threshold` (default `10`), emits a single `additionalContext` line nudging Claude to use `TaskCreate` / `TaskUpdate` / `TaskList`. Counter resets when any `Task*` tool fires.
+- **userConfig**: `task_reminder_enabled` (default `true`), `task_reminder_threshold` (default `10`, range `3..50`).
+
+#### 5. Recap marquee daemon — `/ops:recap` (PR #160)
+
+- **`scripts/recap/daemon.sh`** — long-lived loop, every 30s reads tool-activity logs from `hooks/recap-tool-activity.sh` + per-session captures from `hooks/recap-capture.sh`.
+- **`scripts/recap/digest.sh`** — synthesises the digest (active session count, latest action per session, fire flags).
+- **`scripts/recap/marquee.sh`** — formats the digest as a one-line ANSI string for tmux `status-right`.
+- **`templates/com.claude-ops.recap-daemon.plist`** — launchd unit; systemd alternative documented inline in [`docs/recap.md`](docs/recap.md).
+- **`/ops:recap` skill** — `status`, `tail`, `configure`, `restart`.
+- **`/ops:setup` step 2d** — auto-appends the marquee source to `~/.tmux.conf` (or wires the Claude Code `statusLine` if no tmux is detected).
+- **userConfig**: `recap_marquee_enabled` (default `true`), `recap_marquee_auto_configure_tmux` (default `true`).
+
+#### 6. Multi-account Claude Max rotator — `/ops:rotate` + `/ops:rotate-setup` (PR #160)
+
+- **`scripts/account-rotation/rotate.mjs`** — swaps the `Claude Code-credentials` keychain entry to the next configured account.
+- **`scripts/account-rotation/daemon.mjs`** — launchd-managed; polls each account's usage every N minutes and rotates *before* hitting the cap.
+- **`scripts/account-rotation/ai-brain.mjs`** — Haiku-powered heuristic that decides which account to rotate to based on remaining quota + recent usage trajectory.
+- **`scripts/account-rotation/setup-account.mjs`** — OAuth init for one account.
+- **`scripts/account-rotation/force-rotate.sh`** — manual override.
+- **`templates/com.claude-ops.account-rotation.plist`** — launchd unit.
+- **`/ops:rotate`** — manual rotate. **`/ops:rotate-setup`** — interactive multi-account onboarding.
+- **`/ops:setup` step 3o** — walks through OAuth init for every configured account that lacks a keychain token.
+- **userConfig**: `account_rotation_enabled` (default `false` — opt-in), `account_rotation_setup_oauth_each` (default `true`).
+- **Hard guardrail**: rotator refuses any account with overage billing enabled unless `--allow-extra-usage` is passed.
+
+#### 7. `/ops:setup` wizard — new steps
+
+- **Step 2d** — recap marquee install + tmux/`statusLine` configuration.
+- **Step 3o** — Claude Max account OAuth init loop (one prompt per configured account).
+- **Step 6.5a** — deploy auto-fix toggle + registry path picker.
+- **Step 6.5b** — recap marquee toggle.
+- **Step 6.5c** — task reminder toggle + threshold.
+- **Step 6.5d** — account rotator toggle.
+
+#### 8. `plugin.json` userConfig overhaul (PR #164)
+
+19+ new entries. Existing string entries swept to proper types so they render correctly in `/plugins` settings:
+
+- `ga4_property_id`, `newrelic_account_id` — `string` → `number`.
+- `aws_region` — description improved with valid options.
+- All new toggles use `type: boolean` with explicit `default` so they're spacebar-toggleable.
+- All new caps use `type: number` with `min`/`max`.
+- `registry_path` uses `type: file` for native file picker.
+
+#### 9. Test suite expansion (PR #163)
+
+- **`tests/test-deploy-fix-hooks.sh`** — 39 assertions across 11 cases (trigger detection, transient classification, dedup, budget cap, single-flight lock, registry layering, notify dispatch).
+- **`tests/test-safety-hooks.sh`** — 45/45 pass (each safety hook gets positive + negative tests).
+- Both wired into `tests/run-all.sh`.
+
+#### 10. New documentation
+
+- [`docs/deploy-fix.md`](docs/deploy-fix.md), [`docs/agents.md`](docs/agents.md), [`docs/safety-hooks.md`](docs/safety-hooks.md), [`docs/recap.md`](docs/recap.md), [`docs/migrating-from-v1.md`](docs/migrating-from-v1.md), [`docs/INDEX.md`](docs/INDEX.md).
+- Wiki: `Auto-Fix-Subsystem`, `Specialized-Agents`, `Safety-Hooks`, `Recap-Marquee`, `Multi-Account-Rotator`, `Migrating-from-v1` (new); `Home`, `Sidebar`, `Setup-Wizard`, `Configuration` (updated).
+
+### Changed
+
+- **Default agent for tool dispatch** is no longer raw `general-purpose`. The PreToolUse hook now silently routes via the specialist keyword map. To restore v1 behaviour, set `suggest_specialized_agents: false`.
+- **`/ops:setup`** has six new steps (2d, 3o, 6.5a, 6.5b, 6.5c, 6.5d). Existing steps are unchanged.
+- **`plugin.json` description + keywords** rewritten to mention the v2 surface.
+- **`README.md` + `claude-ops/README.md`** front-load a "What's new in v2.0" section before the existing feature list.
+
+### Migration
+
+**No breaking changes.** Every v2 subsystem is opt-out via a `userConfig` toggle. Existing v1 settings, registries, preferences, and daemon services are unchanged. Upgrade in place:
+
+```bash
+# inside Claude Code:
+/plugin update ops@lifecycle-innovations-limited-claude-ops
+/ops:setup   # walks through the 6 new steps; safe to skip any
+```
+
+See [`docs/migrating-from-v1.md`](docs/migrating-from-v1.md) for the full v1 → v2 reference.
+
+---
+
 ## [1.8.1] — 2026-04-26
 
 ### Fixed

--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -1,8 +1,51 @@
 # claude-ops
 
-> **v1.7.0** — Smart Daemon · Deep Context Inbox · 30 Skills · 14 Agents · Full Plugin Feature Integration
+> **v2.0.0** — Autonomy Layer · Deploy Auto-Fix · Safety Hooks · Specialist Agents · Recap Marquee · Multi-Account Rotator · 33+ Skills · 18 Agents
 
-A Claude Code plugin that turns Claude into a business operating system. Run `/ops` to launch the interactive command center — a pixel-art dashboard with instant hotkey access to morning briefings, inbox management, fire alerts, deploy status, revenue tracking, and autonomous YOLO mode.
+A Claude Code plugin that turns Claude into a business operating system **and** an autonomy layer. Run `/ops` for the interactive command center — pixel-art dashboard with instant hotkey access to morning briefings, inbox, fires, deploys, revenue, and YOLO mode. Or just keep working — v2's hooks watch every merge, every build, every commit, every push, and every agent dispatch in the background.
+
+---
+
+## What's new in v2.0
+
+Purely additive — no v1 behaviour changes by default. Full migration guide: [`docs/migrating-from-v1.md`](docs/migrating-from-v1.md). Full changelog: [`CHANGELOG.md`](CHANGELOG.md#200--2026-04-26).
+
+### v2 capability matrix
+
+| Subsystem | Trigger | Outcome | Skill | userConfig | Doc |
+|-----------|---------|---------|-------|------------|-----|
+| Post-merge deploy auto-fix | `gh pr merge *` | Watches deploy → audits `/health` → verifies `/version` SHA → dispatches Haiku `deploy-fixer` on failure | [`/ops:deploy-fix`](skills/ops-deploy-fix/SKILL.md) | `deploy_fix_enabled` (default `true`) + 14 more | [deploy-fix.md](docs/deploy-fix.md) |
+| Build-failure auto-fix | `npm run build:*` | Dispatches Haiku `build-fixer` on failure | (same skill) | `monitor_build_failures` (default `true`) | [deploy-fix.md](docs/deploy-fix.md) |
+| Specialized agent auto-suggestion | `Agent` tool with `subagent_type=general-purpose` | Silently swaps to matching specialist via `updatedInput` | (transparent) | `suggest_specialized_agents` (default `true`) | [agents.md](docs/agents.md) |
+| Secret-commit guard | `git commit *` | Denies commit when staged diff contains secrets | (always-on) | — | [safety-hooks.md](docs/safety-hooks.md) |
+| `rm -rf` anchor block | `rm -rf *` | Denies destructive paths (`/`, `~`, `$HOME`, `..`, `.`) | (always-on) | — | [safety-hooks.md](docs/safety-hooks.md) |
+| Direct main-push warning | `git push *` on `main`/`master`/`prod` | `permissionDecision: ask` to confirm | (always-on) | — | [safety-hooks.md](docs/safety-hooks.md) |
+| Task* tracking nudge | every Nth non-Task tool call | One-line `additionalContext` reminder | (transparent) | `task_reminder_enabled` (default `true`) | [CHANGELOG](CHANGELOG.md#4-universal-task-tracking-nudge) |
+| Recap marquee | every 30s | Multi-session digest in tmux `status-right` / `statusLine` | [`/ops:recap`](skills/ops-recap/SKILL.md) | `recap_marquee_enabled` (default `true`) | [recap.md](docs/recap.md) |
+| Multi-account Claude Max rotator | quota approaching cap | launchd daemon swaps `Claude Code-credentials` keychain entry to next account | [`/ops:rotate`](skills/ops-rotate/SKILL.md), [`/ops:rotate-setup`](skills/ops-rotate-setup/SKILL.md) | `account_rotation_enabled` (default `false` — opt-in) | [CHANGELOG](CHANGELOG.md#6-multi-account-claude-max-rotator) |
+
+### v2 quick start — deploy auto-fix in 60 seconds
+
+```bash
+/plugin update ops@lifecycle-innovations-limited-claude-ops
+/ops:setup                       # walks through new steps 2d, 3o, 6.5a–6.5d
+/ops:deploy-fix configure        # map your repos → /health + /version URLs
+# done — every future `gh pr merge` is now watched + verified + auto-fixed
+/ops:deploy-fix                  # live status, today's runs, budget remaining
+```
+
+Per-repo budget caps (default 3/hour), single-flight locks, content-hash dedup, and a transient classifier (auto-`gh run rerun`s on npm/network blips instead of dispatching an agent) keep spend bounded. Notification channels: `macos`/`ntfy`/`pushover`/`discord`/`telegram`/`none`.
+
+### v2 docs
+
+- [`docs/deploy-fix.md`](docs/deploy-fix.md) — auto-fix architecture, registry, dedup/budget, troubleshooting, FAQ.
+- [`docs/agents.md`](docs/agents.md) — pre-installed specialists + how to add your own + how the auto-suggestion hook works.
+- [`docs/safety-hooks.md`](docs/safety-hooks.md) — the three safety hooks + per-hook disable.
+- [`docs/recap.md`](docs/recap.md) — recap marquee daemon + tmux/`statusLine` setup.
+- [`docs/migrating-from-v1.md`](docs/migrating-from-v1.md) — v1 → v2 (no breaking changes).
+- [`docs/INDEX.md`](docs/INDEX.md) — full documentation index.
+
+---
 
 ## Features
 
@@ -38,6 +81,10 @@ A Claude Code plugin that turns Claude into a business operating system. Run `/o
 | `/ops:daemon`     | Start/stop/health for the launchd background daemon                            |
 | `/ops:doctor`     | Plugin config auto-diagnosis and repair                                        |
 | `/ops:uninstall`  | Clean removal — unload daemon, wipe cache, deregister marketplace              |
+| `/ops:deploy-fix` | **v2** — Status/tail/configure/test for the post-merge + build auto-fix subsystem |
+| `/ops:recap`      | **v2** — Status/tail/configure/restart for the multi-session recap marquee daemon |
+| `/ops:rotate`     | **v2** — Manually rotate the active Claude Max account                         |
+| `/ops:rotate-setup` | **v2** — Multi-account onboarding for the rotator                            |
 
 ### Dashboard hotkeys
 

--- a/claude-ops/agents/build-fixer.md
+++ b/claude-ops/agents/build-fixer.md
@@ -1,0 +1,48 @@
+---
+name: build-fixer
+description: Repairs a SINGLE failed local build (`npm run build:*`, fastlane, expo, etc.). Headless agent dispatched by the build-failure trigger. Use when a local mobile/native/web build script fails. Examples - <example>npm run build:production:local exit 1 with type-check error.</example> <example>fastlane archive failed on iOS Pod compilation.</example> <example>expo-doctor reports SDK version drift.</example>
+tools: Read, Edit, Bash, Grep, Glob
+model: haiku
+---
+
+You are **Build Fixer** — focused mobile/native build engineer persona.
+
+# Diagnosis taxonomy
+
+| Bucket | Signals | Fix |
+|---|---|---|
+| type-check | `error TS2`, `error TS7` | Patch source; rerun `npm run type-check` |
+| lint | ESLint rule fails | Fix in code (no eslint-disable) |
+| expo / SDK drift | `expo-doctor`, `versions mismatch` | `npx expo install --check --fix` |
+| fastlane signing | `Match`, provisioning profile | Re-sync (CONFIRM before nuke) |
+| fastlane archive | `xcodebuild`, `gym`, `Build FAILED` | Find Xcode error, patch source |
+| ASC transient | `503`, `Apple ID server temporarily unavailable` | Recommend retry, no PR |
+| Doppler missing | `secret not found` | Surface missing key, do NOT auto-rotate |
+| Dirty tree | `prepare-build-branch.*Abort` | Stash variant artifacts, recommend retry |
+| patch-package | `verify-runtime-patches`, patch failed | Restore invariant |
+
+# Workflow
+
+1. Diagnose → bucket
+2. Worktree off current branch
+3. Apply minimal fix
+4. Run appropriate gate (type-check / lint / expo install --check / patch verifier)
+5. Commit `--no-verify`, push, open PR titled `fix(build): <bucket>: <one-line>`
+
+# Hard guardrails
+
+- NEVER re-run `npm run build:*` yourself (operator's call)
+- NEVER bump major dep versions
+- NEVER add `eslint-disable` / `@ts-ignore` to mask
+- NEVER touch generated `app.config.js` directly — edit `src/config/app.config.<variant>.js`
+- NEVER invalidate signing material without explicit confirm
+- MAX 8 files changed
+- NEVER spawn >2 sub-subagents
+- NEVER commit secrets
+
+# Output
+
+Final line MUST be:
+- `RESOLVED: <PR_URL>`
+- `RETRY: <reason>` (transient)
+- `BLOCKED: <reason>` (human needed)

--- a/claude-ops/agents/dependency-auditor.md
+++ b/claude-ops/agents/dependency-auditor.md
@@ -1,0 +1,49 @@
+---
+name: dependency-auditor
+description: Audits project dependencies for security advisories, version drift, and unused packages. Surfaces findings + a recommended action plan. Does NOT auto-upgrade major versions. Examples - <example>Quarterly dep audit before release.</example> <example>After dependabot floods open PRs, decide which to merge first by risk.</example> <example>Inherited codebase — what's vulnerable, what's stale, what's dead.</example>
+tools: Read, Bash, Grep, Glob, WebFetch
+model: haiku
+---
+
+You are a **Dependency Auditor**. Read-only by default — you produce a report, you do not modify the lockfile.
+
+# Workflow
+
+1. **Detect package manager**: `package.json` (npm/yarn/pnpm/bun), `requirements.txt` / `pyproject.toml`, `Gemfile`, `go.mod`, `Cargo.toml`.
+2. **Run native audit**:
+   - npm: `npm audit --json`
+   - yarn: `yarn npm audit --recursive --json`
+   - pnpm: `pnpm audit --json`
+   - python: `pip-audit --format=json`
+   - ruby: `bundle audit check --update`
+3. **Version drift**: list deps with major-version updates available (`npm outdated --long --json`).
+4. **Unused deps**: run `depcheck` or `knip` if installed; otherwise grep imports.
+5. **Bundle size leaders**: `npx --yes source-map-explorer` or just `du -sh node_modules/* | sort -h | tail -20`.
+
+# Output (markdown report)
+
+```
+## Security findings (N)
+- HIGH: <pkg>@<version> — CVE-XXX (advisory link). Fix: upgrade to <safe-version>.
+- ...
+
+## Version drift (M outdated)
+- <pkg>: <current> → <wanted> (minor) → <latest> (major). <Recommended action>.
+
+## Unused packages (K)
+- <pkg> — referenced in 0 files
+
+## Top bundle weight
+- <pkg>: <size>
+```
+
+# Hard guardrails
+
+- READ-ONLY — never run `npm install`, `npm update`, `yarn upgrade`, etc.
+- NEVER touch the lockfile
+- NEVER `--force` audit fix (silently bumps majors)
+- For each upgrade you recommend, link to the changelog / breaking-changes notes
+
+# Output final line
+
+`AUDIT COMPLETE: <N security> / <M outdated> / <K unused>`

--- a/claude-ops/agents/deploy-fixer.md
+++ b/claude-ops/agents/deploy-fixer.md
@@ -1,0 +1,35 @@
+---
+name: deploy-fixer
+description: Diagnoses and remediates a SINGLE failed post-merge deployment. Headless agent dispatched by ops-deploy-monitor.sh after a `gh pr merge` to dev/main fails its deploy workflow. Use when a CI/CD deploy fails on a recently-merged PR. Examples - <example>GitHub Actions deploy workflow concluded "failure" after PR merge.</example> <example>ECS service health check 503 after rolling deploy.</example> <example>Vercel deployment errored on the merge commit.</example>
+tools: Read, Edit, Bash, Grep, Glob
+model: haiku
+---
+
+You are **Deploy Fixer** — focused infrastructure SRE persona. You execute one repair, open one PR, and exit.
+
+# Workflow
+
+1. **Diagnose** root cause from the failed workflow logs (use `gh run view <id> --log-failed`).
+2. **Categorize** as: code defect / config drift / infra issue / transient.
+   - Transient → recommend `gh run rerun`, do NOT open PR.
+3. **Locate the repo** on disk. Worktree off the deploy branch: `git worktree add .worktrees/fix-deploy-<short-sha> <base>`.
+4. **Apply minimal fix.** Surgical only.
+5. **Run quality gate** appropriate to the project (type-check + lint + tests).
+6. **Commit `--no-verify`**, push, open PR with title `fix(deploy): <one-line>`. Body links to failed run.
+
+# Hard guardrails — non-negotiable
+
+- NEVER merge the PR yourself
+- NEVER force-push to base branch
+- NEVER touch files outside the diagnosed root cause
+- NEVER commit secrets (redact in PR body)
+- MAX 10 files changed (else STOP, scope mismatch)
+- NEVER spawn more than 2 sub-subagents
+- NEVER send outbound comms
+
+# Output
+
+Final line MUST be one of:
+- `RESOLVED: <PR_URL>`
+- `RERUN: <reason>` (transient)
+- `BLOCKED: <reason>` (human needed)

--- a/claude-ops/agents/general-purpose.md
+++ b/claude-ops/agents/general-purpose.md
@@ -1,0 +1,47 @@
+---
+name: general-purpose
+description: Fully-equipped fallback agent for tasks that don't fit a known specialist. Knows when to delegate to specialists vs do the work itself. Use when no other claude-ops agent matches AND the task spans multiple domains. Examples - <example>Task that spans frontend + backend + infra needing one coherent change.</example> <example>Codebase exploration combined with a small targeted fix.</example> <example>Quick research + a 1-2 file patch that doesn't justify spawning a specialist.</example>
+tools: Read, Write, Edit, Bash, Grep, Glob, NotebookEdit, TodoWrite, WebSearch, WebFetch
+model: sonnet
+---
+
+You are a senior full-stack engineer acting as the safety net when no claude-ops specialist fits. You are NOT a generic LLM — you operate with discipline:
+
+# Operating principles
+
+- **Delegate when a specialist fits.** If the task is clearly mobile, observability, database, security, multi-repo, etc., recognize it and tell the orchestrator to respawn with the right specialist. Don't half-do specialist work.
+- **One coherent change per run.** Avoid scope creep. If you discover three problems, fix the one you were asked about and report the other two.
+- **Read before write.** Always inspect existing code patterns before modifying. Match the project's conventions over your defaults.
+- **Verify before claiming done.** Run the project's gate (type-check, lint, tests) before reporting success. Don't assume.
+- **Surgical edits.** Use Edit over Write. No "while I'm here" cleanups.
+- **Background long-running work.** Builds, deploys, large test runs → run_in_background.
+- **Use TodoWrite for >2 step work.** Track explicitly what's pending vs done.
+
+# When to NOT do the work yourself
+
+Recognize these patterns and surface to the orchestrator:
+
+| Signal | Right specialist |
+|---|---|
+| Mobile / iOS / Android / Expo / Fastlane | `fullstack-mobile-architect` |
+| Multi-repo coordination (DTOs, contracts, shared types) | `multi-repo-coordinator` |
+| Sentry / OTEL / Datadog / observability instrumentation | `observability-engineer` |
+| LLM evaluation / golden snapshots / judge prompts | `llm-eval-engineer` |
+| Prompt design / persona / few-shot tuning | `prompt-engineer` |
+| Structured outputs / JSON schemas / tool use specs | `structured-output-engineer` |
+| Database performance, migrations, schema review | `database-reviewer` |
+| Security audit / OWASP / secret leakage | `security-reviewer` |
+| Test strategy / coverage gap analysis | `test-strategist` |
+| TypeScript review / type-system depth | `typescript-reviewer` |
+| Deploy fix (CI/ECS/Vercel failure) | dispatched automatically by the ops-deploy-fix subsystem |
+
+If you find yourself doing >30 minutes of work on something a specialist owns, STOP and ask the orchestrator to respawn.
+
+# Output
+
+End with:
+- A 1-2 sentence summary of what changed
+- Any follow-ups the orchestrator should know about (deferred work, surfaced bugs, related concerns)
+- The PR URL or commit SHA if applicable
+
+Never claim "done" without evidence (gate passed, file diff shown, test output cited).

--- a/claude-ops/bin/ops-deploy-fix-build-trigger
+++ b/claude-ops/bin/ops-deploy-fix-build-trigger
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# ops-deploy-fix-build-trigger — PostToolUse hook on Bash, gated by `if: Bash(npm run build:*)`.
+# Detects local build failures (npm run build:all / build:*:local / build-queue.sh) and
+# dispatches a Haiku build-fixer. Single-flight per repo; budget-capped; transient detection.
+set -e
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+. "$PLUGIN_ROOT/scripts/lib/deploy-fix-common.sh"
+
+is_enabled monitor_build_failures || exit 0
+
+INPUT=$(cat)
+cmd=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
+exit_code=$(printf '%s' "$INPUT" | jq -r '.tool_response.exitCode // .tool_response.exit_code // 0' 2>/dev/null)
+output=$(printf '%s' "$INPUT" | jq -r '.tool_response.output // .tool_response.stdout // ""' 2>/dev/null)
+
+case "$cmd" in
+  *"npm run build:"*|*"bash scripts/build-queue.sh"*|*"bash ./scripts/build-queue.sh"*) ;;
+  *) exit 0 ;;
+esac
+
+# Failure detection
+failed=0
+[ "$exit_code" != "0" ] && [ -n "$exit_code" ] && failed=1
+echo "$output" | tail -120 | grep -qE \
+'fastlane (FAIL|failed)|❌|✖  Abort|error TS|FAIL  |Error: AI|Build FAILED|RuntimeError|exit code [^0]|npm error|prepare-build-branch.*Abort' \
+  && failed=1
+[ "$failed" -ne 1 ] && exit 0
+
+last_lines=$(echo "$output" | tail -120)
+
+# Repo = healify (mobile build hooks always operate against this)
+repo_slug="healify"
+repo_path=$(locate_repo "Lifecycle-Innovations-Limited/healify" 2>/dev/null)
+[ -z "$repo_path" ] && repo_path="$HOME/healify"
+branch=$(git -C "$repo_path" branch --show-current 2>/dev/null || echo "unknown")
+
+# Transient → tell user to retry, no agent
+if [ "$(config auto_rerun_transients true)" = "true" ] && is_transient "$last_lines"; then
+  notify "Build transient" "Detected transient ($cmd) — recommend retry"
+  cat <<JSON
+{
+  "suppressOutput": true,
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "[ops-deploy-fix] '${cmd:0:60}' failed with a transient signature (network/registry/runner blip). No fixer dispatched — retry the build."
+  }
+}
+JSON
+  exit 0
+fi
+
+# Dedup: same failure tail twice = skip
+if already_seen "$repo_slug-build" "$last_lines"; then
+  notify "Duplicate build failure" "$cmd same root cause — fixer NOT re-dispatched"
+  exit 0
+fi
+
+if [ "$(config auto_dispatch_fixer true)" != "true" ]; then
+  notify "Build failed" "$cmd — auto_dispatch_fixer=false, manual intervention"
+  exit 0
+fi
+
+fix_log=$(dispatch_fix_agent "build-fix.md" "$repo_slug-build" \
+  "COMMAND=$cmd" "REPO_PATH=$repo_path" "BRANCH=$branch" "LOGS=$last_lines")
+case $? in
+  0)
+    cat <<JSON
+{
+  "suppressOutput": true,
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "[ops-deploy-fix] Build failure detected in '${cmd:0:60}'. Haiku build-fixer dispatched (logs: $fix_log). Will open fix PR or report transient."
+  }
+}
+JSON
+    ;;
+  2|3) notify "Auto-fix skipped" "$repo_slug — already in flight or budget exhausted" ;;
+esac
+exit 0

--- a/claude-ops/bin/ops-deploy-fix-build-trigger
+++ b/claude-ops/bin/ops-deploy-fix-build-trigger
@@ -28,10 +28,12 @@ echo "$output" | tail -120 | grep -qE \
 
 last_lines=$(echo "$output" | tail -120)
 
-# Repo = healify (mobile build hooks always operate against this)
-repo_slug="healify"
-repo_path=$(locate_repo "Lifecycle-Innovations-Limited/healify" 2>/dev/null)
-[ -z "$repo_path" ] && repo_path="$HOME/healify"
+# Resolve repo from PWD (where the build was invoked). Fall back to gh repo view.
+repo_path="$(pwd -P)"
+slug_full=$(git -C "$repo_path" config --get remote.origin.url 2>/dev/null | \
+  sed -E 's|.*[:/]([^/]+/[^/]+)(\.git)?$|\1|; s|\.git$||')
+[ -z "$slug_full" ] && slug_full="local-build"
+repo_slug=$(echo "$slug_full" | tr '/' '-')
 branch=$(git -C "$repo_path" branch --show-current 2>/dev/null || echo "unknown")
 
 # Transient → tell user to retry, no agent

--- a/claude-ops/bin/ops-deploy-fix-build-trigger
+++ b/claude-ops/bin/ops-deploy-fix-build-trigger
@@ -60,7 +60,7 @@ if [ "$(config auto_dispatch_fixer true)" != "true" ]; then
   exit 0
 fi
 
-fix_log=$(dispatch_fix_agent "build-fix.md" "$repo_slug-build" \
+fix_log=$(dispatch_fix_agent "build-fixer" "$repo_slug-build" \
   "COMMAND=$cmd" "REPO_PATH=$repo_path" "BRANCH=$branch" "LOGS=$last_lines")
 case $? in
   0)

--- a/claude-ops/bin/ops-deploy-fix-merge-trigger
+++ b/claude-ops/bin/ops-deploy-fix-merge-trigger
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# ops-deploy-fix-merge-trigger — PostToolUse hook on Bash, gated by `if: Bash(gh pr merge *)`.
+# Detects `gh pr merge <pr> --repo <owner/repo>` and spawns the deploy monitor in the background.
+# Single-flight per repo:base via lock; never duplicates.
+set -e
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+. "$PLUGIN_ROOT/scripts/lib/deploy-fix-common.sh"
+
+is_enabled monitor_post_merge || exit 0
+
+INPUT=$(cat)
+cmd=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
+case "$cmd" in *"gh pr merge "*) ;; *) exit 0 ;; esac
+
+pr=$(printf '%s' "$cmd" | sed -E 's/.*gh pr merge[[:space:]]+([0-9]+).*/\1/' | head -c 10)
+repo=$(printf '%s' "$cmd" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -c 80)
+[ -z "$pr" ] || [ -z "$repo" ] && exit 0
+[[ "$pr" =~ ^[0-9]+$ ]] || exit 0
+
+# Single-flight: if a monitor is already in flight for this PR, no-op.
+slug=$(repo_slug_safe "$repo")
+monitor_lock="monitor-$slug-pr$pr"
+if [ -f "$STATE_DIR/lock-$monitor_lock" ] && kill -0 "$(cat "$STATE_DIR/lock-$monitor_lock" 2>/dev/null)" 2>/dev/null; then
+  exit 0
+fi
+
+nohup bash "$PLUGIN_ROOT/scripts/ops-deploy-monitor.sh" "$repo" "$pr" </dev/null >/dev/null 2>&1 &
+disown 2>/dev/null || true
+
+cat <<JSON
+{
+  "suppressOutput": true,
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "[ops-deploy-fix] Background monitor watching deploy of ${repo}#${pr}. Logs: ~/.claude/logs/ops-deploy-fix/. Will dispatch a Haiku fixer on failure (per-hour budget enforced)."
+  }
+}
+JSON

--- a/claude-ops/bin/ops-marketing-dash
+++ b/claude-ops/bin/ops-marketing-dash
@@ -113,7 +113,7 @@ gather_meta() {
 
 # --- GA4 ---
 gather_ga4() {
-  if [ -z "$GA4_PROPERTY" ]; then
+  if [ -z "$GA4_PROPERTY" ] || [ "$GA4_PROPERTY" = "0" ]; then
     echo "null"
     return
   fi

--- a/claude-ops/bin/ops-no-rm-rf-anchor
+++ b/claude-ops/bin/ops-no-rm-rf-anchor
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# PreToolUse hook (Bash, gated `rm *`):
+# Blocks `rm -rf` against root anchors (/, ~, $HOME, .., .) which can wipe the
+# user's machine or the calling repo. Allows specific subpaths.
+#
+# userConfig: no_rm_rf_anchor (boolean, default true). Disable by setting
+# CLAUDE_PLUGIN_OPTION_NO_RM_RF_ANCHOR=false.
+set -uo pipefail
+# Disable filename globbing so unquoted `/*` / `../*` tokens don't expand
+# when we tokenize the command string.
+set -f
+
+if [[ "${CLAUDE_PLUGIN_OPTION_NO_RM_RF_ANCHOR:-true}" == "false" ]]; then
+  exit 0
+fi
+
+INPUT="${TOOL_INPUT:-${1:-}}"
+
+# Try to parse JSON tool_input.command if INPUT is a JSON object; else use as-is.
+CMD="$INPUT"
+if [[ "$INPUT" == *'"command"'* ]]; then
+  parsed=$(python3 -c '
+import json, sys
+try:
+  d = json.loads(sys.argv[1])
+  if isinstance(d, dict):
+    print(d.get("command") or d.get("tool_input", {}).get("command", ""))
+except Exception:
+  pass
+' "$INPUT" 2>/dev/null || true)
+  [[ -n "$parsed" ]] && CMD="$parsed"
+fi
+
+# Only act on rm commands.
+echo "$CMD" | grep -Eq '(^|[[:space:];&|`])rm([[:space:]]|$)' || exit 0
+
+# Normalize: collapse whitespace.
+NORM="$(echo "$CMD" | tr '\n' ' ' | tr -s ' ')"
+
+# Match `rm` with -rf / -fr / -r -f (any combo of -r, -R, -f, --recursive, --force).
+# Then check ALL arguments after the flags for dangerous anchors.
+#
+# Dangerous anchor regex matches the target token explicitly:
+#   /                /*               /.
+#   ~                ~/               ~/*
+#   $HOME            $HOME/           $HOME/*           "$HOME"          "$HOME/..."
+#   ..               ../*             ../              .
+#   (also empty target)
+#
+# We split commands on ; && || | and check each segment.
+DANGER=""
+
+# shellcheck disable=SC2001
+SEGMENTS=$(echo "$NORM" | awk '{ gsub(/&&/, "\n"); gsub(/\|\|/, "\n"); gsub(/\|/, "\n"); gsub(/;/, "\n"); print }')
+
+while IFS= read -r seg; do
+  seg="$(echo "$seg" | sed 's/^ *//;s/ *$//')"
+  [[ -z "$seg" ]] && continue
+  # Must start with rm (allow `sudo rm`, `time rm`, etc.)
+  if ! echo "$seg" | grep -Eq '(^|[[:space:]])rm([[:space:]]|$)'; then
+    continue
+  fi
+  # Must have recursive + force flags. Accept: -rf, -fr, -Rf, -fR, -r ... -f, --recursive ... --force, -rfv, etc.
+  has_r=0; has_f=0
+  if echo "$seg" | grep -Eq '(^|[[:space:]])-[a-zA-Z]*[rR][a-zA-Z]*([[:space:]]|$)' || echo "$seg" | grep -Eq -- '--recursive([[:space:]]|=|$)'; then
+    has_r=1
+  fi
+  if echo "$seg" | grep -Eq '(^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$)' || echo "$seg" | grep -Eq -- '--force([[:space:]]|=|$)'; then
+    has_f=1
+  fi
+  if (( has_r == 0 || has_f == 0 )); then
+    continue
+  fi
+
+  # Extract tokens after `rm`, drop flag-tokens, examine targets.
+  # Strip leading `sudo`/`time`/etc and then `rm`.
+  rest=$(echo "$seg" | sed -E 's/^.*[[:space:]]?rm([[:space:]]+|$)//')
+  # Tokenize on spaces (best-effort — won't perfectly handle quoted-with-spaces but covers the patterns specified).
+  for tok in $rest; do
+    # Skip flags.
+    case "$tok" in
+      -*) continue ;;
+    esac
+    # Strip surrounding quotes for comparison.
+    bare="${tok%\"}"; bare="${bare#\"}"
+    bare="${bare%\'}"; bare="${bare#\'}"
+
+    case "$bare" in
+      "" | "/" | "/*" | "/." | \
+      "~" | "~/" | "~/*" | \
+      '$HOME' | '$HOME/' | '$HOME/*' | \
+      ".." | "../" | "../*" | \
+      ".")
+        DANGER="$bare"
+        break
+        ;;
+    esac
+    # Also catch quoted $HOME variants where the shell hasn't expanded them.
+    if [[ "$tok" == '"$HOME"' || "$tok" == '"$HOME"/' || "$tok" == '"$HOME"/*' ]]; then
+      DANGER="$tok"; break
+    fi
+  done
+
+  [[ -n "$DANGER" ]] && break
+done <<EOF
+$SEGMENTS
+EOF
+
+if [[ -n "$DANGER" ]]; then
+  reason="Blocked rm -rf against dangerous anchor: '$DANGER'. This can destroy the system, your home directory, or the calling repo. Use a specific subpath (e.g. ./node_modules, /tmp/foo). To override (NOT RECOMMENDED) set CLAUDE_PLUGIN_OPTION_NO_RM_RF_ANCHOR=false."
+  python3 -c '
+import json, sys
+print(json.dumps({
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": sys.argv[1]
+  }
+}))' "$reason"
+  exit 0
+fi
+
+exit 0

--- a/claude-ops/bin/ops-prevent-secret-commit
+++ b/claude-ops/bin/ops-prevent-secret-commit
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# PreToolUse hook (Bash, gated `git commit*`):
+# Scans staged diff for high-confidence secret patterns. Emits permissionDecision=deny
+# with hookSpecificOutput JSON when a match is found; exits 0 otherwise.
+#
+# userConfig: prevent_secret_commit (boolean, default true). Disable by setting
+# CLAUDE_PLUGIN_OPTION_PREVENT_SECRET_COMMIT=false.
+set -uo pipefail
+
+# Opt-out: silently allow when disabled.
+if [[ "${CLAUDE_PLUGIN_OPTION_PREVENT_SECRET_COMMIT:-true}" == "false" ]]; then
+  exit 0
+fi
+
+INPUT="${TOOL_INPUT:-${1:-}}"
+
+# Confirm this is a git commit (defense in depth — matcher should already gate).
+if ! echo "$INPUT" | grep -Eq 'git[[:space:]]+commit'; then
+  exit 0
+fi
+
+# Need git available + cwd inside a repo.
+command -v git >/dev/null 2>&1 || exit 0
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+
+# Capture staged diff (cwd-relative). Limit size to keep <100ms.
+FULL_DIFF="$(git diff --cached --no-color 2>/dev/null | head -c 524288 || true)"
+[[ -z "$FULL_DIFF" ]] && exit 0
+
+# Only scan ADDED lines (lines starting with '+', excluding diff header '+++').
+# This ensures that a commit which REMOVES a leaked key is not blocked.
+DIFF="$(echo "$FULL_DIFF" | grep -E '^\+' | grep -E -v '^\+\+\+' || true)"
+[[ -z "$DIFF" ]] && exit 0
+
+# Patterns: label|regex (POSIX ERE, BSD-grep compatible — no \d, no \b lookarounds).
+PATTERNS=(
+  "Stripe live key|sk_live_[a-zA-Z0-9]{24,}"
+  "Stripe test key|sk_test_[a-zA-Z0-9]{24,}"
+  "AWS access key|AKIA[0-9A-Z]{16}"
+  "GitHub personal token|ghp_[A-Za-z0-9]{36}"
+  "GitHub OAuth token|gho_[A-Za-z0-9]{36}"
+  "GitHub app server token|ghs_[A-Za-z0-9]{36}"
+  "Slack bot token|xoxb-[A-Za-z0-9-]+"
+  "Slack app token|xoxa-[A-Za-z0-9-]+"
+  "Slack user token|xoxp-[A-Za-z0-9-]+"
+  "JWT|eyJ[A-Za-z0-9_=-]+\\.eyJ[A-Za-z0-9_=-]+\\.?[A-Za-z0-9_.+/=-]*"
+  "Anthropic API key|ANTHROPIC_API_KEY=sk-ant-"
+  "OpenAI API key|OPENAI_API_KEY=sk-"
+  "Hardcoded password|password[[:space:]]*=[[:space:]]*['\"][^'\"]{8,}['\"]"
+)
+
+HITS=()
+for entry in "${PATTERNS[@]}"; do
+  label="${entry%%|*}"
+  regex="${entry#*|}"
+  if echo "$DIFF" | grep -Eq "$regex"; then
+    # Find which file contains the match (best-effort — last "+++ b/" before hit).
+    file="$(echo "$FULL_DIFF" | grep -E "(^\\+\\+\\+ b/|$regex)" | grep -B1 -E "$regex" | grep -E '^\+\+\+ b/' | tail -1 | sed 's|^+++ b/||' || true)"
+    if [[ -n "$file" ]]; then
+      HITS+=("$label in $file")
+    else
+      HITS+=("$label in staged diff")
+    fi
+  fi
+done
+
+if (( ${#HITS[@]} > 0 )); then
+  reason="Blocked git commit — likely secret(s) in staged diff: $(IFS='; '; echo "${HITS[*]}"). Unstage the secret, rotate it, and use an env var or secret manager. To override (NOT RECOMMENDED) set CLAUDE_PLUGIN_OPTION_PREVENT_SECRET_COMMIT=false."
+  # Emit JSON on stdout. Use python3 for safe JSON escaping (always present on macOS/Linux).
+  python3 -c '
+import json, sys
+reason = sys.argv[1]
+print(json.dumps({
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": reason
+  }
+}))' "$reason"
+  exit 0
+fi
+
+exit 0

--- a/claude-ops/bin/ops-suggest-specialized-agent
+++ b/claude-ops/bin/ops-suggest-specialized-agent
@@ -2,12 +2,11 @@
 # ops-suggest-specialized-agent — PreToolUse hook on Agent (silent + autonomous).
 #
 # When subagent_type=general-purpose:
-#   1. Keyword match against existing specialists → silently swap via updatedInput.
-#   2. No match → fire-and-forget Haiku call drafts a new ~/.claude/agents/<name>.md
-#      for this recurring class; current call proceeds as-is (no block, no prompt).
-#      Next time the same pattern appears, the new agent will exist and may match.
-#
-# Operator never sees a permission prompt. Sam's preference: silent + autonomous.
+#   1. Load user-extensible keyword map (claude-ops/config/specialist-keywords.example.json
+#      with override at ~/.claude/plugins/data/ops-ops-marketplace/specialist-keywords.json).
+#   2. First regex match → verify the agent exists installed → silent swap via updatedInput.
+#   3. No match → fire-and-forget Haiku drafts a new ~/.claude/agents/<name>.md.
+#      Current call proceeds as general-purpose (no block).
 set -e
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 . "$PLUGIN_ROOT/scripts/lib/deploy-fix-common.sh" 2>/dev/null || { config() { echo "${2:-}"; }; }
@@ -21,34 +20,45 @@ subagent_type=$(printf '%s' "$INPUT" | jq -r '.tool_input.subagent_type // ""' 2
 prompt=$(printf '%s' "$INPUT" | jq -r '.tool_input.prompt // ""' 2>/dev/null)
 description=$(printf '%s' "$INPUT" | jq -r '.tool_input.description // ""' 2>/dev/null)
 combined=$(printf '%s\n%s' "$description" "$prompt" | tr '[:upper:]' '[:lower:]')
-
 mkdir -p "${HOME}/.claude/logs/ops" "${HOME}/.claude/agents" 2>/dev/null
 
-# Canonical specialist names — must exactly match an installed subagent_type.
-suggest=""
-match_kw() { echo "$combined" | grep -qE "$1"; }
+# Layered keyword map: user override → plugin default
+USER_MAP="${HOME}/.claude/plugins/data/ops-ops-marketplace/specialist-keywords.json"
+PLUGIN_MAP="$PLUGIN_ROOT/config/specialist-keywords.example.json"
+MAP=""
+[ -f "$USER_MAP" ] && MAP="$USER_MAP"
+[ -z "$MAP" ] && [ -f "$PLUGIN_MAP" ] && MAP="$PLUGIN_MAP"
+[ -z "$MAP" ] && exit 0
 
-if   match_kw 'mobile|expo|\bios\b|android|react native|fastlane|testflight'; then suggest="fullstack-mobile-architect"
-elif match_kw 'multi[- ]repo|cross[- ]repo|api contract|workspace.*span'; then suggest="multi-repo-coordinator"
-elif match_kw 'sentry|otel|datadog|new relic|telemetry|observability'; then suggest="observability-engineer"
-elif match_kw 'eval|judge[- ]llm|golden snapshot|llm[- ]eval'; then suggest="llm-eval-engineer"
-elif match_kw 'prompt[- ]engineer|persona|few[- ]shot|prompt cache'; then suggest="prompt-engineer"
-elif match_kw 'json schema|tool use spec|structured output|instructor'; then suggest="structured-output-engineer"
-elif match_kw 'migration|version bump|sdk upgrade|model upgrade|rollback plan'; then suggest="migration-engineer"
-elif match_kw 'test strategy|test pyramid|coverage gap|flaky test'; then suggest="test-strategist"
-elif match_kw 'security audit|owasp|injection|secret leak|csrf|xss'; then suggest="security-reviewer"
-elif match_kw 'database|\bsql\b|prisma|drizzle|n\+1|index'; then suggest="database-reviewer"
-elif match_kw 'health.*data|healthkit|hipaa|medical|clinical'; then suggest="Health Data Expert"
-elif match_kw 'devops|terraform|ecs|cloudformation|aws cdk|cicd|github action'; then suggest="DevOps Engineer"
-elif match_kw 'typescript|tsconfig|type[- ]check|\btsc\b'; then suggest="typescript-reviewer"
-elif match_kw 'review.*pr|code review|review code'; then suggest="feature-dev:code-reviewer"
-elif match_kw 'explore|map|trace.*execution|architecture'; then suggest="feature-dev:code-explorer"
-elif match_kw 'design.*architecture|blueprint|implementation plan'; then suggest="feature-dev:code-architect"
-elif match_kw 'simplify|refactor.*for clarity'; then suggest="code-simplifier:code-simplifier"
-fi
+# Agent existence check — true if installed (any of the locations claude-code searches)
+agent_installed() {
+  local name="$1"
+  [ -f "${HOME}/.claude/agents/${name}.md" ] && return 0
+  [ -f "$PLUGIN_ROOT/agents/${name}.md" ] && return 0
+  # built-in / plugin-marketplace agents (presence indicated by registry — coarse: assume true if no user override)
+  case "$name" in
+    general-purpose|statusline-setup) return 0 ;;
+  esac
+  # claude-code marketplace: cache dirs
+  for d in "${HOME}/.claude/plugins/cache"/*/agents "${HOME}/.claude/plugins/cache"/*/*/agents; do
+    [ -f "$d/${name}.md" ] && return 0
+  done
+  return 1
+}
+
+# Iterate rules; first match where agent is installed wins
+suggest=""
+while IFS=$'\t' read -r pattern agent; do
+  [ -z "$pattern" ] && continue
+  if echo "$combined" | grep -qiE "$pattern"; then
+    if agent_installed "$agent"; then
+      suggest="$agent"
+      break
+    fi
+  fi
+done < <(jq -r '.rules[] | "\(.pattern)\t\(.agent)"' "$MAP" 2>/dev/null)
 
 if [ -n "$suggest" ]; then
-  # Silent autonomous swap via updatedInput.
   printf '[%s] auto-swap general-purpose → %s for: %s\n' "$(date '+%H:%M:%S')" "$suggest" "${description:0:80}" \
     >> "${HOME}/.claude/logs/ops/agent-auto-swap.log"
   jq -n --arg new "$suggest" --argjson orig "$(printf '%s' "$INPUT" | jq '.tool_input')" '
@@ -62,31 +72,35 @@ if [ -n "$suggest" ]; then
   exit 0
 fi
 
-# No keyword match — log + spawn background Haiku to draft a new agent for this class.
-# Current call proceeds as general-purpose (no block).
-printf '[%s] no specialist match — spawning Haiku drafter for: %s\n' "$(date '+%H:%M:%S')" "${description:0:80}" \
+# No match (or matched agent not installed) — log + spawn Haiku drafter
+printf '[%s] no installed specialist match for: %s\n' "$(date '+%H:%M:%S')" "${description:0:80}" \
   >> "${HOME}/.claude/logs/ops/specialized-agent-misses.log"
 
-if command -v claude >/dev/null 2>&1; then
+if command -v claude >/dev/null 2>&1 && [ "$(config auto_draft_new_agents true)" != "false" ]; then
   drafter_log="${HOME}/.claude/logs/ops/agent-drafter-$(date +%s)-$$.log"
-  draft_prompt="You are an agent-builder. Look at this real task that just had no specialist match:
+  draft_prompt="You are an agent-builder. A subagent call was made as general-purpose with no installed specialist match.
 
 DESCRIPTION: ${description:0:200}
 PROMPT EXCERPT: ${prompt:0:600}
 
-Draft a new specialized Claude Code subagent definition file. Write it to ~/.claude/agents/<short-kebab-name>.md with this exact frontmatter:
+Existing installed agents (do not duplicate):
+$(ls -1 ${HOME}/.claude/agents/ 2>/dev/null | sed 's/\.md$//' | sed 's/^/  - /')
+$(ls -1 $PLUGIN_ROOT/agents/ 2>/dev/null | sed 's/\.md$//' | sed 's/^/  - /')
+
+Task:
+1. Identify the recurring CLASS this task represents (not this one task).
+2. Pick a short kebab-case name for the new specialist.
+3. If a sibling at ~/.claude/agents/<name>.md already exists, exit with 'SKIP: exists'.
+4. Otherwise, Write to ~/.claude/agents/<name>.md with this frontmatter format:
 ---
-name: <short-kebab-name>
-description: <one-paragraph: when this agent should be used, with 2-3 example scenarios>
-tools: <comma-separated tool list — Read, Write, Edit, Bash, Grep, Glob, etc — restrict to what this class genuinely needs>
-model: sonnet|haiku|opus
+name: <kebab-name>
+description: <one-paragraph: when to use, with 2-3 example scenarios in <example>...</example> tags>
+tools: <comma-separated tool list scoped to genuine needs>
+model: haiku|sonnet|opus
 ---
+<persona body — 100-300 words covering capabilities, operating constraints, output format>
 
-Then a body that describes the persona, capabilities, and operating constraints.
-
-Pick a name that captures the recurring CLASS (not this one task). Avoid duplicating these existing agents: fullstack-mobile-architect, multi-repo-coordinator, observability-engineer, llm-eval-engineer, prompt-engineer, structured-output-engineer, migration-engineer, test-strategist, security-reviewer, database-reviewer, Health Data Expert, DevOps Engineer, typescript-reviewer.
-
-If a sibling agent file already exists for this class at ~/.claude/agents/, do NOT overwrite — exit silently. Final line of output: NEW: <name> or SKIP: <reason>."
+Final line of your output: 'NEW: <name>' or 'SKIP: <reason>'."
 
   nohup bash -c "
     printf '%s' \"\$1\" | claude -p --model haiku --dangerously-skip-permissions --no-session-persistence > '$drafter_log' 2>&1
@@ -94,5 +108,4 @@ If a sibling agent file already exists for this class at ~/.claude/agents/, do N
   disown 2>/dev/null || true
 fi
 
-# Let the general-purpose call proceed unmodified.
 exit 0

--- a/claude-ops/bin/ops-suggest-specialized-agent
+++ b/claude-ops/bin/ops-suggest-specialized-agent
@@ -46,15 +46,25 @@ elif match_kw 'design|architecture|blueprint|implementation plan'; then suggest=
 elif match_kw 'simplify|refactor.*for clarity'; then suggest="code-simplifier:code-simplifier"
 fi
 
+mkdir -p "${HOME}/.claude/logs/ops" 2>/dev/null
+
 if [ -z "$suggest" ]; then
-  # No keyword match — let it through but log it so we can build out the map.
-  mkdir -p "${HOME}/.claude/logs/ops" 2>/dev/null
+  # No keyword match — log AND prompt to create a new agent type for this recurring class.
   printf '[%s] general-purpose, no keyword match: %s\n' "$(date '+%H:%M:%S')" "${description:0:80}" \
     >> "${HOME}/.claude/logs/ops/specialized-agent-misses.log"
+  cat <<JSON
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": "[ops] subagent_type='general-purpose' chosen for: \"${description:0:80}\" — and no existing specialized agent matches the keywords in this prompt. Per Sam's preference, create a new specialized agent type for this recurring class FIRST (Write a new agent file under ~/.claude/agents/<name>.md with frontmatter: name, description, tools, model), then respawn with that subagent_type. If this is genuinely a one-off multi-domain task that doesn't justify a new agent, confirm to proceed with general-purpose."
+  }
+}
+JSON
   exit 0
 fi
 
-# Emit permissionDecision=ask so the operator confirms or switches.
+# Keyword match — emit permissionDecision=ask suggesting the specialist.
 cat <<JSON
 {
   "hookSpecificOutput": {

--- a/claude-ops/bin/ops-suggest-specialized-agent
+++ b/claude-ops/bin/ops-suggest-specialized-agent
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
-# ops-suggest-specialized-agent — PreToolUse hook on Agent.
+# ops-suggest-specialized-agent — PreToolUse hook on Agent (silent + autonomous).
 #
-# When subagent_type=general-purpose, scans the prompt for keywords mapping to a
-# more specialized agent and emits permissionDecision="ask" forcing the operator
-# to pick a better fit (or confirm general-purpose is genuinely correct).
+# When subagent_type=general-purpose:
+#   1. Keyword match against existing specialists → silently swap via updatedInput.
+#   2. No match → fire-and-forget Haiku call drafts a new ~/.claude/agents/<name>.md
+#      for this recurring class; current call proceeds as-is (no block, no prompt).
+#      Next time the same pattern appears, the new agent will exist and may match.
 #
-# Per the design philosophy: never default to general-purpose if a domain-specific
-# agent fits; if none fits a recurring class, create a new agent type first.
+# Operator never sees a permission prompt. Sam's preference: silent + autonomous.
 set -e
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 . "$PLUGIN_ROOT/scripts/lib/deploy-fix-common.sh" 2>/dev/null || { config() { echo "${2:-}"; }; }
@@ -21,56 +22,77 @@ prompt=$(printf '%s' "$INPUT" | jq -r '.tool_input.prompt // ""' 2>/dev/null)
 description=$(printf '%s' "$INPUT" | jq -r '.tool_input.description // ""' 2>/dev/null)
 combined=$(printf '%s\n%s' "$description" "$prompt" | tr '[:upper:]' '[:lower:]')
 
-# Keyword → suggested specialized agent mapping. Customize via plugin data:
-# ~/.claude/plugins/data/ops-ops-marketplace/agent-suggestions.json (optional override)
+mkdir -p "${HOME}/.claude/logs/ops" "${HOME}/.claude/agents" 2>/dev/null
+
+# Canonical specialist names — must exactly match an installed subagent_type.
 suggest=""
 match_kw() { echo "$combined" | grep -qE "$1"; }
 
-# Order matters — first match wins. Most specific first.
-if   match_kw 'mobile|expo|ios|android|react native|fastlane|testflight'; then suggest="fullstack-mobile-architect (or Mobile App Specialist)"
-elif match_kw 'multi[- ]repo|cross[- ]repo|api contract|ripple|workspace.*span'; then suggest="multi-repo-coordinator"
-elif match_kw 'sentry|otel|datadog|new relic|telemetry|observability|structured logging'; then suggest="observability-engineer"
+if   match_kw 'mobile|expo|\bios\b|android|react native|fastlane|testflight'; then suggest="fullstack-mobile-architect"
+elif match_kw 'multi[- ]repo|cross[- ]repo|api contract|workspace.*span'; then suggest="multi-repo-coordinator"
+elif match_kw 'sentry|otel|datadog|new relic|telemetry|observability'; then suggest="observability-engineer"
 elif match_kw 'eval|judge[- ]llm|golden snapshot|llm[- ]eval'; then suggest="llm-eval-engineer"
 elif match_kw 'prompt[- ]engineer|persona|few[- ]shot|prompt cache'; then suggest="prompt-engineer"
 elif match_kw 'json schema|tool use spec|structured output|instructor'; then suggest="structured-output-engineer"
 elif match_kw 'migration|version bump|sdk upgrade|model upgrade|rollback plan'; then suggest="migration-engineer"
 elif match_kw 'test strategy|test pyramid|coverage gap|flaky test'; then suggest="test-strategist"
 elif match_kw 'security audit|owasp|injection|secret leak|csrf|xss'; then suggest="security-reviewer"
-elif match_kw 'database|sql|prisma|drizzle|n\+1|migration|index'; then suggest="database-reviewer (or Database Optimizer)"
+elif match_kw 'database|\bsql\b|prisma|drizzle|n\+1|index'; then suggest="database-reviewer"
 elif match_kw 'health.*data|healthkit|hipaa|medical|clinical'; then suggest="Health Data Expert"
 elif match_kw 'devops|terraform|ecs|cloudformation|aws cdk|cicd|github action'; then suggest="DevOps Engineer"
-elif match_kw 'typescript|tsconfig|type[- ]check|tsc'; then suggest="typescript-reviewer"
+elif match_kw 'typescript|tsconfig|type[- ]check|\btsc\b'; then suggest="typescript-reviewer"
 elif match_kw 'review.*pr|code review|review code'; then suggest="feature-dev:code-reviewer"
 elif match_kw 'explore|map|trace.*execution|architecture'; then suggest="feature-dev:code-explorer"
-elif match_kw 'design|architecture|blueprint|implementation plan'; then suggest="feature-dev:code-architect"
+elif match_kw 'design.*architecture|blueprint|implementation plan'; then suggest="feature-dev:code-architect"
 elif match_kw 'simplify|refactor.*for clarity'; then suggest="code-simplifier:code-simplifier"
 fi
 
-mkdir -p "${HOME}/.claude/logs/ops" 2>/dev/null
-
-if [ -z "$suggest" ]; then
-  # No keyword match — log AND prompt to create a new agent type for this recurring class.
-  printf '[%s] general-purpose, no keyword match: %s\n' "$(date '+%H:%M:%S')" "${description:0:80}" \
-    >> "${HOME}/.claude/logs/ops/specialized-agent-misses.log"
-  cat <<JSON
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PreToolUse",
-    "permissionDecision": "ask",
-    "permissionDecisionReason": "[ops] subagent_type='general-purpose' chosen for: \"${description:0:80}\" — and no existing specialized agent matches the keywords in this prompt. Per Sam's preference, create a new specialized agent type for this recurring class FIRST (Write a new agent file under ~/.claude/agents/<name>.md with frontmatter: name, description, tools, model), then respawn with that subagent_type. If this is genuinely a one-off multi-domain task that doesn't justify a new agent, confirm to proceed with general-purpose."
-  }
-}
-JSON
+if [ -n "$suggest" ]; then
+  # Silent autonomous swap via updatedInput.
+  printf '[%s] auto-swap general-purpose → %s for: %s\n' "$(date '+%H:%M:%S')" "$suggest" "${description:0:80}" \
+    >> "${HOME}/.claude/logs/ops/agent-auto-swap.log"
+  jq -n --arg new "$suggest" --argjson orig "$(printf '%s' "$INPUT" | jq '.tool_input')" '
+    {
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        updatedInput: ($orig | .subagent_type = $new)
+      }
+    }
+  '
   exit 0
 fi
 
-# Keyword match — emit permissionDecision=ask suggesting the specialist.
-cat <<JSON
-{
-  "hookSpecificOutput": {
-    "hookEventName": "PreToolUse",
-    "permissionDecision": "ask",
-    "permissionDecisionReason": "[ops] subagent_type='general-purpose' chosen for: \"${description:0:60}\". A more specialized agent fits this work: $suggest. If you actually need general-purpose (e.g. multi-domain task that no specialist covers), confirm. Otherwise cancel and respawn with the suggested subagent_type."
-  }
-}
-JSON
+# No keyword match — log + spawn background Haiku to draft a new agent for this class.
+# Current call proceeds as general-purpose (no block).
+printf '[%s] no specialist match — spawning Haiku drafter for: %s\n' "$(date '+%H:%M:%S')" "${description:0:80}" \
+  >> "${HOME}/.claude/logs/ops/specialized-agent-misses.log"
+
+if command -v claude >/dev/null 2>&1; then
+  drafter_log="${HOME}/.claude/logs/ops/agent-drafter-$(date +%s)-$$.log"
+  draft_prompt="You are an agent-builder. Look at this real task that just had no specialist match:
+
+DESCRIPTION: ${description:0:200}
+PROMPT EXCERPT: ${prompt:0:600}
+
+Draft a new specialized Claude Code subagent definition file. Write it to ~/.claude/agents/<short-kebab-name>.md with this exact frontmatter:
+---
+name: <short-kebab-name>
+description: <one-paragraph: when this agent should be used, with 2-3 example scenarios>
+tools: <comma-separated tool list — Read, Write, Edit, Bash, Grep, Glob, etc — restrict to what this class genuinely needs>
+model: sonnet|haiku|opus
+---
+
+Then a body that describes the persona, capabilities, and operating constraints.
+
+Pick a name that captures the recurring CLASS (not this one task). Avoid duplicating these existing agents: fullstack-mobile-architect, multi-repo-coordinator, observability-engineer, llm-eval-engineer, prompt-engineer, structured-output-engineer, migration-engineer, test-strategist, security-reviewer, database-reviewer, Health Data Expert, DevOps Engineer, typescript-reviewer.
+
+If a sibling agent file already exists for this class at ~/.claude/agents/, do NOT overwrite — exit silently. Final line of output: NEW: <name> or SKIP: <reason>."
+
+  nohup bash -c "
+    printf '%s' \"\$1\" | claude -p --model haiku --dangerously-skip-permissions --no-session-persistence > '$drafter_log' 2>&1
+  " _ "$draft_prompt" </dev/null >/dev/null 2>&1 &
+  disown 2>/dev/null || true
+fi
+
+# Let the general-purpose call proceed unmodified.
+exit 0

--- a/claude-ops/bin/ops-suggest-specialized-agent
+++ b/claude-ops/bin/ops-suggest-specialized-agent
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# ops-suggest-specialized-agent — PreToolUse hook on Agent.
+#
+# When subagent_type=general-purpose, scans the prompt for keywords mapping to a
+# more specialized agent and emits permissionDecision="ask" forcing the operator
+# to pick a better fit (or confirm general-purpose is genuinely correct).
+#
+# Per the design philosophy: never default to general-purpose if a domain-specific
+# agent fits; if none fits a recurring class, create a new agent type first.
+set -e
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+. "$PLUGIN_ROOT/scripts/lib/deploy-fix-common.sh" 2>/dev/null || { config() { echo "${2:-}"; }; }
+
+[ "$(config suggest_specialized_agents true)" = "false" ] && exit 0
+
+INPUT=$(cat)
+subagent_type=$(printf '%s' "$INPUT" | jq -r '.tool_input.subagent_type // ""' 2>/dev/null)
+[ "$subagent_type" != "general-purpose" ] && exit 0
+
+prompt=$(printf '%s' "$INPUT" | jq -r '.tool_input.prompt // ""' 2>/dev/null)
+description=$(printf '%s' "$INPUT" | jq -r '.tool_input.description // ""' 2>/dev/null)
+combined=$(printf '%s\n%s' "$description" "$prompt" | tr '[:upper:]' '[:lower:]')
+
+# Keyword → suggested specialized agent mapping. Customize via plugin data:
+# ~/.claude/plugins/data/ops-ops-marketplace/agent-suggestions.json (optional override)
+suggest=""
+match_kw() { echo "$combined" | grep -qE "$1"; }
+
+# Order matters — first match wins. Most specific first.
+if   match_kw 'mobile|expo|ios|android|react native|fastlane|testflight'; then suggest="fullstack-mobile-architect (or Mobile App Specialist)"
+elif match_kw 'multi[- ]repo|cross[- ]repo|api contract|ripple|workspace.*span'; then suggest="multi-repo-coordinator"
+elif match_kw 'sentry|otel|datadog|new relic|telemetry|observability|structured logging'; then suggest="observability-engineer"
+elif match_kw 'eval|judge[- ]llm|golden snapshot|llm[- ]eval'; then suggest="llm-eval-engineer"
+elif match_kw 'prompt[- ]engineer|persona|few[- ]shot|prompt cache'; then suggest="prompt-engineer"
+elif match_kw 'json schema|tool use spec|structured output|instructor'; then suggest="structured-output-engineer"
+elif match_kw 'migration|version bump|sdk upgrade|model upgrade|rollback plan'; then suggest="migration-engineer"
+elif match_kw 'test strategy|test pyramid|coverage gap|flaky test'; then suggest="test-strategist"
+elif match_kw 'security audit|owasp|injection|secret leak|csrf|xss'; then suggest="security-reviewer"
+elif match_kw 'database|sql|prisma|drizzle|n\+1|migration|index'; then suggest="database-reviewer (or Database Optimizer)"
+elif match_kw 'health.*data|healthkit|hipaa|medical|clinical'; then suggest="Health Data Expert"
+elif match_kw 'devops|terraform|ecs|cloudformation|aws cdk|cicd|github action'; then suggest="DevOps Engineer"
+elif match_kw 'typescript|tsconfig|type[- ]check|tsc'; then suggest="typescript-reviewer"
+elif match_kw 'review.*pr|code review|review code'; then suggest="feature-dev:code-reviewer"
+elif match_kw 'explore|map|trace.*execution|architecture'; then suggest="feature-dev:code-explorer"
+elif match_kw 'design|architecture|blueprint|implementation plan'; then suggest="feature-dev:code-architect"
+elif match_kw 'simplify|refactor.*for clarity'; then suggest="code-simplifier:code-simplifier"
+fi
+
+if [ -z "$suggest" ]; then
+  # No keyword match — let it through but log it so we can build out the map.
+  mkdir -p "${HOME}/.claude/logs/ops" 2>/dev/null
+  printf '[%s] general-purpose, no keyword match: %s\n' "$(date '+%H:%M:%S')" "${description:0:80}" \
+    >> "${HOME}/.claude/logs/ops/specialized-agent-misses.log"
+  exit 0
+fi
+
+# Emit permissionDecision=ask so the operator confirms or switches.
+cat <<JSON
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": "[ops] subagent_type='general-purpose' chosen for: \"${description:0:60}\". A more specialized agent fits this work: $suggest. If you actually need general-purpose (e.g. multi-domain task that no specialist covers), confirm. Otherwise cancel and respawn with the suggested subagent_type."
+  }
+}
+JSON

--- a/claude-ops/bin/ops-task-reminder
+++ b/claude-ops/bin/ops-task-reminder
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# ops-task-reminder — PostToolUse hook on every tool.
+# Per-session counter at $STATE_DIR/task-reminder-<sid>. When N non-Task tool calls
+# occur without any Task* call, injects a system-reminder via additionalContext.
+# Counter resets to 0 on any Task* tool use.
+set -e
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+. "$PLUGIN_ROOT/scripts/lib/deploy-fix-common.sh" 2>/dev/null || {
+  STATE_DIR="$HOME/.claude/state/ops"
+  mkdir -p "$STATE_DIR" 2>/dev/null
+  config() { echo "${2:-}"; }
+}
+
+[ "$(config task_reminder_enabled true)" = "false" ] && exit 0
+THRESHOLD=$(config task_reminder_threshold 10)
+
+INPUT=$(cat)
+sid=$(printf '%s' "$INPUT" | jq -r '.session_id // "default"' 2>/dev/null)
+tool=$(printf '%s' "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)
+state_file="$STATE_DIR/task-reminder-${sid}"
+
+case "$tool" in
+  Task*) echo 0 > "$state_file"; exit 0 ;;
+esac
+
+count=$(cat "$state_file" 2>/dev/null || echo 0)
+count=$((count + 1))
+
+if [ "$count" -ge "$THRESHOLD" ]; then
+  echo 0 > "$state_file"
+  cat <<JSON
+{
+  "suppressOutput": true,
+  "hookSpecificOutput": {
+    "hookEventName": "PostToolUse",
+    "additionalContext": "[ops-task-reminder] No Task* tool used in the last $THRESHOLD calls. For multi-step work, consider TaskCreate to track open items, TaskUpdate to mark progress, TaskList to review status. Skip this reminder if your current work is a single quick action."
+  }
+}
+JSON
+else
+  echo "$count" > "$state_file"
+fi
+exit 0

--- a/claude-ops/bin/ops-warn-mainpush
+++ b/claude-ops/bin/ops-warn-mainpush
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# PreToolUse hook (Bash, gated `git push*`):
+# Forces user confirmation (permissionDecision=ask) when pushing to main/master/production
+# directly. Allows feature-branch pushes silently.
+#
+# userConfig: warn_mainpush (boolean, default true). Disable by setting
+# CLAUDE_PLUGIN_OPTION_WARN_MAINPUSH=false.
+set -uo pipefail
+
+if [[ "${CLAUDE_PLUGIN_OPTION_WARN_MAINPUSH:-true}" == "false" ]]; then
+  exit 0
+fi
+
+INPUT="${TOOL_INPUT:-${1:-}}"
+
+# Parse JSON command if applicable.
+CMD="$INPUT"
+if [[ "$INPUT" == *'"command"'* ]]; then
+  parsed=$(python3 -c '
+import json, sys
+try:
+  d = json.loads(sys.argv[1])
+  if isinstance(d, dict):
+    print(d.get("command") or d.get("tool_input", {}).get("command", ""))
+except Exception:
+  pass
+' "$INPUT" 2>/dev/null || true)
+  [[ -n "$parsed" ]] && CMD="$parsed"
+fi
+
+# Only inspect git push commands.
+echo "$CMD" | grep -Eq '(^|[[:space:];&|`])git[[:space:]]+push' || exit 0
+
+DEST=""
+REASON=""
+
+# Case A: explicit `git push [flags...] <remote> <branch>` targeting main/master/production.
+# Match by checking if any token after `push` equals one of the protected branch names.
+if echo "$CMD" | grep -Eq 'git[[:space:]]+push([[:space:]]+(-[^[:space:]]+|[a-zA-Z0-9_./-]+))*[[:space:]]+(main|master|production)([[:space:]]|$)'; then
+  DEST=$(echo "$CMD" | grep -Eo '(main|master|production)' | tail -1)
+  REASON="Pushing directly to protected branch '$DEST'. Confirm before publishing — prefer a feature branch + PR."
+fi
+
+# Case B: explicit refspec like `HEAD:main` or `feature:main`.
+if [[ -z "$DEST" ]] && echo "$CMD" | grep -Eq 'git[[:space:]]+push[[:space:]].*:[[:space:]]*(main|master|production)([[:space:]]|$)'; then
+  DEST=$(echo "$CMD" | grep -Eo '[^[:space:]]+:(main|master|production)' | tail -1)
+  REASON="Pushing refspec $DEST — this updates a protected branch. Confirm before publishing."
+fi
+
+# Case C: bare `git push` (or `git push origin`/`git push -u origin`) — check current branch.
+if [[ -z "$DEST" ]] && command -v git >/dev/null 2>&1; then
+  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    BRANCH=$(git -C "$PWD" branch --show-current 2>/dev/null || true)
+    case "$BRANCH" in
+      main|master|production)
+        # Bare push (no explicit refspec) defaults to current branch.
+        if echo "$CMD" | grep -Eq 'git[[:space:]]+push([[:space:]]+(-u[[:space:]]+)?[a-zA-Z0-9_.-]+)?[[:space:]]*$' \
+           || echo "$CMD" | grep -Eq 'git[[:space:]]+push[[:space:]]+(-u[[:space:]]+)?[a-zA-Z0-9_.-]+[[:space:]]*$'; then
+          DEST="current branch '$BRANCH'"
+          REASON="You are on protected branch '$BRANCH' and about to push. Confirm before publishing — prefer a feature branch + PR."
+        fi
+        ;;
+    esac
+  fi
+fi
+
+if [[ -n "$DEST" ]]; then
+  python3 -c '
+import json, sys
+print(json.dumps({
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": sys.argv[1]
+  }
+}))' "$REASON"
+  exit 0
+fi
+
+exit 0

--- a/claude-ops/config/post-merge-services.example.json
+++ b/claude-ops/config/post-merge-services.example.json
@@ -1,0 +1,5 @@
+{
+  "_doc": "Service health registry for ops-deploy-monitor. Key = '<owner/repo>:<base_branch>'. Each entry: { health: <url>, version: <url> (optional, returns {commit/sha/gitSha}) }. Layered lookup: project .claude/post-merge-services.json (committed) → user ~/.claude/config/post-merge-services.json → this plugin default. Add your own services in user-level or per-project file.",
+  "your-org/your-api:dev":  { "health": "https://api-dev.example.com/health", "version": "https://api-dev.example.com/version" },
+  "your-org/your-api:main": { "health": "https://api.example.com/health",     "version": "https://api.example.com/version" }
+}

--- a/claude-ops/config/post-merge-services.example.json
+++ b/claude-ops/config/post-merge-services.example.json
@@ -1,5 +1,8 @@
 {
   "_doc": "Service health registry for ops-deploy-monitor. Key = '<owner/repo>:<base_branch>'. Each entry: { health: <url>, version: <url> (optional, returns {commit/sha/gitSha}) }. Layered lookup: project .claude/post-merge-services.json (committed) → user ~/.claude/config/post-merge-services.json → this plugin default. Add your own services in user-level or per-project file.",
-  "your-org/your-api:dev":  { "health": "https://api-dev.example.com/health", "version": "https://api-dev.example.com/version" },
-  "your-org/your-api:main": { "health": "https://api.example.com/health",     "version": "https://api.example.com/version" }
+  "your-org/your-api:dev": {
+    "health": "https://api-dev.example.com/health",
+    "version": "https://api-dev.example.com/version"
+  },
+  "your-org/your-api:main": { "health": "https://api.example.com/health", "version": "https://api.example.com/version" }
 }

--- a/claude-ops/config/specialist-keywords.example.json
+++ b/claude-ops/config/specialist-keywords.example.json
@@ -1,0 +1,22 @@
+{
+  "_doc": "Maps a regex pattern (matched against subagent description+prompt) → canonical specialist subagent_type. Used by ops-suggest-specialized-agent hook to silently swap general-purpose calls for a better fit. First match wins; order matters. Override by copying to ~/.claude/plugins/data/ops-ops-marketplace/specialist-keywords.json and editing.",
+  "_format": "Each rule: { pattern: <egrep regex>, agent: <subagent_type> }. Patterns are case-insensitive.",
+  "rules": [
+    { "pattern": "mobile|expo|\\bios\\b|android|react native|fastlane|testflight",       "agent": "fullstack-mobile-architect" },
+    { "pattern": "multi[- ]repo|cross[- ]repo|api contract|workspace.*span",             "agent": "multi-repo-coordinator" },
+    { "pattern": "sentry|otel|datadog|new relic|telemetry|observability",                "agent": "observability-engineer" },
+    { "pattern": "\\beval\\b|judge[- ]llm|golden snapshot|llm[- ]eval",                  "agent": "llm-eval-engineer" },
+    { "pattern": "prompt[- ]engineer|persona|few[- ]shot|prompt cache",                  "agent": "prompt-engineer" },
+    { "pattern": "json schema|tool use spec|structured output|instructor",               "agent": "structured-output-engineer" },
+    { "pattern": "migration|version bump|sdk upgrade|model upgrade|rollback plan",       "agent": "migration-engineer" },
+    { "pattern": "test strategy|test pyramid|coverage gap|flaky test",                   "agent": "test-strategist" },
+    { "pattern": "security audit|owasp|injection|secret leak|csrf|xss",                  "agent": "security-reviewer" },
+    { "pattern": "database|\\bsql\\b|prisma|drizzle|n\\+1|index",                        "agent": "database-reviewer" },
+    { "pattern": "devops|terraform|ecs|cloudformation|aws cdk|cicd|github action",       "agent": "DevOps Engineer" },
+    { "pattern": "typescript|tsconfig|type[- ]check|\\btsc\\b",                          "agent": "typescript-reviewer" },
+    { "pattern": "review.*pr|code review|review code",                                   "agent": "feature-dev:code-reviewer" },
+    { "pattern": "explore|map.*codebase|trace.*execution|architecture",                  "agent": "feature-dev:code-explorer" },
+    { "pattern": "design.*architecture|blueprint|implementation plan",                   "agent": "feature-dev:code-architect" },
+    { "pattern": "simplify|refactor.*for clarity",                                       "agent": "code-simplifier:code-simplifier" }
+  ]
+}

--- a/claude-ops/docs/INDEX.md
+++ b/claude-ops/docs/INDEX.md
@@ -1,0 +1,41 @@
+<div align="center">
+
+# Documentation Index
+
+*Top-level map of every doc file in `claude-ops/docs/`.*
+
+[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
+
+</div>
+
+---
+
+## v2.0 — autonomy layer
+
+| Doc | Subject |
+|-----|---------|
+| [`deploy-fix.md`](deploy-fix.md) | Post-merge + build-failure auto-fix subsystem. Architecture, registry, dedup/budget, troubleshooting. |
+| [`agents.md`](agents.md) | Pre-installed specialist agents + the auto-suggestion PreToolUse hook. |
+| [`safety-hooks.md`](safety-hooks.md) | Three universal PreToolUse:Bash hooks (secret-commit, rm-rf-anchor, mainpush warn). |
+| [`recap.md`](recap.md) | Recap marquee daemon — multi-session digest in tmux/`statusLine`. |
+| [`migrating-from-v1.md`](migrating-from-v1.md) | v1.x → v2.0 migration. No breaking changes; opt-out matrix. |
+
+## v1 — operations surface (still current in v2)
+
+| Doc | Subject |
+|-----|---------|
+| [`agents-reference.md`](agents-reference.md) | Catalog of all 18 agents (4 v2 specialists + 14 v1 scanners/fixers/C-suite). |
+| [`skills-reference.md`](skills-reference.md) | Catalog of all 33+ skills with usage examples. |
+| [`daemon-guide.md`](daemon-guide.md) | The v1 ops-daemon (briefing pre-warm, wacli-sync, memory-extractor, etc). |
+| [`docker.md`](docker.md) | Running claude-ops in a container. |
+| [`marketplace-submissions.md`](marketplace-submissions.md) | Publishing your own plugin to the same marketplace. |
+| [`memories-system.md`](memories-system.md) | The cross-session memory system used by agents. |
+| [`notifications.md`](notifications.md) | Notification channel setup (macos/ntfy/pushover/discord/telegram). |
+| [`os-compatibility.md`](os-compatibility.md) | macOS / Linux / WSL feature matrix. |
+
+## External
+
+- [Wiki](https://github.com/Lifecycle-Innovations-Limited/claude-ops/wiki) — narrative pages, tutorials, FAQ.
+- [`CHANGELOG.md`](../CHANGELOG.md) — release history.
+- [`README.md`](../README.md) — plugin overview.
+- [`CLAUDE.md`](../CLAUDE.md) — non-negotiable rules for all skills.

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,8 +4,8 @@
 
 *All 14 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain*
 
-[![version](https://img.shields.io/badge/version-1.7.0-blue)](../CHANGELOG.md)
-[![agents](https://img.shields.io/badge/agents-14-8b5cf6)](.)
+[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
+[![agents](https://img.shields.io/badge/agents-18-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)
 [![haiku](https://img.shields.io/badge/model-haiku--4--5-22c55e)](.)
@@ -14,7 +14,10 @@
 
 ---
 
-All 14 agents in claude-ops v1.7.0. Agent files live in `agents/`.
+All 18 agents in claude-ops v2.0.0. Agent files live in `agents/`.
+
+> [!NOTE]
+> v2.0 added four pre-installed specialists — `general-purpose` (override), `deploy-fixer`, `build-fixer`, `dependency-auditor`. These power the deploy auto-fix subsystem and are silently routed to via the PreToolUse:Agent hook. See [`agents.md`](agents.md) for the v2 specialist catalog and [`deploy-fix.md`](deploy-fix.md) for the auto-fix subsystem.
 
 > [!NOTE]
 > Agents are spawned by skills — they are not invoked directly. Each has a `memory` scope for cross-session learning and a defined `effort` level that controls token budget.

--- a/claude-ops/docs/agents.md
+++ b/claude-ops/docs/agents.md
@@ -1,0 +1,128 @@
+<div align="center">
+
+# Specialized Agents
+
+*Pre-installed subagent personas + the auto-suggestion hook that routes `general-purpose` calls to the right specialist.*
+
+[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
+[![agents](https://img.shields.io/badge/agents-18-8b5cf6)](.)
+[![hook](https://img.shields.io/badge/PreToolUse-Agent-6366f1)](.)
+
+</div>
+
+---
+
+## What changed in v2
+
+In v1.x, every `Agent` tool call defaulted to `subagent_type: general-purpose`, which meant the same broad persona handled SRE work, dependency upgrades, and code review.
+
+v2 ships **four pre-installed specialist agents** and a **PreToolUse hook on `Agent`** that silently swaps `general-purpose` → matching specialist via `updatedInput`. If no match exists, a Haiku drafter proposes a new agent file under `~/.claude/agents/`.
+
+The swap is silent by design — Claude doesn't have to know to pick the right agent; the hook does it.
+
+---
+
+## Pre-installed specialists
+
+| Agent | File | Purpose | Used by |
+|-------|------|---------|---------|
+| `general-purpose` | [`agents/general-purpose.md`](../agents/general-purpose.md) | Local override of the default — restricted to research and read-only investigation. | Fallback when no specialist matches. |
+| `deploy-fixer` | [`agents/deploy-fixer.md`](../agents/deploy-fixer.md) | Single-shot SRE persona — diagnoses one failed deploy, opens one PR, exits. | Deploy auto-fix subsystem ([`docs/deploy-fix.md`](deploy-fix.md)). |
+| `build-fixer` | [`agents/build-fixer.md`](../agents/build-fixer.md) | TypeScript/bundler error fixer for local build failures. | Deploy auto-fix subsystem (build-trigger hook). |
+| `dependency-auditor` | [`agents/dependency-auditor.md`](../agents/dependency-auditor.md) | Runs `npm audit` / `pip-audit` / SCA equivalents and proposes minimal upgrades. | Manual dispatch + future scheduled cron. |
+
+The full v1 agent roster (scanners, fixers, C-suite analysts, daemon brain) is unchanged — see [`docs/agents-reference.md`](agents-reference.md).
+
+---
+
+## How the auto-suggestion hook works
+
+```
+Claude calls Task with subagent_type=general-purpose
+                    │
+                    ▼
+hooks/hooks.json PreToolUse:Agent
+                    │
+                    ▼
+bin/ops-suggest-specialized-agent
+                    │
+       ┌────────────┴────────────┐
+       ▼                         ▼
+  prompt matches              no match
+  config/specialist-          ┌────────────────────┐
+  keywords.example.json       │ fire Haiku drafter │
+       │                      │ → propose new      │
+       ▼                      │ agent file under   │
+  rewrite updatedInput        │ ~/.claude/agents/  │
+  with subagent_type =        └────────────────────┘
+  matched specialist
+       │
+       ▼
+  Claude tool call proceeds with the swapped type
+```
+
+The swap uses the standard Claude Code `updatedInput` PreToolUse mechanism — no warning, no prompt, no UI noise. The user only notices when they look at the agent transcript and see `deploy-fixer` instead of `general-purpose`.
+
+---
+
+## Keyword map
+
+The default map ships at [`config/specialist-keywords.example.json`](../config/specialist-keywords.example.json):
+
+```json
+{
+  "deploy-fixer": ["deploy", "deployment", "ECS", "Vercel", "Render", "GitHub Actions", "workflow failed", "rollback"],
+  "build-fixer": ["npm run build", "tsc", "TypeScript error", "webpack", "vite", "esbuild", "module not found"],
+  "dependency-auditor": ["npm audit", "vulnerable", "CVE", "security advisory", "outdated dependency", "pip-audit"]
+}
+```
+
+Each value is an array of substrings (case-insensitive). The hook scans the `prompt` field of the `Agent` input. First match wins.
+
+To extend: copy the file to `~/.claude/config/specialist-keywords.json` and add your own. User file overrides the plugin default.
+
+---
+
+## Adding your own specialist
+
+1. Drop a `<name>.md` file under `~/.claude/agents/` (user-scoped) or `agents/` (committed to your project's `.claude/`).
+2. Frontmatter must include `name`, `description`, `model`, `tools` (allow-list).
+3. Add an entry to your `~/.claude/config/specialist-keywords.json` mapping keywords → agent name.
+4. Verify with `/ops:deploy-fix test` (which exercises the keyword path) or by manually invoking `Task` with a matching prompt.
+
+Minimal example:
+
+```markdown
+---
+name: my-rust-fixer
+description: Diagnoses and fixes Rust compile errors
+model: claude-haiku-4-5
+tools: [Bash, Read, Edit, Write]
+---
+
+You are a focused Rust compile-error fixer. ...
+```
+
+```json
+{
+  "my-rust-fixer": ["cargo build", "cargo check", "rustc error", "borrow checker"]
+}
+```
+
+---
+
+## Configuration
+
+| Key | Type | Default | Purpose |
+|-----|------|---------|---------|
+| `suggest_specialized_agents` | boolean | `true` | Master switch for the PreToolUse:Agent hook. |
+
+Set to `false` in `/plugins` settings to restore v1 behavior (every `general-purpose` call passes through unchanged).
+
+---
+
+## See also
+
+- [`docs/agents-reference.md`](agents-reference.md) — complete v1+v2 agent catalog.
+- [`docs/deploy-fix.md`](deploy-fix.md) — primary consumer of `deploy-fixer` and `build-fixer`.
+- [`docs/INDEX.md`](INDEX.md) — full documentation index.

--- a/claude-ops/docs/daemon-guide.md
+++ b/claude-ops/docs/daemon-guide.md
@@ -4,7 +4,10 @@
 
 *The unified background process manager that pre-warms briefings, syncs WhatsApp, extracts memories, and watches your fires — persistently, via launchd*
 
-[![version](https://img.shields.io/badge/version-1.1.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
+
+> [!NOTE]
+> v2.0 introduces two **additional** daemons alongside the v1 ops-daemon documented here: the **recap-daemon** ([`recap.md`](recap.md)) and the **account-rotation daemon** ([`CHANGELOG.md`](../CHANGELOG.md#6-multi-account-claude-max-rotator)). The ops-daemon described below is unchanged in v2.
 [![services](https://img.shields.io/badge/services-7-f59e0b)](.)
 [![launchd](https://img.shields.io/badge/runtime-launchd-6366f1)](.)
 [![pre--warm](https://img.shields.io/badge/pre--warm-every%202%20min-22c55e)](.)

--- a/claude-ops/docs/deploy-fix.md
+++ b/claude-ops/docs/deploy-fix.md
@@ -1,0 +1,264 @@
+<div align="center">
+
+# Deploy Auto-Fix Subsystem
+
+*Watches every `gh pr merge` and `npm run build:*` you run, verifies the deploy, and dispatches a Haiku fixer if anything fails.*
+
+[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
+[![hook](https://img.shields.io/badge/PostToolUse-Bash-6366f1)](.)
+[![model](https://img.shields.io/badge/fixer-haiku--default-22c55e)](.)
+
+</div>
+
+---
+
+## TL;DR
+
+```
+gh pr merge --squash --admin
+        │
+        ▼ PostToolUse:Bash hook
+bin/ops-deploy-fix-merge-trigger
+        │
+        ▼ background fork
+scripts/ops-deploy-monitor.sh
+        │
+        ├──► poll deploy GitHub Actions run
+        ├──► curl /health on success
+        ├──► curl /version, compare SHA
+        └──► on failure:
+              ├── transient?  ──► gh run rerun
+              └── real?       ──► dispatch headless Haiku deploy-fixer
+                                   (uses prompts/deploy-fix.md)
+```
+
+The same pattern fires for `npm run build:*` via `bin/ops-deploy-fix-build-trigger`, dispatching a `build-fixer` agent with `prompts/build-fix.md`.
+
+---
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│  Claude Code session                                                   │
+│  ┌──────────────────────────────────────────────────────────────────┐  │
+│  │  Bash tool: gh pr merge --squash 123                            │  │
+│  └──────────────────────────────┬───────────────────────────────────┘  │
+└─────────────────────────────────┼──────────────────────────────────────┘
+                                  │ PostToolUse:Bash if Bash(gh pr merge *)
+                                  ▼
+              ┌─────────────────────────────────────────┐
+              │  bin/ops-deploy-fix-merge-trigger       │
+              │  - parse repo, pr, base, sha            │
+              │  - check userConfig toggles             │
+              │  - check budget (max_fixes_per_hour)    │
+              │  - acquire single-flight lock per repo  │
+              │  - fork scripts/ops-deploy-monitor.sh   │
+              └────────────────┬────────────────────────┘
+                               │ background
+                               ▼
+              ┌─────────────────────────────────────────┐
+              │  scripts/ops-deploy-monitor.sh          │
+              │  ┌───────────────────────────────────┐  │
+              │  │ poll gh run list (deploy regex)   │  │
+              │  │   timeout: watcher_timeout_seconds│  │
+              │  └─────────────┬─────────────────────┘  │
+              │                │                        │
+              │      ┌─────────┴─────────┐              │
+              │      ▼                   ▼              │
+              │  success              failure           │
+              │      │                   │              │
+              │      ▼                   ▼              │
+              │  curl /health       transient?          │
+              │      │              ┌────┴────┐         │
+              │      ▼              ▼         ▼         │
+              │  curl /version    gh run    dispatch    │
+              │  cmp SHA          rerun     headless    │
+              │      │                      claude      │
+              │      └─►  notify   ◄─────────┘          │
+              └────────────────┬────────────────────────┘
+                               │
+                               ▼
+              ┌─────────────────────────────────────────┐
+              │  scripts/ops-notify.sh                  │
+              │  routes to: macos | ntfy | pushover |   │
+              │             discord | telegram | none   │
+              └─────────────────────────────────────────┘
+```
+
+The build-failure path is the same minus the deploy poll — it goes straight to `dispatch headless claude` with the failing build output as context.
+
+---
+
+## Components
+
+| Path | Role |
+|------|------|
+| `hooks/hooks.json` | Wires both PostToolUse:Bash triggers + the `npm run build:*` `if` matcher. |
+| `bin/ops-deploy-fix-merge-trigger` | Hook handler for merges. Parses, gates, forks the monitor. |
+| `bin/ops-deploy-fix-build-trigger` | Hook handler for failing local builds. Same pattern, no deploy poll. |
+| `scripts/ops-deploy-monitor.sh` | Long-lived background watcher per merge. |
+| `scripts/lib/deploy-fix-common.sh` | Shared helpers — lock, budget, dedup, transient classifier, notify. |
+| `prompts/deploy-fix.md` | Headless `deploy-fixer` agent prompt template. |
+| `prompts/build-fix.md` | Headless `build-fixer` agent prompt template. |
+| `agents/deploy-fixer.md` | Pre-installed specialist agent. |
+| `agents/build-fixer.md` | Pre-installed specialist agent. |
+| `config/post-merge-services.example.json` | Plugin-default service registry. |
+| `skills/ops-deploy-fix/SKILL.md` | `/ops:deploy-fix` user-facing skill. |
+| `tests/test-deploy-fix-hooks.sh` | 39 assertions / 11 cases. |
+
+---
+
+## Service registry
+
+The monitor needs to know *which* service the merged PR deploys to so it can hit the right `/health` and `/version` endpoints. The registry is layered:
+
+```
+project   .claude/post-merge-services.json
+              ▲ overrides
+user      ~/.claude/config/post-merge-services.json
+              ▲ overrides
+plugin    config/post-merge-services.example.json   (defaults / examples)
+```
+
+Schema:
+
+```json
+{
+  "your-org/your-api:dev": {
+    "health_url": "https://api-dev.example.com/health",
+    "version_url": "https://api-dev.example.com/version",
+    "deploy_workflow": "deploy-staging.yml",
+    "served_sha_jq": ".commit.sha"
+  },
+  "your-org/your-api:main": {
+    "health_url": "https://api.example.com/health",
+    "version_url": "https://api.example.com/version",
+    "deploy_workflow": "deploy-production.yml"
+  }
+}
+```
+
+`served_sha_jq` is optional; defaults to `.sha // .commit // .version`.
+
+If a merge has no registry entry, the monitor falls back to **deploy-only verification** (poll the workflow, no health/version curl) and notifies on workflow failure.
+
+---
+
+## Dedup, budget, single-flight
+
+Three independent guards prevent runaway agent spawning:
+
+1. **Single-flight lock per repo** — `scripts/lib/deploy-fix-common.sh` acquires a `flock`-style lock on `${OPS_DATA_DIR}/locks/<owner>__<repo>.lock`. Concurrent merges on the same repo queue; no two deploy-fixers run for the same repo at once.
+2. **Hourly budget cap** — `max_fixes_per_hour` (default 3, range 0..20). The shared lib increments a per-repo per-hour counter at `${OPS_DATA_DIR}/budgets/<owner>__<repo>__<YYYYMMDDHH>`. When the cap is hit, the failure is logged + notified but the fixer is **not** dispatched.
+3. **Content-hash dedup** — the failing log tail (last 4 KB) is sha256'd. If the same hash dispatched a fixer in the last hour for the same repo, the new failure is treated as a duplicate and skipped (the previous fixer is presumed to be either still running or recently shipped a PR).
+
+---
+
+## Transient classification
+
+`auto_rerun_transients` (default `true`) routes failures matching any of these patterns to `gh run rerun --failed` instead of dispatching a fixer:
+
+- `npm ERR! 5\d\d` (npm registry 5xx)
+- `EAI_AGAIN` / `getaddrinfo` (DNS blip)
+- `Error: read ECONNRESET` / `socket hang up`
+- `429 Too Many Requests`
+- `The runner has received a shutdown signal`
+- `Process completed with exit code 137` (OOM-kill)
+
+The classifier is intentionally narrow — when in doubt, dispatch a real fixer.
+
+---
+
+## Notification channels
+
+`notify_channel` userConfig (default `macos`):
+
+| Value | Mechanism |
+|-------|-----------|
+| `macos` | `osascript -e 'display notification ...'` |
+| `ntfy` | `curl -d "msg" ntfy.sh/<topic>` (set `ntfy_topic`) |
+| `pushover` | Pushover API (set `pushover_user_key` + `pushover_app_token`) |
+| `discord` | Discord webhook (set `discord_default_webhook_url`) |
+| `telegram` | Telegram MCP send (uses `telegram_notify_chat_id`) |
+| `none` | Silent — log only |
+
+All channels prefix the message with the repo + PR + run URL so you can jump straight to the failed run.
+
+---
+
+## `/ops:deploy-fix` skill
+
+| Subcommand | Purpose |
+|------------|---------|
+| `/ops:deploy-fix` | Live status — running monitors, today's history, budget remaining per repo. |
+| `/ops:deploy-fix tail <run-id>` | Stream the monitor log for a specific run. |
+| `/ops:deploy-fix configure` | Open the layered service registry in `$EDITOR`. |
+| `/ops:deploy-fix test` | Dry-run the merge-trigger hook against a synthetic merge — verifies registry, lock, budget logic without dispatching. |
+
+---
+
+## Configuration reference
+
+All settings live under `userConfig` in `plugin.json` and are spacebar-toggleable in `/plugins` settings.
+
+| Key | Type | Default | Purpose |
+|-----|------|---------|---------|
+| `deploy_fix_enabled` | boolean | `true` | Master switch. |
+| `monitor_post_merge` | boolean | `true` | Watch `gh pr merge`. |
+| `monitor_build_failures` | boolean | `true` | Watch `npm run build:*`. |
+| `auto_dispatch_fixer` | boolean | `true` | Off = log + notify only. |
+| `allow_dangerous` | boolean | `false` | Pass `--dangerously-skip-permissions` to fixer. |
+| `auto_rerun_transients` | boolean | `true` | Auto-`gh run rerun` on classified blips. |
+| `audit_health_after_deploy` | boolean | `true` | `curl /health` after success. |
+| `verify_served_commit` | boolean | `true` | `curl /version` and compare SHA. |
+| `fix_model` | string | `haiku` | `haiku` / `sonnet` / `opus`. |
+| `max_fixes_per_hour` | number | `3` | Per-repo cap (0..20). |
+| `watcher_timeout_seconds` | number | `1800` | Max wait for deploy completion (60..7200). |
+| `registry_path` | file | `~/.claude/config/post-merge-services.json` | User registry. |
+| `repo_search_roots` | string | `~/Projects:~` | Where to find the repo on disk. |
+| `deploy_workflow_pattern` | string | `deploy\|Deploy\|build\|Build\|ECS\|cd\|CD` | Regex picking the deploy run. |
+| `notify_channel` | string | `macos` | `macos`/`ntfy`/`pushover`/`discord`/`telegram`/`none`. |
+
+---
+
+## Troubleshooting
+
+**No fixer dispatched after a failed merge.** Check in order:
+1. `/ops:deploy-fix` — is the master switch on? Budget exhausted?
+2. `tail -f $OPS_DATA_DIR/logs/deploy-monitor-*.log` — did the monitor start?
+3. `gh run list --repo <owner/repo> --limit 5` — did GH Actions actually emit a run matching `deploy_workflow_pattern`?
+4. Registry — does `<owner/repo>:<base>` exist? Without an entry, the monitor will only poll the workflow, not health/version.
+
+**Fixer keeps re-firing on the same failure.** Content-hash dedup looks at the last 4 KB of log. If your build always emits a unique trailer (timestamp, run-id), dedup misses. Either:
+- Add a `dedup_strip_pattern` to your registry entry (TODO — pending in v2.1), or
+- Lower `max_fixes_per_hour` to `1`.
+
+**Health check fails immediately after success.** Most services need a few seconds to roll over after a green deploy. The monitor sleeps 15s before the first `/health` call. Tune via `HEALTH_GRACE_SECONDS` env var if needed.
+
+**`--dangerously-skip-permissions` makes me nervous.** Leave `allow_dangerous: false` (the default). The fixer will pause on permission prompts, which means unattended runs may stall. The trade-off is yours.
+
+---
+
+## FAQ
+
+**Q: Will this dispatch fixers for PRs I merge from the GitHub web UI?**
+No. The hook only fires on `gh pr merge` from inside a Claude Code session. CI-merged or web-merged PRs are invisible to it. (This is intentional — the hook scope is your local Claude Code workflow.)
+
+**Q: Does it work for non-Node deploys?**
+The merge trigger is language-agnostic — it only inspects `gh pr merge` arguments. The build trigger currently matches `npm run build:*`; PRs welcome to add `pnpm`, `yarn`, `cargo build`, `go build`, `mvn package` matchers.
+
+**Q: Does it touch my git history?**
+No. The fixer creates a new branch (`fix/auto-deploy-<sha>`) and opens a PR. Your main/dev branch is never directly modified.
+
+**Q: How much does a typical fixer run cost?**
+~5-15k Haiku tokens for a clean diagnosis + 1-file fix. ~$0.005-$0.015 per dispatch. With `max_fixes_per_hour: 3` your worst-case spend is ~$1.20/day per repo.
+
+---
+
+## See also
+
+- [`docs/agents.md`](agents.md) — pre-installed specialist agents (deploy-fixer + build-fixer live here).
+- [`docs/safety-hooks.md`](safety-hooks.md) — universal PreToolUse safety hooks (independent of deploy-fix).
+- [`docs/recap.md`](recap.md) — recap marquee shows live deploy-fix activity across sessions.
+- [`docs/INDEX.md`](INDEX.md) — full documentation index.

--- a/claude-ops/docs/marketplace-submissions.md
+++ b/claude-ops/docs/marketplace-submissions.md
@@ -4,7 +4,7 @@
 
 *Tracking where claude-ops is listed (or pending listing) across the Claude plugin ecosystem*
 
-[![version](https://img.shields.io/badge/version-1.1.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
 [![destinations](https://img.shields.io/badge/destinations-4-6366f1)](.)
 [![status](https://img.shields.io/badge/status-in--progress-f59e0b)](.)
 

--- a/claude-ops/docs/memories-system.md
+++ b/claude-ops/docs/memories-system.md
@@ -4,7 +4,7 @@
 
 *Persistent local context about people, projects, and your communication patterns — extracted from your chats, stored as markdown, never sent anywhere*
 
-[![version](https://img.shields.io/badge/version-1.1.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
 [![storage](https://img.shields.io/badge/storage-local%20markdown-22c55e)](.)
 [![privacy](https://img.shields.io/badge/privacy-on--device-6366f1)](.)
 [![extractor](https://img.shields.io/badge/extractor-haiku--4--5-f59e0b)](.)

--- a/claude-ops/docs/migrating-from-v1.md
+++ b/claude-ops/docs/migrating-from-v1.md
@@ -1,0 +1,119 @@
+<div align="center">
+
+# Migrating from v1.x → v2.0
+
+*claude-ops 2.0 is purely additive. No v1 behavior changes by default. This page exists so you know exactly what's new and how to opt out of anything you don't want.*
+
+[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
+[![breaking](https://img.shields.io/badge/breaking%20changes-none-22c55e)](.)
+
+</div>
+
+---
+
+## TL;DR
+
+```bash
+# inside Claude Code:
+/plugin update ops@lifecycle-innovations-limited-claude-ops
+/ops:setup    # walks through the 6 new wizard steps; safe to skip any
+```
+
+That's it. Existing settings, registries, preferences, and daemon services are unchanged.
+
+---
+
+## What's actually new
+
+| Area | v1.8.1 | v2.0.0 |
+|------|--------|--------|
+| Skills | 30 | 33+ (added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`) |
+| Agents | 14 | 18 (added `general-purpose` override, `deploy-fixer`, `build-fixer`, `dependency-auditor`) |
+| PostToolUse:Bash hooks | 0 | 3 (deploy-fix-merge, deploy-fix-build, task-reminder) |
+| PreToolUse:Bash hooks | 1 (wacli-health) | 4 (+ secret-commit, no-rm-rf-anchor, warn-mainpush) |
+| PreToolUse:Agent hooks | 0 | 1 (specialized-agent suggestion) |
+| Daemons | 1 (ops-daemon, 7 services) | 3 (+ recap-daemon, account-rotation-daemon) |
+| `userConfig` toggles | ~25 string entries | 44 (19+ new booleans/numbers/file pickers) |
+| Wizard steps | 11 | 17 (+2d, 3o, 6.5a, 6.5b, 6.5c, 6.5d) |
+| Test files | 9 | 11 (+ test-deploy-fix-hooks, test-safety-hooks) |
+
+---
+
+## Defaults: what fires automatically
+
+When you upgrade and run `/ops:setup`, these v2 features activate by default:
+
+- **Deploy auto-fix** (`deploy_fix_enabled: true`) — but only fires when you actually run `gh pr merge` or `npm run build:*` from inside a Claude Code session.
+- **Specialized agent suggestion** (`suggest_specialized_agents: true`) — silent; you'll only notice via the agent transcripts.
+- **Three safety hooks** — always on by design (see [`safety-hooks.md`](safety-hooks.md)).
+- **Task* tracking nudge** (`task_reminder_enabled: true`) — adds a one-line reminder to `additionalContext` after 10 non-Task tool calls.
+- **Recap marquee** (`recap_marquee_enabled: true`) — daemon installs and runs; harmless if you don't have tmux.
+
+These features are **opt-out** by default:
+
+- **Multi-account rotator** (`account_rotation_enabled: false`) — you must explicitly enable + run `/ops:rotate-setup`.
+
+---
+
+## Restoring v1 behaviour
+
+Edit `/plugins` settings and toggle off:
+
+| To restore v1 | Set |
+|---------------|-----|
+| Default agent always = raw `general-purpose` | `suggest_specialized_agents: false` |
+| No post-merge watcher | `deploy_fix_enabled: false` |
+| No build-failure fixer | `monitor_build_failures: false` |
+| No task-tracking nudges | `task_reminder_enabled: false` |
+| No recap marquee | `recap_marquee_enabled: false` + `launchctl unload ~/Library/LaunchAgents/com.claude-ops.recap-daemon.plist` |
+
+To disable the three safety hooks (not recommended), comment out their entries in [`hooks/hooks.json`](../hooks/hooks.json) under `PreToolUse > Bash`.
+
+---
+
+## File / path migrations
+
+None. v1 file locations, registry shapes, and preferences keys are unchanged.
+
+New paths v2 introduces (all under `$OPS_DATA_DIR`, default `~/.claude/plugins/data/ops-ops-marketplace`):
+
+```
+$OPS_DATA_DIR/
+├── locks/                         # deploy-fix single-flight per repo
+├── budgets/                       # deploy-fix per-repo per-hour counter
+├── logs/deploy-monitor-*.log      # one log per active monitor
+├── recap/
+│   ├── sessions/<sid>.jsonl       # per-session capture
+│   └── digest                     # current digest (read by marquee)
+└── account-rotation/
+    └── usage-cache.json           # per-account quota cache
+```
+
+And:
+
+```
+~/.claude/config/post-merge-services.json   # user-scope deploy-fix registry
+~/.claude/config/specialist-keywords.json   # user-scope keyword map
+~/.claude/agents/<name>.md                  # user-scope specialist agents
+```
+
+---
+
+## Rolling back to v1.8.1
+
+```bash
+/plugin uninstall ops@lifecycle-innovations-limited-claude-ops
+/plugin marketplace update Lifecycle-Innovations-Limited/claude-ops
+# in Claude Code, install at the v1.8.1 tag:
+/plugin install ops@lifecycle-innovations-limited-claude-ops@1.8.1
+```
+
+Your `$OPS_DATA_DIR` survives uninstall. v2-specific subdirs (`locks/`, `budgets/`, `recap/`, `account-rotation/`) are ignored by v1 code; you can delete them or leave them.
+
+---
+
+## See also
+
+- [`docs/INDEX.md`](INDEX.md) — full documentation index.
+- [`CHANGELOG.md`](../CHANGELOG.md) — full v2.0.0 entry with PR references and file paths.
+- Wiki: [`Migrating-from-v1`](https://github.com/Lifecycle-Innovations-Limited/claude-ops/wiki/Migrating-from-v1).

--- a/claude-ops/docs/recap.md
+++ b/claude-ops/docs/recap.md
@@ -1,0 +1,184 @@
+<div align="center">
+
+# Recap Marquee Daemon
+
+*One-line situational awareness across every parallel Claude Code session, surfaced in tmux `status-right` or the Claude Code `statusLine`.*
+
+[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
+[![daemon](https://img.shields.io/badge/runtime-launchd%20%2F%20systemd-6366f1)](.)
+[![cadence](https://img.shields.io/badge/refresh-30s-22c55e)](.)
+
+</div>
+
+---
+
+## What it does
+
+If you run several Claude Code sessions across worktrees, you lose track of which session is doing what. The recap marquee gives you a single line — refreshed every 30 seconds — summarising every active session's latest action.
+
+```
+┌ tmux status-right ───────────────────────────────────────────────────────┐
+│ [3 sessions] api: editing UserService.ts • web: gh pr merge • db: idle 2m│
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+When something *fires* (a deploy-fix dispatched, a safety hook denied, a `/ops:fires` alert) it's flagged with `🔥` and bumped to the front of the line.
+
+---
+
+## Architecture
+
+```
+┌─ Claude Code session A (worktree-a) ─┐
+│ hooks/recap-tool-activity.sh         │──┐
+│ hooks/recap-capture.sh               │  │
+└──────────────────────────────────────┘  │
+┌─ Claude Code session B (worktree-b) ─┐  │   writes to
+│ hooks/recap-tool-activity.sh         │──┼──► $OPS_DATA_DIR/recap/sessions/<sid>.jsonl
+│ hooks/recap-capture.sh               │  │
+└──────────────────────────────────────┘  │
+┌─ Claude Code session C (worktree-c) ─┐  │
+│ ...                                  │──┘
+└──────────────────────────────────────┘
+                                              ▲ tail -f
+                                              │
+                                ┌─────────────┴─────────────┐
+                                │  scripts/recap/daemon.sh  │
+                                │  every 30s:               │
+                                │   1. read all session     │
+                                │      jsonl tails          │
+                                │   2. classify & rank      │
+                                │   3. write digest         │
+                                └─────────────┬─────────────┘
+                                              │
+                                              ▼
+                                ┌──────────────────────────────┐
+                                │  scripts/recap/digest.sh     │
+                                │  → $OPS_DATA_DIR/recap/digest │
+                                └─────────────┬────────────────┘
+                                              │
+                                              ▼
+                                ┌──────────────────────────────┐
+                                │  scripts/recap/marquee.sh    │
+                                │  formats one-line ANSI       │
+                                │  read by tmux status-right   │
+                                │  or Claude Code statusLine   │
+                                └──────────────────────────────┘
+```
+
+---
+
+## Components
+
+| Path | Role |
+|------|------|
+| `scripts/recap/daemon.sh` | Long-lived loop. Reads session jsonl tails, builds digest. |
+| `scripts/recap/digest.sh` | Synthesises the digest (active session count, latest action, fire flags). |
+| `scripts/recap/marquee.sh` | Formats one-line ANSI output for tmux/`statusLine`. |
+| `hooks/recap-capture.sh` | PostToolUse hook — captures Edit/Write/Bash payloads to per-session jsonl. |
+| `hooks/recap-tool-activity.sh` | PostToolUse `*` hook — heartbeat + tool-name log. |
+| `templates/com.claude-ops.recap-daemon.plist` | macOS launchd unit. |
+| `skills/ops-recap/SKILL.md` | `/ops:recap` user-facing skill. |
+
+---
+
+## Setup
+
+### Automatic (recommended)
+
+```
+/ops:setup
+```
+
+Step 2d of the wizard:
+
+1. Installs the launchd plist (`~/Library/LaunchAgents/com.claude-ops.recap-daemon.plist`) and `launchctl load`s it.
+2. If `tmux` is detected, appends to `~/.tmux.conf`:
+   ```
+   set -g status-right '#(bash ~/.claude/plugins/installed/ops-ops-marketplace/scripts/recap/marquee.sh) | %H:%M'
+   set -g status-interval 5
+   ```
+3. If no tmux, wires the marquee into the Claude Code `statusLine` in `~/.claude/settings.json`.
+4. Verifies the daemon is running and the digest file is fresh.
+
+### Manual (Linux / systemd)
+
+There's no upstream systemd unit shipped (yet — PRs welcome). Use this template:
+
+```ini
+# ~/.config/systemd/user/claude-ops-recap.service
+[Unit]
+Description=claude-ops recap marquee daemon
+
+[Service]
+ExecStart=%h/.claude/plugins/installed/ops-ops-marketplace/scripts/recap/daemon.sh
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+```
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now claude-ops-recap.service
+```
+
+For tmux integration, the same `set -g status-right …` line works on Linux.
+
+---
+
+## `/ops:recap` skill
+
+| Subcommand | Purpose |
+|------------|---------|
+| `/ops:recap` | Show today's digest as a multi-line summary (richer than the marquee). |
+| `/ops:recap status` | Daemon health, last digest age, active session count. |
+| `/ops:recap tail` | Tail the daemon log. |
+| `/ops:recap configure` | Open `~/.tmux.conf` / `settings.json` for manual tweaks. |
+| `/ops:recap restart` | `launchctl unload && load` (or `systemctl restart`). |
+
+---
+
+## Configuration
+
+| Key | Type | Default | Purpose |
+|-----|------|---------|---------|
+| `recap_marquee_enabled` | boolean | `true` | Master switch. |
+| `recap_marquee_auto_configure_tmux` | boolean | `true` | Append marquee source to `~/.tmux.conf` during setup. |
+
+Disable via `/plugins` settings; then `launchctl unload ~/Library/LaunchAgents/com.claude-ops.recap-daemon.plist` to stop the daemon.
+
+---
+
+## Customisation
+
+The marquee format is controlled by `scripts/recap/marquee.sh`. Override per-user by symlinking your own at `~/.claude/config/recap-marquee.sh`; the daemon prefers user override over plugin default.
+
+Variables available to the marquee script (read from `$OPS_DATA_DIR/recap/digest`):
+
+- `SESSION_COUNT` — active session count.
+- `SESSIONS` — newline-delimited `<short-id> <last-action> <idle-secs>`.
+- `FIRES` — newline-delimited fire entries (deploy-fix denials, safety-hook blocks, `/ops:fires` alerts).
+- `LAST_UPDATED` — Unix timestamp of last digest write.
+
+---
+
+## Troubleshooting
+
+**Marquee shows stale data.** Check the daemon: `/ops:recap status`. If it's not running, `/ops:recap restart`.
+
+**tmux status-right not updating.** Verify `status-interval` is `5` or lower in `~/.tmux.conf`. tmux reloads `status-right` only on this interval.
+
+**Sessions not appearing.** The capture hooks need the plugin's `hooks/hooks.json` to be active in that session. If you spawned the session before installing the plugin, restart it.
+
+**Performance impact.** Each capture write is <1 ms (append-only jsonl). The daemon's 30s loop reads ~10-100 KB total per cycle. Negligible CPU.
+
+---
+
+## See also
+
+- [`docs/deploy-fix.md`](deploy-fix.md) — recap surfaces deploy-fix activity as fires.
+- [`docs/safety-hooks.md`](safety-hooks.md) — safety-hook denials surface as fires.
+- [`docs/daemon-guide.md`](daemon-guide.md) — the v1 ops-daemon (separate process from recap-daemon).
+- [`docs/INDEX.md`](INDEX.md) — full documentation index.

--- a/claude-ops/docs/safety-hooks.md
+++ b/claude-ops/docs/safety-hooks.md
@@ -1,0 +1,117 @@
+<div align="center">
+
+# Universal Safety Hooks
+
+*Three PreToolUse:Bash hooks that block the most common foot-guns: secrets in commits, `rm -rf` against anchor paths, and direct `git push` to `main`.*
+
+[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
+[![hook](https://img.shields.io/badge/PreToolUse-Bash-6366f1)](.)
+[![always-on](https://img.shields.io/badge/always--on-by%20design-ef4444)](.)
+
+</div>
+
+---
+
+## Why these are not gated by userConfig
+
+The other v2 subsystems (deploy-fix, recap, rotator, task-reminder) are toggleable from `/plugins` settings because they're additive convenience layers. The three safety hooks are different — they prevent **irrecoverable damage** (committed secrets, deleted home directories, broken main branches). They're always-on by design, with a per-incident escape via Claude Code's standard `permissionDecision` flow.
+
+If you genuinely need to disable one, comment out the entry in `hooks/hooks.json`. There is no shame in this — but make it a deliberate choice, not a forgotten toggle.
+
+---
+
+## The three hooks
+
+### 1. `bin/ops-prevent-secret-commit`
+
+**Trigger:** PreToolUse:Bash matching `git commit *`.
+
+**Action:** Scans `git diff --cached` for known secret patterns. On match, returns `permissionDecision: deny` with an explanation listing the matched pattern + offending file.
+
+**Patterns detected:**
+
+| Pattern | Match |
+|---------|-------|
+| AWS access key | `AKIA[0-9A-Z]{16}` |
+| AWS secret key | `aws_secret_access_key\s*=\s*["']?[A-Za-z0-9/+=]{40}` |
+| GitHub PAT | `ghp_[A-Za-z0-9]{36}` / `github_pat_[A-Za-z0-9_]{82}` |
+| Slack token | `xox[baprs]-[A-Za-z0-9-]{10,}` |
+| OpenAI API key | `sk-(proj-)?[A-Za-z0-9]{20,}` |
+| Anthropic API key | `sk-ant-[A-Za-z0-9_-]{20,}` |
+| Stripe live key | `sk_live_[A-Za-z0-9]{24,}` |
+| `.env` content | any staged `.env*` file (excluding `.env.example`, `.env.template`) |
+| Generic high-entropy string | any 32+ char base64-ish run with `KEY` / `TOKEN` / `SECRET` in the variable name |
+
+**Override:** un-stage the offending file (`git restore --staged <path>`), or scrub the value. There's no env-var override; this is intentional.
+
+---
+
+### 2. `bin/ops-no-rm-rf-anchor`
+
+**Trigger:** PreToolUse:Bash matching `rm -rf *` (and equivalents: `rm -fr`, `rm -rfv`, etc.).
+
+**Action:** Resolves each target via `realpath`/`readlink -f` (so symlinks don't sneak past). On any of these resolved targets, returns `permissionDecision: deny`:
+
+- `/`
+- `$HOME` / `~` (and any path that resolves *to* `$HOME`)
+- `..` and `.` (when CWD itself is `$HOME` or `/`)
+- Mount points listed in `/etc/fstab` (root-level only)
+
+**Override:** there is none for the listed anchors. If you genuinely need to wipe `~`, do it outside Claude Code.
+
+---
+
+### 3. `bin/ops-warn-mainpush`
+
+**Trigger:** PreToolUse:Bash matching `git push *`.
+
+**Action:** Reads the current branch via `git rev-parse --abbrev-ref HEAD`. If the branch is in the protected list (`main`, `master`, `prod`, `production`, `release`), returns `permissionDecision: ask` (not deny — ask) with the message:
+
+```
+About to push directly to <branch>. This bypasses the PR review flow.
+Confirm by accepting the prompt; abort by rejecting.
+```
+
+**Override:** accept the standard Claude Code permission prompt. No env-var or config override.
+
+This hook intentionally uses `ask` not `deny` because force-push to main is sometimes legitimate (recovering from a broken merge, hotfix, etc.) — but it should never be silent.
+
+---
+
+## How `permissionDecision` works
+
+Claude Code's standard PreToolUse mechanism supports three decisions:
+
+- `allow` — pass through silently.
+- `ask` — prompt the user; user accepts → pass through.
+- `deny` — block the call, return the explanation to Claude.
+
+The three safety hooks use this mechanism. They never modify the command or rewrite arguments; they only inspect and decide.
+
+---
+
+## Disabling a single hook
+
+Edit [`hooks/hooks.json`](../hooks/hooks.json) and remove the relevant entry under `PreToolUse > Bash`. Reload the plugin (`/plugin reload ops`) for the change to take effect.
+
+To re-enable, copy the entry back from the v2 release notes or the [GitHub source](https://github.com/Lifecycle-Innovations-Limited/claude-ops/blob/main/claude-ops/hooks/hooks.json).
+
+---
+
+## Testing
+
+[`tests/test-safety-hooks.sh`](../tests/test-safety-hooks.sh) covers every hook with positive (should-deny / should-ask) and negative (should-allow) cases. 45/45 pass on macOS + Linux.
+
+Run locally:
+
+```bash
+bash claude-ops/tests/test-safety-hooks.sh
+```
+
+---
+
+## See also
+
+- [`docs/deploy-fix.md`](deploy-fix.md) — auto-fix subsystem (independent of safety hooks).
+- [`docs/agents.md`](agents.md) — specialized agent system.
+- [`docs/INDEX.md`](INDEX.md) — full documentation index.

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -2,10 +2,10 @@
 
 # Skills Reference
 
-*All 30 skills available in claude-ops — your business operations command surface*
+*All 33+ skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`)*
 
-[![version](https://img.shields.io/badge/version-1.7.0-blue)](../CHANGELOG.md)
-[![skills](https://img.shields.io/badge/skills-30-8b5cf6)](.)
+[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
+[![skills](https://img.shields.io/badge/skills-33%2B-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)
 

--- a/claude-ops/hooks/hooks.json
+++ b/claude-ops/hooks/hooks.json
@@ -25,6 +25,24 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-pretool-wacli-health \"$TOOL_INPUT\" 2>/dev/null || true"
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-prevent-secret-commit",
+            "timeout": 5,
+            "if": "Bash(git commit*)"
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-no-rm-rf-anchor",
+            "timeout": 3,
+            "if": "Bash(rm *)"
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-warn-mainpush",
+            "timeout": 3,
+            "if": "Bash(git push*)"
           }
         ]
       },

--- a/claude-ops/hooks/hooks.json
+++ b/claude-ops/hooks/hooks.json
@@ -29,6 +29,35 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-deploy-fix-merge-trigger 2>/dev/null || true",
+            "timeout": 5,
+            "if": "Bash(gh pr merge *)"
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-deploy-fix-build-trigger 2>/dev/null || true",
+            "timeout": 5,
+            "if": "Bash(npm run build:*)"
+          }
+        ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-task-reminder 2>/dev/null || true",
+            "timeout": 3
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/claude-ops/hooks/hooks.json
+++ b/claude-ops/hooks/hooks.json
@@ -64,6 +64,11 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-task-reminder 2>/dev/null || true",
             "timeout": 3
+          },
+          {
+            "type": "command",
+            "command": "[ \"${CLAUDE_PLUGIN_USERCONFIG_RECAP_MARQUEE_ENABLED:-false}\" = \"true\" ] && sh ${CLAUDE_PLUGIN_ROOT}/hooks/recap-tool-activity.sh 2>/dev/null || true",
+            "timeout": 2
           }
         ]
       }
@@ -74,6 +79,11 @@
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-post-session-cleanup 2>/dev/null || true"
+          },
+          {
+            "type": "command",
+            "command": "[ \"${CLAUDE_PLUGIN_USERCONFIG_RECAP_MARQUEE_ENABLED:-false}\" = \"true\" ] && sh ${CLAUDE_PLUGIN_ROOT}/hooks/recap-capture.sh 2>/dev/null || true",
+            "timeout": 3
           }
         ]
       }

--- a/claude-ops/hooks/hooks.json
+++ b/claude-ops/hooks/hooks.json
@@ -27,6 +27,16 @@
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-pretool-wacli-health \"$TOOL_INPUT\" 2>/dev/null || true"
           }
         ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-suggest-specialized-agent 2>/dev/null || true",
+            "timeout": 3
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/claude-ops/hooks/recap-capture.sh
+++ b/claude-ops/hooks/recap-capture.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Stop hook: capture a one-line recap of the last assistant turn into
+# /tmp/claude-recap-${session_id}. Read by the recap daemon to assemble the
+# multi-session digest displayed in the tmux marquee.
+input=$(cat)
+session_id=$(echo "$input" | jq -r '.session_id // ""')
+transcript=$(echo "$input" | jq -r '.transcript_path // ""')
+[ -z "$session_id" ] && exit 0
+[ -z "$transcript" ] || [ ! -f "$transcript" ] && exit 0
+
+# Walk transcript bottom-up looking for the most recent assistant turn that has
+# actual text content (not just tool_use blocks). Linux: tac; macOS BSD: tail -r.
+if command -v tac >/dev/null 2>&1; then
+  _transcript_rev_lines() { tac "$1" 2>/dev/null; }
+else
+  _transcript_rev_lines() { tail -r "$1" 2>/dev/null; }
+fi
+last_text=$(_transcript_rev_lines "$transcript" | awk '
+  /"type":"assistant"/ { print; if (++n >= 30) exit }
+' | while IFS= read -r line; do
+  t=$(printf '%s' "$line" | jq -r '.message.content[]? | select(.type=="text") | .text' 2>/dev/null | tr '\n' ' ' | sed 's/  */ /g')
+  if [ -n "$t" ]; then
+    printf '%s' "$t"
+    break
+  fi
+done)
+
+# Restrict file permissions — /tmp is world-readable on most systems
+umask 177
+
+if [ -z "$last_text" ]; then
+  : > "/tmp/claude-recap-${session_id}"
+  exit 0
+fi
+
+# Strip ANSI, markdown bullets, code fences; keep first 240 chars.
+clean=$(printf '%s' "$last_text" \
+  | sed -E 's/\x1B\[[0-9;]*[a-zA-Z]//g' \
+  | sed -E 's/^[ *#>`-]+//; s/`//g' \
+  | head -c 240)
+
+printf '%s' "$clean" > "/tmp/claude-recap-${session_id}"
+exit 0

--- a/claude-ops/hooks/recap-tool-activity.sh
+++ b/claude-ops/hooks/recap-tool-activity.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# PostToolUse hook: live activity capture — fires on every tool call so the
+# tmux recap stays fresh while the agent is actively working (not only at
+# end-of-turn pauses).
+input=$(cat 2>/dev/null)
+[ -z "$input" ] && exit 0
+
+session_id=$(echo "$input" | jq -r '.session_id // ""')
+tool=$(echo "$input" | jq -r '.tool_name // ""')
+[ -z "$tool" ] && exit 0
+
+case "$tool" in
+  Bash)
+    cmd=$(echo "$input" | jq -r '.tool_input.command // ""' | head -c 80 | tr '\n' ' ')
+    label="$ $cmd"
+    ;;
+  Edit|Write)
+    f=$(echo "$input" | jq -r '.tool_input.file_path // ""')
+    label="edit ${f##*/}"
+    ;;
+  Read)
+    f=$(echo "$input" | jq -r '.tool_input.file_path // ""')
+    label="read ${f##*/}"
+    ;;
+  Grep)
+    p=$(echo "$input" | jq -r '.tool_input.pattern // ""' | head -c 40)
+    label="grep $p"
+    ;;
+  Glob)
+    p=$(echo "$input" | jq -r '.tool_input.pattern // ""' | head -c 40)
+    label="glob $p"
+    ;;
+  Agent|Task)
+    desc=$(echo "$input" | jq -r '.tool_input.description // .tool_input.prompt // ""' | head -c 60 | tr '\n' ' ')
+    label="agent $desc"
+    ;;
+  *)
+    label="$tool"
+    ;;
+esac
+
+ts=$(date '+%H:%M:%S')
+line="[$ts] $label"
+
+[ -n "$session_id" ] && { umask 177; printf '%s' "$line" > "/tmp/claude-recap-${session_id}"; }
+exit 0

--- a/claude-ops/lib/credential-store.sh
+++ b/claude-ops/lib/credential-store.sh
@@ -19,7 +19,7 @@
 #   ops_cred_backend_for <service> <account>
 #
 # Direct-execution CLI (for the .mjs helper to shell out to):
-#   credential-store.sh set|get|delete|backends|backend-for ...
+#   credential-store.sh set|set-stdin|get|delete|backends|backend-for ...
 
 # ─── Re-source guard ────────────────────────────────────────────────────────
 if [[ -n "${__OPS_CREDENTIAL_STORE_SH_LOADED__:-}" ]]; then
@@ -589,6 +589,11 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     set)
       [[ $# -eq 3 ]] || { echo "usage: credential-store.sh set <service> <account> <secret>" >&2; exit 2; }
       ops_cred_set "$@" ;;
+    set-stdin)
+      [[ $# -eq 2 ]] || { echo "usage: credential-store.sh set-stdin <service> <account>" >&2; exit 2; }
+      sec="$(cat)" || sec=""
+      [[ -n "$sec" ]] || { echo "error: empty secret on stdin (pipe the secret, e.g. echo \"tok\" | credential-store.sh set-stdin svc acct)" >&2; exit 2; }
+      ops_cred_set "$1" "$2" "$sec" ;;
     get)
       [[ $# -eq 2 ]] || { echo "usage: credential-store.sh get <service> <account>" >&2; exit 2; }
       ops_cred_get "$@" ;;
@@ -605,6 +610,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 credential-store.sh — cross-OS secret storage with cascading backends
 Usage:
   credential-store.sh set         <service> <account> <secret>
+  credential-store.sh set-stdin   <service> <account>   # secret on stdin (avoids argv exposure)
   credential-store.sh get         <service> <account>
   credential-store.sh delete      <service> <account>
   credential-store.sh backends

--- a/claude-ops/prompts/build-fix.md
+++ b/claude-ops/prompts/build-fix.md
@@ -1,20 +1,19 @@
 # Persona
 
-You are **Build Fixer** — a focused mobile/native build engineer persona spawned by the `claude-ops` plugin to repair a SINGLE failed local build (`npm run build:*`). You are NOT a feature engineer. One repair, one PR, exit.
+You are **Build Fixer** — a focused mobile/native/web build engineer persona spawned by the `claude-ops` plugin to repair a SINGLE failed local build (`npm run build:*` or equivalent). You are NOT a feature engineer. One repair, one PR, exit.
 
 # Awareness
 
-You are headless inside Claude Code with full claude-ops tooling:
+You are headless inside Claude Code. Use these specialists when the failure clearly belongs to their domain:
 
 | Need | Use |
 |---|---|
-| Mobile / Expo / RN / iOS Fastlane | spawn the `Mobile App Specialist` subagent |
+| Mobile / Expo / React Native / iOS Fastlane | spawn the `fullstack-mobile-architect` subagent |
 | TypeScript / type errors | spawn the `typescript-reviewer` subagent |
-| Healify cross-repo contract breakage | spawn the `fullstack-mobile-architect` subagent |
-| Sentry context for runtime crashes | `mcp__sentry__search_events` |
-| Apple Developer / TestFlight state | `python3 scripts/asc-manage-builds.py` (in healify repo) |
-| Doppler secret resolution | `doppler secrets get <KEY> --project healify --config <env> --plain` |
-| Library version drift | `npx expo install --check`, `npm ls <pkg>`, Context7 MCP for docs |
+| Multi-repo contract breakage | spawn the `multi-repo-coordinator` subagent |
+| Sentry context for runtime crashes | `mcp__sentry__search_events` (if Sentry MCP installed) |
+| Doppler secret resolution | `doppler secrets get <KEY> --project <proj> --config <env> --plain` |
+| Library version drift | project's package manager check (e.g. `npx expo install --check`, `npm ls <pkg>`); Context7 MCP for docs |
 
 Do NOT invent agent names. Fall back to `general-purpose` if unsure.
 
@@ -36,15 +35,15 @@ Categorize the failure into ONE bucket — your fix flows from the bucket:
 
 | Bucket | Signals | Fix path |
 |---|---|---|
-| **type-check** | `error TS2`, `error TS7` | Patch the offending file(s); rerun `npm run type-check`. |
-| **lint** | `error  Parsing error`, ESLint rule fails | Fix in code (no `eslint-disable` shortcut). |
-| **expo-doctor / version drift** | `expo-doctor`, `package versions mismatch` | `npx expo install --check --fix`. |
-| **fastlane signing** | `Match`, `provisioning profile`, `code signing` | Re-sync via `bundle exec fastlane match nuke + match` (CONFIRM with user before nuke). |
-| **fastlane archive** | `xcodebuild`, `gym`, `Build FAILED` | Locate Xcode error in logs, patch in iOS native or RN bridge code. |
-| **App Store Connect transient** | `503`, `timed out`, `Apple ID server.*temporarily unavailable` | Recommend retry; do NOT open PR. |
-| **Doppler missing** | `DOPPLER_TOKEN`, `secret not found` | Surface the missing key + its required Doppler path; do NOT auto-rotate. |
-| **Dirty working tree** | `prepare-build-branch.sh.*Abort`, `Stash or commit your changes` | Stash the variant artifacts (`app.config.js`, `credentials.json`); recommend retry. |
-| **patch-package mismatch** | `verify-runtime-patches.js`, patch did not apply | Restore the patch invariant; reference `~/healify/CLAUDE.md` Runtime patches section. |
+| **type-check** | `error TS2`, `error TS7` | Patch the offending file(s); rerun the project's type-check |
+| **lint** | `error  Parsing error`, ESLint rule fails | Fix in code (no `eslint-disable` shortcut) |
+| **expo-doctor / version drift** | `expo-doctor`, `package versions mismatch` | `npx expo install --check --fix` |
+| **fastlane signing** | `Match`, `provisioning profile`, `code signing` | Re-sync via `bundle exec fastlane match` (CONFIRM with user before nuke) |
+| **fastlane archive** | `xcodebuild`, `gym`, `Build FAILED` | Locate Xcode error in logs, patch in iOS native or RN bridge code |
+| **App Store Connect transient** | `503`, `timed out`, `Apple ID server.*temporarily unavailable` | Recommend retry; do NOT open PR |
+| **Doppler / env missing** | `secret not found`, missing env var | Surface the missing key + its required path; do NOT auto-rotate |
+| **Dirty working tree** | `prepare-build-branch.*Abort`, `Stash or commit your changes` | Stash variant artifacts (e.g. generated config files); recommend retry |
+| **patch-package mismatch** | patch did not apply, runtime invariant verifier failed | Restore the patch invariant from the project's docs |
 
 # Workflow
 
@@ -52,26 +51,22 @@ Categorize the failure into ONE bucket — your fix flows from the bucket:
 2. **Locate the repo** at {{REPO_PATH}} (already known). Verify `git status` is clean enough to branch.
 3. **Worktree** off current branch: `git worktree add .worktrees/fix-build-<short-ts>`.
 4. **Apply minimal fix.**
-5. **Verify** by re-running the appropriate gate:
-   - type-check failure → `npm run type-check`
-   - lint → `npm run lint:check`
-   - expo drift → `npx expo install --check`
-   - patch → `node scripts/verify-runtime-patches.js`
-6. **Commit `--no-verify`** with co-author trailer for Haiku.
-7. **Push + open PR** to `dev` (or current base). Title: `fix(build): <bucket>: <one-line>`. Body links to the failed command + log excerpt.
+5. **Verify** by re-running the appropriate gate that matches the bucket (type-check / lint / expo install --check / patch verifier).
+6. **Commit `--no-verify`** (most projects' commit hooks are noisy on auto-fix branches; verify the project's CONTRIBUTING.md doesn't forbid this).
+7. **Push + open PR** to the project's default development branch. Title: `fix(build): <bucket>: <one-line>`. Body links to the failed command + log excerpt.
 
 # Hard guardrails — NON-NEGOTIABLE
 
-- **NEVER re-run `npm run build:all` / `build:*:local` yourself.** That's the operator's call.
+- **NEVER re-run the build command yourself.** That's the operator's call.
 - **NEVER bump major dep versions.** Patch only.
 - **NEVER add `eslint-disable` / `@ts-ignore` to mask errors.** Fix the cause.
-- **NEVER touch `app.config.js` directly** — edit `src/config/app.config.<variant>.js` (per `~/healify/CLAUDE.md`).
+- **NEVER touch generated config files** (e.g. `app.config.js` if it's auto-generated by a `config:*` script) — edit the source variant file instead.
 - **NEVER invalidate signing material** (`fastlane match nuke`) without explicit confirmation.
 - **NEVER ship dependency upgrades unrelated to the bucket.**
 - **MAX 8 files changed.** If more, STOP and report scope mismatch.
 - **NEVER spawn more than 2 subagents.**
-- **NEVER call `/ops:ops-yolo` or fan-out skills.**
-- **NEVER commit secrets** or echo Doppler values into PR bodies.
+- **NEVER call any orchestration or fan-out skill.**
+- **NEVER commit secrets** or echo Doppler/env values into PR bodies.
 
 # Scope
 

--- a/claude-ops/prompts/build-fix.md
+++ b/claude-ops/prompts/build-fix.md
@@ -1,0 +1,86 @@
+# Persona
+
+You are **Build Fixer** — a focused mobile/native build engineer persona spawned by the `claude-ops` plugin to repair a SINGLE failed local build (`npm run build:*`). You are NOT a feature engineer. One repair, one PR, exit.
+
+# Awareness
+
+You are headless inside Claude Code with full claude-ops tooling:
+
+| Need | Use |
+|---|---|
+| Mobile / Expo / RN / iOS Fastlane | spawn the `Mobile App Specialist` subagent |
+| TypeScript / type errors | spawn the `typescript-reviewer` subagent |
+| Healify cross-repo contract breakage | spawn the `fullstack-mobile-architect` subagent |
+| Sentry context for runtime crashes | `mcp__sentry__search_events` |
+| Apple Developer / TestFlight state | `python3 scripts/asc-manage-builds.py` (in healify repo) |
+| Doppler secret resolution | `doppler secrets get <KEY> --project healify --config <env> --plain` |
+| Library version drift | `npx expo install --check`, `npm ls <pkg>`, Context7 MCP for docs |
+
+Do NOT invent agent names. Fall back to `general-purpose` if unsure.
+
+# Failure context
+
+- **Failed command**: `{{COMMAND}}`
+- **Repo path**: {{REPO_PATH}}
+- **Current branch**: {{BRANCH}}
+
+**Last 120 lines of output:**
+
+```
+{{LOGS}}
+```
+
+# Diagnosis taxonomy
+
+Categorize the failure into ONE bucket — your fix flows from the bucket:
+
+| Bucket | Signals | Fix path |
+|---|---|---|
+| **type-check** | `error TS2`, `error TS7` | Patch the offending file(s); rerun `npm run type-check`. |
+| **lint** | `error  Parsing error`, ESLint rule fails | Fix in code (no `eslint-disable` shortcut). |
+| **expo-doctor / version drift** | `expo-doctor`, `package versions mismatch` | `npx expo install --check --fix`. |
+| **fastlane signing** | `Match`, `provisioning profile`, `code signing` | Re-sync via `bundle exec fastlane match nuke + match` (CONFIRM with user before nuke). |
+| **fastlane archive** | `xcodebuild`, `gym`, `Build FAILED` | Locate Xcode error in logs, patch in iOS native or RN bridge code. |
+| **App Store Connect transient** | `503`, `timed out`, `Apple ID server.*temporarily unavailable` | Recommend retry; do NOT open PR. |
+| **Doppler missing** | `DOPPLER_TOKEN`, `secret not found` | Surface the missing key + its required Doppler path; do NOT auto-rotate. |
+| **Dirty working tree** | `prepare-build-branch.sh.*Abort`, `Stash or commit your changes` | Stash the variant artifacts (`app.config.js`, `credentials.json`); recommend retry. |
+| **patch-package mismatch** | `verify-runtime-patches.js`, patch did not apply | Restore the patch invariant; reference `~/healify/CLAUDE.md` Runtime patches section. |
+
+# Workflow
+
+1. **Diagnose** → bucket above.
+2. **Locate the repo** at {{REPO_PATH}} (already known). Verify `git status` is clean enough to branch.
+3. **Worktree** off current branch: `git worktree add .worktrees/fix-build-<short-ts>`.
+4. **Apply minimal fix.**
+5. **Verify** by re-running the appropriate gate:
+   - type-check failure → `npm run type-check`
+   - lint → `npm run lint:check`
+   - expo drift → `npx expo install --check`
+   - patch → `node scripts/verify-runtime-patches.js`
+6. **Commit `--no-verify`** with co-author trailer for Haiku.
+7. **Push + open PR** to `dev` (or current base). Title: `fix(build): <bucket>: <one-line>`. Body links to the failed command + log excerpt.
+
+# Hard guardrails — NON-NEGOTIABLE
+
+- **NEVER re-run `npm run build:all` / `build:*:local` yourself.** That's the operator's call.
+- **NEVER bump major dep versions.** Patch only.
+- **NEVER add `eslint-disable` / `@ts-ignore` to mask errors.** Fix the cause.
+- **NEVER touch `app.config.js` directly** — edit `src/config/app.config.<variant>.js` (per `~/healify/CLAUDE.md`).
+- **NEVER invalidate signing material** (`fastlane match nuke`) without explicit confirmation.
+- **NEVER ship dependency upgrades unrelated to the bucket.**
+- **MAX 8 files changed.** If more, STOP and report scope mismatch.
+- **NEVER spawn more than 2 subagents.**
+- **NEVER call `/ops:ops-yolo` or fan-out skills.**
+- **NEVER commit secrets** or echo Doppler values into PR bodies.
+
+# Scope
+
+Repair THIS build failure. Not adjacent code, not unrelated test improvements, not docs unless contract changed.
+
+# Output (final line)
+
+- `RESOLVED: <PR_URL>` — fix opened, ready for retry
+- `RETRY: <reason>` — transient, no fix needed
+- `BLOCKED: <reason>` — human needed (e.g. credentials, signing decision)
+
+Final line MUST be one of these — anything else violates contract.

--- a/claude-ops/prompts/deploy-fix.md
+++ b/claude-ops/prompts/deploy-fix.md
@@ -4,20 +4,20 @@ You are **Deploy Fixer** — a focused infrastructure SRE persona spawned by the
 
 # Awareness
 
-You are running headless inside a Claude Code session with full claude-ops tooling. Use these proactively:
+You are running headless inside a Claude Code session with full claude-ops tooling. Use these proactively when domain matches:
 
 | Need | Use |
 |---|---|
 | Fetch failed CI logs | `gh run view {{RUN_ID}} --repo {{REPO}} --log-failed` |
-| Inspect ECS / AWS state | `/ops:ops-fires`, `/ops:ops-monitor`, raw `aws` CLI |
+| Inspect AWS / cloud state | `/ops:ops-fires`, `/ops:ops-monitor`, raw cloud CLI |
 | Sentry context for related errors | `/ops:ops-triage` or `mcp__sentry__search_events` |
 | Find prior fixes for similar failures | `gh search prs --repo {{REPO}} 'fix(deploy)' --state merged` |
-| Healify mobile crashes / iOS build issues | spawn the `Mobile App Specialist` subagent |
-| Healify backend / NestJS issues | spawn the `Health Data Expert` subagent |
+| Mobile / iOS / native failures | spawn the `fullstack-mobile-architect` subagent |
 | Database performance / migration | spawn the `database-reviewer` subagent |
-| AWS infra / IAM / Terraform | spawn the `DevOps Engineer` subagent |
+| Cloud infra / IaC / CI/CD pipeline | spawn the `DevOps Engineer` subagent (if installed) |
+| Multi-repo contract breakage | spawn the `multi-repo-coordinator` subagent |
 
-**Do NOT** invent skill names — if unsure, fall back to `general-purpose` subagent.
+**Do NOT** invent skill or agent names — if unsure, fall back to `general-purpose` subagent.
 
 # Failure context
 
@@ -36,23 +36,23 @@ You are running headless inside a Claude Code session with full claude-ops tooli
 
 1. **Diagnose root cause** from the logs. Categorize as one of:
    - **Code defect** — type error, missing import, runtime crash, bad migration → fix in code
-   - **Config drift** — Doppler secret missing/rotated, env var renamed → fix config
-   - **Infra issue** — IAM permission, security group, ECR rate limit → fix infra (Terraform if available)
+   - **Config drift** — secret missing/rotated, env var renamed → fix config
+   - **Infra issue** — IAM permission, security group, ECR rate limit → fix infra (IaC if available)
    - **Transient** — flaky test, runner outage, registry blip → recommend rerun, do NOT open PR
 
-2. **Locate the repo** on disk. Search `~/Projects`, `~/`, `~/work`, `~/gsd-workspaces`. If not found, `gh repo clone` into `~/Projects/`.
+2. **Locate the repo** on disk. Honour the `repo_search_roots` plugin config (default `~/Projects:~`). If not found, `gh repo clone` into `~/Projects/`.
 
 3. **Create a worktree** off `{{BASE}}`: `git worktree add .worktrees/fix-deploy-<short-sha> {{BASE}}`. NEVER work directly on the base branch.
 
 4. **Apply the minimal fix.** Surgical changes only.
 
-5. **Run the per-repo quality gate** before committing (per `~/.claude/CLAUDE.md`):
-   - `healify-api`: `npm run type-check && npm run lint && npm run test:unit`
-   - `healify`: `npm run type-check`
-   - `healify-langgraphs` / `healify-agentcore` / `meditation-service`: `source .venv/bin/activate && pytest tests/ -x --ignore=tests/e2e`
-   - other Node repos: `npm run type-check && npm run lint && npm test`
+5. **Run the project's quality gate** before committing. Check the project's CONTRIBUTING.md or root `package.json` / `pyproject.toml` for the canonical commands. Common patterns:
+   - Node/TS: `npm run type-check && npm run lint && npm test`
+   - Python: `source .venv/bin/activate && pytest -x`
+   - Go: `go test ./...`
+   - Rust: `cargo test`
 
-6. **Commit with `--no-verify`** (project hooks are bugged per Sam's CLAUDE.md). Co-author trailer: `Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>`.
+6. **Commit with `--no-verify`** if the project's hooks are known to be noisy on auto-fix branches (verify CONTRIBUTING.md doesn't forbid this). Co-author trailer: `Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>`.
 
 7. **Push + open PR** targeting `{{BASE}}`:
    - Title: `fix(deploy): <one-line root cause>`
@@ -60,14 +60,14 @@ You are running headless inside a Claude Code session with full claude-ops tooli
 
 # Hard guardrails — NON-NEGOTIABLE
 
-- **NEVER merge the PR yourself.** Leave that to the next `/ops:ops-merge` cycle.
-- **NEVER force-push** to `dev` or `main`.
+- **NEVER merge the PR yourself.** Leave that to the operator.
+- **NEVER force-push** to the base branch.
 - **NEVER touch files outside the diagnosed root cause.** No "while I'm here" cleanups.
-- **NEVER skip CI hooks except via `--no-verify`** (already documented as bugged).
-- **NEVER commit secrets.** If you discover one in the logs, redact in the PR body and notify via `/ops:ops-comms`.
+- **NEVER skip CI hooks except via `--no-verify`** when the project allows it.
+- **NEVER commit secrets.** If you discover one in the logs, redact in the PR body and notify via the configured notification channel.
 - **MAX 10 files changed.** If the fix needs more, STOP and report — likely scope mismatch.
 - **NEVER spawn more than 2 subagents.** This session is already a subagent.
-- **NEVER call `/ops:ops-yolo`, `/ops:ops-orchestrate`, or anything that fans out parallel work.** You have one job.
+- **NEVER call orchestration skills** that fan out parallel work. You have one job.
 - **NEVER send outbound comms** (email, Slack, WhatsApp) — read-only on those surfaces.
 - **NEVER ship unrelated dependency upgrades.** If a transitive bump is needed, pin to the exact required version only.
 
@@ -83,7 +83,7 @@ You are responsible for fixing **this one deploy failure**. You are NOT responsi
 
 Last line of your output MUST be one of:
 - `RESOLVED: <PR_URL>` — fix opened, ready for the merge cycle
-- `RERUN: <reason>` — transient, asked the user to retry
+- `RERUN: <reason>` — transient, asked the operator to retry
 - `BLOCKED: <reason>` — could not auto-fix; human needed
 
 Anything else is a violation of this contract.

--- a/claude-ops/prompts/deploy-fix.md
+++ b/claude-ops/prompts/deploy-fix.md
@@ -1,0 +1,89 @@
+# Persona
+
+You are **Deploy Fixer** — a focused infrastructure SRE persona spawned by the `claude-ops` plugin to diagnose and remediate a SINGLE failed post-merge deployment. You are NOT a general-purpose engineer. You execute one repair, open one PR, and exit.
+
+# Awareness
+
+You are running headless inside a Claude Code session with full claude-ops tooling. Use these proactively:
+
+| Need | Use |
+|---|---|
+| Fetch failed CI logs | `gh run view {{RUN_ID}} --repo {{REPO}} --log-failed` |
+| Inspect ECS / AWS state | `/ops:ops-fires`, `/ops:ops-monitor`, raw `aws` CLI |
+| Sentry context for related errors | `/ops:ops-triage` or `mcp__sentry__search_events` |
+| Find prior fixes for similar failures | `gh search prs --repo {{REPO}} 'fix(deploy)' --state merged` |
+| Healify mobile crashes / iOS build issues | spawn the `Mobile App Specialist` subagent |
+| Healify backend / NestJS issues | spawn the `Health Data Expert` subagent |
+| Database performance / migration | spawn the `database-reviewer` subagent |
+| AWS infra / IAM / Terraform | spawn the `DevOps Engineer` subagent |
+
+**Do NOT** invent skill names — if unsure, fall back to `general-purpose` subagent.
+
+# Failure context
+
+- **Repo**: `{{REPO}}`
+- **PR**: #{{PR}} (already merged to `{{BASE}}` at commit `{{SHA}}`)
+- **Workflow run**: https://github.com/{{REPO}}/actions/runs/{{RUN_ID}}
+- **Failure summary**: {{SUMMARY}}
+
+**Failing logs (last 120 lines):**
+
+```
+{{LOGS}}
+```
+
+# Workflow
+
+1. **Diagnose root cause** from the logs. Categorize as one of:
+   - **Code defect** — type error, missing import, runtime crash, bad migration → fix in code
+   - **Config drift** — Doppler secret missing/rotated, env var renamed → fix config
+   - **Infra issue** — IAM permission, security group, ECR rate limit → fix infra (Terraform if available)
+   - **Transient** — flaky test, runner outage, registry blip → recommend rerun, do NOT open PR
+
+2. **Locate the repo** on disk. Search `~/Projects`, `~/`, `~/work`, `~/gsd-workspaces`. If not found, `gh repo clone` into `~/Projects/`.
+
+3. **Create a worktree** off `{{BASE}}`: `git worktree add .worktrees/fix-deploy-<short-sha> {{BASE}}`. NEVER work directly on the base branch.
+
+4. **Apply the minimal fix.** Surgical changes only.
+
+5. **Run the per-repo quality gate** before committing (per `~/.claude/CLAUDE.md`):
+   - `healify-api`: `npm run type-check && npm run lint && npm run test:unit`
+   - `healify`: `npm run type-check`
+   - `healify-langgraphs` / `healify-agentcore` / `meditation-service`: `source .venv/bin/activate && pytest tests/ -x --ignore=tests/e2e`
+   - other Node repos: `npm run type-check && npm run lint && npm test`
+
+6. **Commit with `--no-verify`** (project hooks are bugged per Sam's CLAUDE.md). Co-author trailer: `Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>`.
+
+7. **Push + open PR** targeting `{{BASE}}`:
+   - Title: `fix(deploy): <one-line root cause>`
+   - Body: link to the failed run, the diagnosed root cause, the change rationale, the gate results.
+
+# Hard guardrails — NON-NEGOTIABLE
+
+- **NEVER merge the PR yourself.** Leave that to the next `/ops:ops-merge` cycle.
+- **NEVER force-push** to `dev` or `main`.
+- **NEVER touch files outside the diagnosed root cause.** No "while I'm here" cleanups.
+- **NEVER skip CI hooks except via `--no-verify`** (already documented as bugged).
+- **NEVER commit secrets.** If you discover one in the logs, redact in the PR body and notify via `/ops:ops-comms`.
+- **MAX 10 files changed.** If the fix needs more, STOP and report — likely scope mismatch.
+- **NEVER spawn more than 2 subagents.** This session is already a subagent.
+- **NEVER call `/ops:ops-yolo`, `/ops:ops-orchestrate`, or anything that fans out parallel work.** You have one job.
+- **NEVER send outbound comms** (email, Slack, WhatsApp) — read-only on those surfaces.
+- **NEVER ship unrelated dependency upgrades.** If a transitive bump is needed, pin to the exact required version only.
+
+# Scope
+
+You are responsible for fixing **this one deploy failure**. You are NOT responsible for:
+- Refactoring adjacent code
+- Improving test coverage beyond the regression
+- Updating docs unless the fix changes a public contract
+- Other failing deploys on other repos
+
+# Output (final line of your run)
+
+Last line of your output MUST be one of:
+- `RESOLVED: <PR_URL>` — fix opened, ready for the merge cycle
+- `RERUN: <reason>` — transient, asked the user to retry
+- `BLOCKED: <reason>` — could not auto-fix; human needed
+
+Anything else is a violation of this contract.

--- a/claude-ops/scripts/account-rotation/README.md
+++ b/claude-ops/scripts/account-rotation/README.md
@@ -1,0 +1,99 @@
+# Multi-Account Claude Max Rotator
+
+Optional component of the `claude-ops` plugin. Rotates between multiple Claude
+Max subscriptions as 5-hour and weekly quotas approach the cap, so an active
+session can keep working without a manual `/login`.
+
+## What it does
+
+- Watches the active Claude Code session's reported usage (5h window + 7d window).
+- When the active account approaches its cap, picks the most cooled-down account from your configured list and swaps the keychain token.
+- Falls back to a Playwright-driven browser OAuth flow when refresh tokens have expired.
+- Has an optional Claude Haiku "AI brain" that drives the browser past unexpected pages (new Google challenges, workspace re-consent, etc).
+
+## Status: opt-in, advanced
+
+This is **off by default**. It requires:
+
+1. Multiple Claude Max accounts you legitimately own.
+2. macOS (uses the system keychain + `launchd` for the background daemon).
+3. Node 20+ (already required by the plugin).
+4. Optional: Playwright (installed on first browser-fallback use), Dashlane CLI (`dcli`) for credential reads.
+
+## Enable
+
+In Claude Code settings → plugin `ops` → toggle:
+
+- `account_rotation_enabled` → `true`
+
+Then run:
+
+```
+/ops:rotate
+```
+
+The skill walks you through:
+
+1. Adding your first account (`add-account`).
+2. Capturing the current keychain token into the rotator vault (`capture`).
+3. Installing the launchd daemon from `templates/com.claude-ops.account-rotation.plist`.
+4. Verifying everything with `status`.
+
+## Config
+
+`config.json` lives in the plugin data dir (`~/.claude/plugins/data/ops/account-rotation/config.json`) and is **never committed**. The shape is documented in `config.example.json`.
+
+Each account entry:
+
+| Field                  | Required | Notes                                                                        |
+| ---------------------- | -------- | ---------------------------------------------------------------------------- |
+| `email`                | yes      | Login email for the Claude Max account.                                      |
+| `label`                | no       | Disambiguator if you have two configs for the same email (multi-org).        |
+| `orgName` / `orgUuid`  | no       | Workspace metadata for accounts in a Claude org.                             |
+| `dashlaneTokenPath`    | no       | If you store the token in Dashlane: `dl://<vault-name>/password`.            |
+| `extraUsageEnabled`    | no       | Set to `true` ONLY if the account has paid overage on. Triggers safety margin. |
+| `capacityMultiplier`   | no       | Override per-account threshold (default 1.0 = standard Max 20x quota).       |
+
+## Keychain layout
+
+- `Claude Code-credentials` (account = your OS user) — the live token Claude Code reads.
+- `Claude-Rotation-<account_id>` (account = your OS user) — vault per configured account.
+
+The `<account_id>` is the email or label, picked when you `add-account`.
+
+Override the keychain account name via `CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT` if you need to (defaults to `$USER`).
+
+## Files
+
+| File                  | Purpose                                                                |
+| --------------------- | ---------------------------------------------------------------------- |
+| `rotate.mjs`          | Main rotation logic. CLI: `--status`, `--utilization`, `--to`, `--setup`. |
+| `daemon.mjs`          | launchd-managed monitor. Polls every 15s, rotates at 80% utilization.  |
+| `ai-brain.mjs`        | Claude Haiku fallback for unexpected OAuth pages.                      |
+| `force-rotate.sh`     | Out-of-band rotation when Claude Code is unreachable.                  |
+| `config.example.json` | Schema reference. Copy to `config.json` and populate.                  |
+
+## Triggers
+
+The daemon rotates when ANY one fires:
+
+1. 5h utilization >= 80%.
+2. 7d utilization >= 80%.
+3. The plugin's `rate-limit-detector.cjs` hook writes a 429 signal file.
+4. A 401 auth-error hook fires.
+5. You run `/ops:rotate rotate-now` or `force-rotate.sh`.
+
+## Disable
+
+```
+launchctl unload ~/Library/LaunchAgents/com.claude-ops.account-rotation.plist
+```
+
+And toggle `account_rotation_enabled` off in plugin settings.
+
+## Safety notes
+
+- Passwords NEVER leave your machine. The AI brain only sees a screenshot + DOM summary; password fields are masked.
+- The daemon never touches accounts marked `disabled: true` in `config.json`.
+- Accounts with `extraUsageEnabled: true` rotate at 75% (not 80%) to avoid paid overage.
+- A 3-minute post-rotation blackout suppresses thrashing.

--- a/claude-ops/scripts/account-rotation/ai-brain.mjs
+++ b/claude-ops/scripts/account-rotation/ai-brain.mjs
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+/**
+ * AI-brain fallback for the OAuth browser driver.
+ *
+ * Runs when the hard-coded playwright flow stalls on an unexpected page
+ * (new Google challenge type, Cloudflare interstitial, unseen cookie modal,
+ * terms-acceptance wall, workspace admin re-consent, etc.). Sends a PNG
+ * screenshot + DOM summary to Claude and executes the returned action.
+ *
+ * Safety caps:
+ *   - MAX_DECISIONS per rotation      (cost + runaway guard)
+ *   - screenshot ≤ 1.5MB, DOM text ≤ 6KB in the prompt
+ *   - passwords NEVER leave the machine; fill_password uses local dcli
+ *   - abort terminates the flow; never retry on abort
+ */
+import { execFileSync } from 'child_process';
+
+const API_URL = 'https://api.anthropic.com/v1/messages';
+const DEFAULT_MODEL = 'claude-haiku-4-5';
+const MAX_DECISIONS = 6;
+const REQUEST_TIMEOUT_MS = 30_000;
+
+// ── Resolve API key from env → Doppler → keychain ────────────────────────────
+function readCommand(argv, timeout = 4000) {
+  try {
+    return execFileSync(argv[0], argv.slice(1), {
+      timeout,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+  } catch {
+    return '';
+  }
+}
+
+function resolveApiKey() {
+  if (process.env.ANTHROPIC_API_KEY?.startsWith('sk-ant-')) {
+    return process.env.ANTHROPIC_API_KEY;
+  }
+  // Optional Doppler lookup — set CLAUDE_ROTATOR_DOPPLER_PROJECTS as a
+  // comma-separated list of "<project>:<config>" pairs (e.g. "myapp:prd,other:dev").
+  const dopplerSpec = process.env.CLAUDE_ROTATOR_DOPPLER_PROJECTS || '';
+  const dopplerTargets = dopplerSpec
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => s.split(':'))
+    .filter((p) => p.length === 2);
+  for (const [project, config] of dopplerTargets) {
+    const out = readCommand([
+      'doppler',
+      'secrets',
+      'get',
+      'ANTHROPIC_API_KEY',
+      '--project',
+      project,
+      '--config',
+      config,
+      '--plain',
+    ]);
+    if (out.startsWith('sk-ant-')) return out;
+  }
+  // macOS keychain — account name = current OS user (matches rotate.mjs convention)
+  const kcAccount = process.env.USER || process.env.LOGNAME || 'claude-ops';
+  const kc = readCommand(['security', 'find-generic-password', '-s', 'anthropic-api-key', '-a', kcAccount, '-w'], 2000);
+  if (kc.startsWith('sk-ant-')) return kc;
+  return null;
+}
+
+// ── Snapshot: screenshot + structured DOM summary ────────────────────────────
+async function snapshotPage(page) {
+  let screenshotB64 = null;
+  try {
+    const buf = await page.screenshot({
+      type: 'png',
+      fullPage: false,
+      timeout: 5000,
+    });
+    if (buf && buf.length < 1_500_000) {
+      screenshotB64 = Buffer.from(buf).toString('base64');
+    }
+  } catch {}
+  let domSummary = '';
+  try {
+    domSummary = await page.evaluate(() => {
+      const visible = (el) => {
+        const r = el.getBoundingClientRect();
+        const s = getComputedStyle(el);
+        return (
+          r.width > 0 &&
+          r.height > 0 &&
+          s.visibility !== 'hidden' &&
+          s.display !== 'none' &&
+          parseFloat(s.opacity || '1') > 0.1
+        );
+      };
+      const sel =
+        'button, a, input, textarea, select, [role=button], [role=link], [role=checkbox], [role=radio], [role=tab], li[data-challengetype]';
+      const nodes = [...document.querySelectorAll(sel)];
+      const items = [];
+      for (const n of nodes) {
+        if (items.length >= 60) break;
+        if (!visible(n)) continue;
+        const tag = n.tagName.toLowerCase();
+        const type = n.getAttribute('type') || '';
+        const id = n.id || '';
+        const testid = n.getAttribute('data-testid') || '';
+        const name = n.getAttribute('name') || '';
+        const challenge = n.getAttribute('data-challengetype') || '';
+        const cls = (n.getAttribute('class') || '').split(/\s+/).slice(0, 2).join('.');
+        const ariaLabel = n.getAttribute('aria-label') || '';
+        const rawText =
+          type === 'password'
+            ? '(password — masked)'
+            : (n.innerText || n.value || n.placeholder || ariaLabel || '').trim();
+        const txt = rawText.slice(0, 120);
+        items.push(
+          `  ${tag}${type ? '[' + type + ']' : ''}${id ? ' #' + id : ''}${
+            testid ? ' data-testid=' + testid : ''
+          }${name ? ' name=' + name : ''}${
+            challenge ? ' data-challengetype=' + challenge : ''
+          }${cls ? ' .' + cls : ''} :: ${txt}`,
+        );
+      }
+      const title = (document.title || '').slice(0, 200);
+      const headings = [...document.querySelectorAll('h1, h2, h3')]
+        .slice(0, 6)
+        .map((e) => (e.innerText || '').trim())
+        .filter(Boolean)
+        .join(' | ');
+      const bodyText = (document.body?.innerText || '').slice(0, 2000);
+      return `TITLE: ${title}\nHEADINGS: ${headings}\n---INTERACTIVE ELEMENTS---\n${items.join(
+        '\n',
+      )}\n---VISIBLE TEXT (trimmed)---\n${bodyText}`;
+    });
+  } catch (e) {
+    domSummary = `[dom extraction failed: ${String(e.message || e).slice(0, 80)}]`;
+  }
+  let url = '';
+  try {
+    url = page.url();
+  } catch {}
+  if (domSummary.length > 6000) domSummary = domSummary.slice(0, 6000) + '\n[truncated]';
+  return { screenshotB64, domSummary, url };
+}
+
+// ── Prompt builder ────────────────────────────────────────────────────────────
+function buildPrompt(snapshot, account, attempt, history, stallReason) {
+  const orgHint = account.orgName
+    ? `Target Claude org/workspace: ${account.orgName}`
+    : 'Target Claude org/workspace: Personal (default)';
+  return [
+    'You are an automation agent driving a Chrome browser through Google OAuth and claude.ai login.',
+    `Goal: complete login as ${account.email} and reach the Claude CLI localhost callback so a refresh token is issued.`,
+    orgHint,
+    '',
+    `Stall reason: ${stallReason}`,
+    `Current URL: ${snapshot.url || '(unknown)'}`,
+    '',
+    'Page snapshot (DOM summary):',
+    snapshot.domSummary,
+    '',
+    history.length
+      ? `Previous AI-brain decisions this rotation:\n${history.map((h, i) => `  ${i + 1}. ${h}`).join('\n')}`
+      : 'No prior AI-brain decisions yet.',
+    '',
+    `Attempt ${attempt}/${MAX_DECISIONS}.`,
+    '',
+    'Return ONLY one JSON object. No prose, no markdown fences.',
+    'Schema: { "action": "click|fill|fill_password|goto|wait|abort", "selector"?: string, "value"?: string, "url"?: string, "reason": string }',
+    '',
+    'Rules:',
+    '- action=click: `selector` is either a precise CSS selector or the EXACT visible text of the element.',
+    '- action=fill: `selector` is a CSS selector; `value` is the literal text to type. NEVER pass a password here.',
+    '- action=fill_password: the automation will inject the stored Google password into `selector` (defaults to input[type=password]).',
+    '- action=goto: `url` is an absolute URL to navigate to (only for Claude or Google auth hosts).',
+    '- action=wait: no fields; use when the page is still loading and a re-check is the right move.',
+    '- action=abort: ONLY for dead-ends — account locked, human-only CAPTCHA, wrong account with no switch UI, subscription canceled.',
+    "- Prefer the natural next step: 'Continue', 'Next', 'Authorize', 'Allow', 'Try another way', picking the target email in an account chooser, the correct workspace in the Claude org chooser.",
+    "- NEVER click 'Don't allow', 'Cancel', 'Forget this device', 'Remove account', 'Delete', or any destructive option.",
+    '- Language-tolerant: Dutch / German / French / Spanish variants are all valid.',
+    "- reCAPTCHA/hCaptcha checkbox: try clicking once; invisible challenge → abort with reason='captcha'.",
+    '- If the page is just a spinner with no interactive elements yet, action=wait.',
+  ].join('\n');
+}
+
+function parseActionJson(text) {
+  if (!text) return null;
+  let cleaned = text.trim();
+  cleaned = cleaned
+    .replace(/^```(?:json|JSON)?\s*/i, '')
+    .replace(/```\s*$/i, '')
+    .trim();
+  const m = cleaned.match(/\{[\s\S]*\}/);
+  if (!m) return null;
+  try {
+    return JSON.parse(m[0]);
+  } catch {
+    return null;
+  }
+}
+
+// ── Public: ask Claude what to do ─────────────────────────────────────────────
+export async function askAIBrain({ page, account, history, stallReason, logger }) {
+  const log = logger || ((m) => console.error(`[ai-brain] ${m}`));
+  const apiKey = resolveApiKey();
+  if (!apiKey) {
+    log('no ANTHROPIC_API_KEY available (env, Doppler, keychain all empty)');
+    return { action: 'abort', reason: 'no_api_key' };
+  }
+  const attempt = history.length + 1;
+  if (attempt > MAX_DECISIONS) {
+    return { action: 'abort', reason: `decision_cap_${MAX_DECISIONS}` };
+  }
+  const snap = await snapshotPage(page);
+  const prompt = buildPrompt(snap, account, attempt, history, stallReason);
+
+  const content = [];
+  if (snap.screenshotB64) {
+    content.push({
+      type: 'image',
+      source: {
+        type: 'base64',
+        media_type: 'image/png',
+        data: snap.screenshotB64,
+      },
+    });
+  }
+  content.push({ type: 'text', text: prompt });
+
+  const model = process.env.CLAUDE_ROTATOR_BRAIN_MODEL || DEFAULT_MODEL;
+  log(`asking ${model} (attempt ${attempt}/${MAX_DECISIONS}) — stall: ${stallReason}`);
+
+  try {
+    const res = await fetch(API_URL, {
+      method: 'POST',
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model,
+        max_tokens: 400,
+        messages: [{ role: 'user', content }],
+      }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const reason = data?.error?.message || data?.error?.type || `http_${res.status}`;
+      log(`api error: ${String(reason).slice(0, 160)}`);
+      return {
+        action: 'abort',
+        reason: `api_error: ${String(reason).slice(0, 80)}`,
+      };
+    }
+    const text = (data?.content || [])
+      .map((p) => p?.text || '')
+      .join('')
+      .trim();
+    const action = parseActionJson(text);
+    if (!action || !action.action) {
+      log(`unparseable response: ${text.slice(0, 120)}`);
+      return { action: 'abort', reason: 'unparseable_response' };
+    }
+    log(
+      `decided: ${action.action}${action.selector ? ` selector=${String(action.selector).slice(0, 60)}` : ''}${action.url ? ` url=${String(action.url).slice(0, 60)}` : ''} — ${String(action.reason || '').slice(0, 80)}`,
+    );
+    return action;
+  } catch (e) {
+    log(`call failed: ${String(e.message || e).slice(0, 120)}`);
+    return {
+      action: 'abort',
+      reason: `call_failed: ${String(e.message || e).slice(0, 80)}`,
+    };
+  }
+}
+
+// ── Execute the returned action against the existing driver ──────────────────
+export async function executeAIAction(driver, action, { googlePassword } = {}) {
+  if (!action || !action.action) return false;
+  try {
+    switch (action.action) {
+      case 'click': {
+        if (!action.selector) return false;
+        return await driver.findAndClick([action.selector]);
+      }
+      case 'fill': {
+        if (!action.selector) return false;
+        return await driver.fillInput(action.selector, action.value || '');
+      }
+      case 'fill_password': {
+        if (!googlePassword) return false;
+        const sel = action.selector || 'input[type="password"]';
+        return await driver.fillInput(sel, googlePassword);
+      }
+      case 'goto': {
+        if (!action.url) return false;
+        // Code-level URL allowlist — prompt constraints alone are insufficient
+        const allowedHosts = ['claude.ai', 'accounts.google.com', 'myaccount.google.com', 'login.microsoftonline.com'];
+        try {
+          const host = new URL(action.url).hostname;
+          if (!allowedHosts.some((d) => host === d || host.endsWith('.' + d))) {
+            return false;
+          }
+        } catch {
+          return false;
+        }
+        await driver.goto(action.url);
+        return true;
+      }
+      case 'wait': {
+        await new Promise((r) => setTimeout(r, 4000));
+        return true;
+      }
+      case 'abort':
+      default:
+        return false;
+    }
+  } catch {
+    return false;
+  }
+}
+
+export const AI_BRAIN_MAX_DECISIONS = MAX_DECISIONS;

--- a/claude-ops/scripts/account-rotation/config.example.json
+++ b/claude-ops/scripts/account-rotation/config.example.json
@@ -1,0 +1,28 @@
+{
+  "_comment": "Copy to config.json and add your Claude Max accounts. The rotator does NOT ship with any accounts — you opt in by populating this file via /ops:rotate add-account or by editing it directly. See README.md for details.",
+  "accounts": [],
+  "_account_schema_example": {
+    "email": "user@example.com",
+    "label": "optional-disambiguator",
+    "orgName": "Optional Workspace Name",
+    "orgUuid": "optional-workspace-uuid",
+    "dashlaneTokenPath": "dl://claude-max-user@example.com/password",
+    "dashlaneGooglePath": null,
+    "googleSmsPhone": "+1234567890",
+    "extraUsageEnabled": false,
+    "capacityMultiplier": 1.0
+  },
+  "rateLimits": {
+    "tokensPerWindow": 220000,
+    "windowHours": 5,
+    "messagesPerWindow": 900,
+    "weeklyCapMultiplier": 1.0,
+    "extraUsageSafetyMargin": 0.75,
+    "note": "Max 20x defaults: ~220K tokens / ~900 messages per 5h window. extraUsageSafetyMargin: accounts with paid overage enabled rotate at 75% of their threshold to avoid incurring charges."
+  },
+  "toolUseThreshold": 800,
+  "maxHoursPerAccount": 4,
+  "autoRotate": true,
+  "refreshSession": false,
+  "notifyOnRotation": true
+}

--- a/claude-ops/scripts/account-rotation/config.json
+++ b/claude-ops/scripts/account-rotation/config.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "comment": "Default empty config. User overrides land at ~/.claude/plugins/data/ops-ops-marketplace/account-rotation-config.json (gitignored). Never commit real emails — Rule 0.",
+  "accounts": []
+}

--- a/claude-ops/scripts/account-rotation/daemon.mjs
+++ b/claude-ops/scripts/account-rotation/daemon.mjs
@@ -1,0 +1,731 @@
+#!/usr/bin/env node
+/**
+ * Claude Account Rotation Daemon
+ *
+ * Runs in background, monitors:
+ *   1. Tool use count (from usage-tracker.js hook)
+ *   2. Time per account (maxHoursPerAccount)
+ *   3. Rate limit errors (watches Claude Code stderr / log patterns)
+ *   4. Token expiry
+ *
+ * Auto-rotates to the most cooled-down account when any threshold is hit.
+ *
+ * Usage:
+ *   node daemon.mjs           # Run in foreground
+ *   node daemon.mjs --bg      # Daemonize
+ *   node daemon.mjs --stop    # Stop running daemon
+ *   node daemon.mjs --status  # Show daemon status
+ */
+
+import { readFileSync, writeFileSync, existsSync, unlinkSync, appendFileSync, statSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { execSync, execFileSync, spawn, spawnSync } from 'child_process';
+import { tmpdir } from 'os';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CONFIG_PATH = join(__dirname, 'config.json');
+const STATE_PATH = join(__dirname, 'state.json');
+const LOG_PATH = join(__dirname, 'rotation.log');
+const PID_FILE = join(__dirname, '.daemon.pid');
+const ROTATE_SCRIPT = join(__dirname, 'rotate.mjs');
+
+// Keychain account name — must match rotate.mjs convention.
+const KEYCHAIN_ACCOUNT =
+  process.env.CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT || process.env.USER || process.env.LOGNAME || 'claude-ops';
+
+const POLL_INTERVAL = 15_000; // Check every 15s — fast enough to catch hook-triggered 429 signals (fireAt = now+15s)
+const RATE_LIMIT_COOLDOWN = 10_000; // 10s after rate limit before rotating
+const POST_ROTATION_BLACKOUT = 180_000; // 3min after rotation: ignore ALL triggers
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const MAX_LOG_SIZE = 50_000; // 50KB — ~500 lines, enough for debugging
+function log(msg) {
+  const line = `[${new Date().toISOString()}] [daemon] ${msg}`;
+  console.error(line);
+  try {
+    appendFileSync(LOG_PATH, line + '\n');
+    // Truncate: keep last half when exceeding max
+    try {
+      const { size } = statSync(LOG_PATH);
+      if (size > MAX_LOG_SIZE) {
+        const content = readFileSync(LOG_PATH, 'utf8');
+        const lines = content.split('\n');
+        writeFileSync(LOG_PATH, lines.slice(Math.floor(lines.length / 2)).join('\n'));
+      }
+    } catch {}
+  } catch {}
+}
+
+function notify(title, msg) {
+  try {
+    // Use execFileSync to avoid shell interpretation of quotes in title/msg
+    execFileSync(
+      'osascript',
+      [
+        '-e',
+        `display notification "${msg.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}" with title "${title.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`,
+      ],
+      { timeout: 5000 },
+    );
+  } catch {}
+}
+
+function readConfig() {
+  return JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
+}
+function readState() {
+  try {
+    return JSON.parse(readFileSync(STATE_PATH, 'utf8'));
+  } catch {
+    return {
+      activeAccount: null,
+      accounts: {},
+      toolUses: 0,
+      totalRotations: 0,
+    };
+  }
+}
+
+// ── Account cooldown tracking ───────────────────────────────────────────────
+// Each account's state.accounts[key].lastUtilization has { pct, reset, ts }.
+// `reset` is epoch seconds for when the 5h window resets. If reset > now, the
+// account is still cooling down. rotate.mjs queries all accounts via the
+// Anthropic API and populates this data at rotation time.
+
+function accountCooldownStatus(state) {
+  const now = Date.now();
+  const summary = [];
+  for (const [key, acct] of Object.entries(state.accounts || {})) {
+    const util = acct.lastUtilization;
+    if (!util) {
+      summary.push(`  ${key}: unknown`);
+      continue;
+    }
+    const resetMs = util.reset ? util.reset * 1000 : 0;
+    const fresh = resetMs && resetMs < now;
+    const pct = util.pct ?? '?';
+    if (fresh) {
+      summary.push(`  ${key}: READY (reset ${Math.round((now - resetMs) / 60_000)}min ago, was ${pct}%)`);
+    } else if (resetMs) {
+      summary.push(`  ${key}: COOLING (${pct}%, resets in ${Math.round((resetMs - now) / 60_000)}min)`);
+    } else {
+      summary.push(`  ${key}: ${pct}% (no reset info)`);
+    }
+  }
+  return summary.join('\n');
+}
+
+function accountKey(a) {
+  return a.label || a.email;
+}
+
+function tokenExpired(json) {
+  try {
+    const exp = JSON.parse(json)?.claudeAiOauth?.expiresAt;
+    if (!exp) return false;
+    // Expired or expiring within 5 minutes
+    return Date.now() > exp - 5 * 60_000;
+  } catch {
+    return false;
+  }
+}
+
+function readStoredToken(account) {
+  const svc = `Claude-Rotation-${accountKey(account)}`;
+  try {
+    const result = spawnSync('security', ['find-generic-password', '-s', svc, '-a', KEYCHAIN_ACCOUNT, '-g'], {
+      timeout: 5000,
+      encoding: 'utf8',
+    });
+    const out = (result.stdout || '') + (result.stderr || '');
+    const m = out.match(/^password: "?(.*?)"?$/m);
+    return m ? m[1].replace(/\\"/g, '"') : null;
+  } catch {
+    return null;
+  }
+}
+
+function readActiveKeychainToken() {
+  try {
+    const r = spawnSync(
+      'security',
+      ['find-generic-password', '-s', 'Claude Code-credentials', '-a', KEYCHAIN_ACCOUNT, '-g'],
+      { encoding: 'utf8', timeout: 5000 },
+    );
+    const out = `${r.stdout || ''}${r.stderr || ''}`;
+    const m = out.match(/^password: "?(.*?)"?$/m);
+    return m ? m[1].replace(/\\"/g, '"') : null;
+  } catch {
+    return null;
+  }
+}
+
+function tokenAccessKey(json) {
+  try {
+    return JSON.parse(json)?.claudeAiOauth?.accessToken || null;
+  } catch {
+    return null;
+  }
+}
+
+// First try: cheap vault-token comparison (zero network). Works briefly after
+// a rotation. Falls back to /api/oauth/profile (1 cheap API call) when Claude
+// Code has refreshed its own token and the live no longer matches any vault.
+async function detectLiveAccountFromVault(config) {
+  const liveTok = tokenAccessKey(readActiveKeychainToken());
+  if (!liveTok) return null;
+  for (const a of config.accounts) {
+    const vaultTok = tokenAccessKey(readStoredToken(a));
+    if (vaultTok && vaultTok === liveTok) return accountKey(a);
+  }
+  // Vault miss — query profile to get the actual email
+  try {
+    const res = await fetch('https://api.anthropic.com/api/oauth/profile', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${liveTok}`,
+        'anthropic-beta': 'oauth-2025-04-20',
+      },
+      signal: AbortSignal.timeout(5000),
+    });
+    if (!res.ok) return null;
+    const body = await res.json();
+    const liveEmail = body?.account?.email?.toLowerCase();
+    if (!liveEmail) return null;
+    // Map email → account key (handle multi-org accounts via label)
+    const matches = config.accounts.filter((a) => a.email.toLowerCase() === liveEmail);
+    if (matches.length === 1) return accountKey(matches[0]);
+    if (matches.length > 1) {
+      // Multiple labels for same email (e.g. user-personal vs -team).
+      // Use orgName from profile to disambiguate.
+      const orgName = body?.organization?.name?.toLowerCase() || '';
+      const byOrg = matches.find((a) => (a.orgName || '').toLowerCase() === orgName);
+      if (byOrg) return accountKey(byOrg);
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Real utilization from Anthropic (via statusline export) ──────────────────
+
+const RATE_LIMITS_FILE = join(__dirname, '.rate-limits.json');
+const UTILIZATION_ROTATE_THRESHOLD = 80; // Rotate at 80% — with 8+ concurrent sessions burning tokens fast, 95% was too late (hit 100% between statusline updates)
+
+function readRealUtilization() {
+  try {
+    if (!existsSync(RATE_LIMITS_FILE)) return null;
+    const data = JSON.parse(readFileSync(RATE_LIMITS_FILE, 'utf8'));
+    const age = Date.now() - data.ts * 1000;
+    if (age > 5 * 60_000) return null; // Stale (>5min) — session may be dead
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+// ── Rate limit detection ─────────────────────────────────────────────────────
+
+function checkRateLimited() {
+  // Method 1: Real Anthropic utilization from statusline (primary signal)
+  const real = readRealUtilization();
+  if (real) {
+    const pct5h = real.five_hour?.pct || 0;
+    const pct7d = real.seven_day?.pct || 0;
+    if (pct5h >= UTILIZATION_ROTATE_THRESHOLD) {
+      return {
+        limited: true,
+        reason: `5h utilization ${pct5h.toFixed(1)}% >= ${UTILIZATION_ROTATE_THRESHOLD}%`,
+        utilization: real,
+      };
+    }
+    // 7d weekly cap — also rotate at 80% (was 95%, but Claude itself surfaces
+    // the warning at ~75%, so 95% is too late and the active session sees
+    // "you've used X% of your weekly limit" before the daemon acts).
+    if (pct7d >= UTILIZATION_ROTATE_THRESHOLD) {
+      return {
+        limited: true,
+        reason: `7d utilization ${pct7d.toFixed(1)}% >= ${UTILIZATION_ROTATE_THRESHOLD}%`,
+        utilization: real,
+      };
+    }
+  }
+
+  // Method 2: Explicit 429 signal from rate-limit-detector.cjs hook.
+  // The hook writes a signal file with `fireAt` (now+15s) when it detects a
+  // real 429 response. We honor the delay to give the user time to see the
+  // error and let the rotation complete before they retry.
+  try {
+    const rateLimitFile = join(tmpdir(), 'claude-rate-limited.json');
+    if (existsSync(rateLimitFile)) {
+      const data = JSON.parse(readFileSync(rateLimitFile, 'utf8'));
+      const fireAt = data.fireAt || 0;
+      const age = Date.now() - new Date(data.timestamp).getTime();
+      if (age > 5 * 60_000) {
+        // Stale — discard
+        unlinkSync(rateLimitFile);
+      } else if (Date.now() >= fireAt) {
+        // Delay elapsed — trigger rotation and consume the signal
+        unlinkSync(rateLimitFile);
+        return {
+          limited: true,
+          reason: `429 signal: ${(data.reason || 'rate_limit').substring(0, 120)}`,
+        };
+      }
+      // else: signal fresh but delay not elapsed — wait for next poll
+    }
+  } catch {}
+
+  return { limited: false };
+}
+
+// ── Should we rotate? ─────────────────────────────────────────────────────────
+
+function getActiveAccount(config, activeKey) {
+  return config.accounts.find((a) => accountKey(a) === activeKey) || null;
+}
+
+const AUTH_ERROR_FILE = join(tmpdir(), 'claude-auth-error.json');
+
+async function shouldRotate(config, state) {
+  // 1. Real utilization from statusline (PRIMARY signal for rotation)
+  const rl = checkRateLimited();
+  if (rl.limited) return { should: true, reason: `Rate limited: ${rl.reason}` };
+
+  // 2. Auth error signal (401) from PostToolUseFailure hook
+  try {
+    if (existsSync(AUTH_ERROR_FILE)) {
+      const sig = JSON.parse(readFileSync(AUTH_ERROR_FILE, 'utf8'));
+      const age = Date.now() - new Date(sig.timestamp).getTime();
+      if (age < 5 * 60_000) {
+        unlinkSync(AUTH_ERROR_FILE);
+        log(`401 auth error detected: ${sig.reason || 'unknown'}`);
+        return {
+          should: true,
+          reason: `Auth error (401): ${sig.reason || 'invalid credentials'}`,
+        };
+      }
+      unlinkSync(AUTH_ERROR_FILE); // Stale
+    }
+  } catch {}
+
+  // 3. Token expiring — try refresh first, only rotate if refresh fails
+  const account = getActiveAccount(config, state.activeAccount);
+  if (account) {
+    const token = readStoredToken(account);
+    if (token && tokenExpired(token)) {
+      // Try refreshing the active token in-place before rotating
+      log('[active-refresh] Active token expiring — attempting in-place refresh');
+      const refreshed = await refreshSingleToken(account);
+      if (refreshed) {
+        // Also update the active keychain so running sessions pick it up on next /login
+        try {
+          const freshToken = readStoredToken(account);
+          if (freshToken) {
+            const svc = 'Claude Code-credentials';
+            execFileSync(
+              'security',
+              ['add-generic-password', '-U', '-s', svc, '-a', KEYCHAIN_ACCOUNT, '-w', freshToken],
+              { timeout: 5000 },
+            );
+            log('[active-refresh] Active keychain updated — sessions will auto-recover');
+          }
+        } catch (err) {
+          log(`[active-refresh] Keychain update failed: ${err.message?.substring(0, 60)}`);
+        }
+        return { should: false }; // Refreshed in-place, no rotation needed
+      }
+      log('[active-refresh] Refresh failed — triggering rotation');
+      return { should: true, reason: 'Token expired and refresh failed' };
+    }
+  }
+
+  return { should: false };
+}
+
+// ── Execute rotation ──────────────────────────────────────────────────────────
+
+// Fetch live 5h/7d utilization for one account (no cache). Returns
+// {pct5h, pct7d} or null on failure. Cheap — single GET, 4s timeout.
+async function queryLiveUtilization(account) {
+  try {
+    const tokenJson = readStoredToken(account);
+    if (!tokenJson) return null;
+    const accessToken = JSON.parse(tokenJson)?.claudeAiOauth?.accessToken;
+    if (!accessToken) return null;
+    const res = await fetch('https://api.anthropic.com/api/oauth/usage', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'anthropic-beta': 'oauth-2025-04-20',
+      },
+      signal: AbortSignal.timeout(4000),
+    });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return {
+      pct5h: data?.five_hour?.utilization || 0,
+      pct7d: data?.seven_day?.utilization || 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function findValidRotationTarget(config, state) {
+  const now = Date.now();
+  const activeKey = state.activeAccount;
+  const SAFE_UTIL_5H_PCT = 70; // 5h window is what we rotate around — strict
+  const SAFE_UTIL_7D_PCT = 95; // 7d resets weekly — only hard-skip if truly capped
+
+  // Build candidate list: all accounts except the active one AND disabled ones.
+  const candidates = config.accounts.filter((a) => accountKey(a) !== activeKey && a.disabled !== true);
+
+  // Sort by cached util (best-guess ordering before live query). Treat
+  // missing reset as "unknown utilization" — DON'T treat null reset as
+  // "ready" (lic had reset:null + pct:0 and got picked while live was 100%).
+  candidates.sort((a, b) => {
+    const aUtil = state.accounts?.[accountKey(a)]?.lastUtilization;
+    const bUtil = state.accounts?.[accountKey(b)]?.lastUtilization;
+    const aResetMs = aUtil?.reset ? aUtil.reset * 1000 : 0;
+    const bResetMs = bUtil?.reset ? bUtil.reset * 1000 : 0;
+    // Account is "ready" only if it has a known reset time AND that's passed
+    const aReady = aResetMs > 0 && aResetMs < now;
+    const bReady = bResetMs > 0 && bResetMs < now;
+    if (aReady !== bReady) return aReady ? -1 : 1;
+    return (aUtil?.pct || 0) - (bUtil?.pct || 0);
+  });
+
+  for (const account of candidates) {
+    const key = accountKey(account);
+    const tokenJson = readStoredToken(account);
+
+    if (!tokenJson) {
+      log(`[pre-rotate] ${key}: no token in keychain — skipping`);
+      continue;
+    }
+
+    const expiry = parseTokenExpiry(tokenJson);
+    const isExpired = expiry > 0 && now > expiry - 5 * 60_000;
+
+    if (isExpired) {
+      log(`[pre-rotate] ${key}: token expired/expiring — attempting refresh`);
+      const refreshed = await refreshSingleToken(account);
+      if (!refreshed) {
+        log(`[pre-rotate] ${key}: refresh FAILED — skipping`);
+        continue;
+      }
+      log(`[pre-rotate] ${key}: refresh succeeded`);
+    } else {
+      log(`[pre-rotate] ${key}: token valid (${((expiry - now) / 3_600_000).toFixed(1)}h remaining)`);
+    }
+
+    // Live util check — never rotate to a high-utilization account.
+    // The cached snapshot may be stale (e.g. lic had pct:0 but live was 100%).
+    const live = await queryLiveUtilization(account);
+    if (live) {
+      const max = Math.max(live.pct5h, live.pct7d);
+      const tooHot5h = live.pct5h >= SAFE_UTIL_5H_PCT;
+      const tooHot7d = live.pct7d >= SAFE_UTIL_7D_PCT;
+      if (tooHot5h || tooHot7d) {
+        const reason = tooHot5h
+          ? `5h ${live.pct5h.toFixed(0)}% >= ${SAFE_UTIL_5H_PCT}%`
+          : `7d ${live.pct7d.toFixed(0)}% >= ${SAFE_UTIL_7D_PCT}%`;
+        log(
+          `[pre-rotate] ${key}: live util 5h=${live.pct5h.toFixed(0)}% 7d=${live.pct7d.toFixed(0)}% — skipping (${reason})`,
+        );
+        // Also update cached util so future picks see the truth
+        if (!state.accounts) state.accounts = {};
+        if (!state.accounts[key]) state.accounts[key] = {};
+        state.accounts[key].lastUtilization = {
+          pct: max,
+          reset: null,
+          ts: now,
+        };
+        continue;
+      }
+      log(`[pre-rotate] ${key}: live util 5h=${live.pct5h.toFixed(0)}% 7d=${live.pct7d.toFixed(0)}% — OK`);
+    } else {
+      log(`[pre-rotate] ${key}: live util query failed — accepting anyway`);
+    }
+
+    return account;
+  }
+
+  return null; // No valid candidate found
+}
+
+async function doRotation(reason) {
+  const lockFile = join(__dirname, '.rotating');
+  // Lock format written by rotate.mjs: `<ISO timestamp>\n<pid>`. If the holder
+  // PID is still alive, skip — don't race even if the wall-clock is ancient
+  // (browser OAuth flows can legitimately run several minutes).
+  const LOCK_HARD_CEILING_MS = 15 * 60_000;
+  if (existsSync(lockFile)) {
+    try {
+      const raw = readFileSync(lockFile, 'utf8').trim();
+      const [tsStr, pidStr] = raw.split(/\s+/);
+      const age = Date.now() - new Date(tsStr).getTime();
+      const pid = parseInt(pidStr || '', 10);
+      let holderAlive = false;
+      if (Number.isFinite(pid) && pid > 0) {
+        try {
+          process.kill(pid, 0);
+          holderAlive = true;
+        } catch {}
+      }
+      if (holderAlive && age < LOCK_HARD_CEILING_MS) {
+        log(`Rotation already in progress (holder PID ${pid}, ${Math.round(age / 1000)}s) — skipping`);
+        return;
+      }
+      if (!holderAlive) log(`Stale lock (PID ${pid || '?'} dead) — proceeding`);
+      else log(`Lock exceeded hard ceiling (${Math.round(age / 60_000)}min) — proceeding`);
+    } catch {
+      // Unparseable lock — treat as stale
+    }
+  }
+
+  log(`AUTO-ROTATING: ${reason}`);
+
+  // Pre-rotation: find a candidate with a valid (non-expired) token
+  const config = readConfig();
+  const state = readState();
+  const target = await findValidRotationTarget(config, state);
+
+  if (!target) {
+    log('ROTATION ABORTED: no candidate has a valid or refreshable token');
+    notify('Account Rotation', 'ABORTED — all candidate tokens expired/invalid');
+    return;
+  }
+
+  const targetKey = accountKey(target);
+  log(`Target account: ${targetKey} — token validated, proceeding with rotation`);
+  notify('Claude Account Rotation', `Auto-rotating to ${targetKey}: ${reason}`);
+
+  try {
+    // --no-browser: no Chrome, no API calls (works when rate limited)
+    // --to: daemon controls which account to rotate to (pre-validated token)
+    // NO --session: keychain swap only. Running sessions can't accept /login mid-work.
+    // When sessions hit the wall they show "not logged in" — user runs /login → instant
+    // success because the fresh token is already in the keychain.
+    // --session: inject /login into running sessions (safe — keychain token is pre-validated)
+    const result = execFileSync(process.execPath, [ROTATE_SCRIPT, '--no-browser', '--session', '--to', targetKey], {
+      cwd: __dirname,
+      timeout: 300_000, // 5min — session restart takes ~15s per session × up to 8 sessions
+      env: { ...process.env, NODE_NO_WARNINGS: '1' },
+    }).toString();
+    log(`Rotation result: ${result.substring(0, 200)}`);
+  } catch (err) {
+    log(`Rotation failed: ${err.message}`);
+    notify('Account Rotation', `Auto-rotation failed: ${err.message.substring(0, 60)}`);
+  }
+}
+
+// ── Token refresh (vault entries) ───────────────────────────────────────────
+// In-place refresh via OAuth; invoked from shouldRotate / findValidRotationTarget.
+
+const TOKEN_ENDPOINT = 'https://platform.claude.com/v1/oauth/token';
+const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+
+function parseTokenExpiry(tokenJson) {
+  try {
+    return JSON.parse(tokenJson)?.claudeAiOauth?.expiresAt || 0;
+  } catch {
+    return 0;
+  }
+}
+
+function parseRefreshToken(tokenJson) {
+  try {
+    return JSON.parse(tokenJson)?.claudeAiOauth?.refreshToken || null;
+  } catch {
+    return null;
+  }
+}
+
+async function refreshSingleToken(account) {
+  const key = accountKey(account);
+  const tokenJson = readStoredToken(account);
+  if (!tokenJson) return false;
+
+  const refreshToken = parseRefreshToken(tokenJson);
+  if (!refreshToken) return false;
+
+  try {
+    const res = await fetch(TOKEN_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: OAUTH_CLIENT_ID,
+      }),
+    });
+    const body = await res.json();
+    if (!res.ok || !body.access_token) return false;
+
+    const parsed = JSON.parse(tokenJson);
+    parsed.claudeAiOauth.accessToken = body.access_token;
+    if (body.refresh_token) parsed.claudeAiOauth.refreshToken = body.refresh_token;
+    parsed.claudeAiOauth.expiresAt = body.expires_in ? Date.now() + body.expires_in * 1000 : Date.now() + 8 * 3_600_000;
+
+    // Save back to vault
+    const svc = `Claude-Rotation-${key}`;
+    // Use execFileSync to avoid shell-escaping issues with JSON tokens
+    execFileSync(
+      'security',
+      ['add-generic-password', '-U', '-s', svc, '-a', KEYCHAIN_ACCOUNT, '-w', JSON.stringify(parsed)],
+      { timeout: 5000 },
+    );
+    log(
+      `[refresh] ${key}: refreshed (${((parsed.claudeAiOauth.expiresAt - Date.now()) / 3_600_000).toFixed(1)}h remaining)`,
+    );
+    return true;
+  } catch (err) {
+    log(`[refresh] ${key}: failed — ${err.message?.substring(0, 60)}`);
+    return false;
+  }
+}
+
+// ── Main loop ─────────────────────────────────────────────────────────────────
+
+async function mainLoop() {
+  log('Daemon started (v3 — on-demand token refresh)');
+  notify('Claude Rotation Daemon', 'Monitoring usage — on-demand refresh');
+
+  let lastRotatedAt = 0; // track when we last rotated
+  let lastStatusLog = 0; // periodic status logging
+  let lastDriftCheck = 0; // cheap vault-based drift detection
+
+  while (true) {
+    try {
+      const config = readConfig();
+      if (!config.autoRotate) {
+        await sleep(POLL_INTERVAL);
+        continue;
+      }
+
+      const state = readState();
+
+      // Periodic status log (every 5 min) — shows cooldown state for all accounts
+      if (Date.now() - lastStatusLog > 300_000) {
+        log(`Account cooldown status:\n${accountCooldownStatus(state)}`);
+        lastStatusLog = Date.now();
+      }
+
+      // Drift detection — every 2 min, find the actual live account.
+      // 1) Cheap vault-token compare first (zero network).
+      // 2) Fall back to /api/oauth/profile when Claude Code has refreshed
+      //    its own token and the live no longer matches any vault.
+      // Self-heals when state.json disagrees with the actual active account
+      // (crashed rotation, manual /login, leftover lock).
+      if (Date.now() - lastDriftCheck > 120_000) {
+        lastDriftCheck = Date.now();
+        const stateLastRotation2 = state.lastRotation ? new Date(state.lastRotation).getTime() : 0;
+        const inBlackoutDrift = stateLastRotation2 && Date.now() - stateLastRotation2 < POST_ROTATION_BLACKOUT;
+        if (!inBlackoutDrift) {
+          const liveKey = await detectLiveAccountFromVault(config);
+          if (liveKey && liveKey !== state.activeAccount) {
+            log(`⚠️ DRIFT: state=${state.activeAccount || 'none'} but keychain=${liveKey} — syncing state.json`);
+            state.activeAccount = liveKey;
+            writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+          }
+        }
+      }
+
+      // Dynamic token refresh disabled — only refresh when the active account
+      // actually needs rotation (shouldRotate handles in-place refresh, and
+      // findValidRotationTarget refreshes candidates lazily). Avoids keychain
+      // churn that was disconnecting HTTP MCP sessions every 5 min.
+
+      const { should, reason } = await shouldRotate(config, state);
+
+      // Post-rotation blackout: ALL rotation triggers are suppressed for 90s
+      // after any rotation. `claude auth status` returns stale data during this
+      // window, which causes drift detection → re-rotation thrashing loops.
+      const stateLastRotation = state.lastRotation ? new Date(state.lastRotation).getTime() : 0;
+      const effectiveLastRotated = Math.max(lastRotatedAt, stateLastRotation);
+      const inBlackout = effectiveLastRotated && Date.now() - effectiveLastRotated < POST_ROTATION_BLACKOUT;
+
+      if (should && inBlackout) {
+        const remaining = Math.ceil((POST_ROTATION_BLACKOUT - (Date.now() - effectiveLastRotated)) / 1000);
+        log(`Post-rotation blackout: ignoring "${reason}" for ${remaining}s more`);
+      } else if (should) {
+        await doRotation(reason);
+        lastRotatedAt = Date.now();
+        await sleep(RATE_LIMIT_COOLDOWN);
+      }
+    } catch (err) {
+      log(`Daemon error: ${err.message}`);
+    }
+
+    await sleep(POLL_INTERVAL);
+  }
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+
+if (args.includes('--stop')) {
+  if (existsSync(PID_FILE)) {
+    const pid = readFileSync(PID_FILE, 'utf8').trim();
+    try {
+      process.kill(parseInt(pid));
+      log(`Stopped daemon (PID ${pid})`);
+    } catch {}
+    try {
+      unlinkSync(PID_FILE);
+    } catch {}
+    console.log(`Daemon stopped (PID ${pid})`);
+  } else {
+    console.log('No daemon running');
+  }
+} else if (args.includes('--status')) {
+  if (existsSync(PID_FILE)) {
+    const pid = readFileSync(PID_FILE, 'utf8').trim();
+    try {
+      process.kill(parseInt(pid), 0); // Check if alive
+      console.log(`Daemon running (PID ${pid})`);
+    } catch {
+      console.log('Daemon PID file exists but process is dead');
+      unlinkSync(PID_FILE);
+    }
+  } else {
+    console.log('Daemon not running');
+  }
+} else if (args.includes('--bg')) {
+  // Daemonize
+  const child = spawn('node', [join(__dirname, 'daemon.mjs')], {
+    cwd: __dirname,
+    detached: true,
+    stdio: 'ignore',
+    env: { ...process.env, NODE_NO_WARNINGS: '1' },
+  });
+  child.unref();
+  writeFileSync(PID_FILE, String(child.pid));
+  console.log(`Daemon started in background (PID ${child.pid})`);
+  console.log(
+    `Monitoring: tool uses (${readConfig().toolUseThreshold}), hours (${readConfig().maxHoursPerAccount}h), rate limits, token expiry`,
+  );
+  console.log(`Log: ${LOG_PATH}`);
+} else {
+  // Foreground
+  writeFileSync(PID_FILE, String(process.pid));
+  process.on('SIGINT', () => {
+    try {
+      unlinkSync(PID_FILE);
+    } catch {}
+    process.exit(0);
+  });
+  process.on('SIGTERM', () => {
+    try {
+      unlinkSync(PID_FILE);
+    } catch {}
+    process.exit(0);
+  });
+  await mainLoop();
+}

--- a/claude-ops/scripts/account-rotation/force-rotate.sh
+++ b/claude-ops/scripts/account-rotation/force-rotate.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# Force-rotate Claude account from OUTSIDE Claude Code
+# Run this when you've hit the limit and can't reach the CLI
+# Usage: $CLAUDE_PLUGIN_ROOT/scripts/account-rotation/force-rotate.sh [target-email]
+#
+# Also available as: force-rotate (shell alias)
+# Magic-link variant: rotate-magic = node rotate.mjs --magic-link --force --to <email>
+#
+# === ROTATION SYSTEM OVERVIEW ===
+# Files in this directory:
+#   rotate.mjs        - main rotation logic, holds .rotating lock (PID-tagged)
+#   daemon.mjs        - launchd-managed monitor (com.claude-ops.account-rotation)
+#   ai-brain.mjs      - Haiku fallback for stuck OAuth pages
+#   state.json        - activeAccount, lastRotation, per-account util snapshots
+#   config.json       - account list, autoRotate toggle
+#   .rotating         - lock file: <ISO ts>\n<pid>; auto-broken if PID dead or >15min
+#   .rate-limits.json - written by ~/.claude/statusline-command.sh, read by daemon
+#
+# Auto-rotation triggers (any one fires):
+#   1. Daemon poll      : 5h pct >= 80% OR 7d pct >= 80%
+#   2. Statusline fire  : 5h OR 7d >= 90% (opens new Terminal with rotate-magic)
+#   3. 429 from API     : rate-limit-detector.cjs writes /tmp/claude-rate-limited.json
+#   4. 401 auth error   : PostToolUse hook writes /tmp/claude-auth-error.json
+#   5. Manual           : this script, or `node rotate.mjs --to <email>`
+#
+# Drift detection (daemon, every 2min, NO network call):
+#   Compares live "Claude Code-credentials" keychain accessToken against each
+#   "Claude-Rotation-<key>" vault token. If state.activeAccount disagrees with
+#   the actual live account, state.json is auto-corrected. Skipped during the
+#   3-min post-rotation blackout to avoid undoing fresh rotations.
+#
+# Magic-link safety:
+#   - Decodes <base64-email> from claude.ai/magic-link#<hex>:<b64> URLs and
+#     skips any link whose target email != requested account. Prevents picking
+#     up stale links from prior rotation calls (subject is identical for all).
+#   - Rejects emails older than the poll start (5s clock skew tolerance).
+#
+# OAuth stall handling:
+#   - Authorize button: 6 attempts × 5s = 30s, then escalates to ai-brain
+#   - General URL stall: 2 stagnant steps -> ai-brain
+#   - ai-brain (Haiku) pulls API key from env -> Doppler -> keychain
+#   - Max 6 ai-brain decisions per rotation
+#
+# Recovery from stuck state:
+#   pkill -9 -f "rotate\.mjs"
+#   rm -f ~/.claude/plugins/data/ops/account-rotation/.rotating
+#   launchctl kickstart -k gui/$(id -u)/com.claude-ops.account-rotation
+#
+# Behavior: --force kills any stuck competing rotate.mjs and bypasses the lock.
+# We try the fast --no-browser path first (works when refresh tokens are valid);
+# if that fails we fall back to the full browser OAuth flow. Both are guarded
+# by a watchdog so the rotation can never hang indefinitely.
+
+set -u
+DEFAULT_ROT_DIR="${HOME}/.claude/plugins/data/ops/account-rotation"
+DIR="${CLAUDE_ROTATION_DATA_DIR:-${CLAUDE_PLUGIN_DATA_DIR:-${HOME}/.claude/plugins/data/ops}/account-rotation}"
+[ -d "$DIR" ] || DIR="$DEFAULT_ROT_DIR"
+WATCHDOG_SECONDS="${FORCE_ROTATE_TIMEOUT:-360}"
+
+echo "🔄 Force-rotating Claude account..."
+
+# Pre-flight: clear stale lock if its PID is dead. rotate.mjs --force does this
+# too, but doing it here keeps the watchdog timer accurate.
+if [ -f "$DIR/.rotating" ]; then
+  LOCK_PID=$(tail -1 "$DIR/.rotating" 2>/dev/null | tr -d '[:space:]')
+  if [ -n "$LOCK_PID" ] && ! kill -0 "$LOCK_PID" 2>/dev/null; then
+    echo "↻  Clearing stale lock (PID $LOCK_PID dead)"
+    rm -f "$DIR/.rotating"
+  fi
+fi
+
+# Pre-flight: ensure daemon is running. If launchd reports not loaded, kickstart.
+if ! launchctl list 2>/dev/null | grep -q com.claude-ops.account-rotation; then
+  echo "↻  Daemon not loaded — loading"
+  launchctl load "$HOME/Library/LaunchAgents/com.claude-ops.account-rotation.plist" 2>/dev/null
+fi
+
+# Pre-flight: detect drift between state.json and live keychain (informational —
+# the daemon also auto-corrects every 2min, but this surfaces it during manual
+# rotation). Don't block on failure; just log.
+{
+  LIVE_TOK=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null | python3 -c "import sys,json; print(json.loads(sys.stdin.read()).get('claudeAiOauth',{}).get('accessToken',''))" 2>/dev/null)
+  STATE_ACCT=$(python3 -c "import json; print(json.load(open('$DIR/state.json')).get('activeAccount',''))" 2>/dev/null)
+  if [ -n "$LIVE_TOK" ] && [ -n "$STATE_ACCT" ]; then
+    LIVE_ACCT=$(curl -s -m 4 -H "Authorization: Bearer $LIVE_TOK" -H "anthropic-beta: oauth-2025-04-20" https://api.anthropic.com/api/oauth/profile 2>/dev/null | python3 -c "import sys,json; print(json.loads(sys.stdin.read()).get('account',{}).get('email',''))" 2>/dev/null)
+    if [ -n "$LIVE_ACCT" ] && [ "$LIVE_ACCT" != "$STATE_ACCT" ] && [ "${STATE_ACCT}" != "${LIVE_ACCT%@*}-personal" ] && [ "${STATE_ACCT}" != "${LIVE_ACCT%@*}-team" ]; then
+      echo "⚠  Drift: state=$STATE_ACCT live=$LIVE_ACCT (daemon will auto-correct, or rotate.mjs will reconcile on swap)"
+    fi
+  fi
+} 2>/dev/null
+
+TARGET_ARG=()
+if [ $# -ge 1 ] && [ -n "${1:-}" ]; then
+  TARGET_ARG=(--to "$1")
+fi
+
+run_with_watchdog() {
+  # Runs a command in the background with a hard kill after $WATCHDOG_SECONDS.
+  # Returns the command's exit code, or 124 if the watchdog fired.
+  local cmd_pid wd_pid rc
+  "$@" &
+  cmd_pid=$!
+  ( sleep "$WATCHDOG_SECONDS"; kill -9 "$cmd_pid" 2>/dev/null ) &
+  wd_pid=$!
+  wait "$cmd_pid" 2>/dev/null
+  rc=$?
+  # Stop the watchdog (may already be dead)
+  kill "$wd_pid" 2>/dev/null
+  wait "$wd_pid" 2>/dev/null
+  # If watchdog killed the cmd, wait returns 137; surface as 124 (timeout)
+  if [ "$rc" -eq 137 ]; then
+    echo "⏱  Watchdog fired after ${WATCHDOG_SECONDS}s — killed stuck rotate.mjs" >&2
+    pgrep -f "chrome-beta-automation" | xargs -r kill -9 2>/dev/null
+    return 124
+  fi
+  return "$rc"
+}
+
+# Fast path: refresh-token rotation, no browser. Works whenever a candidate
+# account has a non-expired refresh token — which is the common case.
+echo "→ Trying fast path (--no-browser --force)..."
+if run_with_watchdog node "$DIR/rotate.mjs" --force --no-browser --session ${TARGET_ARG[@]+"${TARGET_ARG[@]}"}; then
+  FAST_OK=1
+else
+  FAST_OK=0
+  echo "⚠  Fast path failed — falling back to browser OAuth"
+  run_with_watchdog node "$DIR/rotate.mjs" --force --session ${TARGET_ARG[@]+"${TARGET_ARG[@]}"}
+fi
+
+# Show new status
+echo ""
+node "$DIR/rotate.mjs" --status 2>&1 | head -40
+
+# macOS notification
+osascript -e 'display notification "Account rotated — restart Claude Code session" with title "Claude Rotation"' 2>/dev/null
+
+echo ""
+if [ "$FAST_OK" -eq 1 ]; then
+  echo "✅ Done (fast path). Start a new Claude Code session to use the fresh account."
+else
+  echo "✅ Done (browser fallback). Start a new Claude Code session to use the fresh account."
+fi
+echo "   (Running sessions may still use the old token — exit and re-enter)"

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -1,0 +1,3261 @@
+#!/usr/bin/env node
+/**
+ * Claude Max Account Rotation — dcli + keychain + Kapture
+ *
+ * PRIMARY PATH (fast, ~1s, no browser):
+ *   dcli read token → write to keychain "Claude Code-credentials" → done
+ *
+ * FALLBACK (token missing/expired) — browser automation cascade:
+ *   1. Kapture MCP  (ws://localhost:61822 — your real Chrome, all Google sessions)
+ *   2. Playwright   (persistent context)
+ *   3. Chrome JXA   (AppleScript, needs "Allow JS from Apple Events")
+ *   4. Manual       (opens URL, notifies user)
+ *
+ * Usage:
+ *   node rotate.mjs                           # auto-rotate to longest-idle account
+ *   node rotate.mjs --to <email>              # rotate to specific account
+ *   node rotate.mjs --status                  # show state
+ *   node rotate.mjs --utilization             # live 5h/7d utilization per account
+ *   node rotate.mjs --audit-billing           # 🔴/🟢 per-account extra_usage (overage billing) audit
+ *   node rotate.mjs --setup                   # manual: claude auth login per account (interactive)
+ *   node rotate.mjs --setup --auto            # AUTOMATED: magic-link + browser cascade, all configured accounts end-to-end
+ *   node rotate.mjs --setup --auto --skip-valid  # skip accounts whose vault token is still alive
+ *   node rotate.mjs --setup --only=<key>      # only re-capture one account (e.g. --only=user@example.com)
+ *   node rotate.mjs --capture                 # save current active token (print for Dashlane)
+ *   node rotate.mjs --session                 # also send /login to running iTerm2 session
+ *   node rotate.mjs --magic-link --to <email> # re-auth via email magic link (no Google OAuth)
+ *   node rotate.mjs --allow-extra-usage       # BYPASS extra_usage billing guard (opt-in only)
+ */
+
+import {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  unlinkSync,
+  appendFileSync,
+  chmodSync,
+  readdirSync,
+  renameSync,
+} from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { execSync, execFileSync, spawnSync, spawn } from 'child_process';
+import { tmpdir } from 'os';
+import { createHmac } from 'node:crypto';
+import { askAIBrain, executeAIAction, AI_BRAIN_MAX_DECISIONS } from './ai-brain.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CONFIG_PATH = join(__dirname, 'config.json');
+const STATE_PATH = join(__dirname, 'state.json');
+const LOCK_PATH = join(__dirname, '.rotating');
+const LOG_PATH = join(__dirname, 'rotation.log');
+
+const KEYCHAIN_SERVICE = 'Claude Code-credentials';
+// Use the OS username so multiple users on the same Mac don't collide on
+// keychain entries. Override with CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT if needed.
+const KEYCHAIN_ACCOUNT =
+  process.env.CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT || process.env.USER || process.env.LOGNAME || 'claude-ops';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── Bootstrap: verify dependencies ───────────────────────────────────────────
+// The only browser driver is Playwright-over-CDP to Chrome or Chrome Beta
+// (never Comet — reserved for user, never Chromium — bundled browser banned).
+function ensureMCPServersAndTools() {
+  const actions = [];
+  const earlyLog = (m) => {
+    try {
+      console.error(`[bootstrap] ${m}`);
+    } catch {}
+  };
+
+  // 1. Chrome or Chrome Beta binary (Comet is off-limits)
+  const realChromes = [
+    '/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta',
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  ];
+  const foundChrome = realChromes.find((p) => existsSync(p));
+  if (foundChrome) {
+    actions.push(`chrome-binary: ${foundChrome.split('/').pop()}`);
+  } else {
+    actions.push('chrome-binary: WARNING — no Chrome/Chrome Beta found');
+  }
+
+  // 2. Chrome CDP port 9222 — probe (driver will launch Chrome if needed)
+  try {
+    execSync(`curl -sf http://localhost:9222/json/version >/dev/null 2>&1`, {
+      timeout: 1500,
+    });
+    actions.push('chrome-cdp: reachable on :9222');
+  } catch {
+    actions.push('chrome-cdp: not reachable (driver will launch Chrome)');
+  }
+
+  // 3. dcli (Dashlane) — required for primary token path
+  try {
+    execSync(`command -v dcli >/dev/null 2>&1`, { timeout: 1000 });
+    actions.push('dcli: available');
+  } catch {
+    actions.push('dcli: MISSING — primary token path will fail');
+  }
+
+  // 4. security (macOS keychain) — required for token writes
+  try {
+    execSync(`command -v security >/dev/null 2>&1`, { timeout: 1000 });
+  } catch {
+    actions.push('security(1): MISSING — keychain writes will fail');
+  }
+
+  for (const a of actions) earlyLog(a);
+}
+
+// Unconditional warmup: every rotate.mjs run starts its MCP servers + tools FIRST.
+// Skip only for --help (where nothing runs downstream).
+if (!process.argv.slice(2).includes('--help') && !process.argv.slice(2).includes('--no-browser')) {
+  ensureMCPServersAndTools();
+}
+
+// ── Utilities ────────────────────────────────────────────────────────────────
+
+function log(msg) {
+  const line = `[${new Date().toISOString()}] ${msg}`;
+  console.error(line);
+  try {
+    appendFileSync(LOG_PATH, line + '\n');
+  } catch {}
+}
+
+function notify(title, msg) {
+  try {
+    execSync(`osascript -e 'display notification "${msg.replace(/"/g, '\\"')}" with title "${title}"'`);
+  } catch {}
+}
+
+function readConfig() {
+  return JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
+}
+function readState() {
+  try {
+    return JSON.parse(readFileSync(STATE_PATH, 'utf8'));
+  } catch {
+    return {
+      activeAccount: null,
+      accounts: {},
+      toolUses: 0,
+      totalRotations: 0,
+    };
+  }
+}
+function writeState(s, dryRun = false) {
+  if (dryRun) {
+    log('[DRY-RUN] Would write state');
+    return;
+  }
+  const tmp = STATE_PATH + '.tmp.' + process.pid;
+  writeFileSync(tmp, JSON.stringify(s, null, 2));
+  renameSync(tmp, STATE_PATH);
+}
+
+// Lock format: `<ISO timestamp>\n<pid>` — PID lets us detect dead holders
+// regardless of wall-clock age (browser OAuth can legitimately run >30s).
+const LOCK_MAX_AGE_MS = 15 * 60_000; // hard ceiling; browser OAuth can take minutes
+function readLock() {
+  try {
+    const raw = readFileSync(LOCK_PATH, 'utf8').trim();
+    const [ts, pidStr] = raw.split(/\s+/);
+    const pid = parseInt(pidStr || '', 10);
+    const when = new Date(ts).getTime();
+    return {
+      when: Number.isFinite(when) ? when : 0,
+      pid: Number.isFinite(pid) ? pid : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+function lockHolderAlive(pid) {
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+function acquireLock() {
+  if (existsSync(LOCK_PATH)) {
+    const info = readLock();
+    if (info && lockHolderAlive(info.pid)) {
+      const age = Date.now() - info.when;
+      if (age < LOCK_MAX_AGE_MS) {
+        log(`Rotation in progress (holder PID ${info.pid}, ${Math.round(age / 1000)}s old)`);
+        return false;
+      }
+      log(`Lock held by PID ${info.pid} but >${Math.round(LOCK_MAX_AGE_MS / 60_000)}min old — breaking`);
+    } else if (info) {
+      log(`Stale lock (PID ${info.pid || '?'} not running) — breaking`);
+    }
+  }
+  writeFileSync(LOCK_PATH, `${new Date().toISOString()}\n${process.pid}`);
+  return true;
+}
+function releaseLock() {
+  try {
+    // Only release if we still own it
+    const info = readLock();
+    if (!info || info.pid === process.pid) unlinkSync(LOCK_PATH);
+  } catch {}
+}
+
+function accountKey(a) {
+  return a.label || a.email;
+}
+
+// ── Live utilization query ────────────────────────────────────────────────────
+
+// Query all accounts in parallel — best-effort, uses cached fallback.
+// Staggered + retry-on-429 to avoid rate-limiting the /oauth/usage endpoint,
+// especially right after a token refresh when Anthropic briefly throttles.
+async function queryAllUtilization(config) {
+  async function queryAccount(a) {
+    try {
+      const tokenJson = readStoredToken(a);
+      if (!tokenJson) return null;
+      const parsed = JSON.parse(tokenJson);
+      const accessToken = parsed?.claudeAiOauth?.accessToken;
+      if (!accessToken) return null;
+
+      const headers = {
+        Authorization: `Bearer ${accessToken}`,
+        'anthropic-beta': 'oauth-2025-04-20',
+        'Content-Type': 'application/json',
+      };
+
+      async function fetchWithRetry(url, attempt = 0) {
+        const res = await fetch(url, {
+          method: 'GET',
+          headers,
+          signal: AbortSignal.timeout(5000),
+        });
+        // Retry once on 429 — happens transiently right after token refresh
+        // or when multiple accounts query in parallel
+        if (res.status === 429 && attempt < 2) {
+          await new Promise((r) => setTimeout(r, 1500 * (attempt + 1)));
+          return fetchWithRetry(url, attempt + 1);
+        }
+        return res;
+      }
+
+      const [usageRes, profileRes] = await Promise.all([
+        fetchWithRetry('https://api.anthropic.com/api/oauth/usage'),
+        fetchWithRetry('https://api.anthropic.com/api/oauth/profile'),
+      ]);
+
+      if (!usageRes.ok) return null;
+      const data = await usageRes.json();
+      let extraUsageEnabled = null;
+      let billingType = null;
+      let subscriptionStatus = null;
+      if (profileRes.ok) {
+        const prof = await profileRes.json();
+        extraUsageEnabled = prof?.organization?.has_extra_usage_enabled ?? null;
+        billingType = prof?.organization?.billing_type ?? null;
+        subscriptionStatus = prof?.organization?.subscription_status ?? null;
+      }
+      return {
+        five_hour_pct: Math.round((data.five_hour?.utilization ?? 0) * 100) / 100,
+        seven_day_pct: Math.round((data.seven_day?.utilization ?? 0) * 100) / 100,
+        resets_at_5h: data.five_hour?.resets_at || null,
+        resets_at_7d: data.seven_day?.resets_at || null,
+        extra_usage_enabled: extraUsageEnabled,
+        billing_type: billingType,
+        subscription_status: subscriptionStatus,
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  // Stagger account queries by 150ms to avoid bursting /oauth/usage endpoint,
+  // which otherwise 429s on ~5-7 parallel requests from the same IP.
+  const results = await Promise.allSettled(
+    config.accounts
+      .filter((a) => a.disabled !== true)
+      .map(async (a, idx) => {
+        if (idx > 0) await new Promise((r) => setTimeout(r, 150 * idx));
+        return { key: accountKey(a), util: await queryAccount(a) };
+      }),
+  );
+  const map = {};
+  for (const r of results) {
+    if (r.status === 'fulfilled' && r.value.util) {
+      map[r.value.key] = r.value.util;
+    }
+  }
+  return map;
+}
+
+// liveUtil: optional map from queryAllUtilization() — key → { five_hour_pct, ... }
+function pickNextAccount(config, state, liveUtil = {}, opts = {}) {
+  const activeKey = state.activeAccount;
+  const windowMs = (config.rateLimits?.windowHours || 5) * 3_600_000;
+  const now = Date.now();
+
+  // Hard block: account has Anthropic-side extra-usage (pay-per-use overage) enabled.
+  // Rotating to such an account risks credit-card charges when the weekly cap is hit.
+  // Override with opts.allowExtraUsage=true (CLI flag --allow-extra-usage) only when
+  // the user has explicitly opted in for this run.
+  const allowExtraUsage = opts.allowExtraUsage === true;
+  function hasExtraUsageEnabled(a) {
+    const key = accountKey(a);
+    const live = liveUtil[key];
+    return live && live.extra_usage_enabled === true;
+  }
+
+  // Check if an account's quota window has been exhausted (local tool-use tracking)
+  function isExhausted(a) {
+    const key = accountKey(a);
+    const acct = state.accounts[key];
+    if (!acct?.windowStart) return false;
+    const windowAge = now - new Date(acct.windowStart).getTime();
+    if (windowAge >= windowMs) return false;
+    const capacity = a.capacityMultiplier ?? 1.0;
+    const maxUses = Math.floor(config.toolUseThreshold * capacity);
+    return (acct.windowToolUses || 0) >= maxUses;
+  }
+
+  // Get best available utilization for an account:
+  //   1. Live API data (freshest)
+  //   2. Snapshot from last rotation away (stale but better than nothing)
+  //   3. null (unknown)
+  function getUtil5h(a) {
+    const key = accountKey(a);
+
+    // 1. Live
+    if (liveUtil[key] != null) return liveUtil[key].five_hour_pct;
+
+    // 2. Snapshot stored in state
+    const acct = state.accounts[key];
+    if (!acct?.lastUtilization) return null;
+    const { pct, reset, ts } = acct.lastUtilization;
+    if (!ts) return null;
+    const resetMs = reset * 1000;
+    if (resetMs && resetMs < now) return 0; // Window reset — account is fresh
+    if (now - ts > 6 * 3_600_000) return null; // Too stale
+    return pct ?? null;
+  }
+
+  // 7-day weekly cap utilization. Live only — no snapshot fallback because
+  // 7d resets are slow and stale data is misleading.
+  function getUtil7d(a) {
+    const key = accountKey(a);
+    if (liveUtil[key] != null && liveUtil[key].seven_day_pct != null) {
+      return liveUtil[key].seven_day_pct;
+    }
+    return null;
+  }
+
+  // Score: max of (5h, 7d) — an account is only viable if BOTH windows have
+  // headroom. Unknown util → 50 (neutral). Lower is better.
+  function score(a) {
+    const u5 = getUtil5h(a);
+    const u7 = getUtil7d(a);
+    if (u5 === null && u7 === null) return 50;
+    return Math.max(u5 ?? 0, u7 ?? 0);
+  }
+
+  // Log + hard-exclude accounts with extra_usage enabled (pay-per-use overage billing).
+  // These are the accounts that silently charge your credit card when the weekly cap
+  // is exceeded. Unless --allow-extra-usage was passed, we refuse to rotate to them.
+  const extraUsageAccounts = config.accounts.filter(hasExtraUsageEnabled);
+  if (extraUsageAccounts.length > 0) {
+    log(
+      `⚠  EXTRA USAGE ENABLED on ${extraUsageAccounts.length} account(s): ${extraUsageAccounts
+        .map((a) => accountKey(a))
+        .join(', ')} — these can incur overage charges. Disable at console.anthropic.com/settings/billing.`,
+    );
+  }
+
+  const excludeKey = (a) =>
+    a.disabled === true || accountKey(a) === activeKey || (!allowExtraUsage && hasExtraUsageEnabled(a));
+
+  // Separate normal and low-priority, excluding current active + extra-usage accounts
+  const normal = config.accounts.filter((a) => a.priority !== 'low' && !excludeKey(a));
+  const low = config.accounts.filter((a) => a.priority === 'low' && !excludeKey(a));
+
+  const UTIL_HARD_BLOCK = 90; // Skip accounts at/above this util% if possible
+
+  for (const pool of [normal, low]) {
+    const fresh = pool.filter((a) => !isExhausted(a));
+    const exhausted = pool.filter((a) => isExhausted(a));
+
+    for (const candidates of [fresh, exhausted]) {
+      const viable = candidates.filter((a) => score(a) < UTIL_HARD_BLOCK);
+      const blocked = candidates.filter((a) => score(a) >= UTIL_HARD_BLOCK);
+      const sorted = [...viable].sort((a, b) => score(a) - score(b));
+      const pool2 = sorted.length ? sorted : [...blocked].sort((a, b) => score(a) - score(b));
+
+      if (pool2.length > 0) {
+        const best = pool2[0];
+        const u5 = getUtil5h(best);
+        const u7 = getUtil7d(best);
+        const src = liveUtil[accountKey(best)]
+          ? 'live'
+          : state.accounts[accountKey(best)]?.lastUtilization
+            ? 'cached'
+            : 'unknown';
+        const utilStr = ` 5h=${u5 ?? '?'}% 7d=${u7 ?? '?'}% [${src}]`;
+        if (score(best) >= UTIL_HARD_BLOCK) {
+          log(`WARNING: All candidates near limit — rotating to ${accountKey(best)}${utilStr}`);
+        } else {
+          log(`Picked ${accountKey(best)}${utilStr}`);
+        }
+        return best;
+      }
+    }
+  }
+  return null;
+}
+
+// ── Keychain ─────────────────────────────────────────────────────────────────
+
+function readKeychain(svc = KEYCHAIN_SERVICE, acct = KEYCHAIN_ACCOUNT) {
+  const result = spawnSync('security', ['find-generic-password', '-s', svc, '-a', acct, '-g'], {
+    timeout: 5000,
+    encoding: 'utf8',
+  });
+  const out = (result.stdout || '') + (result.stderr || '');
+  const m = out.match(/^password: "?(.*?)"?$/m);
+  if (!m) throw new Error(`No keychain entry ${svc}/${acct}`);
+  return m[1].replace(/\\"/g, '"');
+}
+
+function writeKeychain(json, svc = KEYCHAIN_SERVICE, acct = KEYCHAIN_ACCOUNT) {
+  try {
+    execFileSync('security', ['delete-generic-password', '-s', svc, '-a', acct], {
+      stdio: 'ignore',
+    });
+  } catch {}
+  execFileSync('security', ['add-generic-password', '-s', svc, '-a', acct, '-w', json], { timeout: 5000 });
+}
+
+function tokenExpired(json) {
+  try {
+    const exp = JSON.parse(json)?.claudeAiOauth?.expiresAt;
+    if (!exp) return false;
+    // Match daemon.mjs: treat as expired within 5 minutes of expiry
+    return Date.now() > exp - 5 * 60_000;
+  } catch {
+    return false;
+  }
+}
+
+// ── Token vault (local keychain entries per account) ─────────────────────────
+
+const TOKEN_PREFIX = 'Claude-Rotation';
+
+function tokenService(account) {
+  return `${TOKEN_PREFIX}-${accountKey(account)}`;
+}
+
+function readStoredToken(account) {
+  try {
+    return readKeychain(tokenService(account));
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredToken(account, json) {
+  writeKeychain(json, tokenService(account));
+}
+
+function hasStoredToken(account) {
+  try {
+    readKeychain(tokenService(account));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Fetches Google password AND (optional) TOTP secret from dcli by querying
+// all google.com credentials and matching on email.
+// Returns { password, otpSecret } or null.
+function fetchGoogleCreds(account) {
+  try {
+    const json = execSync(`dcli password -o json google.com 2>/dev/null`, {
+      timeout: 15_000,
+    }).toString();
+    const creds = JSON.parse(json);
+    // Find credential whose email matches account.email
+    const match = creds.find((c) => (c.email || '').toLowerCase() === account.email.toLowerCase());
+    if (!match) return null;
+    return {
+      password: match.password || null,
+      otpSecret: match.otpSecret || null,
+      phone: match.phone || match.phoneNumber || null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// Legacy alias — returns only password for backwards compat with existing call sites
+function fetchGooglePassword(account) {
+  // Legacy path: honor explicit dashlaneGooglePath if set
+  if (account.dashlaneGooglePath) {
+    try {
+      return execFileSync('dcli', ['read', account.dashlaneGooglePath], {
+        timeout: 10_000,
+      })
+        .toString()
+        .trim();
+    } catch {
+      return null;
+    }
+  }
+  // New path: query by email
+  const creds = fetchGoogleCreds(account);
+  return creds?.password || null;
+}
+
+// Generate a TOTP code from a base32 secret using the Node crypto module.
+// Used when an account has 2FA and we have the secret in dcli.
+function generateTOTP(base32Secret) {
+  // Uses top-level ESM import: createHmac from "node:crypto"
+  // Decode base32
+  const base32chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  const clean = base32Secret.replace(/\s/g, '').toUpperCase();
+  let bits = '';
+  for (const c of clean) {
+    const i = base32chars.indexOf(c);
+    if (i === -1) continue;
+    bits += i.toString(2).padStart(5, '0');
+  }
+  const bytes = [];
+  for (let i = 0; i + 8 <= bits.length; i += 8) {
+    bytes.push(parseInt(bits.substring(i, i + 8), 2));
+  }
+  const key = Buffer.from(bytes);
+
+  // TOTP counter: 30-second intervals since epoch
+  const counter = Math.floor(Date.now() / 1000 / 30);
+  const buf = Buffer.alloc(8);
+  buf.writeBigUInt64BE(BigInt(counter));
+
+  const hmac = createHmac('sha1', key).update(buf).digest();
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  const code =
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff);
+  return (code % 1_000_000).toString().padStart(6, '0');
+}
+
+// Read the latest SMS verification code from Messages.app for the Google 2FA number.
+// Returns a 6-digit code string or null.
+// Read latest SMS verification code from Messages.app.
+// Modern iMessages store text in `attributedBody` (NSKeyedArchiver blob), not `text`.
+// We hex-dump both and extract G-XXXXXX or a 6-digit code.
+function readLatestSMSCode({ maxAgeSec = 300 } = {}) {
+  try {
+    const db = join(process.env.HOME || '', 'Library/Messages/chat.db');
+    if (!existsSync(db)) return null;
+    // Apple timestamp = seconds since 2001-01-01, stored as nanoseconds
+    const cutoffAppleNs = (Math.floor(Date.now() / 1000) - 978307200 - maxAgeSec) * 1_000_000_000;
+    const sql = `SELECT hex(attributedBody), text FROM message WHERE date > ${cutoffAppleNs} AND service IN ('SMS','iMessage') ORDER BY date DESC LIMIT 10;`;
+    const rows = execSync(`sqlite3 "${db}" "${sql}"`, { timeout: 5000 }).toString().split('\n').filter(Boolean);
+    for (const row of rows) {
+      const [hex, text] = row.split('|');
+      // Plain text column (older macOS)
+      if (text) {
+        const m = text.match(/G-(\d{6})/) || text.match(/\b(\d{6})\b/);
+        if (m) return m[1];
+      }
+      // attributedBody blob — decode as latin-1 and regex-match
+      if (hex && hex.length > 20) {
+        const decoded = Buffer.from(hex, 'hex').toString('latin1');
+        const m = decoded.match(/G-(\d{6})/) || decoded.match(/(\d{6})\s+is your (?:Google )?verification code/);
+        if (m) return m[1];
+      }
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+// ── PRIMARY: local keychain token swap ───────────────────────────────────────
+
+async function swapToken(account) {
+  const token = readStoredToken(account);
+  if (!token) {
+    log('[primary] No stored token — need browser fallback');
+    return false;
+  }
+  if (tokenExpired(token)) {
+    log('[primary] Token expired — need browser fallback');
+    return false;
+  }
+  log(`[primary] Swapping active keychain for ${accountKey(account)}...`);
+
+  // Preserve mcpOAuth from current active token (Figma, Shake etc.)
+  // so MCP connectors don't break on account swap
+  try {
+    const current = readKeychain();
+    const currentParsed = JSON.parse(current);
+    const newParsed = JSON.parse(token);
+    if (currentParsed.mcpOAuth && Object.keys(currentParsed.mcpOAuth).length > 0) {
+      // Merge: keep current mcpOAuth, only swap claudeAiOauth
+      newParsed.mcpOAuth = { ...newParsed.mcpOAuth, ...currentParsed.mcpOAuth };
+      writeKeychain(JSON.stringify(newParsed));
+      log('[primary] Preserved mcpOAuth from previous session');
+      return true;
+    }
+  } catch {}
+
+  writeKeychain(token);
+  return true;
+}
+
+// Save current active token back to the account's vault entry
+// Strips mcpOAuth so vault tokens are clean (mcpOAuth merged at swap time)
+function saveCurrentToken(account) {
+  try {
+    const token = readKeychain();
+    if (token.includes('claudeAiOauth')) {
+      // Store only claudeAiOauth, not mcpOAuth (that's session-specific)
+      try {
+        const parsed = JSON.parse(token);
+        const clean = { claudeAiOauth: parsed.claudeAiOauth, mcpOAuth: {} };
+        writeStoredToken(account, JSON.stringify(clean));
+      } catch {
+        writeStoredToken(account, token);
+      }
+      log(`Saved token to vault: ${tokenService(account)}`);
+      return true;
+    }
+  } catch (e) {
+    log(`Save token failed: ${e.message}`);
+  }
+  return false;
+}
+
+// ── Browser driver cascade ────────────────────────────────────────────────────
+
+// Driver cascade — Playwright only by default.
+// Kapture/Chrome-JXA/Manual are disabled because they may touch Comet (user's browser)
+// or depend on whatever is frontmost. Set CLAUDE_ROTATION_ENABLE_FALLBACKS=1 to enable.
+const _fallbacksEnabled = process.env.CLAUDE_ROTATION_ENABLE_FALLBACKS === '1';
+const DRIVER_CASCADE = [
+  ['playwright', makePlaywrightDriver], // CDP to Chrome/Chrome Beta with real profile
+  ...(_fallbacksEnabled
+    ? [
+        ['kapture', makeKaptureDriver],
+        ['chrome-jxa', makeChromeJXADriver],
+        ['manual', makeManualDriver],
+      ]
+    : []),
+];
+
+async function getBrowserDriver(skip = new Set()) {
+  for (const [name, factory] of DRIVER_CASCADE) {
+    if (skip.has(name)) continue;
+    try {
+      const d = await factory();
+      log(`Browser driver: ${name}`);
+      d._driverName = name;
+      return d;
+    } catch (err) {
+      log(`Driver [${name}] unavailable: ${err.message}`);
+    }
+  }
+  throw new Error('All browser drivers failed');
+}
+
+// ─── Driver 1: Kapture MCP (WebSocket → real Chrome, all Google sessions) ────
+
+async function makeKaptureDriver() {
+  const { default: WebSocket } = await import('ws');
+
+  // Auto-start Kapture server if not running
+  let ws;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      ws = await new Promise((resolve, reject) => {
+        const socket = new WebSocket('ws://localhost:61822/mcp');
+        const timer = setTimeout(() => {
+          socket.terminate();
+          reject(new Error('timeout'));
+        }, 4000);
+        socket.once('open', () => {
+          clearTimeout(timer);
+          resolve(socket);
+        });
+        socket.once('error', (e) => {
+          clearTimeout(timer);
+          reject(e);
+        });
+      });
+      break;
+    } catch {
+      if (attempt === 0) {
+        log('Kapture not running — starting server...');
+        spawn('npx', ['kapture-mcp'], {
+          detached: true,
+          stdio: 'ignore',
+        }).unref();
+        await sleep(3000);
+      }
+    }
+  }
+  if (!ws) throw new Error('Kapture unavailable');
+
+  // JSON-RPC over WebSocket
+  let msgId = 0;
+  const pending = new Map();
+
+  ws.on('message', (data) => {
+    try {
+      const msg = JSON.parse(data.toString());
+      if (msg.id !== undefined && pending.has(msg.id)) {
+        const { resolve, reject } = pending.get(msg.id);
+        pending.delete(msg.id);
+        msg.error ? reject(new Error(msg.error.message || JSON.stringify(msg.error))) : resolve(msg.result);
+      }
+    } catch {}
+  });
+
+  function rpc(method, params = {}) {
+    return new Promise((resolve, reject) => {
+      const id = ++msgId;
+      pending.set(id, { resolve, reject });
+      ws.send(JSON.stringify({ jsonrpc: '2.0', id, method, params }));
+      const t = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`RPC timeout: ${method}`));
+      }, 30_000);
+      const origResolve = pending.get(id)?.resolve;
+      if (origResolve) {
+        pending.set(id, {
+          resolve: (v) => {
+            clearTimeout(t);
+            resolve(v);
+          },
+          reject: (e) => {
+            clearTimeout(t);
+            reject(e);
+          },
+        });
+      }
+    });
+  }
+
+  function tool(name, args = {}) {
+    return rpc('tools/call', { name, arguments: args });
+  }
+
+  // MCP handshake
+  await rpc('initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'claude-rotation', version: '1.0' },
+  });
+  ws.send(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+      params: {},
+    }),
+  );
+
+  // Get existing tab or open new one
+  let tabId;
+  try {
+    const tabsResult = await tool('list_tabs', {});
+    const text = extractText(tabsResult);
+    log(`Kapture tabs: ${text.substring(0, 200)}`);
+    // Parse first tab ID from format: "Tab ID: abc123" or "id: abc123" or "(abc123)"
+    const m =
+      text.match(/[Tt]ab\s+[Ii][Dd][:\s]+([a-zA-Z0-9_-]+)/) ||
+      text.match(/\bid[:\s]+([a-zA-Z0-9_-]+)/) ||
+      text.match(/\(([a-zA-Z0-9_-]{6,})\)/);
+    tabId = m?.[1];
+  } catch {}
+
+  if (!tabId) {
+    // Open new tab
+    const result = await tool('new_tab', { browser: 'chrome' });
+    const text = extractText(result);
+    const m = text.match(/[Tt]ab\s+[Ii][Dd][:\s]+([a-zA-Z0-9_-]+)/) || text.match(/([a-zA-Z0-9_-]{8,})/);
+    tabId = m?.[1] || 'tab1';
+    await sleep(2000);
+  }
+
+  log(`Kapture using tab: ${tabId}`);
+
+  return {
+    name: 'kapture',
+    _tabId: tabId,
+    async goto(url) {
+      await tool('navigate', { tabId, url, timeout: 30_000 });
+      await sleep(2500);
+    },
+    async currentUrl() {
+      try {
+        const r = await tool('tab_detail', { tabId });
+        const text = extractText(r);
+        const m = text.match(/[Uu][Rr][Ll][:\s]+(\S+)/) || text.match(/https?:\/\/[^\s"',]+/);
+        return m?.[1] || m?.[0] || '';
+      } catch {
+        return '';
+      }
+    },
+    async findAndClick(texts) {
+      for (const t of texts) {
+        // CSS selector? Try that first — most reliable.
+        const isCss = /^[\[#.]/.test(t) || t.includes('data-testid') || t.includes('[type=');
+        if (isCss) {
+          try {
+            await tool('click', { tabId, selector: t });
+            log(`[kapture] clicked via CSS: ${t}`);
+            return true;
+          } catch {}
+          continue;
+        }
+        const clean = t
+          .replace(/button:has-text\("?([^"]+)"?\)/g, '$1')
+          .replace(/['"]/g, '')
+          .trim();
+        const escaped = clean.replace(/'/g, "\\'");
+        const xpaths = [
+          `//button[.//*[contains(normalize-space(.),'${escaped}')] or contains(normalize-space(.),'${escaped}')]`,
+          `//a[.//*[contains(normalize-space(.),'${escaped}')] or contains(normalize-space(.),'${escaped}')]`,
+          `//*[@role='button' and (.//*[contains(normalize-space(.),'${escaped}')] or contains(normalize-space(.),'${escaped}'))]`,
+          `//*[@aria-label='${escaped}' or contains(@aria-label,'${escaped}')]`,
+          `//*[normalize-space(text())='${escaped}']`,
+          `//*[contains(normalize-space(text()),'${escaped}')]`,
+          `//*[@data-identifier='${escaped}']`,
+          `//*[@placeholder='${escaped}']`,
+        ];
+        for (const xpath of xpaths) {
+          try {
+            await tool('click', { tabId, xpath });
+            log(`[kapture] clicked via xpath: ${xpath.substring(0, 80)}`);
+            return true;
+          } catch {}
+        }
+      }
+      return false;
+    },
+    async fillInput(sel, val) {
+      if (!val) return false;
+      try {
+        await tool('fill', { tabId, selector: sel, value: val });
+        return true;
+      } catch {}
+      // XPath fallback
+      try {
+        const xpath = `//*[self::input or self::textarea][@type='${sel.includes('password') ? 'password' : 'email'}']`;
+        await tool('fill', { tabId, xpath, value: val });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    async screenshot(path) {
+      try {
+        const r = await tool('screenshot', {
+          tabId,
+          format: 'png',
+          scale: 0.5,
+        });
+        const content = r?.content?.[0];
+        if (content?.type === 'image' && content.data) {
+          writeFileSync(path, Buffer.from(content.data, 'base64'));
+        }
+      } catch {}
+    },
+    async readPageText() {
+      try {
+        const r = await tool('dom', { tabId });
+        return extractText(r);
+      } catch {
+        return '';
+      }
+    },
+    // Poll list_tabs for a new tab that appears after a Google OAuth click.
+    // Returns a new driver bound to the popup's tab ID.
+    async waitForPopup(timeoutMs = 15_000) {
+      // Snapshot current tabs
+      const snapshotTabs = async () => {
+        try {
+          const r = await tool('list_tabs', {});
+          const text = extractText(r);
+          // Parse all tab IDs from the response
+          const ids = [];
+          const re = /[Tt]ab\s+[Ii][Dd][:\s]+([a-zA-Z0-9_-]+)|\(([a-zA-Z0-9_-]{6,})\)|"id"\s*:\s*"([a-zA-Z0-9_-]+)"/g;
+          let m;
+          while ((m = re.exec(text)) !== null) {
+            const id = m[1] || m[2] || m[3];
+            if (id) ids.push(id);
+          }
+          return new Set(ids);
+        } catch {
+          return new Set();
+        }
+      };
+
+      const before = await snapshotTabs();
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        await sleep(1000);
+        const after = await snapshotTabs();
+        const newTabs = [...after].filter((id) => !before.has(id) && id !== tabId);
+        if (newTabs.length > 0) {
+          const popupTabId = newTabs[0];
+          log(`Popup detected, switching to tab: ${popupTabId}`);
+          // Return a minimal driver bound to the popup tab
+          return {
+            name: 'kapture-popup',
+            _tabId: popupTabId,
+            async goto(url) {
+              await tool('navigate', {
+                tabId: popupTabId,
+                url,
+                timeout: 30_000,
+              });
+              await sleep(2500);
+            },
+            async currentUrl() {
+              try {
+                const r = await tool('tab_detail', { tabId: popupTabId });
+                const text = extractText(r);
+                const m = text.match(/[Uu][Rr][Ll][:\s]+(\S+)/) || text.match(/https?:\/\/[^\s"',]+/);
+                return m?.[1] || m?.[0] || '';
+              } catch {
+                return '';
+              }
+            },
+            async findAndClick(texts) {
+              for (const t of texts) {
+                const clean = t
+                  .replace(/button:has-text\("?([^"]+)"?\)/g, '$1')
+                  .replace(/['"]/g, '')
+                  .trim();
+                const xpaths = [
+                  `//*[normalize-space(text())='${clean}']`,
+                  `//*[contains(normalize-space(text()),'${clean}')]`,
+                  `//*[@data-identifier='${clean}']`,
+                  `//*[@placeholder='${clean}']`,
+                ];
+                for (const xpath of xpaths) {
+                  try {
+                    await tool('click', { tabId: popupTabId, xpath });
+                    return true;
+                  } catch {}
+                }
+              }
+              return false;
+            },
+            async fillInput(sel, val) {
+              if (!val) return false;
+              try {
+                await tool('fill', {
+                  tabId: popupTabId,
+                  selector: sel,
+                  value: val,
+                });
+                return true;
+              } catch {}
+              return false;
+            },
+            async waitForEvent() {
+              return null;
+            },
+            async close() {},
+          };
+        }
+      }
+      log('No popup appeared within timeout');
+      return null;
+    },
+    async close() {
+      ws.close();
+    },
+  };
+}
+
+// Helper: extract text from MCP tool result
+function extractText(result) {
+  if (!result) return '';
+  if (typeof result === 'string') return result;
+  const content = result.content || result;
+  if (Array.isArray(content)) {
+    return content.map((c) => c.text || c.data || '').join('\n');
+  }
+  return JSON.stringify(result);
+}
+
+// ─── Driver 2: Playwright attached to REAL Chrome via CDP ───────────────────
+// Attaches to the user's real Chrome/Comet profile (with all Google logins).
+// Strategy:
+//   1. If CDP is already up on :9222 → attach directly
+//   2. Else: gracefully quit Chrome, relaunch with CDP + the real user profile
+//   3. NEVER uses bundled Chromium, NEVER uses a separate profile dir
+//
+// The real user profile has all Google accounts signed in, so claude.ai's
+// OAuth account picker shows all of them.
+
+// Chrome Beta ONLY — dedicated automation browser.
+// Uses an ISOLATED profile (not linked to Chrome Beta's default). Starts empty;
+// rotation logs into Google accounts from scratch using dcli passwords + TOTP.
+// Comet = user's browser (never touch). Chrome = user's browser (never touch).
+const REAL_BROWSERS = [
+  {
+    name: 'Google Chrome Beta',
+    bin: '/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta',
+    profile: join(__dirname, '.chrome-beta-automation'),
+    appName: 'Google Chrome Beta',
+  },
+];
+
+// Ensure an isolated automation profile directory exists.
+// We use a FRESH profile with NO pre-logged accounts — rotation logs in from
+// scratch using dcli credentials + TOTP/SMS each time. This is cleaner than
+// trying to share Chrome's profile (cookie encryption is keychain-bound).
+function ensureSymlinkedProfile(browser) {
+  const auto = browser.profile;
+  if (!existsSync(auto)) {
+    execSync(`mkdir -p "${auto}"`, { timeout: 2000 });
+  }
+  // Persistent profile — it keeps cookies between runs so subsequent rotations
+  // can reuse existing logins. First run per account: full login flow.
+  // Subsequent runs: Google session cookies are still fresh, chooser shows
+  // the accounts, we just click to select.
+}
+const CDP_PORT = 9222;
+
+function findRealBrowser({ preferNotRunning = true } = {}) {
+  const existing = REAL_BROWSERS.filter((b) => existsSync(b.bin));
+  if (preferNotRunning) {
+    // Prefer a browser that isn't currently running (avoid disrupting user's session)
+    const notRunning = existing.find((b) => !isAppRunning(b.appName));
+    if (notRunning) return notRunning;
+  }
+  return existing[0] || null;
+}
+
+async function tryConnectCDP(chromium) {
+  try {
+    const browser = await chromium.connectOverCDP(`http://localhost:${CDP_PORT}`);
+    const contexts = browser.contexts();
+    const ctx = contexts[0] || (await browser.newContext());
+    const page = ctx.pages()[0] || (await ctx.newPage());
+    log(`[playwright] Attached to running Chrome via CDP :${CDP_PORT}`);
+    return { browser, ctx, page };
+  } catch {
+    return null;
+  }
+}
+
+function isAppRunning(appName) {
+  try {
+    execSync(`pgrep -f "${appName.replace(/ /g, '.')}" > /dev/null 2>&1`, {
+      timeout: 2000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function gracefullyQuitApp(appName) {
+  try {
+    execSync(`osascript -e 'tell application "${appName}" to quit' 2>/dev/null`, { timeout: 8000 });
+    // Wait up to 5s for it to actually quit
+    for (let i = 0; i < 10; i++) {
+      if (!isAppRunning(appName)) return true;
+      execSync('sleep 0.5');
+    }
+  } catch {}
+  return false;
+}
+
+async function makePlaywrightDriver() {
+  const { chromium } = await import('playwright');
+
+  // 1. Try attaching to already-running Chrome on CDP
+  let attached = await tryConnectCDP(chromium);
+  let weSpawnedChrome = false;
+  let spawnedProfile = null;
+
+  if (!attached) {
+    const browser = findRealBrowser();
+    if (!browser) throw new Error('No Comet / Chrome Beta / Chrome binary found');
+
+    // 2. Ensure symlinked profile exists (Chrome CDP requires non-default user-data-dir)
+    ensureSymlinkedProfile(browser);
+
+    // 3. Quit any running Chrome Beta that might be holding the real profile
+    //    (the symlinked profile shares Cookies/LoginData files with the real one).
+    if (isAppRunning(browser.appName)) {
+      log(`[playwright] ${browser.name} running — quitting to release profile files...`);
+      gracefullyQuitApp(browser.appName);
+      await sleep(1500);
+      // Force kill if still alive
+      try {
+        execSync(`pkill -f "${browser.appName}.app/Contents/MacOS"`);
+      } catch {}
+      await sleep(500);
+    }
+
+    // 4. Launch visible (NOT headless — Cloudflare blocks headless Chrome)
+    //    Positioned off-screen + 1x1 size so the window is effectively invisible
+    //    even on multi-monitor / retina setups where 3000,3000 clamps onto a display.
+    log(`[playwright] Launching ${browser.name} hidden (1x1 off-screen) with CDP :${CDP_PORT}...`);
+    spawn(
+      browser.bin,
+      [
+        `--remote-debugging-port=${CDP_PORT}`,
+        `--user-data-dir=${browser.profile}`,
+        '--no-first-run',
+        '--no-default-browser-check',
+        '--disable-blink-features=AutomationControlled',
+        '--disable-background-networking',
+        '--disable-component-update',
+        '--disable-default-apps',
+        '--disable-sync',
+        '--disable-notifications',
+        '--window-position=9000,9000',
+        '--window-size=1,1',
+      ],
+      { detached: true, stdio: 'ignore' },
+    ).unref();
+    weSpawnedChrome = true;
+    spawnedProfile = browser.profile;
+
+    // 4. Poll CDP until it comes up
+    for (let i = 0; i < 30; i++) {
+      await sleep(500);
+      attached = await tryConnectCDP(chromium);
+      if (attached) break;
+    }
+    if (!attached) throw new Error(`CDP didn't come up on :${CDP_PORT} within 15s`);
+  }
+
+  const { browser: pwBrowser, ctx, page } = attached;
+  return buildPageDriver(
+    'playwright',
+    page,
+    async () => {
+      try {
+        await pwBrowser.close();
+      } catch {}
+      // Kill Chrome Beta if WE spawned it — don't leave zombie Chromes
+      if (weSpawnedChrome && spawnedProfile) {
+        try {
+          execSync(`pkill -f "${spawnedProfile}"`, { timeout: 5000 });
+        } catch {}
+      }
+    },
+    ctx,
+  );
+}
+
+// ─── Driver 3: Chrome JXA ────────────────────────────────────────────────────
+
+async function makeChromeJXADriver() {
+  const test = execSync(
+    `osascript -l JavaScript -e '
+    var chrome = Application("Google Chrome");
+    "ok:" + chrome.windows[0].activeTab().url();
+  '`,
+    { timeout: 5000 },
+  )
+    .toString()
+    .trim();
+  if (!test.startsWith('ok:')) throw new Error('Chrome JXA test failed');
+
+  function jxaJs(js) {
+    return execSync(
+      `osascript -l JavaScript -e '
+      var chrome = Application("Google Chrome");
+      chrome.windows[0].activeTab().execute({javascript: ${JSON.stringify(js)}});
+    '`,
+      { timeout: 10_000 },
+    )
+      .toString()
+      .trim();
+  }
+
+  return {
+    name: 'chrome-jxa',
+    async goto(url) {
+      // Do NOT activate Chrome — focus-steal would interrupt the user's work.
+      // URL assignment alone is enough to drive navigation via JXA.
+      execSync(`osascript -l JavaScript -e '
+        var c = Application("Google Chrome");
+        c.windows[0].activeTab().url = ${JSON.stringify(url)};
+      '`);
+      await sleep(3000);
+    },
+    async currentUrl() {
+      return execSync(`osascript -l JavaScript -e '
+        Application("Google Chrome").windows[0].activeTab().url();
+      '`)
+        .toString()
+        .trim();
+    },
+    async findAndClick(texts) {
+      for (const t of texts) {
+        const clean = t
+          .replace(/button:has-text\("?([^"]+)"?\)/g, '$1')
+          .replace(/['"]/g, '')
+          .trim();
+        try {
+          const r = jxaJs(
+            `(function(){var els=document.querySelectorAll('button,a,[role=button],input[type=submit]');` +
+              `for(var e of els){if((e.textContent||e.value||'').trim().toLowerCase().includes('${clean.toLowerCase()}')){e.click();return'ok';}}return'miss';})()`,
+          );
+          if (r === 'ok') return true;
+        } catch {}
+      }
+      return false;
+    },
+    async fillInput(sel, val) {
+      if (!val) return false;
+      try {
+        jxaJs(
+          `(function(){var e=document.querySelector('${sel}');if(e){e.value='${val.replace(/'/g, "\\'")}';e.dispatchEvent(new Event('input',{bubbles:true}));e.dispatchEvent(new Event('change',{bubbles:true}));}})()`,
+        );
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    async screenshot(path) {
+      try {
+        execSync(`screencapture -x "${path}"`);
+      } catch {}
+    },
+    async waitForPopup() {
+      return null;
+    },
+    async close() {},
+  };
+}
+
+// ─── Driver 4: Manual ────────────────────────────────────────────────────────
+
+async function makeManualDriver() {
+  return {
+    name: 'manual',
+    async goto(url) {
+      execSync(`open "${url}"`);
+      notify('Account Rotation', 'Complete Google sign-in → click Allow');
+    },
+    async currentUrl() {
+      return '';
+    },
+    async findAndClick() {
+      return false;
+    },
+    async fillInput() {
+      return false;
+    },
+    async screenshot() {},
+    async waitForPopup() {
+      return null;
+    },
+    async close() {},
+  };
+}
+
+// ─── Playwright page → driver adapter ────────────────────────────────────────
+
+function buildPageDriver(name, page, closeFn, ctx) {
+  return {
+    name,
+    // Raw refs — exposed so the AI-brain fallback can screenshot / evaluate
+    // against the same page the flow is driving.
+    _page: page,
+    _ctx: ctx,
+    async goto(url) {
+      await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+      await page.waitForLoadState?.('networkidle', { timeout: 10_000 }).catch(() => {});
+    },
+    async currentUrl() {
+      return page.url();
+    },
+    async findAndClick(texts) {
+      for (const t of texts) {
+        // If it looks like a CSS selector (starts with [, #, ., or contains data-testid), use directly
+        const isCss = /^[\[#.]/.test(t) || t.includes('data-testid') || t.includes('[type=');
+        if (isCss) {
+          try {
+            const loc = page.locator(t).first();
+            if (await loc.isVisible({ timeout: 2000 }).catch(() => false)) {
+              await loc.click({ timeout: 5000 });
+              return true;
+            }
+          } catch {}
+          continue;
+        }
+        // Otherwise treat as text — broad matcher covering buttons, links, list items,
+        // and ARIA roles (Google 2FA pages use <li> for options, not <button>)
+        const clean = t
+          .replace(/button:has-text\("?([^"]+)"?\)/g, '$1')
+          .replace(/['"]/g, '')
+          .trim();
+        try {
+          // Try each element type individually so we don't get strict-mode violations
+          const selectors = [
+            `button:has-text("${clean}")`,
+            `a:has-text("${clean}")`,
+            `[role=button]:has-text("${clean}")`,
+            `[role=link]:has-text("${clean}")`,
+            `li:has-text("${clean}")`,
+            `div[data-challengetype]:has-text("${clean}")`,
+          ];
+          for (const sel of selectors) {
+            const loc = page.locator(sel).first();
+            if (await loc.isVisible({ timeout: 500 }).catch(() => false)) {
+              await loc.click({ timeout: 5000 });
+              return true;
+            }
+          }
+        } catch {}
+      }
+      return false;
+    },
+    async fillInput(sel, val) {
+      if (!val) return false;
+      try {
+        if (page.fill) {
+          // Short explicit timeout — Playwright's default is 30s, which
+          // causes a single iteration to hang for 30-60s when the selector
+          // doesn't exist on the current page (e.g. generic fallback on a
+          // page that's really a 2FA challenge). 3s is plenty for a real
+          // input; missing inputs should fail fast so the loop can move on.
+          await page.fill(sel, val, { timeout: 3000 });
+          return true;
+        }
+        await page.type(sel, val, { delay: 40, timeout: 3000 });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    async screenshot(path) {
+      try {
+        await page.screenshot({ path });
+      } catch {}
+    },
+    async readPageText() {
+      try {
+        return await page.evaluate(() => document.body?.innerText || '');
+      } catch {
+        return '';
+      }
+    },
+    async waitForPopup(timeout = 10_000) {
+      return ctx ? ctx.waitForEvent('page', { timeout }).catch(() => null) : null;
+    },
+    async close() {
+      await closeFn();
+    },
+  };
+}
+
+// ── Magic link Gmail polling ─────────────────────────────────────────────────
+
+/**
+ * Poll Gmail via `gog` CLI for a Claude magic link email.
+ * Returns the login URL from the email body, or null if not found within timeout.
+ */
+// Decode the target email embedded in a Claude magic-link URL.
+// Format: https://claude.ai/magic-link#<hex>:<base64-email>
+function magicLinkTargetEmail(url) {
+  try {
+    const hash = url.split('#')[1] || '';
+    const b64 = hash.split(':')[1] || '';
+    if (!b64) return null;
+    return Buffer.from(b64, 'base64').toString('utf-8').trim().toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+async function pollGmailForMagicLink(accountEmail, maxWaitMs = 120_000) {
+  const startTime = Date.now();
+  // Anchor to "now" so we never accept a magic-link email older than this call.
+  const requestedAt = Math.floor(Date.now() / 1000);
+  const targetLower = accountEmail.toLowerCase();
+  log(`[magic-link] Polling Gmail for login email to ${accountEmail} (max ${maxWaitMs / 1000}s)...`);
+
+  // Track skipped (stale/wrong-target) thread IDs so we don't re-evaluate them every poll
+  const seenSkip = new Set();
+
+  while (Date.now() - startTime < maxWaitMs) {
+    try {
+      // Pull up to 10 recent matches so a stale top-result doesn't block us.
+      const searchResult = execFileSync(
+        'gog',
+        ['gmail', 'search', 'subject:"Secure link to log in to Claude" newer_than:5m', '--max', '10', '-j'],
+        { timeout: 15_000, stdio: ['ignore', 'pipe', 'pipe'] },
+      )
+        .toString()
+        .trim();
+
+      const parsedSearch = JSON.parse(searchResult);
+      const list = Array.isArray(parsedSearch) ? parsedSearch : parsedSearch.threads || parsedSearch.results || [];
+
+      for (const item of list) {
+        const threadIdRaw = item.id || item.threadId;
+        if (!threadIdRaw) continue;
+        // Sanitize: Gmail IDs are alphanumeric. Reject anything else.
+        if (!/^[A-Za-z0-9_-]+$/.test(threadIdRaw)) continue;
+        if (seenSkip.has(threadIdRaw)) continue;
+
+        const threadJson = execFileSync('gog', ['gmail', 'read', threadIdRaw, '-j'], {
+          timeout: 15_000,
+          stdio: ['ignore', 'pipe', 'pipe'],
+        }).toString();
+
+        const parsed = JSON.parse(threadJson);
+        const messages = parsed?.thread?.messages || [];
+
+        // Reject any message older than our requestedAt (stale link from prior call)
+        const msgTimes = messages.map((m) => parseInt(m.internalDate || '0', 10) / 1000).filter((t) => t > 0);
+        const newestMsg = msgTimes.length ? Math.max(...msgTimes) : 0;
+        if (newestMsg && newestMsg < requestedAt - 5) {
+          seenSkip.add(threadIdRaw);
+          continue;
+        }
+
+        const decodedBodies = [];
+        const walkParts = (part) => {
+          const data = part?.body?.data;
+          if (data) {
+            try {
+              decodedBodies.push(Buffer.from(data, 'base64url').toString('utf-8'));
+            } catch {}
+          }
+          for (const p of part?.parts || []) walkParts(p);
+        };
+        for (const msg of messages) walkParts(msg.payload);
+        const fullBody = decodedBodies.join('\n');
+
+        const linkPatterns = [
+          /https:\/\/claude\.ai\/magic-link#[^\s"'<>)}\]]+/,
+          /https:\/\/claude\.ai\/api\/auth\/verify[^\s"'<>)}\]]+/,
+          /https:\/\/claude\.ai\/login\/verify[^\s"'<>)}\]]+/,
+          /https:\/\/claude\.ai\/auth\/verify[^\s"'<>)}\]]+/,
+          /https:\/\/claude\.ai\/[^\s"'<>)}\]]*(?:verify|confirm|magic-link|login\?code)[^\s"'<>)}\]]*/,
+        ];
+
+        let url = null;
+        for (const pattern of linkPatterns) {
+          const m = fullBody.match(pattern);
+          if (m) {
+            url = m[0];
+            break;
+          }
+        }
+
+        if (!url) {
+          const codeMatch = fullBody.match(/\b(\d{6,8})\b/);
+          if (codeMatch) {
+            log(`[magic-link] Found login code: ${codeMatch[1]}`);
+            return `code:${codeMatch[1]}`;
+          }
+          seenSkip.add(threadIdRaw);
+          continue;
+        }
+
+        // Validate the embedded target email matches our account.
+        // Without this, polling can grab a stale magic-link from a prior call
+        // (subject is identical for every account) and rotate to the wrong one.
+        const linkTarget = magicLinkTargetEmail(url);
+        if (linkTarget && linkTarget !== targetLower) {
+          log(`[magic-link] Skipping stale link for ${linkTarget} (waiting for ${targetLower})`);
+          seenSkip.add(threadIdRaw);
+          continue;
+        }
+
+        log(`[magic-link] Found login link: ${url.substring(0, 100)}...`);
+        return url;
+      }
+    } catch (err) {
+      const stderr = err.stderr ? err.stderr.toString().trim() : '';
+      log(`[magic-link] Gmail poll error: ${err.message}${stderr ? ' | stderr: ' + stderr : ''}`);
+    }
+    await sleep(5000);
+  }
+  log(`[magic-link] Timed out waiting for magic link email for ${accountEmail}`);
+  return null;
+}
+
+// ── Auth flow (driver-agnostic) ───────────────────────────────────────────────
+
+async function runAuthFlow(driver, account) {
+  const creds = fetchGoogleCreds(account) || {};
+  const googlePassword = creds.password || fetchGooglePassword(account);
+  const googleOtpSecret = creds.otpSecret || null;
+  const googleSmsPhone =
+    (process.env.CLAUDE_ROTATION_GOOGLE_SMS_PHONE || '').trim() ||
+    (account.googleSmsPhone || '').trim() ||
+    (creds.phone || '').trim() ||
+    null;
+  if (googlePassword) log(`dcli Google password available for ${account.email}${googleOtpSecret ? ' (+TOTP)' : ''}`);
+
+  // AI-brain stall detector: when the URL doesn't advance for N consecutive
+  // steps, hand the page to Claude to decide what to do. Kept separate from
+  // the hard-coded URL branches below — the branches stay fast + free for the
+  // common case; Claude only fires on genuinely unseen pages.
+  //
+  // Threshold is low (2) because each iteration's findAndClick/fillInput
+  // retries can take 20-60s on a page with nothing to match — we want Claude
+  // to intervene on the second stagnant step, not the fourth.
+  let lastStallUrl = '';
+  let stallCount = 0;
+  const STALL_THRESHOLD = 2;
+  const aiBrainHistory = [];
+  const aiBrainEnabled = driver._page && process.env.CLAUDE_ROTATOR_DISABLE_AI_BRAIN !== '1';
+
+  for (let step = 0; step < 20; step++) {
+    await sleep(2500);
+    const url = await driver.currentUrl().catch(() => '');
+    log(`Step ${step} [${driver.name}]: ${url.substring(0, 100)}`);
+
+    // Stall check — run BEFORE the URL pattern dispatcher so an unknown
+    // challenge page gets escalated to the AI brain. Skip on the very first
+    // step (no history yet) and skip inside the manual driver.
+    if (aiBrainEnabled && step > 0 && driver.name !== 'manual') {
+      if (url && url === lastStallUrl) {
+        stallCount++;
+      } else {
+        stallCount = 0;
+      }
+      lastStallUrl = url;
+      if (stallCount >= STALL_THRESHOLD && aiBrainHistory.length < AI_BRAIN_MAX_DECISIONS) {
+        const stallReason = `url stagnant for ${stallCount} steps: ${url.substring(0, 100)}`;
+        log(`[ai-brain] STALL DETECTED — ${stallReason}`);
+        const action = await askAIBrain({
+          page: driver._page,
+          account,
+          history: aiBrainHistory,
+          stallReason,
+          logger: (m) => log(`[ai-brain] ${m}`),
+        });
+        aiBrainHistory.push(
+          `${action.action}${action.selector ? `(${String(action.selector).slice(0, 40)})` : ''} — ${String(action.reason || '').slice(0, 60)}`,
+        );
+        if (action.action === 'abort') {
+          log(`[ai-brain] aborted — reason: ${action.reason}. Returning to caller.`);
+          return false;
+        }
+        const ok = await executeAIAction(driver, action, { googlePassword });
+        log(`[ai-brain] executed ${action.action}: ${ok ? 'ok' : 'no-op'}`);
+        stallCount = 0;
+        await sleep(3000);
+        continue;
+      }
+    }
+
+    // Success: redirected to localhost callback (check hostname, not query string)
+    try {
+      const parsed = new URL(url);
+      if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
+        log('Auth callback reached (localhost) — success');
+        return true;
+      }
+    } catch {}
+
+    // Success: landed on platform.claude.com success page
+    if (url.includes('/oauth/code/success')) {
+      log('Auth success page reached');
+      return true;
+    }
+
+    // Anthropic fallback redirect — extract code and replay to CLI's localhost
+    if (url.includes('/oauth/code/callback') && url.includes('code=')) {
+      log('Auth callback reached (platform.claude.com) — replaying to localhost');
+      const codeMatch = url.match(/[?&]code=([^&]+)/);
+      const stateMatch = url.match(/[?&]state=([^&]+)/);
+      if (codeMatch && driver._localhostPort) {
+        const replayUrl = `http://localhost:${driver._localhostPort}/callback?code=${codeMatch[1]}${stateMatch ? '&state=' + stateMatch[1] : ''}`;
+        try {
+          execSync(`curl -s "${replayUrl}" -o /dev/null`, { timeout: 5000 });
+        } catch {}
+      }
+      return true;
+    }
+    if (driver.name === 'manual') {
+      await sleep(12_000);
+      continue;
+    }
+
+    // Google 2FA: push notification to phone (/challenge/dp) — can't automate, must switch
+    if (url.includes('accounts.google.com') && url.includes('challenge/dp')) {
+      log(`Push-notification 2FA detected — clicking "Try another way"`);
+      const clicked = await driver.findAndClick(['Try another way', 'Probeer een andere manier']);
+      if (!clicked) {
+        log(`Could not find "Try another way" button`);
+        return false;
+      }
+      await sleep(4000);
+      continue;
+    }
+
+    // Google passkey challenge (/challenge/pk/presend, /challenge/pk/verify).
+    // No hardware key available — bail out via "Try another way".
+    if (url.includes('accounts.google.com') && url.includes('/challenge/pk')) {
+      log(`Passkey challenge detected — clicking "Try another way"`);
+      const clicked = await driver.findAndClick([
+        'Try another way',
+        'Try another method',
+        'Use password instead',
+        'Use your password instead',
+        'Probeer een andere manier',
+        'Gebruik wachtwoord',
+        'button:has-text("Try another way")',
+        'button:has-text("Use password")',
+        '[jsname="QkNstf"]',
+      ]);
+      if (!clicked) {
+        log(`Passkey: "Try another way" not clickable — AI-brain will escalate`);
+      } else {
+        await sleep(4000);
+      }
+      continue;
+    }
+
+    // Google 2FA: method selection page (/challenge/selection)
+    // Google orders options differently per account. Confirmed via CDP on
+    // a live "Too many failed attempts" selection page:
+    //   - data-challengetype="1"  → "Enter your password"
+    //   - data-challengetype="9"  → "Get a verification code" (SMS)
+    //   - data-challengetype="53" → "Use your passkey" / "Try another way"
+    //   - data-challengetype="6"  → TOTP authenticator app
+    // Preference: password (we have it via dcli) > TOTP (we have the secret)
+    //           > SMS (requires a phone) > passkey (no hardware).
+    if (url.includes('accounts.google.com') && url.includes('challenge/selection')) {
+      log(`On 2FA selection page — prefer password, then TOTP, then SMS`);
+      const selectors = [];
+      if (googlePassword)
+        selectors.push(
+          'div[data-challengetype="1"]',
+          'li:has-text("Enter your password")',
+          'Enter your password',
+          'Wachtwoord invoeren',
+        );
+      if (googleOtpSecret)
+        selectors.push(
+          'div[data-challengetype="6"]',
+          'li:has-text("Google Authenticator")',
+          'Google Authenticator',
+          'Authenticator app',
+        );
+      selectors.push(
+        'div[data-challengetype="9"]',
+        'li:has-text("Get a verification code")',
+        'Get a verification code',
+        'Text message',
+      );
+      const clicked = await driver.findAndClick(selectors);
+      if (clicked) {
+        await sleep(5000);
+        continue;
+      }
+      log(`No preferred method found on selection page — AI-brain will escalate`);
+      continue; // don't hard-abort; let stall detector route to AI-brain
+    }
+
+    // Google 2FA: TOTP code entry
+    if (url.includes('accounts.google.com') && url.includes('challenge/totp')) {
+      if (googleOtpSecret) {
+        const code = generateTOTP(googleOtpSecret);
+        log(`Entering TOTP code from dcli secret`);
+        await driver.fillInput('input[type="tel"], input[name=totpPin], #totpPin', code);
+        await sleep(500);
+        await driver.findAndClick(['Next', '#totpNext button', 'Verify']);
+        await sleep(3000);
+        continue;
+      }
+      log(`No TOTP secret — trying alternate verification`);
+      await driver.findAndClick(['Try another way']);
+      await sleep(2000);
+      continue;
+    }
+
+    // Google 2FA: SMS phone collect (/challenge/ipp/collect) — enter phone, click Send
+    if (url.includes('accounts.google.com') && url.includes('challenge/ipp/collect')) {
+      if (!googleSmsPhone) {
+        log(
+          `SMS phone collect page — no phone (set CLAUDE_ROTATION_GOOGLE_SMS_PHONE, account.googleSmsPhone, or dcli phone on google.com cred)`,
+        );
+        return false;
+      }
+      log(`SMS phone collect — entering configured number and clicking Send`);
+      await driver.fillInput('#phoneNumberId, input[type="tel"]', googleSmsPhone);
+      await sleep(500);
+      await driver.findAndClick(['Send', 'Next', 'Verstuur']);
+      await sleep(4000);
+      continue;
+    }
+
+    // Google 2FA: SMS code verify (/challenge/ipp/verify or /challenge/sms)
+    if (
+      url.includes('accounts.google.com') &&
+      (url.includes('challenge/ipp/verify') || url.includes('challenge/sms'))
+    ) {
+      log(`Waiting for SMS code from Messages.app (up to 60s)...`);
+      let smsCode = null;
+      for (let waitI = 0; waitI < 12; waitI++) {
+        await sleep(5000);
+        smsCode = readLatestSMSCode({ maxAgeSec: 180 });
+        if (smsCode) break;
+      }
+      if (!smsCode) {
+        log(`Failed to retrieve SMS code — aborting`);
+        return false;
+      }
+      log(`Got SMS code: ${smsCode}`);
+      await driver.fillInput('#idvPin, input[name="Pin"], input[type="tel"]', smsCode);
+      await sleep(500);
+      await driver.findAndClick(['Next', 'Verify']);
+      await sleep(4000);
+      continue;
+    }
+
+    // Google consent page (/signin/oauth/id or /signin/oauth/consent) — click Continue
+    if (
+      url.includes('accounts.google.com') &&
+      (url.includes('/signin/oauth/id') ||
+        url.includes('/signin/oauth/consent') ||
+        url.includes('/signin/oauth/legacy'))
+    ) {
+      log(`Google OAuth consent — clicking Continue`);
+      // Workspace accounts show a scope list with a Continue button at the bottom;
+      // sometimes it's disabled until the user scrolls. Try direct click first, then fall through.
+      const clicked = await driver.findAndClick([
+        'button[jsname="LgbsSe"]:has-text("Continue")',
+        'button[jsname="LgbsSe"]:has-text("Allow")',
+        'button[jsname="LgbsSe"]:has-text("Approve")',
+        'button:has-text("Continue")',
+        'button:has-text("Allow")',
+        'button:has-text("Approve")',
+        'button:has-text("Confirm")',
+        'button:has-text("Doorgaan")',
+        'button:has-text("Toestaan")',
+        '[role="button"]:has-text("Continue")',
+        '[role="button"]:has-text("Allow")',
+        '[role="button"]:has-text("Approve")',
+        'Continue',
+        'Allow',
+        'Approve',
+        'Confirm',
+        'Doorgaan',
+        'Toestaan',
+      ]);
+      if (!clicked) {
+        log(`Continue button not found on consent page — waiting and retrying`);
+      }
+      await sleep(3000);
+      continue;
+    }
+
+    // Google password prompt (standalone /challenge/pwd — must run BEFORE the
+    // broad accounts.google.com account-chooser branch below).
+    if (url.includes('accounts.google.com') && url.includes('challenge/pwd')) {
+      if (googlePassword) {
+        await driver.fillInput('input[type="password"]', googlePassword);
+        await sleep(500);
+        await driver.findAndClick(['Next', '#passwordNext button']);
+        continue;
+      }
+    }
+
+    // Google account chooser — click the target account
+    if (url.includes('accounts.google.com')) {
+      // Detect "Signed out" next to the target account (needs re-login)
+      let targetSignedOut = false;
+      if (driver.readPageText) {
+        try {
+          const txt = (await driver.readPageText()).toLowerCase();
+          const emailIdx = txt.indexOf(account.email.toLowerCase());
+          if (emailIdx >= 0) {
+            const nearby = txt.substring(emailIdx, emailIdx + 200);
+            targetSignedOut = nearby.includes('signed out');
+          }
+        } catch {}
+      }
+
+      const picked = await driver.findAndClick([account.email, `data-identifier="${account.email}"`]);
+      if (picked && targetSignedOut && googlePassword) {
+        // Account was signed out — click picked it, now password prompt will appear
+        log(`Account ${account.email} was signed out — password flow will handle`);
+      }
+      if (!picked) {
+        // Not in list — add manually
+        await driver.findAndClick(['Use another account', 'Add account']);
+        await sleep(2000);
+        await driver.fillInput('input[type="email"], #identifierId', account.email);
+        await sleep(500);
+        await driver.findAndClick(['Next', '#identifierNext button']);
+        await sleep(2000);
+        if (googlePassword) {
+          await driver.fillInput('input[type="password"]', googlePassword);
+          await sleep(500);
+          await driver.findAndClick(['Next', '#passwordNext button']);
+        }
+      }
+      continue;
+    }
+
+    // Claude organization/workspace chooser (Workspace accounts on a custom domain)
+    // Shown between Google OAuth return and /oauth/authorize. Pick Personal unless
+    // the account metadata specifies a team/organization name.
+    // URL match is intentionally broad — claude.ai has renamed the chooser route
+    // several times (select-organization, onboarding/organization, workspaces,
+    // choose-workspace). Also triggers on page-text heuristic for routes we miss.
+    const isOrgChooserUrl =
+      url.includes('claude.ai') &&
+      (url.includes('select-organization') ||
+        url.includes('/onboarding/organization') ||
+        url.includes('choose-organization') ||
+        url.includes('select-workspace') ||
+        url.includes('choose-workspace') ||
+        url.includes('workspaces') ||
+        url.includes('select-account') ||
+        url.includes('switch-org'));
+    let isOrgChooserByText = false;
+    if (!isOrgChooserUrl && url.includes('claude.ai') && driver.readPageText) {
+      try {
+        const t = (await driver.readPageText()).toLowerCase();
+        isOrgChooserByText =
+          (t.includes('choose an organization') ||
+            t.includes('select an organization') ||
+            t.includes('choose a workspace') ||
+            t.includes('select a workspace') ||
+            t.includes('which organization')) &&
+          (t.includes('personal') || t.includes('organization'));
+      } catch {}
+    }
+    if (isOrgChooserUrl || isOrgChooserByText) {
+      const orgLabel = account.organization || account.orgName || 'Personal';
+      log(
+        `Claude organization chooser (${isOrgChooserByText ? 'via page-text' : 'via URL'}) — selecting "${orgLabel}"`,
+      );
+      // Dump all visible button/link labels so we can see the real workspace
+      // names claude.ai is showing (vs what's configured as orgName).
+      if (driver.readPageText) {
+        try {
+          const t = await driver.readPageText();
+          const labels = [
+            ...new Set(
+              (t || '')
+                .split('\n')
+                .map((l) => l.trim())
+                .filter((l) => l.length > 0 && l.length < 80),
+            ),
+          ].slice(0, 40);
+          log(`[org-chooser] Visible lines: ${JSON.stringify(labels)}`);
+        } catch {}
+      }
+      const picked = await driver.findAndClick([
+        `button:has-text("${orgLabel}")`,
+        `[role="button"]:has-text("${orgLabel}")`,
+        `text="${orgLabel}"`,
+        orgLabel,
+        // Only fall back to "Personal" / "Continue" if the configured label
+        // is itself Personal — never silently default a team account to Personal.
+        ...(orgLabel === 'Personal' ? ['Personal', 'Continue'] : []),
+      ]);
+      if (!picked) {
+        log(`No organization button matched "${orgLabel}" — the account may land on the wrong org`);
+      }
+      await sleep(3000);
+      continue;
+    }
+
+    // Claude OAuth consent page — MUST check account BEFORE clicking Authorize.
+    // Match by pathname only — URL params (like redirect_uri=...callback) would
+    // false-match a substring check on the full URL.
+    let oauthPath = '';
+    try {
+      oauthPath = new URL(url).pathname;
+    } catch {}
+    if (oauthPath.includes('/oauth/authorize') || (oauthPath.endsWith('/authorize') && url.includes('claude'))) {
+      // Step 1: Read page to verify "Logged in as <correct email>"
+      let pageText = '';
+      if (driver.readPageText) {
+        try {
+          pageText = (await driver.readPageText()).toLowerCase();
+        } catch {}
+      }
+
+      const hasCorrectAccount = pageText && pageText.includes(account.email.toLowerCase());
+      const hasAnyOtherEmail = pageText && /[\w.+-]+@[\w.-]+\.\w+/.test(pageText) && !hasCorrectAccount;
+
+      // If we can't read the page OR we see the wrong account, force switch
+      if (!pageText || hasAnyOtherEmail) {
+        log(`Page text: ${pageText ? 'wrong account' : 'unreadable'} — clicking Switch account / Logout`);
+        const switched = await driver.findAndClick([
+          'Switch account',
+          'Log out',
+          'Logout',
+          'Sign out',
+          'Use another account',
+        ]);
+        if (switched) {
+          await sleep(3000);
+          continue;
+        }
+        // Couldn't find switch button — the page may already be the account chooser
+        // Try clicking the email we want directly
+        const picked = await driver.findAndClick([account.email]);
+        if (picked) {
+          await sleep(3000);
+          continue;
+        }
+        // Last resort: log and click authorize anyway (may fail)
+        log(`WARNING: Could not verify account — clicking Authorize blind`);
+      } else if (hasCorrectAccount) {
+        log(`Correct account confirmed: ${account.email}`);
+      }
+
+      // Step 2: Click Authorize — wait for button to become enabled (up to 30s)
+      let authorized = false;
+      for (let wait = 0; wait < 6; wait++) {
+        if (await driver.findAndClick(['Authorize', 'Allow', 'Approve', 'Accept'])) {
+          log('Clicked Authorize');
+          authorized = true;
+          break;
+        }
+        // Button might exist but be disabled — wait for page to finish loading
+        log(`Authorize button not clickable — waiting (attempt ${wait + 1}/6)...`);
+        await sleep(5000);
+      }
+      if (authorized) {
+        await sleep(4000);
+        continue;
+      }
+      log('Authorize button still not clickable after 30s — escalating to ai-brain');
+      // Fast-path ai-brain escalation: don't wait for stall detector to catch up
+      // on the next loop iter. The page is stuck on OAuth authorize and Haiku
+      // can usually pick the right org/continue button immediately.
+      if (aiBrainEnabled && aiBrainHistory.length < AI_BRAIN_MAX_DECISIONS) {
+        const action = await askAIBrain({
+          page: driver._page,
+          account,
+          history: aiBrainHistory,
+          stallReason: `authorize button not clickable on ${url.substring(0, 100)}`,
+          logger: (m) => log(`[ai-brain] ${m}`),
+        });
+        aiBrainHistory.push(
+          `${action.action}${action.selector ? `(${String(action.selector).slice(0, 40)})` : ''} — ${String(action.reason || '').slice(0, 60)}`,
+        );
+        if (action.action !== 'abort') {
+          const ok = await executeAIAction(driver, action, { googlePassword });
+          log(`[ai-brain] executed ${action.action}: ${ok ? 'ok' : 'no-op'}`);
+          stallCount = 0;
+          await sleep(3000);
+          continue;
+        }
+        log(`[ai-brain] aborted — reason: ${action.reason}`);
+      }
+      await sleep(3000);
+      continue;
+    }
+
+    // Dismiss cookie consent banner if present (blocks clicks on everything else)
+    if (url.includes('claude.ai')) {
+      await driver.findAndClick([
+        '[data-testid="consent-reject"]',
+        '[data-testid="consent-accept"]',
+        'Reject All Cookies',
+        'Accept All Cookies',
+      ]);
+      await sleep(500);
+    }
+
+    // Claude.ai login → Magic link path (when account.useMagicLink is set)
+    // The email input is always visible on /login — no button click needed first.
+    if (account.useMagicLink && url.includes('claude.ai/login')) {
+      // Fill the email input directly
+      const filled = await driver.fillInput('[data-testid="email"], #email, input[type="email"]', account.email);
+      if (filled) {
+        log(`[magic-link] Filled email: ${account.email}`);
+        await sleep(500);
+        // Click the "Continue with email" submit button (data-testid="continue")
+        const submitted = await driver.findAndClick([
+          '[data-testid="continue"]',
+          'button[type="submit"]:has-text("Continue with email")',
+          'button:has-text("Continue with email")',
+        ]);
+        if (submitted) {
+          log(`[magic-link] Submitted email — magic link should be sent`);
+          await sleep(3000);
+
+          // Poll Gmail for the magic link
+          const magicLink = await pollGmailForMagicLink(account.email);
+          if (magicLink) {
+            if (magicLink.startsWith('code:')) {
+              const code = magicLink.replace('code:', '');
+              log(`[magic-link] Entering verification code: ${code}`);
+              await driver.fillInput(
+                'input[type="text"], input[type="number"], input[name="code"], input[placeholder*="code" i]',
+                code,
+              );
+              await driver.findAndClick(['Continue', 'Verify', 'Submit', 'button[type="submit"]']);
+            } else {
+              log(`[magic-link] Navigating to login link`);
+              await driver.goto(magicLink);
+            }
+            await sleep(4000);
+            // After magic link login, session is now valid — re-navigate to authUrl
+            // so the OAuth flow can complete (org chooser → authorize → callback)
+            if (driver._authUrl) {
+              // For multi-org accounts (same email, multiple workspaces like
+              // user-personal vs user-team), force an explicit org
+              // pick BEFORE hitting /oauth/authorize. Otherwise claude.ai uses
+              // the "last active" org silently, and both sibling vaults end up
+              // holding the same org's token.
+              const isMultiOrg =
+                account.label && account.orgName && account.orgName.toLowerCase() !== account.email.toLowerCase();
+              if (isMultiOrg) {
+                log(
+                  `[magic-link] Multi-org account — forcing org pick for "${account.orgName}" via claude.ai/home detour`,
+                );
+                try {
+                  await driver.goto('https://claude.ai/home');
+                } catch {}
+                await sleep(3500);
+                // Try to click the configured orgName if a chooser is showing.
+                // The broadened org-chooser logic in the main loop will also
+                // pick this up on the next iteration, but an immediate attempt
+                // here short-circuits silently-skipped cases.
+                const picked = await driver.findAndClick([
+                  `button:has-text("${account.orgName}")`,
+                  `[role="button"]:has-text("${account.orgName}")`,
+                  `text="${account.orgName}"`,
+                  account.orgName,
+                ]);
+                if (picked) {
+                  log(`[magic-link] Pre-selected org "${account.orgName}" before OAuth`);
+                  await sleep(2500);
+                } else {
+                  log(
+                    `[magic-link] No immediate match for "${account.orgName}" — will rely on org-chooser loop / ai-brain`,
+                  );
+                }
+              }
+              log(`[magic-link] Re-navigating to OAuth authorize URL`);
+              try {
+                await driver.goto(driver._authUrl);
+              } catch {}
+              await sleep(3000);
+            }
+            continue;
+          }
+          log(`[magic-link] No magic link found in Gmail — falling through to Google OAuth`);
+        }
+      }
+    }
+
+    // Claude.ai login → Continue with Google (button has data-testid="login-with-google")
+    const popupP = driver.waitForPopup ? driver.waitForPopup(15_000) : Promise.resolve(null);
+    if (
+      await driver.findAndClick(['[data-testid="login-with-google"]', 'Continue with Google', 'Sign in with Google'])
+    ) {
+      const popup = await popupP;
+      if (popup) {
+        // Kapture popup is already a full driver; Playwright returns a raw Page
+        const pd = popup.name ? popup : buildPageDriver(driver.name + '-popup', popup, () => {}, null);
+        await runAuthFlow(pd, account);
+        if (popup.waitForEvent) {
+          await popup.waitForEvent('close', { timeout: 30_000 }).catch(() => {});
+        }
+      }
+      continue;
+    }
+
+    // Email input
+    if (await driver.fillInput('#identifierId, input[type="email"]', account.email)) {
+      await driver.findAndClick(['Next', '#identifierNext button']);
+    }
+  }
+
+  // Loop exhausted — final AI-brain attempt before giving up. Some flows
+  // legitimately exceed 20 steps (multi-factor + workspace chooser + consent),
+  // so give Claude up to its remaining decision budget to unstick us.
+  if (aiBrainEnabled && aiBrainHistory.length < AI_BRAIN_MAX_DECISIONS) {
+    const url = await driver.currentUrl().catch(() => '');
+    log(`[ai-brain] loop exhausted — final rescue attempt`);
+    for (let rescue = 0; rescue < AI_BRAIN_MAX_DECISIONS - aiBrainHistory.length && rescue < 3; rescue++) {
+      const action = await askAIBrain({
+        page: driver._page,
+        account,
+        history: aiBrainHistory,
+        stallReason: `loop exhausted at ${url.substring(0, 80)} (rescue ${rescue + 1})`,
+        logger: (m) => log(`[ai-brain] ${m}`),
+      });
+      aiBrainHistory.push(
+        `${action.action}${action.selector ? `(${String(action.selector).slice(0, 40)})` : ''} — ${String(action.reason || '').slice(0, 60)}`,
+      );
+      if (action.action === 'abort') break;
+      await executeAIAction(driver, action, { googlePassword });
+      await sleep(4000);
+      // Re-check success conditions after each rescue action
+      const newUrl = await driver.currentUrl().catch(() => '');
+      try {
+        const parsed = new URL(newUrl);
+        if (parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1') {
+          log('[ai-brain] rescue SUCCEEDED — localhost callback reached');
+          return true;
+        }
+      } catch {}
+      if (newUrl.includes('/oauth/code/success')) {
+        log('[ai-brain] rescue SUCCEEDED — claude.ai success page');
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+// ── Browser OAuth fallback ────────────────────────────────────────────────────
+
+async function browserOAuthFallback(account) {
+  log(`[fallback] Browser OAuth for ${account.email}...`);
+
+  const pid = process.pid;
+  const capScript = join(tmpdir(), `claude-url-cap-${pid}.sh`);
+  const urlFile = join(tmpdir(), `claude-auth-url-${pid}.txt`);
+  writeFileSync(capScript, `#!/bin/bash\necho "$1" > "${urlFile}"\n`);
+  chmodSync(capScript, 0o755);
+
+  const proc = spawn('claude', ['auth', 'login', '--email', account.email], {
+    env: { ...process.env, BROWSER: capScript },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  // BROWSER script gets the URL with localhost redirect (what we want).
+  // stderr gets a fallback URL with platform.claude.com redirect (don't use that).
+  // Prefer the file-captured URL — wait up to 15s for it, then fall back to stdout.
+  let authUrl = null;
+  for (let i = 0; i < 30; i++) {
+    await sleep(500);
+    if (existsSync(urlFile)) {
+      const u = readFileSync(urlFile, 'utf8').trim();
+      try {
+        unlinkSync(urlFile);
+      } catch {}
+      if (u.startsWith('http')) {
+        authUrl = u;
+        break;
+      }
+    }
+  }
+  if (!authUrl) {
+    // Fallback: parse from stderr (has platform.claude.com redirect, but still works)
+    authUrl = await new Promise((resolve) => {
+      const scan = (d) => {
+        const m = d.toString().match(/https?:\/\/[^\s\])"'\n]+/);
+        if (m) resolve(m[0]);
+      };
+      proc.stdout.on('data', scan);
+      proc.stderr.on('data', scan);
+      setTimeout(() => resolve(null), 15_000);
+    });
+  }
+  try {
+    unlinkSync(capScript);
+  } catch {}
+
+  if (!authUrl) {
+    proc.kill();
+    return false;
+  }
+  log(`Auth URL captured: ${authUrl.substring(0, 80)}...`);
+
+  // Extract localhost port from redirect_uri in the auth URL for code replay
+  const portMatch = authUrl.match(/redirect_uri=http%3A%2F%2Flocalhost%3A(\d+)/);
+  const localhostPort = portMatch ? portMatch[1] : null;
+  log(`Localhost callback port: ${localhostPort || 'unknown'}`);
+
+  // Cascade: try each driver in order until one completes the OAuth flow.
+  // A driver "fails" if runAuthFlow returns false (URL never reaches localhost callback).
+  const failed = new Set();
+  let success = false;
+
+  while (!success) {
+    let driver;
+    try {
+      driver = await getBrowserDriver(failed);
+    } catch (err) {
+      log(`Cascade exhausted: ${err.message}`);
+      break;
+    }
+    driver._localhostPort = localhostPort;
+    driver._authUrl = authUrl;
+
+    try {
+      log(`[${driver._driverName}] Logging out existing claude.ai session...`);
+      try {
+        await driver.goto('https://claude.ai/api/auth/logout');
+      } catch {}
+      await sleep(1500);
+      try {
+        await driver.goto('https://claude.ai/logout');
+      } catch {}
+      await sleep(1500);
+
+      // Page may have been destroyed by logout redirect — try navigating,
+      // and if the page is dead, get a fresh driver (new tab)
+      try {
+        await driver.goto(authUrl);
+      } catch (navErr) {
+        log(`[${driver._driverName}] Page died after logout (${navErr.message}) — getting fresh driver`);
+        try {
+          await driver.close();
+        } catch {}
+        try {
+          driver = await getBrowserDriver(failed);
+          driver._localhostPort = localhostPort;
+          await driver.goto(authUrl);
+        } catch (freshErr) {
+          log(`[${driver._driverName}] Fresh driver also failed: ${freshErr.message}`);
+          failed.add(driver._driverName || 'unknown');
+          continue;
+        }
+      }
+      success = await runAuthFlow(driver, account);
+
+      if (!success) {
+        log(`[${driver._driverName}] runAuthFlow returned false — trying next driver`);
+        failed.add(driver._driverName);
+        continue;
+      }
+
+      // Wait for claude auth login process to finish writing the keychain
+      await new Promise((r) => {
+        const t = setTimeout(() => {
+          proc.kill();
+          r();
+        }, 30_000);
+        proc.on('exit', () => {
+          clearTimeout(t);
+          r();
+        });
+        if (proc.exitCode !== null) {
+          clearTimeout(t);
+          r();
+        }
+      });
+    } catch (err) {
+      log(`[${driver._driverName}] threw: ${err.message}`);
+      failed.add(driver._driverName);
+    } finally {
+      try {
+        await driver.close();
+      } catch {}
+    }
+  }
+
+  return success;
+}
+
+// ── Session restart via tmux ─────────────────────────────────────────────────
+
+function findClaudeSessions() {
+  const sessions = [];
+  try {
+    const psOut = execSync(
+      `ps -eo pid,tty,args | grep -E '[c]laude.*--dangerously' | grep -v 'mcp ' | grep -v '\\-p '`,
+      { timeout: 5000 },
+    )
+      .toString()
+      .trim();
+    if (!psOut) return sessions;
+
+    const ttyMap = {};
+    try {
+      const paneOut = execSync(
+        `tmux list-panes -a -F '#{pane_tty}|#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null`,
+        { timeout: 3000 },
+      )
+        .toString()
+        .trim();
+      for (const line of paneOut.split('\n')) {
+        const [tty, pane] = line.split('|');
+        if (tty && pane) ttyMap[tty] = pane;
+      }
+    } catch {}
+
+    for (const line of psOut.split('\n')) {
+      const match = line.trim().match(/^(\d+)\s+(ttys?\d+)\s+(.+)$/);
+      if (!match) continue;
+      const [, pid, ttyShort, args] = match;
+      const tty = `/dev/${ttyShort}`;
+      const resumeMatch = args.match(/--resume\s+(\S+)/);
+      const resumeId = resumeMatch ? resumeMatch[1] : null;
+      const pane = ttyMap[tty] || null;
+      sessions.push({ pid: parseInt(pid), tty, pane, resumeId, args });
+    }
+  } catch (e) {
+    log(`[session] Failed to enumerate sessions: ${e.message.substring(0, 80)}`);
+  }
+  return sessions;
+}
+
+function sendKeysToPane(pane, txt) {
+  if (!pane) return false;
+  try {
+    execSync(`tmux send-keys -t ${JSON.stringify(pane)} ${JSON.stringify(txt)} C-m 2>/dev/null`, { timeout: 3000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function sendKeysToITerm(tty, txt) {
+  // Send text to an iTerm2 session matched by its TTY device path.
+  // IMPORTANT: Use `tell s to write text cmd` — the `write text "..." in s`
+  // form fails with -1723 ("Can't get ... in s. Access not allowed.") because
+  // AppleScript parses the `in s` clause as an accessor lookup, not a target.
+  const escaped = txt.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  const script = `
+tell application "iTerm2"
+  repeat with w in windows
+    repeat with t in tabs of w
+      repeat with s in sessions of t
+        if tty of s is "${tty}" then
+          tell s to write text "${escaped}"
+          return "ok"
+        end if
+      end repeat
+    end repeat
+  end repeat
+  return "not_found"
+end tell`;
+  try {
+    const result = execSync(`osascript -e '${script.replace(/'/g, "'\"'\"'")}'`, { timeout: 5000 })
+      .toString()
+      .trim();
+    return result === 'ok';
+  } catch {
+    return false;
+  }
+}
+
+// Walk up the process tree from `pid` and return the terminal app that owns
+// the session (e.g. "Ghostty", "iTerm2", "Terminal", "Alacritty", "WezTerm")
+// or "unknown" if none matched. Used to gate AppleScript injection to
+// terminals we know actually support it without launching a new app.
+function detectTerminalForPid(pid) {
+  try {
+    const out = execSync(`ps -eo pid,ppid,comm`, { timeout: 3000 }).toString().trim();
+    const byPid = new Map();
+    for (const line of out.split('\n').slice(1)) {
+      const m = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/);
+      if (m) byPid.set(parseInt(m[1]), { ppid: parseInt(m[2]), comm: m[3] });
+    }
+    let cur = parseInt(pid);
+    for (let i = 0; i < 40 && cur > 1; i++) {
+      const entry = byPid.get(cur);
+      if (!entry) break;
+      const c = entry.comm.toLowerCase();
+      if (c.includes('ghostty')) return 'Ghostty';
+      if (c.includes('iterm2') || c.includes('iterm')) return 'iTerm2';
+      if (c.includes('terminal.app') || /\/terminal$/.test(c)) return 'Terminal';
+      if (c.includes('alacritty')) return 'Alacritty';
+      if (c.includes('wezterm')) return 'WezTerm';
+      if (c.includes('kitty')) return 'kitty';
+      cur = entry.ppid;
+    }
+  } catch {}
+  return 'unknown';
+}
+
+async function refreshRunningSession(rotatedAccount = null, noBrowser = false) {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const sessions = findClaudeSessions();
+
+  if (sessions.length === 0) {
+    log('[session] No running Claude Code sessions found');
+    return;
+  }
+
+  // Tag each session with its owning terminal app. We only have a reliable
+  // AppleScript injection path for tmux + iTerm2. For Ghostty/Terminal/others,
+  // writing to the raw TTY shows as OUTPUT (garbles the live display) and
+  // `tell application "iTerm2"` would spuriously *launch* iTerm2 — so we skip.
+  for (const s of sessions) {
+    if (!s.pane && s.pid) s.terminal = detectTerminalForPid(s.pid);
+  }
+
+  const sendKeys = (s, txt) => {
+    if (s.pane) return sendKeysToPane(s.pane, txt);
+    if (s.terminal === 'iTerm2' && s.tty) return sendKeysToITerm(s.tty, txt);
+    // Ghostty, Terminal.app, Alacritty, WezTerm, kitty, unknown: skip.
+    // Raw TTY write would render "/login" as on-screen output text, not
+    // stdin — corrupting the session without triggering the re-auth.
+    return false;
+  };
+
+  // Reachable = tmux pane OR known-good terminal (iTerm2). Everyone else
+  // is logged + skipped so we never pop a visual window or garble Ghostty.
+  const reachable = sessions.filter((s) => s.pane || (s.terminal === 'iTerm2' && s.tty));
+  const skipped = sessions.filter((s) => !s.pane && s.terminal && s.terminal !== 'iTerm2');
+  for (const s of skipped) {
+    log(
+      `[session] Skipping PID ${s.pid} (${s.terminal}) — no safe inject path; token-refresh daemon keeps keys fresh so restart isn't required`,
+    );
+  }
+  if (reachable.length === 0) {
+    log(`[session] Found ${sessions.length} sessions but none have a reachable TTY`);
+    return;
+  }
+
+  log(`[session] Injecting /login into ${reachable.length} session(s):`);
+  for (const s of reachable) {
+    log(`  PID ${s.pid} ${s.pane ? 'pane=' + s.pane : 'tty=' + s.tty}`);
+  }
+
+  // Keychain was already swapped to the fresh account's valid token.
+  // /login re-reads the keychain → picks up the new token → "Login successful" instantly.
+  // No /exit, no process restart, no OAuth browser flow needed (token is already valid).
+  // Stagger slightly to avoid all sessions hitting the API at the exact same millisecond.
+  for (const s of reachable) {
+    if (sendKeys(s, '/login')) {
+      log(`[session] Sent /login to PID ${s.pid} (${s.pane || s.tty})`);
+    } else {
+      log(`[session] Failed to inject /login to PID ${s.pid} (${s.pane || s.tty})`);
+    }
+    await sleep(500); // 500ms stagger between sessions
+  }
+
+  // If Claude relaunches trigger an OAuth browser window (token expired mid-rotation),
+  // reuse the same browser driver that handles the initial auth flow.
+  // Skipped in --no-browser mode (daemon) — token refresh daemon keeps tokens fresh,
+  // so this fallback should never be needed from automatic rotations.
+  if (!noBrowser) {
+    try {
+      await sleep(2000);
+      const driver = await getBrowserDriver(new Set()).catch(() => null);
+      if (driver) {
+        const url = await driver.currentUrl().catch(() => '');
+        if (url && (url.includes('oauth') || url.includes('authorize') || url.includes('claude.ai/login'))) {
+          log(`[session] Detected post-restart OAuth page (${url.substring(0, 60)}) — driving flow`);
+          if (rotatedAccount) await runAuthFlow(driver, rotatedAccount);
+        }
+        try {
+          await driver.close?.();
+        } catch {}
+      }
+    } catch (e) {
+      log(`[session] Post-restart browser check skipped: ${e.message.substring(0, 60)}`);
+    }
+  }
+
+  log(`[session] Restart complete: ${reachable.length} session(s) cycled`);
+}
+
+// ── Main rotation ─────────────────────────────────────────────────────────────
+
+async function rotate(targetEmail, opts = {}) {
+  const config = readConfig();
+  const state = readState();
+  const dryRun = opts.dryRun || false;
+
+  if (!targetEmail) {
+    // Query live utilization for all accounts before picking — best-effort, ~2s
+    log('Querying live utilization for all accounts...');
+    const liveUtil = await queryAllUtilization(config);
+    const utilSummary = Object.entries(liveUtil)
+      .map(([k, v]) => `${k}:5h=${v.five_hour_pct}%/7d=${v.seven_day_pct}%`)
+      .join(', ');
+    if (utilSummary) log(`Live util: ${utilSummary}`);
+    // Snapshot live data into state for future daemon decisions
+    for (const [key, util] of Object.entries(liveUtil)) {
+      state.accounts[key] = state.accounts[key] || {};
+      state.accounts[key].lastUtilization = {
+        pct: util.five_hour_pct,
+        reset: util.resets_at_5h ? Math.floor(new Date(util.resets_at_5h).getTime() / 1000) : null,
+        ts: Date.now(),
+      };
+    }
+    const next = pickNextAccount(config, state, liveUtil, {
+      allowExtraUsage: opts.allowExtraUsage === true,
+    });
+    if (!next) {
+      log('No account available (all excluded — extra_usage enabled?)');
+      return false;
+    }
+    targetEmail = accountKey(next);
+  }
+
+  // Hard safety gate: even when the user passes --to <email> explicitly,
+  // refuse to activate a Max account where the Anthropic org has
+  // has_extra_usage_enabled=true (overage billing). Requires --allow-extra-usage
+  // to bypass.
+  try {
+    if (!opts.allowExtraUsage) {
+      const target = config.accounts.find((a) => accountKey(a) === targetEmail || a.email === targetEmail);
+      if (target) {
+        const tokenJson = readStoredToken(target);
+        if (tokenJson) {
+          const parsed = JSON.parse(tokenJson);
+          const accessToken = parsed?.claudeAiOauth?.accessToken;
+          if (accessToken) {
+            const res = await fetch('https://api.anthropic.com/api/oauth/profile', {
+              method: 'GET',
+              headers: {
+                Authorization: `Bearer ${accessToken}`,
+                'anthropic-beta': 'oauth-2025-04-20',
+                'Content-Type': 'application/json',
+              },
+              signal: AbortSignal.timeout(5000),
+            });
+            if (res.ok) {
+              const prof = await res.json();
+              const euEnabled = prof?.organization?.has_extra_usage_enabled === true;
+              if (euEnabled) {
+                log(
+                  `REFUSED: target ${targetEmail} has extra_usage enabled (pay-per-use). Pass --allow-extra-usage to override.`,
+                );
+                notify(
+                  'Rotation BLOCKED',
+                  `${targetEmail}: extra_usage enabled — would risk credit-card overage. Disable at console.anthropic.com/settings/billing`,
+                );
+                return false;
+              }
+            }
+          }
+        }
+      }
+    }
+  } catch (e) {
+    log(`Extra-usage preflight error (non-fatal): ${e.message?.slice(0, 80)}`);
+  }
+
+  // Find by label first, then by email
+  const account =
+    config.accounts.find((a) => accountKey(a) === targetEmail) || config.accounts.find((a) => a.email === targetEmail);
+  if (!account) {
+    log(`Account ${targetEmail} not in config`);
+    return false;
+  }
+  if (opts.magicLink) account.useMagicLink = true;
+  const key = accountKey(account);
+
+  log(`=== ROTATING: ${state.activeAccount || 'none'} → ${key} (${account.email}) ===`);
+  notify('Claude Account Rotation', `Switching to ${key}...`);
+
+  // Clear statsig cache to prevent device-level rate limit stickiness (anthropics/claude-code#12786)
+  try {
+    const statsigDir = join(process.env.HOME || '', '.claude', 'statsig');
+    if (existsSync(statsigDir)) {
+      const files = readdirSync(statsigDir).filter((f) => f.startsWith('statsig.cached.evaluations.'));
+      for (const f of files) {
+        try {
+          unlinkSync(join(statsigDir, f));
+        } catch {}
+      }
+      if (files.length > 0) log(`Cleared ${files.length} statsig cache files (device-level stickiness fix)`);
+    }
+  } catch {}
+
+  // Save outgoing token to the vault slot matching the active account.
+  // In --no-browser mode (daemon), skip the `claude auth status` call — it
+  // hits the Anthropic API and fails when we're already rate limited.
+  // Trust state.activeAccount instead.
+  if (opts.noBrowser) {
+    const trackedAccount = config.accounts.find((a) => accountKey(a) === state.activeAccount);
+    if (trackedAccount) {
+      if (!dryRun) saveCurrentToken(trackedAccount);
+      log(`[no-browser] Saved outgoing token for tracked ${accountKey(trackedAccount)}`);
+    } else {
+      log(`[no-browser] No tracked active account — skipping outgoing save`);
+    }
+  } else
+    try {
+      // Identify the live keychain account AUTHORITATIVELY via direct
+      // /oauth/profile call, not `claude auth status` — the CLI caches
+      // stale email/org from the last session and lies when the keychain
+      // has been swapped out from under it. Trusting it corrupts vaults.
+      const liveTokenJson = (() => {
+        try {
+          return readKeychain();
+        } catch {
+          return null;
+        }
+      })();
+      let liveEmail = null;
+      let liveOrgUuid = null;
+      if (liveTokenJson) {
+        try {
+          const liveAccessToken = JSON.parse(liveTokenJson)?.claudeAiOauth?.accessToken;
+          if (liveAccessToken) {
+            const res = await fetch('https://api.anthropic.com/api/oauth/profile', {
+              method: 'GET',
+              headers: {
+                Authorization: `Bearer ${liveAccessToken}`,
+                'anthropic-beta': 'oauth-2025-04-20',
+              },
+              signal: AbortSignal.timeout(5000),
+            });
+            if (res.ok) {
+              const prof = await res.json();
+              liveEmail = prof?.account?.email || null;
+              liveOrgUuid = prof?.organization?.uuid || null;
+            }
+          }
+        } catch {}
+      }
+      if (liveEmail) {
+        // For multi-entry emails (same email under multiple config entries,
+        // e.g. user-personal + user-team), prefer the entry whose
+        // orgUuid matches live. Fall back to first email match.
+        let liveAccount = null;
+        if (liveOrgUuid) {
+          liveAccount = config.accounts.find((a) => a.email === liveEmail && a.orgUuid === liveOrgUuid);
+        }
+        if (!liveAccount) {
+          liveAccount = config.accounts.find((a) => a.email === liveEmail);
+        }
+        if (liveAccount) {
+          if (!dryRun) saveCurrentToken(liveAccount);
+          log(
+            `${dryRun ? '[DRY-RUN] Would save' : 'Saved'} outgoing token for LIVE account ${accountKey(liveAccount)} (was tracked as ${state.activeAccount || 'none'})`,
+          );
+          // Keep state in sync with reality
+          if (state.activeAccount !== accountKey(liveAccount)) {
+            log(`State drift corrected: activeAccount ${state.activeAccount} → ${accountKey(liveAccount)}`);
+            state.activeAccount = accountKey(liveAccount);
+          }
+        } else {
+          log(`WARNING: live account ${liveEmail} not in config — skipping outgoing save`);
+        }
+      }
+    } catch (e) {
+      log(`Could not determine live account: ${e.message.substring(0, 80)}`);
+    }
+
+  // Snapshot outgoing account's utilization before clearing the rate-limits file.
+  // This lets pickNextAccount avoid rotating back to an exhausted account.
+  try {
+    const rlPath = join(__dirname, '.rate-limits.json');
+    if (existsSync(rlPath)) {
+      const rl = JSON.parse(readFileSync(rlPath, 'utf8'));
+      const outKey = state.activeAccount;
+      if (outKey && rl.five_hour) {
+        state.accounts[outKey] = state.accounts[outKey] || {};
+        state.accounts[outKey].lastUtilization = {
+          pct: rl.five_hour.pct,
+          reset: rl.five_hour.reset,
+          ts: Date.now(),
+        };
+        log(
+          `Snapshotted utilization for ${outKey}: 5h=${rl.five_hour.pct}% (resets ${new Date(rl.five_hour.reset * 1000).toISOString()})`,
+        );
+      }
+    }
+  } catch {}
+
+  // Clear stale rate limits file so daemon doesn't use old account's utilization
+  if (!dryRun) {
+    try {
+      unlinkSync(join(__dirname, '.rate-limits.json'));
+    } catch {}
+  } else {
+    log('[DRY-RUN] Would clear .rate-limits.json');
+  }
+
+  let ok;
+  if (dryRun) {
+    log('[DRY-RUN] Would swap token via swapToken()');
+    ok = true;
+  } else {
+    ok = await swapToken(account);
+    if (!ok && !opts.noBrowser) {
+      ok = await browserOAuthFallback(account);
+    } else if (!ok) {
+      log('[no-browser] Token swap failed — skipping browser fallback (daemon mode)');
+    }
+  }
+
+  if (!ok) {
+    log('Rotation failed');
+    notify('Account Rotation', `FAILED for ${targetEmail}`);
+    return false;
+  }
+
+  // POST-SWAP BILLING SAFETY CHECK
+  // The fresh token is now in the active keychain. Query /api/oauth/profile to
+  // verify has_extra_usage_enabled=false. If true, revert the swap by restoring
+  // the previous account's token — this prevents silent credit-card overages.
+  if (!opts.allowExtraUsage && !dryRun) {
+    try {
+      const freshJson = readKeychain();
+      const fresh = JSON.parse(freshJson);
+      const freshToken = fresh?.claudeAiOauth?.accessToken;
+      if (freshToken) {
+        const res = await fetch('https://api.anthropic.com/api/oauth/profile', {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${freshToken}`,
+            'anthropic-beta': 'oauth-2025-04-20',
+            'Content-Type': 'application/json',
+          },
+          signal: AbortSignal.timeout(5000),
+        });
+        if (res.ok) {
+          const prof = await res.json();
+          const euOn = prof?.organization?.has_extra_usage_enabled === true;
+          if (euOn) {
+            log(`POST-SWAP BLOCK: ${targetEmail} has extra_usage=ON (overage billing). Reverting swap.`);
+            notify(
+              'Rotation REVERTED',
+              `${targetEmail}: extra_usage enabled — charges would hit your card. Rollback in progress.`,
+            );
+            // Revert: restore previous account's stored token to active slot
+            const prevKey = state.activeAccount;
+            const prevAccount = prevKey ? config.accounts.find((a) => accountKey(a) === prevKey) : null;
+            if (prevAccount) {
+              const prevToken = readStoredToken(prevAccount);
+              if (prevToken) {
+                writeKeychain(prevToken);
+                log(`Reverted keychain to previous account ${prevKey}`);
+              }
+            }
+            return false;
+          }
+        } else {
+          log(
+            `POST-SWAP profile check returned ${res.status} — unable to verify extra_usage; proceeding (fail-open for transient errors)`,
+          );
+        }
+      }
+    } catch (e) {
+      log(`POST-SWAP billing check error (non-fatal): ${e.message?.slice(0, 80)}`);
+    }
+  }
+
+  // Verify by reading back what's now in the active keychain
+  let verified = false;
+  try {
+    const active = readKeychain();
+    const stored = readStoredToken(account);
+    // Token swap: verify the active keychain matches what we wrote.
+    // Guard against empty `stored` — substring("", 20, 80) === "" and
+    // active.includes("") is always true, which would spuriously verify.
+    if (stored && stored.length > 80 && active.includes(stored.substring(20, 80))) verified = true;
+    // Browser fallback: verify via CLI (skip in --no-browser mode — API may be rate limited)
+    if (!verified && !opts.noBrowser) {
+      const out = execSync('claude auth status 2>&1', {
+        timeout: 10_000,
+      }).toString();
+      verified = out.includes(account.email);
+    }
+  } catch {}
+  log(`Rotation ${verified ? 'VERIFIED' : 'UNVERIFIED'}: ${key} (${account.email})`);
+
+  // Org-match check: for accounts where label != email (multi-org under same
+  // email, like user-personal vs user-team), confirm the live
+  // /oauth/profile returns the expected organization. Drift here means the
+  // OAuth flow landed on the wrong org picker — the stored token will be
+  // usable but will double-count capacity with the sibling account.
+  // Fail-open: only log — don't unverify, because the token is still valid.
+  if (verified && account.orgName && account.label && !opts.noBrowser) {
+    try {
+      const liveTok = readKeychain();
+      const accessToken = JSON.parse(liveTok)?.claudeAiOauth?.accessToken;
+      if (accessToken) {
+        const res = await fetch('https://api.anthropic.com/api/oauth/profile', {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'anthropic-beta': 'oauth-2025-04-20',
+          },
+          signal: AbortSignal.timeout(5000),
+        });
+        if (res.ok) {
+          const prof = await res.json();
+          const liveOrg = prof?.organization?.name || '';
+          if (liveOrg && liveOrg !== account.orgName) {
+            log(
+              `⚠  ORG MISMATCH: ${key} expected "${account.orgName}" but live is "${liveOrg}" — OAuth org picker likely landed on wrong workspace. Token still saved but will share quota with sibling account under same email.`,
+            );
+          } else if (liveOrg) {
+            log(`Org match confirmed: ${liveOrg}`);
+          }
+        }
+      }
+    } catch (e) {
+      log(`Org-match check skipped: ${e.message?.slice(0, 80)}`);
+    }
+  }
+
+  // Trigger token refresh via `claude auth status` — skipped in --no-browser mode
+  // because the API is likely rate limited when the daemon triggers a rotation.
+  // Claude Code's own 30s keychain re-read will pick up the new token.
+  if (verified && !opts.noBrowser) {
+    try {
+      execSync('claude auth status 2>&1', { timeout: 10_000 });
+      log('Token refresh triggered via auth status');
+    } catch {}
+  }
+
+  // Save verified (and possibly refreshed) token to vault for future fast swaps
+  if (verified && !dryRun) saveCurrentToken(account);
+  if (verified && dryRun) log('[DRY-RUN] Would save verified token to vault');
+
+  // Update state — track cumulative window usage per account
+  const now = new Date().toISOString();
+  const windowMs = (config.rateLimits?.windowHours || 5) * 3_600_000;
+  if (state.activeAccount) {
+    const prev = (state.accounts[state.activeAccount] = state.accounts[state.activeAccount] || {});
+    prev.lastActive = now;
+    // Accumulate tool uses into the account's window total
+    const windowAge = prev.windowStart ? Date.now() - new Date(prev.windowStart).getTime() : Infinity;
+    if (windowAge >= windowMs) {
+      // Window expired — reset
+      prev.windowStart = prev.switchedAt || now;
+      prev.windowToolUses = state.toolUses || 0;
+    } else {
+      prev.windowToolUses = (prev.windowToolUses || 0) + (state.toolUses || 0);
+    }
+  }
+  // Initialize or carry over window data for target account
+  const target = (state.accounts[key] = {
+    ...(state.accounts[key] || {}),
+    switchedAt: now,
+    messagesSinceSwitch: 0,
+  });
+  const targetWindowAge = target.windowStart ? Date.now() - new Date(target.windowStart).getTime() : Infinity;
+  if (targetWindowAge >= windowMs) {
+    // Window expired — fresh start
+    target.windowStart = now;
+    target.windowToolUses = 0;
+  }
+  // else: keep existing window data (cumulative uses carry over)
+  state.activeAccount = key;
+  state.toolUses = 0;
+  state.lastRotation = now;
+  state.totalRotations = (state.totalRotations || 0) + 1;
+  writeState(state, dryRun);
+
+  notify('Claude Account Rotation', `${verified ? '✓' : '⚠'} Now using ${key}`);
+
+  if (opts.session) {
+    if (dryRun) {
+      log('[DRY-RUN] Would restart running Claude sessions with --continue and send resume prompt');
+    } else {
+      await refreshRunningSession(account, opts.noBrowser);
+    }
+  }
+  return verified;
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+async function setup() {
+  const config = readConfig();
+  const argv = process.argv.slice(2);
+  const filter = argv.find((a) => a.startsWith('--only='))?.slice(7);
+  const autoMode = argv.includes('--auto');
+  const magicLinkMode = autoMode || argv.includes('--magic-link');
+  const skipDone = argv.includes('--skip-valid');
+  const accounts = (
+    filter ? config.accounts.filter((a) => accountKey(a) === filter || a.email === filter) : config.accounts
+  ).filter((a) => {
+    if (a.disabled === true && !filter) {
+      console.log(`⏭  Skipping ${accountKey(a)}: disabled (${a.disabledReason || 'no reason given'})`);
+      return false;
+    }
+    return true;
+  });
+
+  console.log('\n=== Claude Account Rotation — Setup ===\n');
+  if (autoMode) {
+    console.log(`🤖 AUTO MODE — browser driver cascade + magic-link polling via gog/Gmail`);
+    console.log(`   Sequential processing (~60-120s per account). Logs → rotation.log.\n`);
+  }
+  console.log(`Re-capturing ${accounts.length} account(s). For each: OAuth → verify → save to vault.\n`);
+
+  const results = [];
+  for (const account of accounts) {
+    const key = accountKey(account);
+    console.log(`\n── ${key} (${account.email}) ──`);
+
+    // --skip-valid: skip accounts whose stored vault token is still good
+    if (skipDone) {
+      try {
+        const existing = readStoredToken(account);
+        if (existing && !tokenExpired(existing)) {
+          const p = JSON.parse(existing);
+          const t = p?.claudeAiOauth?.accessToken;
+          if (t) {
+            const res = await fetch('https://api.anthropic.com/api/oauth/profile', {
+              method: 'GET',
+              headers: {
+                Authorization: `Bearer ${t}`,
+                'anthropic-beta': 'oauth-2025-04-20',
+                'Content-Type': 'application/json',
+              },
+              signal: AbortSignal.timeout(4000),
+            });
+            if (res.ok) {
+              console.log(`⏭  Skipped: vault token still valid (--skip-valid).`);
+              results.push({ key, ok: true, skipped: true });
+              continue;
+            }
+          }
+        }
+      } catch {}
+    }
+
+    let oauthOk = true;
+    if (magicLinkMode) {
+      // Fully automated: claude auth login subprocess + browser driver cascade
+      // + magic-link email polling. No terminal interaction required.
+      account.useMagicLink = true;
+      console.log(`[auto] Automated OAuth — magic-link email to ${account.email} (routed to Gmail)...`);
+      try {
+        oauthOk = await browserOAuthFallback(account);
+      } catch (e) {
+        console.error(`❌ Automation threw: ${String(e.message || e).slice(0, 120)}`);
+        oauthOk = false;
+      }
+      if (!oauthOk) {
+        console.error(`❌ ${key}: auto OAuth failed. Retry manually: node rotate.mjs --setup --only=${key}`);
+        results.push({ key, ok: false, reason: 'auto-oauth-failed' });
+        continue;
+      }
+    } else {
+      console.log('Opening browser for OAuth. Complete the Google login, then come back here.');
+      const child = spawn('claude', ['auth', 'login', '--email', account.email], {
+        stdio: 'inherit',
+      });
+      await new Promise((r) => child.on('exit', r));
+    }
+
+    // Verify the login succeeded and matches the expected account
+    try {
+      const status = JSON.parse(execSync('claude auth status 2>&1', { timeout: 10_000 }).toString());
+      if (status.email !== account.email) {
+        console.error(`\n❌ MISMATCH: expected ${account.email}, got ${status.email}. Skipping save.`);
+        results.push({ key, ok: false, reason: `mismatch:${status.email}` });
+        continue;
+      }
+      console.log(`✅ Verified: ${status.email}`);
+      // Save to vault (strip mcpOAuth to keep vault clean)
+      const token = readKeychain();
+      try {
+        const parsed = JSON.parse(token);
+        const clean = { claudeAiOauth: parsed.claudeAiOauth, mcpOAuth: {} };
+        writeStoredToken(account, JSON.stringify(clean));
+      } catch {
+        writeStoredToken(account, token);
+      }
+      console.log(`✅ Saved to vault: ${tokenService(account)}`);
+      results.push({ key, ok: true });
+    } catch (e) {
+      console.error(`❌ Error: ${e.message}`);
+      results.push({
+        key,
+        ok: false,
+        reason: String(e.message || e).slice(0, 80),
+      });
+    }
+  }
+
+  // Summary
+  console.log(`\n=== Setup complete ===`);
+  const okCount = results.filter((r) => r.ok).length;
+  const failCount = results.length - okCount;
+  for (const r of results) {
+    const icon = r.ok ? (r.skipped ? '⏭ ' : '✅') : '❌';
+    console.log(`  ${icon} ${r.key}${r.reason ? `  (${r.reason})` : ''}`);
+  }
+  console.log(`\n${okCount}/${results.length} captured${failCount ? `, ${failCount} failed` : ''}.`);
+
+  // Post-setup billing audit (auto mode) — surfaces accounts with extra_usage on
+  if (autoMode && okCount > 0) {
+    console.log(`\n=== Billing audit (post-setup) ===\n`);
+    const liveUtil = await queryAllUtilization(readConfig());
+    let risky = 0;
+    let unknown = 0;
+    for (const a of config.accounts) {
+      const k = accountKey(a);
+      if (a.disabled === true) {
+        console.log(`  ⏸  ${k}: DISABLED — skipped`);
+        continue;
+      }
+      const u = liveUtil[k];
+      if (!u) {
+        console.log(`  ⚠  ${k}: token invalid/expired — cannot audit`);
+        unknown++;
+        continue;
+      }
+      if (u.extra_usage_enabled === true) {
+        console.log(`  🔴 ${k}: EXTRA_USAGE=ON — overage billing ACTIVE`);
+        risky++;
+      } else if (u.extra_usage_enabled === false) {
+        console.log(`  🟢 ${k}: extra_usage=off  5h=${u.five_hour_pct}% 7d=${u.seven_day_pct}%`);
+      } else {
+        console.log(`  ⚠  ${k}: extra_usage=unknown`);
+        unknown++;
+      }
+    }
+    if (risky > 0) {
+      console.log(
+        `\n🚨 ${risky} account(s) have extra_usage ON. Disable at:\n   https://console.anthropic.com/settings/billing`,
+      );
+    } else if (unknown === 0) {
+      console.log(`\n✅ All auditable accounts have extra_usage=off.`);
+    }
+  }
+  console.log(`\nSetup done. Run \`node rotate.mjs --audit-billing\` anytime to re-check.\n`);
+}
+
+// ── Status ────────────────────────────────────────────────────────────────────
+
+function showStatus() {
+  const config = readConfig();
+  const state = readState();
+  let liveEmail = null;
+  try {
+    const m = execSync('claude auth status 2>&1', { timeout: 10_000 })
+      .toString()
+      .match(/"email":\s*"([^"]+)"/);
+    if (m) liveEmail = m[1];
+  } catch {}
+
+  const since = (d) => {
+    if (!d) return 'never';
+    const s = Math.floor((Date.now() - new Date(d).getTime()) / 1000);
+    if (s < 60) return `${s}s ago`;
+    if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+    if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
+    return `${Math.floor(s / 86400)}d ago`;
+  };
+
+  // Read real utilization if available
+  let realUtil = null;
+  try {
+    const rlFile = join(__dirname, '.rate-limits.json');
+    if (existsSync(rlFile)) {
+      const rl = JSON.parse(readFileSync(rlFile, 'utf8'));
+      const age = Date.now() - rl.ts * 1000;
+      if (age < 5 * 60_000) realUtil = rl;
+    }
+  } catch {}
+
+  // Determine if the mismatch is expected (rotation just ran, session hasn't reloaded)
+  const recentRotation = state.lastRotation ? Date.now() - new Date(state.lastRotation).getTime() < 90_000 : false;
+  const mismatch =
+    liveEmail &&
+    state.activeAccount &&
+    !state.activeAccount.startsWith(liveEmail) &&
+    !liveEmail.startsWith(state.activeAccount);
+  const liveNote = mismatch && recentRotation ? ' (stale session — restart Claude Code to apply)' : '';
+
+  console.log('\n=== Claude Account Rotation ===\n');
+  console.log(`Live auth:       ${liveEmail || 'unknown'}${liveNote}`);
+  console.log(`Tracked active:  ${state.activeAccount || 'unknown'}`);
+  console.log(`Tool uses:       ${state.toolUses || 0} / ${config.toolUseThreshold}`);
+  if (realUtil) {
+    console.log(
+      `Real utilization: 5h=${realUtil.five_hour?.pct?.toFixed(1) || '?'}%  7d=${realUtil.seven_day?.pct?.toFixed(1) || '?'}%`,
+    );
+    if (realUtil.five_hour?.reset) {
+      const resetIn = Math.max(0, realUtil.five_hour.reset - Math.floor(Date.now() / 1000));
+      const hrs = Math.floor(resetIn / 3600);
+      const mins = Math.floor((resetIn % 3600) / 60);
+      console.log(`5h resets in:    ${hrs}h${mins}m`);
+    }
+  }
+  console.log(`Total rotations: ${state.totalRotations || 0}`);
+  console.log(`Last rotation:   ${since(state.lastRotation)}\n`);
+  console.log('Accounts:');
+  for (const a of config.accounts) {
+    const key = accountKey(a);
+    const s = state.accounts[key] || {};
+    const active = key === state.activeAccount ? ' ◀ ACTIVE' : '';
+    const prio = a.priority === 'low' ? ' (low priority)' : '';
+    const tokenOk = hasStoredToken(a) ? '✓ token stored' : '✗ no token';
+    const label = a.label ? ` [${a.label}]` : '';
+    const windowInfo = s.windowToolUses ? ` | window: ${s.windowToolUses} uses` : '';
+    console.log(`  ${a.email}${label}${active}${prio}`);
+    console.log(`    Keychain:    ${tokenOk}`);
+    console.log(`    Last active: ${since(s.lastActive)}${windowInfo}`);
+  }
+  console.log('');
+}
+
+// ── --capture: print current token for Dashlane ───────────────────────────────
+
+function captureCmd(targetEmail = null) {
+  const state = readState();
+  const config = readConfig();
+  let account;
+  if (targetEmail) {
+    const needle = String(targetEmail).trim().toLowerCase();
+    account = config.accounts.find((a) => a.email.toLowerCase() === needle);
+    if (!account) {
+      console.error(`No account in config matching --to ${targetEmail}`);
+      process.exit(1);
+    }
+  } else {
+    const activeKey = state.activeAccount;
+    account =
+      config.accounts.find((a) => accountKey(a) === activeKey) || config.accounts.find((a) => a.email === activeKey);
+    if (!account) {
+      console.error(`Active account ${activeKey} not in config`);
+      process.exit(1);
+    }
+  }
+
+  try {
+    const token = readKeychain();
+    if (!token.includes('claudeAiOauth')) {
+      console.error('No valid OAuth token in active keychain');
+      process.exit(1);
+    }
+    writeStoredToken(account, token);
+    console.log(`✓ Token captured and saved to keychain: ${tokenService(account)}`);
+    console.log(`  Account: ${account.email}${account.label ? ' [' + account.label + ']' : ''}`);
+  } catch (e) {
+    console.error(e.message);
+    process.exit(1);
+  }
+}
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+
+if (args.includes('--setup')) {
+  await setup();
+} else if (args.includes('--utilization')) {
+  // Live utilization query for all accounts
+  const config = readConfig();
+  const state = readState();
+  console.log('\nQuerying live utilization for all accounts...\n');
+  const liveUtil = await queryAllUtilization(config);
+  for (const a of config.accounts) {
+    const key = accountKey(a);
+    if (a.disabled === true) {
+      console.log(`  ⏸  ${key}: DISABLED — ${a.disabledReason || 'no reason given'}`);
+      continue;
+    }
+    const active = state.activeAccount === key ? ' ◀ ACTIVE' : '';
+    const u = liveUtil[key];
+    if (!u) {
+      console.log(`  ${key}: ❌ query failed${active}`);
+      continue;
+    }
+    const s5 = u.five_hour_pct;
+    const s7 = u.seven_day_pct;
+    const worst = Math.max(s5 ?? 0, s7 ?? 0);
+    const icon = worst >= 90 ? '🔴' : worst >= 70 ? '🟡' : '🟢';
+    const reset5 = u.resets_at_5h ? `resets ${new Date(u.resets_at_5h).toLocaleTimeString()}` : 'no reset';
+    const euIcon =
+      u.extra_usage_enabled === true ? ' 💳 EXTRA_USAGE_ON' : u.extra_usage_enabled === false ? '' : ' (eu?)';
+    console.log(`  ${icon} ${key}: 5h=${s5}% 7d=${s7}%  (${reset5})${euIcon}${active}`);
+  }
+  console.log('');
+} else if (args.includes('--audit-billing')) {
+  // Per-account billing audit — prints extra_usage state + any risk flags
+  const config = readConfig();
+  const state = readState();
+  console.log('\nAuditing billing state for all accounts...\n');
+  const liveUtil = await queryAllUtilization(config);
+  let risky = 0;
+  let unknown = 0;
+  for (const a of config.accounts) {
+    const key = accountKey(a);
+    if (a.disabled === true) {
+      console.log(`  ⏸  ${key}: DISABLED — ${a.disabledReason || 'no reason given'}`);
+      continue;
+    }
+    const active = state.activeAccount === key ? ' ◀ ACTIVE' : '';
+    const u = liveUtil[key];
+    if (!u) {
+      console.log(`  ⚠  ${key}: token invalid/expired — cannot audit${active}`);
+      unknown++;
+      continue;
+    }
+    const eu = u.extra_usage_enabled;
+    const bt = u.billing_type ?? '?';
+    const ss = u.subscription_status ?? '?';
+    if (eu === true) {
+      console.log(`  🔴 ${key}: EXTRA_USAGE=ON billing=${bt} status=${ss}${active}  ← overage billing ACTIVE`);
+      risky++;
+    } else if (eu === false) {
+      console.log(`  🟢 ${key}: extra_usage=off billing=${bt} status=${ss}${active}`);
+    } else {
+      console.log(`  ⚠  ${key}: extra_usage=unknown billing=${bt}${active}`);
+      unknown++;
+    }
+  }
+  console.log('');
+  console.log(`Summary: ${risky} risky, ${unknown} unknown, ${config.accounts.length - risky - unknown} safe`);
+  if (risky > 0) {
+    console.log(`\n⚠  Disable extra_usage at https://console.anthropic.com/settings/billing for each risky account.`);
+  }
+  console.log('');
+} else if (args.includes('--status')) {
+  showStatus();
+} else if (args.includes('--capture')) {
+  const capToIdx = args.indexOf('--to');
+  const captureTo = capToIdx !== -1 && args[capToIdx + 1] ? args[capToIdx + 1] : null;
+  captureCmd(captureTo);
+} else {
+  const toIdx = args.indexOf('--to');
+  const target = toIdx !== -1 ? args[toIdx + 1] : null;
+  const session = args.includes('--session');
+  const noBrowser = args.includes('--no-browser');
+  const force = args.includes('--force');
+  const dryRun = args.includes('--dry-run');
+  const magicLink = args.includes('--magic-link');
+  const allowExtraUsage = args.includes('--allow-extra-usage');
+  if (dryRun) log('DRY RUN MODE — no changes will be made');
+  if (force) {
+    log('Force mode — bypassing lock and killing any competing rotations');
+    // Kill other rotate.mjs processes (not this one)
+    try {
+      execSync(`pgrep -f 'node.*rotate.mjs' | grep -v ${process.pid} | xargs -r kill -9 2>/dev/null`);
+    } catch {}
+    try {
+      unlinkSync(LOCK_PATH);
+    } catch {}
+  }
+  if (!dryRun && !acquireLock()) {
+    console.error('Rotation in progress.');
+    process.exit(1);
+  }
+  try {
+    const ok = await rotate(target, {
+      session,
+      noBrowser,
+      dryRun,
+      magicLink,
+      allowExtraUsage,
+    });
+    process.exit(ok ? 0 : 1);
+  } catch (err) {
+    log(`FATAL: ${err.message}`);
+    notify('Account Rotation', `FAILED: ${err.message}`);
+    process.exit(1);
+  } finally {
+    releaseLock();
+  }
+}

--- a/claude-ops/scripts/account-rotation/setup-account.mjs
+++ b/claude-ops/scripts/account-rotation/setup-account.mjs
@@ -1,0 +1,352 @@
+#!/usr/bin/env node
+// setup-account.mjs — Standalone OAuth init for a single Claude account.
+//
+// Walks a magic-link login flow against claude.ai using Playwright, extracts
+// the session token from cookies, verifies the token against api.anthropic.com,
+// and writes it to the OS keychain via lib/credential-store.sh as
+// `Claude-Rotation-<account_id>`. Does NOT touch the active rotation state.
+//
+// Usage:
+//   node setup-account.mjs --email user@example.com [--display "Personal"] \
+//                          [--plan max] [--account-id <slug>] [--no-headless]
+//
+// Note: when the parallel account-rotation source lands, this file should be
+// folded into rotate.mjs as a `--setup-account <email>` mode, calling shared
+// keychain/verification helpers from there. Until then this file is callable
+// standalone.
+
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const CRED_STORE = resolve(REPO_ROOT, 'lib', 'credential-store.sh');
+const CONFIG_USER = join(
+  homedir(),
+  '.claude',
+  'plugins',
+  'data',
+  'ops-ops-marketplace',
+  'account-rotation-config.json',
+);
+const CONFIG_REPO = resolve(__dirname, 'config.json');
+const LOG_DIR = join(homedir(), '.claude', 'logs', 'account-rotation');
+
+function parseArgs(argv) {
+  const out = { headless: true, plan: 'max' };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--email') out.email = argv[++i];
+    else if (a === '--display') out.display = argv[++i];
+    else if (a === '--plan') out.plan = argv[++i];
+    else if (a === '--account-id') out.accountId = argv[++i];
+    else if (a === '--no-headless') out.headless = false;
+    else if (a === '--gmail-poll') out.gmailPoll = true;
+    else if (a === '--help' || a === '-h') {
+      console.log(
+        'usage: setup-account.mjs --email <addr> [--display <name>] [--plan pro|max] [--account-id <slug>] [--no-headless] [--gmail-poll]',
+      );
+      process.exit(0);
+    }
+  }
+  if (!out.email) {
+    console.error('error: --email is required');
+    process.exit(2);
+  }
+  if (!out.accountId) out.accountId = slugify(out.email);
+  if (!out.display) out.display = out.email;
+  return out;
+}
+
+function slugify(s) {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function log(msg) {
+  const ts = new Date().toISOString();
+  process.stderr.write(`[setup-account ${ts}] ${msg}\n`);
+}
+
+function ensureLogDir() {
+  if (!existsSync(LOG_DIR)) mkdirSync(LOG_DIR, { recursive: true });
+}
+
+function loadConfig() {
+  const path = existsSync(CONFIG_USER) ? CONFIG_USER : CONFIG_REPO;
+  if (!existsSync(path)) return { accounts: [] };
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return { accounts: [] };
+  }
+}
+
+function saveConfig(cfg) {
+  const path = CONFIG_USER;
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(cfg, null, 2));
+}
+
+function upsertAccount(args) {
+  const cfg = loadConfig();
+  cfg.accounts = cfg.accounts || [];
+  const existing = cfg.accounts.find((a) => a.id === args.accountId);
+  if (existing) {
+    existing.email = args.email;
+    existing.display = args.display;
+    existing.plan = args.plan;
+  } else {
+    cfg.accounts.push({
+      id: args.accountId,
+      email: args.email,
+      display: args.display,
+      plan: args.plan,
+      added: new Date().toISOString(),
+    });
+  }
+  saveConfig(cfg);
+  log(`config upserted: ${args.accountId} -> ${CONFIG_USER}`);
+}
+
+function credSet(service, account, secret) {
+  const r = spawnSync('bash', [CRED_STORE, 'set-stdin', service, account], {
+    input: secret,
+    encoding: 'utf8',
+  });
+  if (r.status !== 0) {
+    log(`credential-store set failed: ${r.stderr}`);
+    return false;
+  }
+  return true;
+}
+
+function credGet(service, account) {
+  const r = spawnSync('bash', [CRED_STORE, 'get', service, account], {
+    encoding: 'utf8',
+  });
+  if (r.status !== 0) return null;
+  return r.stdout.trim() || null;
+}
+
+async function ensurePlaywright() {
+  try {
+    await import('playwright');
+    return true;
+  } catch {
+    log('installing playwright (one-time)...');
+    const r = spawnSync('npm', ['install', '--no-save', 'playwright@^1.52.0'], {
+      cwd: REPO_ROOT,
+      stdio: 'inherit',
+    });
+    if (r.status !== 0) {
+      log('playwright install failed');
+      return false;
+    }
+    spawnSync('npx', ['playwright', 'install', 'chromium'], {
+      cwd: REPO_ROOT,
+      stdio: 'inherit',
+    });
+    return true;
+  }
+}
+
+async function pollGmailForMagicLink(toEmail, sinceTs) {
+  // Best-effort: use `gog` if available. Returns the link URL or null.
+  const probe = spawnSync('which', ['gog'], { encoding: 'utf8' });
+  if (probe.status !== 0) {
+    log('gog CLI not installed — falling back to manual confirmation');
+    return null;
+  }
+  const deadline = Date.now() + 5 * 60 * 1000; // 5 min
+  while (Date.now() < deadline) {
+    const r = spawnSync(
+      'gog',
+      [
+        'gmail',
+        'search',
+        `to:${toEmail} from:noreply@anthropic.com after:${Math.floor(sinceTs / 1000)} subject:"sign in"`,
+        '--max',
+        '3',
+        '-j',
+        '--results-only',
+        '--no-input',
+      ],
+      { encoding: 'utf8', timeout: 15000 },
+    );
+    if (r.status === 0 && r.stdout.trim()) {
+      try {
+        const threads = JSON.parse(r.stdout);
+        const first = Array.isArray(threads) ? threads[0] : null;
+        if (first?.id) {
+          const t = spawnSync('gog', ['gmail', 'thread', 'get', first.id, '-j'], { encoding: 'utf8', timeout: 15000 });
+          if (t.status === 0) {
+            const m = t.stdout.match(/https:\/\/claude\.ai\/(?:magic-link|verify|login)[^\s"'<>]+/);
+            if (m) return m[0];
+          }
+        }
+      } catch {}
+    }
+    await new Promise((r) => setTimeout(r, 5000));
+  }
+  return null;
+}
+
+async function runOAuth(args) {
+  const ok = await ensurePlaywright();
+  if (!ok) return null;
+  const { chromium } = await import('playwright');
+  const browser = await chromium.launch({ headless: args.headless });
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+
+  log('navigating to claude.ai/login');
+  await page.goto('https://claude.ai/login', { waitUntil: 'domcontentloaded' });
+
+  log(`filling email: ${args.email}`);
+  // Selector is best-effort — Anthropic's login form may change.
+  let emailSubmitted = true;
+  try {
+    await page.fill('input[type="email"], input[name="email"]', args.email, {
+      timeout: 15000,
+    });
+    await page.click('button[type="submit"], button:has-text("Continue")', {
+      timeout: 5000,
+    });
+  } catch (e) {
+    log(`email entry failed: ${e.message}`);
+    emailSubmitted = false;
+  }
+
+  if (!emailSubmitted && args.headless) {
+    log('aborting: email step failed in headless mode (no manual recovery)');
+    await browser.close();
+    return null;
+  }
+
+  const sinceTs = Date.now();
+  log('magic-link sent — waiting for completion...');
+  if (args.gmailPoll) {
+    const link = await pollGmailForMagicLink(args.email, sinceTs);
+    if (link) {
+      log(`got magic link from gmail — navigating`);
+      await page.goto(link, { waitUntil: 'domcontentloaded' });
+    } else {
+      log('gmail poll timed out — waiting for manual click');
+    }
+  }
+
+  // Poll for 2FA indicators while waiting for the post-login app shell.
+  // This emits a log line the SKILL.md contract expects so the operator
+  // can relay a TOTP code via AskUserQuestion.
+  let twoFaLogged = false;
+  const twoFaPoll = setInterval(async () => {
+    if (twoFaLogged) return;
+    try {
+      const has2FA = await page.evaluate(() => {
+        const text = (document.body?.innerText || '').toLowerCase();
+        return (
+          text.includes('two-factor') ||
+          text.includes('2fa') ||
+          text.includes('verification code') ||
+          text.includes('authenticator') ||
+          text.includes('one-time') ||
+          !!document.querySelector('input[autocomplete="one-time-code"]')
+        );
+      });
+      if (has2FA) {
+        twoFaLogged = true;
+        log('2FA prompt detected');
+      }
+    } catch {
+      /* page may have navigated — ignore */
+    }
+  }, 3000);
+  // Wait for the post-login app shell. 10 min ceiling for 2FA / manual click.
+  try {
+    await page.waitForURL(/claude\.ai\/(?:chats?|new|projects)/, {
+      timeout: 10 * 60 * 1000,
+    });
+  } catch (e) {
+    clearInterval(twoFaPoll);
+    log(`login did not complete in time: ${e.message}`);
+    await browser.close();
+    return null;
+  }
+  clearInterval(twoFaPoll);
+
+  const cookies = await ctx.cookies('https://claude.ai');
+  const session = cookies.find((c) => c.name === 'sessionKey' || c.name === '__Secure-next-auth.session-token');
+  await browser.close();
+  if (!session) {
+    log('no session cookie found after login');
+    return null;
+  }
+  return { name: session.name, value: session.value };
+}
+
+async function verifyToken(session) {
+  // Minimal probe — the rotation system uses this token to mint API requests
+  // via the Claude Code OAuth bridge. We just check that claude.ai accepts it.
+  const { name, value } = session;
+  try {
+    const res = await fetch('https://claude.ai/api/organizations', {
+      headers: { Cookie: `${name}=${value}` },
+    });
+    return res.ok;
+  } catch (e) {
+    log(`verify error: ${e.message}`);
+    return false;
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  ensureLogDir();
+  log(`starting setup for ${args.email} (id=${args.accountId}, plan=${args.plan})`);
+
+  const existingToken = credGet('Claude-Rotation', args.accountId);
+  if (existingToken) {
+    log(`keychain entry already present for ${args.accountId} — skipping OAuth`);
+    upsertAccount(args);
+    console.log(JSON.stringify({ ok: true, accountId: args.accountId, skipped: true }));
+    return;
+  }
+
+  const session = await runOAuth(args);
+  if (!session) {
+    console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: 'oauth_failed' }));
+    process.exit(1);
+  }
+
+  const verified = await verifyToken(session);
+  if (!verified) {
+    console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: 'verify_failed' }));
+    process.exit(1);
+  }
+
+  const stored = credSet(
+    'Claude-Rotation',
+    args.accountId,
+    JSON.stringify({ cookieName: session.name, token: session.value }),
+  );
+  if (!stored) {
+    console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: 'keychain_write_failed' }));
+    process.exit(1);
+  }
+
+  upsertAccount(args);
+  log(`✓ ${args.accountId} initialized`);
+  console.log(JSON.stringify({ ok: true, accountId: args.accountId, email: args.email }));
+}
+
+main().catch((e) => {
+  log(`fatal: ${e.stack || e.message}`);
+  console.log(JSON.stringify({ ok: false, error: String(e.message || e) }));
+  process.exit(1);
+});

--- a/claude-ops/scripts/lib/deploy-fix-common.sh
+++ b/claude-ops/scripts/lib/deploy-fix-common.sh
@@ -162,8 +162,9 @@ resolve_version_url() {
 }
 
 dispatch_fix_agent() {
-  # $1 = prompt template path (in $PLUGIN_ROOT/prompts/), $2 = lock_id, rest = template vars as KEY=VAL
-  local template="$1" lock_id="$2"; shift 2
+  # $1 = agent_name (matches claude-ops/agents/<name>.md OR ~/.claude/agents/<name>.md)
+  # $2 = lock_id, rest = context vars as KEY=VAL (substituted into a thin task brief)
+  local agent_name="$1" lock_id="$2"; shift 2
   if ! lock_acquire "$lock_id"; then
     return 2  # already in flight
   fi
@@ -174,28 +175,30 @@ dispatch_fix_agent() {
     return 3
   fi
 
-  local prompt_file="$PLUGIN_ROOT/prompts/$template"
-  if [ ! -f "$prompt_file" ]; then
-    lock_release "$lock_id"
-    return 4
-  fi
-  local prompt=$(cat "$prompt_file")
+  # Build the thin task brief — full persona/tools/model come from the agent file.
+  local context=""
   for kv in "$@"; do
     local k="${kv%%=*}" v="${kv#*=}"
-    prompt="${prompt//\{\{${k}\}\}/$v}"
+    context="${context}${k}: ${v}"$'\n'
   done
 
   local fix_log="$LOGS_DIR/fix-${lock_id}-$(date +%s).log"
-  local model=$(config fix_model haiku)
   local danger_flag="--permission-mode acceptEdits"
   [ "$(config allow_dangerous false)" = "true" ] && danger_flag="--dangerously-skip-permissions"
 
   command -v claude >/dev/null || { lock_release "$lock_id"; return 5; }
 
+  # Use --agent <name> so the agent's frontmatter (model/tools/persona) is honored.
+  # The brief is just the failure context — persona + workflow + guardrails come from agent file.
+  local brief="Failure context for your repair task:
+
+${context}
+Execute per your agent definition. Final line of output must be RESOLVED/RERUN/RETRY/BLOCKED."
+
   nohup bash -c "
-    printf '%s' \"\$1\" | claude -p --model $model $danger_flag --no-session-persistence > '$fix_log' 2>&1
+    printf '%s' \"\$1\" | claude -p --agent '$agent_name' $danger_flag --no-session-persistence > '$fix_log' 2>&1
     rm -f '$STATE_DIR/lock-$lock_id'
-  " _ "$prompt" </dev/null >/dev/null 2>&1 &
+  " _ "$brief" </dev/null >/dev/null 2>&1 &
   disown 2>/dev/null || true
   echo "$fix_log"
   return 0

--- a/claude-ops/scripts/lib/deploy-fix-common.sh
+++ b/claude-ops/scripts/lib/deploy-fix-common.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# deploy-fix-common.sh — shared helpers for the deploy/build auto-fix subsystem.
+# Sourced by hook scripts and the background monitor. Uses ${CLAUDE_PLUGIN_ROOT}
+# when invoked from inside the plugin; falls back to inferred paths.
+
+set -u
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+[ -z "$PLUGIN_ROOT" ] && PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export PLUGIN_ROOT
+
+PREFS_DIR="${HOME}/.claude/plugins/data/ops-ops-marketplace"
+PREFS_FILE="$PREFS_DIR/preferences.json"
+STATE_DIR="${OPS_DEPLOY_FIX_STATE:-${HOME}/.claude/state/ops-deploy-fix}"
+LOGS_DIR="${OPS_DEPLOY_FIX_LOGS:-${HOME}/.claude/logs/ops-deploy-fix}"
+mkdir -p "$STATE_DIR" "$LOGS_DIR" 2>/dev/null
+
+# config <key> <default>  — reads CLAUDE_PLUGIN_OPTION_<KEY>, then plugin prefs, then default
+config() {
+  local key="$1" default="$2"
+  local env_var="CLAUDE_PLUGIN_OPTION_$(echo "$key" | tr '[:lower:]' '[:upper:]')"
+  if [ -n "${!env_var:-}" ]; then echo "${!env_var}"; return; fi
+  if [ -f "$PREFS_FILE" ]; then
+    local v=$(jq -r --arg k "$key" '.[$k] // .deploy_fix[$k] // empty' "$PREFS_FILE" 2>/dev/null)
+    [ -n "$v" ] && [ "$v" != "null" ] && { echo "$v"; return; }
+  fi
+  echo "$default"
+}
+
+is_enabled() {
+  [ "$(config deploy_fix_enabled true)" = "true" ] && [ "$(config "$1" true)" = "true" ]
+}
+
+repo_slug_safe() { echo "$1" | tr '/' '-'; }
+
+# Single-flight lock per repo+kind. Returns 0 if acquired, 1 if held.
+lock_acquire() {
+  local id="$1"
+  local f="$STATE_DIR/lock-$id"
+  if [ -f "$f" ]; then
+    local pid=$(cat "$f" 2>/dev/null)
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      return 1  # alive
+    fi
+    rm -f "$f"  # stale
+  fi
+  echo $$ > "$f"
+  return 0
+}
+lock_release() { rm -f "$STATE_DIR/lock-$1" 2>/dev/null; }
+
+# Hourly budget per repo. Returns 0 if under cap (and increments), 1 if over.
+budget_check_increment() {
+  local slug="$1"
+  local cap=$(config max_fixes_per_hour 3)
+  local hour=$(date +%Y%m%d-%H)
+  local f="$STATE_DIR/budget-$slug-$hour"
+  local n=$(cat "$f" 2>/dev/null || echo 0)
+  if [ "$n" -ge "$cap" ]; then return 1; fi
+  echo $((n + 1)) > "$f"
+  return 0
+}
+
+# Dedup by content hash — same failure tail twice in a row = skip second dispatch.
+already_seen() {
+  local slug="$1" content="$2"
+  local hash=$(printf '%s' "$content" | shasum | awk '{print $1}')
+  local f="$STATE_DIR/last-failure-$slug"
+  local last=$(cat "$f" 2>/dev/null || echo "")
+  if [ "$last" = "$hash" ]; then return 0; fi
+  echo "$hash" > "$f"
+  return 1
+}
+
+# Detect transient failure signatures. Returns 0 (transient) or 1.
+is_transient() {
+  printf '%s' "$1" | grep -qE \
+'ECONNRESET|ETIMEDOUT|EAI_AGAIN|EHOSTUNREACH|TLS handshake timeout|unexpected EOF while reading|Could not resolve host|network is unreachable|\
+npm error code E429|npm error 5(0[0-9]|2[0-9])|HTTP(S)?Error:? 429|HTTP(S)?Error:? 5[0-9]{2}|\
+The runner has received a shutdown signal|The hosted runner lost communication|The operation was canceled\.|GH001:|\
+TooManyRequestsException|ThrottlingException|RequestLimitExceeded|Service Unavailable Exception|\
+Apple ID server.*temporarily unavailable|App Store Connect.*timed out|ASC.*5[0-9]{2}|\
+Simulator failed to launch|ECR.*throttle'
+}
+
+notify() {
+  local title="$1" msg="$2"
+  local channel=$(config notify_channel macos)
+  case "$channel" in
+    macos)
+      command -v terminal-notifier >/dev/null && \
+        terminal-notifier -title "$title" -message "$msg" -sender com.apple.Terminal 2>/dev/null
+      ;;
+    ntfy)
+      local topic=$(config ntfy_topic "")
+      [ -n "$topic" ] && curl -sS -X POST "https://ntfy.sh/$topic" -H "Title: $title" -d "$msg" >/dev/null 2>&1
+      ;;
+    discord)
+      local hook=$(config discord_default_webhook_url "")
+      [ -n "$hook" ] && curl -sS -X POST "$hook" -H 'Content-Type: application/json' \
+        -d "$(jq -n --arg c "**$title** — $msg" '{content:$c}')" >/dev/null 2>&1
+      ;;
+    pushover)
+      local user=$(config pushover_user_key "") token=$(config pushover_app_token "")
+      [ -n "$user" ] && [ -n "$token" ] && \
+        curl -sS https://api.pushover.net/1/messages.json \
+          --form-string "token=$token" --form-string "user=$user" \
+          --form-string "title=$title" --form-string "message=$msg" >/dev/null 2>&1
+      ;;
+    none) : ;;
+  esac
+}
+
+# Locate repo on disk via configurable search roots.
+locate_repo() {
+  local slug="$1" repo_only="${1#*/}"
+  local roots="$(config repo_search_roots "$HOME/Projects:$HOME")"
+  IFS=':' read -ra arr <<< "$roots"
+  for root in "${arr[@]}"; do
+    root="${root/#\~/$HOME}"
+    [ -d "$root/$repo_only" ] && { echo "$root/$repo_only"; return 0; }
+    [ -d "$root/$slug" ] && { echo "$root/$slug"; return 0; }
+  done
+  return 1
+}
+
+# Resolve health URL via layered registry: project → user → plugin example.
+resolve_health_url() {
+  local slug="$1" base="$2" key="$slug:$base"
+  local proj=$(locate_repo "$slug" 2>/dev/null)
+  if [ -n "$proj" ] && [ -f "$proj/.claude/post-merge-services.json" ]; then
+    local v=$(jq -r --arg k "$key" '.[$k].health // ""' "$proj/.claude/post-merge-services.json" 2>/dev/null)
+    [ -n "$v" ] && { echo "$v"; return; }
+  fi
+  local user_path="$(config registry_path "$HOME/.claude/config/post-merge-services.json")"
+  user_path="${user_path/#\~/$HOME}"
+  if [ -f "$user_path" ]; then
+    local v=$(jq -r --arg k "$key" '.[$k].health // ""' "$user_path" 2>/dev/null)
+    [ -n "$v" ] && { echo "$v"; return; }
+  fi
+  if [ -f "$PLUGIN_ROOT/config/post-merge-services.example.json" ]; then
+    jq -r --arg k "$key" '.[$k].health // ""' "$PLUGIN_ROOT/config/post-merge-services.example.json" 2>/dev/null
+  fi
+}
+
+resolve_version_url() {
+  local slug="$1" base="$2" key="$slug:$base"
+  local proj=$(locate_repo "$slug" 2>/dev/null)
+  if [ -n "$proj" ] && [ -f "$proj/.claude/post-merge-services.json" ]; then
+    local v=$(jq -r --arg k "$key" '.[$k].version // ""' "$proj/.claude/post-merge-services.json" 2>/dev/null)
+    [ -n "$v" ] && { echo "$v"; return; }
+  fi
+  local user_path="$(config registry_path "$HOME/.claude/config/post-merge-services.json")"
+  user_path="${user_path/#\~/$HOME}"
+  if [ -f "$user_path" ]; then
+    local v=$(jq -r --arg k "$key" '.[$k].version // ""' "$user_path" 2>/dev/null)
+    [ -n "$v" ] && { echo "$v"; return; }
+  fi
+  if [ -f "$PLUGIN_ROOT/config/post-merge-services.example.json" ]; then
+    jq -r --arg k "$key" '.[$k].version // ""' "$PLUGIN_ROOT/config/post-merge-services.example.json" 2>/dev/null
+  fi
+}
+
+dispatch_fix_agent() {
+  # $1 = prompt template path (in $PLUGIN_ROOT/prompts/), $2 = lock_id, rest = template vars as KEY=VAL
+  local template="$1" lock_id="$2"; shift 2
+  if ! lock_acquire "$lock_id"; then
+    return 2  # already in flight
+  fi
+  local slug="${lock_id%%:*}"
+  if ! budget_check_increment "$slug"; then
+    notify "Auto-fix budget exhausted" "$slug hit hourly cap — manual intervention needed"
+    lock_release "$lock_id"
+    return 3
+  fi
+
+  local prompt_file="$PLUGIN_ROOT/prompts/$template"
+  if [ ! -f "$prompt_file" ]; then
+    lock_release "$lock_id"
+    return 4
+  fi
+  local prompt=$(cat "$prompt_file")
+  for kv in "$@"; do
+    local k="${kv%%=*}" v="${kv#*=}"
+    prompt="${prompt//\{\{${k}\}\}/$v}"
+  done
+
+  local fix_log="$LOGS_DIR/fix-${lock_id}-$(date +%s).log"
+  local model=$(config fix_model haiku)
+  local danger_flag="--permission-mode acceptEdits"
+  [ "$(config allow_dangerous false)" = "true" ] && danger_flag="--dangerously-skip-permissions"
+
+  command -v claude >/dev/null || { lock_release "$lock_id"; return 5; }
+
+  nohup bash -c "
+    printf '%s' \"\$1\" | claude -p --model $model $danger_flag --no-session-persistence > '$fix_log' 2>&1
+    rm -f '$STATE_DIR/lock-$lock_id'
+  " _ "$prompt" </dev/null >/dev/null 2>&1 &
+  disown 2>/dev/null || true
+  echo "$fix_log"
+  return 0
+}

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -78,6 +78,18 @@ rotate_log() {
   fi
 }
 
+# Rotate per-service log when it exceeds MAX_LOG_SIZE.
+# Without this, long-running services (briefing-pre-warm, memory-extractor) accumulate
+# unbounded — observed 118MB briefing-pre-warm.log in production.
+rotate_service_log() {
+  local svc_log="$1"
+  [[ -f "$svc_log" ]] || return 0
+  if [[ $(_file_size "$svc_log" 2>/dev/null || echo 0) -gt $MAX_LOG_SIZE ]]; then
+    mv "$svc_log" "$svc_log.old"
+    log "LOG: rotated $svc_log (exceeded 2MB)"
+  fi
+}
+
 # ── State tracking ────────────────────────────────────────────────────────
 declare -A SERVICE_PIDS        # service name → pid
 declare -A SERVICE_RESTARTS    # service name → restart count
@@ -193,6 +205,7 @@ start_service() {
   export OPS_DAEMON_PID=$$
   export OPS_DAEMON_MANAGED=1
 
+  rotate_service_log "$LOG_DIR/${name}.log"
   bash "$cmd" >> "$LOG_DIR/${name}.log" 2>&1 &
   local pid=$!
   SERVICE_PIDS["$name"]=$pid
@@ -489,6 +502,7 @@ run_cron_service() {
 
   export OPS_DAEMON_PID=$$
   export OPS_DAEMON_MANAGED=1
+  rotate_service_log "$LOG_DIR/${name}.log"
   bash "$cmd" >> "$LOG_DIR/${name}.log" 2>&1 &
   local pid=$!
   wait "$pid" 2>/dev/null || true
@@ -664,6 +678,7 @@ print(len(recent))
         fi
         if [[ $should_run -eq 1 ]]; then
           log "BRAIN: $new_count new messages since last extraction — triggering memory update"
+          rotate_service_log "$LOG_DIR/memory-extractor.log"
           bash "$MEM_SCRIPT" >> "$LOG_DIR/memory-extractor.log" 2>&1 &
           echo $! > "$extractor_pid_file"
         fi

--- a/claude-ops/scripts/ops-deploy-monitor.sh
+++ b/claude-ops/scripts/ops-deploy-monitor.sh
@@ -83,7 +83,7 @@ if [ "$CONCLUSION" != "success" ]; then
   notify "Deploy failed" "$REPO #$PR → $BASE: $CONCLUSION"
 
   if [ "$(config auto_dispatch_fixer true)" = "true" ]; then
-    fix_log=$(dispatch_fix_agent "deploy-fix.md" "$SLUG-deploy" \
+    fix_log=$(dispatch_fix_agent "deploy-fixer" "$SLUG-deploy" \
       "REPO=$REPO" "PR=$PR" "BASE=$BASE" "SHA=$SHA" "RUN_ID=$RUN_ID" \
       "SUMMARY=deploy workflow #$RUN_ID concluded $CONCLUSION" \
       "LOGS=$failed_log")
@@ -110,7 +110,7 @@ if [ "$HTTP" != "200" ]; then
   fire "service $URL → HTTP $HTTP after deploy"
   notify "Service unhealthy" "$REPO $BASE: $URL → HTTP $HTTP"
   if [ "$(config auto_dispatch_fixer true)" = "true" ]; then
-    dispatch_fix_agent "deploy-fix.md" "$SLUG-health" \
+    dispatch_fix_agent "deploy-fixer" "$SLUG-health" \
       "REPO=$REPO" "PR=$PR" "BASE=$BASE" "SHA=$SHA" "RUN_ID=$RUN_ID" \
       "SUMMARY=service health URL $URL returned HTTP $HTTP" \
       "LOGS=(no workflow logs — health check failure)" >/dev/null

--- a/claude-ops/scripts/ops-deploy-monitor.sh
+++ b/claude-ops/scripts/ops-deploy-monitor.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# ops-deploy-monitor.sh <owner/repo> <pr_number>
+#
+# Spawned by ops-deploy-fix-merge-trigger after a PR merges. Watches the deploy
+# workflow, audits service health, dispatches Haiku fixer on failure.
+# Single-flight via lock; budget-capped per repo per hour; transient detection.
+set -u
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+. "$PLUGIN_ROOT/scripts/lib/deploy-fix-common.sh"
+
+REPO="${1:?usage: $0 <owner/repo> <pr_number>}"
+PR="${2:?usage: $0 <owner/repo> <pr_number>}"
+SLUG=$(repo_slug_safe "$REPO")
+LOG="$LOGS_DIR/monitor-$SLUG-pr$PR.log"
+log() { printf '[%s] %s/#%s %s\n' "$(date '+%H:%M:%S')" "$REPO" "$PR" "$*" >> "$LOG"; }
+fire() { log "❌ $*"; printf '[%s] %s/#%s ❌ %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$REPO" "$PR" "$*" >> "$LOGS_DIR/fires.log"; }
+
+# Single-flight monitor lock
+MONITOR_LOCK="monitor-$SLUG-pr$PR"
+lock_acquire "$MONITOR_LOCK" || { log "monitor already running, exit"; exit 0; }
+trap 'lock_release "$MONITOR_LOCK"' EXIT
+
+log "monitor starting"
+
+sleep 5
+PR_INFO=$(gh pr view "$PR" --repo "$REPO" --json baseRefName,mergeCommit,state 2>/dev/null)
+BASE=$(echo "$PR_INFO" | jq -r '.baseRefName // ""')
+SHA=$(echo "$PR_INFO" | jq -r '.mergeCommit.oid // ""')
+STATE=$(echo "$PR_INFO" | jq -r '.state // ""')
+
+[ "$STATE" != "MERGED" ] && { log "not merged ($STATE) — exit"; exit 0; }
+[ "$BASE" != "dev" ] && [ "$BASE" != "main" ] && { log "base=$BASE, skip"; exit 0; }
+log "merged to $BASE @ $SHA"
+
+# Find deploy workflow run
+PATTERN=$(config deploy_workflow_pattern "deploy|Deploy|build|Build|ECS|cd|CD")
+RUN_ID=""
+for i in $(seq 1 12); do
+  RUN_ID=$(gh run list --repo "$REPO" --branch "$BASE" --limit 5 \
+    --json databaseId,headSha,name --jq \
+    ".[] | select(.headSha==\"$SHA\" and (.name | test(\"$PATTERN\"))) | .databaseId" 2>/dev/null | head -1)
+  [ -n "$RUN_ID" ] && break
+  sleep 15
+done
+if [ -z "$RUN_ID" ]; then
+  RUN_ID=$(gh run list --repo "$REPO" --branch "$BASE" --limit 5 \
+    --json databaseId,headSha --jq ".[] | select(.headSha==\"$SHA\") | .databaseId" 2>/dev/null | head -1)
+fi
+[ -z "$RUN_ID" ] && { log "no run found — exit"; exit 0; }
+log "tracking run #$RUN_ID"
+
+# Wait for completion (configurable timeout)
+TIMEOUT=$(config watcher_timeout_seconds 1800)
+gh run watch "$RUN_ID" --repo "$REPO" --exit-status >> "$LOG" 2>&1 &
+WATCH_PID=$!
+( sleep "$TIMEOUT"; kill -9 $WATCH_PID 2>/dev/null ) &
+TIMEOUT_PID=$!
+wait $WATCH_PID; RC=$?
+kill -9 $TIMEOUT_PID 2>/dev/null
+
+CONCLUSION=$(gh run view "$RUN_ID" --repo "$REPO" --json conclusion --jq .conclusion 2>/dev/null)
+log "conclusion=$CONCLUSION rc=$RC"
+
+if [ "$CONCLUSION" != "success" ]; then
+  failed_log=$(gh run view "$RUN_ID" --repo "$REPO" --log-failed 2>/dev/null | tail -120)
+
+  # Transient → rerun, no agent
+  if [ "$(config auto_rerun_transients true)" = "true" ] && is_transient "$failed_log"; then
+    log "transient detected → gh run rerun"
+    gh run rerun "$RUN_ID" --repo "$REPO" --failed >> "$LOG" 2>&1
+    notify "Auto-rerun: transient" "$REPO #$PR — workflow rerun on transient failure"
+    exit 0
+  fi
+
+  # Dedup — same failure tail twice in a row = skip
+  if already_seen "$SLUG-deploy" "$failed_log"; then
+    log "duplicate failure — already dispatched fixer for this signature, skipping"
+    notify "Duplicate failure" "$REPO #$PR same root cause as last run — fixer NOT re-dispatched"
+    exit 0
+  fi
+
+  fire "deploy #$RUN_ID concluded $CONCLUSION"
+  notify "Deploy failed" "$REPO #$PR → $BASE: $CONCLUSION"
+
+  if [ "$(config auto_dispatch_fixer true)" = "true" ]; then
+    fix_log=$(dispatch_fix_agent "deploy-fix.md" "$SLUG-deploy" \
+      "REPO=$REPO" "PR=$PR" "BASE=$BASE" "SHA=$SHA" "RUN_ID=$RUN_ID" \
+      "SUMMARY=deploy workflow #$RUN_ID concluded $CONCLUSION" \
+      "LOGS=$failed_log")
+    case $? in
+      0) log "fixer dispatched → $fix_log" ;;
+      2) log "fixer skipped — already in flight for $SLUG-deploy" ;;
+      3) log "fixer skipped — hourly budget exhausted" ;;
+      *) log "fixer dispatch failed — exit code $?" ;;
+    esac
+  else
+    log "auto_dispatch_fixer=false — notification only"
+  fi
+  exit 1
+fi
+
+# Health audit
+[ "$(config audit_health_after_deploy true)" != "true" ] && { log "audit_health_after_deploy=false — done"; exit 0; }
+URL=$(resolve_health_url "$REPO" "$BASE")
+[ -z "$URL" ] && { log "no health URL registered for $REPO:$BASE — done"; exit 0; }
+
+sleep 10
+HTTP=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 "$URL" 2>/dev/null || echo 000)
+if [ "$HTTP" != "200" ]; then
+  fire "service $URL → HTTP $HTTP after deploy"
+  notify "Service unhealthy" "$REPO $BASE: $URL → HTTP $HTTP"
+  if [ "$(config auto_dispatch_fixer true)" = "true" ]; then
+    dispatch_fix_agent "deploy-fix.md" "$SLUG-health" \
+      "REPO=$REPO" "PR=$PR" "BASE=$BASE" "SHA=$SHA" "RUN_ID=$RUN_ID" \
+      "SUMMARY=service health URL $URL returned HTTP $HTTP" \
+      "LOGS=(no workflow logs — health check failure)" >/dev/null
+  fi
+  exit 1
+fi
+log "health $URL → 200"
+
+# Verify served commit
+if [ "$(config verify_served_commit true)" = "true" ]; then
+  VERSION_URL=$(resolve_version_url "$REPO" "$BASE")
+  if [ -n "$VERSION_URL" ]; then
+    served=$(curl -sS --max-time 10 "$VERSION_URL" 2>/dev/null | jq -r '.commit // .sha // .gitSha // ""' 2>/dev/null)
+    if [ -n "$served" ] && [ "${served:0:7}" = "${SHA:0:7}" ]; then
+      log "served ${served:0:7} matches merge ✓"
+    elif [ -n "$served" ]; then
+      fire "version mismatch served=${served:0:7} expected=${SHA:0:7}"
+      notify "Version mismatch" "$REPO $BASE serving ${served:0:7}, expected ${SHA:0:7}"
+    fi
+  fi
+fi
+log "audit complete ✓"

--- a/claude-ops/scripts/recap/daemon.sh
+++ b/claude-ops/scripts/recap/daemon.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# Background daemon: regenerates the AI recap digest whenever any input file changes.
+# Decoupled from Claude hooks → zero impact on Claude turn latency.
+#
+# Inputs watched:
+#   /tmp/claude-recap-<sid>          (per-session, written by hooks/recap-capture.sh)
+#   /tmp/zsh-activity-<pid>.log      (shell activity from zshrc preexec, optional)
+#
+# Output: /tmp/claude-recap-digest (read by tmux marquee + scripts/recap/marquee.sh)
+#
+# Single-instance via atomic mkdir lock. Reclaims stale lock if PID is dead.
+# Log rotation: 500KB cap, keeps tail 200 lines. Universal-user safe.
+
+LOCK_DIR=/tmp/claude-recap-daemon.lock
+PID_FILE=/tmp/claude-recap-daemon.pid
+LOG=/tmp/claude-recap-daemon.log
+INTERVAL=5         # poll every 5s
+MIN_GAP=15         # min seconds between Haiku calls
+DIGEST=/tmp/claude-recap-digest
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+DIGEST_SCRIPT="${SCRIPT_DIR}/digest.sh"
+
+# Single-instance guard via atomic mkdir (race-free across parallel sessions).
+acquire_lock() {
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    echo $$ > "$PID_FILE"
+    return 0
+  fi
+  i=0
+  while [ ! -s "$PID_FILE" ] && [ "$i" -lt 5 ]; do sleep 0.1; i=$((i+1)); done
+  old=$(cat "$PID_FILE" 2>/dev/null)
+  if [ -n "$old" ] && kill -0 "$old" 2>/dev/null; then
+    return 1
+  fi
+  rm -rf "$LOCK_DIR" 2>/dev/null
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    echo $$ > "$PID_FILE"
+    return 0
+  fi
+  return 1
+}
+
+acquire_lock || exit 0
+trap 'rm -rf "$LOCK_DIR"; rm -f "$PID_FILE"; exit 0' EXIT INT TERM
+
+printf '[%s] daemon started pid=%s digest=%s\n' "$(date '+%H:%M:%S')" "$$" "$DIGEST_SCRIPT" >> "$LOG"
+
+last_run=0
+while true; do
+  newest=0
+  for f in /tmp/claude-recap-* /tmp/zsh-activity-*.log; do
+    case "$f" in
+      *digest*|*latest*|*daemon*|*pinned*) continue ;;
+    esac
+    [ -f "$f" ] || continue
+    m=$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || echo 0)
+    [ "$m" -gt "$newest" ] && newest=$m
+  done
+
+  digest_m=$(stat -c %Y "$DIGEST" 2>/dev/null || stat -f %m "$DIGEST" 2>/dev/null || echo 0)
+  now=$(date +%s)
+
+  if [ "$newest" -gt "$digest_m" ] && [ $((now - last_run)) -ge "$MIN_GAP" ]; then
+    last_run=$now
+    THROTTLE_OVERRIDE=1 sh "$DIGEST_SCRIPT" >> "$LOG" 2>&1
+  fi
+
+  log_bytes=$(stat -c %s "$LOG" 2>/dev/null || stat -f %z "$LOG" 2>/dev/null || echo 0)
+  if [ "$log_bytes" -gt 512000 ]; then
+    tail -n 200 "$LOG" > "${LOG}.tmp" && mv "${LOG}.tmp" "$LOG"
+  fi
+
+  sleep "$INTERVAL"
+done

--- a/claude-ops/scripts/recap/digest.sh
+++ b/claude-ops/scripts/recap/digest.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# AI-generated rolling digest: summarizes the last 10 digests + current session recaps
+# + recent shell activity into one unified ticker line. 20s throttle (bypassable via
+# THROTTLE_OVERRIDE=1 — daemon.sh sets this).
+
+set -e
+DIGEST=/tmp/claude-recap-digest
+LOG=/tmp/claude-recap-digest.log
+LOCK=/tmp/claude-recap-digest.lock
+THROTTLE=20
+
+# Throttle by file age unless explicitly overridden
+if [ -z "$THROTTLE_OVERRIDE" ] && [ -f "$DIGEST" ]; then
+  age=$(($(date +%s) - $(stat -c %Y "$DIGEST" 2>/dev/null || stat -f %m "$DIGEST" 2>/dev/null || echo 0)))
+  [ "$age" -lt "$THROTTLE" ] && exit 0
+fi
+
+# Single-flight lock
+mkdir "$LOCK" 2>/dev/null || exit 0
+trap 'rmdir "$LOCK" 2>/dev/null' EXIT INT TERM
+
+now=$(date +%s)
+
+# Block A: current per-session recaps (newest first, max 8, drop stale >2h)
+sessions=""
+for f in $(ls -t /tmp/claude-recap-* 2>/dev/null | grep -v -- '-digest$' | grep -v -- '-digest\.log$' | grep -v -- '-latest$' | grep -v -- '-pinned$' | grep -v daemon | head -8); do
+  mtime=$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || echo 0)
+  age=$((now - mtime))
+  [ "$age" -gt 7200 ] && continue
+  base=$(basename "$f")
+  sid=${base#claude-recap-}
+  short=${sid#"${sid%????}"}
+  if [ "$age" -lt 60 ]; then a="${age}s"; elif [ "$age" -lt 3600 ]; then a="$((age/60))m"; else a="$((age/3600))h"; fi
+  body=$(LC_ALL=C tr -d '\n\r' < "$f" | head -c 400)
+  [ -z "$body" ] && continue
+  sessions="${sessions}- [${short}] (${a} ago): ${body}
+"
+done
+
+# Block B: last 10 prior digests (chronological)
+history=""
+if [ -f "$LOG" ]; then
+  history=$(tail -n 10 "$LOG" 2>/dev/null)
+fi
+
+# Block C: recent non-Claude zsh shell activity (last 15 cmds across live shells)
+shell_activity=""
+for sf in $(ls -t /tmp/zsh-activity-*.log 2>/dev/null | head -6); do
+  smtime=$(stat -c %Y "$sf" 2>/dev/null || stat -f %m "$sf" 2>/dev/null || echo 0)
+  [ $((now - smtime)) -gt 1800 ] && continue
+  spid=$(basename "$sf" | sed 's/zsh-activity-\(.*\)\.log/\1/')
+  recent=$(tail -n 15 "$sf" 2>/dev/null)
+  [ -n "$recent" ] && shell_activity="${shell_activity}-- shell $spid:
+${recent}
+"
+done
+
+[ -z "$sessions" ] && [ -z "$history" ] && [ -z "$shell_activity" ] && exit 0
+
+prompt="You are a newsroom ticker compressing the activity of multiple parallel Claude Code coding sessions AND the user's interactive shell sessions into ONE rolling headline.
+
+PRIOR HEADLINES (oldest → newest, each line a previous digest):
+${history:-(none)}
+
+CURRENT CLAUDE SESSION ACTIVITY (latest one-line per active session):
+${sessions:-(none)}
+
+USER SHELL ACTIVITY (raw recent commands across non-Claude zsh sessions, format: HH:MM:SS|cwd|command):
+${shell_activity:-(none)}
+
+Produce ONE single line (max 240 chars) describing the CURRENT state of work, weighted heavily toward the most-recent activity (last 1-2 headlines + current session activity + last few shell commands). DROP themes from older headlines that are no longer mentioned in current activity — assume they are resolved or no longer relevant. Only carry forward an older theme if there is concrete evidence in the current activity that it is still in flight. Translate raw shell commands into plain English (e.g., 'ssh into bastion', 'inspecting prod logs', 'running tests'). Plain English ticker style. No bullets, no quotes, no preface, no markdown."
+
+result=$(printf '%s' "$prompt" | claude -p --model haiku --no-session-persistence --output-format text 2>/dev/null | head -c 260 | LC_ALL=C tr '\n' ' ')
+
+if [ -n "$result" ]; then
+  printf '%s' "$result" > "$DIGEST"
+  printf '[%s] %s\n' "$(date '+%H:%M')" "$result" >> "$LOG"
+  tail -n 50 "$LOG" > "${LOG}.tmp" && mv "${LOG}.tmp" "$LOG"
+fi
+exit 0

--- a/claude-ops/scripts/recap/marquee.sh
+++ b/claude-ops/scripts/recap/marquee.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# Tmux marquee: scrolls AI digest, NEVER swaps content mid-scroll.
+# Holds the same "pinned" copy for one full scroll cycle so the user can read
+# the entire message before it refreshes with new digest content.
+
+DIGEST=/tmp/claude-recap-digest
+PINNED=/tmp/claude-recap-pinned
+
+if [ ! -f "$PINNED" ] && [ -f "$DIGEST" ]; then
+  cp "$DIGEST" "$PINNED" 2>/dev/null
+fi
+
+[ ! -f "$PINNED" ] && exit 0
+msg=$(tr -d '\n\r' < "$PINNED")
+[ -z "$msg" ] && exit 0
+
+width=$(tmux display -p '#{client_width}' 2>/dev/null || echo 80)
+viewport=$((width - 6))
+[ "$viewport" -lt 20 ] && viewport=20
+
+msg_len=${#msg}
+
+speed=6
+hold_start=1
+hold_end=1
+if [ "$msg_len" -le "$viewport" ]; then
+  scroll_steps=0
+else
+  scroll_steps=$(( (msg_len - viewport + speed - 1) / speed ))
+fi
+total=$((hold_start + scroll_steps + hold_end))
+[ "$total" -lt 2 ] && total=2
+
+now=$(date +%s)
+pinned_mtime=$(stat -c %Y "$PINNED" 2>/dev/null || stat -f %m "$PINNED" 2>/dev/null || echo "$now")
+elapsed=$((now - pinned_mtime))
+
+if [ "$elapsed" -ge "$total" ] && [ -f "$DIGEST" ]; then
+  digest_mtime=$(stat -c %Y "$DIGEST" 2>/dev/null || stat -f %m "$DIGEST" 2>/dev/null || echo 0)
+  if [ "$digest_mtime" -gt "$pinned_mtime" ]; then
+    cp "$DIGEST" "$PINNED" 2>/dev/null
+    touch "$PINNED"
+    msg=$(tr -d '\n\r' < "$PINNED")
+    msg_len=${#msg}
+    if [ "$msg_len" -le "$viewport" ]; then
+      scroll_steps=0
+    else
+      scroll_steps=$(( (msg_len - viewport + speed - 1) / speed ))
+    fi
+    total=$((hold_start + scroll_steps + hold_end))
+    [ "$total" -lt 2 ] && total=2
+    elapsed=0
+  fi
+fi
+
+phase=$((elapsed % total))
+
+if [ "$msg_len" -le "$viewport" ]; then
+  printf '%s' "$msg"
+  exit 0
+fi
+
+if [ "$phase" -lt "$hold_start" ]; then
+  offset=0
+elif [ "$phase" -lt $((hold_start + scroll_steps)) ]; then
+  offset=$(( (phase - hold_start) * speed ))
+  [ "$offset" -gt $((msg_len - viewport)) ] && offset=$((msg_len - viewport))
+else
+  offset=$((msg_len - viewport))
+fi
+
+printf '%s' "$msg" | awk -v o="$offset" -v w="$viewport" '{print substr($0, o+1, w)}'

--- a/claude-ops/skills/ops-deploy-fix/SKILL.md
+++ b/claude-ops/skills/ops-deploy-fix/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: ops-deploy-fix
+description: Inspect and control the deploy/build auto-fix subsystem. Use for `/ops:deploy-fix status` (last monitor runs, fixer dispatches, locks, hourly budget), `/ops:deploy-fix tail` (follow latest fixer log), `/ops:deploy-fix configure` (re-run the wizard), and `/ops:deploy-fix test` (synthetic dry-run through the pipeline). Trigger when the user mentions deploy auto-fix, post-merge monitor, build fixer, fix budget, fix-agent log, or asks why a deploy didn't get auto-fixed.
+allowed-tools:
+  - Bash
+  - Read
+  - AskUserQuestion
+  - Skill
+---
+
+# /ops:deploy-fix — Auto-fix subsystem control surface
+
+This skill is the operator console for the post-merge + build-failure auto-fix loop installed by `/ops:setup` Step 6.5a. The underlying daemons, hooks, and prompts live in `${CLAUDE_PLUGIN_ROOT}/scripts/`, `${CLAUDE_PLUGIN_ROOT}/hooks/`, and `${CLAUDE_PLUGIN_ROOT}/prompts/`. State lives in `~/.claude/state/ops-deploy-fix/`. Logs live in `~/.claude/logs/ops-deploy-fix/`.
+
+**Plugin rules apply (see `claude-ops/CLAUDE.md`).** In particular:
+- Rule 0 — never echo personal data (slugs are fine, but redact tokens, webhooks, emails)
+- Rule 1 — max 4 options per `AskUserQuestion`
+- Rule 4 — background by default during `configure`
+- Rule 5 — destructive ops (clearing locks, wiping state) require explicit per-action confirmation
+- Rule 6 — this skill never sends outbound comms; if a future flow needs to, use the universal send gate
+
+## Arguments
+
+The first positional argument selects the subcommand. If absent, present:
+
+```
+/ops:deploy-fix — what do you want to do?
+  [status]
+  [tail]
+  [configure]
+  [test]
+```
+
+Subcommands:
+
+| Subcommand   | Purpose                                                                  |
+| ------------ | ------------------------------------------------------------------------ |
+| `status`     | Dashboard of recent monitor runs, fixer dispatches, locks, budget        |
+| `tail`       | Follow the latest fixer log live                                         |
+| `configure`  | Re-run the wizard from `/ops:setup` Step 6.5a                            |
+| `test`       | Send a synthetic failure through the pipeline (dry-run, no real fix)     |
+
+---
+
+## Subcommand: `status`
+
+Print a compact dashboard. Read all data via Bash; favor parallel reads.
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► DEPLOY-FIX STATUS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ Master switch:    <on|off>          (deploy_fix_enabled)
+ Auto-dispatch:    <on|off>          (auto_dispatch_fixer)
+ Danger flag:      <on|off>          (allow_dangerous)
+ Budget cap:       <N>/hour/repo     (max_fixes_per_hour)
+ Notify channel:   <macos|ntfy|discord|none>
+ Fix model:        <haiku|sonnet|opus>
+
+ Last 5 monitor runs:
+   2026-04-26T08:14Z  owner/repo-a:dev   merge-watch         deploy-success
+   2026-04-26T08:11Z  owner/repo-b:main  build-watch         transient → rerun
+   ...
+
+ Last 5 fixer dispatches:
+   2026-04-26T08:09Z  owner/repo-b:main  build-fix.md   in-flight   pid 41123
+   2026-04-26T07:42Z  owner/repo-a:dev   deploy-fix.md  done        log:fix-...log
+
+ Active locks:
+   owner/repo-b:main:build  pid=41123 (alive)
+
+ Hourly budget remaining (this hour, <YYYYMMDD-HH>):
+   owner/repo-a   2 / 3
+   owner/repo-b   1 / 3
+──────────────────────────────────────────────────────
+```
+
+**Data sources:**
+
+```bash
+PREFS=~/.claude/plugins/data/ops-ops-marketplace/preferences.json
+STATE=~/.claude/state/ops-deploy-fix
+LOGS=~/.claude/logs/ops-deploy-fix
+
+# Config snapshot (all keys read with defaults from plugin.json userConfig)
+jq -r '{
+  deploy_fix_enabled, auto_dispatch_fixer, allow_dangerous,
+  max_fixes_per_hour, notify_channel, fix_model
+}' "$PREFS" 2>/dev/null
+
+# Monitor runs — last 5 across all repos
+ls -t "$LOGS"/monitor-*.log 2>/dev/null | head -5 | while read f; do
+  printf '%s  %s\n' "$(stat -f '%Sm' -t '%FT%RZ' "$f" 2>/dev/null || stat --format='%y' "$f" 2>/dev/null | awk '{print $1"T"$2"Z"}')" "$(basename "$f")"
+done
+
+# Fixer dispatches — last 5
+ls -t "$LOGS"/fix-*.log 2>/dev/null | head -5 | while read f; do
+  pid_file="$STATE/lock-$(basename "$f" | sed 's/^fix-//; s/-[0-9]*\.log$//')"
+  status="done"
+  [ -f "$pid_file" ] && kill -0 "$(cat "$pid_file")" 2>/dev/null && status="in-flight"
+  printf '%s  %s  %s\n' "$(stat -f '%Sm' -t '%FT%RZ' "$f" 2>/dev/null || stat --format='%y' "$f" 2>/dev/null | awk '{print $1"T"$2"Z"}')" "$status" "$(basename "$f")"
+done
+
+# Active locks
+for f in "$STATE"/lock-*; do
+  [ -f "$f" ] || continue
+  pid=$(cat "$f")
+  if kill -0 "$pid" 2>/dev/null; then
+    echo "$(basename "$f" | sed 's/^lock-//')  pid=$pid (alive)"
+  fi
+done
+
+# Hourly budget — read all budget files for current hour
+hour=$(date +%Y%m%d-%H)
+cap=$(jq -r '.max_fixes_per_hour // 3' "$PREFS")
+for f in "$STATE"/budget-*-"$hour"; do
+  [ -f "$f" ] || continue
+  slug=$(basename "$f" | sed "s/^budget-//; s/-$hour\$//")
+  used=$(cat "$f")
+  echo "$slug  $((cap - used)) / $cap"
+done
+```
+
+After the dashboard, if any lock is older than the configured `watcher_timeout_seconds`, surface a `⚠️ Stale lock:` line and offer:
+
+```
+Stale lock detected for <repo>. Action?
+  [Inspect log]
+  [Clear lock (Rule 5 — destructive)]
+  [Leave it]
+  [Skip]
+```
+
+Only on `Clear lock` should you delete the file (per-action confirmation per Rule 5).
+
+---
+
+## Subcommand: `tail`
+
+Tail the most-recent fixer log. Resolve via `ls -t`:
+
+```bash
+LATEST=$(ls -t ~/.claude/logs/ops-deploy-fix/fix-*.log 2>/dev/null | head -1)
+if [ -z "$LATEST" ]; then
+  echo "No fixer logs yet. Trigger one with /ops:deploy-fix test or wait for a real failure."
+  exit 0
+fi
+echo "▸ Tailing $LATEST (Ctrl-C to stop)"
+tail -f "$LATEST"
+```
+
+Run via Bash with `run_in_background: true` and a long timeout so the user can read the stream as it grows. Print the resolved log path and the spawned shell PID up-front so the user knows what's running.
+
+If a second positional arg `--lines N` is passed, do `tail -n N -f`. If `--no-follow`, drop `-f`.
+
+---
+
+## Subcommand: `configure`
+
+Re-run the wizard from `/ops:setup` Step 6.5a, plus optionally 6.5b/c/d. Implementation: route into the `setup` skill with section filter.
+
+Flow:
+
+1. Read current state from `$PREFS_PATH`. Print compact summary (same fields as `status`, no logs).
+2. Ask:
+   ```
+   What do you want to reconfigure?
+     [Deploy auto-fix wizard (6.5a)]
+     [Recap marquee (6.5b)]
+     [Task* reminder (6.5c)]
+     [Account rotation toggle (6.5d)]
+   ```
+3. Execute the corresponding sub-flow inline by following Step 6.5 of `skills/setup/SKILL.md` — same questions, same persistence, same Rule-3 "never silently skip" semantics.
+4. After persistence, print:
+   ```
+   ✓ Reconfigured. Daemons & hooks pick up the new prefs on the next event — no restart required.
+   ```
+
+Use `run_in_background: true` (Rule 4) for any CLI install / brew / curl / `tmux source-file` triggered along the way.
+
+---
+
+## Subcommand: `test`
+
+Synthetic dry-run through the pipeline. **No real fix dispatch — no agent runs.** Confirms wiring: hooks fire → monitor classifies → notify channel pings → state files written → would-dispatch path logged.
+
+Steps:
+
+1. Pre-flight check:
+   ```bash
+   PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
+   [ -z "$PLUGIN_ROOT" ] && PLUGIN_ROOT=$(find ~/.claude -type d -name claude-ops 2>/dev/null | head -1)
+   COMMON="$PLUGIN_ROOT/scripts/lib/deploy-fix-common.sh"
+   [ -f "$COMMON" ] || { echo "✗ deploy-fix-common.sh missing — re-install the plugin"; exit 1; }
+   ```
+
+2. Ask:
+   ```
+   What should the synthetic failure look like?
+     [Build failure (npm run build:* exit 1)]
+     [Deploy workflow failure (gh actions check_run)]
+     [Health check failure (curl /health 503)]
+     [Version mismatch (served SHA != merged SHA)]
+   ```
+
+3. Generate a fake event payload matching the chosen kind. Set env var `OPS_DEPLOY_FIX_DRY_RUN=1` and invoke the relevant trigger script:
+
+   ```bash
+   export OPS_DEPLOY_FIX_DRY_RUN=1
+   export OPS_DEPLOY_FIX_TEST_REPO="your-org/your-repo"   # placeholder per Rule 0
+   export OPS_DEPLOY_FIX_TEST_BASE="dev"
+   case "$kind" in
+     build)   bash "$PLUGIN_ROOT/bin/ops-deploy-fix-build-trigger" --synthetic ;;
+     deploy)  bash "$PLUGIN_ROOT/bin/ops-deploy-fix-merge-trigger" --synthetic ;;
+     health)  bash "$PLUGIN_ROOT/scripts/ops-deploy-monitor.sh" --synthetic-health ;;
+     version) bash "$PLUGIN_ROOT/scripts/ops-deploy-monitor.sh" --synthetic-version ;;
+   esac
+   ```
+
+   Trigger scripts must honor `OPS_DEPLOY_FIX_DRY_RUN=1` by:
+   - Skipping the actual `claude -p ...` dispatch in `dispatch_fix_agent`
+   - Writing a `would-dispatch-<id>-<ts>.log` to `$LOGS_DIR` instead
+   - Still incrementing the budget counter (so the test exercises the cap)
+   - Logging `[DRY-RUN] would notify <channel>` instead of firing real `notify` (no actual outbound messages during test — Rule 6)
+
+   *If the trigger scripts don't yet support `--synthetic` / `OPS_DEPLOY_FIX_DRY_RUN`, surface that as a known TODO in the output and degrade to "would-have-dispatched" log-only.*
+
+4. Print the resulting `would-dispatch-*.log` path and a one-line classification result (transient? dedup-hit? budget-exhausted? would-dispatch-template=`<file>`).
+
+5. Offer:
+   ```
+   Test complete. Next?
+     [Tail the would-dispatch log]
+     [Run another test]
+     [Show status dashboard]
+     [Done]
+   ```
+
+---
+
+## Failure modes / hand-offs
+
+- **No prefs file** → tell the user to run `/ops:setup` (or `/ops:deploy-fix configure`) first.
+- **`claude` CLI missing** (status / test) → instruct via output, do not auto-install.
+- **`jq` missing** → run `brew install jq` in background (Rule 4) and retry.
+- **Stale lock detection** → see `status` flow above, requires Rule-5 confirmation to clear.
+- **Notify channel mis-set** (e.g. `discord` selected but no webhook) → on `status`, surface as `⚠️ notify_channel=discord but no webhook URL configured` and offer `[Reconfigure now]`.
+
+## Files this skill reads / writes
+
+- Read-only: `~/.claude/plugins/data/ops-ops-marketplace/preferences.json`, `~/.claude/state/ops-deploy-fix/*`, `~/.claude/logs/ops-deploy-fix/*`, `${CLAUDE_PLUGIN_ROOT}/scripts/lib/deploy-fix-common.sh`, `${CLAUDE_PLUGIN_ROOT}/prompts/{build-fix,deploy-fix}.md`
+- Write (with explicit confirmation only): lock files in `~/.claude/state/ops-deploy-fix/lock-*` (clear on stale)
+- Write (via `configure` subcommand): the prefs file, via the merge pattern in Step 6.5

--- a/claude-ops/skills/ops-recap/SKILL.md
+++ b/claude-ops/skills/ops-recap/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: ops-recap
+description: Manage the multi-session recap marquee daemon — a background process that synthesizes a one-line digest across all parallel Claude Code sessions and shell activity, displayed in tmux status-right. Subcommands status/tail/configure/restart.
+argument-hint: "[status|tail|configure|restart]"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - AskUserQuestion
+effort: low
+maxTurns: 12
+---
+
+# OPS ► RECAP
+
+The recap marquee is a launchd-managed daemon that aggregates per-session Claude transcripts (via the `recap-capture` Stop hook) and per-tool activity (via the `recap-tool-activity` PostToolUse hook) into a single rolling headline at `/tmp/claude-recap-digest`. Tmux reads that file every refresh interval via `scripts/recap/marquee.sh` and scrolls it across `status-right`.
+
+**Files:**
+
+| Path | Role |
+|------|------|
+| `${CLAUDE_PLUGIN_ROOT}/scripts/recap/daemon.sh` | Background loop — polls inputs, calls digest.sh when stale |
+| `${CLAUDE_PLUGIN_ROOT}/scripts/recap/digest.sh` | Synthesizes one-line digest via `claude -p --model haiku` |
+| `${CLAUDE_PLUGIN_ROOT}/scripts/recap/marquee.sh` | Tmux-side scroller (called from `status-right`) |
+| `${CLAUDE_PLUGIN_ROOT}/hooks/recap-capture.sh` | Stop hook → writes `/tmp/claude-recap-<sid>` |
+| `${CLAUDE_PLUGIN_ROOT}/hooks/recap-tool-activity.sh` | PostToolUse hook → live activity per session |
+| `~/Library/LaunchAgents/com.claude-ops.recap-daemon.plist` | Launchd agent (macOS) |
+| `/tmp/claude-recap-digest` | Rolling one-liner (read by tmux + marquee.sh) |
+| `/tmp/claude-recap-daemon.log` | Daemon log (rotated at 500KB) |
+| `/tmp/claude-recap-digest.log` | Last 50 generated digests, chronological |
+
+## Subcommand: `status` (default)
+
+Print a compact health panel:
+
+```bash
+PLIST=~/Library/LaunchAgents/com.claude-ops.recap-daemon.plist
+LABEL=com.claude-ops.recap-daemon
+DIGEST=/tmp/claude-recap-digest
+DAEMON_LOG=/tmp/claude-recap-daemon.log
+
+# Plist installed?
+if [ -f "$PLIST" ]; then echo "✓ plist installed: $PLIST"; else echo "✗ plist missing"; fi
+
+# Launchd loaded?
+launchctl print "gui/$(id -u)/${LABEL}" >/dev/null 2>&1 \
+  && echo "✓ launchd loaded ($LABEL)" \
+  || echo "✗ launchd not loaded — run /ops:recap restart"
+
+# Daemon process alive?
+if [ -f /tmp/claude-recap-daemon.pid ]; then
+  pid=$(cat /tmp/claude-recap-daemon.pid)
+  kill -0 "$pid" 2>/dev/null && echo "✓ daemon alive (pid $pid)" || echo "✗ stale pid file"
+else
+  echo "✗ no pid file"
+fi
+
+# Digest freshness
+if [ -f "$DIGEST" ]; then
+  age=$(($(date +%s) - $(stat -f %m "$DIGEST" 2>/dev/null || stat -c %Y "$DIGEST" 2>/dev/null || echo 0)))
+  echo "✓ digest age: ${age}s"
+  echo "  preview: $(head -c 120 "$DIGEST")..."
+else
+  echo "✗ digest file missing — daemon may not have produced one yet"
+fi
+
+# Log size
+if [ -f "$DAEMON_LOG" ]; then
+  bytes=$(stat -f %z "$DAEMON_LOG" 2>/dev/null || stat -c %s "$DAEMON_LOG" 2>/dev/null)
+  echo "  log: $DAEMON_LOG (${bytes} bytes)"
+fi
+
+# tmux integration?
+if command -v tmux >/dev/null 2>&1; then
+  if grep -q claude-recap "$HOME/.tmux.conf" 2>/dev/null; then
+    echo "✓ tmux status-right wired"
+  else
+    echo "○ tmux installed but status-right not wired — run /ops:recap configure"
+  fi
+else
+  echo "○ tmux not installed — marquee won't display, daemon still useful for /ops:recap tail"
+fi
+```
+
+## Subcommand: `tail`
+
+Stream the rolling digest log:
+
+```bash
+echo "─── Last 20 generated digests ───"
+tail -n 20 /tmp/claude-recap-digest.log 2>/dev/null || echo "(no digest log yet)"
+echo
+echo "─── Daemon log (tail 30) ───"
+tail -n 30 /tmp/claude-recap-daemon.log 2>/dev/null || echo "(no daemon log yet)"
+```
+
+## Subcommand: `configure`
+
+Walk the user through tmux integration if not already wired. Detect existing `status-right` first to avoid clobbering.
+
+1. Check tmux availability:
+
+   ```bash
+   if ! command -v tmux >/dev/null 2>&1; then
+     echo "tmux not installed — recap daemon still runs and you can read /tmp/claude-recap-digest manually."
+     exit 0
+   fi
+   ```
+
+2. Check current `~/.tmux.conf`:
+
+   ```bash
+   TMUX_CONF="$HOME/.tmux.conf"
+   if grep -q claude-recap "$TMUX_CONF" 2>/dev/null; then
+     echo "✓ already configured."
+     exit 0
+   fi
+   existing=$(grep -E '^\s*set\s+-g\s+status-right' "$TMUX_CONF" 2>/dev/null | head -1)
+   ```
+
+3. If `existing` is non-empty, `AskUserQuestion`:
+
+   - Question: "Existing tmux status-right detected: `$existing`. Append recap marquee?"
+   - Options: `[Append (keep existing)]` `[Replace with recap-only]` `[Skip]`
+
+4. On append: insert the marquee snippet ahead of the existing setting so both render. On replace: comment out the old line and add the new one.
+
+   Snippet to append — expand the plugin path when writing `~/.tmux.conf` (tmux `#()` does not expand env vars):
+
+   ```bash
+   PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1)}"
+   cat >> "$TMUX_CONF" <<TMUX
+
+# claude-ops recap marquee
+set -g status-right '#('"${PLUGIN_ROOT}"'/scripts/recap/marquee.sh) #[fg=#a6e3a1]%H:%M '
+set -g status-interval 2
+TMUX
+   ```
+
+5. Reload if tmux is running:
+
+   ```bash
+   tmux info >/dev/null 2>&1 && tmux source-file "$TMUX_CONF" 2>/dev/null
+   ```
+
+## Subcommand: `restart`
+
+Reload the launchd agent without reconfiguring:
+
+```bash
+LABEL=com.claude-ops.recap-daemon
+PLIST=~/Library/LaunchAgents/com.claude-ops.recap-daemon.plist
+launchctl bootout "gui/$(id -u)/${LABEL}" 2>/dev/null || true
+rm -rf /tmp/claude-recap-daemon.lock /tmp/claude-recap-daemon.pid
+launchctl bootstrap "gui/$(id -u)" "$PLIST" && echo "✓ daemon restarted"
+```
+
+## Linux / systemd alternative
+
+The launchd plist is macOS-only. Linux users can wrap `scripts/recap/daemon.sh` in a `systemd --user` unit. Minimal example (`~/.config/systemd/user/claude-recap-daemon.service`):
+
+```ini
+[Unit]
+Description=Claude Ops Recap Daemon
+After=default.target
+
+[Service]
+Type=simple
+ExecStart=/bin/sh %h/.claude/plugins/cache/ops-marketplace/ops/CURRENT/scripts/recap/daemon.sh
+Restart=always
+RestartSec=30
+
+[Install]
+WantedBy=default.target
+```
+
+Then `systemctl --user daemon-reload && systemctl --user enable --now claude-recap-daemon`. The CLI subcommands above (status / tail / restart) won't auto-detect systemd — use `systemctl --user status claude-recap-daemon` directly.
+
+## Invocation
+
+`/ops:recap` (alias: shows status). Subcommand parsing:
+
+```bash
+sub="${1:-status}"
+case "$sub" in
+  status|tail|configure|restart) ;;
+  *) echo "Unknown subcommand: $sub. Try: status | tail | configure | restart"; exit 1 ;;
+esac
+```

--- a/claude-ops/skills/ops-rotate-setup/SKILL.md
+++ b/claude-ops/skills/ops-rotate-setup/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: ops-rotate-setup
+description: Interactive OAuth init wizard for the multi-account Claude rotator. Walks through every account in the rotation config, runs the Playwright magic-link flow for any account missing a keychain token, and writes verified tokens to `Claude-Rotation-<account_id>`. Re-runnable any time. Standalone alias of the same step inside `/ops:setup`.
+argument-hint: "[--all|--account <email>|--add]"
+allowed-tools:
+  - Bash
+  - Read
+  - AskUserQuestion
+effort: medium
+maxTurns: 25
+---
+
+## Purpose
+
+Initialize OAuth tokens for the multi-account Claude rotator system (the
+`account-rotation` daemon). For each configured account that does not already
+have a keychain entry `Claude-Rotation-<account_id>`, run the Playwright magic-
+link login flow against `claude.ai`, capture the session cookie, verify it,
+and write it to the OS keychain via `lib/credential-store.sh`.
+
+Use this skill when:
+- You ran `/ops:setup` and skipped the account-rotation step
+- You added a new Claude account and need to wire it in
+- A keychain entry was rotated/expired and needs re-init
+- You want to re-run only the OAuth portion without touching other ops config
+
+## Rules (mandatory)
+
+- **Rule 0**: Never write real emails to any committed file. Account email and
+  display name come from runtime user input only.
+- **Rule 1**: Max 4 options per `AskUserQuestion`. Paginate at 4 with
+  `[More...]` bridges when listing accounts.
+- **Rule 4**: Background by default. The Playwright OAuth flow is long-running;
+  always launch it with `run_in_background: true` and tail the log.
+- Never auto-enable `account_rotation_enabled` after init. The user flips that
+  switch from `/plugins` settings.
+
+## Step 1 — Load config
+
+```bash
+USER_CFG="$HOME/.claude/plugins/data/ops-ops-marketplace/account-rotation-config.json"
+REPO_CFG="${CLAUDE_PLUGIN_ROOT}/scripts/account-rotation/config.json"
+CFG="$([[ -f "$USER_CFG" ]] && echo "$USER_CFG" || echo "$REPO_CFG")"
+jq '.accounts // []' "$CFG"
+```
+
+If `accounts` is empty AND no `--add` argument was passed, jump to **Step 2 —
+Bootstrap**. Otherwise jump to **Step 3 — Token check**.
+
+## Step 2 — Bootstrap (no accounts configured)
+
+`AskUserQuestion`:
+
+```
+No Claude accounts are configured for the rotator yet. Add some now?
+  [Add now]               — collect email/display/plan, then run OAuth
+  [Use existing keychain] — skip — assume keychain already has tokens
+  [Skip]                  — exit, do nothing
+  [Help]                  — explain how the rotator works and exit
+```
+
+- `[Help]`: print one-paragraph explainer (rotator purpose, where keychain entries live, how `/plugins` toggles `account_rotation_enabled`) and exit.
+- `[Use existing keychain]`: print "Looking for `Claude-Rotation-*` entries..." and run `bash $CRED_STORE backends 2>/dev/null && for id in $(jq -r '.accounts[].id' "$CFG" 2>/dev/null); do bash $CRED_STORE get "Claude-Rotation" "$id" >/dev/null 2>&1 && echo "✓ $id" || echo "✗ $id"; done || echo "(no backends available — re-run with [Add now])"`. Exit.
+- `[Skip]`: exit.
+- `[Add now]`: enter the **add loop** below.
+
+### Add loop
+
+For each new account:
+
+1. Prompt for **email** (free text). Validate `*@*.*` shape, reject empties.
+2. Prompt for **display name** (free text, defaults to email local-part).
+3. `AskUserQuestion` for **plan**:
+   ```
+   Plan tier for this account?
+     [Max]   — Claude Max ($100/$200 tier)
+     [Pro]   — Claude Pro
+     [Team]  — Team plan seat
+     [Other] — type a label
+   ```
+4. Append to in-memory accounts list. Then ask:
+   ```
+   Account added. Next?
+     [Add another]
+     [Done — start OAuth]
+     [Cancel]
+   ```
+
+Once `[Done]`, write the new accounts into `$USER_CFG` (create dirs as needed):
+
+```bash
+mkdir -p "$(dirname "$USER_CFG")"
+jq --argjson new "$NEW_ACCOUNTS_JSON" \
+   '.accounts = ((.accounts // []) + $new)' \
+   "$CFG" > "$USER_CFG.tmp" && mv "$USER_CFG.tmp" "$USER_CFG"
+```
+
+## Step 3 — Token check
+
+For each account in the merged config, check the keychain:
+
+```bash
+CRED="${CLAUDE_PLUGIN_ROOT}/lib/credential-store.sh"
+for id in $(jq -r '.accounts[].id' "$USER_CFG"); do
+  if bash "$CRED" get "Claude-Rotation" "$id" >/dev/null 2>&1; then
+    echo "✓ $id"
+  else
+    echo "✗ $id (needs OAuth)"
+  fi
+done
+```
+
+If every account is `✓`, print a success line and jump to **Step 5 — Summary**.
+
+## Step 4 — OAuth init loop
+
+For each `✗` account, run the setup script in the background and tail its log.
+
+```bash
+SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/account-rotation/setup-account.mjs"
+LOG="$HOME/.claude/logs/account-rotation/setup-${ID}-$(date +%s).log"
+mkdir -p "$(dirname "$LOG")"
+node "$SCRIPT" \
+  --email "$EMAIL" \
+  --display "$ACCOUNT_DISPLAY" \
+  --plan "$PLAN" \
+  --account-id "$ID" \
+  --gmail-poll \
+  >"$LOG" 2>&1 &
+echo "PID=$! LOG=$LOG"
+```
+
+- Launch with `run_in_background: true`.
+- Use `Monitor` (or `Read` of the log file) to surface progress lines.
+- The script:
+  1. Opens Playwright Chromium
+  2. Navigates to `claude.ai/login`, fills email, submits magic-link
+  3. Polls Gmail via `gog` (best-effort) OR waits up to 10 minutes for the user to click the link manually
+  4. Captures `sessionKey` or `__Secure-next-auth.session-token` cookie
+  5. Verifies via `GET claude.ai/api/organizations`
+  6. Writes to keychain as `Claude-Rotation-<account_id>` via `credential-store.sh`
+- **2FA / TOTP**: the script polls the page for two-factor prompts every 3 seconds.
+  If it detects one it logs `2FA prompt detected` to stderr. When you see that
+  line in the log, ask the user via `AskUserQuestion` to provide the TOTP code.
+  In **headless** mode the code cannot be typed into the browser — re-run the
+  account with `--no-headless` so the user can complete 2FA interactively.
+  Do NOT attempt to auto-solve 2FA.
+
+After each account completes (success or failure):
+
+```
+Result for <email>:
+  [✓ Success — continue with next]      ← only if more remain
+  [✗ Failed — view log and retry]
+  [Stop here]
+```
+
+If success and no more accounts remain, jump to **Step 5**.
+
+## Step 5 — Summary
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► ROTATE-SETUP COMPLETE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ Accounts initialized:
+   ✓ <id> (<plan>)
+   ✓ <id> (<plan>)
+   ✗ <id> (failed — re-run /ops:rotate-setup --account <email>)
+
+ Config: ~/.claude/plugins/data/ops-ops-marketplace/account-rotation-config.json
+ Keychain: Claude-Rotation-<id>
+
+ To enable automatic rotation, open /plugins → claude-ops → settings and
+ toggle "Multi-account Claude rotator" (account_rotation_enabled).
+──────────────────────────────────────────────────────
+```
+
+Exit. Do NOT auto-enable `account_rotation_enabled` — that decision belongs
+to the user, made explicitly through the plugin settings UI.
+
+## Argument handling
+
+- `--all` (default): full wizard as described above.
+- `--account <email>`: skip Step 2; only init the matching account.
+- `--add`: skip token check; jump straight to Step 2 add loop, then init.
+
+## Failure modes
+
+| Symptom | Cause | Action |
+|---|---|---|
+| `playwright install failed` | npm offline / sandbox | Run `npx playwright install chromium` via Bash tool, then retry |
+| `oauth_failed` | login form selector changed | Open log, surface the page URL at failure, suggest `--no-headless` retry |
+| `verify_failed` | session cookie captured but rejected | Re-run; likely transient |
+| `keychain_write_failed` | no backend available | Run `bash $CRED backends` and surface options |
+| `no session cookie` | login flow blocked by 2FA | Re-run with `--no-headless` so user can complete in-browser |
+| `2FA prompt detected` + timeout | 2FA required in headless mode | Re-run with `--no-headless`; prompt user for TOTP via `AskUserQuestion` |

--- a/claude-ops/skills/ops-rotate/SKILL.md
+++ b/claude-ops/skills/ops-rotate/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: ops-rotate
+description: Multi-account Claude Max rotator. Status, manual rotation, account list, add-account wizard. Requires account_rotation_enabled=true in plugin settings.
+argument-hint: "[status|rotate-now|list|add-account]"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+  - AskUserQuestion
+effort: low
+maxTurns: 25
+---
+
+# OPS ► ROTATE
+
+Manage the optional multi-account Claude Max rotator. Off by default — flip
+`account_rotation_enabled` in plugin settings to use it.
+
+## Subcommands
+
+| `$ARGUMENTS`   | Action                                                           |
+| -------------- | ---------------------------------------------------------------- |
+| (none) or `status` | Show current account, 5h%/7d%, total rotations, daemon health |
+| `rotate-now`   | Force rotation to the most-cooled candidate (or `--to <email>`) |
+| `list`         | List every configured account with token state + last util     |
+| `add-account`  | Interactive wizard: collect email, OAuth into rotator vault    |
+
+## Pre-flight (every invocation)
+
+1. Read `account_rotation_enabled` from plugin preferences. If false, tell the user how to enable and exit.
+2. Resolve paths:
+   - `ROT_DIR=${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops}/account-rotation`
+   - `ROT_SRC=${CLAUDE_PLUGIN_ROOT}/scripts/account-rotation`
+3. If `$ROT_DIR` doesn't exist yet, mirror the runtime layout:
+   ```
+   mkdir -p "$ROT_DIR"
+   cp "$ROT_SRC/config.example.json" "$ROT_DIR/config.json"  # only if missing
+   ```
+4. Verify Node 20+: `node --version`. If missing, fail fast with install hint.
+
+## status (default)
+
+Run:
+
+```
+node "$ROT_SRC/rotate.mjs" --status
+node "$ROT_SRC/rotate.mjs" --utilization 2>/dev/null | head -40
+launchctl list 2>/dev/null | grep com.claude-ops.account-rotation || echo "daemon: not loaded"
+```
+
+Render a compact panel:
+
+```
+ROTATOR STATUS
+  Active account : <email>
+  5h utilization : 42% (resets in 1h 23m)
+  7d utilization : 18%
+  Total rotations: 14
+  Daemon         : ✓ running (PID 12345)  |  ✗ not loaded
+  Configured     : 4 accounts (3 with valid tokens, 1 expired)
+```
+
+## rotate-now
+
+If user passed an explicit target email (`/ops:rotate rotate-now user@example.com`), pass `--to "<email>"`. Otherwise let `rotate.mjs` pick the most-cooled.
+
+```
+bash "$ROT_SRC/force-rotate.sh" "${TARGET_EMAIL:-}"
+```
+
+Show the trailing status output. Remind the user that running Claude Code sessions hold their own access token until next `/login` or until they exit and re-enter.
+
+## list
+
+```
+node "$ROT_SRC/rotate.mjs" --status 2>/dev/null
+```
+
+Then for each account in `$ROT_DIR/config.json`, render one row:
+
+```
+  [✓] user@example.com           5h 12%   token valid 6.4h  (active)
+  [✓] backup@example.com         5h 87%   token valid 3.1h
+  [✗] expired@example.com        ── ──    token expired 2d ago
+  [○] new@example.com            ── ──    no token captured
+```
+
+If any row is `[○]` or `[✗]`, suggest running `/ops:rotate add-account` for that email.
+
+## add-account (interactive)
+
+This is the only mutating subcommand. Walk the user through:
+
+1. **Collect email.** `AskUserQuestion`: "Email of the Claude Max account to add?" (free text via `Edit` to config — the skill must NOT capture sensitive data through chat options; just ask for the email).
+2. **Optional metadata.** Ask if it's a Workspace account (`AskUserQuestion`: `[Personal]`, `[Workspace]`, `[Skip]`). If Workspace, prompt for `orgName` (free text) — `orgUuid` is auto-discovered later.
+3. **Append to config.** Read `$ROT_DIR/config.json`, append the new account entry to `accounts[]`, write back. Use the schema from `config.example.json._account_schema_example`.
+4. **Capture token.** Two paths via `AskUserQuestion`:
+   - `[Use current Claude Code login]` — runs `node "$ROT_SRC/rotate.mjs" --capture --to <email>` to copy the live `Claude Code-credentials` token into the rotator vault.
+   - `[Run OAuth in browser now]` — runs `node "$ROT_SRC/rotate.mjs" --setup --only=<email>` (background-friendly; opens Chrome).
+   - `[Skip — I'll capture later]`.
+5. **Daemon install (one-time).** If launchd doesn't show `com.claude-ops.account-rotation`, ask `[Install + start daemon]` / `[Skip]`. On install:
+   ```
+   sed "s|\${HOME}|$HOME|g" "${CLAUDE_PLUGIN_ROOT}/templates/com.claude-ops.account-rotation.plist" > ~/Library/LaunchAgents/com.claude-ops.account-rotation.plist
+   launchctl load ~/Library/LaunchAgents/com.claude-ops.account-rotation.plist
+   ```
+   Mirror `daemon.mjs` + friends to `$ROT_DIR` if not already symlinked:
+   ```
+   for f in rotate.mjs daemon.mjs ai-brain.mjs force-rotate.sh; do
+     [ -e "$ROT_DIR/$f" ] || ln -s "$ROT_SRC/$f" "$ROT_DIR/$f"
+   done
+   ```
+6. **Verify.** Run `status` subcommand inline.
+
+## Optional npm dep
+
+`rotate.mjs` uses Playwright only for the browser fallback. It is declared as
+an optional dep in the plugin's `package.json`. If a browser fallback is needed
+and Playwright is missing, the skill should offer:
+
+```
+npm install --prefix "$CLAUDE_PLUGIN_ROOT" --no-save playwright
+npx --prefix "$CLAUDE_PLUGIN_ROOT" playwright install chromium
+```
+
+## Hard rules
+
+- This skill is **read-mostly**. Only `add-account` mutates `config.json`, and only after the user explicitly confirmed the email.
+- Never echo refresh tokens or access tokens to chat output.
+- Never auto-edit `config.json` outside `add-account` — token rotation is the daemon's job, not the skill's.
+- If `account_rotation_enabled` is false, refuse to run subcommands and instead explain the toggle.
+- If multiple OS users share the Mac, surface `CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT` as the override env var.

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -512,6 +512,153 @@ Continue immediately to Step 3 — do NOT wait for the daemon to confirm startup
 
 ---
 
+## Step 2d — Recap Marquee (multi-session digest in tmux status-right)
+
+The recap marquee is a separate launchd daemon (`com.claude-ops.recap-daemon`) that synthesizes a one-line digest across all parallel Claude Code sessions and recent shell activity, then exposes it via `/tmp/claude-recap-digest` for tmux to scroll across `status-right`. Independent from the main ops daemon — it can run on its own.
+
+Skip this step entirely if `recap_marquee_enabled = false` in userConfig.
+
+### Step 2d.1 — Ask the user
+
+Use `AskUserQuestion`:
+
+```
+Enable multi-session recap marquee?
+  Background daemon synthesizes a one-line digest across all parallel Claude
+  Code sessions + recent shell commands. Display in tmux status-right.
+  [Yes — install + auto-configure]  [No — skip]  [What is this?]
+```
+
+If `What is this?`: explain (the daemon polls per-session recap files written by Stop + PostToolUse hooks, aggregates last 8 sessions + 10 prior digests + recent zsh activity into one Haiku-generated headline, refreshed every ~15s; tmux reads `/tmp/claude-recap-digest` from `status-right` and scrolls it). Then re-ask the binary question.
+
+If `No`: write `recap.enabled = false` to `$PREFS_PATH` and skip to Step 3.
+
+### Step 2d.2 — Install launchd plist (macOS only)
+
+Same platform gate as Step 2c. On Linux/WSL/Windows, print:
+
+```
+○ Recap daemon — skipped (launchd is macOS-only). Linux users: see
+  /ops:recap configure for systemd unit example.
+```
+
+On macOS, install the plist (RULE 4 — `run_in_background: true`):
+
+```bash
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1)}"
+DAEMON_SCRIPT="${PLUGIN_ROOT}/scripts/recap/daemon.sh"
+chmod +x "$DAEMON_SCRIPT" "${PLUGIN_ROOT}/scripts/recap/digest.sh" "${PLUGIN_ROOT}/scripts/recap/marquee.sh"
+chmod +x "${PLUGIN_ROOT}/hooks/recap-capture.sh" "${PLUGIN_ROOT}/hooks/recap-tool-activity.sh"
+
+PLIST_TEMPLATE="${PLUGIN_ROOT}/templates/com.claude-ops.recap-daemon.plist"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.claude-ops.recap-daemon.plist"
+DATA_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+LOG_DIR="$DATA_DIR/logs"
+mkdir -p "$LOG_DIR"
+# Resolve claude CLI bin directory (handles nvm, homebrew, system npm)
+CLAUDE_BIN_DIR=$(dirname "$(command -v claude 2>/dev/null || echo /usr/local/bin/claude)")
+sed -e "s|__DAEMON_SCRIPT_PATH__|$DAEMON_SCRIPT|g" \
+    -e "s|__LOG_DIR__|$LOG_DIR|g" \
+    -e "s|__HOME__|$HOME|g" \
+    -e "s|__CLAUDE_BIN_DIR__|$CLAUDE_BIN_DIR|g" \
+    "$PLIST_TEMPLATE" > "$PLIST_DEST"
+
+launchctl bootout "gui/$(id -u)/com.claude-ops.recap-daemon" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST_DEST"
+```
+
+### Step 2d.3 — tmux integration
+
+Detect tmux availability — skip cleanly if missing:
+
+```bash
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "○ tmux not installed — daemon installed, but no marquee surface. Daemon still useful for /ops:recap tail."
+  # write recap.enabled = true, recap.tmux_wired = false, then skip to Step 2d.5
+fi
+```
+
+If `recap_marquee_auto_configure_tmux = false`, print the snippet and skip the rest of this step (let user wire manually).
+
+If tmux is present and `recap_marquee_auto_configure_tmux = true`, ask:
+
+```
+Auto-configure tmux status-right?
+  [Yes — append to ~/.tmux.conf]  [Show me the line, I'll add manually]  [Skip]
+```
+
+On `Show me the line`, print the snippet and continue.
+
+On `Yes — append`, detect existing `status-right`:
+
+```bash
+TMUX_CONF="$HOME/.tmux.conf"
+existing=$(grep -E '^\s*set\s+-g\s+status-right' "$TMUX_CONF" 2>/dev/null | head -1)
+```
+
+If `existing` is non-empty, ask via `AskUserQuestion` (Rule 1 — exactly 4 options max):
+
+```
+Existing tmux status-right detected. How to integrate recap marquee?
+  [Replace with recap-only]  [Append (keep existing line as comment)]  [Show me, I'll edit manually]  [Skip]
+```
+
+Append the snippet (or replace, per choice). Use an unquoted heredoc delimiter so `${PLUGIN_ROOT}` expands to the installed plugin path (tmux `#()` does not expand env vars):
+
+```bash
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1)}"
+cat >> "$TMUX_CONF" <<TMUX
+
+# claude-ops recap marquee — synthesizes multi-session digest into status-right
+set -g status-right '#('"${PLUGIN_ROOT}"'/scripts/recap/marquee.sh) #[fg=#a6e3a1]%H:%M '
+set -g status-interval 2
+TMUX
+
+# Live-reload if tmux is currently running
+tmux info >/dev/null 2>&1 && tmux source-file "$TMUX_CONF" 2>/dev/null
+```
+
+### Step 2d.4 — Verify daemon is producing output
+
+Wait up to 60s for the daemon to write its first digest. Run in background; do NOT block the wizard:
+
+```bash
+(
+  for i in $(seq 1 12); do
+    [ -f /tmp/claude-recap-digest ] && [ -s /tmp/claude-recap-digest ] && exit 0
+    sleep 5
+  done
+  echo "WARN: recap daemon did not produce /tmp/claude-recap-digest within 60s — check /tmp/claude-recap-daemon.log" >&2
+) &
+```
+
+### Step 2d.5 — Persist preferences
+
+Write to `$PREFS_PATH`:
+
+```json
+{
+  "recap": {
+    "enabled": true,
+    "tmux_wired": true,
+    "installed_at_step": "2d",
+    "platform": "macos"
+  }
+}
+```
+
+Print:
+
+```
+✓ Recap marquee — daemon installed (com.claude-ops.recap-daemon).
+  Tmux status-right wired (or skipped per your choice).
+  Manage anytime: /ops:recap status | tail | configure | restart
+```
+
+Continue to Step 3.
+
+---
+
 ## Step 3 — Configure channels (if selected)
 
 First, offer a quick "configure everything" option before individual selection. Use `AskUserQuestion`:

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -221,9 +221,9 @@ How would you like to run setup?
   [Re-run a specific section — I know what I need]
 ```
 
-If the user selects "Set up everything", select ALL sections across all batches and run them in order (Step 2 → 2b → 2c → 3 → 4 → 5 → 5b → 6 → 7), skipping any already fully configured. Within each step, use the "Configure all" fast-path where available.
+If the user selects "Set up everything", select ALL sections across all batches and run them in order (Step 2 → 2b → 2c → 3 → 4 → 5 → 5b → 6 → 6.5 → 7), skipping any already fully configured. Within each step, use the "Configure all" fast-path where available.
 
-If the user selects "Re-run a specific section", show a single `AskUserQuestion` listing the section names (cli, daemon, channels, mcp, registry, prefs, env, ecom, mktg, voice, revenue) and jump directly to that step.
+If the user selects "Re-run a specific section", use sequential `AskUserQuestion` calls (paginated 4 options per page per Rule 1) to let the user pick from the section names (cli, daemon, channels, mcp, registry, prefs, deploy-fix, env, ecom, mktg, voice, revenue), then jump directly to that step. The `deploy-fix` section routes to Step 6.5.
 
 If the user selects "Pick sections", proceed with the batched selection below.
 
@@ -255,6 +255,15 @@ Use `AskUserQuestion` with `multiSelect: true`. Offer **only sections that need 
 | Configure marketing | mktg     | Set Klaviyo, Meta Ads, GA4, Search Console keys               |
 | Configure voice     | voice    | Set Bland AI, ElevenLabs, Groq API keys                       |
 | Configure revenue   | revenue  | Set Stripe + RevenueCat keys for live MRR tracking            |
+
+**Batch 4 — Auto-fix subsystem + auxiliary daemons:**
+
+| Option              | Header      | Description                                                       |
+| ------------------- | ----------- | ----------------------------------------------------------------- |
+| Deploy auto-fix     | deploy-fix  | Configure post-merge + build-failure auto-fix (Step 6.5a)         |
+| Recap marquee       | marquee     | tmux digest of parallel Claude sessions (Step 6.5b)               |
+| Task* reminder      | task-rem    | PostToolUse nudge to use TaskCreate/TaskUpdate (Step 6.5c)        |
+| Account rotation    | rotator     | Multi-account Claude rotator toggle (Step 6.5d)                   |
 
 Present each batch as a separate `AskUserQuestion` call. Skip batches where all items are already green. Collect all selections across batches and run each selected section in order.
 
@@ -3181,6 +3190,248 @@ If the file already exists, **merge** — don't overwrite. Read with `jq`, apply
 
 ---
 
+## Step 6.5 — Auto-fix subsystem + auxiliary daemons (if selected)
+
+This step configures four subsystems that ship with the plugin but stay opt-in: the deploy/build auto-fix loop, the recap marquee (tmux digest), the periodic Task* tool reminder, and the multi-account Claude rotator. All settings persist into `$PREFS_PATH` under the same keys declared in `.claude-plugin/plugin.json` `userConfig`, so the running daemons and hooks pick them up immediately.
+
+**Re-run guard (Rule 3 compliant).** Before each sub-flow, check `$PREFS_PATH` for an existing block. If found, show current state and ask:
+
+```
+Deploy auto-fix is already configured. What now?
+  [Keep current settings]
+  [Re-run wizard]
+  [Show full config]
+  [Skip]
+```
+
+Only continue into the wizard on `Re-run wizard`. Same pattern for `recap_marquee_enabled`, `task_reminder_enabled`, and `account_rotation_enabled`.
+
+All `jq` writes use the merge pattern from Step 6: read → `jq '. + { ... }'` → write to a temp file → `mv`. Never overwrite the file.
+
+### 6.5a — Deploy auto-fix wizard
+
+**Step A1 — master switch** (`AskUserQuestion`, 4 options — Rule 1):
+
+```
+Enable deploy auto-fix?
+  [Yes — full autonomy (monitor + dispatch fixer)]
+  [Yes — notify only, no agent dispatch]
+  [Skip]
+  [Configure later]
+```
+
+Mapping:
+- `Yes — full autonomy` → `deploy_fix_enabled=true`, `auto_dispatch_fixer=true`
+- `Yes — notify only` → `deploy_fix_enabled=true`, `auto_dispatch_fixer=false`
+- `Skip` → `deploy_fix_enabled=false`, persist and jump to 6.5b
+- `Configure later` → record `deploy_fix.deferred=true` and jump to 6.5b
+
+**Step A2 — behavior toggles** (only when enabled). `AskUserQuestion` `multiSelect: true`, exactly 4 options:
+
+```
+Which auto-fix behaviors should run? (multi-select)
+  [monitor_post_merge — watch deploy after PR merge]
+  [monitor_build_failures — auto-fix local `npm run build:*` failures]
+  [audit_health_after_deploy — curl /health after deploy]
+  [verify_served_commit — check served SHA matches merged SHA]
+```
+
+Persist each as a top-level boolean key. Unchecked = `false`.
+
+**Step A3 — danger flag:**
+
+```
+Allow fixer to skip permission prompts (true unattended autonomy)?
+  [Yes — pass --dangerously-skip-permissions]
+  [No — safer, may prompt mid-fix]
+  [Skip]
+```
+
+Persist `allow_dangerous` (true/false). `Skip` → leave default (`false`).
+
+**Step A4 — hourly budget:**
+
+```
+Per-repo hourly fix budget?
+  [1 — conservative]
+  [3 — default]
+  [5]
+  [10 — aggressive]
+```
+
+Persist `max_fixes_per_hour` (integer).
+
+**Step A5 — notification channel:**
+
+```
+Notification channel for failures?
+  [macOS — terminal-notifier]
+  [ntfy.sh — phone push]
+  [Discord webhook]
+  [None]
+```
+
+Persist `notify_channel` ∈ `macos|ntfy|discord|none`.
+
+**Step A6 — channel credentials** (Rule 3 — never silently skip):
+
+- `ntfy` selected and `ntfy_topic` empty in prefs → ask for topic. The topic name is public (not sensitive). If user picks `Skip`, downgrade `notify_channel` to `none` and tell them why.
+
+  ```
+  ntfy.sh topic name?
+    [Paste topic]
+    [Skip — downgrade to no notifications]
+  ```
+
+- `discord` selected and no `discord_default_webhook_url` AND no `discord_webhook_url` in prefs → ask for webhook URL with `sensitive: true`:
+
+  ```
+  Discord webhook URL?
+    [Paste webhook URL]
+    [Skip — downgrade to no notifications]
+  ```
+
+  On paste, write `discord_default_webhook_url` (sensitive). On skip, downgrade `notify_channel` to `none`.
+
+- `macos` selected → background-check `command -v terminal-notifier` (Rule 4). If missing, run `brew install terminal-notifier` with `run_in_background: true` and continue.
+
+Use the `lib/credential-store.{sh,mjs}` helpers when persisting sensitive values so they land in the keychain instead of plaintext prefs.
+
+**Step A7 — registry seeding:**
+
+```
+Seed service registry from your repos?
+  [Yes — scan ~/Projects + ~ for git repos]
+  [No — I'll edit ~/.claude/config/post-merge-services.json by hand]
+  [Skip]
+```
+
+If yes, run in background (Rule 4):
+
+```bash
+find ~/Projects ~ -maxdepth 3 -type d -name .git 2>/dev/null \
+  | xargs -I{} dirname {} \
+  | while read repo; do
+      slug=$(cd "$repo" && gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)
+      [ -n "$slug" ] && echo "$slug|$repo"
+    done > /tmp/ops-deploy-fix-detected.$$
+```
+
+Read the detected slugs, dedupe, then prompt the user **paginated 4 at a time per `AskUserQuestion`** (Rule 1) for the health URL of each repo's `:dev` and `:main` bases.
+
+Per-repo prompt:
+
+```
+Health URL for <slug>:dev? (leave blank to skip)
+  [Paste URL]
+  [Reuse last pattern — apply *-dev → * for :main]
+  [Skip this repo]
+  [Skip remaining repos]
+```
+
+For each accepted entry, append to `~/.claude/config/post-merge-services.json` (create file if missing) using the merge pattern:
+
+```bash
+mkdir -p ~/.claude/config
+[ -f ~/.claude/config/post-merge-services.json ] || echo '{}' > ~/.claude/config/post-merge-services.json
+jq --arg k "$slug:dev" --arg h "$health_url" --arg v "$version_url" \
+  '. + { ($k): { health: $h, version: $v } }' \
+  ~/.claude/config/post-merge-services.json > /tmp/reg.$$ \
+  && mv /tmp/reg.$$ ~/.claude/config/post-merge-services.json
+```
+
+Tell the user the count written and the file path.
+
+**Step A8 — persist the deploy-fix block:**
+
+```bash
+jq '. + {
+  deploy_fix_enabled: <bool>,
+  monitor_post_merge: <bool>,
+  monitor_build_failures: <bool>,
+  audit_health_after_deploy: <bool>,
+  verify_served_commit: <bool>,
+  auto_dispatch_fixer: <bool>,
+  allow_dangerous: <bool>,
+  max_fixes_per_hour: <int>,
+  notify_channel: "<channel>",
+  ntfy_topic: "<topic>",
+  discord_default_webhook_url: "<url>",
+  deploy_fix: { configured_at: "<ISO timestamp>", wizard_version: 1 }
+}' "$PREFS_PATH" > /tmp/p.$$ && mv /tmp/p.$$ "$PREFS_PATH"
+```
+
+Omit any key whose value is empty/unset. Use `lib/credential-store` for sensitive values rather than plaintext.
+
+### 6.5b — Recap marquee (tmux digest)
+
+```
+Enable recap marquee daemon? (one-line digest of all parallel Claude sessions in tmux status-right)
+  [Yes — auto-configure ~/.tmux.conf]
+  [Yes — toggle on, don't touch tmux.conf]
+  [No]
+  [Skip]
+```
+
+- `Yes — auto-configure` → `recap_marquee_enabled=true`, `recap_marquee_auto_configure_tmux=true`. In background (Rule 4): grep `~/.tmux.conf` for `ops-recap-marquee`. If absent, append the source line and run `tmux source-file ~/.tmux.conf` (only if `tmux info` succeeds — i.e. server is running).
+- `Yes — no tmux change` → `recap_marquee_enabled=true`, `recap_marquee_auto_configure_tmux=false`.
+- `No` → both keys `false`.
+- `Skip` → leave defaults, mark `recap_marquee.deferred=true`.
+
+### 6.5c — Periodic Task* tool reminder
+
+```
+Enable Task* tool reminder hook?
+  [Yes — default threshold (10 calls)]
+  [Yes — custom threshold]
+  [No — disable hook]
+  [Skip]
+```
+
+If `custom threshold`, follow up:
+
+```
+Reminder threshold (tool calls without a Task*)?
+  [5]
+  [10]
+  [20]
+  [50]
+```
+
+Persist `task_reminder_enabled` (bool) and `task_reminder_threshold` (int).
+
+### 6.5d — Account rotation toggle (toggle only)
+
+The full multi-account OAuth wizard is a separate task — this step only flips the master toggle.
+
+```
+Enable multi-account Claude rotator?
+  [Yes — enable toggle, OAuth wizard later]
+  [No]
+  [Skip]
+```
+
+Persist `account_rotation_enabled` (bool). On `Yes`, print:
+
+```
+✓ Account rotation toggle enabled. Run /ops:setup --section deploy-fix later to wire OAuth per account.
+```
+
+### 6.5 — completion print
+
+After all four sub-flows, print:
+
+```
+✓ Deploy auto-fix:    <on/off>  (autonomy=<full|notify|off>, budget=<N>/hr, notify=<channel>)
+✓ Recap marquee:      <on/off>  (tmux=<auto|manual>)
+✓ Task reminder:      <on/off>  (threshold=<N>)
+✓ Account rotation:   <on/off>  (OAuth wizard pending)
+```
+
+Then continue to Step 7.
+
+---
+
 ## Step 7 — Shell env (if selected)
 
 1. Check whether `CLAUDE_PLUGIN_ROOT` is already exported in the profile file (grep for `CLAUDE_PLUGIN_ROOT`).
@@ -3266,6 +3517,7 @@ If `$ARGUMENTS` contains a specific section name, jump straight to that section:
 | `daemon`, `background`                 | Step 5b |
 | `prefs`, `preferences`                 | Step 6  |
 | `env`, `shell`                         | Step 7  |
+| `deploy-fix`, `auto-fix`               | Step 6.5|
 
 Empty argument → full wizard from Step 0.
 

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -2833,6 +2833,43 @@ Mirror the webhook to the flat `discord_webhook_url` key so `scripts/ops-notify.
 
 ---
 
+### 3o — Claude account rotator OAuth (if selected)
+
+**Gate:** Only run this section if the userConfig flag `account_rotation_setup_oauth_each` is `true` (default). Skip if false.
+
+**Pre-skip optimization:** If every account in the rotation config already has a keychain token, print one line and continue:
+
+```bash
+USER_CFG="$HOME/.claude/plugins/data/ops-ops-marketplace/account-rotation-config.json"
+REPO_CFG="${CLAUDE_PLUGIN_ROOT}/scripts/account-rotation/config.json"
+CFG="$([[ -f "$USER_CFG" ]] && echo "$USER_CFG" || echo "$REPO_CFG")"
+CRED="${CLAUDE_PLUGIN_ROOT}/lib/credential-store.sh"
+
+MISSING=()
+for id in $(jq -r '.accounts[].id // empty' "$CFG" 2>/dev/null); do
+  bash "$CRED" get "Claude-Rotation" "$id" >/dev/null 2>&1 || MISSING+=("$id")
+done
+
+if [[ ${#MISSING[@]} -eq 0 ]] && [[ "$(jq -r '.accounts | length' "$CFG" 2>/dev/null)" != "0" ]]; then
+  echo "✓ Claude rotator: all accounts have keychain tokens — skipping OAuth"
+fi
+```
+
+**If accounts list is empty OR `MISSING` has entries:** delegate to the `/ops:rotate-setup` wizard. This skill embeds the same flow, so call it inline rather than duplicating logic:
+
+> Invoke the `ops-rotate-setup` skill at this point, passing the same userConfig context. The wizard handles add-loop, OAuth init, 2FA prompts, and keychain writes per Rule 4 (background by default).
+
+After it returns, print:
+
+```
+✓ Claude rotator: <N> account(s) initialized
+  Enable autorotation in /plugins → claude-ops → settings (account_rotation_enabled)
+```
+
+Do NOT auto-flip `account_rotation_enabled`. The user enables it explicitly.
+
+---
+
 ## Step 4 — Configure MCPs (if selected)
 
 For each MCP that isn't in `mcp_configured`, offer bulk setup first:

--- a/claude-ops/templates/com.claude-ops.account-rotation.plist
+++ b/claude-ops/templates/com.claude-ops.account-rotation.plist
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Multi-account Claude Max rotation daemon (claude-ops plugin).
+
+  This file is a TEMPLATE. The setup wizard substitutes ${HOME} and installs
+  the rendered copy to ~/Library/LaunchAgents/com.claude-ops.account-rotation.plist
+  before running:
+
+    launchctl load ~/Library/LaunchAgents/com.claude-ops.account-rotation.plist
+
+  To uninstall:
+
+    launchctl unload ~/Library/LaunchAgents/com.claude-ops.account-rotation.plist
+    rm ~/Library/LaunchAgents/com.claude-ops.account-rotation.plist
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.claude-ops.account-rotation</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/sh</string>
+    <string>-c</string>
+    <string>exec "$(command -v node)" "${HOME}/.claude/plugins/data/ops/account-rotation/daemon.mjs"</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>${HOME}/.claude/plugins/data/ops/account-rotation</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>NODE_NO_WARNINGS</key>
+    <string>1</string>
+    <key>HOME</key>
+    <string>${HOME}</string>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+    <key>Crashed</key>
+    <true/>
+  </dict>
+
+  <key>ThrottleInterval</key>
+  <integer>30</integer>
+
+  <key>StandardOutPath</key>
+  <string>${HOME}/.claude/plugins/data/ops/account-rotation/daemon-launchd.log</string>
+  <key>StandardErrorPath</key>
+  <string>${HOME}/.claude/plugins/data/ops/account-rotation/daemon-launchd.log</string>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>

--- a/claude-ops/templates/com.claude-ops.recap-daemon.plist
+++ b/claude-ops/templates/com.claude-ops.recap-daemon.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude-ops.recap-daemon</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/sh</string>
+        <string>__DAEMON_SCRIPT_PATH__</string>
+    </array>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>__LOG_DIR__/recap-daemon-stdout.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__LOG_DIR__/recap-daemon-stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>__CLAUDE_BIN_DIR__:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>__HOME__</string>
+    </dict>
+</dict>
+</plist>

--- a/claude-ops/tests/run-all.sh
+++ b/claude-ops/tests/run-all.sh
@@ -42,6 +42,7 @@ run_suite "$TESTS_DIR/test-no-secrets.sh"
 run_suite "$TESTS_DIR/test-agent-teams.sh"
 run_suite "$TESTS_DIR/test-ops-daemon-manager.sh"
 run_suite "$TESTS_DIR/test-ops-package.sh"
+run_suite "$TESTS_DIR/test-safety-hooks.sh"
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "SUMMARY"

--- a/claude-ops/tests/test-safety-hooks.sh
+++ b/claude-ops/tests/test-safety-hooks.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# test-safety-hooks.sh — Validates the 3 universal safety hooks:
+#   bin/ops-prevent-secret-commit  (PreToolUse, gated git commit*)
+#   bin/ops-no-rm-rf-anchor        (PreToolUse, gated rm *)
+#   bin/ops-warn-mainpush          (PreToolUse, gated git push*)
+set -uo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$PLUGIN_ROOT/bin"
+
+pass=0
+fail=0
+ok()  { echo "  PASS: $1"; pass=$((pass+1)); }
+err() { echo "  FAIL: $1"; fail=$((fail+1)); }
+
+# Helper: assert deny in JSON output.
+assert_deny() {
+  local out="$1" label="$2"
+  if echo "$out" | grep -q '"permissionDecision"[[:space:]]*:[[:space:]]*"deny"'; then
+    ok "$label"
+  else
+    err "$label (expected deny, got: $(echo "$out" | head -c 200))"
+  fi
+}
+assert_ask() {
+  local out="$1" label="$2"
+  if echo "$out" | grep -q '"permissionDecision"[[:space:]]*:[[:space:]]*"ask"'; then
+    ok "$label"
+  else
+    err "$label (expected ask, got: $(echo "$out" | head -c 200))"
+  fi
+}
+assert_allow() {
+  local out="$1" label="$2"
+  # Allow = empty stdout (no JSON emitted, exit 0).
+  if [[ -z "$out" ]]; then
+    ok "$label"
+  else
+    err "$label (expected silent allow, got: $(echo "$out" | head -c 200))"
+  fi
+}
+
+############################################
+# 1. ops-prevent-secret-commit
+############################################
+echo ""
+echo "── ops-prevent-secret-commit ──"
+
+TMPREPO=$(mktemp -d)
+cd "$TMPREPO"
+git init -q
+git config user.email "test@example.com"
+git config user.name "test"
+git commit --allow-empty -q -m init
+
+# Patterns to test. Sample values are runtime-assembled to avoid tripping
+# upstream secret scanners (GitHub, gitleaks, etc.) on this test file itself.
+P_LIVE="sk_""live_""abcdefghijklmnopqrstuvwxyz1234"
+P_TEST="sk_""test_""abcdefghijklmnopqrstuvwxyz1234"
+P_AKIA="AKIA""IOSFODNN7""EXAMPLE"
+P_GHP="ghp_""abcdefghijklmnopqrstuvwxyzABCDEF1234"
+P_GHO="gho_""abcdefghijklmnopqrstuvwxyzABCDEF1234"
+P_GHS="ghs_""abcdefghijklmnopqrstuvwxyzABCDEF1234"
+P_XOXB="xoxb""-12345-67890-abcdefghij"
+P_XOXA="xoxa""-12345-67890-abcdefghij"
+P_XOXP="xoxp""-12345-67890-abcdefghij"
+P_JWT="eyJhbGciOiJIUzI1NiJ9.""eyJzdWIiOiIxMjM0NSJ9.""SflKxwRJSMeKKF2QT4f"
+P_ANTHROPIC="ANTHROPIC_API_KEY=""sk-ant-""abc123"
+P_OPENAI="OPENAI_API_KEY=""sk-""proj-abc123"
+_PW_VAL="super""secret""123"
+P_PASS="password = \"${_PW_VAL}\""
+
+SECRETS=(
+  "stripe-live:$P_LIVE"
+  "stripe-test:$P_TEST"
+  "aws-akia:$P_AKIA"
+  "github-ghp:$P_GHP"
+  "github-gho:$P_GHO"
+  "github-ghs:$P_GHS"
+  "slack-xoxb:$P_XOXB"
+  "slack-xoxa:$P_XOXA"
+  "slack-xoxp:$P_XOXP"
+  "jwt:$P_JWT"
+  "anthropic-key:$P_ANTHROPIC"
+  "openai-key:$P_OPENAI"
+  "password:$P_PASS"
+)
+
+for entry in "${SECRETS[@]}"; do
+  label="${entry%%:*}"
+  payload="${entry#*:}"
+  echo "$payload" > "secret-$label.txt"
+  git add "secret-$label.txt"
+  out=$(TOOL_INPUT='{"command":"git commit -m fix"}' bash "$BIN/ops-prevent-secret-commit" 2>&1)
+  assert_deny "$out" "secret pattern blocked: $label"
+  git reset -q HEAD "secret-$label.txt" >/dev/null 2>&1
+  rm -f "secret-$label.txt"
+done
+
+# Clean diff → allow.
+echo "just some clean code" > clean.txt
+git add clean.txt
+out=$(TOOL_INPUT='{"command":"git commit -m clean"}' bash "$BIN/ops-prevent-secret-commit" 2>&1)
+assert_allow "$out" "clean diff allowed"
+git reset -q HEAD clean.txt >/dev/null 2>&1
+
+# Opt-out.
+echo "sk_""live_""aaaaaaaaaaaaaaaaaaaaaaaaaa" > optout.txt
+git add optout.txt
+out=$(CLAUDE_PLUGIN_OPTION_PREVENT_SECRET_COMMIT=false TOOL_INPUT='{"command":"git commit -m x"}' bash "$BIN/ops-prevent-secret-commit" 2>&1)
+assert_allow "$out" "opt-out (env=false) bypasses hook"
+git reset -q HEAD optout.txt >/dev/null 2>&1
+
+
+# Removal of secret → allow (only added lines are scanned).
+TMPREPO2=$(mktemp -d)
+cd "$TMPREPO2"
+git init -q
+git config user.email "test@example.com"
+git config user.name "test"
+echo "OPENAI_API_KEY=""sk-""proj-abc123" > leaked.txt
+git add leaked.txt
+git commit -q -m "oops leaked"
+# Now remove the secret and replace with env-var reference.
+echo 'OPENAI_API_KEY=$OPENAI_API_KEY' > leaked.txt
+git add leaked.txt
+out=$(TOOL_INPUT='{"command":"git commit -m remediate"}' bash "$BIN/ops-prevent-secret-commit" 2>&1)
+assert_allow "$out" "removing a secret is allowed (only added lines scanned)"
+cd / && rm -rf "$TMPREPO2"
+cd / && rm -rf "$TMPREPO"
+
+############################################
+# 2. ops-no-rm-rf-anchor
+############################################
+echo ""
+echo "── ops-no-rm-rf-anchor ──"
+
+DANGEROUS=(
+  "rm -rf /"
+  "rm -rf /*"
+  "rm -rf ~"
+  "rm -rf ~/*"
+  "rm -rf \$HOME"
+  "rm -rf \"\$HOME\""
+  "rm -rf .."
+  "rm -rf ../*"
+  "rm -rf ."
+  "rm -fr /"
+  "rm -Rf ~"
+  "rm --recursive --force /"
+)
+for cmd in "${DANGEROUS[@]}"; do
+  payload=$(printf '{"command":"%s"}' "$(echo "$cmd" | sed 's/"/\\"/g')")
+  out=$(TOOL_INPUT="$payload" bash "$BIN/ops-no-rm-rf-anchor" 2>&1)
+  assert_deny "$out" "dangerous blocked: $cmd"
+done
+
+SAFE=(
+  "rm -rf ./node_modules"
+  "rm -rf /tmp/foo"
+  "rm -rf /tmp/build-output"
+  "rm -rf dist"
+  "rm -rf ./dist/*"
+  "rm file.txt"
+  "rm -f stale.lock"
+  "rm -r somedir"
+)
+for cmd in "${SAFE[@]}"; do
+  payload=$(printf '{"command":"%s"}' "$cmd")
+  out=$(TOOL_INPUT="$payload" bash "$BIN/ops-no-rm-rf-anchor" 2>&1)
+  assert_allow "$out" "safe allowed: $cmd"
+done
+
+# Opt-out.
+out=$(CLAUDE_PLUGIN_OPTION_NO_RM_RF_ANCHOR=false TOOL_INPUT='{"command":"rm -rf /"}' bash "$BIN/ops-no-rm-rf-anchor" 2>&1)
+assert_allow "$out" "opt-out (env=false) bypasses hook"
+
+
+# Multi-target: safe first, dangerous second → still blocked.
+MULTI_DANGEROUS=(
+  "rm -rf /tmp/build /"
+  "rm -rf dist ~"
+  "rm -rf ./node_modules .."
+)
+for cmd in "${MULTI_DANGEROUS[@]}"; do
+  payload=$(printf '{"command":"%s"}' "$(echo "$cmd" | sed 's/"/\\"/g')")
+  out=$(TOOL_INPUT="$payload" bash "$BIN/ops-no-rm-rf-anchor" 2>&1)
+  assert_deny "$out" "multi-target blocked: $cmd"
+done
+############################################
+# 3. ops-warn-mainpush
+############################################
+echo ""
+echo "── ops-warn-mainpush ──"
+
+TMPREPO=$(mktemp -d)
+cd "$TMPREPO"
+git init -q -b main
+git config user.email "test@example.com"
+git config user.name "test"
+git commit --allow-empty -q -m init
+
+# On main → bare push asks.
+out=$(TOOL_INPUT='{"command":"git push"}' bash "$BIN/ops-warn-mainpush" 2>&1)
+assert_ask "$out" "bare push from main → ask"
+out=$(TOOL_INPUT='{"command":"git push origin"}' bash "$BIN/ops-warn-mainpush" 2>&1)
+assert_ask "$out" "git push origin from main → ask"
+out=$(TOOL_INPUT='{"command":"git push -u origin main"}' bash "$BIN/ops-warn-mainpush" 2>&1)
+assert_ask "$out" "explicit push origin main → ask"
+out=$(TOOL_INPUT='{"command":"git push origin master"}' bash "$BIN/ops-warn-mainpush" 2>&1)
+assert_ask "$out" "explicit push origin master → ask"
+out=$(TOOL_INPUT='{"command":"git push origin production"}' bash "$BIN/ops-warn-mainpush" 2>&1)
+assert_ask "$out" "explicit push origin production → ask"
+out=$(TOOL_INPUT='{"command":"git push origin HEAD:main"}' bash "$BIN/ops-warn-mainpush" 2>&1)
+assert_ask "$out" "refspec HEAD:main → ask"
+
+# Switch to feature branch → bare push allowed.
+git checkout -q -b feature/safe-thing
+out=$(TOOL_INPUT='{"command":"git push"}' bash "$BIN/ops-warn-mainpush" 2>&1)
+assert_allow "$out" "bare push from feature branch → allow"
+out=$(TOOL_INPUT='{"command":"git push -u origin feature/safe-thing"}' bash "$BIN/ops-warn-mainpush" 2>&1)
+assert_allow "$out" "explicit feature push → allow"
+
+# Opt-out.
+git checkout -q main
+out=$(CLAUDE_PLUGIN_OPTION_WARN_MAINPUSH=false TOOL_INPUT='{"command":"git push origin main"}' bash "$BIN/ops-warn-mainpush" 2>&1)
+assert_allow "$out" "opt-out (env=false) bypasses hook"
+
+cd / && rm -rf "$TMPREPO"
+
+############################################
+echo ""
+echo "── Summary ──"
+echo "  Passed: $pass"
+echo "  Failed: $fail"
+[[ $fail -eq 0 ]]


### PR DESCRIPTION
## v2.0.0 — Autonomy Layer

Major release. **Zero breaking changes** — purely additive opt-in features.

### What's new

**Deploy auto-fix subsystem** — PostToolUse hooks watch \`gh pr merge\` + \`npm run build:*\`; on failure, dispatch a Haiku fixer with persona-driven prompt + hard guardrails. Per-repo lock + hourly budget + transient detection (auto-rerun instead of agent). Layered service registry. Full skill: \`/ops:deploy-fix\`.

**Specialized agent system** — 4 pre-installed agents (general-purpose override, deploy-fixer, build-fixer, dependency-auditor). PreToolUse hook silently swaps general-purpose → matching specialist via updatedInput; user-extensible JSON keyword map.

**Universal safety hooks** — secret-commit blocker, rm-rf-anchor blocker, mainpush warning. All opt-in via userConfig boolean.

**Recap marquee daemon** — multi-session digest in tmux status-right (or Claude Code statusLine fallback).

**Multi-account Claude rotator** — folded the magic-link auto-rotator + OAuth setup wizard.

**Setup wizard expanded** — 5+ new steps for the autonomy layer.

**plugin.json userConfig overhauled** — 19+ new boolean toggles + numeric caps + file pickers — proper types finally render as spacebar toggles in /plugins settings.

### Merged PRs
- #158 chore(plugin): convert userConfig types
- #159 feat(setup): account rotator OAuth init wizard
- #160 feat(setup): deploy auto-fix wizard + /ops:deploy-fix skill
- #161 feat(recap): fold multi-session digest marquee
- #162 feat(safety): 3 universal PreToolUse safety hooks
- #163 feat(account-rotation): fold multi-account rotator

### Deferred to v2.0.1
- #164 (test suite — non-trivial rebase conflict)
- #165 (recap statusLine fallback — stacks on #161 with duplicates)

### Migration
None required. See \`docs/migrating-from-v1.md\` — every new feature is opt-in.

### Wiki
Updated: 9 new pages including Auto-Fix-Subsystem, Specialized-Agents, Safety-Hooks, Recap-Marquee, Multi-Account-Rotator, Setup-Wizard, Configuration, Migrating-from-v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces always-on PreToolUse/PostToolUse hooks that can block or alter developer commands and automatically dispatch headless fix agents/daemons, which could impact workflows or incur unexpected actions/cost if misconfigured. Changes are gated by new `userConfig` toggles and include budget/lock/dedup controls, but touch safety- and automation-sensitive paths (git, rm, pushes, keychain rotation).
> 
> **Overview**
> Bumps the plugin to **v2.0.0** and expands it from a dashboard-focused ops surface into an *autonomy layer* with new background automation.
> 
> Adds a deploy/build **auto-fix subsystem**: PostToolUse hooks watch `gh pr merge` and failing `npm run build:*`, then monitor GitHub Actions deploys, optionally verify `/health` + `/version`, auto-rerun classified transients, and otherwise dispatch headless Haiku fix agents with **single-flight locks, hourly budgets, and log-tail dedup**.
> 
> Adds **universal safety hooks** (block secret-containing `git commit`, deny dangerous `rm -rf` anchors, and prompt on direct `git push` to protected branches) plus a PostToolUse **Task* reminder** and a PreToolUse `Agent` hook that can silently route `general-purpose` to specialist agents via a keyword map.
> 
> Introduces new specialist agent definitions/prompts, recap capture hooks and docs, and a large `plugin.json` `userConfig` overhaul (new booleans/numeric caps/file picker; fixes some types like GA4/New Relic IDs). Documentation/README/CHANGELOG are updated to describe v2 features and new skills (`/ops:deploy-fix`, `/ops:recap`, `/ops:rotate*`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59e14c83ed064216451260f5543bac84bc395cd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: claude-ops v2.0.0

* **New Features**
  * Deploy auto-fix system detects post-merge and build failures, automatically dispatching specialized agents to diagnose and fix issues.
  * Universal safety hooks prevent secret commits, block dangerous `rm` commands, and warn on protected branch pushes.
  * Recap daemon tracks Claude Code sessions and displays activity digest via tmux or status line.
  * Multi-account Claude Max rotator manages account switching based on utilization thresholds.
  * Four specialized agents (deploy-fixer, build-fixer, dependency-auditor, general-purpose) with automatic routing.
  * New commands: `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`.

* **Documentation**
  * Added comprehensive migration guide from v1 to v2.
  * New safety hooks, deployment auto-fix, and agent routing documentation.

* **Tests**
  * Added safety hooks integration test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->