### PR TITLE
fix(marketplace): bump version to 2.0.9 to match plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 30 skills, 14 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "category": "productivity",
       "keywords": [
         "ops",


### PR DESCRIPTION
Pins marketplace ops plugin to v2.0.9 (released via PR #196 — fix ops-ci stale data → 57% noise reduction).

Same pattern as PR #192 (2.0.7→2.0.8 bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single metadata/version pin change in `.claude-plugin/marketplace.json` with no runtime logic modifications.
> 
> **Overview**
> Updates `.claude-plugin/marketplace.json` to pin the `ops` marketplace plugin version from `2.0.8` to `2.0.9`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85532d8417d65b685413c6ae30c72ecc7a78d640. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->