### PR TITLE
fix(ops-gsd-states): annotate SUBORDINATE projects so YOLO doesn't false-flag them

### DIFF
--- a/claude-ops/bin/ops-gsd-states
+++ b/claude-ops/bin/ops-gsd-states
@@ -5,6 +5,11 @@
 # STATE.md files it finds with a header and `---` separator so callers can grep
 # or read them as a single stream.
 #
+# Surfaces the `status:` field from each STATE.md frontmatter as a SUBORDINATE
+# annotation when it equals `subordinate_to_workspace`, so the YOLO C-suite
+# agents don't flag those projects as stalled (their tracking is intentionally
+# delegated to a workspace-level coordinator).
+#
 # Extracted from skills/ops-yolo/SKILL.md (used to be an inline `! ` shell
 # block) so it runs under bash explicitly. The previous inline form used
 # `${d/#\~/$HOME}` (a bash-only parameter expansion) and aborted under `sh`.
@@ -20,13 +25,39 @@ fi
 
 expand_path() { echo "${1/#\~/$HOME}"; }
 
+# Extract a top-level YAML frontmatter scalar (between leading --- and the
+# first closing ---). Strips quotes. Empty if the key is missing.
+frontmatter_value() {
+  local file="$1" key="$2"
+  awk -v k="$key" '
+    BEGIN { fm = 0 }
+    /^---[[:space:]]*$/ { fm++; if (fm == 2) exit; next }
+    fm == 1 {
+      idx = index($0, ":")
+      if (idx > 0) {
+        f = substr($0, 1, idx - 1)
+        v = substr($0, idx + 1)
+        sub(/^[[:space:]]+/, "", f); sub(/[[:space:]]+$/, "", f)
+        sub(/^[[:space:]]+/, "", v); sub(/[[:space:]]+$/, "", v)
+        gsub(/^"|"$/, "", v); gsub(/^'\''|'\''$/, "", v)
+        if (f == k) { print v; exit }
+      }
+    }
+  ' "$file"
+}
+
 jq -r '.projects[] | select(.gsd == true) | .paths[]' "$REGISTRY" 2>/dev/null \
 | while IFS= read -r raw; do
     [ -z "$raw" ] && continue
     expanded=$(expand_path "$raw")
     state="$expanded/.planning/STATE.md"
     if [ -f "$state" ]; then
-      printf '=== %s ===\n' "$(basename "$expanded")"
+      status=$(frontmatter_value "$state" "status" || true)
+      header="=== $(basename "$expanded") ==="
+      if [ "$status" = "subordinate_to_workspace" ]; then
+        header="$header [SUBORDINATE — tracking delegated to workspace; do NOT flag as stalled]"
+      fi
+      printf '%s\n' "$header"
       cat "$state"
       printf -- '---\n'
     fi


### PR DESCRIPTION
## Summary
When a GSD project's STATE.md frontmatter has `status: subordinate_to_workspace`, its phase tracking is intentionally delegated to a workspace-level coordinator. C-suite YOLO agents were treating these as independent and flagging them as 'stalled' when their phase progress was static — but the staticness is correct: the workspace owns the schedule.

Adds a header annotation `[SUBORDINATE — tracking delegated to workspace; do NOT flag as stalled]` so the C-suite agents have an inline short-circuit. Pairs with the CLAIM VERIFICATION GUARDRAIL from #202.

## Concrete case (2026-05-01 YOLO session)
COO claimed `healify-api v3.1 Phase 1 stalled 6d on closed PR #3217`. Reality: #3217 was intentionally closed and superseded by #3222 (merged 2026-04-25). The workspace-level STATE.md reflects this with `status: subordinate_to_workspace`; the YOLO scan would have surfaced that status if the script annotated it.

## Implementation
- Small awk frontmatter scalar parser
- Activates only on the literal value `subordinate_to_workspace`
- All other status values stay silent (no header noise for normal projects)
- Falls back cleanly if awk fails or the field is absent (no `set -e` regression)

## Test plan
- [x] Smoke test: `bin/ops-gsd-states | grep ===` correctly tags `healify-agentcore` (subordinate) but not active projects
- [x] No `set -euo pipefail` regression
- [ ] Next YOLO run produces no 'stalled' false positives for subordinate projects

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to a reporting script that only adjusts output formatting based on optional `STATE.md` frontmatter, with a `|| true` guard to avoid `set -e` failures.
> 
> **Overview**
> `ops-gsd-states` now parses YAML frontmatter in each project’s `.planning/STATE.md` to read the `status` field, and appends a **SUBORDINATE** annotation to the printed header when `status: subordinate_to_workspace`.
> 
> This adds a small `awk`-based `frontmatter_value` helper and keeps behavior unchanged for projects without that status (or when parsing fails), aside from the new header tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57a449a1c4232cb8d0adb8a9e7b9ae56930a8a95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->