### PR TITLE
fix(ops-yolo): extract STATE.md walker to bin/ops-gsd-states for shell portability

### DIFF
--- a/claude-ops/bin/ops-gsd-states
+++ b/claude-ops/bin/ops-gsd-states
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# ops-gsd-states — Concatenate .planning/STATE.md from every GSD-tracked project
+#
+# Reads registry.json, walks each project flagged `gsd: true`, and prints any
+# STATE.md files it finds with a header and `---` separator so callers can grep
+# or read them as a single stream.
+#
+# Extracted from skills/ops-yolo/SKILL.md (used to be an inline `! ` shell
+# block) so it runs under bash explicitly. The previous inline form used
+# `${d/#\~/$HOME}` (a bash-only parameter expansion) and aborted under `sh`.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OPS_PLUGIN_ROOT_FALLBACK="${SCRIPT_DIR}/.." . "${SCRIPT_DIR}/../lib/registry-path.sh"
+
+if [ ! -f "$REGISTRY" ]; then
+  exit 0
+fi
+
+expand_path() { echo "${1/#\~/$HOME}"; }
+
+jq -r '.projects[] | select(.gsd == true) | .paths[]' "$REGISTRY" 2>/dev/null \
+| while IFS= read -r raw; do
+    [ -z "$raw" ] && continue
+    expanded=$(expand_path "$raw")
+    state="$expanded/.planning/STATE.md"
+    if [ -f "$state" ]; then
+      printf '=== %s ===\n' "$(basename "$expanded")"
+      cat "$state"
+      printf -- '---\n'
+    fi
+  done

--- a/claude-ops/skills/ops-yolo/SKILL.md
+++ b/claude-ops/skills/ops-yolo/SKILL.md
@@ -118,10 +118,7 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ops-external 2>/dev/null || echo '[]'
 ```
 
 ```!
-for d in $(jq -r '.projects[] | select(.gsd == true) | .paths[]' "${CLAUDE_PLUGIN_ROOT}/scripts/registry.json" 2>/dev/null); do
-  expanded="${d/#\~/$HOME}"
-  [ -f "$expanded/.planning/STATE.md" ] && echo "=== $(basename $expanded) ===" && cat "$expanded/.planning/STATE.md" && echo "---"
-done
+${CLAUDE_PLUGIN_ROOT}/bin/ops-gsd-states 2>/dev/null || true
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Phase 1 data-gathering in `skills/ops-yolo/SKILL.md` used a bash-only parameter expansion (`\${d/#\~/\$HOME}`) inside a `! ` inline shell block.
- When the host runs that block under `sh`/`dash`, the expansion is a syntax error and the block aborts — taking the rest of the YOLO session data-gathering with it. Repro: invoking `/ops:ops-yolo` returned \`Shell command failed for pattern \"\`\`\`!\\nfor d in \$(jq …)\"\` with no Phase 2 spawn.
- Fix: extract the loop to `bin/ops-gsd-states` with an explicit `#!/usr/bin/env bash` shebang. Same convention as every other Phase 1 block (each is already a thin shim around a bin script).

## Test plan
- [x] `bin/ops-gsd-states` runs standalone, returns STATE.md aggregation, exit 0
- [x] Output format unchanged: `=== <basename> ===` header + STATE.md body + `---` separator
- [x] No registry → silent exit 0 (matches old `2>/dev/null` swallow behavior)
- [ ] `/ops:ops-yolo` Phase 1 completes end-to-end after this lands

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: refactors an inline shell snippet into a standalone script with the same output format, primarily improving shell portability and failure behavior.
> 
> **Overview**
> Fixes `/ops:yolo` Phase 1 data gathering by replacing the inline `jq`/`for` loop (which used bash-only `~` expansion and could fail under `sh`) with a new `bin/ops-gsd-states` script that runs under `bash` and reuses `lib/registry-path.sh`.
> 
> The new script walks `gsd: true` projects from `registry.json`, concatenates any `.planning/STATE.md` files with the existing `=== name ===` header and `---` separator, and exits cleanly when the registry is missing; `skills/ops-yolo/SKILL.md` now calls this script instead of embedding the loop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9df11d6604403bb4dbab01ca1a40f212562a6972. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->