### PR TITLE
fix(marketplace): bump version to 2.0.8 to match plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 30 skills, 14 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "category": "productivity",
       "keywords": [
         "ops",


### PR DESCRIPTION
Marketplace.json was still 2.0.7. Without this, /plugin serves the broken cache.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single metadata change updating the marketplace version string, with no code or runtime behavior changes beyond which plugin build is referenced/cached.
> 
> **Overview**
> Updates `.claude-plugin/marketplace.json` to bump the `ops` plugin version from `2.0.7` to `2.0.8`, aligning the local marketplace entry with the current plugin release to avoid serving a stale cached version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5943bde85a62c058342830fd370b46b6c16ff2e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->