### PR TITLE
fix(marketplace): bump version to 2.1.0 to match plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 30 skills, 14 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.0.9",
+      "version": "2.1.0",
       "category": "productivity",
       "keywords": [
         "ops",


### PR DESCRIPTION
Pins marketplace ops plugin to v2.1.0 (released via PR #199 — minor release rolling up v2.0.5–v2.0.9 features as a single semver-correct version).

Same pattern as PR #192 and #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single metadata change pins the marketplace entry to a newer plugin version with no code or runtime logic changes.
> 
> **Overview**
> Updates `.claude-plugin/marketplace.json` to pin the `ops` marketplace plugin version from `2.0.9` to `2.1.0` so the marketplace metadata matches the released plugin version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d142c34741682e1773fe5f8d1692e35b3c1dad6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->