### PR TITLE
release: 2.1.2 — SUBORDINATE annotation for ops-gsd-states

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 30 skills, 14 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Business operations command center for Claude Code — 35 skills, 18 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.2] — 2026-05-02
+
+Patch release — second pass on YOLO false-fire suppression. Adds an inline annotation so C-suite agents can short-circuit on projects whose tracking is intentionally delegated to a workspace-level coordinator.
+
+### Changed
+
+- **`bin/ops-gsd-states` annotates SUBORDINATE projects** (PR #204). When a GSD project's `.planning/STATE.md` frontmatter has `status: subordinate_to_workspace`, its phase tracking is intentionally delegated to a workspace-level coordinator (e.g. `healify-api` and `healify-agentcore` both delegate to `healify-workspace`). Prior to this fix, the C-suite YOLO agents treated these as independent projects and flagged them as "stalled" when their phase progress was static — but the staticness is correct: the workspace owns the schedule. Now the script appends `[SUBORDINATE — tracking delegated to workspace; do NOT flag as stalled]` to the project header, giving C-suite agents an inline short-circuit. Pairs with the CLAIM VERIFICATION GUARDRAIL shipped in 2.1.1. Concrete case from 2026-05-01 YOLO session: COO claimed `healify-api v3.1 Phase 1 stalled 6d on closed PR #3217`. Reality: PR #3217 was intentionally closed and superseded by #3222, which merged 2026-04-25. The workspace-level STATE.md correctly reflects this with `status: subordinate_to_workspace`; the YOLO scan would have surfaced that status if the script annotated it. Implementation uses a small awk frontmatter scalar parser; activates only on the literal value `subordinate_to_workspace`; all other status values stay silent.
+
 ## [2.1.1] — 2026-05-02
 
 Patch release — `/ops:ops-yolo` reliability fixes. Restores Phase 1 data-gathering after a regression, and adds a verification guardrail to the C-suite agents so they stop reporting false fires.

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Patch release rolling up #204. `bin/ops-gsd-states` now annotates `[SUBORDINATE — tracking delegated to workspace; do NOT flag as stalled]` for projects with `status: subordinate_to_workspace` in STATE.md frontmatter, so C-suite YOLO agents stop false-flagging delegated projects as stalled. Bumps: plugin.json 2.1.1→2.1.2, marketplace.json 2.1.1→2.1.2, package.json 1.7.1→1.7.2. No breaking changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk patch: small change to `bin/ops-gsd-states` output formatting plus version/changelog bumps; main risk is downstream consumers relying on the exact header string.
> 
> **Overview**
> Bumps the `ops` plugin release to `2.1.2` (and `claude-ops-bin` to `1.7.2`) across `marketplace.json`, `plugin.json`, and `package.json`, and documents the release in `CHANGELOG.md`.
> 
> Updates `bin/ops-gsd-states` to detect `status: subordinate_to_workspace` in `.planning/STATE.md` frontmatter and append a `[SUBORDINATE — tracking delegated to workspace; do NOT flag as stalled]` annotation to the project header so YOLO C-suite agents can ignore delegated projects during stall detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58a64f89a73a88bffcf85e4817d6d1bb849d4710. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->