### PR TITLE
chore(release): v2.1.0 — consolidate v2.0.5–v2.0.9 features as minor release

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.0.9",
+  "version": "2.1.0",
   "description": "Business operations command center for Claude Code — 35 skills, 18 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.0] — 2026-05-02
+
+Minor release — consolidates the feature work from the v2.0.5–v2.0.9 patch series into a single coherent version. No breaking changes; drop-in replacement for v2.0.x.
+
+### Added
+
+- **Multi-workspace Slack support** (was v2.0.9 / PR #195). Single ops install can now connect to multiple Slack workspaces simultaneously and route messages by workspace context. Adds `bin/ops-slack-workspaces` for inspection.
+- **`/ops:credentials` audit skill** (was v2.0.6 / PR #184). On-demand audit of which integration credentials are configured, expiring soon (<7d), or stale (>180d). Plugin.json `userConfig` now carries field hints so the audit can tell users which env var or vault key holds each credential.
+- **ops-ci current-state filter** (was v2.0.9 / PR #196). `bin/ops-ci` now emits ONLY workflows whose latest run on a tracked branch (main/dev/master) is currently failing — not "any failure in the last 24h". Eliminates the false-fire cascade in `/ops-fires` and `/ops-go` where stale failures triggered fix-agent dispatch on already-resolved CI. Smoke test on a real 38-repo portfolio: 14 → 6 entries (57% noise reduction). Behind `OPS_CI_MODE=current` default; `OPS_CI_MODE=legacy` reverts.
+- **MANDATORY pre-dispatch staleness check in ops-fires SKILL** (was v2.0.9 / PR #196). Defense-in-depth gate — `gh run list --workflow X --branch Y --limit 1` — before spawning any fix agent. Catches cache races where a fix landed in the seconds since the CI cache was written.
+- **Telegram preflight + keychain fallback** (was v2.0.7 / PR #185). SSE/user-config detection runs before Telegram MCP auth; macOS keychain is the fallback secret store when Doppler is unconfigured.
+- **userConfig schema upgrades** (was v2.0.5 / PR #182). `enum` values, `sensitive` flags, and per-integration toggles for fine-grained capability gating.
+
+### Fixed
+
+- userConfig `enum` rejection by Claude Code stable (was v2.0.8 / PR #190). Removed unsupported `enum` keys from `fix_model`, `max_fixes_per_hour`, `watcher_timeout_seconds`, `notify_channel`, `task_reminder_threshold`, `aws_region`, `doppler_config`. Field descriptions retain the valid value lists.
+- Cross-OS macOS keychain guard in `/ops:credentials` (was v2.0.6 hotfix).
+- Plugin.json Prettier formatting (was v2.0.5 hotfix).
+
+### Notes
+
+- Plugin v2.1.0 ships 35 skills, 18 agents.
+- Marketplace pin must be bumped to `2.1.0` — see follow-up PR.
+- Local plugin cache: clear old `ops/2.0.*` cache directories and re-install via marketplace refresh after merge.
+
 ## [2.0.9] — 2026-05-01
 
 ### Fixed

--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -1,14 +1,10 @@
 # claude-ops
 
-> **v2.0.9** — Autonomy Layer · Deploy Auto-Fix · Safety Hooks · Specialist Agents · Recap Marquee · Multi-Account Rotator · Multi-Workspace Slack · ops-ci Current-State Filter · Credentials Audit · 35 Skills · 18 Agents
+> **v2.1.0** — Autonomy Layer · Deploy Auto-Fix · Safety Hooks · Specialist Agents · Recap Marquee · Multi-Account Rotator · Multi-Workspace Slack · ops-ci Current-State Filter · Credentials Audit · 35 Skills · 18 Agents
 
 ## What's new since v2.0.0
 
-- **v2.0.9** — ops-ci current-state filter (57% noise reduction in `/ops:fires`); MANDATORY pre-dispatch staleness check in ops-fires SKILL
-- **v2.0.8** — multi-workspace Slack support; userConfig schema fixes
-- **v2.0.7** — Telegram keychain fallback + SSE/user-config preflight
-- **v2.0.6** — `/ops:credentials` audit skill + plugin.json field hints
-- **v2.0.5** — userConfig enums + per-integration toggles
+- **v2.1.0** — Minor release rolling up the v2.0.5–v2.0.9 feature series. Multi-workspace Slack, ops-ci current-state filter, `/ops:credentials` audit, telegram preflight, userConfig schema upgrades — see [CHANGELOG.md](CHANGELOG.md#210--2026-05-02) for the full list.
 
 A Claude Code plugin that turns Claude into a business operating system **and** an autonomy layer. Run `/ops` for the interactive command center — pixel-art dashboard with instant hotkey access to morning briefings, inbox, fires, deploys, revenue, and YOLO mode. Or just keep working — v2's hooks watch every merge, every build, every commit, every push, and every agent dispatch in the background.
 

--- a/claude-ops/docs/INDEX.md
+++ b/claude-ops/docs/INDEX.md
@@ -4,7 +4,7 @@
 
 *Top-level map of every doc file in `claude-ops/docs/`.*
 
-[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.1.0-blue)](../CHANGELOG.md)
 
 </div>
 

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 *All 18 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain*
 
-[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.1.0-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-18-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)
@@ -14,7 +14,7 @@
 
 ---
 
-All 18 agents in claude-ops v2.0.9. Agent files live in `agents/`.
+All 18 agents in claude-ops v2.1.0. Agent files live in `agents/`.
 
 > [!NOTE]
 > v2.0 added four pre-installed specialists — `general-purpose` (override), `deploy-fixer`, `build-fixer`, `dependency-auditor`. These power the deploy auto-fix subsystem and are silently routed to via the PreToolUse:Agent hook. See [`agents.md`](agents.md) for the v2 specialist catalog and [`deploy-fix.md`](deploy-fix.md) for the auto-fix subsystem.

--- a/claude-ops/docs/agents.md
+++ b/claude-ops/docs/agents.md
@@ -4,7 +4,7 @@
 
 *Pre-installed subagent personas + the auto-suggestion hook that routes `general-purpose` calls to the right specialist.*
 
-[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.1.0-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-18-8b5cf6)](.)
 [![hook](https://img.shields.io/badge/PreToolUse-Agent-6366f1)](.)
 

--- a/claude-ops/docs/daemon-guide.md
+++ b/claude-ops/docs/daemon-guide.md
@@ -4,7 +4,7 @@
 
 *The unified background process manager that pre-warms briefings, syncs WhatsApp, extracts memories, and watches your fires — persistently, via launchd*
 
-[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.1.0-blue)](../CHANGELOG.md)
 
 > [!NOTE]
 > v2.0 introduces two **additional** daemons alongside the v1 ops-daemon documented here: the **recap-daemon** ([`recap.md`](recap.md)) and the **account-rotation daemon** ([`CHANGELOG.md`](../CHANGELOG.md#6-multi-account-claude-max-rotator)). The ops-daemon described below is unchanged in v2.

--- a/claude-ops/docs/deploy-fix.md
+++ b/claude-ops/docs/deploy-fix.md
@@ -4,7 +4,7 @@
 
 *Watches every `gh pr merge` and `npm run build:*` you run, verifies the deploy, and dispatches a Haiku fixer if anything fails.*
 
-[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.1.0-blue)](../CHANGELOG.md)
 [![hook](https://img.shields.io/badge/PostToolUse-Bash-6366f1)](.)
 [![model](https://img.shields.io/badge/fixer-haiku--default-22c55e)](.)
 

--- a/claude-ops/docs/marketplace-submissions.md
+++ b/claude-ops/docs/marketplace-submissions.md
@@ -4,7 +4,7 @@
 
 *Tracking where claude-ops is listed (or pending listing) across the Claude plugin ecosystem*
 
-[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.1.0-blue)](../CHANGELOG.md)
 [![destinations](https://img.shields.io/badge/destinations-4-6366f1)](.)
 [![status](https://img.shields.io/badge/status-in--progress-f59e0b)](.)
 

--- a/claude-ops/docs/memories-system.md
+++ b/claude-ops/docs/memories-system.md
@@ -4,7 +4,7 @@
 
 *Persistent local context about people, projects, and your communication patterns — extracted from your chats, stored as markdown, never sent anywhere*
 
-[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.1.0-blue)](../CHANGELOG.md)
 [![storage](https://img.shields.io/badge/storage-local%20markdown-22c55e)](.)
 [![privacy](https://img.shields.io/badge/privacy-on--device-6366f1)](.)
 [![extractor](https://img.shields.io/badge/extractor-haiku--4--5-f59e0b)](.)

--- a/claude-ops/docs/migrating-from-v1.md
+++ b/claude-ops/docs/migrating-from-v1.md
@@ -9,7 +9,7 @@
 
 </div>
 
-> **Latest stable: v2.0.9** — see [CHANGELOG.md](../CHANGELOG.md) for releases since v2.0.0.
+> **Latest stable: v2.1.0** — see [CHANGELOG.md](../CHANGELOG.md) for releases since v2.0.0.
 
 ---
 

--- a/claude-ops/docs/recap.md
+++ b/claude-ops/docs/recap.md
@@ -4,7 +4,7 @@
 
 *One-line situational awareness across every parallel Claude Code session, surfaced in tmux `status-right` or the Claude Code `statusLine`.*
 
-[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.1.0-blue)](../CHANGELOG.md)
 [![daemon](https://img.shields.io/badge/runtime-launchd%20%2F%20systemd-6366f1)](.)
 [![cadence](https://img.shields.io/badge/refresh-30s-22c55e)](.)
 

--- a/claude-ops/docs/safety-hooks.md
+++ b/claude-ops/docs/safety-hooks.md
@@ -4,7 +4,7 @@
 
 *Three PreToolUse:Bash hooks that block the most common foot-guns: secrets in commits, `rm -rf` against anchor paths, and direct `git push` to `main`.*
 
-[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.1.0-blue)](../CHANGELOG.md)
 [![hook](https://img.shields.io/badge/PreToolUse-Bash-6366f1)](.)
 [![always-on](https://img.shields.io/badge/always--on-by%20design-ef4444)](.)
 

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 *All 35 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack)*
 
-[![version](https://img.shields.io/badge/version-2.0.9-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.1.0-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-35-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)


### PR DESCRIPTION
## Summary

Roll up the v2.0.5–v2.0.9 patch series into a single semver-correct minor release.

The patch series shipped real features (multi-workspace Slack #195, `/ops:credentials` audit #184, ops-ci current-state filter #196, telegram preflight #185, userConfig schema upgrades #182) that should have been a minor bump per semver. This PR retroactively does that without re-shipping any code.

## What changed

- `plugin.json`: 2.0.9 → 2.1.0
- `CHANGELOG.md`: new `[2.1.0] — 2026-05-02` entry with consolidated Added/Fixed/Notes
- `README.md`: header + "What's new" section refer to v2.1.0; replaced per-version bullets with a single rollup line + CHANGELOG link
- 11 `docs/*.md` badges: 2.0.9 → 2.1.0
- `docs/agents-reference.md` subtitle, `docs/migrating-from-v1.md` latest-stable note: bumped

No code changes. No breaking changes. Drop-in replacement for v2.0.x.

## Follow-up

- Bump `.claude-plugin/marketplace.json` ops plugin pin: 2.0.9 → 2.1.0 (separate PR per established pattern, see #192/#197)
- Tag `v2.1.0` + GitHub release after merge
- Clear local `~/.claude/plugins/cache/ops-marketplace/ops/2.0.*` and re-install

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/metadata-only release bump (versions, badges, and release notes) with no runtime code changes, so functional risk is minimal aside from packaging/version pinning drift.
> 
> **Overview**
> **Release metadata bump to `v2.1.0`.** Updates `plugin.json` version, adds a consolidated `2.1.0` entry to `CHANGELOG.md` summarizing the prior `v2.0.5–v2.0.9` patch features/fixes, and refreshes `README.md` plus docs badges/text to reference `2.1.0`.
> 
> No functional code changes are included; this PR is a semver-correct roll-up and documentation alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dca444350ffb8b02915377838314d5c4886506e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->