### PR TITLE
release: 2.1.1 — YOLO Phase 1 abort fix + C-suite claim verification

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 30 skills, 14 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Business operations command center for Claude Code — 35 skills, 18 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.1] — 2026-05-02
+
+Patch release — `/ops:ops-yolo` reliability fixes. Restores Phase 1 data-gathering after a regression, and adds a verification guardrail to the C-suite agents so they stop reporting false fires.
+
+### Fixed
+
+- **`/ops:ops-yolo` Phase 1 silent abort** (PR #201). The inline `! ` shell block in `skills/ops-yolo/SKILL.md` used the bash-only parameter expansion `${d/#\~/$HOME}` for tilde substitution. Claude Code's `!` block executor runs under `sh`/`dash`, so the expansion was a syntax error and the GSD-state aggregation step silently aborted — taking the rest of YOLO data-gathering down with it. Extracted the loop to `bin/ops-gsd-states` with an explicit `#!/usr/bin/env bash` shebang. Same convention as every other Phase 1 block, which are all thin shims around `bin/` scripts. Output format unchanged: `=== <basename> ===` header + STATE.md body + `---` separator.
+
+### Changed
+
+- **YOLO C-suite agents now require claim verification** (PR #202). The 2026-05-01 YOLO session produced multiple false-positive fires: agents flagged `CLERK_AUTHORIZED_PARTIES` as missing on a stagery-api Doppler config that already had it set; flagged `healify-langgraphs-prod` desired=0 as a fire when the most recent commit was `chore(decomm): disable prod deploy workflow per phase 19.4 Stage 2`; and referenced a Doppler `stg` config that does not exist on stagery-api. Root cause: agent prompts told them to be "brutally honest" but did not require them to verify external state before asserting it. Stale STATE.md notes were promoted to P0 claims. Added a `## CLAIM VERIFICATION GUARDRAIL` section to all four agents (`yolo-ceo`, `yolo-cto`, `yolo-cfo`, `yolo-coo`). Identical block in each, placed before the existing `DESTRUCTIVE ACTION GUARDRAIL`. Mandates concrete verification commands per claim type (`doppler secrets get --plain`, `aws secretsmanager get-secret-value`, `git log --grep decomm`), distinguishes "set to empty" from "unset", and requires `UNVERIFIED` labeling when verification is impossible (rate limit, missing creds). Forbidden output patterns include "X is missing in production" without a corresponding read, and any P0/CRITICAL label on state that is the result of a documented planned change.
+
 ## [2.1.0] — 2026-05-02
 
 Minor release — consolidates the feature work from the v2.0.5–v2.0.9 patch series into a single coherent version. No breaking changes; drop-in replacement for v2.0.x.

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
## Summary
Patch release rolling up the two YOLO reliability fixes merged earlier tonight:

- **#201** — extract STATE.md walker to `bin/ops-gsd-states` for shell portability. Restores Phase 1 data-gathering after an inline shell block silently aborted under `sh`/`dash` on a bash-only `${d/#\~/\$HOME}` expansion.
- **#202** — add `CLAIM VERIFICATION GUARDRAIL` to all 4 YOLO C-suite agents (`yolo-{ceo,cto,cfo,coo}`). Stops false-positive fires from STATE.md pattern-matching by requiring concrete verification (`doppler secrets get --plain`, `git log --grep decomm`, etc.) before asserting state, and `UNVERIFIED` labeling when verification is impossible.

## Version bumps
- `claude-ops/.claude-plugin/plugin.json`: 2.1.0 → 2.1.1
- `.claude-plugin/marketplace.json`: 2.1.0 → 2.1.1
- `claude-ops/package.json` (bin): 1.7.0 → 1.7.1

## CHANGELOG
New `[2.1.1]` entry with details on both fixes and the real-world false-positive cases that motivated the verification rule (stagery `CLERK_AUTHORIZED_PARTIES` not actually missing, healify-langgraphs intentional Phase 19.4 Stage 2 decomm flagged as fire, non-existent stagery `stg` Doppler config referenced).

## Test plan
- [x] `bash tests/test-no-secrets.sh` — 14/14 passed
- [x] `bash -n bin/ops-gsd-states` — syntax clean
- [x] `bin/ops-gsd-states` standalone smoke — returns STATE.md aggregation, exit 0
- [x] All 3 version locations bumped (plugin.json, marketplace.json, package.json)
- [x] No breaking changes — drop-in replacement for 2.1.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only metadata/version and documentation updates; no runtime code changes are included in this diff, so functional risk is minimal aside from release/versioning correctness.
> 
> **Overview**
> Publishes patch release `2.1.1` by bumping the plugin version in `plugin.json` and the marketplace pin, and incrementing the bin package version to `1.7.1`.
> 
> Updates `CHANGELOG.md` with a new `2.1.1` entry describing `/ops:ops-yolo` reliability fixes (Phase 1 data-gathering abort fix and new C-suite claim-verification guardrail).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30427f878c242471ebfdff9a489590ac7be0a939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->