### PR TITLE
docs(ops-inbox): correct whatsmeow naming + add archive_chat tool docs

### DIFF
--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -36,6 +36,8 @@ allowed-tools:
   - mcp__whatsapp__send_message
   - mcp__whatsapp__get_chat
   - mcp__whatsapp__get_message_context
+  - mcp__whatsapp__archive_chat
+  - mcp__whatsapp__resync_app_state
 effort: high
 maxTurns: 60
 ---

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -109,7 +109,7 @@ If bridge is not running: `launchctl kickstart -k gui/$UID/com.samrenders.whatsa
 
 **Bulk archive non-actionable WA chats** — for newsletters, dead group chats, one-word reactions, etc.:
 ```bash
-for jid in "120363...@newsletter" "120363...@g.us" "31...@s.whatsapp.net"; do
+for jid in "<NEWSLETTER_JID>@newsletter" "<GROUP_JID>@g.us" "<CONTACT_PHONE>@s.whatsapp.net"; do
   curl -s -X POST http://localhost:8080/api/archive \
     -H 'Content-Type: application/json' \
     -d "{\"chat_jid\":\"$jid\",\"archive\":true}"

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ops-inbox
-description: Full inbox management across all channels — WhatsApp (Baileys bridge via mcp__whatsapp__*), Email (Gmail MCP), Slack (MCP), Telegram (user-auth MCP), Discord (webhook + REST read), Notion (MCP — comments, mentions, assigned tasks). Scans FULL inbox (not just unread), identifies messages needing replies, archives handled conversations.
+description: Full inbox management across all channels — WhatsApp (whatsmeow bridge via mcp__whatsapp__*), Email (Gmail MCP), Slack (MCP), Telegram (user-auth MCP), Discord (webhook + REST read), Notion (MCP — comments, mentions, assigned tasks). Scans FULL inbox (not just unread), identifies messages needing replies, archives handled conversations.
 argument-hint: "[channel: whatsapp|email|slack|telegram|discord|notion|all]"
 allowed-tools:
   - Bash
@@ -44,7 +44,7 @@ maxTurns: 60
 
 ## ⚠️ WHATSAPP TRANSPORT — MCP ONLY, NEVER `wacli`
 
-For **all** WhatsApp operations in this skill (list chats, read messages, search contacts, send replies), use the `mcp__whatsapp__*` tool family backed by the Baileys whatsapp-bridge.
+For **all** WhatsApp operations in this skill (list chats, read messages, search contacts, send replies, archive chats), use the `mcp__whatsapp__*` tool family backed by the whatsmeow (Go) whatsapp-bridge — upstream `lharries/whatsapp-mcp`. (Earlier docs misnamed this as "Baileys" — Baileys is the Node.js WhatsApp library; this bridge uses `go.mau.fi/whatsmeow`.)
 
 **NEVER call the legacy `wacli` CLI** (`wacli chats list`, `wacli messages list`, `wacli send`, `wacli doctor`, `wacli history backfill`, etc). The wacli store and keepalive daemon are deprecated for this skill.
 
@@ -102,6 +102,18 @@ If bridge is not running: `launchctl kickstart -k gui/$UID/com.samrenders.whatsa
 | `mcp__whatsapp__send_message` | `{recipient, message}` | Send result |
 | `mcp__whatsapp__get_chat` | `{chat_jid}` | Chat metadata |
 | `mcp__whatsapp__get_message_context` | `{chat_jid, message_id}` | Message context window |
+| `mcp__whatsapp__archive_chat` | `{chat_jid, archive: true}` | Archive (or unarchive with `archive: false`) a chat — sends app-state mutation via whatsmeow |
+| `mcp__whatsapp__resync_app_state` | `{name: "regular_low", full_sync: true}` | Force full app-state resync — run when archive fails with `LTHash mismatch` (server/local desync) |
+
+**Bulk archive non-actionable WA chats** — for newsletters, dead group chats, one-word reactions, etc.:
+```bash
+for jid in "120363...@newsletter" "120363...@g.us" "31...@s.whatsapp.net"; do
+  curl -s -X POST http://localhost:8080/api/archive \
+    -H 'Content-Type: application/json' \
+    -d "{\"chat_jid\":\"$jid\",\"archive\":true}"
+done
+```
+If you get `409 conflict / LTHash mismatch`, run resync first: `curl -s -X POST http://localhost:8080/api/resync_app_state -d '{"name":"regular_low","full_sync":true}'`.
 
 **Full-text search** — use `mcp__whatsapp__list_messages` with a `query` param (backed by FTS5 after running `scripts/whatsapp-bridge-migrate.sh`):
 ```bash
@@ -115,7 +127,7 @@ sqlite3 "$DB" "SELECT chat_jid, sender, content, timestamp FROM messages WHERE r
 sqlite3 "$DB" "SELECT jid, name, phone FROM contacts WHERE name LIKE '%<name>%' COLLATE NOCASE LIMIT 10;"
 ```
 
-**History backfill** — the Baileys bridge automatically syncs history on connection. No manual backfill command exists; if messages are missing, restart the bridge:
+**History backfill** — the whatsmeow bridge automatically syncs history on connection. No manual backfill command exists; if messages are missing, restart the bridge:
 ```bash
 launchctl kickstart -k gui/$UID/com.samrenders.whatsapp-bridge
 ```
@@ -309,7 +321,7 @@ If only 3 channels are configured, "All channels" + 3 channel options = 4, fits 
 6. Classify each chat:
    - **NEEDS REPLY**: Last message has `is_from_me: false` (they sent last)
    - **WAITING**: Last message has `is_from_me: true` (you sent last)
-   - **ARCHIVE**: Old conversation, no recent activity, or concluded
+   - **ARCHIVE**: Newsletters (`@newsletter` JIDs), dead group chats with no recent activity, one-word reactions, or concluded conversations. Bulk-archive these via `mcp__whatsapp__archive_chat {chat_jid, archive: true}` after user confirmation. If the call fails with `LTHash mismatch`, run `mcp__whatsapp__resync_app_state {name: "regular_low", full_sync: true}` first, then retry.
 
 **Phase 2 — Build context for NEEDS REPLY chats (run in parallel):**
 For each NEEDS REPLY chat:

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -1168,7 +1168,7 @@ Sub-flow (only runs if user selected Yes above):
 
 ### 3b — WhatsApp (bridge health + QR pair)
 
-WhatsApp is handled exclusively by the Baileys `whatsapp-bridge` (managed by `com.samrenders.whatsapp-bridge` LaunchAgent) and accessed via `mcp__whatsapp__*` tools.
+WhatsApp is handled exclusively by the whatsmeow `whatsapp-bridge` (managed by `com.samrenders.whatsapp-bridge` LaunchAgent) and accessed via `mcp__whatsapp__*` tools.
 
 #### Step 3b.1 — Presence
 
@@ -1183,8 +1183,8 @@ lsof -i :8080 2>/dev/null | grep LISTEN
 If binary missing: ask `AskUserQuestion`: `[Show install docs]`, `[Skip WhatsApp]`. On install docs, print:
 
 ```
-whatsapp-bridge (Baileys) is not installed. Install:
-  git clone https://github.com/Lifecycle-Innovations-Limited/whatsapp-mcp ~/.local/share/whatsapp-mcp
+whatsapp-bridge (whatsmeow) is not installed. Install:
+  git clone https://github.com/lharries/whatsapp-mcp ~/.local/share/whatsapp-mcp
   cd ~/.local/share/whatsapp-mcp/whatsapp-bridge && go build -o whatsapp-bridge .
   mkdir -p ~/.local/share/whatsapp-mcp/whatsapp-bridge/logs
 ```

--- a/claude-ops/tests/test-bin-scripts.sh
+++ b/claude-ops/tests/test-bin-scripts.sh
@@ -116,8 +116,8 @@ install_script="$BIN_DIR/ops-setup-install"
 if [[ -f "$preflight" && -f "$install_script" ]]; then
   # Extract tool names from preflight — lines like: check_tool jq / command -v jq
   preflight_tools=$(grep -oE 'command -v [a-z_-]+' "$preflight" 2>/dev/null | awk '{print $3}' | sort -u || true)
-  # Extract tools handled by install script — lines like: jq) / "jq")
-  install_tools=$(grep -oE '"?[a-z_-]+"?\)' "$install_script" 2>/dev/null | tr -d '"()' | sort -u || true)
+  # Extract tools handled by install script — lines like: jq) / "jq") / jq|git|brew)
+  install_tools=$(grep -oE '"?[a-z_-]+"?[|)]' "$install_script" 2>/dev/null | tr -d '"()|' | sort -u || true)
 
   missing_count=0
   while IFS= read -r tool; do


### PR DESCRIPTION
## Summary
- Fix recurring "Baileys" misnomer in ops-inbox skill — upstream `lharries/whatsapp-mcp` bridge is Go + `go.mau.fi/whatsmeow`, NOT Baileys
- Document the two new MCP tools added to the local bridge:
  - `mcp__whatsapp__archive_chat {chat_jid, archive: true|false}` — sends a `regular_low` app-state mutation via `appstate.BuildArchive`
  - `mcp__whatsapp__resync_app_state {name, full_sync}` — forces a fresh snapshot when archive (or any state op) hits an LTHash desync (`409 conflict`)
- Update WhatsApp Phase 1 ARCHIVE classification to actually invoke the new archive tool, with the LTHash-recovery fallback wired in

## Background
While running `/ops:ops-inbox`, hit the limit that the MCP bridge had no archive endpoint. The underlying `whatsmeow` lib supports it (binary symbols confirmed: `AppState.GetArchiveChatAction`, `archived` state). I added the Go endpoint + Python wrapper to the local install at `~/.local/share/whatsapp-mcp/`, rebuilt the bridge with whatsmeow `v0.0.0-20260414172242-d4ffc1df2442` + `sqlite_fts5` tag, and used it to bulk-archive 12 non-actionable chats. An upstream PR to `lharries/whatsapp-mcp` will follow with the Go + Python source changes; this PR just updates claude-ops docs so future sessions know to reach for the new tools instead of falling back to manual SQLite or wacli.

## Test plan
- [ ] Read updated SKILL.md to confirm tools table + bulk-archive example render correctly
- [ ] Run `/ops:ops-inbox` and verify ARCHIVE classification offers the archive tool path (requires updated MCP server `~/.local/share/whatsapp-mcp/whatsapp-mcp-server/main.py` and rebuilt bridge binary — both already deployed locally)
- [ ] Confirm "Baileys" no longer appears in ops-inbox SKILL.md (`grep -i baileys claude-ops/skills/ops-inbox/SKILL.md` should return nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only updates; risk is limited to potentially confusing operators if the new WhatsApp MCP tool names/usage are incorrect.
> 
> **Overview**
> Updates `ops-inbox` WhatsApp documentation to correct the bridge naming from *Baileys* to *whatsmeow* and clarify that all WhatsApp actions must go through `mcp__whatsapp__*`.
> 
> Adds documentation for new WhatsApp MCP capabilities: `mcp__whatsapp__archive_chat` and `mcp__whatsapp__resync_app_state`, including a bulk-archive example and guidance for recovering from `LTHash mismatch`/`409 conflict` during archive operations.
> 
> Adjusts the WhatsApp Phase 1 classification guidance so **ARCHIVE** items (e.g., newsletters and inactive group chats) are explicitly handled via the archive tool with the resync fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dcb95cae7f53ee9b1e875dd7e991ab0f8128e0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated WhatsApp operations docs: added chat-archiving and full app-state resync capabilities
  * Added bulk-archive workflow with error handling and remediation for synchronization failures
  * Clarified archiving behavior and explicit user confirmation/ retry flows

* **Tests**
  * Improved test parsing to recognize alternate tool-list syntax and handle delimiter cleanup for reliable comparisons
<!-- end of auto-generated comment: release notes by coderabbit.ai -->