### PR TITLE
feat: decommission wacli, run WhatsApp ops on Baileys MCP only

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] — 2026-04-27
+
+### Changed
+
+- **Decommission wacli daemon. WhatsApp ops now Baileys-only via `mcp__whatsapp__*`.** Migration script in `scripts/whatsapp-bridge-migrate.sh`.
+  - All skill references to `wacli chats list`, `wacli messages list/search`, `wacli contacts --search`, `wacli send`, `wacli history backfill`, and `wacli doctor` replaced with `mcp__whatsapp__*` tool calls or direct `sqlite3` queries against the bridge `messages.db`.
+  - `scripts/wacli-keepalive.sh` and `scripts/com.claude-ops.wacli-keepalive.plist` moved to `legacy/` (preserved for reference).
+  - `bin/wacli-health` rewritten to check bridge port 8080 and launchd status.
+  - `bin/wacli-safe` replaced with a deprecation shim.
+  - New `bin/ops-pretool-whatsapp-bridge-health` PreToolUse hook for bridge liveness.
+  - New `assets/launchagents/com.samrenders.whatsapp-bridge.plist` template.
+  - `scripts/whatsapp-bridge-migrate.sh`: idempotent FTS5 virtual table + contacts table migration for `messages.db`; seeds contacts from macOS Contacts.app via osascript.
+
+### Migration steps (manual, post-merge)
+
+1. Run `scripts/whatsapp-bridge-migrate.sh` to add FTS5 index and contacts table to bridge `messages.db`.
+2. Revoke the wacli linked device on your phone (WhatsApp → Settings → Linked Devices).
+3. `launchctl bootout gui/$UID ~/Library/LaunchAgents/com.claude-ops.wacli-keepalive.plist 2>/dev/null || true`
+4. `rm -f ~/Library/LaunchAgents/com.claude-ops.wacli-keepalive.plist`
+
+### Rollback
+
+WhatsApp supports 4 linked devices. Re-link wacli at any time:
+```bash
+wacli auth   # scan QR
+launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.claude-ops.wacli-keepalive.plist
+```
+History from before rollback won't be in new wacli store, but bridge keeps running independently — no message loss.
+
+---
+
 ## [2.0.0] — 2026-04-26
 
 > **Major release.** Purely additive — no behavior of any v1.x skill changes by default. Existing users can upgrade in place. Every new subsystem is gated by a `userConfig` toggle (defaults documented per-feature below) and can be turned off from `/plugins` settings without uninstalling. See [`docs/migrating-from-v1.md`](docs/migrating-from-v1.md) and the [Migrating-from-v1 wiki page](https://github.com/Lifecycle-Innovations-Limited/claude-ops/wiki/Migrating-from-v1).

--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -123,7 +123,7 @@ Full feature parity with the legacy v1 bash script: `--gpu` reports GPU + Neural
 The background memory extractor now prefers the Claude Code OAuth token stored in macOS Keychain (`Claude Code-credentials`) over `ANTHROPIC_API_KEY`. Calls are billed against your Claude Max subscription instead of your API credit. The token is never exported to the shell environment, so parent terminal sessions stay unaffected. Falls back to `ANTHROPIC_API_KEY` (env → keychain → Doppler).
 
 ### Persistent WhatsApp follower
-`scripts/wacli-keepalive.sh` now keeps `wacli --follow` alive indefinitely. Previously the supervisor invoked `wacli sync --once` on the first tick before `--follow` had stabilized its store lock, which tore down the persistent connection every 5-20 minutes. Fixed via `INITIAL_BACKFILL_DELAY=30` plus a reentrant guard against overlapping sweeps.
+`whatsapp-bridge` (Baileys) now manages WhatsApp connectivity via the `com.samrenders.whatsapp-bridge` LaunchAgent. Previously `whatsapp-bridge-keepalive.sh` kept `whatsapp-bridge --follow` alive — that daemon has been decommissioned (see `legacy/`). Which tore down the persistent connection every 5-20 minutes. Fixed via `INITIAL_BACKFILL_DELAY=30` plus a reentrant guard against overlapping sweeps.
 
 ### Full Plugin Feature Adoption
 - All 30 skills: `effort`, `maxTurns`, `disallowedTools`, `model` annotations
@@ -149,7 +149,7 @@ The setup wizard (`/ops:setup`) walks through each one interactively. You choose
 |------|---------------|--------------|
 | `gh` (GitHub CLI) | Yes (Homebrew) | PRs, CI logs, issue triage, merge pipeline — used by 8+ skills |
 | `aws` (AWS CLI) | Yes (Homebrew) | ECS health, Cost Explorer, CloudWatch — used by ops-fires, ops-revenue, ops-deploy |
-| `wacli` (WhatsApp) | Manual ([source](https://github.com/Lifecycle-Innovations-Limited/wacli)) | WhatsApp inbox, send/read, contact lookup — no MCP equivalent exists |
+| `whatsapp-bridge` (WhatsApp) | Bundled ([source](https://github.com/Lifecycle-Innovations-Limited/whatsapp-mcp)) | WhatsApp inbox, send/read, contact lookup via `mcp__whatsapp__*` tools |
 | Node.js 18+ | Yes (Homebrew) | Runs the bundled Telegram MCP server |
 
 #### MCP-only (no CLI needed)
@@ -341,7 +341,7 @@ After the report, type `YOLO` to hand over the controls — Claude will autonomo
 ┌─────────────────────────┼────────────────────────┐
 │              ops-daemon (launchd)                  │
 │  ┌──────────┐ ┌──────────┐ ┌──────────────────┐ │
-│  │ wacli    │ │ memory   │ │   brain layer    │ │
+│  │ bridge  │ │ memory   │ │   brain layer    │ │
 │  │ sync     │ │ extractor│ │ briefing cache   │ │
 │  │ (follow) │ │ (cron)   │ │ urgent detect    │ │
 │  └──────────┘ └──────────┘ └──────────────────┘ │

--- a/claude-ops/agents/comms-scanner.md
+++ b/claude-ops/agents/comms-scanner.md
@@ -25,9 +25,10 @@ Run all channel scans in parallel:
 
 ```bash
 # WhatsApp — ALL non-archived chats (not just unread)
-wacli chats list --json 2>/dev/null || echo '{"error": "wacli not available"}'
+# WhatsApp via bridge MCP tools
+mcp__whatsapp__list_chats sort_by=last_active  # or via sqlite3 direct query
 # Then for each chat with recent activity (last 7 days):
-# wacli messages list --chat "<JID>" --limit 5 --json
+# mcp__whatsapp__list_messages chat_jid="<JID>" limit=5
 # Check FromMe on last message to classify NEEDS_REPLY vs WAITING
 ```
 

--- a/claude-ops/agents/daemon-agent.md
+++ b/claude-ops/agents/daemon-agent.md
@@ -60,11 +60,11 @@ tail -f ~/.claude/plugins/data/ops-ops-marketplace/logs/<service-name>.log
 
 ## Action Needed
 
-When a service requires user intervention (e.g. wacli reauth), `action_needed` is set:
+When a service requires user intervention (e.g. whatsapp-bridge restart), `action_needed` is set:
 
 ```json
 {
-  "action_needed": {"service": "wacli-sync", "action": "reauth"}
+  "action_needed": {"service": "whatsapp-bridge", "action": "restart"}
 }
 ```
 
@@ -78,7 +78,7 @@ Any ops skill that reads `daemon-health.json` should surface this to the user im
   "pid": 12345,
   "uptime_seconds": 3600,
   "services": {
-    "wacli-sync": {"status": "running", "pid": 67890, "last_health": "connected", "restarts": 0},
+    "whatsapp-bridge": {"status": "running", "pid": 67890, "last_health": "connected", "restarts": 0},
     "memory-extractor": {"status": "scheduled", "next_run": "2026-04-13T15:30:00Z", "last_run": "2026-04-13T15:00:00Z"}
   },
   "action_needed": null

--- a/claude-ops/agents/memory-extractor.md
+++ b/claude-ops/agents/memory-extractor.md
@@ -10,7 +10,7 @@ memory: project
 ## Purpose
 
 Builds structured memory from raw chat data so ops skills (inbox, comms, go) can draft
-context-aware messages. Reads WhatsApp (wacli) and email (gog) history, calls Claude Haiku
+context-aware messages. Reads WhatsApp (bridge messages.db) and email (gog) history, calls Claude Haiku
 for extraction, and writes/merges structured markdown memory files.
 
 ## Memory Location
@@ -56,8 +56,12 @@ CONTACT_FILE=$(ls "${MEMORIES}/contact_"*deeksha* 2>/dev/null | head -1)
 
 ## Data Sources
 
-- **WhatsApp**: `wacli messages list --after=<yesterday> --limit=200 --json`
-  - Requires wacli connected (`~/.wacli/.health` contains "connected")
+- **WhatsApp**: direct sqlite3 query on bridge messages.db:
+  ```bash
+  DB="${WHATSAPP_BRIDGE_DB:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db}"
+  sqlite3 "$DB" "SELECT chat_jid, sender, content, timestamp, is_from_me FROM messages WHERE timestamp >= '<yesterday>' ORDER BY timestamp DESC LIMIT 200;"
+  ```
+  - Requires bridge running: `lsof -i :8080 | grep LISTEN`
 - **Email**: `gog gmail search -j --results-only --no-input --max 20 "newer_than:1d"`
   - Requires gog available
 

--- a/claude-ops/bin/ops-autofix
+++ b/claude-ops/bin/ops-autofix
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # ops-autofix — Automatically fix common ops plugin issues without user interaction
 # Called by /ops:setup and /ops:doctor to silently repair what can be repaired.
-# Usage: ops-autofix [--json] [--fix=all|wacli-fts|slack-mcp|vercel-mcp]
+# Usage: ops-autofix [--json] [--fix=all|bridge-fts|slack-mcp|vercel-mcp]
 set -euo pipefail
 
 JSON_OUTPUT=false
@@ -73,59 +73,38 @@ log_fail() { FIXES_FAILED+=("$1"); }
 log_skip() { FIXES_SKIPPED+=("$1"); }
 
 # ─── 1. WhatsApp FTS5 ───────────────────────────────────────────────────────
-fix_wacli_fts() {
-  if ! command -v wacli >/dev/null 2>&1; then
-    log_skip "wacli-fts: wacli not installed"
+fix_bridge_fts() {
+  if [[ ! -f "${WHATSAPP_BRIDGE_DB:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db}" ]]; then
+    log_skip "bridge-fts: bridge DB not found"
     return
   fi
 
   # Check if FTS is already enabled
-  FTS_STATUS=$(wacli doctor --json 2>/dev/null | jq -r '.data.fts_enabled // false' 2>/dev/null || echo "false")
+  BRIDGE_DB="${WHATSAPP_BRIDGE_DB:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db}"
+  FTS_STATUS=$(sqlite3 "$BRIDGE_DB" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='messages_fts';" 2>/dev/null || echo "0")
+  [[ "$FTS_STATUS" == "1" ]] && FTS_STATUS="true" || FTS_STATUS="false"
   if [ "$FTS_STATUS" = "true" ]; then
-    log_skip "wacli-fts: already enabled"
+    log_skip "bridge-fts: already enabled"
     return
   fi
 
   # Check if Go is available for rebuild
   if ! command -v go >/dev/null 2>&1; then
-    log_fail "wacli-fts: Go toolchain not installed (needed to rebuild wacli with FTS5)"
+    log_skip "bridge-fts: FTS5 available (sqlite built-in) — run scripts/whatsapp-bridge-migrate.sh"
     return
   fi
 
-  # Check if wacli was built without sqlite_fts5 tag
-  WACLI_PATH=$(which wacli)
-  HAS_FTS5_TAG=$(strings "$WACLI_PATH" 2>/dev/null | grep -c "sqlite_fts5" || echo "0")
-
-  # Find or clone wacli source
-  WACLI_SRC=""
-  for candidate in ~/src/wacli /tmp/wacli-rebuild; do
-    if [ -f "$candidate/go.mod" ] && grep -q "wacli" "$candidate/go.mod" 2>/dev/null; then
-      WACLI_SRC="$candidate"
-      break
-    fi
-  done
-
-  if [ -z "$WACLI_SRC" ]; then
-    # Clone source
-    WACLI_SRC="/tmp/wacli-rebuild"
-    rm -rf "$WACLI_SRC"
-    if ! git clone --depth 1 https://github.com/steipete/wacli.git "$WACLI_SRC" 2>/dev/null; then
-      log_fail "wacli-fts: failed to clone wacli source"
-      return
-    fi
-  fi
-
-  # Rebuild with FTS5 tag
-  if (cd "$WACLI_SRC" && CGO_ENABLED=1 go build -tags "sqlite_fts5" -o "$WACLI_PATH" ./cmd/wacli 2>/dev/null); then
-    # Verify
-    NEW_FTS=$(wacli doctor --json 2>/dev/null | jq -r '.data.fts_enabled // false' 2>/dev/null || echo "false")
-    if [ "$NEW_FTS" = "true" ]; then
-      log_fix "wacli-fts: rebuilt with FTS5 support"
+  # Run bridge schema migration to add FTS5 index (sqlite built-in, no rebuild needed)
+  MIGRATE="${CLAUDE_PLUGIN_ROOT:-$(dirname "$0")/..}/scripts/whatsapp-bridge-migrate.sh"
+  if bash "$MIGRATE" 2>/dev/null; then
+    FTS_AFTER=$(sqlite3 "$BRIDGE_DB" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='messages_fts';" 2>/dev/null || echo "0")
+    if [ "$FTS_AFTER" = "1" ]; then
+      log_fix "bridge-fts: FTS5 index created"
     else
-      log_fail "wacli-fts: rebuilt binary but FTS still reports disabled"
+      log_fail "bridge-fts: migration ran but FTS still missing"
     fi
   else
-    log_fail "wacli-fts: go build failed"
+    log_fail "bridge-fts: migration script failed"
   fi
 }
 
@@ -187,14 +166,14 @@ fix_vercel_mcp() {
 # ─── 4. Channel health — detect auth'd but broken channels ──────────────────
 fix_channel_health() {
   # ── WhatsApp: @lid JID sync + stale connection ──
-  if command -v wacli >/dev/null 2>&1; then
-    DOCTOR=$(wacli doctor --json 2>/dev/null || echo '{"success":false}')
+  if lsof -i :8080 2>/dev/null | grep -q LISTEN; then
+    DOCTOR='{"success":true,"bridge":"running"}'
     WA_AUTH=$(echo "$DOCTOR" | jq -r '.data.authenticated // false' 2>/dev/null)
     WA_LOCK=$(echo "$DOCTOR" | jq -r '.data.lock_held // false' 2>/dev/null)
 
     if [ "$WA_AUTH" = "true" ]; then
       # Kill stale lock if held >2 min — but never kill the legitimate
-      # persistent `wacli sync --follow` daemon (it holds the lock for its
+      # bridge manages its own locking internally
       # entire lifetime by design; that's not "stale").
       if [ "$WA_LOCK" = "true" ]; then
         LOCK_PID=$(echo "$DOCTOR" | jq -r '.data.lock_info' 2>/dev/null | grep -oE 'pid=[0-9]+' | cut -d= -f2)
@@ -202,8 +181,8 @@ fix_channel_health() {
           LOCK_CMD=$(ps -p "$LOCK_PID" -o command= 2>/dev/null || echo "")
           LOCK_ETIME=$(ps -p "$LOCK_PID" -o etime= 2>/dev/null | tr -d ' ')
           # Skip if it's the persistent --follow daemon
-          if echo "$LOCK_CMD" | grep -q "wacli sync --follow"; then
-            log_skip "wacli-health: lock held by persistent --follow daemon (pid=$LOCK_PID) — leaving alone"
+          if false; then  # bridge manages locking internally
+            log_skip "bridge-health: lock held by persistent --follow daemon (pid=$LOCK_PID) — leaving alone"
           else
             # Parse etime to seconds. Formats: SS, MM:SS, HH:MM:SS, DD-HH:MM:SS
             LOCK_AGE=$(echo "$LOCK_ETIME" | awk -F'[-:]' '{
@@ -215,11 +194,11 @@ fix_channel_health() {
               print s
             }')
             if [ -n "$LOCK_AGE" ] && [ "$LOCK_AGE" -gt 120 ]; then
-              log_fix "wacli-health: killed stale lock holder (pid=$LOCK_PID, age=${LOCK_AGE}s, cmd=$LOCK_CMD)"
+              log_fix "bridge-health: killed stale lock holder (pid=$LOCK_PID, age=${LOCK_AGE}s, cmd=$LOCK_CMD)"
               kill "$LOCK_PID" 2>/dev/null; sleep 2
               kill -0 "$LOCK_PID" 2>/dev/null && kill -9 "$LOCK_PID" 2>/dev/null
             else
-              log_skip "wacli-health: lock holder pid=$LOCK_PID is young (${LOCK_AGE}s) — not stale"
+              log_skip "bridge-health: lock holder pid=$LOCK_PID is young (${LOCK_AGE}s) — not stale"
             fi
           fi
         fi
@@ -227,35 +206,38 @@ fix_channel_health() {
 
       # Check @lid JIDs with empty messages
       LID_EMPTY=0
-      for jid in $(wacli chats list --json 2>/dev/null | jq -r '.data[] | select(.jid | contains("@lid")) | .jid' 2>/dev/null | head -5); do
-        MSG_COUNT=$(wacli messages list --chat "$jid" --limit 3 --json 2>/dev/null | jq -r '.data.messages | length' 2>/dev/null || echo "0")
+      # Bridge handles @lid resolution automatically — just ensure it is running
+      if true; then
+        jid="bridge"
+        MSG_COUNT=1
         [ "$MSG_COUNT" = "0" ] && LID_EMPTY=$((LID_EMPTY + 1))
       done
 
       if [ "$LID_EMPTY" -gt 0 ]; then
-        if timeout 30 wacli sync 2>/dev/null; then
-          log_fix "wacli-health: synced @lid chats ($LID_EMPTY had empty messages)"
+        if launchctl kickstart -k gui/$(id -u)/com.samrenders.whatsapp-bridge 2>/dev/null; then
+          log_fix "bridge-health: synced @lid chats ($LID_EMPTY had empty messages)"
         else
-          log_fail "wacli-health: sync timed out"
+          log_fail "bridge-health: sync timed out"
         fi
       fi
 
       # Check for zero recent messages (auth'd but dead session)
-      RECENT=$(wacli messages list --after="$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d '1 day ago' +%Y-%m-%d)" --limit 1 --json 2>/dev/null | jq -r '.data.messages | length' 2>/dev/null || echo "0")
+      BRIDGE_DB="${WHATSAPP_BRIDGE_DB:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db}"
+      RECENT=$(sqlite3 "$BRIDGE_DB" "SELECT COUNT(*) FROM messages WHERE timestamp >= datetime('now','-1 day');" 2>/dev/null || echo "0")
       if [ "$RECENT" = "0" ]; then
         # Try sync first
-        timeout 30 wacli sync 2>/dev/null
-        RECENT2=$(wacli messages list --after="$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d '1 day ago' +%Y-%m-%d)" --limit 1 --json 2>/dev/null | jq -r '.data.messages | length' 2>/dev/null || echo "0")
+        launchctl kickstart -k gui/$(id -u)/com.samrenders.whatsapp-bridge 2>/dev/null || true
+        RECENT2=$(sqlite3 "$BRIDGE_DB" "SELECT COUNT(*) FROM messages WHERE timestamp >= datetime('now','-1 day');" 2>/dev/null || echo "0")
         if [ "$RECENT2" = "0" ]; then
-          log_fail "wacli-health: auth'd but 0 messages in 24h (likely app-state key desync — needs re-pair)"
+          log_fail "bridge-health: auth'd but 0 messages in 24h (likely app-state key desync — needs re-pair)"
         else
-          log_fix "wacli-health: sync restored message flow"
+          log_fix "bridge-health: sync restored message flow"
         fi
       else
-        log_skip "wacli-health: messages flowing normally"
+        log_skip "bridge-health: messages flowing normally"
       fi
     else
-      log_skip "wacli-health: not authenticated"
+      log_skip "bridge-health: not authenticated"
     fi
   fi
 
@@ -306,7 +288,7 @@ case "$FIX_TARGET" in
     fix_slack_mcp
     fix_vercel_mcp
     ;;
-  wacli-fts)        fix_wacli_fts ;;
+  wacli-fts)        fix_bridge_fts ;;
   channel-health)   fix_channel_health ;;
   slack-mcp)        fix_slack_mcp ;;
   vercel-mcp)       fix_vercel_mcp ;;

--- a/claude-ops/bin/ops-autofix
+++ b/claude-ops/bin/ops-autofix
@@ -88,12 +88,6 @@ fix_bridge_fts() {
     return
   fi
 
-  # Check if Go is available for rebuild
-  if ! command -v go >/dev/null 2>&1; then
-    log_skip "bridge-fts: FTS5 available (sqlite built-in) — run scripts/whatsapp-bridge-migrate.sh"
-    return
-  fi
-
   # Run bridge schema migration to add FTS5 index (sqlite built-in, no rebuild needed)
   MIGRATE="${CLAUDE_PLUGIN_ROOT:-$(dirname "$0")/..}/scripts/whatsapp-bridge-migrate.sh"
   if bash "$MIGRATE" 2>/dev/null; then
@@ -211,7 +205,7 @@ fix_channel_health() {
         jid="bridge"
         MSG_COUNT=1
         [ "$MSG_COUNT" = "0" ] && LID_EMPTY=$((LID_EMPTY + 1))
-      done
+      fi
 
       if [ "$LID_EMPTY" -gt 0 ]; then
         if launchctl kickstart -k gui/$(id -u)/com.samrenders.whatsapp-bridge 2>/dev/null; then
@@ -283,7 +277,7 @@ fix_channel_health() {
 # ─── Run fixes ───────────────────────────────────────────────────────────────
 case "$FIX_TARGET" in
   all)
-    fix_wacli_fts
+    fix_bridge_fts
     fix_channel_health
     fix_slack_mcp
     fix_vercel_mcp

--- a/claude-ops/bin/ops-autofix
+++ b/claude-ops/bin/ops-autofix
@@ -159,79 +159,20 @@ fix_vercel_mcp() {
 
 # ─── 4. Channel health — detect auth'd but broken channels ──────────────────
 fix_channel_health() {
-  # ── WhatsApp: @lid JID sync + stale connection ──
+  # ── WhatsApp: bridge listen + recent message flow (wacli doctor removed) ──
   if lsof -i :8080 2>/dev/null | grep -q LISTEN; then
-    DOCTOR='{"success":true,"bridge":"running"}'
-    WA_AUTH=$(echo "$DOCTOR" | jq -r '.data.authenticated // false' 2>/dev/null)
-    WA_LOCK=$(echo "$DOCTOR" | jq -r '.data.lock_held // false' 2>/dev/null)
-
-    if [ "$WA_AUTH" = "true" ]; then
-      # Kill stale lock if held >2 min — but never kill the legitimate
-      # bridge manages its own locking internally
-      # entire lifetime by design; that's not "stale").
-      if [ "$WA_LOCK" = "true" ]; then
-        LOCK_PID=$(echo "$DOCTOR" | jq -r '.data.lock_info' 2>/dev/null | grep -oE 'pid=[0-9]+' | cut -d= -f2)
-        if [ -n "$LOCK_PID" ] && kill -0 "$LOCK_PID" 2>/dev/null; then
-          LOCK_CMD=$(ps -p "$LOCK_PID" -o command= 2>/dev/null || echo "")
-          LOCK_ETIME=$(ps -p "$LOCK_PID" -o etime= 2>/dev/null | tr -d ' ')
-          # Skip if it's the persistent --follow daemon
-          if false; then  # bridge manages locking internally
-            log_skip "bridge-health: lock held by persistent --follow daemon (pid=$LOCK_PID) — leaving alone"
-          else
-            # Parse etime to seconds. Formats: SS, MM:SS, HH:MM:SS, DD-HH:MM:SS
-            LOCK_AGE=$(echo "$LOCK_ETIME" | awk -F'[-:]' '{
-              n=NF; s=0
-              if (n==1) s=$1
-              else if (n==2) s=$1*60+$2
-              else if (n==3) s=$1*3600+$2*60+$3
-              else if (n==4) s=$1*86400+$2*3600+$3*60+$4
-              print s
-            }')
-            if [ -n "$LOCK_AGE" ] && [ "$LOCK_AGE" -gt 120 ]; then
-              log_fix "bridge-health: killed stale lock holder (pid=$LOCK_PID, age=${LOCK_AGE}s, cmd=$LOCK_CMD)"
-              kill "$LOCK_PID" 2>/dev/null; sleep 2
-              kill -0 "$LOCK_PID" 2>/dev/null && kill -9 "$LOCK_PID" 2>/dev/null
-            else
-              log_skip "bridge-health: lock holder pid=$LOCK_PID is young (${LOCK_AGE}s) — not stale"
-            fi
-          fi
-        fi
-      fi
-
-      # Check @lid JIDs with empty messages
-      LID_EMPTY=0
-      # Bridge handles @lid resolution automatically — just ensure it is running
-      if true; then
-        jid="bridge"
-        MSG_COUNT=1
-        [ "$MSG_COUNT" = "0" ] && LID_EMPTY=$((LID_EMPTY + 1))
-      fi
-
-      if [ "$LID_EMPTY" -gt 0 ]; then
-        if launchctl kickstart -k gui/$(id -u)/com.samrenders.whatsapp-bridge 2>/dev/null; then
-          log_fix "bridge-health: synced @lid chats ($LID_EMPTY had empty messages)"
-        else
-          log_fail "bridge-health: sync timed out"
-        fi
-      fi
-
-      # Check for zero recent messages (auth'd but dead session)
-      BRIDGE_DB="${WHATSAPP_BRIDGE_DB:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db}"
-      RECENT=$(sqlite3 "$BRIDGE_DB" "SELECT COUNT(*) FROM messages WHERE timestamp >= datetime('now','-1 day');" 2>/dev/null || echo "0")
-      if [ "$RECENT" = "0" ]; then
-        # Try sync first
-        launchctl kickstart -k gui/$(id -u)/com.samrenders.whatsapp-bridge 2>/dev/null || true
-        RECENT2=$(sqlite3 "$BRIDGE_DB" "SELECT COUNT(*) FROM messages WHERE timestamp >= datetime('now','-1 day');" 2>/dev/null || echo "0")
-        if [ "$RECENT2" = "0" ]; then
-          log_fail "bridge-health: auth'd but 0 messages in 24h (likely app-state key desync — needs re-pair)"
-        else
-          log_fix "bridge-health: sync restored message flow"
-        fi
+    BRIDGE_DB="${WHATSAPP_BRIDGE_DB:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db}"
+    RECENT=$(sqlite3 "$BRIDGE_DB" "SELECT COUNT(*) FROM messages WHERE timestamp >= datetime('now','-1 day');" 2>/dev/null || echo "0")
+    if [ "$RECENT" = "0" ]; then
+      launchctl kickstart -k gui/$(id -u)/com.samrenders.whatsapp-bridge 2>/dev/null || true
+      RECENT2=$(sqlite3 "$BRIDGE_DB" "SELECT COUNT(*) FROM messages WHERE timestamp >= datetime('now','-1 day');" 2>/dev/null || echo "0")
+      if [ "$RECENT2" = "0" ]; then
+        log_fail "bridge-health: bridge up but 0 messages in 24h (may need re-pair or sync)"
       else
-        log_skip "bridge-health: messages flowing normally"
+        log_fix "bridge-health: sync restored message flow"
       fi
     else
-      log_skip "bridge-health: not authenticated"
+      log_skip "bridge-health: messages flowing normally"
     fi
   fi
 
@@ -282,7 +223,7 @@ case "$FIX_TARGET" in
     fix_slack_mcp
     fix_vercel_mcp
     ;;
-  wacli-fts)        fix_bridge_fts ;;
+  bridge-fts|wacli-fts) fix_bridge_fts ;;
   channel-health)   fix_channel_health ;;
   slack-mcp)        fix_slack_mcp ;;
   vercel-mcp)       fix_vercel_mcp ;;

--- a/claude-ops/bin/ops-doctor
+++ b/claude-ops/bin/ops-doctor
@@ -268,7 +268,7 @@ TOOLS_JSON=$(cat <<TOOLS
   "gh": $(has gh),
   "aws": $(has aws),
   "node": $(has node),
-  "wacli": $(has wacli),
+  "whatsapp-bridge": $(lsof -i :8080 2>/dev/null | grep -q LISTEN && echo true || echo false),
   "gog": $(has gog),
   "sentry-cli": $(has sentry-cli),
   "doppler": $(has doppler)

--- a/claude-ops/bin/ops-post-session-cleanup
+++ b/claude-ops/bin/ops-post-session-cleanup
@@ -2,7 +2,7 @@
 # Stop hook: cleanup stale worktrees and temp files on session end
 set -euo pipefail
 
-# Clean temp wacli files
+# Clean temp bridge files (formerly wacli temp files)
 rm -f /tmp/wacli-sync-probe-*.log /tmp/wacli-bootstrap-*.log 2>/dev/null || true
 
 # Clean stale agent worktrees older than 2 hours

--- a/claude-ops/bin/ops-pretool-wacli-health
+++ b/claude-ops/bin/ops-pretool-wacli-health
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# PreToolUse hook: check wacli health before WhatsApp commands
-# Receives tool input as $1, checks if it contains wacli commands
+# PreToolUse hook: DEPRECATED — replaced by ops-pretool-whatsapp-bridge-health
+# Kept as no-op shim for backwards compat
 set -euo pipefail
 
 INPUT="${1:-}"
@@ -15,7 +15,7 @@ HEALTH_FILE="$HOME/.wacli/.health"
 if [[ -f "$HEALTH_FILE" ]]; then
   STATUS=$(grep "^status=" "$HEALTH_FILE" | cut -d= -f2)
   if [[ "$STATUS" == "needs_auth" ]] || [[ "$STATUS" == "needs_reauth" ]]; then
-    echo "⚠ WhatsApp needs re-authentication. Run 'wacli auth' in a separate terminal."
+    echo "⚠ WhatsApp bridge may not be running. Check: launchctl list com.samrenders.whatsapp-bridge"
     # Don't block — just warn. The skill's own health check will handle it.
   fi
 fi

--- a/claude-ops/bin/ops-pretool-whatsapp-bridge-health
+++ b/claude-ops/bin/ops-pretool-whatsapp-bridge-health
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# PreToolUse hook: check whatsapp-bridge health before WhatsApp MCP tool calls
+# Receives tool input as $1, warns if bridge appears down
+set -euo pipefail
+
+INPUT="${1:-}"
+
+# Only check if the tool call involves whatsapp MCP tools
+if ! echo "$INPUT" | grep -q "whatsapp"; then
+  exit 0
+fi
+
+# Check bridge is listening on port 8080
+if ! lsof -i :8080 2>/dev/null | grep -q LISTEN; then
+  echo "⚠ WhatsApp bridge not running on :8080. Restart: launchctl kickstart -k gui/$(id -u)/com.samrenders.whatsapp-bridge"
+  # Don't block — just warn. The skill's own health check will handle it.
+fi
+
+# Check launchd registration
+if ! launchctl list com.samrenders.whatsapp-bridge 2>/dev/null | grep -q '"PID"'; then
+  echo "⚠ com.samrenders.whatsapp-bridge not active in launchd. Check: launchctl list com.samrenders.whatsapp-bridge"
+fi
+
+exit 0

--- a/claude-ops/bin/ops-setup-install
+++ b/claude-ops/bin/ops-setup-install
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # ops-setup-install — Idempotent installer for ops CLI dependencies
 # Usage: ops-setup-install [--dry-run] [--json] [--list-pkg-mgr] <tool> [<tool>...]
-# Tools: jq git gh aws node brew doppler wacli gog sentry-cli expect
+# Tools: jq git gh aws node brew doppler gog sentry-cli expect
 set -euo pipefail
 
 # ─── Source the os-detect helper (cross-OS pkg mgr detection) ───────────────
@@ -148,10 +148,9 @@ install_special() {
       fi
       echo "○ sentry-cli needs npm or Homebrew — install Node first, then retry." >&2
       return 2 ;;
-    wacli)
-      # wacli isn't on any package manager yet — point users to source install.
-      echo "○ wacli is not on any package manager — install from source:" >&2
-      echo "  git clone https://github.com/wacli/wacli && cd wacli && ./install.sh" >&2
+    whatsapp-bridge)
+      # whatsapp-bridge is installed as part of whatsapp-mcp
+      echo "○ whatsapp-bridge install: git clone https://github.com/Lifecycle-Innovations-Limited/whatsapp-mcp ~/.local/share/whatsapp-mcp && cd ~/.local/share/whatsapp-mcp/whatsapp-bridge && go build -o whatsapp-bridge ." >&2
       return 2 ;;
     brew)
       # Homebrew has its own bootstrap installer.

--- a/claude-ops/bin/ops-setup-preflight
+++ b/claude-ops/bin/ops-setup-preflight
@@ -96,8 +96,6 @@ cred_get() {
     echo '{"bridge":"running"}' > "$OUT/bridge-health.json"
   else
     echo '{"bridge":"stopped"}' > "$OUT/bridge-health.json"
-  else
-    echo '{"success":false,"reason":"not_installed"}' > "$OUT/wacli-doctor.json"
   fi
 } &
 

--- a/claude-ops/bin/ops-setup-preflight
+++ b/claude-ops/bin/ops-setup-preflight
@@ -47,7 +47,7 @@ cred_get() {
 
 {
   # CLI detection
-  for tool in jq git gh aws node brew doppler wacli gog sentry-cli expect; do
+  for tool in jq git gh aws node brew doppler gog sentry-cli expect; do
     if command -v "$tool" &>/dev/null; then
       ver=$("$tool" --version 2>/dev/null | head -1 || echo "installed")
       echo "$tool=$ver" >> "$OUT/clis.txt"
@@ -91,9 +91,11 @@ cred_get() {
 
 {
   # WhatsApp probe
-  if command -v wacli &>/dev/null; then
-    wacli doctor --json 2>/dev/null > "$OUT/wacli-doctor.json" || echo '{"success":false}' > "$OUT/wacli-doctor.json"
-    wacli chats list --json 2>/dev/null > "$OUT/wacli-chats.json" || echo '{"success":false,"data":[]}' > "$OUT/wacli-chats.json"
+  # Bridge health check
+  if lsof -i :8080 2>/dev/null | grep -q LISTEN; then
+    echo '{"bridge":"running"}' > "$OUT/bridge-health.json"
+  else
+    echo '{"bridge":"stopped"}' > "$OUT/bridge-health.json"
   else
     echo '{"success":false,"reason":"not_installed"}' > "$OUT/wacli-doctor.json"
   fi
@@ -141,7 +143,7 @@ cred_get() {
 } &
 
 {
-  # Auto-fix pass: silently repair wacli FTS, missing MCPs, etc.
+  # Auto-fix pass: silently repair bridge FTS, missing MCPs, etc.
   SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
   if [ -x "$SCRIPT_DIR/bin/ops-autofix" ]; then
     "$SCRIPT_DIR/bin/ops-autofix" --json > "$OUT/autofix.json" 2>/dev/null || true

--- a/claude-ops/bin/ops-status
+++ b/claude-ops/bin/ops-status
@@ -104,7 +104,8 @@ _channel_configured() {
   case "$channel" in
     whatsapp)
       _pref_has ".channels.whatsapp" && return 0
-      has_cmd wacli && return 0
+      # wacli decommissioned — bridge check instead
+  lsof -i :8080 2>/dev/null | grep -q LISTEN && return 0
       ;;
     telegram)
       _pref_has ".channels.telegram" && return 0
@@ -141,7 +142,7 @@ _mcp_present() {
 }
 
 # ─── 1. CLIs ────────────────────────────────────────────────────────────────
-CLI_LIST=(gh aws jq node wacli gog doppler)
+CLI_LIST=(gh aws jq node gog doppler)
 declare -A CLI_STATUS
 for c in "${CLI_LIST[@]}"; do
   if has_cmd "$c"; then CLI_STATUS[$c]="ok"; else CLI_STATUS[$c]="missing"; fi

--- a/claude-ops/bin/ops-status
+++ b/claude-ops/bin/ops-status
@@ -105,7 +105,7 @@ _channel_configured() {
     whatsapp)
       _pref_has ".channels.whatsapp" && return 0
       # wacli decommissioned — bridge check instead
-  lsof -i :8080 2>/dev/null | grep -q LISTEN && return 0
+      lsof -i :8080 2>/dev/null | grep -q LISTEN && return 0
       ;;
     telegram)
       _pref_has ".channels.telegram" && return 0

--- a/claude-ops/bin/ops-unread
+++ b/claude-ops/bin/ops-unread
@@ -1,57 +1,39 @@
 #!/usr/bin/env bash
 # ops-unread — Channel availability + unread counts → JSON
-# Checks WhatsApp (wacli), Email (gog), Slack (env), Telegram (env)
+# Checks WhatsApp (Baileys bridge), Email (gog), Slack (env), Telegram (env)
 # All secrets via env vars or CLI auth — no hardcoded credentials.
 #
 # ENV VARS (optional — tools auto-detect if installed):
 #   GMAIL_ACCOUNT     — Gmail account for gog (default: auto-detect)
 #   SLACK_MCP_ENABLED — "true" if Slack MCP server is configured
 #   TELEGRAM_ENABLED  — "true" if Telegram user-auth MCP is configured
-#   WACLI_STORE       — wacli store path (default: ~/.wacli)
+#   WHATSAPP_BRIDGE_DB — bridge messages.db path (default: ~/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db)
 
 set -euo pipefail
 
 RESULT='{"channels":{}}'
 
-# ── WhatsApp via wacli ──
-if command -v wacli &>/dev/null; then
-  # Check connection status
-  WA_STATUS=$(wacli doctor 2>/dev/null | grep -i "CONNECTED" | awk '{print $2}' || echo "unknown")
-  WA_AUTH=$(wacli doctor 2>/dev/null | grep -i "AUTHENTICATED" | awk '{print $2}' || echo "unknown")
+# ── WhatsApp via Baileys bridge ──
+BRIDGE_DB="${WHATSAPP_BRIDGE_DB:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db}"
+BRIDGE_RUNNING=0
+if lsof -i :8080 2>/dev/null | grep -q LISTEN; then
+  BRIDGE_RUNNING=1
+fi
 
-  if [ "$WA_AUTH" = "true" ]; then
-    # Count non-archived chats with recent activity (7 days)
-    WA_RECENT=$(wacli chats list --json 2>/dev/null | python3 -c "
-import json, sys
-from datetime import datetime, timezone, timedelta
-try:
-    raw = json.loads(sys.stdin.read())
-    data = raw.get('data', raw)
-    chats = data if isinstance(data, list) else data.get('chats', [])
-    cutoff = datetime.now(timezone.utc) - timedelta(days=7)
-    count = 0
-    for c in chats:
-        ts = c.get('LastMessageTS', '')
-        try:
-            t = datetime.fromisoformat(ts.replace('Z', '+00:00'))
-            if t > cutoff:
-                count += 1
-        except: pass
-    print(count)
-except:
-    print(0)
-" 2>/dev/null || echo "0")
-
-    [[ "$WA_RECENT" =~ ^[0-9]+$ ]] || WA_RECENT="0"
-    RESULT=$(echo "$RESULT" | jq \
-      --argjson c "$WA_RECENT" \
-      --arg status "$WA_STATUS" \
-      '.channels.whatsapp = {"recent_chats": $c, "connected": ($status == "true"), "available": true}')
-  else
-    RESULT=$(echo "$RESULT" | jq '.channels.whatsapp = {"unread": 0, "available": false, "note": "wacli not authenticated — run: wacli auth"}')
-  fi
+if [[ $BRIDGE_RUNNING -eq 1 ]] && [[ -f "$BRIDGE_DB" ]]; then
+  # Count chats with recent activity (7 days) directly from bridge messages.db
+  WA_RECENT=$(sqlite3 "$BRIDGE_DB" "
+    SELECT COUNT(DISTINCT chat_jid) FROM messages
+    WHERE timestamp >= datetime('now', '-7 days');
+  " 2>/dev/null || echo "0")
+  [[ "$WA_RECENT" =~ ^[0-9]+$ ]] || WA_RECENT="0"
+  RESULT=$(echo "$RESULT" | jq \
+    --argjson c "$WA_RECENT" \
+    '.channels.whatsapp = {"recent_chats": $c, "connected": true, "available": true}')
+elif [[ $BRIDGE_RUNNING -eq 0 ]]; then
+  RESULT=$(echo "$RESULT" | jq '.channels.whatsapp = {"unread": 0, "available": false, "note": "whatsapp-bridge not running — restart: launchctl kickstart -k gui/$UID/com.samrenders.whatsapp-bridge"}')
 else
-  RESULT=$(echo "$RESULT" | jq '.channels.whatsapp = {"unread": 0, "available": false, "note": "wacli not installed"}')
+  RESULT=$(echo "$RESULT" | jq '.channels.whatsapp = {"unread": 0, "available": false, "note": "whatsapp-bridge DB not found — run scripts/whatsapp-bridge-migrate.sh"}')
 fi
 
 # ── Email via gog ──

--- a/claude-ops/bin/wacli-health
+++ b/claude-ops/bin/wacli-health
@@ -1,93 +1,40 @@
 #!/usr/bin/env bash
-# wacli-health — Check wacli + keepalive health. Returns 0 if healthy, 1 if not.
+# wacli-health — DEPRECATED. Checks whatsapp-bridge health instead (wacli decommissioned).
+# Kept for backwards compatibility. Returns 0 if bridge is healthy, 1 if not.
 #
 # Usage: wacli-health            # exit code only
 #        wacli-health --json     # JSON output
-#        wacli-health --repair   # auto-fix if unhealthy
-#
-# Any ops skill can call this before using wacli to ensure the connection is live.
 set -euo pipefail
 
-WACLI="${WACLI_BIN:-/usr/local/bin/wacli}"
-STORE="${WACLI_STORE:-$HOME/.wacli}"
-HEALTH_FILE="$STORE/.health"
-KEEPALIVE_LABEL="com.claude-ops.wacli-keepalive"
-SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-
 JSON_MODE=0
-REPAIR_MODE=0
 for arg in "$@"; do
-  case "$arg" in
-    --json) JSON_MODE=1 ;;
-    --repair) REPAIR_MODE=1 ;;
-  esac
+  [[ "$arg" == "--json" ]] && JSON_MODE=1
 done
 
 healthy=1
 issues=()
 
-# 1. Check wacli binary exists
-if ! command -v "$WACLI" &>/dev/null; then
+# Check bridge is listening
+if ! lsof -i :8080 2>/dev/null | grep -q LISTEN; then
   healthy=0
-  issues+=("wacli binary not found at $WACLI")
+  issues+=("whatsapp-bridge not listening on :8080")
 fi
 
-# 2. Check authentication
-if [[ $healthy -eq 1 ]]; then
-  doctor_out=$("$WACLI" doctor 2>&1) || true
-  if ! echo "$doctor_out" | grep -q "AUTHENTICATED.*true"; then
-    healthy=0
-    issues+=("not authenticated — QR scan required")
-  fi
-fi
-
-# 3. Check health file
-if [[ -f "$HEALTH_FILE" ]]; then
-  status=$(grep '^status=' "$HEALTH_FILE" 2>/dev/null | cut -d= -f2- || echo "unknown")
-  case "$status" in
-    connected|running|ok) ;;
-    needs_auth|needs_reauth)
-      healthy=0
-      issues+=("health file reports: $status")
-      ;;
-    paused)
-      issues+=("sync currently paused for external command")
-      ;;
-    *)
-      issues+=("health file status: $status")
-      ;;
-  esac
-  health_pid=$(grep '^pid=' "$HEALTH_FILE" 2>/dev/null | cut -d= -f2- || true)
-  if [[ -n "$health_pid" ]] && ! kill -0 "$health_pid" 2>/dev/null; then
-    healthy=0
-    issues+=("keepalive pid=$health_pid is dead")
-  fi
-else
-  healthy=0
-  issues+=("no health file — keepalive may not be running")
-fi
-
-# 4. Check launchd/systemd registration
+# Check launchd registration
 if [[ "$(uname -s)" == "Darwin" ]]; then
-  pid_str=$(launchctl list 2>/dev/null | awk -v lbl="$KEEPALIVE_LABEL" '$3==lbl {print $1}' || true)
-  if [[ -z "$pid_str" ]]; then
+  if ! launchctl list 2>/dev/null | grep -q "com.samrenders.whatsapp-bridge"; then
     healthy=0
-    issues+=("$KEEPALIVE_LABEL not registered in launchd")
-  elif [[ "$pid_str" == "-" ]]; then
-    healthy=0
-    issues+=("$KEEPALIVE_LABEL registered but not running")
-  elif ! kill -0 "$pid_str" 2>/dev/null; then
-    healthy=0
-    issues+=("$KEEPALIVE_LABEL has stale PID $pid_str")
-  fi
-elif command -v systemctl &>/dev/null; then
-  if ! systemctl --user is-active claude-ops-wacli-keepalive.service &>/dev/null; then
-    healthy=0
-    issues+=("claude-ops-wacli-keepalive.service not active")
+    issues+=("com.samrenders.whatsapp-bridge not registered in launchd")
   fi
 fi
 
-# Output
+# Check bridge DB exists
+BRIDGE_DB="${WHATSAPP_BRIDGE_DB:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db}"
+if [[ ! -f "$BRIDGE_DB" ]]; then
+  healthy=0
+  issues+=("bridge DB not found at $BRIDGE_DB")
+fi
+
 if [[ $JSON_MODE -eq 1 ]]; then
   issues_json="["
   first=1
@@ -97,26 +44,16 @@ if [[ $JSON_MODE -eq 1 ]]; then
     issues_json+="\"$(echo "$i" | sed 's/"/\\"/g')\""
   done
   issues_json+="]"
-  echo "{\"healthy\": $([ $healthy -eq 1 ] && echo true || echo false), \"issues\": $issues_json}"
+  echo "{\"healthy\": $([ $healthy -eq 1 ] && echo true || echo false), \"issues\": $issues_json, \"backend\": \"whatsapp-bridge\"}"
 else
   if [[ $healthy -eq 1 ]]; then
-    echo "wacli: healthy"
+    echo "whatsapp-bridge: healthy"
   else
-    echo "wacli: UNHEALTHY"
+    echo "whatsapp-bridge: UNHEALTHY"
     for i in "${issues[@]+"${issues[@]}"}"; do
       echo "  - $i"
     done
-  fi
-fi
-
-# Auto-repair if requested and unhealthy
-if [[ $REPAIR_MODE -eq 1 ]] && [[ $healthy -eq 0 ]]; then
-  echo "Attempting auto-repair..."
-  if [[ -f "$SCRIPT_DIR/scripts/ops-daemon.sh" ]]; then
-    bash "$SCRIPT_DIR/scripts/ops-daemon.sh" --install 2>&1 || true
-    echo "Reinstalled launchd/systemd services. Check again in ~15s."
-  else
-    echo "Cannot find ops-daemon.sh for repair" >&2
+    echo "Restart: launchctl kickstart -k gui/$(id -u)/com.samrenders.whatsapp-bridge"
   fi
 fi
 

--- a/claude-ops/bin/wacli-safe
+++ b/claude-ops/bin/wacli-safe
@@ -1,48 +1,18 @@
 #!/usr/bin/env bash
-# wacli-safe — Run a one-shot wacli command without store-lock conflicts.
+# wacli-safe — DEPRECATED. wacli is decommissioned.
 #
-# Pauses the persistent keepalive sync, runs the command, then lets sync resume.
-# Usage: wacli-safe send --to "+1234567890" --text "Hello"
-#        wacli-safe history backfill --chat "12345@s.whatsapp.net" --count 50
+# The Baileys whatsapp-bridge manages its own store locking internally.
+# No external lock/pause mechanism is needed. This script is a no-op shim
+# kept for backwards compatibility with any scripts that may invoke it.
 #
-# The keepalive script watches for the pause signal file and gracefully stops
-# its persistent sync. After this script exits (or after 60s timeout), the
-# keepalive resumes automatically.
+# For bridge operations use mcp__whatsapp__* tools directly.
 set -euo pipefail
 
-WACLI="${WACLI_BIN:-/usr/local/bin/wacli}"
-STORE="${WACLI_STORE:-$HOME/.wacli}"
-PAUSE_SIGNAL="$STORE/.pause_sync"
-
 if [[ $# -eq 0 ]]; then
-  echo "Usage: wacli-safe <wacli-subcommand> [args...]" >&2
-  echo "  Pauses keepalive sync, runs the wacli command, then resumes sync." >&2
+  echo "wacli-safe: wacli is decommissioned. Use mcp__whatsapp__* tools instead." >&2
   exit 1
 fi
 
-cleanup() {
-  rm -f "$PAUSE_SIGNAL"
-}
-trap cleanup EXIT INT TERM
-
-# Write pause signal with our PID + timestamp
-mkdir -p "$STORE"
-echo "$$" > "$PAUSE_SIGNAL"
-
-# Wait for keepalive to stop its sync (check every 500ms, max 10s)
-waited=0
-while pgrep -f "wacli sync --follow" >/dev/null 2>&1 && [[ $waited -lt 20 ]]; do
-  sleep 0.5
-  (( waited++ )) || true
-done
-
-if pgrep -f "wacli sync --follow" >/dev/null 2>&1; then
-  echo "warning: keepalive sync still running after 10s — proceeding anyway" >&2
-fi
-
-# Run the actual wacli command
-"$WACLI" "$@"
-exit_code=$?
-
-# Cleanup happens via trap
-exit $exit_code
+echo "wacli-safe: wacli is decommissioned. Command ignored: $*" >&2
+echo "Use mcp__whatsapp__send_message / mcp__whatsapp__list_messages etc. instead." >&2
+exit 1

--- a/claude-ops/docs/INDEX.md
+++ b/claude-ops/docs/INDEX.md
@@ -26,7 +26,7 @@
 |-----|---------|
 | [`agents-reference.md`](agents-reference.md) | Catalog of all 18 agents (4 v2 specialists + 14 v1 scanners/fixers/C-suite). |
 | [`skills-reference.md`](skills-reference.md) | Catalog of all 33+ skills with usage examples. |
-| [`daemon-guide.md`](daemon-guide.md) | The v1 ops-daemon (briefing pre-warm, wacli-sync, memory-extractor, etc). |
+| [`daemon-guide.md`](daemon-guide.md) | The v1 ops-daemon (briefing pre-warm, whatsapp-bridge-sync, memory-extractor, etc). |
 | [`docker.md`](docker.md) | Running claude-ops in a container. |
 | [`marketplace-submissions.md`](marketplace-submissions.md) | Publishing your own plugin to the same marketplace. |
 | [`memories-system.md`](memories-system.md) | The cross-session memory system used by agents. |

--- a/claude-ops/docs/daemon-guide.md
+++ b/claude-ops/docs/daemon-guide.md
@@ -30,7 +30,7 @@ The daemon supervises **seven** long-lived services:
 | Service | Cadence | Purpose |
 |---------|---------|---------|
 | `briefing-pre-warm` | every **2 min** | Runs `bin/ops-gather` to keep `/ops:go` cache hot |
-| `wacli-sync` | persistent | Keeps WhatsApp connected, auto-reconnects, backfills `@lid` chats |
+| `whatsapp-bridge-sync` | persistent | Keeps WhatsApp connected, auto-reconnects, backfills `@lid` chats |
 | `memory-extractor` | every 30 min | Spawns `memory-extractor` agent to refresh `memories/` |
 | `inbox-digest` | every 15 min | Pre-classifies comms across channels for `/ops:inbox` |
 | `store-health` | every 10 min | Shopify orders + inventory polling (if configured) |
@@ -125,7 +125,7 @@ The daemon script lives at `scripts/ops-daemon.sh`.
 
 ## 📋 Health File Contract
 
-The daemon writes `~/.wacli/.health` on every successful wacli sync. Skills read this file before any WhatsApp operation.
+The daemon writes `~/.whatsapp-bridge/.health` on every successful whatsapp-bridge sync. Skills read this file before any WhatsApp operation.
 
 ```json
 {
@@ -139,8 +139,8 @@ The daemon writes `~/.wacli/.health` on every successful wacli sync. Skills read
 | Field | Meaning |
 |-------|---------|
 | `status` | `ok`, `degraded`, or `down` |
-| `last_sync` | ISO timestamp of last successful wacli poll |
-| `wacli_pid` | PID of the running wacli process |
+| `last_sync` | ISO timestamp of last successful whatsapp-bridge poll |
+| `wacli_pid` | PID of the running whatsapp-bridge process |
 | `message_count` | Total messages in local DB |
 
 > [!WARNING]
@@ -150,7 +150,7 @@ The daemon writes `~/.wacli/.health` on every successful wacli sync. Skills read
 
 ## 🪝 PreToolUse Hook
 
-`hooks/whatsapp-health-check.sh` runs automatically before any `wacli` call. It checks the health file and either:
+`hooks/whatsapp-health-check.sh` runs automatically before any `whatsapp-bridge` call. It checks the health file and either:
 - Proceeds silently if `status === ok` and `last_sync` is recent
 - Surfaces a warning with instructions to restart the daemon if degraded
 
@@ -191,7 +191,7 @@ Common issues:
 
 | Symptom | Likely cause | Fix |
 |---------|--------------|-----|
-| `wacli not connected` | Auth expired | `/ops:setup whatsapp` to re-authenticate |
+| `whatsapp-bridge not connected` | Auth expired | `/ops:setup whatsapp` to re-authenticate |
 | `health file stale` | Daemon crashed | Check `/tmp/com.claude-ops.daemon.log`, restart via launchctl |
 | `memory extractor not running` | Missing Haiku API key | Configure in preferences or Doppler |
 | `briefing-pre-warm errors` | `bin/ops-gather` failing | Run `bin/ops-gather` manually to see the error, often a missing CLI |

--- a/claude-ops/docs/memories-system.md
+++ b/claude-ops/docs/memories-system.md
@@ -16,13 +16,13 @@
 The memories system gives claude-ops persistent context about people, projects, and your communication patterns. Introduced in v0.5.0, upgraded in v1.1.0 with richer project context blocks.
 
 > [!IMPORTANT]
-> **Files never leave your machine.** Memories are plain markdown on your local disk at `~/.claude/plugins/data/ops-ops-marketplace/memories/`. The extractor reads your local wacli database and local email cache — nothing is uploaded. See [Privacy](#-privacy) below.
+> **Files never leave your machine.** Memories are plain markdown on your local disk at `~/.claude/plugins/data/ops-ops-marketplace/memories/`. The extractor reads your local whatsapp-bridge database and local email cache — nothing is uploaded. See [Privacy](#-privacy) below.
 
 ---
 
 ## 🧠 How It Works
 
-1. **Extraction** — the `memory-extractor` agent (`agents/memory-extractor.md`) runs every 30 minutes as a daemon service. It reads recent WhatsApp messages (via `wacli`) and email threads (via `gog`) and calls Claude Haiku to extract structured profiles.
+1. **Extraction** — the `memory-extractor` agent (`agents/memory-extractor.md`) runs every 30 minutes as a daemon service. It reads recent WhatsApp messages (via `whatsapp-bridge`) and email threads (via `gog`) and calls Claude Haiku to extract structured profiles.
 2. **Storage** — profiles are written as markdown files to `~/.claude/plugins/data/ops-ops-marketplace/memories/`.
 3. **Consumption** — skills load the relevant memory files at runtime via the Runtime Context block at the top of each `SKILL.md`.
 
@@ -36,10 +36,10 @@ flowchart TB
     Trigger -->|/ops:doctor --run-memory-extractor| Start
 
     Start --> ReadLocal[Read LOCAL sources only]
-    ReadLocal --> Wacli[(~/.wacli<br/>local SQLite)]
+    ReadLocal --> Bridge[(~/.whatsapp-bridge<br/>local SQLite)]
     ReadLocal --> Gog[(~/.gog<br/>local email cache)]
 
-    Wacli --> Haiku[Claude Haiku 4.5<br/>structured extraction]
+    Bridge --> Haiku[Claude Haiku 4.5<br/>structured extraction]
     Gog --> Haiku
 
     Haiku --> Merge[Merge into existing<br/>profiles — never overwrite]
@@ -64,7 +64,7 @@ flowchart TB
 
     class Trigger,ReadLocal primary
     class Start,Haiku agent
-    class Wacli,Gog,Contacts,Prefs,Projects daemon
+    class Bridge,Gog,Contacts,Prefs,Projects daemon
     class Consumed,Inbox,Comms,Go success
 ```
 
@@ -182,7 +182,7 @@ The daemon triggers extraction when **any** of these conditions are met:
 | Trigger | Condition |
 |---------|-----------|
 | Time-based | 30 minutes elapsed since last run |
-| Volume-based | Message count in `~/.wacli/.health` increased by more than 5 |
+| Volume-based | Message count in `~/.whatsapp-bridge/.health` increased by more than 5 |
 | Manual | `/ops:doctor --run-memory-extractor` |
 
 The extractor uses `claude-haiku-4-5-20251001` (fast + cheap) for all extraction work. It merges new information into existing profiles rather than overwriting, so context accumulates over time.
@@ -199,7 +199,7 @@ The extractor uses `claude-haiku-4-5-20251001` (fast + cheap) for all extraction
 >
 > - **Location:** `~/.claude/plugins/data/ops-ops-marketplace/memories/`
 > - **Storage:** plain markdown files on your local disk
-> - **Sources:** the extractor reads your **local** wacli database and **local** email cache — not cloud APIs
+> - **Sources:** the extractor reads your **local** whatsapp-bridge database and **local** email cache — not cloud APIs
 > - **Upload:** nothing is sent to any server. Files are read by skills at runtime and that's it.
 >
 > If you want to wipe everything: `rm -rf ~/.claude/plugins/data/ops-ops-marketplace/memories/`.

--- a/claude-ops/docs/migrating-from-v1.md
+++ b/claude-ops/docs/migrating-from-v1.md
@@ -30,7 +30,7 @@ That's it. Existing settings, registries, preferences, and daemon services are u
 | Skills | 30 | 33+ (added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`) |
 | Agents | 14 | 18 (added `general-purpose` override, `deploy-fixer`, `build-fixer`, `dependency-auditor`) |
 | PostToolUse:Bash hooks | 0 | 3 (deploy-fix-merge, deploy-fix-build, task-reminder) |
-| PreToolUse:Bash hooks | 1 (wacli-health) | 4 (+ secret-commit, no-rm-rf-anchor, warn-mainpush) |
+| PreToolUse:Bash hooks | 1 (whatsapp-bridge-health) | 4 (+ secret-commit, no-rm-rf-anchor, warn-mainpush) |
 | PreToolUse:Agent hooks | 0 | 1 (specialized-agent suggestion) |
 | Daemons | 1 (ops-daemon, 7 services) | 3 (+ recap-daemon, account-rotation-daemon) |
 | `userConfig` toggles | ~25 string entries | 44 (19+ new booleans/numbers/file pickers) |

--- a/claude-ops/docs/os-compatibility.md
+++ b/claude-ops/docs/os-compatibility.md
@@ -73,11 +73,11 @@ Tokens are stored via the credential cascade (see below). Service names: `slack-
 
 `bin/ops-telegram-autolink.mjs` uses gram.js to capture an MTProto session string. Works identically on every OS — the only platform difference is where the credentials are persisted (cred cascade). Service names: `telegram-api-id`, `telegram-api-hash`, `telegram-phone`, `telegram-session`.
 
-### WhatsApp — `wacli`
+### WhatsApp — `whatsapp-bridge`
 
 | OS | Status | Notes |
 |---|---|---|
-| macOS | Tier 1 | `wacli` builds from source: `git clone … && go build -o /usr/local/bin/wacli ./cmd/wacli` |
+| macOS | Tier 1 | `whatsapp-bridge` builds from source: `git clone … && go build -o /usr/local/bin/whatsapp-bridge ./cmd/whatsapp-bridge` |
 | Linux | Tier 1 | Same build flow; install Go first: `apt-get install -y golang` etc. |
 | WSL2 | Tier 1 | Same as Linux. |
 | Windows | Tier 3 | Build under WSL — native Windows builds untested. |
@@ -157,8 +157,8 @@ Backend names: `security`, `secret-tool`, `wincred`, `keytar`, `enc-json`, `plai
 
 | OS | Mechanism | Files written |
 |---|---|---|
-| macOS | `launchd` user agent | `~/Library/LaunchAgents/com.claude-ops.daemon.plist` + `…wacli-keepalive.plist` |
-| Linux / WSL2 | `systemd --user` unit + timer | `~/.config/systemd/user/claude-ops.service`, `claude-ops.timer`, `claude-ops-wacli-keepalive.service` |
+| macOS | `launchd` user agent | `~/Library/LaunchAgents/com.claude-ops.daemon.plist` + `…whatsapp-bridge-keepalive.plist` |
+| Linux / WSL2 | `systemd --user` unit + timer | `~/.config/systemd/user/claude-ops.service`, `claude-ops.timer`, `claude-ops-whatsapp-bridge-keepalive.service` |
 | Windows | Task Scheduler | `ClaudeOpsDaemon` task running `bash.exe scripts/ops-daemon.sh --run-once` every 5 min (falls back to `pwsh.exe` wrapper if Git Bash isn't on PATH) |
 
 **Cadence** is 5 minutes everywhere (`/SC MINUTE /MO 5` on Windows, `OnUnitActiveSec=5min` on systemd, throttled-loop on launchd).

--- a/claude-ops/hooks/hooks.json
+++ b/claude-ops/hooks/hooks.json
@@ -24,7 +24,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-pretool-wacli-health \"$TOOL_INPUT\" 2>/dev/null || true"
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-pretool-whatsapp-bridge-health \"$TOOL_INPUT\" 2>/dev/null || true"
           }
         ]
       },

--- a/claude-ops/scripts/daemon-services.default.json
+++ b/claude-ops/scripts/daemon-services.default.json
@@ -6,10 +6,10 @@
       "cron": "*/2 * * * *",
       "_note": "Pre-warms /ops:go briefing cache every 2 minutes. Runs immediately after daemon install so /ops:go is instant by the time setup finishes."
     },
-    "wacli-sync": {
+    "whatsapp-bridge": {
       "enabled": true,
-      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/wacli-keepalive.sh",
-      "health_file": "~/.wacli/.health",
+      "command": "launchctl kickstart -k gui/$UID/com.samrenders.whatsapp-bridge",
+      "health_check": "lsof -i :8080 | grep LISTEN",
       "restart_delay": 60,
       "max_restarts": 10
     },

--- a/claude-ops/scripts/daemon-services.example.json
+++ b/claude-ops/scripts/daemon-services.example.json
@@ -5,10 +5,10 @@
     "OPS_DATA_DIR": "Override default data dir (~/.claude/plugins/data/ops-ops-marketplace)"
   },
   "services": {
-    "wacli-sync": {
+    "whatsapp-bridge": {
       "enabled": true,
-      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/wacli-keepalive.sh",
-      "health_file": "~/.wacli/health.txt",
+      "command": "launchctl kickstart -k gui/$UID/com.samrenders.whatsapp-bridge",
+      "health_check": "lsof -i :8080 | grep LISTEN",
       "restart_delay": 60,
       "max_restarts": 10
     },
@@ -36,7 +36,7 @@
       "health_file": "~/.claude/plugins/data/ops-ops-marketplace/listener-health.txt",
       "restart_delay": 30,
       "max_restarts": 20,
-      "_note": "Requires: wacli installed. Optional: TELEGRAM_BOT_TOKEN, TELEGRAM_OWNER_ID."
+      "_note": "Requires: whatsapp-bridge running (com.samrenders.whatsapp-bridge LaunchAgent). Optional: TELEGRAM_BOT_TOKEN, TELEGRAM_OWNER_ID."
     },
     "memory-extractor": {
       "enabled": false,

--- a/claude-ops/scripts/ops-cron-inbox-digest.sh
+++ b/claude-ops/scripts/ops-cron-inbox-digest.sh
@@ -27,8 +27,8 @@ if [[ -f "$BRIDGE_DB" ]]; then
   WA_COUNT=$(echo "$WA_RAW" | python3 -c "
 import json, sys
 msgs = json.load(sys.stdin)
-# Filter out messages from owner (from_me=true)
-unread = [m for m in msgs if not m.get('from_me', False)]
+# Filter out messages from owner (is_from_me=true)
+unread = [m for m in msgs if not m.get('is_from_me', False)]
 print(len(unread))
 " 2>/dev/null || echo "0")
 
@@ -38,7 +38,7 @@ print(len(unread))
     WA_SENDERS=$(echo "$WA_RAW" | python3 -c "
 import json, sys
 msgs = json.load(sys.stdin)
-unread = [m for m in msgs if not m.get('from_me', False)]
+unread = [m for m in msgs if not m.get('is_from_me', False)]
 senders = list({m.get('contact_name', m.get('from', 'unknown')) for m in unread})[:5]
 print(', '.join(senders))
 " 2>/dev/null || echo "unknown")

--- a/claude-ops/scripts/ops-cron-inbox-digest.sh
+++ b/claude-ops/scripts/ops-cron-inbox-digest.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 DATA_DIR="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
 LOG_DIR="$DATA_DIR/logs"
 LOG="$LOG_DIR/inbox-digest.log"
-WACLI="${WACLI_BIN:-$(command -v wacli 2>/dev/null || echo /usr/local/bin/wacli)}"
+BRIDGE_DB="${WHATSAPP_BRIDGE_DB:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db}"
 
 mkdir -p "$LOG_DIR"
 log() { printf '%s [inbox-digest] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" | tee -a "$LOG"; }
@@ -21,9 +21,9 @@ fi
 
 # ── Gather WhatsApp unread count ──────────────────────────────────────────
 WA_SUMMARY="WhatsApp: unavailable"
-if command -v wacli &>/dev/null || [[ -x "$WACLI" ]]; then
+if [[ -f "$BRIDGE_DB" ]]; then
   SINCE=$(date -u -v-4H "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "4 hours ago" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u "+%Y-%m-%dT%H:%M:%SZ")
-  WA_RAW=$("$WACLI" messages list --after="$SINCE" --limit 20 --json 2>/dev/null || echo "[]")
+  WA_RAW=$(sqlite3 "$BRIDGE_DB" "SELECT json_group_array(json_object('chat_jid',chat_jid,'sender',sender,'content',content,'timestamp',timestamp,'is_from_me',is_from_me)) FROM messages WHERE timestamp >= '${SINCE}' ORDER BY timestamp DESC LIMIT 20;" 2>/dev/null || echo "[]")
   WA_COUNT=$(echo "$WA_RAW" | python3 -c "
 import json, sys
 msgs = json.load(sys.stdin)

--- a/claude-ops/scripts/ops-cron-inbox-digest.sh
+++ b/claude-ops/scripts/ops-cron-inbox-digest.sh
@@ -23,7 +23,7 @@ fi
 WA_SUMMARY="WhatsApp: unavailable"
 if [[ -f "$BRIDGE_DB" ]]; then
   SINCE=$(date -u -v-4H "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u -d "4 hours ago" "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || date -u "+%Y-%m-%dT%H:%M:%SZ")
-  WA_RAW=$(sqlite3 "$BRIDGE_DB" "SELECT json_group_array(json_object('chat_jid',chat_jid,'sender',sender,'content',content,'timestamp',timestamp,'is_from_me',is_from_me)) FROM messages WHERE timestamp >= '${SINCE}' ORDER BY timestamp DESC LIMIT 20;" 2>/dev/null || echo "[]")
+  WA_RAW=$(sqlite3 "$BRIDGE_DB" "SELECT json_group_array(json_object('chat_jid',chat_jid,'sender',sender,'content',content,'timestamp',timestamp,'is_from_me',is_from_me)) FROM (SELECT chat_jid, sender, content, timestamp, is_from_me FROM messages WHERE timestamp >= '${SINCE}' ORDER BY timestamp DESC LIMIT 20);" 2>/dev/null || echo "[]")
   WA_COUNT=$(echo "$WA_RAW" | python3 -c "
 import json, sys
 msgs = json.load(sys.stdin)

--- a/claude-ops/scripts/ops-cron-inbox-digest.sh
+++ b/claude-ops/scripts/ops-cron-inbox-digest.sh
@@ -28,7 +28,10 @@ if [[ -f "$BRIDGE_DB" ]]; then
 import json, sys
 msgs = json.load(sys.stdin)
 # Filter out messages from owner (is_from_me=true)
-unread = [m for m in msgs if not m.get('is_from_me', False)]
+def _from_me(m):
+    v = m.get('is_from_me', False)
+    return v is True or v == 1
+unread = [m for m in msgs if not _from_me(m)]
 print(len(unread))
 " 2>/dev/null || echo "0")
 
@@ -38,8 +41,11 @@ print(len(unread))
     WA_SENDERS=$(echo "$WA_RAW" | python3 -c "
 import json, sys
 msgs = json.load(sys.stdin)
-unread = [m for m in msgs if not m.get('is_from_me', False)]
-senders = list({m.get('contact_name', m.get('from', 'unknown')) for m in unread})[:5]
+def _from_me(m):
+    v = m.get('is_from_me', False)
+    return v is True or v == 1
+unread = [m for m in msgs if not _from_me(m)]
+senders = list({m.get('sender') or m.get('contact_name') or m.get('from') or 'unknown' for m in unread})[:5]
 print(', '.join(senders))
 " 2>/dev/null || echo "unknown")
     WA_SUMMARY="WhatsApp: $WA_COUNT unread from $WA_SENDERS"

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -159,13 +159,13 @@ else:
 
 # ── Launchd ownership check ──────────────────────────────────────────────
 # Returns 0 if the launchd service for whatsapp-bridge is loaded and has a
-# live process.  When true, the daemon must NOT start wacli-sync itself —
+# live process.  When true, the daemon must NOT start whatsapp-bridge itself —
 # launchd is the sole owner and handles restarts via KeepAlive=true.
-_wacli_owned_by_launchd() {
+_whatsapp_bridge_owned_by_launchd() {
   command -v launchctl >/dev/null 2>&1 || return 1
   local pid_str
   pid_str=$(launchctl list 2>/dev/null \
-    | awk '$3=="com.claude-ops.wacli-keepalive" {print $1}' || true)
+    | awk '$3=="com.samrenders.whatsapp-bridge" {print $1}' || true)
   # Service must be registered AND have a live PID (not "-")
   if [[ -n "$pid_str" ]] && [[ "$pid_str" != "-" ]] && kill -0 "$pid_str" 2>/dev/null; then
     return 0
@@ -177,14 +177,14 @@ _wacli_owned_by_launchd() {
 start_service() {
   local name="$1"
 
-  # ── Race-condition guard: wacli-sync ownership ──────────────────────────
-  # The launchd keepalive service (com.claude-ops.wacli-keepalive) is the
-  # whatsapp-bridge is the sole owner of the WA connection.  If it is loaded and running, the
-  # daemon must not spawn a competing wacli-sync — doing so causes store-lock
-  # errors and WhatsApp disconnections.  Instead we mark the service as
-  # "delegated" and monitor health passively via the health file.
-  if [[ "$name" == "wacli-sync" ]] && _wacli_owned_by_launchd; then
-    log "START: $name — launchd keepalive is running, deferring ownership (no duplicate spawn)"
+  # ── Race-condition guard: whatsapp-bridge ownership ─────────────────────
+  # The LaunchAgent com.samrenders.whatsapp-bridge is the sole owner of the WA
+  # connection. If it is loaded and running, the daemon must not spawn a
+  # competing whatsapp-bridge — doing so causes store-lock errors and
+  # disconnections. Instead we mark the service as "delegated" and monitor
+  # health passively.
+  if [[ "$name" == "whatsapp-bridge" ]] && _whatsapp_bridge_owned_by_launchd; then
+    log "START: $name — launchd WhatsApp bridge is running, deferring ownership (no duplicate spawn)"
     SERVICE_STATUS["$name"]="delegated"
     SERVICE_LAST_HEALTH["$name"]="launchd-owned"
     return 0
@@ -285,8 +285,8 @@ restart_service() {
   local name="$1"
 
   # ── Race-condition guard (mirrors start_service) ────────────────────────
-  if [[ "$name" == "wacli-sync" ]] && _wacli_owned_by_launchd; then
-    log "RESTART: $name — launchd keepalive owns this service, skipping daemon restart"
+  if [[ "$name" == "whatsapp-bridge" ]] && _whatsapp_bridge_owned_by_launchd; then
+    log "RESTART: $name — launchd WhatsApp bridge owns this service, skipping daemon restart"
     SERVICE_STATUS["$name"]="delegated"
     return 0
   fi
@@ -1647,15 +1647,15 @@ while true; do
       fi
     else
       # Persistent service: check health + restart if needed
-      # For wacli-sync delegated to launchd, re-check ownership each loop.
+      # For whatsapp-bridge delegated to launchd, re-check ownership each loop.
       # If launchd stopped unexpectedly, the daemon can take over.
-      if [[ "$svc" == "wacli-sync" ]] && [[ "${SERVICE_STATUS[$svc]:-}" == "delegated" ]]; then
-        if _wacli_owned_by_launchd; then
+      if [[ "$svc" == "whatsapp-bridge" ]] && [[ "${SERVICE_STATUS[$svc]:-}" == "delegated" ]]; then
+        if _whatsapp_bridge_owned_by_launchd; then
           # Still owned by launchd — just read the health file passively
           check_health "$svc" || true
           SERVICE_STATUS["$svc"]="delegated"
         else
-          log "MONITOR: $svc — launchd keepalive no longer running, daemon taking ownership"
+          log "MONITOR: $svc — launchd WhatsApp bridge no longer running, daemon taking ownership"
           SERVICE_STATUS["$svc"]="dead"
           start_service "$svc"
         fi

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # ops-daemon.sh — Unified background process manager for claude-ops
-# Manages: wacli sync, memory extraction, health monitors
+# Manages: whatsapp-bridge health, memory extraction, health monitors
 # daemon registration: launchd on macOS, systemd on Linux, Task Scheduler on Windows
 set -euo pipefail
 
@@ -158,7 +158,7 @@ else:
 }
 
 # ── Launchd ownership check ──────────────────────────────────────────────
-# Returns 0 if the launchd keepalive service for wacli is loaded and has a
+# Returns 0 if the launchd service for whatsapp-bridge is loaded and has a
 # live process.  When true, the daemon must NOT start wacli-sync itself —
 # launchd is the sole owner and handles restarts via KeepAlive=true.
 _wacli_owned_by_launchd() {
@@ -179,7 +179,7 @@ start_service() {
 
   # ── Race-condition guard: wacli-sync ownership ──────────────────────────
   # The launchd keepalive service (com.claude-ops.wacli-keepalive) is the
-  # sole owner of the wacli sync process.  If it is loaded and running, the
+  # whatsapp-bridge is the sole owner of the WA connection.  If it is loaded and running, the
   # daemon must not spawn a competing wacli-sync — doing so causes store-lock
   # errors and WhatsApp disconnections.  Instead we mark the service as
   # "delegated" and monitor health passively via the health file.
@@ -1289,7 +1289,7 @@ EOF
   # wacli-keepalive: persistent service (Restart=always) — no timer needed.
   cat > "$unit_dir/claude-ops-wacli-keepalive.service" <<EOF
 [Unit]
-Description=claude-ops wacli keepalive
+Description=claude-ops whatsapp-bridge keepalive
 After=default.target
 
 [Service]
@@ -1389,7 +1389,7 @@ ENSURE_SERVICES_INTERVAL="${ENSURE_SERVICES_INTERVAL:-300}"  # every 5 min
 # Format: "label|plist_src_basename|description"
 EXPECTED_SERVICES=(
   "com.claude-ops.daemon|com.claude-ops.daemon.plist|ops daemon"
-  "com.claude-ops.wacli-keepalive|com.claude-ops.wacli-keepalive.plist|wacli keepalive"
+  "com.samrenders.whatsapp-bridge|com.samrenders.whatsapp-bridge.plist|whatsapp-bridge"
 )
 
 ensure_all_services() {

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -206,7 +206,7 @@ start_service() {
   export OPS_DAEMON_MANAGED=1
 
   rotate_service_log "$LOG_DIR/${name}.log"
-  bash "$cmd" >> "$LOG_DIR/${name}.log" 2>&1 &
+  bash -c "$cmd" >> "$LOG_DIR/${name}.log" 2>&1 &
   local pid=$!
   SERVICE_PIDS["$name"]=$pid
   SERVICE_STATUS["$name"]="running"
@@ -503,7 +503,7 @@ run_cron_service() {
   export OPS_DAEMON_PID=$$
   export OPS_DAEMON_MANAGED=1
   rotate_service_log "$LOG_DIR/${name}.log"
-  bash "$cmd" >> "$LOG_DIR/${name}.log" 2>&1 &
+  bash -c "$cmd" >> "$LOG_DIR/${name}.log" 2>&1 &
   local pid=$!
   wait "$pid" 2>/dev/null || true
 

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -1143,7 +1143,7 @@ except Exception:
 # Resolve plugin-root-relative paths for daemon scripts (so the unit files
 # embed absolute paths that still work when invoked by another user context).
 OPS_DAEMON_SCRIPT="$SCRIPT_DIR/scripts/ops-daemon.sh"
-OPS_KEEPALIVE_SCRIPT="$SCRIPT_DIR/scripts/wacli-keepalive.sh"
+OPS_KEEPALIVE_SCRIPT="$SCRIPT_DIR/legacy/wacli-keepalive.sh.deprecated"
 
 install_daemon_launchd() {
   command -v launchctl >/dev/null 2>&1 || {

--- a/claude-ops/scripts/ops-memory-extractor.sh
+++ b/claude-ops/scripts/ops-memory-extractor.sh
@@ -140,27 +140,28 @@ resolve_api_key() { resolve_auth; }
 
 # ── Collect raw data ──────────────────────────────────────────────────────────
 collect_data() {
-  local wacli_data="" email_data=""
+  local wa_data="" email_data=""
   local yesterday
   yesterday=$(TZ=UTC _date_days_ago 1 "+%Y-%m-%d")
 
-  # WhatsApp via wacli
-  if command -v wacli &>/dev/null; then
+  # WhatsApp via Baileys bridge messages.db
+  local bridge_db="${WHATSAPP_BRIDGE_DB:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db}"
+  if [[ -f "$bridge_db" ]]; then
     local health_status=""
-    if [[ -f "${HOME}/.wacli/.health" ]]; then
-      health_status=$(cat "${HOME}/.wacli/.health" 2>/dev/null || true)
+    if lsof -i :8080 2>/dev/null | grep -q LISTEN; then
+      health_status="connected"
     fi
     if echo "${health_status}" | grep -qi "connected\|ok\|healthy" 2>/dev/null; then
       log "Collecting WhatsApp messages..."
-      wacli_data=$(wacli messages list --after="${yesterday}" --limit=200 --json 2>/dev/null || true)
-      if [[ -z "${wacli_data}" ]]; then
-        log "wacli returned no data (skipping)"
+      wa_data=$(sqlite3 "$bridge_db" "SELECT json_group_array(json_object('chat_jid',chat_jid,'sender',sender,'content',content,'timestamp',timestamp,'is_from_me',is_from_me)) FROM messages WHERE timestamp >= '${yesterday}' ORDER BY timestamp DESC LIMIT 200;" 2>/dev/null || true)
+      if [[ -z "${wa_data}" ]]; then
+        log "bridge db returned no data (skipping)"
       fi
     else
-      log "wacli not connected (skipping WhatsApp)"
+      log "whatsapp-bridge not running (skipping WhatsApp)"
     fi
   else
-    log "wacli not available (skipping WhatsApp)"
+    log "bridge db not found (skipping WhatsApp)"
   fi
 
   # Email via gog
@@ -174,7 +175,7 @@ collect_data() {
     log "gog not available (skipping email)"
   fi
 
-  if [[ -z "${wacli_data}" && -z "${email_data}" ]]; then
+  if [[ -z "${wa_data}" && -z "${email_data}" ]]; then
     log "No data sources available — nothing to extract"
     write_health "skipped" "no data sources"
     exit 0
@@ -183,7 +184,7 @@ collect_data() {
   # Write combined raw payload
   cat > "${TMP_RAW}" <<EOF
 {
-  "whatsapp_messages": ${wacli_data:-null},
+  "whatsapp_messages": ${wa_data:-null},
   "emails": ${email_data:-null},
   "collected_at": "$(ts)"
 }

--- a/claude-ops/scripts/ops-memory-extractor.sh
+++ b/claude-ops/scripts/ops-memory-extractor.sh
@@ -153,7 +153,7 @@ collect_data() {
     fi
     if echo "${health_status}" | grep -qi "connected\|ok\|healthy" 2>/dev/null; then
       log "Collecting WhatsApp messages..."
-      wa_data=$(sqlite3 "$bridge_db" "SELECT json_group_array(json_object('chat_jid',chat_jid,'sender',sender,'content',content,'timestamp',timestamp,'is_from_me',is_from_me)) FROM messages WHERE timestamp >= '${yesterday}' ORDER BY timestamp DESC LIMIT 200;" 2>/dev/null || true)
+      wa_data=$(sqlite3 "$bridge_db" "SELECT json_group_array(json_object('chat_jid',chat_jid,'sender',sender,'content',content,'timestamp',timestamp,'is_from_me',is_from_me)) FROM (SELECT chat_jid, sender, content, timestamp, is_from_me FROM messages WHERE timestamp >= '${yesterday}' ORDER BY timestamp DESC LIMIT 200);" 2>/dev/null || true)
       if [[ -z "${wa_data}" ]]; then
         log "bridge db returned no data (skipping)"
       fi

--- a/claude-ops/scripts/ops-message-listener.sh
+++ b/claude-ops/scripts/ops-message-listener.sh
@@ -98,13 +98,13 @@ poll_whatsapp() {
   local raw
   raw=$(sqlite3 "$BRIDGE_DB" "SELECT json_group_array(json_object('chat_jid',chat_jid,'sender',sender,'content',content,'timestamp',timestamp,'is_from_me',is_from_me)) FROM messages WHERE timestamp > '${WA_LAST_SEEN:-1970-01-01}' ORDER BY timestamp DESC LIMIT 20;" 2>/dev/null || echo "[]")
 
-  # Filter: only non-owner (from_me=false) messages
+  # Filter: only non-owner (is_from_me=false) messages
   echo "$raw" | python3 -c "
 import json, sys
 msgs = json.load(sys.stdin)
 filtered = []
 for m in msgs:
-    if not m.get('from_me', False):
+    if not m.get('is_from_me', False):
         filtered.append({
             'id': m.get('id', ''),
             'channel': 'whatsapp',

--- a/claude-ops/scripts/ops-message-listener.sh
+++ b/claude-ops/scripts/ops-message-listener.sh
@@ -92,11 +92,8 @@ poll_whatsapp() {
     return
   fi
 
-  local since_flag=""
-  [[ -n "$since" ]] && since_flag="--after=$since"
-
   local raw
-  raw=$(sqlite3 "$BRIDGE_DB" "SELECT json_group_array(json_object('chat_jid',chat_jid,'sender',sender,'content',content,'timestamp',timestamp,'is_from_me',is_from_me)) FROM messages WHERE timestamp > '${WA_LAST_SEEN:-1970-01-01}' ORDER BY timestamp DESC LIMIT 20;" 2>/dev/null || echo "[]")
+  raw=$(sqlite3 "$BRIDGE_DB" "SELECT json_group_array(json_object('chat_jid',chat_jid,'sender',sender,'content',content,'timestamp',timestamp,'is_from_me',is_from_me)) FROM (SELECT chat_jid, sender, content, timestamp, is_from_me FROM messages WHERE timestamp > '${since:-1970-01-01}' ORDER BY timestamp DESC LIMIT 20);" 2>/dev/null || echo "[]")
 
   # Filter: only non-owner (is_from_me=false) messages
   echo "$raw" | python3 -c "

--- a/claude-ops/scripts/ops-message-listener.sh
+++ b/claude-ops/scripts/ops-message-listener.sh
@@ -102,14 +102,17 @@ poll_whatsapp() {
   echo "$raw" | python3 -c "
 import json, sys
 msgs = json.load(sys.stdin)
+def _from_me(m):
+    v = m.get('is_from_me', False)
+    return v is True or v == 1
 filtered = []
 for m in msgs:
-    if not m.get('is_from_me', False):
+    if not _from_me(m):
         filtered.append({
             'id': m.get('id', ''),
             'channel': 'whatsapp',
-            'from': m.get('contact_name', m.get('from', '')),
-            'text': m.get('body', m.get('text', '')),
+            'from': m.get('sender') or m.get('contact_name') or m.get('from', ''),
+            'text': m.get('content') or m.get('body') or m.get('text', ''),
             'timestamp': m.get('timestamp', ''),
             'raw': m
         })

--- a/claude-ops/scripts/ops-message-listener.sh
+++ b/claude-ops/scripts/ops-message-listener.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # ops-message-listener.sh — Poll-based message listener (replaces OpenClaw WebSocket gateway)
-# Supervised by ops-daemon. Polls WhatsApp (wacli) + Telegram every 60s.
+# Supervised by ops-daemon. Polls WhatsApp (Baileys bridge messages.db) + Telegram every 60s.
 # New non-owner messages → written to inbox-queue.json for /ops:inbox to consume.
 # Health status written to listener-health.txt for daemon monitoring.
 set -euo pipefail
@@ -11,7 +11,7 @@ LOG="$LOG_DIR/message-listener.log"
 QUEUE_FILE="$DATA_DIR/inbox-queue.json"
 HEALTH_FILE="$DATA_DIR/listener-health.txt"
 STATE_FILE="$DATA_DIR/listener-state.json"
-WACLI="${WACLI_BIN:-$(command -v wacli 2>/dev/null || echo /usr/local/bin/wacli)}"
+BRIDGE_DB="${WHATSAPP_BRIDGE_DB:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db}"
 POLL_INTERVAL="${OPS_LISTENER_POLL_INTERVAL:-60}"
 
 mkdir -p "$LOG_DIR" "$DATA_DIR"
@@ -87,7 +87,7 @@ print(added)
 # ── Poll WhatsApp ─────────────────────────────────────────────────────────
 poll_whatsapp() {
   local since="$1"
-  if ! command -v wacli &>/dev/null && [[ ! -x "$WACLI" ]]; then
+  if [[ ! -f "$BRIDGE_DB" ]]; then
     echo "[]"
     return
   fi
@@ -96,7 +96,7 @@ poll_whatsapp() {
   [[ -n "$since" ]] && since_flag="--after=$since"
 
   local raw
-  raw=$("$WACLI" messages list $since_flag --limit 20 --json 2>/dev/null || echo "[]")
+  raw=$(sqlite3 "$BRIDGE_DB" "SELECT json_group_array(json_object('chat_jid',chat_jid,'sender',sender,'content',content,'timestamp',timestamp,'is_from_me',is_from_me)) FROM messages WHERE timestamp > '${WA_LAST_SEEN:-1970-01-01}' ORDER BY timestamp DESC LIMIT 20;" 2>/dev/null || echo "[]")
 
   # Filter: only non-owner (from_me=false) messages
   echo "$raw" | python3 -c "

--- a/claude-ops/scripts/ops-message-listener.sh
+++ b/claude-ops/scripts/ops-message-listener.sh
@@ -93,7 +93,7 @@ poll_whatsapp() {
   fi
 
   local raw
-  raw=$(sqlite3 "$BRIDGE_DB" "SELECT json_group_array(json_object('chat_jid',chat_jid,'sender',sender,'content',content,'timestamp',timestamp,'is_from_me',is_from_me)) FROM (SELECT chat_jid, sender, content, timestamp, is_from_me FROM messages WHERE timestamp > '${since:-1970-01-01}' ORDER BY timestamp DESC LIMIT 20);" 2>/dev/null || echo "[]")
+  raw=$(sqlite3 "$BRIDGE_DB" "SELECT json_group_array(json_object('id',rowid,'chat_jid',chat_jid,'sender',sender,'content',content,'timestamp',timestamp,'is_from_me',is_from_me)) FROM (SELECT rowid, chat_jid, sender, content, timestamp, is_from_me FROM messages WHERE timestamp > '${since:-1970-01-01}' ORDER BY timestamp DESC LIMIT 20);" 2>/dev/null || echo "[]")
 
   # Filter: only non-owner (is_from_me=false) messages
   echo "$raw" | python3 -c "
@@ -106,7 +106,7 @@ filtered = []
 for m in msgs:
     if not _from_me(m):
         filtered.append({
-            'id': m.get('id', ''),
+            'id': str(m.get('id', m.get('rowid', ''))),  # rowid from sqlite
             'channel': 'whatsapp',
             'from': m.get('sender') or m.get('contact_name') or m.get('from', ''),
             'text': m.get('content') or m.get('body') or m.get('text', ''),

--- a/claude-ops/scripts/whatsapp-bridge-migrate.sh
+++ b/claude-ops/scripts/whatsapp-bridge-migrate.sh
@@ -24,7 +24,7 @@ for arg in "$@"; do
     --dry-run)  DRY_RUN=1 ;;
     --verbose)  VERBOSE=1 ;;
     -h|--help)
-      sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,9p' "$0" | sed 's/^# \{0,1\}//'
       exit 0 ;;
   esac
 done
@@ -74,35 +74,28 @@ else
     content='messages',
     content_rowid='rowid'
   );"
-
   log "  Backfilling FTS index from existing messages..."
   run_sql "INSERT INTO messages_fts(rowid, content)
     SELECT rowid, content FROM messages WHERE content IS NOT NULL AND content != '';"
 fi
 
-FTS_EXISTS=$(query_sql "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='messages_fts';" 2>/dev/null || echo "0")
-if [[ "$FTS_EXISTS" == "1" ]]; then
-  log "  Ensuring FTS sync triggers..."
-  run_sql "CREATE TRIGGER IF NOT EXISTS messages_fts_insert
-    AFTER INSERT ON messages
-    WHEN new.content IS NOT NULL AND new.content != ''
-    BEGIN
-      INSERT INTO messages_fts(rowid, content) VALUES (new.rowid, new.content);
-    END;"
-
+# Always ensure triggers exist (idempotent — handles partial failure recovery)
+log "  Ensuring FTS triggers exist..."
+run_sql "CREATE TRIGGER IF NOT EXISTS messages_fts_insert
+  AFTER INSERT ON messages BEGIN
+    INSERT INTO messages_fts(rowid, content) VALUES (new.rowid, new.content);
+  END;"
   run_sql "CREATE TRIGGER IF NOT EXISTS messages_fts_update
-    AFTER UPDATE ON messages BEGIN
-      INSERT INTO messages_fts(messages_fts, rowid, content) VALUES ('delete', old.rowid, old.content);
-      INSERT INTO messages_fts(rowid, content)
-        SELECT new.rowid, new.content
-        WHERE new.content IS NOT NULL AND new.content != '';
-    END;"
-
+  AFTER UPDATE ON messages BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, content) VALUES ('delete', old.rowid, old.content);
+    INSERT INTO messages_fts(rowid, content) VALUES (new.rowid, new.content);
+  END;"
   run_sql "CREATE TRIGGER IF NOT EXISTS messages_fts_delete
-    AFTER DELETE ON messages BEGIN
-      INSERT INTO messages_fts(messages_fts, rowid, content) VALUES ('delete', old.rowid, old.content);
-    END;"
-fi
+  AFTER DELETE ON messages BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, content) VALUES ('delete', old.rowid, old.content);
+  END;"
+
+log "  FTS5 index and triggers verified."
 
 # ── Step 2: contacts table ────────────────────────────────────────────────────
 log "Step 2: Checking contacts table..."
@@ -124,10 +117,6 @@ fi
 
 # ── Step 3: Seed contacts from macOS Contacts.app ────────────────────────────
 log "Step 3: Seeding contacts..."
-
-if [[ $DRY_RUN -eq 1 ]]; then
-  log "  DRY RUN — skipping contact seed entirely."
-else
 
 CONTACT_COUNT=$(query_sql "SELECT COUNT(*) FROM contacts;" 2>/dev/null || echo "0")
 if [[ "$CONTACT_COUNT" -gt 0 ]]; then
@@ -157,11 +146,12 @@ OSASCRIPT
       log "  Contacts.app returned 0 contacts (permissions or empty) — leaving contacts table empty."
       log "  Re-run with WHATSAPP_BRIDGE_DB set after granting Contacts access to run a refresh."
     else
-      INSERTED=$(CONTACTS_JSON_DATA="$CONTACTS_JSON" python3 - "$BRIDGE_DB" <<'PYEOF' 2>/dev/null || echo "0"
-import json, os, sqlite3, sys, re, time
+      INSERTED=$(python3 - "$BRIDGE_DB" "$CONTACTS_JSON" <<'PYEOF' 2>/dev/null || echo "0"
+import json, sqlite3, sys, re, time
 
 db_path = sys.argv[1]
-contacts = json.loads(os.environ["CONTACTS_JSON_DATA"])
+raw = sys.argv[2]
+contacts = json.loads(raw)
 
 def normalize_phone(p):
     digits = re.sub(r'[^\d+]', '', p)
@@ -198,8 +188,6 @@ PYEOF
     log "  Populate manually: INSERT INTO contacts (jid, name, phone, source) VALUES (...)"
   fi
 fi
-
-fi  # end DRY_RUN guard for contact seed
 
 # ── Done ──────────────────────────────────────────────────────────────────────
 log "Migration complete."

--- a/claude-ops/skills/ops-comms/SKILL.md
+++ b/claude-ops/skills/ops-comms/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ops-comms
-description: Send and read messages across all channels. Routes based on arguments — whatsapp, email, slack, telegram, discord, notion, or natural language like "send [msg] to [contact]".
+description: Send and read messages across all channels. Routes based on arguments — whatsapp, email, slack, telegram, discord, notion, or natural language like "send [msg] to [contact]". WhatsApp via mcp__whatsapp__* (Baileys bridge).
 argument-hint: "[channel] | send [message] to [contact] | read [channel] | notion [search query]"
 allowed-tools:
   - Bash
@@ -36,8 +36,8 @@ maxTurns: 40
 Before executing, load available context:
 
 1. **Daemon health**: Read `${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/daemon-health.json`
-   - Check `wacli-sync` status before any WhatsApp operation
-   - Also check `~/.wacli/.health` — if not `status=connected`, surface auth issue before proceeding
+   - Check bridge liveness before any WhatsApp operation: `lsof -i :8080 | grep LISTEN`
+   - If bridge not running, prompt user to restart: `launchctl kickstart -k gui/$UID/com.samrenders.whatsapp-bridge`
 
 2. **Ops memories**: Before drafting any message, check `${CLAUDE_PLUGIN_DATA_DIR}/memories/`:
    - `contact_*.md` — load profile for the recipient
@@ -48,20 +48,23 @@ Before executing, load available context:
 
 ## CLI/API Reference
 
-### wacli (WhatsApp)
+### whatsapp-bridge (WhatsApp — mcp__whatsapp__*)
 
-**Health file** — check `~/.wacli/.health` BEFORE any wacli command:
-- `status=connected` → proceed
-- `status=needs_auth` or `status=needs_reauth` → prompt user for QR scan, do NOT run wacli commands
+**Bridge health** — check bridge is running before any WhatsApp operation:
+```bash
+lsof -i :8080 | grep LISTEN
+launchctl list com.samrenders.whatsapp-bridge
+```
+If not running: `launchctl kickstart -k gui/$(id -u)/com.samrenders.whatsapp-bridge`
 
-| Command | Usage | Output |
-|---------|-------|--------|
-| `wacli doctor --json` | Check auth/connected/lock/FTS | `{data: {authenticated, connected, lock_held, fts_enabled}}` |
-| `wacli chats list --json` | All chats | `{data: [{JID, Name, Kind, LastMessageTS}]}` |
-| `wacli messages list --chat "<JID>" --limit N --json` | Messages for chat | `{data: {messages: [{FromMe, Text, Timestamp, SenderName, ChatName}]}}` |
-| `wacli messages search --query "<text>" --json` | FTS search | Same as above |
-| `wacli contacts --search "<name>" --json` | Contact lookup | Contact objects |
-| `wacli send --to "<JID>" --message "<msg>"` | Send text | Success/error |
+| Tool | Params | Output |
+|------|--------|--------|
+| `mcp__whatsapp__list_chats` | `{sort_by: "last_active"}` | Array of chats with jid, name, last_message_time |
+| `mcp__whatsapp__list_messages` | `{chat_jid, limit, query}` | Array of messages with is_from_me, content, timestamp, sender |
+| `mcp__whatsapp__search_contacts` | `{query}` | Contacts matching name or phone |
+| `mcp__whatsapp__send_message` | `{recipient, message}` | Send result |
+| `mcp__whatsapp__get_chat` | `{chat_jid}` | Chat metadata |
+| `mcp__whatsapp__get_message_context` | `{chat_jid, message_id}` | Message context window |
 
 ### gog CLI (Gmail/Calendar)
 
@@ -100,7 +103,7 @@ Natural-language parsing: phrases like `send "deploy done" to #general on discor
 
 1. Parse contact name and message from `$ARGUMENTS`.
 2. Determine channel by contact lookup:
-   - Check WhatsApp: `wacli contacts --search "[contact]" --json 2>/dev/null`
+   - Check WhatsApp: `mcp__whatsapp__search_contacts {query: "[contact]"}` 2>/dev/null
    - Check Slack: `mcp__claude_ai_Slack__slack_search_users` with `query: "[contact]"`
    - Check email: known from context or ask
 3. If multiple channels found, use `AskUserQuestion`: `[WhatsApp]` / `[Slack]` / `[Email]`
@@ -121,17 +124,17 @@ If user picks "Edit message", use `AskUserQuestion` with free-text to get the re
 ### WhatsApp send
 
 **CRITICAL — READ BEFORE SENDING:** Before drafting ANY WhatsApp reply, you MUST:
-1. Read the full conversation: `wacli messages list --chat "<JID>" --limit 20 --json`
-2. Understand which messages are from the user (`FromMe: true`) vs the contact
+1. Read the full conversation: `mcp__whatsapp__list_messages {chat_jid: "<JID>", limit: 20}`
+2. Understand which messages have `is_from_me: true` (user sent) vs `is_from_me: false` (contact sent)
 3. Summarize what the conversation is about and what the contact is asking
 4. Only THEN draft a reply that addresses what the contact actually said
 
 **Never send a reply based on a single message.** A message like "can you pull it from Klaviyo?" means nothing without knowing what "it" refers to from prior messages.
 
-**Pre-flight:** Before any wacli command, check `~/.wacli/.health`. If `status=needs_auth` or `status=needs_reauth`, prompt the user: "WhatsApp needs re-authentication. Run `wacli auth` in a separate terminal and scan the QR code, then type 'done'." Use `AskUserQuestion`: `[Done — re-paired]`, `[Skip WhatsApp]`. On Done, restart daemon: `launchctl kickstart -k gui/$(id -u)/com.claude-ops.wacli-keepalive`, wait 5s.
+**Pre-flight:** Check bridge is running: `lsof -i :8080 | grep LISTEN`. If not running, restart: `launchctl kickstart -k gui/$(id -u)/com.samrenders.whatsapp-bridge` and wait 5s.
 
-```bash
-wacli send --to "[contact]" --message "[message]"
+```
+mcp__whatsapp__send_message {recipient: "[contact_jid]", message: "[message]"}
 ```
 
 ### Slack send
@@ -155,11 +158,11 @@ Draft created for [recipient]:
 
 **WhatsApp:**
 
-```bash
-wacli chats --limit 10 --json 2>/dev/null
+```
+mcp__whatsapp__list_chats {sort_by: "last_active"}
 ```
 
-Show last 10 chats with sender, preview, timestamp.
+Show last 10 chats with sender, preview, timestamp. Use `mcp__whatsapp__list_messages {chat_jid, limit: 5}` to preview each chat.
 
 **Email:**
 Use `mcp__claude_ai_Gmail__search_threads` with `query: "in:inbox"` (NOT `is:unread` — scan full inbox including read messages), show thread list.

--- a/claude-ops/skills/ops-daemon/SKILL.md
+++ b/claude-ops/skills/ops-daemon/SKILL.md
@@ -162,8 +162,8 @@ Run each check and track results as `pass` / `fail` / `warn`:
 10. **Every service has a command** — iterate `daemon-services.json` services; each enabled entry must have a non-empty `command` field. Missing `command` silently skips the service (historical bug).
 11. **Running services alive** — for each service in the health file with `status=running|polling`, verify `kill -0 <pid>` succeeds.
 12. **Cron services have future `next_run`** — `scheduled` services must have a `next_run` timestamp in the future.
-13. **wacli-sync path resolves** — if enabled, `~/.wacli/.health` exists and is fresh. (Optional — mark warn not fail if missing.)
-14. **No zombie children** — no orphaned `ops-message-listener.sh` or `wacli-keepalive.sh` processes without a parent `ops-daemon.sh`.
+13. **whatsapp-bridge running** — if enabled, `lsof -i :8080 | grep LISTEN` returns a result. (Optional — mark warn not fail if missing.)
+14. **No zombie children** — no orphaned `ops-message-listener.sh` processes without a parent `ops-daemon.sh`.
 
 ### Fix playbook
 

--- a/claude-ops/skills/ops-dash/SKILL.md
+++ b/claude-ops/skills/ops-dash/SKILL.md
@@ -313,7 +313,7 @@ When user selects `h`:
 | 5 | Command reference | List all `/ops:*` commands with descriptions |
 | 6 | Shortcuts | `1-9, 0` for actions, `a-h` for power/comms/settings, `b` always goes back, `q` exits |
 | 7 | MCP disconnected | Wait 5s and retry (auto-reconnect hook). After 3 fails, falls back to CLI tools. |
-| 8 | WhatsApp | First check `~/.wacli/.health` — if `status` is not `connected`, surface the auth warning before running `wacli doctor`. Check `wacli doctor`. If 405 error: rebuild from source. If store locked: `kill $(pgrep wacli)`. |
+| 8 | WhatsApp | Check bridge liveness: `lsof -i :8080 | grep LISTEN`. If not running, prompt restart: `launchctl kickstart -k gui/$(id -u)/com.samrenders.whatsapp-bridge`. Check `launchctl list com.samrenders.whatsapp-bridge` for status. If store locked: `kill $(pgrep whatsapp-bridge)`. |
 | 9 | Telegram | Needs user-auth (not bot). Run `/ops:setup` → Telegram section. API ID + hash from my.telegram.org. |
 | 10 | Unread | Channel must be configured in `/ops:setup`. Check `ops-unread` script output for errors. |
 

--- a/claude-ops/skills/ops-go/SKILL.md
+++ b/claude-ops/skills/ops-go/SKILL.md
@@ -35,23 +35,23 @@ Before executing, load available context:
 
 2. **Daemon health**: Read `${CLAUDE_PLUGIN_DATA_DIR}/daemon-health.json`
    - If `action_needed` is not null → surface it before the briefing
-   - Check `wacli-sync` status before including WhatsApp unread counts
-   - Also check `~/.wacli/.health` for live auth status
+   - Check `whatsapp-bridge` status before including WhatsApp unread counts
+   - Also check bridge liveness: `lsof -i :8080 | grep LISTEN`
 
-3. **WhatsApp pre-check**: Only include WhatsApp data if `~/.wacli/.health` shows `status=connected`.
+3. **WhatsApp pre-check**: Only include WhatsApp data if bridge is running (`lsof -i :8080 | grep LISTEN`).
 
 ## CLI/API Reference
 
-### wacli (WhatsApp)
+### whatsapp-bridge (WhatsApp — mcp__whatsapp__*)
 
-**Health file** — check `~/.wacli/.health` BEFORE any wacli command:
-- `status=connected` → proceed
-- `status=needs_auth` or `status=needs_reauth` → prompt user for QR scan
+**Bridge health** — check before any WhatsApp operation:
+- Running: `lsof -i :8080 | grep LISTEN` → proceed
+- Not running → `launchctl kickstart -k gui/$(id -u)/com.samrenders.whatsapp-bridge`, wait 5s
 
-| Command | Usage | Output |
-|---------|-------|--------|
-| `wacli doctor --json` | Check auth/connected/lock/FTS | `{data: {authenticated, connected, lock_held, fts_enabled}}` |
-| `wacli chats list --json` | All chats | `{data: [{JID, Name, Kind, LastMessageTS}]}` |
+| Tool | Params | Output |
+|------|--------|--------|
+| `mcp__whatsapp__list_chats` | `{sort_by: "last_active"}` | Array of chats with jid, name, last_message_time |
+| `mcp__whatsapp__list_messages` | `{chat_jid, limit, query}` | Message array with is_from_me, content, timestamp |
 
 ### gog CLI (Gmail/Calendar)
 

--- a/claude-ops/skills/ops-inbox/CHANNELS.md
+++ b/claude-ops/skills/ops-inbox/CHANNELS.md
@@ -2,55 +2,49 @@
 
 This document explains how to configure each communication channel for the `/ops:ops-inbox` skill. All credentials come from environment variables or CLI auth — **no secrets are committed to this repo**.
 
-## WhatsApp (wacli)
+## WhatsApp (Baileys bridge)
 
-**Status:** CLI-based (wacli), no MCP needed.
+**Status:** MCP-based via `mcp__whatsapp__*` tools. No CLI needed.
 
-**Setup:**
+The Baileys `whatsapp-bridge` binary runs as a persistent LaunchAgent (`com.samrenders.whatsapp-bridge`)
+and exposes WhatsApp over a local HTTP/MCP interface on port 8080.
 
-```bash
-# Install latest version from source (brew version may be outdated)
-git clone https://github.com/steipete/wacli.git /tmp/wacli-src
-cd /tmp/wacli-src
-go build -o wacli ./cmd/wacli/
-cp wacli /usr/local/bin/
+### Setup
 
-# Authenticate (scans QR code with phone)
-wacli auth
+1. Ensure the bridge binary is installed at `~/.local/share/whatsapp-mcp/whatsapp-bridge/whatsapp-bridge`
+2. Install the LaunchAgent plist from `assets/launchagents/com.samrenders.whatsapp-bridge.plist`:
+   ```bash
+   PLIST="$HOME/Library/LaunchAgents/com.samrenders.whatsapp-bridge.plist"
+   BRIDGE_DIR="$HOME/.local/share/whatsapp-mcp/whatsapp-bridge"
+   sed -e "s|__BRIDGE_BINARY_PATH__|$BRIDGE_DIR/whatsapp-bridge|g" \
+       -e "s|__BRIDGE_WORKING_DIR__|$BRIDGE_DIR|g" \
+       -e "s|__HOME__|$HOME|g" \
+       "${CLAUDE_PLUGIN_ROOT}/assets/launchagents/com.samrenders.whatsapp-bridge.plist" > "$PLIST"
+   launchctl bootstrap gui/$(id -u) "$PLIST"
+   ```
+3. On first run the bridge prints a QR code to its log — scan from WhatsApp → Linked Devices.
+4. Run schema migration: `${CLAUDE_PLUGIN_ROOT}/scripts/whatsapp-bridge-migrate.sh`
 
-# Verify
-wacli doctor
-# Expected: AUTHENTICATED true, CONNECTED false (until sync runs)
-
-# Initial sync (takes a minute for 142+ conversations)
-wacli sync
-```
-
-**Troubleshooting:**
-
-- `Client outdated (405)`: Rebuild from source above
-- `store is locked`: Kill stale process: `kill $(pgrep wacli)`
-- After version upgrade: `wacli auth logout && wacli auth`
-
-**History limitations:**
-wacli only captures messages **received while connected**. It cannot reliably backfill historical messages after the fact:
-
-- `wacli history backfill --chat <jid>` requires ≥1 existing local message per chat and often times out on the WhatsApp on-demand sync response.
-- Chats in the new `@lid` (Linked Device) format frequently return empty message queries because their history was never captured during an active sync session.
-- For ongoing inbox management, run `wacli sync --follow` in a persistent terminal (outside Claude Code) so new messages land in the local DB in real-time.
-
-**Env vars (optional):**
-
-- `WACLI_STORE` — default `~/.wacli`
-
-**Run sync persistently (recommended):**
+### Check health
 
 ```bash
-# In a dedicated terminal tab — keeps wacli connected so new messages are captured
-wacli sync --follow
+lsof -i :8080 | grep LISTEN                           # bridge running?
+launchctl list com.samrenders.whatsapp-bridge         # launchd status
+cat ~/.local/share/whatsapp-mcp/whatsapp-bridge/logs/bridge.err.log | tail -20
 ```
 
----
+### Troubleshooting
+
+- `bridge not running`: `launchctl kickstart -k gui/$(id -u)/com.samrenders.whatsapp-bridge`
+- Auth expired: check `bridge.err.log` for QR prompt; session stored in `whatsapp.db`
+- Missing messages: restart bridge (re-syncs history on connect)
+- FTS search slow: run `scripts/whatsapp-bridge-migrate.sh` to add FTS5 index
+
+### Persistence note
+
+The bridge syncs messages continuously while running. History is stored in
+`~/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db`.
+The `WHATSAPP_BRIDGE_DB` env var overrides the DB path.
 
 ## Email (gog)
 

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ops-inbox
-description: Full inbox management across all channels — WhatsApp (wacli), Email (Gmail MCP), Slack (MCP), Telegram (user-auth MCP), Discord (webhook + REST read), Notion (MCP — comments, mentions, assigned tasks). Scans FULL inbox (not just unread), identifies messages needing replies, archives handled conversations.
+description: Full inbox management across all channels — WhatsApp (Baileys bridge via mcp__whatsapp__*), Email (Gmail MCP), Slack (MCP), Telegram (user-auth MCP), Discord (webhook + REST read), Notion (MCP — comments, mentions, assigned tasks). Scans FULL inbox (not just unread), identifies messages needing replies, archives handled conversations.
 argument-hint: "[channel: whatsapp|email|slack|telegram|discord|notion|all]"
 allowed-tools:
   - Bash
@@ -30,6 +30,12 @@ allowed-tools:
   - mcp__claude_ai_Notion__notion-create-comment
   - mcp__claude_ai_Notion__notion-update-page
   - mcp__claude_ai_Notion__notion-create-pages
+  - mcp__whatsapp__list_chats
+  - mcp__whatsapp__list_messages
+  - mcp__whatsapp__search_contacts
+  - mcp__whatsapp__send_message
+  - mcp__whatsapp__get_chat
+  - mcp__whatsapp__get_message_context
 effort: high
 maxTurns: 60
 ---
@@ -45,8 +51,8 @@ Before executing, load available context:
    - `secrets_manager` / `doppler` — how to resolve channel credentials if not in env
 
 2. **Daemon health**: Read `${CLAUDE_PLUGIN_DATA_DIR}/daemon-health.json`
-   - Check `wacli-sync` status — if not running or auth needed, skip WhatsApp and surface the issue
-   - Also check `~/.wacli/.health` for live auth status before any wacli command
+   - Check `whatsapp-bridge` status — verify `com.samrenders.whatsapp-bridge` is running (`lsof -i :8080` or `launchctl list com.samrenders.whatsapp-bridge`)
+   - If bridge is not running, surface the issue before WhatsApp operations
 
 3. **Ops memories**: Check `${CLAUDE_PLUGIN_DATA_DIR}/memories/` before drafting any reply:
    - `contact_*.md` — load profile for the contact you're about to reply to
@@ -56,23 +62,42 @@ Before executing, load available context:
 
 ## CLI/API Reference
 
-### wacli (WhatsApp)
+### whatsapp-bridge (WhatsApp — mcp__whatsapp__*)
 
-**Health file** — check `~/.wacli/.health` BEFORE any wacli command:
-- `status=connected` → proceed normally
-- `status=needs_auth` → prompt user: "Run `wacli auth` in terminal, scan QR"
-- `status=needs_reauth` → prompt user: "WhatsApp session expired. Run `wacli auth` to re-pair"
-- File missing → fall back to `wacli doctor --json`
+**Bridge health** — check bridge is running before any WhatsApp operation:
+```bash
+lsof -i :8080 | grep LISTEN   # bridge listens on :8080
+launchctl list com.samrenders.whatsapp-bridge  # check launchd status
+```
+If bridge is not running: `launchctl kickstart -k gui/$UID/com.samrenders.whatsapp-bridge`
 
-| Command | Usage | Output |
-|---------|-------|--------|
-| `wacli doctor --json` | Check auth/connected/lock/FTS | `{data: {authenticated, connected, lock_held, fts_enabled}}` |
-| `wacli chats list --json` | All chats | `{data: [{JID, Name, Kind, LastMessageTS}]}` |
-| `wacli messages list --chat "<JID>" --limit N --json` | Messages for chat | `{data: {messages: [{FromMe, Text, Timestamp, SenderName, ChatName}]}}` |
-| `wacli messages search --query "<text>" --json` | FTS search | Same as above |
-| `wacli contacts --search "<name>" --json` | Contact lookup | Contact objects |
-| `wacli send --to "<JID>" --message "<msg>"` | Send text | Success/error |
-| `wacli history backfill --chat="<JID>" --count=50 --requests=2 --wait=30s --idle-exit=5s --json` | Fetch older messages | Backfill result |
+**MCP tools** (use these instead of any wacli CLI command):
+
+| Tool | Usage | Output |
+|------|-------|--------|
+| `mcp__whatsapp__list_chats` | `{sort_by: "last_active"}` | Array of chats with jid, name, last_message_time |
+| `mcp__whatsapp__list_messages` | `{chat_jid, limit, query}` | Array of messages with id, sender, content, timestamp, is_from_me |
+| `mcp__whatsapp__search_contacts` | `{query}` | Contacts matching name or phone |
+| `mcp__whatsapp__send_message` | `{recipient, message}` | Send result |
+| `mcp__whatsapp__get_chat` | `{chat_jid}` | Chat metadata |
+| `mcp__whatsapp__get_message_context` | `{chat_jid, message_id}` | Message context window |
+
+**Full-text search** — use `mcp__whatsapp__list_messages` with a `query` param (backed by FTS5 after running `scripts/whatsapp-bridge-migrate.sh`):
+```bash
+# Direct sqlite3 FTS query (fallback when MCP unavailable):
+DB="${WHATSAPP_BRIDGE_DB:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db}"
+sqlite3 "$DB" "SELECT chat_jid, sender, content, timestamp FROM messages WHERE rowid IN (SELECT rowid FROM messages_fts WHERE messages_fts MATCH '<query>') ORDER BY timestamp DESC LIMIT 20;"
+```
+
+**Contact lookup** — use `mcp__whatsapp__search_contacts` or query contacts table directly:
+```bash
+sqlite3 "$DB" "SELECT jid, name, phone FROM contacts WHERE name LIKE '%<name>%' COLLATE NOCASE LIMIT 10;"
+```
+
+**History backfill** — the Baileys bridge automatically syncs history on connection. No manual backfill command exists; if messages are missing, restart the bridge:
+```bash
+launchctl kickstart -k gui/$UID/com.samrenders.whatsapp-bridge
+```
 
 ### gog CLI (Gmail/Calendar)
 
@@ -128,7 +153,7 @@ All channel credentials come from env vars or CLI auth — no hardcoded secrets.
 | `SLACK_MCP_ENABLED` | `false`     | Set `true` when Slack MCP server is configured       |
 | `TELEGRAM_ENABLED`  | `false`     | Set `true` when Telegram user-auth MCP is configured |
 | `NOTION_MCP_ENABLED`| `false`     | Set `true` when Notion MCP integration is configured |
-| `WACLI_STORE`       | `~/.wacli`  | wacli store directory                                |
+| `WHATSAPP_BRIDGE_DB`| `~/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db` | Bridge messages DB path |
 
 ## Core principle: FULL INBOX SCAN
 
@@ -151,16 +176,16 @@ The user does NOT remember every thread. For EVERY message you present, you MUST
 
 **For every NEEDS REPLY item, gather this context automatically:**
 
-1. **Full thread body** — read the ENTIRE thread (`gog gmail thread get` / `wacli messages list --limit 20`), not just the last message. Summarize the full conversation arc.
+1. **Full thread body** — read the ENTIRE thread (`gog gmail thread get` / `mcp__whatsapp__list_messages {limit: 20}`), not just the last message. Summarize the full conversation arc.
 2. **Contact profile** — search across channels to build a card:
    - `gog gmail search "from:<contact_email>" --max 10` — recent email history
-   - `wacli contacts --search "<name>" --json` — WhatsApp presence
-   - `wacli messages search --query "<name>" --json --limit 5` — recent WhatsApp mentions
+   - `mcp__whatsapp__search_contacts {query: "<name>"}` — WhatsApp presence
+   - `mcp__whatsapp__list_messages {query: "<name>", limit: 5}` — recent WhatsApp mentions
    - If Linear configured: search for issues assigned to or mentioning this contact
    - Present: who they are, role/company, last N interactions, relationship context
 3. **Topic context** — identify the subject matter and search for related threads:
    - `gog gmail search "subject:<keywords>" --max 5` — related email threads
-   - `wacli messages search --query "<topic keywords>" --json --limit 5` — related WA messages
+   - `mcp__whatsapp__list_messages {query: "<topic keywords>", limit: 5}` — related WA messages
    - Summarize: what this topic is about, any deadlines, any pending decisions
 4. **ops-memories** (if available) — check `~/.claude/plugins/data/ops-ops-marketplace/memories/` for any stored context about this contact or topic
 
@@ -195,7 +220,7 @@ The user does NOT remember every thread. For EVERY message you present, you MUST
 For each channel, detect availability at runtime:
 
 1. **Email**: Try `gog` CLI first. If `gog` unavailable, try `mcp__gog__gmail_*` MCP tools. If neither, report unavailable.
-2. **WhatsApp**: First check `~/.wacli/.health` for keepalive daemon status. If `status=needs_auth` or `status=needs_reauth`, do NOT attempt wacli commands — instead prompt the user: "WhatsApp needs re-authentication. Run `wacli auth` in a separate terminal and scan the QR code, then type 'done'." Use `AskUserQuestion`: `[Done — re-paired]`, `[Skip WhatsApp]`. On Done, restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.claude-ops.wacli-keepalive`, wait 5s, re-check health. If no health file exists, fall back to `wacli doctor` for auth/connection status. If outdated (405 error), advise rebuilding from source.
+2. **WhatsApp**: Check bridge liveness: `lsof -i :8080 | grep LISTEN`. If not listening, prompt the user: "WhatsApp bridge is not running." Use `AskUserQuestion`: `[Restart bridge]`, `[Skip WhatsApp]`. On restart: `launchctl kickstart -k gui/$(id -u)/com.samrenders.whatsapp-bridge`, wait 5s, re-check. If bridge is running but MCP tools fail, the bridge may need QR re-pairing — check `~/.local/share/whatsapp-mcp/whatsapp-bridge/logs/bridge.err.log` for auth errors.
 3. **Slack**: Only via MCP tools (`mcp__claude_ai_Slack__*`). Check `SLACK_MCP_ENABLED` env var.
 4. **Telegram**: Only via user-auth MCP (tdlib/MTProto). Check `TELEGRAM_ENABLED` env var. Never use BotFather bots.
 5. **Discord**: Via `${CLAUDE_PLUGIN_ROOT}/bin/ops-discord read <CHANNEL_ID> --limit 20 --json`. Requires `DISCORD_BOT_TOKEN` (v1 is channel-scoped — no DM/gateway support yet). Pre-configured read list lives at `${CLAUDE_PLUGIN_DATA_DIR}/preferences.json` under `discord.inbox_channels` (array of channel IDs). If neither a bot token nor a read list is configured, skip Discord with a one-line note ("Discord not configured — run `/ops:setup discord`") rather than prompting — ops-inbox is not a setup flow. Rule 3 still applies to `/ops:setup`.
@@ -207,7 +232,7 @@ For each channel, detect availability at runtime:
 
 2. **For each channel, run a FULL scan** (not just unread):
    - **Email**: Search `in:inbox` (not `is:unread`) via `gog gmail search -a $GMAIL_ACCOUNT -j --results-only --no-input --max 30 "in:inbox"`. For each thread, read the last message to determine who sent it last. Check for DRAFT or SENT labels. **Before suggesting to send a draft, verify no reply was already sent in the thread.**
-   - **WhatsApp**: Run `wacli chats list --json` to get all chats. Filter to non-archived chats with `LastMessageTS` in the last 7 days. For each, fetch the FULL conversation via `wacli messages list --chat <JID> --limit 20 --json` (20 messages, not 5 — you need the full thread). Parse `data.messages[]` with fields `FromMe`, `Text`, `Timestamp`, `ChatName`. Understand which messages are from the user (`FromMe: true`) vs the contact (`FromMe: false`). Classify by last message `FromMe` field.
+   - **WhatsApp**: Call `mcp__whatsapp__list_chats {sort_by: "last_active"}` to get all chats. Filter to chats with `last_message_time` in the last 7 days. For each, fetch the FULL conversation via `mcp__whatsapp__list_messages {chat_jid, limit: 20}` (20 messages, not 5 — you need the full thread). Parse message array with fields `is_from_me`, `content`, `timestamp`, `sender`. Classify by last message `is_from_me` field.
    - **Slack**: Search via Slack MCP tools. Check who sent last message in each thread.
    - **Telegram**: Use user-auth MCP (NOT bot API) to read recent conversations.
 
@@ -252,31 +277,31 @@ If only 3 channels are configured, "All channels" + 3 channel options = 4, fits 
 ### WhatsApp (FULL SCAN + DEEP CONTEXT)
 
 **Phase 1 — Classify:**
-1. Get all chats: `wacli chats list --json`
-2. Filter to chats with `LastMessageTS` in the last 7 days
-3. For each, fetch the FULL recent conversation: `wacli messages list --chat "<JID>" --limit 20 --json` — get 20 messages, NOT 5. You need the full conversation thread to understand context.
-4. Parse `data.messages[]` — fields: `FromMe`, `Text`, `Timestamp`, `ChatName`, `SenderName`
+1. Get all chats: `mcp__whatsapp__list_chats` with `{sort_by: "last_active"}`
+2. Filter to chats with `last_message_time` in the last 7 days
+3. For each, fetch the FULL recent conversation: `mcp__whatsapp__list_messages` with `{chat_jid: "<JID>", limit: 20}` — get 20 messages, NOT 5.
+4. Parse message array — fields: `is_from_me`, `content`, `timestamp`, `sender`
 5. For EVERY chat, understand the conversation:
-   - Read ALL messages in order. Know which are `FromMe: true` (user sent) vs `FromMe: false` (contact sent)
+   - Read ALL messages in order. Know which have `is_from_me: true` (user sent) vs `is_from_me: false` (contact sent)
    - Understand what the conversation is about, what was discussed, what's pending
    - Identify the user's tone and style in their sent messages
 6. Classify each chat:
-   - **NEEDS REPLY**: Last message has `FromMe: false` (they sent last)
-   - **WAITING**: Last message has `FromMe: true` (you sent last)
+   - **NEEDS REPLY**: Last message has `is_from_me: false` (they sent last)
+   - **WAITING**: Last message has `is_from_me: true` (you sent last)
    - **ARCHIVE**: Old conversation, no recent activity, or concluded
 
 **Phase 2 — Build context for NEEDS REPLY chats (run in parallel):**
 For each NEEDS REPLY chat:
 1. **Full conversation summary** — read all 20 messages, summarize the arc: what was discussed, key decisions, open questions
 2. **Contact profile** — search for this person:
-   - `wacli messages search --query "<contact_name>" --json --limit 10` — mentions in other chats
+   - `mcp__whatsapp__list_messages` with `{query: "<contact_name>", limit: 10}` — mentions across chats
    - `gog gmail search -j --results-only --no-input --max 5 "from:<name> OR to:<name>"` — email history
    - Check `~/.claude/plugins/data/ops-ops-marketplace/memories/contact_*.md` for stored profile
    - Build: who they are, relationship, communication history across channels
 3. **Topic context** — extract keywords from the conversation and search:
-   - `wacli messages search --query "<topic keywords>" --json --limit 5` — related WA messages
+   - `mcp__whatsapp__list_messages` with `{query: "<topic keywords>", limit: 5}` — related WA messages
    - `gog gmail search -j --results-only --no-input --max 3 "<topic keywords>"` — related emails
-4. **User's messaging style** — from the `FromMe: true` messages in this chat, note: language (NL/EN), formality, emoji usage, typical response length
+4. **User's messaging style** — from the `is_from_me: true` messages in this chat, note: language (NL/EN), formality, emoji usage, typical response length
 
 **Phase 3 — Present with full context:**
 
@@ -313,45 +338,28 @@ Use `AskUserQuestion` for each NEEDS REPLY chat.
 - If ops-memories has preferences for this contact, apply them
 - Never generate a generic reply — every draft must show you understood the full conversation
 
-Reply via: `wacli send --to "<JID>" --message "<msg>"`
+Reply via: `mcp__whatsapp__send_message` with `{recipient: "<JID>", message: "<msg>"}`
 
-**wacli CLI reference (v0.5.0):**
+**WhatsApp bridge reference:**
 
-| Command | Usage | Notes |
-|---------|-------|-------|
-| `wacli doctor` | `wacli doctor --json` | Check auth/connected/lock/FTS status |
-| `wacli auth` | `wacli auth` | QR pairing (interactive — shows QR in terminal) |
-| `wacli sync` | `wacli sync --follow --refresh-contacts --refresh-groups` | Persistent sync (managed by launchd keepalive) |
-| `wacli sync --once` | `wacli sync --once --idle-exit=10s` | One-shot sync, exits when idle |
-| `wacli chats list` | `wacli chats list --json` | All chats with JID, Name, Kind, LastMessageTS |
-| `wacli messages list` | `wacli messages list --chat "<JID>" --limit 5 --json` | Messages: ChatJID, FromMe, Text, Timestamp, SenderName |
-| `wacli messages search` | `wacli messages search --query "<text>" --json` | FTS5 search across all messages |
-| `wacli contacts` | `wacli contacts --search "<name>" --json` | Contact lookup by name |
-| `wacli send` | `wacli send --to "<JID>" --message "<msg>"` | Send text message |
-| `wacli history backfill` | `wacli history backfill --chat="<JID>" --count=50 --requests=2 --wait=30s --idle-exit=5s --json` | Fetch older messages from phone (needs store lock) |
+| Operation | Tool / Command |
+|-----------|---------------|
+| List chats | `mcp__whatsapp__list_chats {sort_by: "last_active"}` |
+| Read messages | `mcp__whatsapp__list_messages {chat_jid, limit: 20}` |
+| Search messages (FTS) | `mcp__whatsapp__list_messages {query: "<text>", limit: 20}` |
+| Find contact | `mcp__whatsapp__search_contacts {query: "<name>"}` |
+| Send message | `mcp__whatsapp__send_message {recipient, message}` |
+| Chat metadata | `mcp__whatsapp__get_chat {chat_jid}` |
+| Message context | `mcp__whatsapp__get_message_context {chat_jid, message_id}` |
+| Check bridge | `lsof -i :8080 | grep LISTEN` |
+| Restart bridge | `launchctl kickstart -k gui/$(id -u)/com.samrenders.whatsapp-bridge` |
 
-**Health file contract (`~/.wacli/.health`):**
+**Bridge troubleshooting:**
 
-Before ANY wacli command, read `~/.wacli/.health`:
-- `status=connected` → proceed normally
-- `status=needs_auth` → prompt user: "Run `wacli auth` in terminal, scan QR"
-- `status=needs_reauth` → prompt user: "WhatsApp session expired. Run `wacli auth` to re-pair"
-- File missing → fall back to `wacli doctor --json`
-
-**Requesting backfill for @lid chats with empty messages:**
-
-The keepalive daemon holds the store lock, so you can't run backfill directly. Instead:
-1. Write JIDs to `~/.wacli/.backfill_jids` (one per line)
-2. Restart the daemon: `launchctl kickstart -k gui/$(id -u)/com.claude-ops.wacli-keepalive`
-3. The daemon runs backfill before starting persistent sync
-
-**wacli troubleshooting:**
-
-- `@lid` JIDs (linked device format) may return empty messages → request backfill via the daemon (see above)
-- "Client outdated (405)" → rebuild from source: `cd /tmp && git clone https://github.com/Lifecycle-Innovations-Limited/wacli.git && cd wacli && go build -o /usr/local/bin/wacli ./cmd/wacli/`
-- "store is locked" → the keepalive daemon holds the lock; to release: `launchctl bootout gui/$(id -u)/com.claude-ops.wacli-keepalive`
-- Auth expired → daemon writes `needs_auth` to health file; prompt user for QR scan
-- Key desync (0 messages synced) → daemon writes `needs_reauth`; user needs `wacli auth` re-pair
+- Bridge not running → `launchctl kickstart -k gui/$(id -u)/com.samrenders.whatsapp-bridge`; wait 5s, re-check
+- Auth expired / QR needed → check `~/.local/share/whatsapp-mcp/whatsapp-bridge/logs/bridge.err.log`; bridge prints QR to log on startup if session is invalid
+- Missing messages → bridge syncs history on connect; if gap persists, restart bridge
+- FTS not available → run `scripts/whatsapp-bridge-migrate.sh` to add FTS5 index to messages.db
 
 ### Email (FULL SCAN + DEEP CONTEXT)
 
@@ -370,8 +378,8 @@ For each NEEDS REPLY thread, gather:
 1. **Full thread summary** — read every message in the thread, summarize the conversation arc (who said what, key decisions, open questions)
 2. **Contact profile** — for the sender:
    - `gog gmail search -j --results-only --no-input --max 10 "from:<sender_email>"` — their recent emails to you
-   - `wacli contacts --search "<sender_name>" --json` — WhatsApp contact
-   - `wacli messages search --query "<sender_name>" --json --limit 5` — recent WhatsApp mentions
+   - `mcp__whatsapp__search_contacts {query: "<sender_name>"}` — WhatsApp contact
+   - `mcp__whatsapp__list_messages {query: "<sender_name>", limit: 5}` — recent WhatsApp mentions
    - Build: name, role/company, relationship history, last N interactions
 3. **Topic search** — extract key terms from subject + body, then:
    - `gog gmail search -j --results-only --no-input --max 5 "subject:<keywords>"` — related threads
@@ -444,7 +452,7 @@ For each result, show channel, sender, preview. Read thread for context.
 
 ### Telegram (FULL SCAN — User Account, NOT Bot)
 
-Telegram integration must authenticate as the user's personal account (user-auth via tdlib/MTProto), NOT a BotFather bot. The goal is to manage real conversations just like WhatsApp via wacli.
+Telegram integration must authenticate as the user's personal account (user-auth via tdlib/MTProto), NOT a BotFather bot. The goal is to manage real conversations just like WhatsApp via the bridge MCP tools.
 
 Use the Telegram user-auth MCP server if available.
 

--- a/claude-ops/skills/ops-status/SKILL.md
+++ b/claude-ops/skills/ops-status/SKILL.md
@@ -68,7 +68,7 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ops-status $ARGUMENTS
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  OPS ► STATUS — Mon 14 Apr 2026 09:45 UTC
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- CLIs         ✓ gh   ✓ aws  ✓ jq   ✓ node   ✗ wacli
+ CLIs         ✓ gh   ✓ aws  ✓ jq   ✓ node   ✗ whatsapp-bridge
  Channels     ✓ gog   ✓ slack  ○ telegram   ✗ whatsapp
  MCPs         ✓ linear  ✓ sentry  ✓ vercel  ○ gmail
  Commerce     ○ shopify
@@ -83,7 +83,7 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ops-status $ARGUMENTS
 
 ```json
 {
-  "clis": {"gh": "ok", "aws": "ok", "jq": "ok", "node": "ok", "wacli": "missing"},
+  "clis": {"gh": "ok", "aws": "ok", "jq": "ok", "node": "ok", "whatsapp-bridge": "missing"},
   "channels": {"whatsapp": "ok", "slack": "ok", "telegram": "not-configured"},
   "mcps": {"linear": "ok", "sentry": "ok", "vercel": "ok", "gmail": "not-configured"},
   "commerce": {"shopify": "not-configured"},

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -48,7 +48,7 @@ Every Bash tool call MUST include a short `description` parameter (5-10 words, e
 - Show what's already configured first, so the user only fills gaps.
 - **Never show the user's real name or email in output unless the user explicitly provided it in THIS session.** Do not read from memory, existing configs, or environment variables to populate display names.
 - **Max 4 options per `AskUserQuestion` call.** The tool schema enforces `<=4` items in the `options` array. When a step lists >4 choices, filter already-configured items first, then batch the rest into multiple sequential calls of <=4 options each, grouped logically. Use `[More options...]` as the last option to bridge between batches.
-- Run ALL diagnostic/probe commands in parallel when possible. Use multiple Bash tool calls in a single message. Never run sequential probes when they're independent (e.g., `gog auth status` AND `wacli doctor` AND keychain scouts should all run simultaneously).
+- Run ALL diagnostic/probe commands in parallel when possible. Use multiple Bash tool calls in a single message. Never run sequential probes when they're independent (e.g., `gog auth status` AND `lsof -i :8080 | grep LISTEN` AND keychain scouts should all run simultaneously).
 - All writes go to one of these paths — and nothing else:
   - **`$PREFS_PATH`** — per-user preferences + secrets. Resolves to `${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json`. Lives in Claude Code's plugin data dir so it survives plugin reinstalls and version bumps. Never committed to git.
   - **`${CLAUDE_PLUGIN_ROOT}/scripts/registry.json`** — per-user project registry (gitignored in the source repo). `mkdir -p` its parent if missing.
@@ -142,7 +142,7 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ops-setup-preflight &>/dev/null &
 - Telegram: `cat /tmp/ops-preflight/telegram.txt`
 - gog/Gmail: `cat /tmp/ops-preflight/gog-gmail.json`
 - gog/Calendar: `cat /tmp/ops-preflight/gog-cal.json`
-- WhatsApp: `cat /tmp/ops-preflight/wacli-doctor.json` and `wacli-chats.json`
+- WhatsApp: `cat /tmp/ops-preflight/bridge-health.json`
 - MCP servers: `cat /tmp/ops-preflight/mcp-servers.txt`
 - GitHub: `cat /tmp/ops-preflight/gh-auth.txt`
 - AWS: `cat /tmp/ops-preflight/aws-identity.json`
@@ -180,7 +180,7 @@ Print a compact status header to the user, one line per category:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Shell:       zsh → ~/.zshrc
  Core CLIs:   ✓ jq  ✓ git  ✓ gh  ✓ aws  ✓ node
- Channels:    ✓ wacli  ✓ gog  ○ telegram (no token)
+ Channels:    ✓ bridge  ✓ gog  ○ telegram (no token)
  Secrets:     ✓ doppler (project: my-app, config: dev)
  MCPs:        ✓ linear  ✓ sentry  ○ slack  ○ vercel
  Registry:    19 projects
@@ -274,7 +274,7 @@ Present each batch as a separate `AskUserQuestion` call. Skip batches where all 
 If multiple CLIs are missing, offer a bulk install first:
 
 ```
-Missing CLIs detected: jq, gh, wacli. What would you like to do?
+Missing CLIs detected: jq, gh. What would you like to do?
   [Install all missing CLIs (Recommended)]
   [Pick which to install]
   [Skip CLI installation]
@@ -285,7 +285,7 @@ If the user selects "Install all", install every missing tool in sequence withou
 ```
 Install jq?           [Yes, install now] [Skip]
 Install gh?           [Yes, install now] [Skip]
-Install wacli?        [Yes, install now] [Skip — manual install required]
+
 ```
 
 For each `Yes`, run:
@@ -398,7 +398,7 @@ Install later with: /plugin marketplace add obra/superpowers-marketplace
 
 ## Step 2c — Background Daemon (early install, pre-warm caches)
 
-**Why install the daemon this early?** Running the daemon in parallel with the rest of setup lets it start pre-warming the briefing cache (`ops-gather` results for infra/git/PRs/CI), so by the time the user reaches Step 7 and runs `/ops:go`, the briefing is already cached and loads in under 3 seconds instead of 10. Channel-dependent services (wacli-sync, message-listener, inbox-digest, store-health) are added later in Step 5b once their channels are configured.
+**Why install the daemon this early?** Running the daemon in parallel with the rest of setup lets it start pre-warming the briefing cache (`ops-gather` results for infra/git/PRs/CI), so by the time the user reaches Step 7 and runs `/ops:go`, the briefing is already cached and loads in under 3 seconds instead of 10. Channel-dependent services (message-listener, inbox-digest) are added later in Step 5b once their channels are configured.
 
 ### Platform support
 
@@ -438,7 +438,7 @@ Otherwise ask via `AskUserQuestion`:
 Install the ops background daemon now?
   Starts pre-warming briefing cache while you finish the rest of setup.
   Auto-heals on failure. Single launchd agent (com.claude-ops.daemon).
-  Channel services (wacli-sync, message-listener) added after channels are set up.
+  Channel services (whatsapp-bridge health, message-listener) added after channels are set up.
   [Yes — install now]  [Skip — I'll run it manually later]
 ```
 
@@ -491,15 +491,15 @@ cat > "$SERVICES_CONFIG" <<JSON
       "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-memory-extractor.sh",
       "cron": "*/30 * * * *",
       "health_file": "~/.claude/plugins/data/ops-ops-marketplace/memories/.health",
-      "_note": "Idle until channels are configured; will extract profiles once wacli/gog are live."
+      "_note": "Idle until channels are configured; will extract profiles once whatsapp-bridge/gog are live."
     }
   }
 }
 JSON
 
-# Remove the old standalone wacli keepalive if present
-launchctl bootout gui/$(id -u)/com.claude-ops.wacli-keepalive 2>/dev/null || true
-rm -f "$HOME/Library/LaunchAgents/com.claude-ops.wacli-keepalive.plist"
+# Remove legacy whatsapp-bridge keepalive if still present
+launchctl bootout gui/$(id -u)/com.claude-ops.whatsapp-bridge-keepalive 2>/dev/null || true
+rm -f "$HOME/Library/LaunchAgents/com.claude-ops.whatsapp-bridge-keepalive.plist" 2>/dev/null || true
 
 # Load daemon in background — does NOT block the wizard
 launchctl bootout gui/$(id -u) "$PLIST_DEST" 2>/dev/null || true
@@ -794,7 +794,7 @@ If the user selects "Pick individually", ask which channels using `AskUserQuesti
 | Option   | Header   | Description                                                             |
 | -------- | -------- | ----------------------------------------------------------------------- |
 | Telegram | telegram | Bot token + owner ID for `/ops-comms telegram`                          |
-| WhatsApp | whatsapp | wacli doctor + auto-heal + backfill                                     |
+| WhatsApp | whatsapp | bridge health check + QR pair + schema migration                         |
 | Email    | email    | gog CLI → Gmail MCP fallback for `/ops-inbox email`                     |
 | Slack    | slack    | Slack MCP server (managed by Claude Code)                               |
 
@@ -862,7 +862,7 @@ Whenever a channel has a **browser-based OAuth flow** available, offer that firs
 | Sentry         | `claude mcp add sentry`                                    | DSN / auth token                       |
 | Vercel         | `claude mcp add vercel`                                    | personal access token                  |
 | Telegram       | ❌ no OAuth (Bot API is token-only by design)              | auto-scan + manual paste (only option) |
-| WhatsApp       | QR pairing via `wacli auth` (similar UX to OAuth)          | n/a — paired sessions only             |
+| WhatsApp       | QR pairing via `whatsapp-bridge auth` (similar UX to OAuth)          | n/a — paired sessions only             |
 
 When a channel supports OAuth, the default `AskUserQuestion` should lead with it:
 
@@ -1137,220 +1137,98 @@ Sub-flow (only runs if user selected Yes above):
 
 > **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-comms/SKILL.md` for full operational instructions, CLI reference, and troubleshooting for this integration. The setup agent can load that file directly when it needs more depth than this wizard provides.
 
-### 3b — WhatsApp (doctor + self-heal + backfill)
+### 3b — WhatsApp (bridge health + QR pair)
 
-WhatsApp is the channel that most often breaks silently. The wizard must **auto-diagnose, doctor, and fix** — not just report status and give up. Run this whole sub-flow top-to-bottom, stopping only when the system is healthy or the user declines a remediation.
+WhatsApp is handled exclusively by the Baileys `whatsapp-bridge` (managed by `com.samrenders.whatsapp-bridge` LaunchAgent) and accessed via `mcp__whatsapp__*` tools.
 
 #### Step 3b.1 — Presence
 
-Run `command -v wacli`. If missing, ask `AskUserQuestion`: `[Show install docs]`, `[Skip WhatsApp]`. On install docs, print:
-
-```
-wacli is not on Homebrew. Install:
-  git clone https://github.com/Lifecycle-Innovations-Limited/wacli ~/src/wacli
-  cd ~/src/wacli && go build -o /usr/local/bin/wacli ./cmd/wacli
-```
-
-and stop this sub-flow.
-
-#### Step 3b.2 — Collect state
-
-Run these in parallel:
+Check bridge binary exists and LaunchAgent is installed:
 
 ```bash
-wacli doctor --json 2>&1
-wacli auth status --json 2>&1
-wacli messages list --after="$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d '1 day ago' +%Y-%m-%d)" --limit=5 --json 2>&1
-wacli chats list --json 2>&1 | head -c 4000
+ls ~/.local/share/whatsapp-mcp/whatsapp-bridge/whatsapp-bridge 2>/dev/null && echo "binary ok"
+launchctl list com.samrenders.whatsapp-bridge 2>/dev/null | head -3
+lsof -i :8080 2>/dev/null | grep LISTEN
 ```
 
-Parse:
-
-- `doctor.data.authenticated` (bool)
-- `doctor.data.lock_held` + `doctor.data.lock_info` (PID + acquired_at timestamp)
-- `doctor.data.fts_enabled` (bool — if false, search is degraded, not fatal)
-- `messages.data.messages` length → **this is the key health signal**. Authed with zero messages in the last 24h = broken.
-- `chats` count and whether it populated at all
-
-#### Step 3b.3 — Diagnose and classify
-
-Apply these rules in order. Stop at the first match.
-
-**A. Not authenticated**
-If `doctor.authenticated: false` → print "WhatsApp needs QR pairing. Run `wacli auth` in a separate terminal and scan the QR code with your phone (WhatsApp → Linked Devices → Link a device), then re-run /ops:setup whatsapp." End of sub-flow. Do **not** try to automate the QR scan — it requires the user's phone camera pointed at the terminal (exception to Rule 2).
-
-**B. Stuck sync (stale lock)**
-If `lock_held: true` AND the `lock_info.acquired_at` is older than 2 minutes AND the lock-holder PID is still alive (`ps -p <pid>`):
-
-1. Run `wacli sync` in the background (`timeout 15 wacli sync 2>&1`) via the existing process's stderr tail — OR if we can't tee into it, fall back to:
-2. Ask `AskUserQuestion`: `"A wacli sync process (pid=N) has been holding the store lock for Xm. Most likely stuck. Kill it?"` → `[Kill pid N and restart sync]`, `[Leave it running]`.
-3. On kill: `kill <pid>` (not -9 first). Wait 3s. If still alive, `kill -9 <pid>`. Verify with `ps -p <pid>`.
-4. After kill, re-run `wacli doctor --json` to confirm lock is released. Continue to the next rule.
-
-**C. App-state key desync (the big one)**
-Run `timeout 15 wacli sync 2>&1 | tee /tmp/wacli-sync-probe.log` (must be done after B so the lock is free). Grep the output for:
-
-- `didn't find app state key` → **session keys are desynced**, needs re-pair
-- `failed to decode app state` → same class of error
-- `Failed to do initial fetch of app state` → same class of error
-
-If any match:
-
-1. Print the diagnosis verbatim:
-   ```
-   ⚠  WhatsApp session is authenticated but the app-state decryption keys
-      are out of sync with your primary device. This happens when the
-      linked-device session is partially wiped on the phone side.
-      Symptom: sync runs but 0 messages come through.
-      Fix: logout this session and re-pair via QR.
-   ```
-2. Ask `AskUserQuestion`: `[Logout and walk me through re-pair]`, `[Skip — I'll fix manually]`.
-3. On logout: run `wacli auth logout --json` and show the result. Then print:
-   ```
-   Now run `wacli auth` in a separate terminal (QR-based auth — requires your phone camera).
-   A QR code will appear — scan it from WhatsApp → Settings → Linked Devices → Link a device.
-   When it says "Connected", come back and type "done".
-   ```
-4. Wait for the user to confirm via `AskUserQuestion`: `[Done — re-paired]`, `[Cancel]`.
-5. On Done, re-run Step 3b.2 to re-collect state and continue to rule D.
-
-**D. Authenticated, lock free, no recent messages, no key errors**
-This is usually a cold cache. Go to Step 3b.4 (backfill).
-
-**E. Healthy (messages flowing)**
-If `messages.data.messages` has ≥1 entry from the last 24h, print a ✓ summary and skip to Step 3b.5.
-
-#### Step 3b.4 — Historical backfill (background, silent)
-
-Always run this after a fresh re-pair, AND run it when rule D matches. Never skip unless the user explicitly declines.
-
-Backfill is a background optimization — it should not produce verbose output or alarming status messages. Run it silently and swallow non-fatal errors.
-
-1. Load the top 10 chats by recency:
-   ```bash
-   wacli chats list --json 2>&1 | jq -r '[.data[] | select(.jid) | {jid, name, last_msg: .last_message_ts}] | sort_by(.last_msg) | reverse | .[0:10]'
-   ```
-2. Tell the user: `"Running historical backfill on your 10 most-recent chats. This runs in the background."` Do not print per-chat progress or 0-message results.
-3. For each chat JID, run **sequentially** (backfill shares the store lock, can't parallelize):
-   ```bash
-   wacli history backfill --chat="<jid>" --count=50 --requests=2 --wait=30s --idle-exit=5s --json 2>&1
-   ```
-4. **Suppress all per-chat output.** If the command exits non-zero, swallow the error silently — backfill failures are not user-visible events. Do NOT print "0 messages synced", error tracebacks, or explanations about device connectivity.
-5. After the loop completes, print only the final health summary (Step 3b.6).
-
-#### Step 3b.5 — FTS index check (optional)
-
-If `doctor.fts_enabled: false`, print:
+If binary missing: ask `AskUserQuestion`: `[Show install docs]`, `[Skip WhatsApp]`. On install docs, print:
 
 ```
-ℹ  Full-text search is disabled — `wacli messages search` will use SQL LIKE (slower).
-   This is a non-fatal known-limitation. See wacli docs to enable FTS5.
+whatsapp-bridge (Baileys) is not installed. Install:
+  git clone https://github.com/Lifecycle-Innovations-Limited/whatsapp-mcp ~/.local/share/whatsapp-mcp
+  cd ~/.local/share/whatsapp-mcp/whatsapp-bridge && go build -o whatsapp-bridge .
+  mkdir -p ~/.local/share/whatsapp-mcp/whatsapp-bridge/logs
 ```
 
-Don't block on this.
-
-#### Step 3b.6 — Record state
-
-Write `channels.whatsapp = "wacli"` to `$PREFS_PATH` and print the final ✓ summary:
-
-```
-✓ WhatsApp — wacli authenticated, N chats
-```
-
-Never include message counts or backfill results in this summary line.
-
-#### Step 3b.7 — Persistent connection (keepalive)
-
-After successful auth and backfill, set up a persistent connection that keeps wacli connected and auto-syncing. This is what makes WhatsApp reliable across sessions — without it, the linked device disconnects after ~14 days of inactivity and @lid JIDs return empty messages.
-
-**If the ops-daemon is configured (Step 5b), wacli runs as a daemon service** — skip the standalone launchd path below and note to the user that wacli sync is managed by the daemon. The daemon handles bootstrap, auto-backfill, and health reporting centrally.
-
-**Standalone launchd fallback** (only if the ops-daemon is NOT being set up):
-
-**1. Install the keepalive script:**
-
+If LaunchAgent not installed, install it from template:
 ```bash
-KEEPALIVE_SCRIPT="${CLAUDE_PLUGIN_ROOT}/scripts/wacli-keepalive.sh"
-chmod +x "$KEEPALIVE_SCRIPT"
-```
-
-**2. Generate the launchd plist from template:**
-
-```bash
-PLIST_TEMPLATE="${CLAUDE_PLUGIN_ROOT}/scripts/com.claude-ops.wacli-keepalive.plist"
-PLIST_DEST="$HOME/Library/LaunchAgents/com.claude-ops.wacli-keepalive.plist"
-LOG_DIR="$HOME/.claude/plugins/data/ops-ops-marketplace/logs"
-mkdir -p "$LOG_DIR" "$HOME/Library/LaunchAgents"
-
-# Resolve bash 4+ (same logic as daemon plist)
-BASH_PATH="/bin/bash"
-if [[ -x /opt/homebrew/bin/bash ]]; then
-  BASH_PATH="/opt/homebrew/bin/bash"
-elif [[ -x /usr/local/bin/bash ]]; then
-  BASH_PATH="/usr/local/bin/bash"
-fi
-
-sed -e "s|__KEEPALIVE_SCRIPT_PATH__|$KEEPALIVE_SCRIPT|g" \
-    -e "s|__BASH_PATH__|$BASH_PATH|g" \
-    -e "s|__LOG_DIR__|$LOG_DIR|g" \
+PLIST_TEMPLATE="${CLAUDE_PLUGIN_ROOT}/assets/launchagents/com.samrenders.whatsapp-bridge.plist"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.samrenders.whatsapp-bridge.plist"
+BRIDGE_DIR="$HOME/.local/share/whatsapp-mcp/whatsapp-bridge"
+mkdir -p "$BRIDGE_DIR/logs"
+sed -e "s|__BRIDGE_BINARY_PATH__|$BRIDGE_DIR/whatsapp-bridge|g" \
+    -e "s|__BRIDGE_WORKING_DIR__|$BRIDGE_DIR|g" \
     -e "s|__HOME__|$HOME|g" \
     "$PLIST_TEMPLATE" > "$PLIST_DEST"
-```
-
-**3. Load the agent:**
-
-```bash
-# Unload if already loaded (idempotent)
-launchctl bootout gui/$(id -u) "$PLIST_DEST" 2>/dev/null || true
 launchctl bootstrap gui/$(id -u) "$PLIST_DEST"
 ```
 
-**4. Verify it's running:**
+#### Step 3b.2 — QR pairing (first run)
 
-Wait 3 seconds, then check:
+On first run, the bridge needs QR pairing. Check `bridge.err.log`:
+
 ```bash
-launchctl print gui/$(id -u)/com.claude-ops.wacli-keepalive 2>&1 | head -5
-cat "$HOME/.wacli/.health" 2>/dev/null
+tail -50 ~/.local/share/whatsapp-mcp/whatsapp-bridge/logs/bridge.err.log 2>/dev/null
 ```
 
-If the health file shows `status=connected` or `status=needs_reauth`, the daemon is working. Print:
+If log contains a QR code or "scan QR" message, print to the user:
 
 ```
-✓ WhatsApp keepalive — launchd agent installed and running
-  Persistent sync active. Auto-restarts on disconnect.
-  Health: ~/.wacli/.health | Logs: ~/.claude/plugins/data/ops-ops-marketplace/logs/
+The bridge is waiting for QR pairing.
+Open ~/.local/share/whatsapp-mcp/whatsapp-bridge/logs/bridge.err.log in a terminal to see the QR code.
+Scan it from WhatsApp → Settings → Linked Devices → Link a device.
 ```
 
-If `status=needs_reauth`, immediately trigger the re-pair flow from Step 3b.3 Rule C.
+Use `AskUserQuestion`: `[Done — QR scanned]`, `[Skip WhatsApp]`. This is the ONLY step that requires user's phone.
 
-**5. How the keepalive self-heals:**
+#### Step 3b.3 — Schema migration
 
-The keepalive script (`wacli-keepalive.sh`) handles these failure modes automatically:
+After bridge is running and paired, run the idempotent schema migration:
 
-| Failure | Auto-fix |
-|---------|----------|
-| Orphaned wacli process holding lock | Kills stale PIDs, clears lock |
-| Connection drop (WhatsApp server restart) | launchd restarts within 60s |
-| App-state key desync | Writes `needs_reauth` to health file — ops skills detect this and prompt QR |
-| Auth expired | Writes `needs_auth` — same prompt flow |
-| Script crash | launchd KeepAlive=true restarts immediately (throttled 60s) |
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/whatsapp-bridge-migrate.sh"
+```
 
-**6. Health file contract for other ops skills:**
+This adds FTS5 index and contacts table to messages.db. Safe to re-run.
 
-All ops skills that use WhatsApp (`ops-inbox`, `ops-comms`, `ops-go`) MUST check `~/.wacli/.health` before attempting wacli commands. If `status=needs_auth` or `status=needs_reauth`:
+#### Step 3b.4 — Smoke test
 
-1. Print the diagnosis to the user:
-   ```
-   ⚠ WhatsApp needs re-authentication.
-   Run `wacli auth` in a separate terminal and scan the QR code with your phone
-   (QR-based auth — exception to Rule 2). Then type "done" to continue.
-   ```
-2. Use `AskUserQuestion`: `[Done — re-paired]`, `[Skip WhatsApp]`.
-3. On Done: restart the keepalive daemon via `launchctl kickstart -k gui/$(id -u)/com.claude-ops.wacli-keepalive` and wait 5s for health file update.
+```bash
+lsof -i :8080 | grep LISTEN   # bridge running?
+DB="$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db"
+sqlite3 "$DB" "SELECT COUNT(*) FROM messages;" 2>/dev/null   # messages present?
+sqlite3 "$DB" "SELECT COUNT(*) FROM messages_fts;" 2>/dev/null   # FTS index present?
+```
 
-This ensures the user is never silently left with a broken WhatsApp connection — every ops skill surfaces the problem and walks them through the fix.
+If messages > 0 and FTS index present, print:
 
-> **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-comms/SKILL.md` and `${CLAUDE_PLUGIN_ROOT}/skills/ops-inbox/SKILL.md` for full operational instructions, CLI reference, and troubleshooting for this integration. The setup agent can load those files directly when it needs more depth than this wizard provides.
+```
+✓ WhatsApp — bridge running, N messages, FTS indexed
+```
+
+#### Step 3b.5 — Record state
+
+Write `channels.whatsapp = "whatsapp-bridge"` to `$PREFS_PATH`.
+
+**Health contract for other ops skills:**
+
+All ops skills that use WhatsApp must check `lsof -i :8080 | grep LISTEN` before MCP tool calls.
+If bridge is not running:
+1. Print: "WhatsApp bridge is not running."
+2. Use `AskUserQuestion`: `[Restart bridge]`, `[Skip WhatsApp]`.
+3. On restart: `launchctl kickstart -k gui/$(id -u)/com.samrenders.whatsapp-bridge`, wait 5s.
+
+> **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-comms/SKILL.md` and `${CLAUDE_PLUGIN_ROOT}/skills/ops-inbox/SKILL.md` for full operational instructions.
 
 ### 3c — Email
 
@@ -3120,7 +2998,7 @@ After auto-discovery (or if the user selects "I'll enter projects manually"):
 
 ## Step 5b — Daemon Service Reconciliation
 
-By now, the daemon was already installed in Step 2c and has been pre-warming the briefing cache in the background while the user configured channels. This step adds **channel-dependent services** (`wacli-sync`, `message-listener`, `inbox-digest`, `store-health`, `competitor-intel`) now that we know which channels and integrations are configured.
+By now, the daemon was already installed in Step 2c and has been pre-warming the briefing cache in the background while the user configured channels. This step adds **channel-dependent services** (`whatsapp-bridge-sync`, `message-listener`, `inbox-digest`, `store-health`, `competitor-intel`) now that we know which channels and integrations are configured.
 
 **Skip conditions:**
 - If the user declined daemon install in Step 2c, skip this step entirely.
@@ -3148,7 +3026,7 @@ cat "$DATA_DIR/daemon-health.json" 2>/dev/null
 Parse the JSON. If `action_needed` is not null, surface the required action to the user. If the daemon wrote a health file, print:
 
 ```
-✓ Background daemon — running (wacli-sync: connected, memory-extractor: scheduled)
+✓ Background daemon — running (whatsapp-bridge-sync: connected, memory-extractor: scheduled)
 ```
 
 If the health file is missing (daemon may still be initializing), wait 5 more seconds and retry once. If still missing, print:
@@ -3163,7 +3041,7 @@ If the health file is missing (daemon may still be initializing), wait 5 more se
 
 Determine which services to enable based on what was configured in earlier steps. The `briefing-pre-warm` and `memory-extractor` services were already enabled at Step 2c — preserve them. Add channel-dependent services based on what's now configured:
 
-- `wacli-sync` — always include if WhatsApp is configured (`channels.whatsapp` is set)
+- `whatsapp-bridge-sync` — always include if WhatsApp is configured (`channels.whatsapp` is set)
 - `memory-extractor` — always include
 - `inbox-digest` — always include (runs every 4h, aggregates all configured channels)
 - `store-health` — include ONLY if ecommerce was configured (`ecom.shopify.store_url` is set in `$PREFS_PATH`)
@@ -3174,9 +3052,9 @@ Build the services array programmatically (starting from the 2c baseline):
 ```bash
 SERVICES='["briefing-pre-warm","memory-extractor","inbox-digest","competitor-intel"]'
 PREFS=$(cat "$PREFS_PATH" 2>/dev/null || echo '{}')
-# Add wacli-sync + message-listener if WhatsApp is configured
+# Add whatsapp-bridge-sync + message-listener if WhatsApp is configured
 if echo "$PREFS" | jq -e '.channels.whatsapp' > /dev/null 2>&1; then
-  SERVICES=$(echo "$SERVICES" | jq '. + ["wacli-sync","message-listener"]')
+  SERVICES=$(echo "$SERVICES" | jq '. + ["whatsapp-bridge-sync","message-listener"]')
 fi
 # Add message-listener for Telegram too (deduplicate)
 if echo "$PREFS" | jq -e '.channels.telegram' > /dev/null 2>&1; then
@@ -3191,7 +3069,7 @@ echo "Services to enable: $SERVICES"
 
 Write daemon services config to `$DATA_DIR/daemon-services.json` — merge with the existing config from Step 2c, preserving `briefing-pre-warm` and `memory-extractor`, and enabling the new channel-dependent services. **Every service MUST include a `command` field** — the daemon's `start_service()` skips any service without one. Use `${CLAUDE_PLUGIN_ROOT}` (resolved at runtime) for script paths. Each service entry should include:
 - `briefing-pre-warm`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/bin/ops-gather", "cron": "*/2 * * * *" }` — pre-warms /ops:go cache (installed in 2c)
-- `wacli-sync`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/wacli-keepalive.sh", "health_file": "~/.wacli/.health", "restart_delay": 60, "max_restarts": 10 }` — only if WhatsApp configured
+- `whatsapp-bridge-sync`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/whatsapp-bridge-keepalive.sh", "health_file": "~/.whatsapp-bridge/.health", "restart_delay": 60, "max_restarts": 10 }` — only if WhatsApp configured
 - `memory-extractor`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-memory-extractor.sh", "health_file": "~/.claude/plugins/data/ops-ops-marketplace/memories/.health", "cron": "*/30 * * * *" }` — every 30 min (installed in 2c)
 - `inbox-digest`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-cron-inbox-digest.sh", "cron": "0 */4 * * *" }` — every 4h
 - `store-health`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-cron-store-health.sh", "cron": "0 9 * * *" }` — daily 9am, only if ecom configured
@@ -3217,7 +3095,7 @@ Use `run_in_background: true` on the reload command. Do NOT wait for it — cont
 Write `daemon.enabled = true` and `daemon.services` (the reconciled array) to `$PREFS_PATH`. Print:
 
 ```
-✓ Daemon services reconciled — N services enabled (briefing-pre-warm, memory-extractor, wacli-sync, ...)
+✓ Daemon services reconciled — N services enabled (briefing-pre-warm, memory-extractor, whatsapp-bridge-sync, ...)
   Daemon reloading in background.
 ```
 
@@ -3563,7 +3441,7 @@ Re-run the detector and present a final status dashboard:
  ✓ MCPs:       linear, sentry, vercel
  ✓ Registry:   20 projects
  ✓ Prefs:      saved to ~/.claude/plugins/data/ops-ops-marketplace/preferences.json
- ✓ Daemon:     ops-daemon → wacli-sync, memory-extractor, inbox-digest
+ ✓ Daemon:     ops-daemon → whatsapp-bridge-sync, memory-extractor, inbox-digest
 
  Next: /ops-go for your first briefing
 ──────────────────────────────────────────────────────
@@ -3607,7 +3485,7 @@ If `$ARGUMENTS` contains a specific section name, jump straight to that section:
 | `cli`, `install`                       | Step 2  |
 | `channels`                             | Step 3  |
 | `telegram`                             | Step 3a |
-| `whatsapp`, `wacli`, `whatsapp-doctor` | Step 3b |
+| `whatsapp`, `whatsapp-bridge`, `whatsapp-doctor` | Step 3b |
 | `email`                                | Step 3c |
 | `slack`                                | Step 3d |
 | `notion`                               | Step 3e |
@@ -3717,35 +3595,35 @@ gog auth status                                                     # Check auth
 gog auth add user@example.com --services gmail,calendar,drive,contacts,docs,sheets
 ```
 
-### wacli
+### whatsapp-bridge
 
 ```bash
 # Health check
-wacli doctor --json
+lsof -i :8080 | grep LISTEN --json
 
 # Auth status
-wacli auth status --json
+whatsapp-bridge auth status --json
 
 # List chats (MUST use subcommand `list`)
-wacli chats list --json
+whatsapp-bridge chats list --json
 
 # List messages (--after flag uses YYYY-MM-DD)
 # macOS
-wacli messages list --after="$(date -v-1d +%Y-%m-%d)" --limit=5 --json
+whatsapp-bridge messages list --after="$(date -v-1d +%Y-%m-%d)" --limit=5 --json
 # Linux
-wacli messages list --after="$(date -d '1 day ago' +%Y-%m-%d)" --limit=5 --json
+whatsapp-bridge messages list --after="$(date -d '1 day ago' +%Y-%m-%d)" --limit=5 --json
 
 # Send message
-wacli send --to "JID" --message "text"
+whatsapp-bridge send --to "JID" --message "text"
 
 # Sync (connect and pull)
-wacli sync
+whatsapp-bridge sync
 
 # Backfill history
-wacli history backfill --chat="JID" --count=50 --requests=2 --wait=30s --idle-exit=5s --json
+whatsapp-bridge history backfill --chat="JID" --count=50 --requests=2 --wait=30s --idle-exit=5s --json
 
 # Contact lookup
-wacli contacts --search "name" --json
+whatsapp-bridge contacts --search "name" --json
 ```
 
 > After setup, the memory-extractor daemon service will populate `memories/contact_*.md` from this contact data.

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -2998,7 +2998,7 @@ After auto-discovery (or if the user selects "I'll enter projects manually"):
 
 ## Step 5b — Daemon Service Reconciliation
 
-By now, the daemon was already installed in Step 2c and has been pre-warming the briefing cache in the background while the user configured channels. This step adds **channel-dependent services** (`whatsapp-bridge-sync`, `message-listener`, `inbox-digest`, `store-health`, `competitor-intel`) now that we know which channels and integrations are configured.
+By now, the daemon was already installed in Step 2c and has been pre-warming the briefing cache in the background while the user configured channels. This step adds **channel-dependent services** (`whatsapp-bridge`, `message-listener`, `inbox-digest`, `store-health`, `competitor-intel`) now that we know which channels and integrations are configured.
 
 **Skip conditions:**
 - If the user declined daemon install in Step 2c, skip this step entirely.
@@ -3026,7 +3026,7 @@ cat "$DATA_DIR/daemon-health.json" 2>/dev/null
 Parse the JSON. If `action_needed` is not null, surface the required action to the user. If the daemon wrote a health file, print:
 
 ```
-✓ Background daemon — running (whatsapp-bridge-sync: connected, memory-extractor: scheduled)
+✓ Background daemon — running (whatsapp-bridge: connected, memory-extractor: scheduled)
 ```
 
 If the health file is missing (daemon may still be initializing), wait 5 more seconds and retry once. If still missing, print:
@@ -3041,7 +3041,7 @@ If the health file is missing (daemon may still be initializing), wait 5 more se
 
 Determine which services to enable based on what was configured in earlier steps. The `briefing-pre-warm` and `memory-extractor` services were already enabled at Step 2c — preserve them. Add channel-dependent services based on what's now configured:
 
-- `whatsapp-bridge-sync` — always include if WhatsApp is configured (`channels.whatsapp` is set)
+- `whatsapp-bridge` — always include if WhatsApp is configured (`channels.whatsapp` is set)
 - `memory-extractor` — always include
 - `inbox-digest` — always include (runs every 4h, aggregates all configured channels)
 - `store-health` — include ONLY if ecommerce was configured (`ecom.shopify.store_url` is set in `$PREFS_PATH`)
@@ -3052,9 +3052,9 @@ Build the services array programmatically (starting from the 2c baseline):
 ```bash
 SERVICES='["briefing-pre-warm","memory-extractor","inbox-digest","competitor-intel"]'
 PREFS=$(cat "$PREFS_PATH" 2>/dev/null || echo '{}')
-# Add whatsapp-bridge-sync + message-listener if WhatsApp is configured
+# Add whatsapp-bridge + message-listener if WhatsApp is configured
 if echo "$PREFS" | jq -e '.channels.whatsapp' > /dev/null 2>&1; then
-  SERVICES=$(echo "$SERVICES" | jq '. + ["whatsapp-bridge-sync","message-listener"]')
+  SERVICES=$(echo "$SERVICES" | jq '. + ["whatsapp-bridge","message-listener"]')
 fi
 # Add message-listener for Telegram too (deduplicate)
 if echo "$PREFS" | jq -e '.channels.telegram' > /dev/null 2>&1; then
@@ -3069,7 +3069,7 @@ echo "Services to enable: $SERVICES"
 
 Write daemon services config to `$DATA_DIR/daemon-services.json` — merge with the existing config from Step 2c, preserving `briefing-pre-warm` and `memory-extractor`, and enabling the new channel-dependent services. **Every service MUST include a `command` field** — the daemon's `start_service()` skips any service without one. Use `${CLAUDE_PLUGIN_ROOT}` (resolved at runtime) for script paths. Each service entry should include:
 - `briefing-pre-warm`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/bin/ops-gather", "cron": "*/2 * * * *" }` — pre-warms /ops:go cache (installed in 2c)
-- `whatsapp-bridge-sync`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/whatsapp-bridge-keepalive.sh", "health_file": "~/.whatsapp-bridge/.health", "restart_delay": 60, "max_restarts": 10 }` — only if WhatsApp configured
+- `whatsapp-bridge`: `{ "enabled": true, "command": "launchctl kickstart -k gui/$UID/com.samrenders.whatsapp-bridge", "health_check": "lsof -i :8080 | grep LISTEN", "restart_delay": 60, "max_restarts": 10 }` — only if WhatsApp configured (matches `daemon-services.default.json`; bridge is owned by LaunchAgent, not a plugin script)
 - `memory-extractor`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-memory-extractor.sh", "health_file": "~/.claude/plugins/data/ops-ops-marketplace/memories/.health", "cron": "*/30 * * * *" }` — every 30 min (installed in 2c)
 - `inbox-digest`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-cron-inbox-digest.sh", "cron": "0 */4 * * *" }` — every 4h
 - `store-health`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-cron-store-health.sh", "cron": "0 9 * * *" }` — daily 9am, only if ecom configured
@@ -3095,7 +3095,7 @@ Use `run_in_background: true` on the reload command. Do NOT wait for it — cont
 Write `daemon.enabled = true` and `daemon.services` (the reconciled array) to `$PREFS_PATH`. Print:
 
 ```
-✓ Daemon services reconciled — N services enabled (briefing-pre-warm, memory-extractor, whatsapp-bridge-sync, ...)
+✓ Daemon services reconciled — N services enabled (briefing-pre-warm, memory-extractor, whatsapp-bridge, ...)
   Daemon reloading in background.
 ```
 
@@ -3441,7 +3441,7 @@ Re-run the detector and present a final status dashboard:
  ✓ MCPs:       linear, sentry, vercel
  ✓ Registry:   20 projects
  ✓ Prefs:      saved to ~/.claude/plugins/data/ops-ops-marketplace/preferences.json
- ✓ Daemon:     ops-daemon → whatsapp-bridge-sync, memory-extractor, inbox-digest
+ ✓ Daemon:     ops-daemon → whatsapp-bridge, memory-extractor, inbox-digest
 
  Next: /ops-go for your first briefing
 ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Removes the `wacli` keepalive daemon and all `wacli` CLI callsites from skills, scripts, and bin tools
- All WhatsApp ops now route through `mcp__whatsapp__*` tools (Baileys bridge) or direct `sqlite3` queries against `messages.db`
- Adds `scripts/whatsapp-bridge-migrate.sh`: idempotent FTS5 + contacts table migration; seeds contacts from macOS Contacts.app

## Why now

wacli was burning one of four WhatsApp linked-device slots and double-storing messages alongside the Baileys bridge. The bridge already had full message coverage (confirmed by `whatsapp-contact-mapper.py` which was already reading `messages.db`). The only missing pieces were the FTS5 index and a contacts table — both added by the migration script in this PR.

## Migration steps for users (manual, post-merge)

1. Run `scripts/whatsapp-bridge-migrate.sh` — adds FTS5 + contacts to bridge `messages.db` (idempotent, safe to re-run)
2. Revoke the wacli linked device on your phone: WhatsApp → Settings → Linked Devices → tap the wacli device → Remove
3. Remove the wacli LaunchAgent:
   ```bash
   launchctl bootout gui/$UID ~/Library/LaunchAgents/com.claude-ops.wacli-keepalive.plist 2>/dev/null || true
   rm -f ~/Library/LaunchAgents/com.claude-ops.wacli-keepalive.plist
   ```

## Rollback

WhatsApp supports 4 linked devices. Re-link wacli at any time without touching the bridge:
```bash
wacli auth   # scan QR — re-pairs as a fresh device
launchctl bootstrap gui/$UID ~/Library/LaunchAgents/com.claude-ops.wacli-keepalive.plist
```
The bridge continues running independently; no message loss.

**Known:** `bin/ops-pretool-wacli-health` is kept as a backwards-compat shim (renamed body, same filename) so any existing `hooks.json` entries that haven't updated yet don't break. The new `bin/ops-pretool-whatsapp-bridge-health` is the canonical hook going forward.

## Test plan

- [ ] `scripts/whatsapp-bridge-migrate.sh` runs to completion on a fresh messages.db
- [ ] `scripts/whatsapp-bridge-migrate.sh` is a no-op on second run (idempotent)
- [ ] `bin/ops-unread` returns `whatsapp.available: true` with bridge running
- [ ] `mcp__whatsapp__list_chats` returns chats (bridge running + paired)
- [ ] `mcp__whatsapp__list_messages {query: "test"}` hits FTS5 index (check via `EXPLAIN QUERY PLAN`)
- [ ] `mcp__whatsapp__search_contacts {query: "name"}` resolves from contacts table
- [ ] `/ops:inbox whatsapp` completes without invoking any `wacli` CLI command
- [ ] `rg "wacli " claude-ops/skills/ claude-ops/scripts/ claude-ops/bin/ --glob '!legacy/*'` returns zero live callsites
- [ ] `bin/wacli-health --json` returns `{"healthy": true, "backend": "whatsapp-bridge"}` with bridge up

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadly replaces the WhatsApp backend across skills, daemon supervision, and health checks, which could break inbox/comms flows if the bridge or DB schema isn’t present or differs across environments. Adds a schema migration and new liveness hooks, but relies on local launchd/port 8080 and SQLite queries that need validation on real user setups.
> 
> **Overview**
> **Migrates all WhatsApp operations from the `wacli` CLI/keepalive to the Baileys `whatsapp-bridge` accessed via `mcp__whatsapp__*` tools and direct `sqlite3` reads of `messages.db`.** This updates key user-facing skills (`ops-inbox`, `ops-comms`, `ops-go`) plus scanners/daemons to use bridge message fields (`is_from_me`, `content`, etc.) and bridge liveness checks (port `8080`, `launchctl`).
> 
> Adds an idempotent `scripts/whatsapp-bridge-migrate.sh` to create an FTS5 `messages_fts` index (with triggers) and a `contacts` table (optionally seeded from macOS Contacts), and rewires `ops-autofix`, `ops-doctor`, `ops-unread`, and cron/listener scripts to depend on the bridge DB + migration rather than rebuilding `wacli`.
> 
> Deprecates `wacli` tooling (`bin/wacli-health`, `bin/wacli-safe`, `ops-pretool-wacli-health`) into compatibility shims, introduces `bin/ops-pretool-whatsapp-bridge-health`, updates daemon service definitions to supervise `com.samrenders.whatsapp-bridge`, and refreshes docs/README/CHANGELOG with new install/migration/rollback steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64209962aaf0905079c7bfb2d7d7a4d5f6c13aa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * WhatsApp messaging now uses a persistent bridge service for improved reliability.
  * New MCP-based tools for managing WhatsApp operations.

* **Improvements**
  * Simplified service health monitoring and channel diagnostics.
  * Enhanced message database synchronization with full-text search capabilities.

* **Documentation**
  * Updated setup, installation, configuration, and troubleshooting guides.
  * Added database migration and service management procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->