### PR TITLE
docs(release): sync README + all docs to v2.0.9

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ops",
   "version": "2.0.9",
-  "description": "Business operations command center for Claude Code — 30 skills, 14 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
+  "description": "Business operations command center for Claude Code — 35 skills, 18 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",
     "url": "https://github.com/Lifecycle-Innovations-Limited"

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -4,12 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [2.0.9] — 2026-05-01
 
-### Added
+### Fixed
 
-- **Multi-workspace Slack support.** `preferences.json` now accepts a `slack_workspaces` array so ops briefings, inbox scans, and comms reads iterate ALL configured Slack workspaces instead of stopping at one. Each entry carries `name`, `token_env` (the env var holding the token — never stored in prefs), and `kind` (`bot_token` | `user_token`). Backwards-compatible: configs with no `slack_workspaces` fall back to legacy `SLACK_MCP_ENABLED=true` single-workspace path.
-- **`bin/ops-slack-workspaces` helper.** Lists every configured workspace, resolves token env vars, and calls `slack.com/api/auth.test` for each. Outputs a table or `--json` for machine consumers. Exit code is non-zero if any token is missing or invalid.
-- **Setup wizard multi-workspace loop.** Step 3d now persists each workspace into `slack_workspaces[]` and asks "Add another workspace?" until done. Running `/ops:setup slack` a second time appends to the array without overwriting existing entries.
-- Updated `ops-go`, `ops-inbox`, `ops-comms`, `ops-dash` SKILL.md docs to describe multi-workspace iteration, per-workspace labelling, and the MCP-bound-token fallback path (direct curl for non-primary workspaces).
+- **ops-ci current-state filter (57% noise reduction).** `bin/ops-ci` previously pulled "last 3 failures" per repo regardless of whether those workflows are still red on HEAD. Downstream consumers (`ops-fires`, `ops-go`) treated any 24h failure as actionable and dispatched fix agents to already-self-resolved fires — burning ~50–150k Sonnet tokens per agent before it concluded "nothing to fix". Smoke test on a real portfolio: legacy mode emits 14 repos with failures, new mode emits 6 (8 stale entries filtered). Now surveys last 30 runs per repo and emits only workflows whose latest run on the tracked branch (main/dev/master) has `conclusion=="failure"`. Behind `OPS_CI_MODE=current` default; `OPS_CI_MODE=legacy` reverts to old behaviour.
+- **MANDATORY pre-dispatch staleness check in ops-fires SKILL.** Adds a defense-in-depth gate — `gh run list --workflow X --branch Y --limit 1` — before spawning any fix agent. Catches cache races where a fix landed in the seconds since the CI cache was written.
 
 ## [2.0.8] — 2026-05-01
 

--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -1,6 +1,14 @@
 # claude-ops
 
-> **v2.0.0** — Autonomy Layer · Deploy Auto-Fix · Safety Hooks · Specialist Agents · Recap Marquee · Multi-Account Rotator · 33+ Skills · 18 Agents
+> **v2.0.9** — Autonomy Layer · Deploy Auto-Fix · Safety Hooks · Specialist Agents · Recap Marquee · Multi-Account Rotator · Multi-Workspace Slack · ops-ci Current-State Filter · Credentials Audit · 35 Skills · 18 Agents
+
+## What's new since v2.0.0
+
+- **v2.0.9** — ops-ci current-state filter (57% noise reduction in `/ops:fires`); MANDATORY pre-dispatch staleness check in ops-fires SKILL
+- **v2.0.8** — multi-workspace Slack support; userConfig schema fixes
+- **v2.0.7** — Telegram keychain fallback + SSE/user-config preflight
+- **v2.0.6** — `/ops:credentials` audit skill + plugin.json field hints
+- **v2.0.5** — userConfig enums + per-integration toggles
 
 A Claude Code plugin that turns Claude into a business operating system **and** an autonomy layer. Run `/ops` for the interactive command center — pixel-art dashboard with instant hotkey access to morning briefings, inbox, fires, deploys, revenue, and YOLO mode. Or just keep working — v2's hooks watch every merge, every build, every commit, every push, and every agent dispatch in the background.
 
@@ -126,8 +134,8 @@ The background memory extractor now prefers the Claude Code OAuth token stored i
 `whatsapp-bridge` (Baileys) now manages WhatsApp connectivity via the `com.samrenders.whatsapp-bridge` LaunchAgent. Previously `whatsapp-bridge-keepalive.sh` kept `whatsapp-bridge --follow` alive — that daemon has been decommissioned (see `legacy/`). Which tore down the persistent connection every 5-20 minutes. Fixed via `INITIAL_BACKFILL_DELAY=30` plus a reentrant guard against overlapping sweeps.
 
 ### Full Plugin Feature Adoption
-- All 30 skills: `effort`, `maxTurns`, `disallowedTools`, `model` annotations
-- All 14 agents: `memory` (cross-session learning), `initialPrompt`, `isolation`
+- All 35 skills: `effort`, `maxTurns`, `disallowedTools`, `model` annotations
+- All 18 agents: `memory` (cross-session learning), `initialPrompt`, `isolation`
 - PreToolUse hooks for WhatsApp health checks and MCP auto-reconnect
 - Runtime Context loading in every skill (preferences, daemon health, memories, secrets)
 - CLI/API reference tables in all operational skills

--- a/claude-ops/docs/INDEX.md
+++ b/claude-ops/docs/INDEX.md
@@ -4,7 +4,7 @@
 
 *Top-level map of every doc file in `claude-ops/docs/`.*
 
-[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
 
 </div>
 
@@ -25,7 +25,7 @@
 | Doc | Subject |
 |-----|---------|
 | [`agents-reference.md`](agents-reference.md) | Catalog of all 18 agents (4 v2 specialists + 14 v1 scanners/fixers/C-suite). |
-| [`skills-reference.md`](skills-reference.md) | Catalog of all 33+ skills with usage examples. |
+| [`skills-reference.md`](skills-reference.md) | Catalog of all 35 skills with usage examples. |
 | [`daemon-guide.md`](daemon-guide.md) | The v1 ops-daemon (briefing pre-warm, whatsapp-bridge-sync, memory-extractor, etc). |
 | [`docker.md`](docker.md) | Running claude-ops in a container. |
 | [`marketplace-submissions.md`](marketplace-submissions.md) | Publishing your own plugin to the same marketplace. |

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -2,9 +2,9 @@
 
 # Agents Reference
 
-*All 14 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain*
+*All 18 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain*
 
-[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-18-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)
@@ -14,7 +14,7 @@
 
 ---
 
-All 18 agents in claude-ops v2.0.0. Agent files live in `agents/`.
+All 18 agents in claude-ops v2.0.9. Agent files live in `agents/`.
 
 > [!NOTE]
 > v2.0 added four pre-installed specialists — `general-purpose` (override), `deploy-fixer`, `build-fixer`, `dependency-auditor`. These power the deploy auto-fix subsystem and are silently routed to via the PreToolUse:Agent hook. See [`agents.md`](agents.md) for the v2 specialist catalog and [`deploy-fix.md`](deploy-fix.md) for the auto-fix subsystem.

--- a/claude-ops/docs/agents.md
+++ b/claude-ops/docs/agents.md
@@ -4,7 +4,7 @@
 
 *Pre-installed subagent personas + the auto-suggestion hook that routes `general-purpose` calls to the right specialist.*
 
-[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-18-8b5cf6)](.)
 [![hook](https://img.shields.io/badge/PreToolUse-Agent-6366f1)](.)
 

--- a/claude-ops/docs/daemon-guide.md
+++ b/claude-ops/docs/daemon-guide.md
@@ -4,7 +4,7 @@
 
 *The unified background process manager that pre-warms briefings, syncs WhatsApp, extracts memories, and watches your fires — persistently, via launchd*
 
-[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
 
 > [!NOTE]
 > v2.0 introduces two **additional** daemons alongside the v1 ops-daemon documented here: the **recap-daemon** ([`recap.md`](recap.md)) and the **account-rotation daemon** ([`CHANGELOG.md`](../CHANGELOG.md#6-multi-account-claude-max-rotator)). The ops-daemon described below is unchanged in v2.

--- a/claude-ops/docs/deploy-fix.md
+++ b/claude-ops/docs/deploy-fix.md
@@ -4,7 +4,7 @@
 
 *Watches every `gh pr merge` and `npm run build:*` you run, verifies the deploy, and dispatches a Haiku fixer if anything fails.*
 
-[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
 [![hook](https://img.shields.io/badge/PostToolUse-Bash-6366f1)](.)
 [![model](https://img.shields.io/badge/fixer-haiku--default-22c55e)](.)
 

--- a/claude-ops/docs/marketplace-submissions.md
+++ b/claude-ops/docs/marketplace-submissions.md
@@ -4,7 +4,7 @@
 
 *Tracking where claude-ops is listed (or pending listing) across the Claude plugin ecosystem*
 
-[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
 [![destinations](https://img.shields.io/badge/destinations-4-6366f1)](.)
 [![status](https://img.shields.io/badge/status-in--progress-f59e0b)](.)
 

--- a/claude-ops/docs/memories-system.md
+++ b/claude-ops/docs/memories-system.md
@@ -4,7 +4,7 @@
 
 *Persistent local context about people, projects, and your communication patterns — extracted from your chats, stored as markdown, never sent anywhere*
 
-[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
 [![storage](https://img.shields.io/badge/storage-local%20markdown-22c55e)](.)
 [![privacy](https://img.shields.io/badge/privacy-on--device-6366f1)](.)
 [![extractor](https://img.shields.io/badge/extractor-haiku--4--5-f59e0b)](.)

--- a/claude-ops/docs/migrating-from-v1.md
+++ b/claude-ops/docs/migrating-from-v1.md
@@ -9,6 +9,8 @@
 
 </div>
 
+> **Latest stable: v2.0.9** — see [CHANGELOG.md](../CHANGELOG.md) for releases since v2.0.0.
+
 ---
 
 ## TL;DR

--- a/claude-ops/docs/recap.md
+++ b/claude-ops/docs/recap.md
@@ -4,7 +4,7 @@
 
 *One-line situational awareness across every parallel Claude Code session, surfaced in tmux `status-right` or the Claude Code `statusLine`.*
 
-[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
 [![daemon](https://img.shields.io/badge/runtime-launchd%20%2F%20systemd-6366f1)](.)
 [![cadence](https://img.shields.io/badge/refresh-30s-22c55e)](.)
 

--- a/claude-ops/docs/safety-hooks.md
+++ b/claude-ops/docs/safety-hooks.md
@@ -4,7 +4,7 @@
 
 *Three PreToolUse:Bash hooks that block the most common foot-guns: secrets in commits, `rm -rf` against anchor paths, and direct `git push` to `main`.*
 
-[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
 [![hook](https://img.shields.io/badge/PreToolUse-Bash-6366f1)](.)
 [![always-on](https://img.shields.io/badge/always--on-by%20design-ef4444)](.)
 

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -2,10 +2,10 @@
 
 # Skills Reference
 
-*All 33+ skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`)*
+*All 35 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack)*
 
-[![version](https://img.shields.io/badge/version-2.0.0-blue)](../CHANGELOG.md)
-[![skills](https://img.shields.io/badge/skills-33%2B-8b5cf6)](.)
+[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
+[![skills](https://img.shields.io/badge/skills-35-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)
 


### PR DESCRIPTION
## Summary

- 14 files updated: README, CHANGELOG, plugin.json, 10 docs badges, agents-reference subtitle, skills-reference subtitle, INDEX count
- Fixes CHANGELOG v2.0.9 body (was copy-pasted v2.0.8 Slack content; corrected to ops-ci current-state filter)
- Adds "What's new since v2.0.0" 5-line section to README
- Count drifts fixed: 30→35 skills, 14→18 agents everywhere (plugin.json, README, docs subtitles, badges)

## Test plan

- [x] `tests/test-no-secrets.sh` — 14 passed, 0 failed
- [x] `bash -n bin/ops-*` — clean
- [x] `node --check bin/*.mjs lib/*.mjs` — clean
- [x] `npx prettier --check` — all files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates plus minor metadata tweaks; no runtime code paths changed, so risk is low aside from potential release-note confusion if inaccurate.
> 
> **Overview**
> **Docs/metadata sync for `v2.0.9`.** Updates `README.md`, `CHANGELOG.md`, `plugin.json` description text, and multiple docs to consistently reflect `v2.0.9` (badges, “latest stable” note, and 35 skills / 18 agents counts).
> 
> **Release notes correction.** Fixes the `2.0.9` changelog section to describe the `ops-ci` current-state filtering change and the `ops-fires` pre-dispatch staleness check, and adds a short “What’s new since v2.0.0” section to the README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bd2cb7b1394211ec814efa818f44f0ae3a097ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->