### PR TITLE
feat(credentials): /ops:credentials audit + plugin.json field hints (v2.0.6)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code \u2014 30 skills, 14 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Business operations command center for Claude Code — 30 skills, 14 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",
@@ -222,7 +222,7 @@
     },
     "telegram_api_hash": {
       "title": "Telegram API Hash",
-      "description": "API hash from https://my.telegram.org/apps. Optional — run /ops:setup telegram to auto-configure.",
+      "description": "API hash from https://my.telegram.org/apps. Optional — run /ops:setup telegram to auto-configure. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -236,7 +236,7 @@
     },
     "telegram_session": {
       "title": "Telegram Session String",
-      "description": "gram.js StringSession. Optional — run /ops:setup telegram to auto-configure.",
+      "description": "gram.js StringSession. Optional — run /ops:setup telegram to auto-configure. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -282,14 +282,14 @@
     },
     "klaviyo_private_key": {
       "title": "Klaviyo Private API Key",
-      "description": "Private API key from Klaviyo Settings > API Keys (starts with pk_ or ck_)",
+      "description": "Private API key from Klaviyo Settings > API Keys (starts with pk_ or ck_) If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "meta_ads_token": {
       "title": "Meta Ads Access Token",
-      "description": "Meta Marketing API access token from Facebook Business",
+      "description": "Meta Marketing API access token from Facebook Business If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -325,49 +325,49 @@
     },
     "shopify_admin_token": {
       "title": "Shopify Admin API Token",
-      "description": "Admin API access token from Shopify Partners or custom app",
+      "description": "Admin API access token from Shopify Partners or custom app If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "shipbob_access_token": {
       "title": "ShipBob Access Token",
-      "description": "ShipBob Personal Access Token for fulfillment tracking (optional)",
+      "description": "ShipBob Personal Access Token for fulfillment tracking (optional) If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "bland_ai_api_key": {
       "title": "Bland AI API Key",
-      "description": "API key from https://app.bland.ai — used for /ops:ops-voice call",
+      "description": "API key from https://app.bland.ai — used for /ops:ops-voice call If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "elevenlabs_api_key": {
       "title": "ElevenLabs API Key",
-      "description": "API key from https://elevenlabs.io — used for /ops:ops-voice tts",
+      "description": "API key from https://elevenlabs.io — used for /ops:ops-voice tts If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "groq_api_key": {
       "title": "Groq API Key",
-      "description": "API key from https://console.groq.com — used for /ops:ops-voice transcribe (Whisper)",
+      "description": "API key from https://console.groq.com — used for /ops:ops-voice transcribe (Whisper) If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "stripe_secret_key": {
       "title": "Stripe Secret Key",
-      "description": "Stripe secret key (sk_live_... or sk_test_...) for revenue tracking. Prefer Doppler reference.",
+      "description": "Stripe secret key (sk_live_... or sk_test_...) for revenue tracking. Prefer Doppler reference. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "revenuecat_api_key": {
       "title": "RevenueCat API Key",
-      "description": "RevenueCat API key for mobile subscription revenue tracking (V2 API).",
+      "description": "RevenueCat API key for mobile subscription revenue tracking (V2 API). If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -381,21 +381,21 @@
     },
     "datadog_api_key": {
       "title": "Datadog API Key",
-      "description": "From Datadog Organization Settings > API Keys — used for /ops:monitor",
+      "description": "From Datadog Organization Settings > API Keys — used for /ops:monitor If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "datadog_app_key": {
       "title": "Datadog Application Key",
-      "description": "From Datadog Organization Settings > Application Keys",
+      "description": "From Datadog Organization Settings > Application Keys If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "newrelic_api_key": {
       "title": "New Relic API Key",
-      "description": "User API Key from one.newrelic.com/api-keys — used for /ops:monitor",
+      "description": "User API Key from one.newrelic.com/api-keys — used for /ops:monitor If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -431,21 +431,21 @@
     },
     "pushover_user_key": {
       "title": "Pushover User Key",
-      "description": "From https://pushover.net/ — paired with pushover_app_token.",
+      "description": "From https://pushover.net/ — paired with pushover_app_token. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "pushover_app_token": {
       "title": "Pushover App Token",
-      "description": "App-specific token from https://pushover.net/apps/build",
+      "description": "App-specific token from https://pushover.net/apps/build If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "discord_bot_token": {
       "title": "Discord Bot Token",
-      "description": "Bot token from Discord Developer Portal — used for channel reads and DMs. Prefer Doppler reference.",
+      "description": "Bot token from Discord Developer Portal — used for channel reads and DMs. Prefer Doppler reference. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -459,14 +459,14 @@
     },
     "discord_default_webhook_url": {
       "title": "Discord Default Webhook URL",
-      "description": "Optional default webhook URL (https://discord.com/api/webhooks/…) for /ops:comms discord send. Shared with the ops-fires notification sink (which also reads discord_webhook_url).",
+      "description": "Optional default webhook URL (https://discord.com/api/webhooks/…) for /ops:comms discord send. Shared with the ops-fires notification sink (which also reads discord_webhook_url). If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "doppler_token": {
       "title": "Doppler Token",
-      "description": "Doppler service or personal token for the @dopplerhq/mcp-server MCP integration. Generated by /ops:setup or paste manually.",
+      "description": "Doppler service or personal token for the @dopplerhq/mcp-server MCP integration. Generated by /ops:setup or paste manually. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -551,7 +551,7 @@
     },
     "dpd_password": {
       "title": "DPD Password",
-      "description": "Password for the DelisID. Exchanged at login for a short-lived token.",
+      "description": "Password for the DelisID. Exchanged at login for a short-lived token. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -565,7 +565,7 @@
     },
     "ups_client_secret": {
       "title": "UPS OAuth Client Secret",
-      "description": "Client secret for the UPS app. Used for OAuth2 client_credentials.",
+      "description": "Client secret for the UPS app. Used for OAuth2 client_credentials. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -586,7 +586,7 @@
     },
     "fedex_client_secret": {
       "title": "FedEx OAuth Client Secret",
-      "description": "Secret Key for the FedEx project. Used for OAuth2 client_credentials.",
+      "description": "Secret Key for the FedEx project. Used for OAuth2 client_credentials. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -750,4 +750,3 @@
     }
   }
 }
-

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.6] — 2026-04-30
+
+### Added
+
+- **`/ops:credentials` skill + `bin/ops-credentials` audit CLI.** Scans shell env, ops preferences.json, Doppler (resolves `doppler:KEY` references live), macOS Keychain, and Dashlane to report which integration credentials are configured vs missing. Output formats: human table (default), JSON (`--json`), single-service filter (`--service stripe`). Values masked as `first6•••last4`; never prints raw secrets. Auto-switches to compact one-line-per-cred format on SSH/mobile (`$SSH_CONNECTION` or `$OPS_MOBILE=1` per Rule 7). Solves the "Claude Code settings UI can't see my keychain" problem — users can now check at a glance which integrations are ready to use.
+- **Credential field hints in plugin.json descriptions.** All 22 credential fields now include "If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically" in their description, so users don't waste time pasting values that are already in scope.
+
 ## [2.0.5] — 2026-04-30
 
 ### Fixed

--- a/claude-ops/bin/ops-credentials
+++ b/claude-ops/bin/ops-credentials
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# ops-credentials — Audit which integration credentials are configured.
+#
+# For each integration the plugin knows about, scans every credential source
+# (shell env, ops preferences.json, Doppler if configured, macOS Keychain,
+# Dashlane if installed) and reports configured-vs-missing with a masked
+# preview of any value found.
+#
+# Output modes:
+#   ops-credentials              # human-readable table
+#   ops-credentials --json       # JSON array for programmatic use
+#   ops-credentials --service X  # only check service X
+#
+# Never prints raw credential values. Mask format: first 6 chars + "•••" +
+# last 4 chars. Values shorter than 12 chars print as "•••".
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+OPS_DATA_DIR="${OPS_DATA_DIR:-${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}}"
+PREFS="$OPS_DATA_DIR/preferences.json"
+
+OUTPUT_MODE="text"
+SERVICE_FILTER=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json) OUTPUT_MODE="json"; shift ;;
+    --service) SERVICE_FILTER="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,15p' "$0" | sed 's/^# \?//'
+      exit 0 ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# ─── credential catalog ───────────────────────────────────────────────────
+# service|label|env_var|prefs_jq_path|keychain_service|dashlane_keyword
+read -r -d '' CATALOG <<'CATEOF' || true
+telegram|Telegram (api_hash)|TELEGRAM_API_HASH|.telegram.api_hash|telegram-api-hash|telegram
+telegram|Telegram (session)|TELEGRAM_SESSION||telegram-session|telegram
+slack|Slack (xoxc)|SLACK_MCP_XOXC_TOKEN||slack-xoxc|slack
+slack|Slack (xoxd)|SLACK_MCP_XOXD_TOKEN||slack-xoxd|slack
+discord|Discord bot token|DISCORD_BOT_TOKEN|.discord.bot_token||discord
+discord|Discord webhook|DISCORD_WEBHOOK_URL|.discord.default_webhook_url||discord
+pushover|Pushover user key|PUSHOVER_USER|.pushover_user_key|pushover-user|pushover
+pushover|Pushover app token|PUSHOVER_TOKEN|.pushover_app_token|pushover-app|pushover
+sentry|Sentry auth token|SENTRY_AUTH_TOKEN||sentry-auth-token|sentry
+linear|Linear API key|LINEAR_API_KEY||linear-api-key|linear
+datadog|Datadog API key|DATADOG_API_KEY|.datadog.api_key||datadog
+datadog|Datadog app key|DATADOG_APP_KEY|.datadog.app_key||datadog
+newrelic|New Relic API key|NEW_RELIC_API_KEY|.newrelic.api_key||newrelic
+doppler|Doppler service token|DOPPLER_TOKEN|.doppler.service_token||doppler
+klaviyo|Klaviyo private key|KLAVIYO_API_KEY|.marketing.klaviyo.api_key|klaviyo-api-key|klaviyo
+meta_ads|Meta Ads access token|META_ACCESS_TOKEN|.marketing.meta.access_token||meta
+shopify|Shopify admin token|SHOPIFY_ACCESS_TOKEN|.ecom.shopify.admin_token|shopify-admin-token|shopify
+shipbob|ShipBob access token|SHIPBOB_ACCESS_TOKEN|.ecom.partners.shipbob.credentials.api_token||shipbob
+bland_ai|Bland AI API key|BLAND_AI_API_KEY|.voice.bland.api_key|bland-ai-api-key|bland
+elevenlabs|ElevenLabs API key|ELEVENLABS_API_KEY|.voice.elevenlabs.api_key|elevenlabs-api-key|elevenlabs
+groq|Groq API key|GROQ_API_KEY|.voice.groq.api_key|groq-api-key|groq
+stripe|Stripe secret key|STRIPE_SECRET_KEY|.revenue.stripe.secret_key|stripe-secret-key|stripe
+revenuecat|RevenueCat API key|REVENUECAT_API_KEY|.revenue.revenuecat.api_key|revenuecat-api-key|revenuecat
+postnl|PostNL customer code|POSTNL_CUSTOMER_CODE|.shipping.postnl.customer_code||postnl
+dpd|DPD password|DPD_PASSWORD|.shipping.dpd.password||dpd
+ups|UPS client secret|UPS_CLIENT_SECRET|.shipping.ups.client_secret||ups
+fedex|FedEx client secret|FEDEX_CLIENT_SECRET|.shipping.fedex.client_secret||fedex
+CATEOF
+
+# ─── helpers ──────────────────────────────────────────────────────────────
+mask() {
+  local v="${1:-}"
+  local len=${#v}
+  if [[ $len -eq 0 ]]; then printf ''
+  elif [[ $len -lt 12 ]]; then printf '•••'
+  else printf '%s•••%s' "${v:0:6}" "${v: -4}"
+  fi
+}
+
+dollar='$'  # avoid shell expansion when echoing
+
+resolve() {
+  local env_var="$1" prefs_path="$2" keychain_svc="$3" dashlane_kw="$4"
+  local value="" source=""
+
+  # 1. shell env
+  if [[ -n "$env_var" ]]; then
+    local v="${!env_var:-}"
+    if [[ -n "$v" ]]; then echo "${v}|env:${env_var}"; return 0; fi
+  fi
+
+  # 2. preferences.json
+  if [[ -n "$prefs_path" && -f "$PREFS" ]] && command -v jq >/dev/null 2>&1; then
+    local v
+    v=$(jq -r "${prefs_path} // empty" "$PREFS" 2>/dev/null)
+    if [[ -n "$v" && "$v" != "null" ]]; then
+      # Doppler reference is "configured" but resolves elsewhere
+      if [[ "$v" == doppler:* ]]; then
+        local key="${v#doppler:}"
+        local resolved=""
+        if command -v doppler >/dev/null 2>&1; then
+          resolved=$(doppler secrets get "$key" --plain 2>/dev/null || true)
+        fi
+        if [[ -n "$resolved" ]]; then
+          echo "${resolved}|doppler:${key}"; return 0
+        fi
+        echo "doppler-ref|prefs:${prefs_path}=${v}"; return 0
+      fi
+      echo "${v}|prefs:${prefs_path}"; return 0
+    fi
+  fi
+
+  # 3. macOS keychain
+  if [[ -n "$keychain_svc" ]] && command -v security >/dev/null 2>&1; then
+    local v
+    v=$(security find-generic-password -s "$keychain_svc" -w 2>/dev/null || true)
+    if [[ -n "$v" ]]; then echo "${v}|keychain:${keychain_svc}"; return 0; fi
+  fi
+
+  # 4. Dashlane
+  if [[ -n "$dashlane_kw" ]] && command -v dcli >/dev/null 2>&1; then
+    local v
+    v=$(dcli password "$dashlane_kw" --output json 2>/dev/null | jq -r '.[0].password // empty' 2>/dev/null || true)
+    if [[ -n "$v" && "$v" != "null" ]]; then echo "${v}|dashlane:${dashlane_kw}"; return 0; fi
+  fi
+
+  echo ""
+}
+
+# ─── scan ─────────────────────────────────────────────────────────────────
+results_json="[]"
+configured=0
+missing=0
+declare -a configured_lines=()
+declare -a missing_lines=()
+
+while IFS='|' read -r service label env_var prefs_path keychain_svc dashlane_kw; do
+  [[ -z "$service" || "$service" == \#* ]] && continue
+  if [[ -n "$SERVICE_FILTER" && "$service" != "$SERVICE_FILTER" ]]; then continue; fi
+
+  found=$(resolve "$env_var" "$prefs_path" "$keychain_svc" "$dashlane_kw")
+  if [[ -n "$found" ]]; then
+    value="${found%|*}"
+    src="${found##*|}"
+    masked=$(mask "$value")
+    configured=$((configured+1))
+    configured_lines+=("$(printf '  ✓ %-32s %-22s %s' "$label" "$masked" "($src)")")
+    results_json=$(jq -c --arg s "$service" --arg l "$label" --arg m "$masked" --arg src "$src" \
+      '. + [{service:$s, label:$l, configured:true, masked:$m, source:$src}]' <<<"$results_json")
+  else
+    missing=$((missing+1))
+    missing_lines+=("$(printf '  ✗ %-32s — run /ops:setup %s' "$label" "$service")")
+    results_json=$(jq -c --arg s "$service" --arg l "$label" \
+      '. + [{service:$s, label:$l, configured:false}]' <<<"$results_json")
+  fi
+done <<<"$CATALOG"
+
+# ─── output ───────────────────────────────────────────────────────────────
+if [[ "$OUTPUT_MODE" == "json" ]]; then
+  echo "$results_json" | jq '.'
+  exit 0
+fi
+
+# Mobile / SSH compact mode
+COMPACT=0
+if [[ -n "${SSH_CONNECTION:-}${SSH_CLIENT:-}${SSH_TTY:-}" || "${OPS_MOBILE:-}" == "1" ]]; then COMPACT=1; fi
+
+if [[ $COMPACT -eq 1 ]]; then
+  echo "credentials: ${configured} configured, ${missing} missing"
+  if [[ $configured -gt 0 ]]; then
+    printf '%s\n' "${configured_lines[@]}" | sed 's/^  ✓ /✓ /'
+  fi
+  if [[ $missing -gt 0 ]]; then
+    printf '%s\n' "${missing_lines[@]}" | sed 's/^  ✗ /✗ /'
+  fi
+  exit 0
+fi
+
+cat <<EOF
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► CREDENTIALS AUDIT
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+EOF
+
+if [[ $configured -gt 0 ]]; then
+  echo
+  echo "Configured ($configured):"
+  printf '%s\n' "${configured_lines[@]}"
+fi
+
+if [[ $missing -gt 0 ]]; then
+  echo
+  echo "Missing ($missing):"
+  printf '%s\n' "${missing_lines[@]}"
+fi
+
+cat <<EOF
+
+──────────────────────────────────────────────────────
+ Total: $((configured + missing)) tracked services · $configured set · $missing pending
+ Configure: /ops:setup <service-name>
+ Re-audit:  /ops:credentials  (or  bin/ops-credentials --json)
+──────────────────────────────────────────────────────
+EOF

--- a/claude-ops/skills/ops-credentials/SKILL.md
+++ b/claude-ops/skills/ops-credentials/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: ops-credentials
+description: Audit which integration credentials are configured. Scans shell env, ops preferences.json, Doppler, macOS Keychain, and Dashlane to report a configured-vs-missing table per service. Never displays raw values — always masks as first6•••last4. Use when you want to see which integrations have keys set up and which still need /ops:setup.
+argument-hint: "[--service <name>] [--json]"
+allowed-tools:
+  - Bash
+  - Read
+  - AskUserQuestion
+effort: low
+maxTurns: 5
+---
+
+# OPS ► CREDENTIALS
+
+## CLI/API Reference
+
+| Command | Output |
+|---------|--------|
+| `bin/ops-credentials` | Human table — configured + missing per service |
+| `bin/ops-credentials --json` | JSON array, one entry per credential |
+| `bin/ops-credentials --service stripe` | Filter to one integration |
+
+The bin script is the source of truth. It scans these sources in order and reports the FIRST hit per credential:
+
+1. Shell env (`$STRIPE_SECRET_KEY`, etc.)
+2. `$OPS_DATA_DIR/preferences.json` (`.revenue.stripe.secret_key`, etc., including `doppler:KEY` references that get resolved live)
+3. macOS Keychain (`security find-generic-password -s <name> -w`)
+4. Dashlane (`dcli password <keyword> --output json`)
+
+Values shorter than 12 chars print as `•••`; longer values print as `first6•••last4`.
+
+## Your task
+
+When the user runs `/ops:credentials`:
+
+1. **Run** `bin/ops-credentials` and present the output verbatim — it's already formatted for the user's terminal (compact mode for SSH/mobile, table layout otherwise).
+
+2. **Offer follow-ups via AskUserQuestion (max 4 options per Rule 1):**
+
+```
+What would you like to do next?
+  [Configure a missing service — pick one to set up now]
+  [Re-audit a specific service]
+  [Export to JSON]
+  [Done]
+```
+
+3. **On "Configure missing"**: list missing services 4-at-a-time via `AskUserQuestion`. For each pick, call the `/ops:setup <service>` skill.
+
+4. **On "Re-audit specific"**: ask for the service name and run `bin/ops-credentials --service <name>`.
+
+5. **On "Export to JSON"**: run `bin/ops-credentials --json` and write the result to `/tmp/ops-credentials-audit-$(date +%s).json`. Print the path.
+
+## Why this skill exists
+
+Claude Code's plugin settings UI cannot introspect external credential stores. If a user has `STRIPE_SECRET_KEY` in macOS Keychain or `klaviyo_api_key` in Doppler, the settings panel shows those fields as empty (because the value isn't stored in Claude Code's user-config). The user can't tell at a glance which integrations they've already wired up.
+
+`/ops:credentials` solves that — one command, one table, complete picture of which integrations are ready to use vs which still need `/ops:setup`.
+
+## Privacy guarantees
+
+- **Never prints raw values.** All output is masked.
+- **Never copies values to disk.** Reads happen in-process; the JSON export contains only `{service, label, configured, masked, source}`, never the raw secret.
+- **Read-only.** Does not write to keychain, Doppler, or preferences.
+
+## Mobile / SSH (Rule 7)
+
+When `$SSH_CONNECTION` / `$SSH_CLIENT` / `$SSH_TTY` is set or `$OPS_MOBILE=1`, the bin script auto-switches to compact one-line-per-cred format. Skill output should pass it through unchanged.


### PR DESCRIPTION
## Summary

Claude Code's plugin settings UI cannot introspect external credential stores. If a user has `STRIPE_SECRET_KEY` in macOS Keychain or `klaviyo_api_key` in Doppler, the settings panel shows those fields as empty — even when those integrations are working. This PR ships a separate audit surface so users can see configured-vs-missing at a glance.

**Adds:**
- `bin/ops-credentials` — credential audit CLI. Scans shell env, `preferences.json`, Doppler (resolves `doppler:KEY` references live), macOS Keychain, and Dashlane. Reports configured-vs-missing with `first6•••last4` masking. Output: human table | `--json` | `--service <name>`. Compact mode on SSH/mobile per Rule 7.
- `skills/ops-credentials/SKILL.md` — `/ops:credentials` slash command wrapping the bin with follow-up actions (configure missing, re-audit, JSON export).
- Description hints on 22 sensitive fields in `plugin.json`: "If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically."

## Smoke test result

Run on dev machine — detected 21/27 tracked credentials across 4 sources (env, keychain, Dashlane, Doppler). 6 missing flagged for `/ops:setup`.

## Privacy

- Never prints raw values
- JSON export contains only `{service, label, configured, masked, source}`
- Read-only — no writes to keychain/Doppler/prefs

## Test plan

- [x] `bash -n` passes
- [x] End-to-end run detects creds across all 4 source backends
- [x] Mask format: `first6•••last4` for 12+ char values, `•••` for shorter
- [x] `--json` output shape stable
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new credential-auditing CLI/skill that reads from env, prefs, Doppler, macOS Keychain, and Dashlane; while secrets are masked and read-only, it touches sensitive credential-resolution paths and external CLIs.
> 
> **Overview**
> Introduces a new `/ops:credentials` skill backed by `bin/ops-credentials` to audit which integration credentials are configured vs missing across shell env, `preferences.json`, Doppler refs (live-resolved), macOS Keychain, and Dashlane, with masked output plus `--json` and `--service` filtering.
> 
> Updates `plugin.json` credential field descriptions to explicitly tell users they can leave fields blank when credentials are already available via `/ops:setup` or external stores, and bumps the marketplace/plugin version to `2.0.6` with an accompanying changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 209ea5b5af414ef153300c1fc3aef009da01a116. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->