### PR TITLE
docs(ops-inbox): banner — WhatsApp MCP only, never wacli

### DIFF
--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -42,6 +42,27 @@ maxTurns: 60
 
 # OPS ► INBOX ZERO
 
+## ⚠️ WHATSAPP TRANSPORT — MCP ONLY, NEVER `wacli`
+
+For **all** WhatsApp operations in this skill (list chats, read messages, search contacts, send replies), use the `mcp__whatsapp__*` tool family backed by the Baileys whatsapp-bridge.
+
+**NEVER call the legacy `wacli` CLI** (`wacli chats list`, `wacli messages list`, `wacli send`, `wacli doctor`, `wacli history backfill`, etc). The wacli store and keepalive daemon are deprecated for this skill.
+
+If you find yourself reaching for any `wacli ...` shell command, stop and use the MCP tool with the same intent:
+
+| Intent                  | ✅ Use this                                                              | ❌ Do NOT use            |
+|-------------------------|--------------------------------------------------------------------------|---------------------------|
+| List recent chats       | `mcp__whatsapp__list_chats {sort_by: "last_active", limit: 25}`          | `wacli chats list`        |
+| Read full thread        | `mcp__whatsapp__list_messages {chat_jid, limit: 20}`                     | `wacli messages list`     |
+| Full-text search        | `mcp__whatsapp__list_messages {query: "<text>", limit: 20}`              | `wacli messages search`   |
+| Resolve a contact       | `mcp__whatsapp__search_contacts {query: "<name>"}`                        | `wacli contacts`          |
+| Send a reply (after approval) | `mcp__whatsapp__send_message {recipient: "<JID>", message: "<text>"}` | `wacli send`              |
+| Health check            | `lsof -i :8080 \| grep LISTEN` + `launchctl list com.samrenders.whatsapp-bridge` | `wacli doctor` / `~/.wacli/.health` |
+
+**Rationale:** the bridge exposes a typed MCP surface, returns consistent JSON shapes (`is_from_me`, `content`, `timestamp`, `sender`), supports FTS5 search natively, and avoids store-lock contention with the wacli keepalive daemon. Mixing the two surfaces caused inconsistent state in past sessions.
+
+**Sole exception:** the `~/.wacli/.health` file is still readable for legacy daemon-health surfacing in other skills, but no `wacli` command should be invoked from this skill.
+
 ## Runtime Context
 
 Before executing, load available context:


### PR DESCRIPTION
## Summary
- Adds a prominent ⚠️ banner at the top of `skills/ops-inbox/SKILL.md` making the transport rule impossible to miss: all WhatsApp ops go through `mcp__whatsapp__*` (Baileys bridge), never the legacy `wacli` CLI.
- Side-by-side ✅/❌ table maps every common intent (list, read, search, send, contacts, health) to the correct MCP tool.

## Why
A recent `/ops:ops-inbox` session loaded the cached SKILL.md still referencing `wacli` throughout. The agent reached for `wacli chats list` / `wacli messages list` etc. The MCP-only direction was already documented later in the file but the historical `wacli` wording at the top of the skill primed the wrong tool choice. Banner makes the rule the first thing the agent reads.

## Test plan
- [x] `tests/test-no-secrets.sh` passes (14/0)
- [ ] Next `/ops:ops-inbox whatsapp` session loads the banner and uses MCP tools end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that doesn’t affect runtime behavior; risk is limited to potential confusion if the guidance is wrong or becomes outdated.
> 
> **Overview**
> Adds a prominent WhatsApp transport warning at the top of `skills/ops-inbox/SKILL.md` that **mandates using `mcp__whatsapp__*` tools via the Baileys bridge** and **explicitly forbids invoking legacy `wacli` commands**.
> 
> Includes a ✅/❌ intent mapping table (list chats, read/search messages, resolve contacts, send replies, and health checks), plus a short rationale and a narrow exception allowing only reading `~/.wacli/.health` (no `wacli` execution).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75c57d80bb0e3e10f7640ab1fbc5761055caca2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/lifecycle-innovations-limited/claude-ops/pull/176" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated operational guidelines for WhatsApp channel tasks within the ops-inbox skill, establishing standardized procedures for chat listing, message reading, contact search, and reply sending.
  * Revised health-check instructions for improved system reliability monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->