### PR TITLE
fix(registry): resolve registry.json from canonical data-dir, survive plugin updates

### DIFF
--- a/claude-ops/bin/ops-ci
+++ b/claude-ops/bin/ops-ci
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REGISTRY="${SCRIPT_DIR}/../scripts/registry.json"
+OPS_PLUGIN_ROOT_FALLBACK="${SCRIPT_DIR}/.." . "${SCRIPT_DIR}/../lib/registry-path.sh"
 
 if [ ! -f "$REGISTRY" ]; then
   echo '{"error":"registry.json not found"}' && exit 1

--- a/claude-ops/bin/ops-dash
+++ b/claude-ops/bin/ops-dash
@@ -4,8 +4,8 @@
 set -euo pipefail
 
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-REGISTRY="${PLUGIN_ROOT}/scripts/registry.json"
-PREFS="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+. "${PLUGIN_ROOT}/lib/registry-path.sh"
+PREFS="${OPS_DATA_DIR}/preferences.json"
 
 # --- Color setup ---
 if [[ -z "${NO_COLOR:-}" && "${TERM:-dumb}" != "dumb" ]]; then

--- a/claude-ops/bin/ops-doctor
+++ b/claude-ops/bin/ops-doctor
@@ -9,7 +9,7 @@ has_env() { [ -n "${!1:-}" ] && echo true || echo false; }
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 PLUGIN_JSON="$SCRIPT_DIR/.claude-plugin/plugin.json"
-REGISTRY="$SCRIPT_DIR/scripts/registry.json"
+OPS_PLUGIN_ROOT_FALLBACK="$SCRIPT_DIR" . "$SCRIPT_DIR/lib/registry-path.sh"
 MCP_JSON_FILE="$SCRIPT_DIR/.mcp.json"
 PREFS_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
 PREFS="$PREFS_DIR/preferences.json"
@@ -247,7 +247,7 @@ if [ -f "$REGISTRY" ]; then
     fi
   fi
 else
-  WARNINGS+=("registry_missing: scripts/registry.json not found — run /ops:setup to create")
+  WARNINGS+=("registry_missing: registry.json not found at $OPS_DATA_DIR/registry.json — run /ops:setup to create")
 fi
 
 # --- 7. Preferences ---

--- a/claude-ops/bin/ops-external
+++ b/claude-ops/bin/ops-external
@@ -6,7 +6,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REGISTRY="${SCRIPT_DIR}/../scripts/registry.json"
+OPS_PLUGIN_ROOT_FALLBACK="${SCRIPT_DIR}/.." . "${SCRIPT_DIR}/../lib/registry-path.sh"
 
 if [ ! -f "$REGISTRY" ]; then
   echo '[]' && exit 0

--- a/claude-ops/bin/ops-git
+++ b/claude-ops/bin/ops-git
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REGISTRY="${SCRIPT_DIR}/../scripts/registry.json"
+OPS_PLUGIN_ROOT_FALLBACK="${SCRIPT_DIR}/.." . "${SCRIPT_DIR}/../lib/registry-path.sh"
 
 if [ ! -f "$REGISTRY" ]; then
   echo '{"error":"registry.json not found"}' && exit 1

--- a/claude-ops/bin/ops-infra
+++ b/claude-ops/bin/ops-infra
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REGISTRY="${SCRIPT_DIR}/../scripts/registry.json"
+OPS_PLUGIN_ROOT_FALLBACK="${SCRIPT_DIR}/.." . "${SCRIPT_DIR}/../lib/registry-path.sh"
 
 if [ ! -f "$REGISTRY" ]; then
   echo '{"error":"registry.json not found"}' && exit 1

--- a/claude-ops/bin/ops-merge-scan
+++ b/claude-ops/bin/ops-merge-scan
@@ -7,8 +7,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_DIR="${CLAUDE_PLUGIN_ROOT:-${SCRIPT_DIR}/..}"
-REGISTRY="${PLUGIN_DIR}/scripts/registry.json"
-PREFS="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+OPS_PLUGIN_ROOT_FALLBACK="$PLUGIN_DIR" . "${PLUGIN_DIR}/lib/registry-path.sh"
+PREFS="${OPS_DATA_DIR}/preferences.json"
 
 # Optional: scope to a single repo
 FILTER_REPO="${1:-}"

--- a/claude-ops/bin/ops-prs
+++ b/claude-ops/bin/ops-prs
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REGISTRY="${SCRIPT_DIR}/../scripts/registry.json"
+OPS_PLUGIN_ROOT_FALLBACK="${SCRIPT_DIR}/.." . "${SCRIPT_DIR}/../lib/registry-path.sh"
 
 if [ ! -f "$REGISTRY" ]; then
   echo '{"error":"registry.json not found"}' && exit 1

--- a/claude-ops/bin/ops-setup-detect
+++ b/claude-ops/bin/ops-setup-detect
@@ -14,7 +14,7 @@ if [ -f "$PREFLIGHT/.complete" ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-REGISTRY="$SCRIPT_DIR/scripts/registry.json"
+OPS_PLUGIN_ROOT_FALLBACK="$SCRIPT_DIR" . "$SCRIPT_DIR/lib/registry-path.sh"
 
 LIB_OS_DETECT="$SCRIPT_DIR/lib/os-detect.sh"
 [ -r "$LIB_OS_DETECT" ] && . "$LIB_OS_DETECT"

--- a/claude-ops/lib/registry-path.sh
+++ b/claude-ops/lib/registry-path.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# lib/registry-path.sh — canonical resolver for registry.json + OPS_DATA_DIR
+#
+# Resolves OPS_DATA_DIR (canonical, survives plugin updates) and REGISTRY
+# (registry.json path). Prefers the per-user data dir; falls back to the
+# in-repo cache path for back-compat with installs that pre-date the data-dir
+# migration.
+#
+# Sourcing convention:
+#   PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+#   . "${PLUGIN_ROOT}/lib/registry-path.sh"
+#   # or, when the caller already exports its own root variable:
+#   OPS_PLUGIN_ROOT_FALLBACK="$PLUGIN_DIR" . "${PLUGIN_DIR}/lib/registry-path.sh"
+#
+# Exports:
+#   OPS_DATA_DIR   — ${CLAUDE_PLUGIN_DATA_DIR:-~/.claude/plugins/data/ops-ops-marketplace}
+#   REGISTRY       — first existing of: $OPS_DATA_DIR/registry.json,
+#                    $OPS_PLUGIN_ROOT_FALLBACK/scripts/registry.json,
+#                    $PLUGIN_ROOT/scripts/registry.json. Defaults to the
+#                    canonical data-dir path even if the file is missing, so
+#                    callers can write to it.
+
+OPS_DATA_DIR="${OPS_DATA_DIR:-${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}}"
+export OPS_DATA_DIR
+
+_ops_canonical_registry="${OPS_DATA_DIR}/registry.json"
+_ops_legacy_registry=""
+if [ -n "${OPS_PLUGIN_ROOT_FALLBACK:-}" ] && [ -f "${OPS_PLUGIN_ROOT_FALLBACK}/scripts/registry.json" ]; then
+  _ops_legacy_registry="${OPS_PLUGIN_ROOT_FALLBACK}/scripts/registry.json"
+elif [ -n "${PLUGIN_ROOT:-}" ] && [ -f "${PLUGIN_ROOT}/scripts/registry.json" ]; then
+  _ops_legacy_registry="${PLUGIN_ROOT}/scripts/registry.json"
+fi
+
+if [ -f "$_ops_canonical_registry" ]; then
+  REGISTRY="$_ops_canonical_registry"
+elif [ -n "$_ops_legacy_registry" ]; then
+  REGISTRY="$_ops_legacy_registry"
+else
+  REGISTRY="$_ops_canonical_registry"
+fi
+export REGISTRY
+
+unset _ops_canonical_registry _ops_legacy_registry

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -820,7 +820,9 @@ prefetch_calendar() {
 prefetch_project_health() {
   local PROJ_CACHE="$DATA_DIR/cache/projects_health.json"
   local LAST_FETCH="$DATA_DIR/cache/.projects_ts"
-  local REGISTRY="${CLAUDE_PLUGIN_ROOT:-$(dirname "$0")/../}/scripts/registry.json"
+  local PLUGIN_ROOT_LOCAL="${CLAUDE_PLUGIN_ROOT:-$(dirname "$0")/../}"
+  local REGISTRY="${OPS_DATA_DIR:-${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}}/registry.json"
+  [[ -f "$REGISTRY" ]] || REGISTRY="${PLUGIN_ROOT_LOCAL}/scripts/registry.json"
 
   # Every 10 min
   if [[ -f "$LAST_FETCH" ]]; then


### PR DESCRIPTION
## Summary

- Plugin updates wipe `\$PLUGIN_ROOT/scripts/registry.json` (cache path), which most bin scripts read from. After every version bump, `/ops:ops-dash` and friends report "No project registry found" even though the user's data-dir registry is intact.
- `bin/ops-projects` already resolves from `\$CLAUDE_PLUGIN_DATA_DIR/registry.json` (canonical, survives updates). This PR brings the rest of the surface in line via a shared `lib/registry-path.sh` helper.
- 9 bin scripts + the daemon's `prefetch_project_health` now use the helper. Resolution order: data-dir → caller-supplied legacy fallback → \$PLUGIN_ROOT legacy → canonical default for write-paths.

## Test plan

- [x] `bash -n` on all 11 modified files
- [x] Smoke: resolver finds 38-project registry from data-dir without cache symlink
- [x] Legacy fallback: synthetic plugin tree with registry only in `scripts/` resolves correctly
- [x] End-to-end: `bin/ops-dash` reports `38 projects | 14 GSD active` after cache wipe
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple operational scripts and the daemon to change how `registry.json`/preferences paths are resolved; mistakes could cause dashboards/health checks to see an empty registry or write to the wrong location.
> 
> **Overview**
> **Standardizes how ops scripts find `registry.json` so plugin updates don’t wipe state.** Adds `lib/registry-path.sh` to resolve `OPS_DATA_DIR` and pick `REGISTRY` from the canonical per-user data directory first, with fallback to legacy `scripts/registry.json` paths.
> 
> Updates the affected `bin/ops-*` commands to source the resolver (and in a couple cases derive `PREFS` from `OPS_DATA_DIR`), and adjusts `ops-daemon.sh`’s project-health prefetch to prefer the data-dir registry with a legacy fallback. Also updates the `ops-doctor` missing-registry warning to point at the canonical location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 979fd12189afd7f6dbf0220d2eced9bdfee231d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->