### PR TITLE
fix(ops-ci): emit only currently-failing workflows; add pre-dispatch staleness check

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "Business operations command center for Claude Code — 30 skills, 14 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/bin/ops-ci
+++ b/claude-ops/bin/ops-ci
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
-# ops-ci — Recent CI failures across all repos → JSON
-# Checks last 24h of GitHub Actions failures
+# ops-ci — Currently-failing CI workflows across all repos → JSON
+#
+# Returns workflows where the LATEST run on a tracked branch (main/dev/master)
+# is currently failing. Stale failures that have since been fixed by a newer
+# successful run are excluded — this prevents downstream consumers
+# (ops-fires, ops-go) from dispatching fix agents to already-resolved fires
+# and burning tokens.
+#
+# Algorithm per repo:
+#   1. Pull last 30 runs (any branch, any conclusion) — survey workflows in play
+#   2. Extract distinct workflow names from those runs
+#   3. For each workflow × tracked branch (main, dev, master), fetch latest run
+#   4. Emit only entries where conclusion == "failure"
+#
+# Override: OPS_CI_MODE=legacy reverts to "any failure in last 24h" (slower
+# but matches pre-1.7.x behaviour). Default is "current-state".
 
 set -euo pipefail
 
@@ -16,19 +30,70 @@ if ! command -v gh &>/dev/null; then
 fi
 
 REPOS=$(jq -r '[.projects[].repos[]] | unique | .[]' "$REGISTRY")
-SINCE=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d '1 day ago' +%Y-%m-%d 2>/dev/null || date +%Y-%m-%d)
+MODE="${OPS_CI_MODE:-current}"
+TRACKED_BRANCHES=("main" "dev" "master")
 
 TMPDIR_OPS=$(mktemp -d)
 trap 'rm -rf "$TMPDIR_OPS"' EXIT
 
+# ─── Per-repo scan ──────────────────────────────────────────────────────────
+scan_repo_current() {
+  local repo="$1"
+  local safe_name
+  safe_name=$(echo "$repo" | tr '/' '_')
+
+  # Survey workflows in recent activity (last 30 runs across all branches)
+  local recent_workflows
+  recent_workflows=$(gh run list --repo "$repo" --limit 30 \
+    --json name,workflowName 2>/dev/null \
+    | jq -r '[.[] | (.workflowName // .name)] | unique | .[]' 2>/dev/null || true)
+
+  [ -z "$recent_workflows" ] && return 0
+
+  local failures="[]"
+  while IFS= read -r workflow; do
+    [ -z "$workflow" ] && continue
+    for branch in "${TRACKED_BRANCHES[@]}"; do
+      # Latest run for this workflow + branch
+      local latest
+      latest=$(gh run list --repo "$repo" --workflow "$workflow" --branch "$branch" --limit 1 \
+        --json name,headBranch,createdAt,conclusion,event,workflowName 2>/dev/null || echo '[]')
+
+      # Skip if no run, or latest is success/skipped/cancelled/in_progress
+      local conclusion
+      conclusion=$(echo "$latest" | jq -r '.[0].conclusion // empty' 2>/dev/null)
+      [ "$conclusion" != "failure" ] && continue
+
+      # Append to failures array
+      failures=$(echo "$failures" | jq --argjson new "$latest" '. + $new')
+    done
+  done <<< "$recent_workflows"
+
+  if [ "$(echo "$failures" | jq 'length')" -gt 0 ]; then
+    echo "{\"repo\":\"$repo\",\"failures\":$failures}" > "$TMPDIR_OPS/$safe_name.json"
+  fi
+}
+
+scan_repo_legacy() {
+  local repo="$1"
+  local safe_name
+  safe_name=$(echo "$repo" | tr '/' '_')
+
+  local failures
+  failures=$(gh run list --repo "$repo" --status failure --limit 3 \
+    --json name,headBranch,createdAt,conclusion,event 2>/dev/null || echo '[]')
+
+  if [ "$failures" != "[]" ] && [ -n "$failures" ]; then
+    echo "{\"repo\":\"$repo\",\"failures\":$failures}" > "$TMPDIR_OPS/$safe_name.json"
+  fi
+}
+
 for repo in $REPOS; do
   (
-    SAFE_NAME=$(echo "$repo" | tr '/' '_')
-    FAILURES=$(gh run list --repo "$repo" --status failure --limit 3 \
-      --json name,headBranch,createdAt,conclusion,event 2>/dev/null || echo '[]')
-
-    if [ "$FAILURES" != "[]" ] && [ -n "$FAILURES" ]; then
-      echo "{\"repo\":\"$repo\",\"failures\":$FAILURES}" > "$TMPDIR_OPS/$SAFE_NAME.json"
+    if [ "$MODE" = "legacy" ]; then
+      scan_repo_legacy "$repo"
+    else
+      scan_repo_current "$repo"
     fi
   ) &
 done

--- a/claude-ops/skills/ops-fires/SKILL.md
+++ b/claude-ops/skills/ops-fires/SKILL.md
@@ -185,6 +185,29 @@ If no fires: show "ALL SYSTEMS OPERATIONAL" with last-checked timestamps.
 
 ---
 
+## Pre-dispatch staleness check (MANDATORY)
+
+The pre-gathered CI data is cached and may be minutes-to-hours old. Before
+dispatching ANY fix agent, verify the failure is still red on its branch HEAD.
+This is defense-in-depth: even after the `bin/ops-ci` "current-state" filter
+(which only emits workflows whose latest run on a tracked branch is failing),
+a fix may have landed in the seconds since the cache was written. Dispatching
+to a self-resolved fire wastes Sonnet quota — typically 50–150k tokens per
+agent before it figures out there's nothing to fix.
+
+For each fire the user selects:
+
+```bash
+gh run list --repo "$REPO" --workflow "$WORKFLOW" --branch "$BRANCH" --limit 1 \
+  --json conclusion,databaseId,createdAt --jq '.[0]'
+```
+
+- If `conclusion == "success"` → SKIP. Mark task completed with metadata `{resolution: "self-resolved-pre-dispatch"}`. Do NOT spawn agent.
+- If `conclusion == "failure"` → proceed to dispatch.
+- If `conclusion == null` (in_progress) → wait 30s, recheck once, then proceed if still null.
+
+For workflows scoped only to PRs (no main/dev runs), check the PR's combined CI status instead: `gh pr checks <num> --repo "$REPO" --json bucket,name`.
+
 ## Dispatch fix agent
 
 When user selects to fix an issue, use `AskUserQuestion` to confirm the scope before dispatching:


### PR DESCRIPTION
## Summary

Stop wasting Sonnet quota dispatching `/ops-fires` agents to already-self-resolved CI failures.

`bin/ops-ci` previously pulled "last 3 failures" per repo regardless of whether those workflows are still red on branch HEAD. `/ops-fires` and `/ops-go` treated any 24h-old failure as actionable and dispatched fix agents — burning ~50–150k Sonnet tokens per agent before concluding "nothing to fix".

**Real-world signal:** during a `/ops-fires` session tonight, 4 of 7 dispatched fixers reported "self-resolved before I started" (PRs already merged: healify-agentcore #520, fiberwifi #471/#473, stagery-contracts #30, stagery-api Inngest Vercel redeploy). That's ~400k tokens spent confirming green builds.

## Smoke test

Real portfolio (38 repos, ops-ci registry):
- `OPS_CI_MODE=legacy bash bin/ops-ci`: 14 repos with failures
- `bash bin/ops-ci` (new default): 6 repos with failures
- 8 stale entries filtered → **57% noise reduction**

## Changes

- `bin/ops-ci`: survey workflows from last 30 runs, then for each workflow × tracked branch (main/dev/master) fetch latest run, emit only when `conclusion=="failure"`. Behind `OPS_CI_MODE=current` default; `OPS_CI_MODE=legacy` reverts.
- `skills/ops-fires/SKILL.md`: MANDATORY pre-dispatch staleness check — `gh run list --workflow X --branch Y --limit 1` before spawning any fix agent. Defense in depth for cache races.
- Bump plugin version 2.0.8 → 2.0.9.

## Test plan

- [x] `bash -n bin/ops-ci` syntax check
- [x] Real-portfolio smoke (legacy 14 → current 6)
- [x] JSON output schema unchanged (consumers don't break)
- [ ] Verify `/ops-fires` skips self-resolved failures on next invocation
- [ ] Confirm `/ops-go` morning briefing surface count drops to actionable-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI failure detection logic used by downstream automation, so false negatives/positives could alter what incidents get surfaced or fixed; also increases `gh` API calls per repo which may hit rate limits or slow runs.
> 
> **Overview**
> **CI failure reporting is switched from “recent failures” to “current state.”** `bin/ops-ci` now surveys recent workflow names, then for each workflow and tracked branch (`main`/`dev`/`master`) fetches the latest run and emits only those whose latest `conclusion` is `failure`, filtering out stale failures; `OPS_CI_MODE=legacy` restores the prior behavior.
> 
> **Ops-fires adds a defense-in-depth staleness check.** `skills/ops-fires/SKILL.md` now requires re-checking the latest `gh run` result (and handling `in_progress`) before dispatching any fix agent, skipping self-resolved failures. Plugin version bumps to `2.0.9`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09d8e62db91a8bd95834fb2a0cd16a6f51064a4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced CI failure detection with a new default mode that surveys latest workflow runs per repository and branch for improved accuracy
  * Added pre-dispatch staleness verification to ensure CI fires are still active before attempting fixes, with special handling for PR-scoped workflows

* **Chores**
  * Updated plugin version to 2.0.9

<!-- end of auto-generated comment: release notes by coderabbit.ai -->