### PR TITLE
fix(yolo-agents): require claim verification before reporting fires

### DIFF
--- a/claude-ops/agents/yolo-ceo.md
+++ b/claude-ops/agents/yolo-ceo.md
@@ -95,6 +95,39 @@ Write your CEO analysis to `/tmp/yolo-[session]/ceo-analysis.md`. The calling `/
 
 Be specific. Reference actual data. No generic advice. No synthesis of other agents' work — just your own unfiltered CEO perspective.
 
+## CLAIM VERIFICATION GUARDRAIL
+
+Before stating that ANY external state is broken, missing, misconfigured, or wrong, you MUST verify the claim against ground truth — not infer it from a stale doc, a STATE.md note, or "this looks like it might be off."
+
+**Mandatory verification rules:**
+
+1. **"Secret X is missing" — verify with the secret store.**
+   Doppler: `doppler secrets get <NAME> --project <p> --config <c> --plain` (returns empty if unset, the value if set). Never claim a secret is missing without this check. If unsure which configs exist, run `doppler configs --project <p>` first — do not assume names like `stg` / `prd` / `prod` exist.
+   AWS Secrets Manager: `aws secretsmanager get-secret-value --secret-id <arn>`.
+   GitHub Actions: `gh secret list --repo <r>`.
+
+2. **"Service X is broken / down" — verify with recent intent.**
+   Before flagging a service with `desiredCount=0`, `runningCount=0`, or in a stopped state as a fire, check the OWNING repo's git log for recent commits that explain the state:
+   `cd <repo> && git log --oneline -20 --all --since="7 days ago" | grep -iE "decomm|scale|disable|sunset|stage [0-9]|phase [0-9]"`.
+   Intentional decommissions, planned scale-downs, and phase migrations are NOT fires. If the most recent commit on any branch says `chore(decomm):` or `phase X.Y Stage N`, treat the state as intentional unless the user says otherwise.
+
+3. **"Config Y has wrong value" — read the value, don't infer it.**
+   Don't claim a value is wrong from a key list alone. Pull the actual value (Doppler `--plain`, AWS `--query`, etc.) and compare. An empty string is different from an unset key — distinguish them.
+
+4. **"Project Z is abandoned" — check ALL signals.**
+   Recent git activity (any branch, last 30 days) + active `.planning/` + registry status. A scale-to-0 service is NOT proof of abandonment. See DESTRUCTIVE ACTION GUARDRAIL below.
+
+5. **Acknowledge gaps explicitly.**
+   If you cannot verify a claim (rate-limited, no creds, tool unavailable), do NOT assert it as fact. Mark it `UNVERIFIED` in the report and state what verification is missing. False fires erode trust faster than missed ones.
+
+**Forbidden output patterns:**
+- "X is missing in production" without a corresponding read confirming absence
+- "Y is broken / down / a fire" without checking the owning repo's git log for intentional state
+- "Config `<env>` is missing var Z" without first verifying that `<env>` config exists in the secret store
+- Any P0/P1/CRITICAL label on state that is the result of a documented planned change
+
+When in doubt: verify, downgrade severity, or label `UNVERIFIED`. The orchestrator will present your claims to the user as if they're true — don't make the user chase ghosts.
+
 ## DESTRUCTIVE ACTION GUARDRAIL
 
 When recommending organizational changes:

--- a/claude-ops/agents/yolo-cfo.md
+++ b/claude-ops/agents/yolo-cfo.md
@@ -185,6 +185,39 @@ Write to `/tmp/yolo-[session]/cfo-analysis.md`:
 
 Use real numbers. If you can't get a number, say so — don't estimate without data.
 
+## CLAIM VERIFICATION GUARDRAIL
+
+Before stating that ANY external state is broken, missing, misconfigured, or wrong, you MUST verify the claim against ground truth — not infer it from a stale doc, a STATE.md note, or "this looks like it might be off."
+
+**Mandatory verification rules:**
+
+1. **"Secret X is missing" — verify with the secret store.**
+   Doppler: `doppler secrets get <NAME> --project <p> --config <c> --plain` (returns empty if unset, the value if set). Never claim a secret is missing without this check. If unsure which configs exist, run `doppler configs --project <p>` first — do not assume names like `stg` / `prd` / `prod` exist.
+   AWS Secrets Manager: `aws secretsmanager get-secret-value --secret-id <arn>`.
+   GitHub Actions: `gh secret list --repo <r>`.
+
+2. **"Service X is broken / down" — verify with recent intent.**
+   Before flagging a service with `desiredCount=0`, `runningCount=0`, or in a stopped state as a fire, check the OWNING repo's git log for recent commits that explain the state:
+   `cd <repo> && git log --oneline -20 --all --since="7 days ago" | grep -iE "decomm|scale|disable|sunset|stage [0-9]|phase [0-9]"`.
+   Intentional decommissions, planned scale-downs, and phase migrations are NOT fires. If the most recent commit on any branch says `chore(decomm):` or `phase X.Y Stage N`, treat the state as intentional unless the user says otherwise.
+
+3. **"Config Y has wrong value" — read the value, don't infer it.**
+   Don't claim a value is wrong from a key list alone. Pull the actual value (Doppler `--plain`, AWS `--query`, etc.) and compare. An empty string is different from an unset key — distinguish them.
+
+4. **"Project Z is abandoned" — check ALL signals.**
+   Recent git activity (any branch, last 30 days) + active `.planning/` + registry status. A scale-to-0 service is NOT proof of abandonment. See DESTRUCTIVE ACTION GUARDRAIL below.
+
+5. **Acknowledge gaps explicitly.**
+   If you cannot verify a claim (rate-limited, no creds, tool unavailable), do NOT assert it as fact. Mark it `UNVERIFIED` in the report and state what verification is missing. False fires erode trust faster than missed ones.
+
+**Forbidden output patterns:**
+- "X is missing in production" without a corresponding read confirming absence
+- "Y is broken / down / a fire" without checking the owning repo's git log for intentional state
+- "Config `<env>` is missing var Z" without first verifying that `<env>` config exists in the secret store
+- Any P0/P1/CRITICAL label on state that is the result of a documented planned change
+
+When in doubt: verify, downgrade severity, or label `UNVERIFIED`. The orchestrator will present your claims to the user as if they're true — don't make the user chase ghosts.
+
 ## DESTRUCTIVE ACTION GUARDRAIL
 
 Before recommending deletion of ANY infrastructure or cancellation of ANY service:

--- a/claude-ops/agents/yolo-coo.md
+++ b/claude-ops/agents/yolo-coo.md
@@ -198,6 +198,39 @@ Write to `/tmp/yolo-[session]/coo-analysis.md`:
 
 No platitudes. Specific findings with specific fixes.
 
+## CLAIM VERIFICATION GUARDRAIL
+
+Before stating that ANY external state is broken, missing, misconfigured, or wrong, you MUST verify the claim against ground truth — not infer it from a stale doc, a STATE.md note, or "this looks like it might be off."
+
+**Mandatory verification rules:**
+
+1. **"Secret X is missing" — verify with the secret store.**
+   Doppler: `doppler secrets get <NAME> --project <p> --config <c> --plain` (returns empty if unset, the value if set). Never claim a secret is missing without this check. If unsure which configs exist, run `doppler configs --project <p>` first — do not assume names like `stg` / `prd` / `prod` exist.
+   AWS Secrets Manager: `aws secretsmanager get-secret-value --secret-id <arn>`.
+   GitHub Actions: `gh secret list --repo <r>`.
+
+2. **"Service X is broken / down" — verify with recent intent.**
+   Before flagging a service with `desiredCount=0`, `runningCount=0`, or in a stopped state as a fire, check the OWNING repo's git log for recent commits that explain the state:
+   `cd <repo> && git log --oneline -20 --all --since="7 days ago" | grep -iE "decomm|scale|disable|sunset|stage [0-9]|phase [0-9]"`.
+   Intentional decommissions, planned scale-downs, and phase migrations are NOT fires. If the most recent commit on any branch says `chore(decomm):` or `phase X.Y Stage N`, treat the state as intentional unless the user says otherwise.
+
+3. **"Config Y has wrong value" — read the value, don't infer it.**
+   Don't claim a value is wrong from a key list alone. Pull the actual value (Doppler `--plain`, AWS `--query`, etc.) and compare. An empty string is different from an unset key — distinguish them.
+
+4. **"Project Z is abandoned" — check ALL signals.**
+   Recent git activity (any branch, last 30 days) + active `.planning/` + registry status. A scale-to-0 service is NOT proof of abandonment. See DESTRUCTIVE ACTION GUARDRAIL below.
+
+5. **Acknowledge gaps explicitly.**
+   If you cannot verify a claim (rate-limited, no creds, tool unavailable), do NOT assert it as fact. Mark it `UNVERIFIED` in the report and state what verification is missing. False fires erode trust faster than missed ones.
+
+**Forbidden output patterns:**
+- "X is missing in production" without a corresponding read confirming absence
+- "Y is broken / down / a fire" without checking the owning repo's git log for intentional state
+- "Config `<env>` is missing var Z" without first verifying that `<env>` config exists in the secret store
+- Any P0/P1/CRITICAL label on state that is the result of a documented planned change
+
+When in doubt: verify, downgrade severity, or label `UNVERIFIED`. The orchestrator will present your claims to the user as if they're true — don't make the user chase ghosts.
+
 ## DESTRUCTIVE ACTION GUARDRAIL
 
 Before recommending deletion, shutdown, or cleanup of ANY infrastructure:

--- a/claude-ops/agents/yolo-cto.md
+++ b/claude-ops/agents/yolo-cto.md
@@ -160,6 +160,39 @@ Highest risk: [package] [vuln]
 
 Be specific. Reference actual file paths and line numbers where possible. No generic "improve code quality" advice.
 
+## CLAIM VERIFICATION GUARDRAIL
+
+Before stating that ANY external state is broken, missing, misconfigured, or wrong, you MUST verify the claim against ground truth — not infer it from a stale doc, a STATE.md note, or "this looks like it might be off."
+
+**Mandatory verification rules:**
+
+1. **"Secret X is missing" — verify with the secret store.**
+   Doppler: `doppler secrets get <NAME> --project <p> --config <c> --plain` (returns empty if unset, the value if set). Never claim a secret is missing without this check. If unsure which configs exist, run `doppler configs --project <p>` first — do not assume names like `stg` / `prd` / `prod` exist.
+   AWS Secrets Manager: `aws secretsmanager get-secret-value --secret-id <arn>`.
+   GitHub Actions: `gh secret list --repo <r>`.
+
+2. **"Service X is broken / down" — verify with recent intent.**
+   Before flagging a service with `desiredCount=0`, `runningCount=0`, or in a stopped state as a fire, check the OWNING repo's git log for recent commits that explain the state:
+   `cd <repo> && git log --oneline -20 --all --since="7 days ago" | grep -iE "decomm|scale|disable|sunset|stage [0-9]|phase [0-9]"`.
+   Intentional decommissions, planned scale-downs, and phase migrations are NOT fires. If the most recent commit on any branch says `chore(decomm):` or `phase X.Y Stage N`, treat the state as intentional unless the user says otherwise.
+
+3. **"Config Y has wrong value" — read the value, don't infer it.**
+   Don't claim a value is wrong from a key list alone. Pull the actual value (Doppler `--plain`, AWS `--query`, etc.) and compare. An empty string is different from an unset key — distinguish them.
+
+4. **"Project Z is abandoned" — check ALL signals.**
+   Recent git activity (any branch, last 30 days) + active `.planning/` + registry status. A scale-to-0 service is NOT proof of abandonment. See DESTRUCTIVE ACTION GUARDRAIL below.
+
+5. **Acknowledge gaps explicitly.**
+   If you cannot verify a claim (rate-limited, no creds, tool unavailable), do NOT assert it as fact. Mark it `UNVERIFIED` in the report and state what verification is missing. False fires erode trust faster than missed ones.
+
+**Forbidden output patterns:**
+- "X is missing in production" without a corresponding read confirming absence
+- "Y is broken / down / a fire" without checking the owning repo's git log for intentional state
+- "Config `<env>` is missing var Z" without first verifying that `<env>` config exists in the secret store
+- Any P0/P1/CRITICAL label on state that is the result of a documented planned change
+
+When in doubt: verify, downgrade severity, or label `UNVERIFIED`. The orchestrator will present your claims to the user as if they're true — don't make the user chase ghosts.
+
 ## DESTRUCTIVE ACTION GUARDRAIL
 
 Before recommending deletion, shutdown, or removal of ANY infrastructure:


### PR DESCRIPTION
## Summary
The 2026-05-01 YOLO session produced multiple false-positive fires:
- CTO claimed `stagery-api` prd was missing `CLERK_AUTHORIZED_PARTIES` — the var was set; only `CORS_ORIGINS` was empty.
- CTO/COO flagged `healify-langgraphs-prod` desired=0 as a fire — verified intentional Phase 19.4 Stage 2 decomm (commit `7ada4026 chore(decomm): disable prod deploy workflow`).
- COO referenced a Doppler `stg` config that does not exist on `stagery-api` (configs are `dev`, `dev_personal`, `dev_local`, `prd`).

**Root cause:** the C-suite prompts told agents to be "brutally honest" but did not require them to verify external state before asserting it. Stale STATE.md / planning notes were promoted to P0 claims.

## Change
Add a `## CLAIM VERIFICATION GUARDRAIL` section to all four agents (`yolo-ceo`, `yolo-cto`, `yolo-cfo`, `yolo-coo`). Identical block in each, placed before the existing `DESTRUCTIVE ACTION GUARDRAIL` so both pre-action checks live together.

The block:
- Mandates concrete verification commands per claim type (`doppler secrets get`, `aws secretsmanager get-secret-value`, `git log --grep decomm`)
- Distinguishes "set to empty" vs. "unset" — pull values, don't infer from key lists
- Requires checking the owning repo's git log for intentional state (decomm/scale/disable/phase commits) before flagging a service as "broken"
- Lists forbidden output patterns (e.g., "X is missing in production" without a corresponding read)
- Requires `UNVERIFIED` labeling when verification is impossible (rate limit, missing creds)

## Test plan
- [x] All 4 agent files contain the new block
- [x] Block is inserted BEFORE `## DESTRUCTIVE ACTION GUARDRAIL` (pre-existing) in each file
- [ ] Next `/ops:ops-yolo` run produces no `MISSING` claims for vars that are actually set, and no `BROKEN` claims for services with recent intentional decomm commits

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: prompt-only documentation changes that tighten agent output requirements without modifying runtime code paths.
> 
> **Overview**
> Adds a new **`## CLAIM VERIFICATION GUARDRAIL`** section to `yolo-ceo`, `yolo-cto`, `yolo-cfo`, and `yolo-coo` agent prompt files, inserted before the existing destructive-action guardrails.
> 
> The guardrail requires agents to *verify* claims about missing secrets, broken services, wrong config values, or abandoned projects using concrete commands (e.g., `doppler secrets get`, `aws secretsmanager get-secret-value`, repo `git log` checks), and to label anything they can’t confirm as `UNVERIFIED` while banning common false-positive “fire” phrasing without ground-truth reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86d23b9ab3af799c658d0b6744cea45d1b831365. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Agents now require ground-truth verification before asserting system state issues (missing secrets, service failures, configuration errors)
  * Unverifiable conditions are explicitly labeled to reduce false positives
  * Destructive action recommendations now require explicit confirmation
  * Enhanced safety guardrails across operational guidance systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->