### PR TITLE
feat: multi-workspace Slack support

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.9] — 2026-05-01
+
+### Added
+
+- **Multi-workspace Slack support.** `preferences.json` now accepts a `slack_workspaces` array so ops briefings, inbox scans, and comms reads iterate ALL configured Slack workspaces instead of stopping at one. Each entry carries `name`, `token_env` (the env var holding the token — never stored in prefs), and `kind` (`bot_token` | `user_token`). Backwards-compatible: configs with no `slack_workspaces` fall back to legacy `SLACK_MCP_ENABLED=true` single-workspace path.
+- **`bin/ops-slack-workspaces` helper.** Lists every configured workspace, resolves token env vars, and calls `slack.com/api/auth.test` for each. Outputs a table or `--json` for machine consumers. Exit code is non-zero if any token is missing or invalid.
+- **Setup wizard multi-workspace loop.** Step 3d now persists each workspace into `slack_workspaces[]` and asks "Add another workspace?" until done. Running `/ops:setup slack` a second time appends to the array without overwriting existing entries.
+- Updated `ops-go`, `ops-inbox`, `ops-comms`, `ops-dash` SKILL.md docs to describe multi-workspace iteration, per-workspace labelling, and the MCP-bound-token fallback path (direct curl for non-primary workspaces).
+
 ## [2.0.8] — 2026-05-01
 
 ### Fixed

--- a/claude-ops/bin/ops-slack-workspaces
+++ b/claude-ops/bin/ops-slack-workspaces
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# ops-slack-workspaces — List configured Slack workspaces and test each token.
+#
+# Reads slack_workspaces[] from preferences.json. For each entry, resolves the
+# named token env var and calls slack.com/api/auth.test. Also handles the legacy
+# single-workspace path (SLACK_MCP_ENABLED=true).
+#
+# Output: one line per workspace with status. Exit 0 if all tokens valid,
+# non-zero if any are missing or invalid.
+#
+# Usage:
+#   bin/ops-slack-workspaces            # human-readable table
+#   bin/ops-slack-workspaces --json     # JSON array
+
+set -uo pipefail
+
+PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+JSON_MODE=0
+[[ "${1:-}" == "--json" ]] && JSON_MODE=1
+
+# Colours (suppressed when not a tty or JSON mode)
+if [[ -t 1 && $JSON_MODE -eq 0 ]]; then
+  GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[0;33m'; RESET='\033[0m'
+else
+  GREEN=''; RED=''; YELLOW=''; RESET=''
+fi
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+_test_token() {
+  local token="$1"
+  curl -s --max-time 5 \
+    -H "Authorization: Bearer $token" \
+    "https://slack.com/api/auth.test" 2>/dev/null
+}
+
+_jq() { command -v jq >/dev/null 2>&1 && jq -r "$@" 2>/dev/null || echo ""; }
+
+# ── load workspaces ───────────────────────────────────────────────────────────
+
+WS_COUNT=0
+if command -v jq >/dev/null 2>&1 && [[ -f "$PREFS_PATH" ]]; then
+  WS_COUNT=$(jq -r '(.slack_workspaces // []) | length' "$PREFS_PATH" 2>/dev/null || echo "0")
+  [[ "$WS_COUNT" =~ ^[0-9]+$ ]] || WS_COUNT=0
+fi
+
+# ── JSON output path ──────────────────────────────────────────────────────────
+
+if [[ $JSON_MODE -eq 1 ]]; then
+  RESULTS="[]"
+  EXIT_CODE=0
+
+  if [[ $WS_COUNT -eq 0 ]]; then
+    # Legacy fallback
+    SLACK_ENABLED="${SLACK_MCP_ENABLED:-false}"
+    if [[ "$SLACK_ENABLED" == "true" ]]; then
+      RESULTS='[{"name":"legacy","mode":"mcp","status":"mcp_bound","note":"Single-workspace MCP mode. Migrate to slack_workspaces[] for multi-workspace support."}]'
+    else
+      RESULTS='[]'
+    fi
+    echo "$RESULTS"
+    exit 0
+  fi
+
+  for i in $(seq 0 $((WS_COUNT - 1))); do
+    ws_name=$(jq -r ".slack_workspaces[$i].name // \"workspace-$i\"" "$PREFS_PATH" 2>/dev/null)
+    token_env=$(jq -r ".slack_workspaces[$i].token_env // \"\"" "$PREFS_PATH" 2>/dev/null)
+    ws_kind=$(jq -r ".slack_workspaces[$i].kind // \"bot_token\"" "$PREFS_PATH" 2>/dev/null)
+
+    ws_token=""
+    [[ -n "$token_env" ]] && ws_token="${!token_env:-}"
+
+    if [[ -z "$ws_token" ]]; then
+      RESULTS=$(echo "$RESULTS" | jq \
+        --arg name "$ws_name" \
+        --arg env "$token_env" \
+        --arg kind "$ws_kind" \
+        '. + [{"name":$name,"token_env":$env,"kind":$kind,"status":"token_missing","team_id":null,"url":null}]')
+      EXIT_CODE=1
+    else
+      resp=$(_test_token "$ws_token")
+      ok=$(echo "$resp" | jq -r '.ok // false' 2>/dev/null)
+      team_id=$(echo "$resp" | jq -r '.team_id // ""' 2>/dev/null)
+      url=$(echo "$resp" | jq -r '.url // ""' 2>/dev/null)
+      if [[ "$ok" == "true" ]]; then
+        RESULTS=$(echo "$RESULTS" | jq \
+          --arg name "$ws_name" \
+          --arg env "$token_env" \
+          --arg kind "$ws_kind" \
+          --arg team "$team_id" \
+          --arg u "$url" \
+          '. + [{"name":$name,"token_env":$env,"kind":$kind,"status":"ok","team_id":$team,"url":$u}]')
+      else
+        err=$(echo "$resp" | jq -r '.error // "unknown"' 2>/dev/null)
+        RESULTS=$(echo "$RESULTS" | jq \
+          --arg name "$ws_name" \
+          --arg env "$token_env" \
+          --arg kind "$ws_kind" \
+          --arg err "$err" \
+          '. + [{"name":$name,"token_env":$env,"kind":$kind,"status":"token_invalid","error":$err,"team_id":null,"url":null}]')
+        EXIT_CODE=1
+      fi
+    fi
+  done
+
+  echo "$RESULTS"
+  exit $EXIT_CODE
+fi
+
+# ── human-readable output path ────────────────────────────────────────────────
+
+printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+printf ' OPS ► SLACK WORKSPACES\n'
+printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+
+EXIT_CODE=0
+
+if [[ $WS_COUNT -eq 0 ]]; then
+  SLACK_ENABLED="${SLACK_MCP_ENABLED:-false}"
+  if [[ "$SLACK_ENABLED" == "true" ]]; then
+    printf " ${YELLOW}○${RESET}  (legacy)   SLACK_MCP_ENABLED=true  — single MCP-bound workspace\n"
+    printf "    Migrate to slack_workspaces[] in preferences.json for multi-workspace support.\n"
+    printf "    Run /ops:setup slack to add named workspaces.\n"
+  else
+    printf " ${RED}✗${RESET}  No Slack workspaces configured.\n"
+    printf "    Run: /ops:setup slack\n"
+    EXIT_CODE=1
+  fi
+  printf '──────────────────────────────────────────────────────\n'
+  exit $EXIT_CODE
+fi
+
+printf " %-20s %-35s %-12s %s\n" "WORKSPACE" "TOKEN ENV" "KIND" "STATUS"
+printf ' %.0s─' {1..54}; printf '\n'
+
+for i in $(seq 0 $((WS_COUNT - 1))); do
+  ws_name=$(jq -r ".slack_workspaces[$i].name // \"workspace-$i\"" "$PREFS_PATH" 2>/dev/null)
+  token_env=$(jq -r ".slack_workspaces[$i].token_env // \"\"" "$PREFS_PATH" 2>/dev/null)
+  ws_kind=$(jq -r ".slack_workspaces[$i].kind // \"bot_token\"" "$PREFS_PATH" 2>/dev/null)
+
+  ws_token=""
+  [[ -n "$token_env" ]] && ws_token="${!token_env:-}"
+
+  if [[ -z "$ws_token" ]]; then
+    printf " ${RED}✗${RESET}  %-20s %-35s %-12s ${RED}token env not set${RESET}\n" \
+      "$ws_name" "$token_env" "$ws_kind"
+    EXIT_CODE=1
+  else
+    printf "    %-20s %-35s %-12s testing..." "$ws_name" "$token_env" "$ws_kind"
+    resp=$(_test_token "$ws_token")
+    ok=$(echo "$resp" | jq -r '.ok // false' 2>/dev/null)
+    if [[ "$ok" == "true" ]]; then
+      team_url=$(echo "$resp" | jq -r '.url // ""' 2>/dev/null)
+      printf "\r ${GREEN}✓${RESET}  %-20s %-35s %-12s ${GREEN}ok${RESET}  %s\n" \
+        "$ws_name" "$token_env" "$ws_kind" "$team_url"
+    else
+      err=$(echo "$resp" | jq -r '.error // "unknown"' 2>/dev/null)
+      printf "\r ${RED}✗${RESET}  %-20s %-35s %-12s ${RED}invalid: %s${RESET}\n" \
+        "$ws_name" "$token_env" "$ws_kind" "$err"
+      EXIT_CODE=1
+    fi
+  fi
+done
+
+printf '──────────────────────────────────────────────────────\n'
+printf ' %d workspace(s) configured. To add another: /ops:setup slack\n' "$WS_COUNT"
+printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+
+exit $EXIT_CODE

--- a/claude-ops/bin/ops-slack-workspaces
+++ b/claude-ops/bin/ops-slack-workspaces
@@ -18,8 +18,18 @@ PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketp
 JSON_MODE=0
 [[ "${1:-}" == "--json" ]] && JSON_MODE=1
 
-# Colours (suppressed when not a tty or JSON mode)
-if [[ -t 1 && $JSON_MODE -eq 0 ]]; then
+# Mobile / SSH detection — switches to compact plain-text output without
+# wide tables, banners, or ANSI colours so output stays readable on small
+# terminals (per repo formatting rule for claude-ops/bin/**/*).
+IS_MOBILE=0
+if [[ -n "${OPS_MOBILE:-}" && "${OPS_MOBILE:-0}" == "1" ]] \
+  || [[ -n "${SSH_CONNECTION:-}" || -n "${SSH_CLIENT:-}" || -n "${SSH_TTY:-}" ]] \
+  || [[ "${COLUMNS:-120}" -lt 80 ]]; then
+  IS_MOBILE=1
+fi
+
+# Colours (suppressed when not a tty, JSON mode, or mobile/SSH compact mode)
+if [[ -t 1 && $JSON_MODE -eq 0 && $IS_MOBILE -eq 0 ]]; then
   GREEN='\033[0;32m'; RED='\033[0;31m'; YELLOW='\033[0;33m'; RESET='\033[0m'
 else
   GREEN=''; RED=''; YELLOW=''; RESET=''
@@ -67,8 +77,20 @@ if [[ $JSON_MODE -eq 1 ]]; then
     token_env=$(jq -r ".slack_workspaces[$i].token_env // \"\"" "$PREFS_PATH" 2>/dev/null)
     ws_kind=$(jq -r ".slack_workspaces[$i].kind // \"bot_token\"" "$PREFS_PATH" 2>/dev/null)
 
+    # Validate token_env is a legal POSIX shell identifier before indirect expansion;
+    # bash aborts under set -u/-e if `${!var}` is given a name with invalid chars.
     ws_token=""
-    [[ -n "$token_env" ]] && ws_token="${!token_env:-}"
+    if [[ "$token_env" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+      ws_token="${!token_env:-}"
+    elif [[ -n "$token_env" ]]; then
+      RESULTS=$(echo "$RESULTS" | jq \
+        --arg name "$ws_name" \
+        --arg env "$token_env" \
+        --arg kind "$ws_kind" \
+        '. + [{"name":$name,"token_env":$env,"kind":$kind,"status":"invalid_token_env","note":"token_env must match [A-Za-z_][A-Za-z0-9_]*","team_id":null,"url":null}]')
+      EXIT_CODE=1
+      continue
+    fi
 
     if [[ -z "$ws_token" ]]; then
       RESULTS=$(echo "$RESULTS" | jq \
@@ -109,61 +131,102 @@ fi
 
 # ── human-readable output path ────────────────────────────────────────────────
 
-printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
-printf ' OPS ► SLACK WORKSPACES\n'
-printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+if [[ $IS_MOBILE -eq 0 ]]; then
+  printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+  printf ' OPS ► SLACK WORKSPACES\n'
+  printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+fi
 
 EXIT_CODE=0
 
 if [[ $WS_COUNT -eq 0 ]]; then
   SLACK_ENABLED="${SLACK_MCP_ENABLED:-false}"
   if [[ "$SLACK_ENABLED" == "true" ]]; then
-    printf " ${YELLOW}○${RESET}  (legacy)   SLACK_MCP_ENABLED=true  — single MCP-bound workspace\n"
-    printf "    Migrate to slack_workspaces[] in preferences.json for multi-workspace support.\n"
-    printf "    Run /ops:setup slack to add named workspaces.\n"
+    if [[ $IS_MOBILE -eq 1 ]]; then
+      printf "○ legacy: SLACK_MCP_ENABLED=true (single MCP-bound workspace)\n"
+      printf "  migrate via /ops:setup slack\n"
+    else
+      printf " ${YELLOW}○${RESET}  (legacy)   SLACK_MCP_ENABLED=true  — single MCP-bound workspace\n"
+      printf "    Migrate to slack_workspaces[] in preferences.json for multi-workspace support.\n"
+      printf "    Run /ops:setup slack to add named workspaces.\n"
+    fi
   else
-    printf " ${RED}✗${RESET}  No Slack workspaces configured.\n"
-    printf "    Run: /ops:setup slack\n"
+    if [[ $IS_MOBILE -eq 1 ]]; then
+      printf "✗ no Slack workspaces — /ops:setup slack\n"
+    else
+      printf " ${RED}✗${RESET}  No Slack workspaces configured.\n"
+      printf "    Run: /ops:setup slack\n"
+    fi
     EXIT_CODE=1
   fi
-  printf '──────────────────────────────────────────────────────\n'
+  [[ $IS_MOBILE -eq 0 ]] && printf '──────────────────────────────────────────────────────\n'
   exit $EXIT_CODE
 fi
 
-printf " %-20s %-35s %-12s %s\n" "WORKSPACE" "TOKEN ENV" "KIND" "STATUS"
-printf ' %.0s─' {1..54}; printf '\n'
+if [[ $IS_MOBILE -eq 0 ]]; then
+  printf " %-20s %-35s %-12s %s\n" "WORKSPACE" "TOKEN ENV" "KIND" "STATUS"
+  printf ' %.0s─' {1..54}; printf '\n'
+fi
 
 for i in $(seq 0 $((WS_COUNT - 1))); do
   ws_name=$(jq -r ".slack_workspaces[$i].name // \"workspace-$i\"" "$PREFS_PATH" 2>/dev/null)
   token_env=$(jq -r ".slack_workspaces[$i].token_env // \"\"" "$PREFS_PATH" 2>/dev/null)
   ws_kind=$(jq -r ".slack_workspaces[$i].kind // \"bot_token\"" "$PREFS_PATH" 2>/dev/null)
 
+  # Validate token_env before indirect expansion (see JSON path above).
   ws_token=""
-  [[ -n "$token_env" ]] && ws_token="${!token_env:-}"
+  if [[ "$token_env" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+    ws_token="${!token_env:-}"
+  elif [[ -n "$token_env" ]]; then
+    if [[ $IS_MOBILE -eq 1 ]]; then
+      printf "✗ %s: invalid token_env=%s\n" "$ws_name" "$token_env"
+    else
+      printf " ${RED}✗${RESET}  %-20s %-35s %-12s ${RED}invalid token_env (must match [A-Za-z_][A-Za-z0-9_]*)${RESET}\n" \
+        "$ws_name" "$token_env" "$ws_kind"
+    fi
+    EXIT_CODE=1
+    continue
+  fi
 
   if [[ -z "$ws_token" ]]; then
-    printf " ${RED}✗${RESET}  %-20s %-35s %-12s ${RED}token env not set${RESET}\n" \
-      "$ws_name" "$token_env" "$ws_kind"
+    if [[ $IS_MOBILE -eq 1 ]]; then
+      printf "✗ %s: token env not set (%s)\n" "$ws_name" "$token_env"
+    else
+      printf " ${RED}✗${RESET}  %-20s %-35s %-12s ${RED}token env not set${RESET}\n" \
+        "$ws_name" "$token_env" "$ws_kind"
+    fi
     EXIT_CODE=1
   else
-    printf "    %-20s %-35s %-12s testing..." "$ws_name" "$token_env" "$ws_kind"
+    [[ $IS_MOBILE -eq 0 ]] && printf "    %-20s %-35s %-12s testing..." "$ws_name" "$token_env" "$ws_kind"
     resp=$(_test_token "$ws_token")
     ok=$(echo "$resp" | jq -r '.ok // false' 2>/dev/null)
     if [[ "$ok" == "true" ]]; then
       team_url=$(echo "$resp" | jq -r '.url // ""' 2>/dev/null)
-      printf "\r ${GREEN}✓${RESET}  %-20s %-35s %-12s ${GREEN}ok${RESET}  %s\n" \
-        "$ws_name" "$token_env" "$ws_kind" "$team_url"
+      if [[ $IS_MOBILE -eq 1 ]]; then
+        printf "✓ %s: ok %s\n" "$ws_name" "$team_url"
+      else
+        printf "\r ${GREEN}✓${RESET}  %-20s %-35s %-12s ${GREEN}ok${RESET}  %s\n" \
+          "$ws_name" "$token_env" "$ws_kind" "$team_url"
+      fi
     else
       err=$(echo "$resp" | jq -r '.error // "unknown"' 2>/dev/null)
-      printf "\r ${RED}✗${RESET}  %-20s %-35s %-12s ${RED}invalid: %s${RESET}\n" \
-        "$ws_name" "$token_env" "$ws_kind" "$err"
+      if [[ $IS_MOBILE -eq 1 ]]; then
+        printf "✗ %s: invalid (%s)\n" "$ws_name" "$err"
+      else
+        printf "\r ${RED}✗${RESET}  %-20s %-35s %-12s ${RED}invalid: %s${RESET}\n" \
+          "$ws_name" "$token_env" "$ws_kind" "$err"
+      fi
       EXIT_CODE=1
     fi
   fi
 done
 
-printf '──────────────────────────────────────────────────────\n'
-printf ' %d workspace(s) configured. To add another: /ops:setup slack\n' "$WS_COUNT"
-printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+if [[ $IS_MOBILE -eq 0 ]]; then
+  printf '──────────────────────────────────────────────────────\n'
+  printf ' %d workspace(s) configured. To add another: /ops:setup slack\n' "$WS_COUNT"
+  printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+else
+  printf "%d workspace(s); add: /ops:setup slack\n" "$WS_COUNT"
+fi
 
 exit $EXIT_CODE

--- a/claude-ops/bin/ops-status
+++ b/claude-ops/bin/ops-status
@@ -112,6 +112,9 @@ _channel_configured() {
       _pref_has ".user_config.telegram_session" && return 0
       ;;
     slack)
+      # Multi-workspace: at least one entry in slack_workspaces[]
+      _pref_has ".slack_workspaces[0]" && return 0
+      # Legacy single-workspace
       _pref_has ".channels.slack" && return 0
       ;;
     email|gmail)

--- a/claude-ops/bin/ops-unread
+++ b/claude-ops/bin/ops-unread
@@ -79,8 +79,8 @@ fi
 #
 # preferences.json schema (new):
 #   "slack_workspaces": [
-#     { "name": "lifecycle", "token_env": "SLACK_BOT_TOKEN_LIFECYCLE", "kind": "bot_token" },
-#     { "name": "stagery",   "token_env": "SLACK_BOT_TOKEN_STAGERY",   "kind": "user_token" }
+#     { "name": "<workspace_a>", "token_env": "SLACK_BOT_TOKEN_<WORKSPACE_A>", "kind": "bot_token" },
+#     { "name": "<workspace_b>", "token_env": "SLACK_BOT_TOKEN_<WORKSPACE_B>", "kind": "user_token" }
 #   ]
 #
 # Backwards-compat (legacy):
@@ -104,10 +104,21 @@ if [ "$SLACK_WS_COUNT" -gt 0 ]; then
     token_env=$(jq -r ".slack_workspaces[$i].token_env // \"\"" "$PREFS_PATH" 2>/dev/null)
     ws_kind=$(jq -r ".slack_workspaces[$i].kind // \"bot_token\"" "$PREFS_PATH" 2>/dev/null)
 
-    # Resolve token from the named env var
+    # Resolve token from the named env var.
+    # Validate token_env is a legal POSIX shell identifier before indirect expansion;
+    # bash aborts the entire script under `set -u`/`set -e` if `${!var}` is given a
+    # name with invalid characters (e.g. "SLACK-TOKEN" → "invalid variable name").
     ws_token=""
-    if [ -n "$token_env" ]; then
+    if [[ "$token_env" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
       ws_token="${!token_env:-}"
+    elif [ -n "$token_env" ]; then
+      # Configured but the env var name is not a valid shell identifier — emit an
+      # explicit error record and skip without aborting the rest of the scan.
+      WS_ARRAY=$(echo "$WS_ARRAY" | jq \
+        --arg name "$ws_name" \
+        --arg env "$token_env" \
+        '. + [{"name": $name, "available": false, "unread": null, "note": ("invalid token_env (must match [A-Za-z_][A-Za-z0-9_]*): " + $env)}]')
+      continue
     fi
 
     if [ -n "$ws_token" ]; then

--- a/claude-ops/bin/ops-unread
+++ b/claude-ops/bin/ops-unread
@@ -73,12 +73,67 @@ else
   RESULT=$(echo "$RESULT" | jq '.channels.email = {"inbox_count": 0, "available": false, "note": "gog not installed — install gogcli: `brew install gogcli` (macOS/Linuxbrew), `winget install -e --id steipete.gogcli` (Windows), or see https://github.com/steipete/gogcli"}')
 fi
 
-# ── Slack — MCP-based, check env ──
-SLACK_ENABLED="${SLACK_MCP_ENABLED:-false}"
-if [ "$SLACK_ENABLED" = "true" ]; then
-  RESULT=$(echo "$RESULT" | jq '.channels.slack = {"unread": null, "available": true, "note": "Scan via Slack MCP tools"}')
+# ── Slack — multi-workspace support ──
+# Reads slack_workspaces array from preferences.json.
+# Backwards-compat: if array is absent/empty, falls back to legacy SLACK_MCP_ENABLED env var.
+#
+# preferences.json schema (new):
+#   "slack_workspaces": [
+#     { "name": "lifecycle", "token_env": "SLACK_BOT_TOKEN_LIFECYCLE", "kind": "bot_token" },
+#     { "name": "stagery",   "token_env": "SLACK_BOT_TOKEN_STAGERY",   "kind": "user_token" }
+#   ]
+#
+# Backwards-compat (legacy):
+#   SLACK_MCP_ENABLED=true  →  single unnamed workspace via mcp__claude_ai_Slack__*
+PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+
+SLACK_WS_COUNT=0
+SLACK_WS_NAMES=()
+SLACK_WS_AVAILABLE=()
+
+if command -v jq >/dev/null 2>&1 && [ -f "$PREFS_PATH" ]; then
+  SLACK_WS_COUNT=$(jq -r '(.slack_workspaces // []) | length' "$PREFS_PATH" 2>/dev/null || echo "0")
+  [[ "$SLACK_WS_COUNT" =~ ^[0-9]+$ ]] || SLACK_WS_COUNT=0
+fi
+
+if [ "$SLACK_WS_COUNT" -gt 0 ]; then
+  # New multi-workspace path — iterate each configured workspace
+  WS_ARRAY="[]"
+  for i in $(seq 0 $((SLACK_WS_COUNT - 1))); do
+    ws_name=$(jq -r ".slack_workspaces[$i].name // \"workspace-$i\"" "$PREFS_PATH" 2>/dev/null)
+    token_env=$(jq -r ".slack_workspaces[$i].token_env // \"\"" "$PREFS_PATH" 2>/dev/null)
+    ws_kind=$(jq -r ".slack_workspaces[$i].kind // \"bot_token\"" "$PREFS_PATH" 2>/dev/null)
+
+    # Resolve token from the named env var
+    ws_token=""
+    if [ -n "$token_env" ]; then
+      ws_token="${!token_env:-}"
+    fi
+
+    if [ -n "$ws_token" ]; then
+      # Token present — mark available, actual unread count requires MCP at scan time
+      WS_ARRAY=$(echo "$WS_ARRAY" | jq \
+        --arg name "$ws_name" \
+        --arg kind "$ws_kind" \
+        --arg env "$token_env" \
+        '. + [{"name": $name, "kind": $kind, "token_env": $env, "available": true, "unread": null, "note": "Scan via mcp__claude_ai_Slack__* or direct curl with token_env"}]')
+    else
+      # Token env var not set — workspace configured but credential missing
+      WS_ARRAY=$(echo "$WS_ARRAY" | jq \
+        --arg name "$ws_name" \
+        --arg env "$token_env" \
+        '. + [{"name": $name, "available": false, "unread": null, "note": ("token env var not set: " + $env)}]')
+    fi
+  done
+  RESULT=$(echo "$RESULT" | jq --argjson ws "$WS_ARRAY" '.channels.slack = {"workspaces": $ws, "multi_workspace": true}')
 else
-  RESULT=$(echo "$RESULT" | jq '.channels.slack = {"unread": null, "available": false, "note": "Set SLACK_MCP_ENABLED=true when Slack MCP server is configured"}')
+  # Legacy single-workspace path — honour SLACK_MCP_ENABLED env var
+  SLACK_ENABLED="${SLACK_MCP_ENABLED:-false}"
+  if [ "$SLACK_ENABLED" = "true" ]; then
+    RESULT=$(echo "$RESULT" | jq '.channels.slack = {"unread": null, "available": true, "multi_workspace": false, "note": "Scan via Slack MCP tools (legacy single-workspace mode)"}')
+  else
+    RESULT=$(echo "$RESULT" | jq '.channels.slack = {"unread": null, "available": false, "multi_workspace": false, "note": "No slack_workspaces configured. Set SLACK_MCP_ENABLED=true (legacy) or add slack_workspaces[] to preferences.json"}')
+  fi
 fi
 
 # ── Telegram — user-auth MCP, check env ──

--- a/claude-ops/skills/ops-comms/SKILL.md
+++ b/claude-ops/skills/ops-comms/SKILL.md
@@ -169,10 +169,10 @@ Use `mcp__claude_ai_Gmail__search_threads` with `query: "in:inbox"` (NOT `is:unr
 
 **Slack (multi-workspace):**
 
-Read `preferences.json` → `slack_workspaces[]`. Iterate all entries:
-- For each `available: true` entry, use `mcp__claude_ai_Slack__slack_search_public_and_private` with `query: "in:channel"` (NOT `is:unread`) if the MCP token matches, or direct curl for non-bound workspaces.
-- Label results with the workspace name: `Slack/lifecycle`, `Slack/stagery`, etc.
-- **0 workspaces / legacy mode**: fall back to `mcp__claude_ai_Slack__slack_search_public_and_private` if `SLACK_MCP_ENABLED=true`, otherwise report "Slack not configured".
+Read the **derived** `channels.slack.workspaces[]` object from the pre-gathered `bin/ops-unread` output (NOT the raw `preferences.json` → `slack_workspaces[]`, which has no `available` field — it only persists workspace metadata). The `bin/ops-unread` step resolves each workspace's `token_env` and emits `available: true|false` per entry. Iterate that array:
+- For each `available: true` entry, use `mcp__claude_ai_Slack__slack_search_public_and_private` with `query: "in:channel"` (NOT `is:unread`) if the MCP token matches, or direct curl for non-bound workspaces. To resolve the token for direct curl, the entry's `token_env` field is the **name** of the env var; validate it matches `^[A-Za-z_][A-Za-z0-9_]*$` before indirect expansion (`${!token_env}`) to avoid bash aborting on invalid identifiers.
+- Label results with the workspace name: `Slack/<workspace_a>`, `Slack/<workspace_b>`, etc.
+- **`channels.slack.multi_workspace == false` / legacy mode**: fall back to `mcp__claude_ai_Slack__slack_search_public_and_private` if `channels.slack.available == true`, otherwise report "Slack not configured".
 
 **Telegram:**
 Use `mcp__claude_ops_telegram__get_updates` (limit: 20) and `mcp__claude_ops_telegram__list_chats`.

--- a/claude-ops/skills/ops-comms/SKILL.md
+++ b/claude-ops/skills/ops-comms/SKILL.md
@@ -167,8 +167,12 @@ Show last 10 chats with sender, preview, timestamp. Use `mcp__whatsapp__list_mes
 **Email:**
 Use `mcp__claude_ai_Gmail__search_threads` with `query: "in:inbox"` (NOT `is:unread` — scan full inbox including read messages), show thread list.
 
-**Slack:**
-Use `mcp__claude_ai_Slack__slack_search_public_and_private` with `query: "in:channel"` (NOT `is:unread` — scan full recent activity).
+**Slack (multi-workspace):**
+
+Read `preferences.json` → `slack_workspaces[]`. Iterate all entries:
+- For each `available: true` entry, use `mcp__claude_ai_Slack__slack_search_public_and_private` with `query: "in:channel"` (NOT `is:unread`) if the MCP token matches, or direct curl for non-bound workspaces.
+- Label results with the workspace name: `Slack/lifecycle`, `Slack/stagery`, etc.
+- **0 workspaces / legacy mode**: fall back to `mcp__claude_ai_Slack__slack_search_public_and_private` if `SLACK_MCP_ENABLED=true`, otherwise report "Slack not configured".
 
 **Telegram:**
 Use `mcp__claude_ops_telegram__get_updates` (limit: 20) and `mcp__claude_ops_telegram__list_chats`.

--- a/claude-ops/skills/ops-dash/SKILL.md
+++ b/claude-ops/skills/ops-dash/SKILL.md
@@ -172,7 +172,7 @@ Display the full settings menu as text (for reference), then use **batched AskUs
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
  PROFILE:       Owner=[value] | TZ=[value] | Style=[value]
- CHANNELS:      Email=[✓/✗] | WA=[✓/✗] | Slack=[✓/✗] | Telegram=[✓/✗]
+ CHANNELS:      Email=[✓/✗] | WA=[✓/✗] | Slack=[N workspaces/✗] | Telegram=[✓/✗]
  INTEGRATIONS:  AWS=[value] | Sentry=[value] | Linear=[value]
  PROJECTS:      [N] registered
  PLUGIN:        v[version]

--- a/claude-ops/skills/ops-go/SKILL.md
+++ b/claude-ops/skills/ops-go/SKILL.md
@@ -203,7 +203,13 @@ If `$ARGUMENTS` contains a project alias, focus the briefing on that project onl
 
 After the briefing, use **batched AskUserQuestion calls** (max 4 options each) for the "What's next?" prompt. Show the top 3 priority actions + `[More...]` in the first call, then remaining actions + `[/ops-yolo — let me run your business today]` in the second call. Route to the appropriate ops skill or project.
 
-For Slack counts: if the pre-gathered data shows `"count": -1`, use `mcp__claude_ai_Slack__slack_search_public_and_private` with query `in:channel` (NOT `is:unread` — scan full recent activity) to get actual message counts. Do this as a parallel tool call while analyzing other data.
+For Slack counts: read the `channels.slack` object from the pre-gathered data.
+
+- **Multi-workspace mode** (`"multi_workspace": true`): the object has a `workspaces` array. For each entry where `available: true`, call `mcp__claude_ai_Slack__slack_search_public_and_private` with `query: "in:channel"` scoped to that workspace. If the MCP is bound to a single token at startup (only one workspace is active in `~/.claude.json`), fall back to direct curl: `curl -s -H "Authorization: Bearer ${TOKEN_ENV_VALUE}" "https://slack.com/api/conversations.list?limit=1"` to verify the token, then use `mcp__claude_ai_Slack__*` for the bound workspace and log a note that the others require a direct API call. Aggregate results and label each with the workspace name (e.g. `Slack/lifecycle: 3 unread`, `Slack/stagery: 1 unread`).
+- **Legacy mode** (`"multi_workspace": false`, `"available": true`): use `mcp__claude_ai_Slack__slack_search_public_and_private` with `query: "in:channel"` (NOT `is:unread`) as before.
+- If `available: false` for all workspaces: show `Slack: not configured` and skip.
+
+Always do Slack queries as parallel tool calls while analyzing other data.
 
 For Notion counts: if `NOTION_MCP_ENABLED=true` and pre-gathered data shows Notion as available, use `mcp__claude_ai_Notion__notion-search` with `query: ""` sorted by `last_edited_time` descending to surface recently active pages. Then call `mcp__claude_ai_Notion__notion-get-comments` on the top results to find comments needing response. Note: Notion search does not support date range filters — sort by recency and limit to the first 10-20 results instead.
 

--- a/claude-ops/skills/ops-go/SKILL.md
+++ b/claude-ops/skills/ops-go/SKILL.md
@@ -18,6 +18,13 @@ allowed-tools:
   - CronCreate
   - CronList
   - WebFetch
+  # Slack — multi-workspace scan during the briefing. The flow falls back to
+  # direct curl from Bash for workspaces whose token_env is not bound to the MCP.
+  - mcp__claude_ai_Slack__slack_search_public_and_private
+  - mcp__claude_ai_Slack__slack_read_channel
+  # Notion — comments/mentions surfaced in the briefing.
+  - mcp__claude_ai_Notion__notion-search
+  - mcp__claude_ai_Notion__notion-get-comments
 effort: medium
 maxTurns: 40
 ---
@@ -205,7 +212,24 @@ After the briefing, use **batched AskUserQuestion calls** (max 4 options each) f
 
 For Slack counts: read the `channels.slack` object from the pre-gathered data.
 
-- **Multi-workspace mode** (`"multi_workspace": true`): the object has a `workspaces` array. For each entry where `available: true`, call `mcp__claude_ai_Slack__slack_search_public_and_private` with `query: "in:channel"` scoped to that workspace. If the MCP is bound to a single token at startup (only one workspace is active in `~/.claude.json`), fall back to direct curl: `curl -s -H "Authorization: Bearer ${TOKEN_ENV_VALUE}" "https://slack.com/api/conversations.list?limit=1"` to verify the token, then use `mcp__claude_ai_Slack__*` for the bound workspace and log a note that the others require a direct API call. Aggregate results and label each with the workspace name (e.g. `Slack/lifecycle: 3 unread`, `Slack/stagery: 1 unread`).
+- **Multi-workspace mode** (`"multi_workspace": true`): the object has a `workspaces` array. For each entry where `available: true`, call `mcp__claude_ai_Slack__slack_search_public_and_private` with `query: "in:channel"` scoped to that workspace. If the MCP is bound to a single token at startup (only one workspace is active in `~/.claude.json`), fall back to direct curl. The entry's `token_env` field is the **name** of the env var holding the token, so resolve it before passing to curl:
+
+  ```bash
+  # token_env is the env var NAME (e.g. "SLACK_BOT_TOKEN_<WORKSPACE>"), not the token value.
+  # Validate it's a legal shell identifier before indirect expansion to avoid script abort
+  # under set -u when token_env contains hyphens or other invalid characters.
+  if [[ "$token_env" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+    token_value="${!token_env:-}"
+  else
+    token_value=""
+  fi
+  if [ -n "$token_value" ]; then
+    curl -s -H "Authorization: Bearer $token_value" \
+      "https://slack.com/api/conversations.list?limit=1"
+  fi
+  ```
+
+  Use `mcp__claude_ai_Slack__*` for the bound workspace and log a note that the others require a direct API call. Aggregate results and label each with the workspace name (e.g. `Slack/<workspace_a>: 3 unread`, `Slack/<workspace_b>: 1 unread`).
 - **Legacy mode** (`"multi_workspace": false`, `"available": true`): use `mcp__claude_ai_Slack__slack_search_public_and_private` with `query: "in:channel"` (NOT `is:unread`) as before.
 - If `available: false` for all workspaces: show `Slack: not configured` and skip.
 

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -21,7 +21,12 @@ allowed-tools:
   - mcp__gog__gmail_read_thread
   - mcp__gog__gmail_send
   - mcp__gog__gmail_labels
-  # Slack: MCP tools added when configured
+  # Slack — multi-workspace inbox scan uses these MCP tools when a workspace's
+  # token is bound to the Slack MCP in ~/.claude.json. Workspaces whose
+  # token_env is NOT bound to the MCP are scanned via direct curl from Bash
+  # (no MCP entry needed for those).
+  - mcp__claude_ai_Slack__slack_search_public_and_private
+  - mcp__claude_ai_Slack__slack_read_channel
   # Telegram: user-auth MCP tools added when configured
   # Notion: MCP tools (claude.ai integration or self-hosted)
   - mcp__claude_ai_Notion__notion-search
@@ -256,9 +261,9 @@ For each channel, detect availability at runtime:
 
 1. **Email**: Try `gog` CLI first. If `gog` unavailable, try `mcp__gog__gmail_*` MCP tools. If neither, report unavailable.
 2. **WhatsApp**: Check bridge liveness: `lsof -i :8080 | grep LISTEN`. If not listening, prompt the user: "WhatsApp bridge is not running." Use `AskUserQuestion`: `[Restart bridge]`, `[Skip WhatsApp]`. On restart: `launchctl kickstart -k gui/$(id -u)/com.samrenders.whatsapp-bridge`, wait 5s, re-check. If bridge is running but MCP tools fail, the bridge may need QR re-pairing — check `~/.local/share/whatsapp-mcp/whatsapp-bridge/logs/bridge.err.log` for auth errors.
-3. **Slack**: Read `channels.slack` from pre-gathered data (or `preferences.json` directly).
-   - **Multi-workspace** (`"multi_workspace": true`): iterate the `workspaces` array. For each `available: true` entry, scan via `mcp__claude_ai_Slack__*` if the MCP token matches, or via direct curl with the workspace's `token_env` value. Aggregate results; label each message block with the workspace name.
-   - **Legacy** (`"multi_workspace": false`): use `mcp__claude_ai_Slack__*` as before. Check `SLACK_MCP_ENABLED` env var.
+3. **Slack**: Read the derived `channels.slack` object from pre-gathered `bin/ops-unread` data (it resolves each `token_env` and reports per-workspace `available`; do NOT read raw `preferences.json → slack_workspaces[]` directly — that array has no `available` flag).
+   - **Multi-workspace** (`"multi_workspace": true`): iterate the `workspaces` array. For each `available: true` entry, scan via `mcp__claude_ai_Slack__*` if the MCP token matches, or via direct curl. To resolve the token for direct curl, validate `token_env` matches `^[A-Za-z_][A-Za-z0-9_]*$` before `${!token_env}` indirect expansion. Aggregate results; label each message block with the workspace name.
+   - **Legacy** (`"multi_workspace": false`): use `mcp__claude_ai_Slack__*` if `channels.slack.available == true` (which itself reflects `SLACK_MCP_ENABLED`).
    - 0 workspaces configured → skip Slack with a one-line note: "Slack: no workspaces configured — run /ops:setup slack".
 4. **Telegram**: Only via user-auth MCP (tdlib/MTProto). Check `TELEGRAM_ENABLED` env var. Never use BotFather bots.
 5. **Discord**: Via `${CLAUDE_PLUGIN_ROOT}/bin/ops-discord read <CHANNEL_ID> --limit 20 --json`. Requires `DISCORD_BOT_TOKEN` (v1 is channel-scoped — no DM/gateway support yet). Pre-configured read list lives at `${CLAUDE_PLUGIN_DATA_DIR}/preferences.json` under `discord.inbox_channels` (array of channel IDs). If neither a bot token nor a read list is configured, skip Discord with a one-line note ("Discord not configured — run `/ops:setup discord`") rather than prompting — ops-inbox is not a setup flow. Rule 3 still applies to `/ops:setup`.
@@ -479,19 +484,25 @@ Draft replies via `gog gmail send`. Archive via `gog gmail archive <messageId> .
 
 ### Slack (multi-workspace)
 
-Read `preferences.json` → `slack_workspaces[]`. For each configured workspace:
+Read the **derived** `channels.slack.workspaces[]` from the pre-gathered `bin/ops-unread` output. That object resolves each workspace's `token_env` and emits `available: true|false` per entry — `preferences.json → slack_workspaces[]` itself only persists metadata and does not contain `available`. For each entry where `available: true`:
 
-1. **Resolve the workspace token**: the entry's `token_env` names the env var holding the token (e.g. `SLACK_BOT_TOKEN_LIFECYCLE`). If the env var is set, use it for direct curl; otherwise rely on the bound MCP token.
+1. **Resolve the workspace token (only when falling back to direct curl)**: the entry's `token_env` field is the **name** of an env var. Validate it matches `^[A-Za-z_][A-Za-z0-9_]*$` before using `${!token_env}` (bash aborts under `set -u` if an indirect expansion is given an invalid identifier):
+   ```bash
+   if [[ "$token_env" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+     TOKEN="${!token_env:-}"
+   fi
+   ```
+   If the env var is set, use it for direct curl; otherwise rely on the bound MCP token.
 2. **Scan**: use `mcp__claude_ai_Slack__slack_search_public_and_private` with `query: "in:channel"` (NOT `is:unread`). If the MCP is only bound to one workspace, make direct `curl` calls for the others:
    ```bash
-   curl -s -H "Authorization: Bearer ${TOKEN}" \
+   curl -s -H "Authorization: Bearer $TOKEN" \
      "https://slack.com/api/conversations.history?channel=<CHANNEL_ID>&limit=20"
    ```
 3. **Label output per workspace**: prefix every result block with the workspace name.
 
 ```
-💬 Slack / lifecycle   [N need reply] | [N waiting]
-💬 Slack / stagery     [N need reply] | [N waiting]
+💬 Slack / <workspace_a>   [N need reply] | [N waiting]
+💬 Slack / <workspace_b>   [N need reply] | [N waiting]
 ```
 
 For each result, show channel, sender, preview. Read thread for context.

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -256,7 +256,10 @@ For each channel, detect availability at runtime:
 
 1. **Email**: Try `gog` CLI first. If `gog` unavailable, try `mcp__gog__gmail_*` MCP tools. If neither, report unavailable.
 2. **WhatsApp**: Check bridge liveness: `lsof -i :8080 | grep LISTEN`. If not listening, prompt the user: "WhatsApp bridge is not running." Use `AskUserQuestion`: `[Restart bridge]`, `[Skip WhatsApp]`. On restart: `launchctl kickstart -k gui/$(id -u)/com.samrenders.whatsapp-bridge`, wait 5s, re-check. If bridge is running but MCP tools fail, the bridge may need QR re-pairing — check `~/.local/share/whatsapp-mcp/whatsapp-bridge/logs/bridge.err.log` for auth errors.
-3. **Slack**: Only via MCP tools (`mcp__claude_ai_Slack__*`). Check `SLACK_MCP_ENABLED` env var.
+3. **Slack**: Read `channels.slack` from pre-gathered data (or `preferences.json` directly).
+   - **Multi-workspace** (`"multi_workspace": true`): iterate the `workspaces` array. For each `available: true` entry, scan via `mcp__claude_ai_Slack__*` if the MCP token matches, or via direct curl with the workspace's `token_env` value. Aggregate results; label each message block with the workspace name.
+   - **Legacy** (`"multi_workspace": false`): use `mcp__claude_ai_Slack__*` as before. Check `SLACK_MCP_ENABLED` env var.
+   - 0 workspaces configured → skip Slack with a one-line note: "Slack: no workspaces configured — run /ops:setup slack".
 4. **Telegram**: Only via user-auth MCP (tdlib/MTProto). Check `TELEGRAM_ENABLED` env var. Never use BotFather bots.
 5. **Discord**: Via `${CLAUDE_PLUGIN_ROOT}/bin/ops-discord read <CHANNEL_ID> --limit 20 --json`. Requires `DISCORD_BOT_TOKEN` (v1 is channel-scoped — no DM/gateway support yet). Pre-configured read list lives at `${CLAUDE_PLUGIN_DATA_DIR}/preferences.json` under `discord.inbox_channels` (array of channel IDs). If neither a bot token nor a read list is configured, skip Discord with a one-line note ("Discord not configured — run `/ops:setup discord`") rather than prompting — ops-inbox is not a setup flow. Rule 3 still applies to `/ops:setup`.
 6. **Notion**: Only via MCP tools (`mcp__claude_ai_Notion__*` or self-hosted Notion MCP). Check `NOTION_MCP_ENABLED` env var. Searches workspace for recent comments, mentions, and assigned tasks.
@@ -474,9 +477,23 @@ Archive N FYI/newsletter emails?
 
 Draft replies via `gog gmail send`. Archive via `gog gmail archive <messageId> ... --no-input --force`.
 
-### Slack
+### Slack (multi-workspace)
 
-Use Slack MCP tools with `query: "in:*"` (NOT `is:unread` — scan full recent activity, not just unread) for mentions.
+Read `preferences.json` → `slack_workspaces[]`. For each configured workspace:
+
+1. **Resolve the workspace token**: the entry's `token_env` names the env var holding the token (e.g. `SLACK_BOT_TOKEN_LIFECYCLE`). If the env var is set, use it for direct curl; otherwise rely on the bound MCP token.
+2. **Scan**: use `mcp__claude_ai_Slack__slack_search_public_and_private` with `query: "in:channel"` (NOT `is:unread`). If the MCP is only bound to one workspace, make direct `curl` calls for the others:
+   ```bash
+   curl -s -H "Authorization: Bearer ${TOKEN}" \
+     "https://slack.com/api/conversations.history?channel=<CHANNEL_ID>&limit=20"
+   ```
+3. **Label output per workspace**: prefix every result block with the workspace name.
+
+```
+💬 Slack / lifecycle   [N need reply] | [N waiting]
+💬 Slack / stagery     [N need reply] | [N waiting]
+```
+
 For each result, show channel, sender, preview. Read thread for context.
 
 ```
@@ -484,6 +501,9 @@ For each result, show channel, sender, preview. Read thread for context.
   b) Reply
   c) Mark read / skip
 ```
+
+**0 workspaces** → skip with: "Slack: no workspaces configured — run /ops:setup slack".
+**Legacy mode** (no `slack_workspaces`, `SLACK_MCP_ENABLED=true`) → single unnamed workspace, behaviour unchanged.
 
 ### Telegram (FULL SCAN — User Account, NOT Bot)
 

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -1391,49 +1391,74 @@ Sub-flow:
 
 6. **Persist — multi-workspace schema.**
 
-   The plugin now supports multiple Slack workspaces. Each workspace is stored as an entry in `slack_workspaces[]` in `$PREFS_PATH`. The raw token is stored in a named env var (never in preferences.json).
+   The plugin supports multiple Slack workspaces. Each is stored as an entry in `slack_workspaces[]` in `$PREFS_PATH`. The raw token is stored in a named env var (never in `preferences.json`). The wizard performs env-var persistence and MCP registration **itself via the Bash tool** — it does not hand these steps back to the user. `slack_workspaces[]` is only written **after** persistence and MCP registration succeed; if either step fails, the entry is rolled back so the configured-but-unusable state never appears in `preferences.json`.
 
-   a. Ask the user for a short workspace name (e.g. `lifecycle`, `stagery`, `personal`). Use `AskUserQuestion` with free-text.
-   b. Ask which env var name to use for this workspace's token (suggest `SLACK_BOT_TOKEN_<UPPERCASE_NAME>`). Free-text.
-   c. Advise the user to add the token to their shell profile or Doppler:
+   a. Ask the user for a short workspace name (e.g. `<workspace_a>`, `<workspace_b>`, `personal`). Use `AskUserQuestion` with free-text.
+   b. Derive the env-var name automatically: `SLACK_BOT_TOKEN_<UPPERCASE_NAME>`. Validate the resulting identifier matches `^[A-Za-z_][A-Za-z0-9_]*$` (uppercase the name and substitute non-alphanumerics with `_` before validating). If validation fails, re-prompt for a name.
+   c. **Persist the token to keychain (macOS) / libsecret (Linux) / Credential Manager (Windows)** via the Bash tool:
       ```bash
-      echo 'export SLACK_BOT_TOKEN_LIFECYCLE="xoxb-..."' >> ~/.zshrc
-      ```
-   d. Also persist to keychain as `slack-<name>-token`:
-      ```bash
+      # macOS
       security add-generic-password -U -s "slack-<name>-token" -a "$USER" -w "$TOKEN"
+      # Linux (requires libsecret-tools)
+      echo -n "$TOKEN" | secret-tool store --label="slack-<name>-token" service slack-<name>-token account "$USER"
+      # Windows (PowerShell from WSL or native)
+      cmdkey /generic:slack-<name>-token /user:"$USER" /pass:"$TOKEN"
       ```
-   e. Append the entry to `$PREFS_PATH` → `slack_workspaces[]`:
+   d. **Persist to the user's shell profile** via the Bash tool (do not hand this back to the user — write the line into `~/.zshrc`/`~/.bashrc`/`~/.zprofile`/`~/.envrc` directly, idempotent):
       ```bash
-      jq --arg name "<name>" --arg env "SLACK_BOT_TOKEN_<NAME>" --arg kind "bot_token" \
+      PROFILE="${ZDOTDIR:-$HOME}/.zshrc"
+      [ -f "$HOME/.zshrc" ] || PROFILE="$HOME/.bashrc"
+      LINE="export SLACK_BOT_TOKEN_<NAME>=\"\$(security find-generic-password -s slack-<name>-token -a \$USER -w 2>/dev/null)\""
+      grep -qF "SLACK_BOT_TOKEN_<NAME>" "$PROFILE" 2>/dev/null || printf '\n%s\n' "$LINE" >> "$PROFILE"
+      # Export into the current shell so the next steps see it
+      export SLACK_BOT_TOKEN_<NAME>="$TOKEN"
+      ```
+      For Windows users on PowerShell, append to `$PROFILE` with `Add-Content`.
+
+   e. **Register the workspace token with the Slack MCP via `claude mcp add`** (this is Claude Code's official mechanism — the wizard runs it via Bash so the user doesn't touch a separate terminal):
+      ```bash
+      claude mcp add "slack-<name>" --transport stdio --env "SLACK_BOT_TOKEN=$TOKEN" \
+        -- npx -y slack-mcp-server@latest --transport stdio || \
+        echo "WARN: claude mcp add failed — workspace will use direct-curl fallback only"
+      ```
+      Capture the exit code. If it succeeds, set `kind` to `bot_token` (or `xoxc_with_cookie` for browser-session tokens with `d` cookie). If it fails, set `kind` to `bot_token_curl_only` so downstream skills know to use direct curl.
+
+   f. **Only after (c)–(e) succeed**, append the entry to `$PREFS_PATH` → `slack_workspaces[]` (atomic write via `jq` + `mv`):
+      ```bash
+      jq --arg name "<name>" --arg env "SLACK_BOT_TOKEN_<NAME>" --arg kind "$KIND" \
         '.slack_workspaces = ((.slack_workspaces // []) + [{"name": $name, "token_env": $env, "kind": $kind}])' \
         "$PREFS_PATH" > "${PREFS_PATH}.tmp" && mv "${PREFS_PATH}.tmp" "$PREFS_PATH"
       ```
-   f. Also write the legacy compat key for backwards-compat: `channels.slack = {backend: "mcp:slack", team_id: "...", source: "...", status: "configured"}`.
+      If any of (c)–(e) failed, **do not** append to `slack_workspaces[]` — surface the failure to the user via `AskUserQuestion`: `[Retry]` / `[Skip this workspace]` / `[Abort setup]`.
 
-   **After persisting**, ask: "Add another Slack workspace?" → `[Yes — add another]` / `[No — done]`. Loop until done. This is how to register the Stagery workspace alongside the Lifecycle workspace.
+   g. Also write the legacy compat key for backwards-compat: `channels.slack = {backend: "mcp:slack", team_id: "...", source: "...", status: "configured"}`.
+
+   **After persisting**, ask: "Add another Slack workspace?" → `[Yes — add another]` / `[No — done]`. Loop until done.
 
    Run `bin/ops-slack-workspaces` to verify all configured workspaces and their token status.
 
-7. **Wire into Claude Code plugin settings.** Print instructions:
+7. **Verify MCP registration.** Run via Bash:
 
-   ```
-   Slack tokens saved. To activate the MCP for a workspace, Claude Code needs
-   the token in ~/.claude.json. Since this skill can't write to ~/.claude.json directly,
-   either:
-     a) Run: claude mcp add slack --transport stdio -- npx -y slack-mcp-server@latest --transport stdio
-        and Claude Code will prompt for the env vars.
-     b) Manually paste the token into /plugin settings for the Slack MCP.
-   For workspaces not bound to the MCP, ops-inbox/ops-go will use direct curl
-   with the token from the named env var.
-   ```
-
-   (The reason we don't auto-write: ~/.claude.json is a Claude Code internal file. MCP registration is Claude Code's responsibility.)
-
-8. **Smoke test per workspace**: for each entry in `slack_workspaces[]`, resolve the token env var and call:
    ```bash
-   curl -s -H "Authorization: Bearer ${TOKEN}" "https://slack.com/api/auth.test"
+   claude mcp list 2>&1 | grep -E "^slack-" || echo "No Slack MCPs registered"
    ```
+
+   Report which workspaces have a bound MCP and which will rely on direct-curl scans (those still work but are bot-token-only — no Socket Mode events). If a workspace was configured with `kind: bot_token_curl_only` from step 6e, advise the user this is expected when `claude mcp add` is unavailable in the current Claude Code build.
+
+8. **Smoke test per workspace**: for each entry in `slack_workspaces[]`, resolve the token env var and call `auth.test`. The exact syntax depends on the token type:
+
+   - **`bot_token` (`xoxb-…`)** or **user-app token (`xoxp-…`)** — pass via `Authorization: Bearer` only:
+     ```bash
+     curl -s -H "Authorization: Bearer ${TOKEN}" "https://slack.com/api/auth.test"
+     ```
+
+   - **Browser-session token (`xoxc-…`)** — Slack's Web API REJECTS `xoxc` tokens unless the request also carries the companion `d=xoxd-…` cookie from the same browser session. Bearer-only requests will return `{"ok":false,"error":"not_authed"}`. For these workspaces, store both tokens (e.g. `SLACK_BOT_TOKEN_<WORKSPACE>` for `xoxc-…` and `SLACK_BOT_COOKIE_<WORKSPACE>` for `xoxd-…`) and call:
+     ```bash
+     curl -s -H "Authorization: Bearer ${XOXC_TOKEN}" -b "d=${XOXD_TOKEN}" \
+       "https://slack.com/api/auth.test"
+     ```
+     If only an `xoxc-…` token is configured without the cookie, mark the workspace as `kind: "xoxc_no_cookie"` in `slack_workspaces[]` and surface a warning that direct-curl scans will not work — the workspace must go through the Slack MCP (which holds both halves) or the user must rerun `/ops:setup slack` to extract the cookie via `bin/ops-slack-autolink.mjs`.
+
    Expect `{"ok":true, "team_id":"T...", "url":"https://<workspace>.slack.com/"}`. Report pass/fail per workspace.
 
    Or run the helper: `${CLAUDE_PLUGIN_ROOT}/bin/ops-slack-workspaces`

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -1389,24 +1389,54 @@ Sub-flow:
    ```
    Expect `{"ok":true, "team_id":"T...", "user_id":"U...", "url":"https://<workspace>.slack.com/"}`. If `ok:false`, show the error and re-ask.
 
-6. **Persist.**
-   - Keychain: `security add-generic-password -U -s slack-xoxc -a "$USER" -w "$XOXC"; security add-generic-password -U -s slack-xoxd -a "$USER" -w "$XOXD"`.
-   - `$PREFS_PATH` → `channels.slack = {backend: "mcp:slack", team_id: "...", source: "...", status: "configured"}`. **Do not** store the raw tokens in preferences.json — keychain only.
+6. **Persist — multi-workspace schema.**
+
+   The plugin now supports multiple Slack workspaces. Each workspace is stored as an entry in `slack_workspaces[]` in `$PREFS_PATH`. The raw token is stored in a named env var (never in preferences.json).
+
+   a. Ask the user for a short workspace name (e.g. `lifecycle`, `stagery`, `personal`). Use `AskUserQuestion` with free-text.
+   b. Ask which env var name to use for this workspace's token (suggest `SLACK_BOT_TOKEN_<UPPERCASE_NAME>`). Free-text.
+   c. Advise the user to add the token to their shell profile or Doppler:
+      ```bash
+      echo 'export SLACK_BOT_TOKEN_LIFECYCLE="xoxb-..."' >> ~/.zshrc
+      ```
+   d. Also persist to keychain as `slack-<name>-token`:
+      ```bash
+      security add-generic-password -U -s "slack-<name>-token" -a "$USER" -w "$TOKEN"
+      ```
+   e. Append the entry to `$PREFS_PATH` → `slack_workspaces[]`:
+      ```bash
+      jq --arg name "<name>" --arg env "SLACK_BOT_TOKEN_<NAME>" --arg kind "bot_token" \
+        '.slack_workspaces = ((.slack_workspaces // []) + [{"name": $name, "token_env": $env, "kind": $kind}])' \
+        "$PREFS_PATH" > "${PREFS_PATH}.tmp" && mv "${PREFS_PATH}.tmp" "$PREFS_PATH"
+      ```
+   f. Also write the legacy compat key for backwards-compat: `channels.slack = {backend: "mcp:slack", team_id: "...", source: "...", status: "configured"}`.
+
+   **After persisting**, ask: "Add another Slack workspace?" → `[Yes — add another]` / `[No — done]`. Loop until done. This is how to register the Stagery workspace alongside the Lifecycle workspace.
+
+   Run `bin/ops-slack-workspaces` to verify all configured workspaces and their token status.
 
 7. **Wire into Claude Code plugin settings.** Print instructions:
 
    ```
-   Slack tokens saved to keychain. To activate the MCP, Claude Code needs them
-   in ~/.claude.json. Since this skill can't write to ~/.claude.json directly,
+   Slack tokens saved. To activate the MCP for a workspace, Claude Code needs
+   the token in ~/.claude.json. Since this skill can't write to ~/.claude.json directly,
    either:
      a) Run: claude mcp add slack --transport stdio -- npx -y slack-mcp-server@latest --transport stdio
         and Claude Code will prompt for the env vars.
-     b) Manually paste the xoxc + xoxd into /plugin settings for the Slack MCP.
+     b) Manually paste the token into /plugin settings for the Slack MCP.
+   For workspaces not bound to the MCP, ops-inbox/ops-go will use direct curl
+   with the token from the named env var.
    ```
 
-   (The reason we don't auto-write: per user-level feedback, ~/.claude.json is a Claude Code internal file and the plugin must not touch it. MCP registration is Claude Code's responsibility.)
+   (The reason we don't auto-write: ~/.claude.json is a Claude Code internal file. MCP registration is Claude Code's responsibility.)
 
-8. **Smoke test**: call `https://slack.com/api/conversations.list?limit=1` with the tokens. Expect `ok:true` with at least one channel in the response.
+8. **Smoke test per workspace**: for each entry in `slack_workspaces[]`, resolve the token env var and call:
+   ```bash
+   curl -s -H "Authorization: Bearer ${TOKEN}" "https://slack.com/api/auth.test"
+   ```
+   Expect `{"ok":true, "team_id":"T...", "url":"https://<workspace>.slack.com/"}`. Report pass/fail per workspace.
+
+   Or run the helper: `${CLAUDE_PLUGIN_ROOT}/bin/ops-slack-workspaces`
 
 **Privacy notes**:
 


### PR DESCRIPTION
## Summary

- `preferences.json` gains `slack_workspaces[]` — each entry has `name`, `token_env`, `kind`. Skills iterate all entries and label output per workspace (`Slack/lifecycle`, `Slack/stagery`, etc.)
- Backwards-compatible: no `slack_workspaces` → falls back to legacy `SLACK_MCP_ENABLED=true` single-workspace path. Zero behaviour change for existing installs.
- New `bin/ops-slack-workspaces` helper: lists configured workspaces, resolves token env vars, smoke-tests each via `auth.test`. Exits non-zero on any missing/invalid token.
- Setup wizard step 3d now loops ("Add another workspace?") and appends each workspace to the array — tokens go into named env vars and keychain, never in prefs.
- `ops-unread`, `ops-go`, `ops-inbox`, `ops-comms`, `ops-dash`, `ops-status` all updated.

## Schema

```jsonc
// preferences.json
{
  "slack_workspaces": [
    { "name": "lifecycle", "token_env": "SLACK_BOT_TOKEN_LIFECYCLE", "kind": "bot_token" },
    { "name": "stagery",   "token_env": "SLACK_BOT_TOKEN_STAGERY",   "kind": "user_token" }
  ]
}
```

Token env vars live in shell profile or Doppler — never committed.

## Migration story

Existing single-workspace configs keep working unchanged. To opt into multi-workspace, run `/ops:setup slack` — it appends to `slack_workspaces[]` without touching existing entries.

## MCP wrinkle

Claude Code's MCP is bound to one Slack token at startup. For the bound workspace, `mcp__claude_ai_Slack__*` tools are used as before. For additional workspaces, skills fall back to direct curl with the workspace's `token_env` value. This is documented in each SKILL.md.

## Test plan

- [ ] 0 workspaces + `SLACK_MCP_ENABLED` unset → `ops-unread` shows `available: false`, skills skip with one-line note
- [ ] 0 workspaces + `SLACK_MCP_ENABLED=true` → legacy path, single unnamed workspace, unchanged behaviour
- [ ] 1 workspace with valid token → `ops-slack-workspaces` shows `✓`, ops-go labels `Slack/lifecycle`
- [ ] 2 workspaces → both appear in briefing/inbox output with separate labels
- [ ] Missing token env var → `ops-slack-workspaces` shows `✗ token env not set`, exits 1
- [ ] `/ops:setup slack` → adds first workspace, prompts "Add another?", adds second, both persist in prefs

## To add the Stagery workspace post-merge

```bash
# 1. Add token to shell profile
echo 'export SLACK_BOT_TOKEN_STAGERY="xoxb-..."' >> ~/.zshrc && source ~/.zshrc

# 2. Run setup to register it
/ops:setup slack
# → enter name: stagery
# → enter token env: SLACK_BOT_TOKEN_STAGERY
# → "Add another?" → No

# 3. Verify
bin/ops-slack-workspaces
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Slack availability/output schema in `bin/ops-unread` and channel detection in `bin/ops-status`, which downstream skills rely on; failures would primarily affect comms scanning rather than core data integrity.
> 
> **Overview**
> Adds **multi-workspace Slack support** via a new `preferences.json` `slack_workspaces[]` schema (name + token env var + kind) while keeping the legacy `SLACK_MCP_ENABLED=true` single-workspace path as a fallback.
> 
> Updates `bin/ops-unread` to emit per-workspace Slack availability (resolving each `token_env` safely) and adjusts `bin/ops-status` to treat Slack as configured if any workspace entry exists. Introduces `bin/ops-slack-workspaces` to list/test all configured workspace tokens (table or `--json`, non-zero exit on missing/invalid).
> 
> Extends setup/skill docs to loop Slack setup for multiple workspaces, label results per workspace, and document MCP-bound vs direct-curl fallback behavior, and bumps the changelog to `2.0.9`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f2f95d958b2ad25b56347e5c3c3443d48b1a903. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-workspace Slack support and a new workspace validation CLI with human and JSON output

* **Documentation**
  * Setup wizard updated to persist multiple Slack workspaces and append on subsequent runs
  * Guidance updated across Slack-related skills to reflect per-workspace iteration and fallback behavior

* **Improvements**
  * Per-workspace labeling in results and settings now show workspace counts
  * Backward-compatible single-workspace legacy fallback preserved; validation returns non-zero on missing/invalid tokens
<!-- end of auto-generated comment: release notes by coderabbit.ai -->