### PR TITLE
fix(ops): preferences-aware ops-external + ops-marketing-dash, wired into dash/go/yolo (v2.1.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 30 skills, 14 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Business operations command center for Claude Code — 35 skills, 18 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.3] — 2026-05-03
+
+Patch release — `bin/ops-external` and `bin/ops-marketing-dash` are now preferences-aware and surface real Shopify, Klaviyo, Meta, Instagram, and GSC data per project. `/ops:ops-yolo` always archives prior session reports to force a fresh-state run.
+
+### Fixed
+
+- **`bin/ops-external` now reads `preferences.json`** (Shopify stores in `.ecom.projects` and `.partner_registry.shopify_admin.stores`, marketing channels in `.marketing.projects`, `.integrations`) instead of returning `[]` when only `registry.json` is empty. Resolves credential references using a shared grammar (`env:VAR` / `doppler:project/config/SECRET` / inline). Probes Shopify Admin API for live `healthy / auth_expired / not_found / unreachable` status. Adds `-g` (globoff) to all curl calls so bracketed query params (`fields[shop]=…`) don't get mangled. Guards against the BSD `seq 0 -1` quirk that previously emitted spurious `alias: null` entries when the registry selection was empty.
+- **`bin/ops-marketing-dash` is now project-aware**. Reads `marketing.default_project` from `preferences.json` (overridable via `--project <name>` arg or `OPS_MARKETING_PROJECT` env). Resolves nested cred refs (`env:AB_KLAVIYO_TOKEN`, `doppler:hueman/prd/BRIGHT_KLAVIYO_TOKEN`, etc.) before falling back to the legacy flat env / `claude plugin config get` / bare-Doppler chain. Adds `-g` and `--max-time 5` to every curl. Output now includes a `project` field so downstream surfaces know which project's data they're seeing.
+
+### Added
+
+- **`bin/ops-dash` surfaces marketing health + Shopify count** in the header status block (`marketing N/100 Status (project) | shopify N/N`), backgrounded against the existing probes so render time is unchanged.
+- **`/ops:ops-go` Phase-1 pre-gather** now invokes `ops-marketing-dash` so the briefing's MARKETING section actually has data instead of falling through to `(marketing not configured)`.
+- **`/ops:ops-yolo` Phase 0** archives any prior `/tmp/yolo-*/` to `~/.claude/yolo-archive/<session>-<epoch>/` and allocates a fresh `SESSION_DIR` on every run. C-suite agent prompts now include a verbatim "fresh-state" directive forbidding reuse of cached reports. `ops-marketing-dash` added to Phase-1 data.
+
 ## [2.1.2] — 2026-05-02
 
 Patch release — second pass on YOLO false-fire suppression. Adds an inline annotation so C-suite agents can short-circuit on projects whose tracking is intentionally delegated to a workspace-level coordinator.

--- a/claude-ops/bin/ops-dash
+++ b/claude-ops/bin/ops-dash
@@ -81,6 +81,12 @@ trap 'rm -rf "$TMPDIR_DASH"' EXIT
   echo "${LATEST_YOLO:-none}" > "$TMPDIR_DASH/yolo"
 ) &
 
+(
+  # Marketing health (live, project-aware) + external/Shopify surface
+  "$PLUGIN_ROOT/bin/ops-marketing-dash" 2>/dev/null > "$TMPDIR_DASH/marketing.json" || echo '{}' > "$TMPDIR_DASH/marketing.json"
+  "$PLUGIN_ROOT/bin/ops-external"       2>/dev/null > "$TMPDIR_DASH/external.json"  || echo '[]' > "$TMPDIR_DASH/external.json"
+) &
+
 wait
 
 # --- Read results ---
@@ -90,6 +96,13 @@ PRS=$(cat "$TMPDIR_DASH/prs" 2>/dev/null || echo "?")
 CI_FAILS=$(cat "$TMPDIR_DASH/ci_fails" 2>/dev/null || echo "?")
 GSD_ACTIVE=$(cat "$TMPDIR_DASH/gsd" 2>/dev/null || echo "?")
 LATEST_YOLO=$(cat "$TMPDIR_DASH/yolo" 2>/dev/null || echo "none")
+MARKETING_JSON=$(cat "$TMPDIR_DASH/marketing.json" 2>/dev/null || echo '{}')
+EXTERNAL_JSON=$(cat "$TMPDIR_DASH/external.json"   2>/dev/null || echo '[]')
+MK_HEALTH=$(echo "$MARKETING_JSON" | jq -r '.health_score // "?"' 2>/dev/null || echo "?")
+MK_STATUS=$(echo "$MARKETING_JSON" | jq -r '.health_status // "n/a"' 2>/dev/null || echo "n/a")
+MK_PROJECT=$(echo "$MARKETING_JSON" | jq -r '.project // ""' 2>/dev/null || echo "")
+SHOPIFY_HEALTHY=$(echo "$EXTERNAL_JSON" | jq -r '[.[] | select(.source=="shopify_admin" and .status=="healthy")] | length' 2>/dev/null || echo "0")
+SHOPIFY_TOTAL=$(echo "$EXTERNAL_JSON"   | jq -r '[.[] | select(.source | startswith("shopify"))] | length' 2>/dev/null || echo "0")
 
 # Unread parsing
 UNREAD_JSON=$(cat "$TMPDIR_DASH/unread.json" 2>/dev/null || echo '{}')
@@ -135,6 +148,7 @@ sp "${DIM}${CYN}  ╠═══════════════════�
 sp "${DIM}${CYN}  ║${RST}                                                              ${DIM}${CYN}║${RST}"
 sp "${DIM}${CYN}  ║${RST}   ${FIRE_ICON} ${BWHT}STATUS${RST}  ${FIRE_STATUS}    ${DIM}|${RST}  ${BWHT}${TOTAL_UNREAD}${RST} unread  ${DIM}|${RST}  ${BWHT}${PRS}${RST} PRs    ${DIM}${CYN}║${RST}"
 sp "${DIM}${CYN}  ║${RST}   ${DIM}  ${PROJECTS} projects${RST}  ${DIM}|${RST}  ${DIM}${GSD_ACTIVE} GSD active${RST}  ${DIM}|${RST}  ${DIM}${CLUSTERS} clusters${RST}   ${DIM}${CYN}║${RST}"
+sp "${DIM}${CYN}  ║${RST}   ${DIM}  marketing ${MK_HEALTH}/100 ${MK_STATUS}${MK_PROJECT:+ (${MK_PROJECT})}  ${DIM}|${RST}  ${DIM}shopify ${SHOPIFY_HEALTHY}/${SHOPIFY_TOTAL}${RST}   ${DIM}${CYN}║${RST}"
 sp "${DIM}${CYN}  ║${RST}                                                              ${DIM}${CYN}║${RST}"
 sp "${DIM}${CYN}  ╠══════════════════════════════════════════════════════════════╣${RST}"
 sp "${DIM}${CYN}  ║${RST}                                                              ${DIM}${CYN}║${RST}"

--- a/claude-ops/bin/ops-external
+++ b/claude-ops/bin/ops-external
@@ -1,151 +1,274 @@
 #!/usr/bin/env bash
 # ops-external — Health status for non-git (external) projects → JSON
-# Checks Shopify stores, Linear teams, Slack workspaces, Notion, custom endpoints
-# Reads from registry.json, outputs compact JSON for skill injection
+# Reads from TWO sources, merged + deduped:
+#   1. preferences.json — .ecom.projects.<alias>.{shopify,shipbob,...}
+#                       — .partner_registry.shopify_admin.stores.<alias>
+#                       — .partner_registry.{klaviyo,revenuecat,...}
+#                       — .marketing.projects.<alias>.<channel>  (declared but not probed here)
+#   2. registry.json    — legacy .projects[] entries with type/source markers
+#
+# Emits a JSON array; each entry: {alias, source, status, details, ...}.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 OPS_PLUGIN_ROOT_FALLBACK="${SCRIPT_DIR}/.." . "${SCRIPT_DIR}/../lib/registry-path.sh"
-
-if [ ! -f "$REGISTRY" ]; then
-  echo '[]' && exit 0
-fi
-
-# Extract external projects (type=external or source is set without paths/repos)
-EXTERNAL=$(jq -c '[.projects[] | select(.type == "external" or (.source != null and .source != "git"))]' "$REGISTRY" 2>/dev/null)
-
-if [ "$EXTERNAL" = "[]" ] || [ -z "$EXTERNAL" ]; then
-  echo '[]' && exit 0
-fi
+PREFS="${OPS_DATA_DIR}/preferences.json"
 
 TMPDIR_OPS=$(mktemp -d)
 trap 'rm -rf "$TMPDIR_OPS"' EXIT
 
-COUNT=$(echo "$EXTERNAL" | jq 'length')
+# Resolve a cred reference. Same grammar as ops-marketing-dash.
+#   env:VAR | doppler:project/config/SECRET | inline literal
+resolve_cred() {
+  local ref="${1:-}"
+  [ -z "$ref" ] || [ "$ref" = "null" ] && return 0
+  case "$ref" in
+    env:*)
+      local var="${ref#env:}"
+      printf '%s' "${!var:-}"
+      ;;
+    doppler:*)
+      local path="${ref#doppler:}"
+      local proj="${path%%/*}"
+      local rest="${path#*/}"
+      local cfg="${rest%%/*}"
+      local secret="${rest#*/}"
+      [ -z "$proj" ] || [ -z "$cfg" ] || [ -z "$secret" ] && return 0
+      doppler secrets get "$secret" --project "$proj" --config "$cfg" --plain 2>/dev/null || true
+      ;;
+    *)
+      printf '%s' "$ref"
+      ;;
+  esac
+}
 
-for i in $(seq 0 $((COUNT - 1))); do
-  PROJECT=$(echo "$EXTERNAL" | jq -c ".[$i]")
-  ALIAS=$(echo "$PROJECT" | jq -r '.alias')
-  SOURCE=$(echo "$PROJECT" | jq -r '.source // "unknown"')
-
-  (
-    STATUS="unknown"
-    DETAILS="{}"
-
-    case "$SOURCE" in
-      shopify)
-        STORE_URL=$(echo "$PROJECT" | jq -r '.shopify.store_url // empty')
-        CRED_KEY=$(echo "$PROJECT" | jq -r '.shopify.credential_key // "SHOPIFY_TOKEN"')
-        TOKEN="${!CRED_KEY:-}"
-
-        if [ -n "$TOKEN" ] && [ -n "$STORE_URL" ]; then
-          RESP=$(curl -s -w "\n%{http_code}" \
-            -H "X-Shopify-Access-Token: $TOKEN" \
-            "https://$STORE_URL/admin/api/2024-10/shop.json" 2>/dev/null || echo -e "\n000")
-          HTTP_CODE=$(echo "$RESP" | tail -1)
-          BODY=$(echo "$RESP" | sed '$d')
-
-          if [ "$HTTP_CODE" = "200" ]; then
-            STATUS="healthy"
-            SHOP_NAME=$(echo "$BODY" | jq -r '.shop.name // "unknown"' 2>/dev/null)
-            PLAN=$(echo "$BODY" | jq -r '.shop.plan_name // "unknown"' 2>/dev/null)
-            DETAILS=$(jq -n --arg n "$SHOP_NAME" --arg p "$PLAN" '{shop_name:$n,plan:$p}')
-          elif [ "$HTTP_CODE" = "401" ]; then
-            STATUS="auth_expired"
-          else
-            STATUS="unreachable"
-          fi
-        else
-          STATUS="not_configured"
-        fi
-        ;;
-
-      linear)
-        TEAM_KEY=$(echo "$PROJECT" | jq -r '.linear.team_key // empty')
-        LINEAR_KEY="${LINEAR_API_KEY:-}"
-
-        if [ -n "$LINEAR_KEY" ] && [ -n "$TEAM_KEY" ]; then
-          RESP=$(curl -s -w "\n%{http_code}" -X POST \
-            -H "Authorization: $LINEAR_KEY" \
-            -H "Content-Type: application/json" \
-            -d "{\"query\":\"{ team(id: \\\"$TEAM_KEY\\\") { name issueCount } }\"}" \
-            "https://api.linear.app/graphql" 2>/dev/null || echo -e "\n000")
-          HTTP_CODE=$(echo "$RESP" | tail -1)
-          BODY=$(echo "$RESP" | sed '$d')
-
-          if [ "$HTTP_CODE" = "200" ]; then
-            ERRORS=$(echo "$BODY" | jq '.errors' 2>/dev/null)
-            if [ "$ERRORS" = "null" ] || [ -z "$ERRORS" ]; then
-              STATUS="healthy"
-              TEAM_NAME=$(echo "$BODY" | jq -r '.data.team.name // "unknown"' 2>/dev/null)
-              ISSUES=$(echo "$BODY" | jq -r '.data.team.issueCount // 0' 2>/dev/null)
-              DETAILS=$(jq -n --arg n "$TEAM_NAME" --arg c "$ISSUES" '{team_name:$n,issue_count:($c|tonumber)}')
-            else
-              STATUS="error"
-            fi
-          else
-            STATUS="unreachable"
-          fi
-        else
-          STATUS="not_configured"
-        fi
-        ;;
-
-      slack)
-        # Slack health is checked via MCP — just mark as discovered
-        WORKSPACE=$(echo "$PROJECT" | jq -r '.slack.workspace // "unknown"')
-        STATUS="discovered"
-        DETAILS=$(jq -n --arg w "$WORKSPACE" '{workspace:$w,note:"use Slack MCP for details"}')
-        ;;
-
-      notion)
-        # Notion health is checked via MCP — just mark as discovered
-        WORKSPACE=$(echo "$PROJECT" | jq -r '.notion.workspace // "unknown"')
-        STATUS="discovered"
-        DETAILS=$(jq -n --arg w "$WORKSPACE" '{workspace:$w,note:"use Notion MCP for details"}')
-        ;;
-
-      custom)
-        HEALTH_URL=$(echo "$PROJECT" | jq -r '.custom.health_endpoint // empty')
-        CRED_KEY=$(echo "$PROJECT" | jq -r '.custom.credential_key // empty')
-        TOKEN="${CRED_KEY:+${!CRED_KEY:-}}"
-
-        if [ -n "$HEALTH_URL" ]; then
-          AUTH_HEADER=""
-          [ -n "$TOKEN" ] && AUTH_HEADER="-H \"Authorization: Bearer $TOKEN\""
-          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" $AUTH_HEADER "$HEALTH_URL" 2>/dev/null || echo "000")
-
-          if [ "$HTTP_CODE" = "200" ]; then
-            STATUS="healthy"
-          elif [ "$HTTP_CODE" = "401" ] || [ "$HTTP_CODE" = "403" ]; then
-            STATUS="auth_expired"
-          else
-            STATUS="degraded"
-          fi
-          DETAILS=$(jq -n --arg u "$HEALTH_URL" --arg c "$HTTP_CODE" '{health_url:$u,http_status:$c}')
-        else
-          STATUS="not_configured"
-        fi
-        ;;
-
-      *)
-        STATUS="unknown_source"
-        ;;
+# Probe a Shopify Admin API store. Echoes a JSON entry to stdout.
+#   $1 alias  $2 store_url  $3 token  $4 origin (preferences|partner_registry|registry)
+probe_shopify_admin() {
+  local alias="$1" store="$2" token="$3" origin="$4"
+  local status="unknown" shop_name="" plan=""
+  if [ -n "$token" ] && [ -n "$store" ]; then
+    local resp http body
+    resp=$(curl -gsS --max-time 5 -w "\n%{http_code}" \
+      -H "X-Shopify-Access-Token: $token" \
+      "https://${store}/admin/api/2024-10/shop.json" 2>/dev/null || echo -e "\n000")
+    http=$(echo "$resp" | tail -1)
+    body=$(echo "$resp" | sed '$d')
+    case "$http" in
+      200)  status="healthy"
+            shop_name=$(echo "$body" | jq -r '.shop.name // ""' 2>/dev/null || echo "")
+            plan=$(echo "$body"      | jq -r '.shop.plan_name // ""' 2>/dev/null || echo "") ;;
+      401)  status="auth_expired" ;;
+      404)  status="not_found" ;;
+      000)  status="unreachable" ;;
+      *)    status="degraded_http_${http}" ;;
     esac
+  else
+    status="not_configured"
+  fi
+  jq -n --arg a "$alias" --arg s "shopify_admin" --arg st "$status" \
+        --arg store "$store" --arg name "$shop_name" --arg plan "$plan" --arg o "$origin" \
+        '{alias:$a, source:$s, status:$st, origin:$o,
+          details:{store_url:$store, shop_name:$name, plan:$plan}}' \
+    > "$TMPDIR_OPS/shopify-${alias}.json"
+}
 
-    REVENUE_STAGE=$(echo "$PROJECT" | jq -r '.revenue.stage // "unknown"')
-    REVENUE_MODEL=$(echo "$PROJECT" | jq -r '.revenue.model // "unknown"')
-    PRIORITY=$(echo "$PROJECT" | jq -r '.priority // 99')
+# Probe Shopify Partner API token (used for app developers, not merchants).
+probe_shopify_partner() {
+  local alias="$1" token="$2" origin="$3"
+  local status="unknown"
+  if [ -n "$token" ]; then
+    # Cheap reachability probe: token presence is the signal; full Partner API
+    # GraphQL needs an org_id which varies by app. Mark as configured if non-empty.
+    status="configured"
+  else
+    status="not_configured"
+  fi
+  jq -n --arg a "$alias" --arg s "shopify_partner" --arg st "$status" --arg o "$origin" \
+        '{alias:$a, source:$s, status:$st, origin:$o,
+          details:{type:"partner_app", note:"Token presence verified; full Partner API probe requires org_id."}}' \
+    > "$TMPDIR_OPS/shopify-partner-${alias}.json"
+}
 
-    jq -n \
-      --arg a "$ALIAS" --arg s "$SOURCE" --arg st "$STATUS" \
-      --arg rs "$REVENUE_STAGE" --arg rm "$REVENUE_MODEL" --arg p "$PRIORITY" \
-      --argjson d "$DETAILS" \
-      '{alias:$a,source:$s,status:$st,revenue_stage:$rs,revenue_model:$rm,priority:($p|tonumber),details:$d}' \
-      > "$TMPDIR_OPS/$ALIAS.json"
-  ) &
-done
+# --- 1. preferences.json: Shopify stores in .ecom.projects ---
+if [ -f "$PREFS" ]; then
+  ECOM_ALIASES=$(jq -r '.ecom.projects // {} | keys[]' "$PREFS" 2>/dev/null || true)
+  for alias in $ECOM_ALIASES; do
+    SHOP=$(jq -c --arg a "$alias" '.ecom.projects[$a].shopify // empty' "$PREFS" 2>/dev/null || true)
+    [ -z "$SHOP" ] || [ "$SHOP" = "null" ] && continue
+
+    TYPE=$(echo "$SHOP" | jq -r '.type // "merchant"')
+    if [ "$TYPE" = "partner_app" ]; then
+      DOPPLER_KEY=$(echo "$SHOP" | jq -r '.partner_api_token_doppler_key // empty')
+      DOPPLER_PROJ=$(echo "$SHOP" | jq -r '.partner_api_token_project // empty')
+      TOKEN=""
+      if [ -n "$DOPPLER_KEY" ] && [ -n "$DOPPLER_PROJ" ]; then
+        PROJ="${DOPPLER_PROJ%%/*}"; CFG="${DOPPLER_PROJ#*/}"
+        TOKEN=$(doppler secrets get "$DOPPLER_KEY" --project "$PROJ" --config "$CFG" --plain 2>/dev/null || true)
+      fi
+      ( probe_shopify_partner "$alias" "$TOKEN" "preferences.ecom" ) &
+    else
+      STORE_REF=$(echo "$SHOP" | jq -r '.store_url // empty')
+      TOKEN_REF=$(echo "$SHOP" | jq -r '.admin_token // empty')
+      STORE=$(resolve_cred "$STORE_REF")
+      TOKEN=$(resolve_cred "$TOKEN_REF")
+      ( probe_shopify_admin "$alias" "$STORE" "$TOKEN" "preferences.ecom" ) &
+    fi
+  done
+
+  # --- 2. preferences.json: partner_registry.shopify_admin.stores ---
+  PR_ALIASES=$(jq -r '.partner_registry.shopify_admin.stores // {} | keys[]' "$PREFS" 2>/dev/null || true)
+  for alias in $PR_ALIASES; do
+    # Skip if we already emitted this alias from .ecom.projects
+    [ -f "$TMPDIR_OPS/shopify-${alias}.json" ] && continue
+    [ -f "$TMPDIR_OPS/shopify-partner-${alias}.json" ] && continue
+
+    STORE_INFO=$(jq -c --arg a "$alias" '.partner_registry.shopify_admin.stores[$a]' "$PREFS")
+    TYPE=$(echo "$STORE_INFO" | jq -r '.type // "merchant"')
+    DOPPLER_KEY=$(echo "$STORE_INFO" | jq -r '.doppler_key // empty')
+    DOPPLER_PROJ=$(echo "$STORE_INFO" | jq -r '.doppler_project // empty')
+    STORE=$(echo "$STORE_INFO" | jq -r '.store // empty')
+
+    if [ "$TYPE" = "partner_app" ]; then
+      TOKEN=""
+      if [ -n "$DOPPLER_KEY" ] && [ -n "$DOPPLER_PROJ" ]; then
+        PROJ="${DOPPLER_PROJ%%/*}"; CFG="${DOPPLER_PROJ#*/}"
+        TOKEN=$(doppler secrets get "$DOPPLER_KEY" --project "$PROJ" --config "$CFG" --plain 2>/dev/null || true)
+      fi
+      ( probe_shopify_partner "$alias" "$TOKEN" "preferences.partner_registry" ) &
+    else
+      TOKEN=""
+      if [ -n "$DOPPLER_KEY" ]; then
+        # Single-segment doppler key — try $alias/prd as the canonical path
+        TOKEN=$(doppler secrets get "$DOPPLER_KEY" --project "${alias}" --config "prd" --plain 2>/dev/null || true)
+      fi
+      ( probe_shopify_admin "$alias" "$STORE" "$TOKEN" "preferences.partner_registry" ) &
+    fi
+  done
+
+  # --- 3. preferences.json: marketing.projects (declared channels per project) ---
+  MARKETING_ALIASES=$(jq -r '.marketing.projects // {} | keys[]' "$PREFS" 2>/dev/null || true)
+  for alias in $MARKETING_ALIASES; do
+    CHANNELS=$(jq -r --arg a "$alias" \
+      '.marketing.projects[$a] | to_entries | map(select(.value | type == "object" and ([.[] | select(. != null and . != {})] | length) > 0)) | .[].key' \
+      "$PREFS" 2>/dev/null | sort -u | tr '\n' ',' | sed 's/,$//')
+    [ -z "$CHANNELS" ] && continue
+    jq -n --arg a "$alias" --arg c "$CHANNELS" \
+      '{alias:$a, source:"marketing", status:"declared", origin:"preferences.marketing",
+        details:{channels:($c | split(","))}}' \
+      > "$TMPDIR_OPS/marketing-${alias}.json" &
+  done
+
+  # --- 4. preferences.json: integrations (RevenueCat etc.) ---
+  jq -r '.integrations // {} | to_entries[] | "\(.key)\t\(.value.status // "unknown")"' "$PREFS" 2>/dev/null \
+  | while IFS=$'\t' read -r name status; do
+    [ -z "$name" ] && continue
+    jq -n --arg a "$name" --arg s "integration" --arg st "$status" \
+      '{alias:$a, source:$s, status:$st, origin:"preferences.integrations", details:{}}' \
+      > "$TMPDIR_OPS/integration-${name}.json" &
+  done
+fi
+
+# --- 5. registry.json: legacy external entries (Linear teams, Slack, custom endpoints) ---
+if [ -f "$REGISTRY" ]; then
+  EXTERNAL=$(jq -c '[.projects[]? | select(.type == "external" or (.source != null and .source != "git"))]' "$REGISTRY" 2>/dev/null || echo '[]')
+  COUNT=$(echo "$EXTERNAL" | jq 'length')
+  # BSD `seq 0 -1` counts down (prints 0\n-1) — guard explicitly when COUNT==0.
+  if [ "$COUNT" -gt 0 ]; then
+   for i in $(seq 0 $((COUNT - 1))); do
+    PROJECT=$(echo "$EXTERNAL" | jq -c ".[$i]")
+    ALIAS=$(echo "$PROJECT" | jq -r '.alias')
+    SOURCE=$(echo "$PROJECT" | jq -r '.source // "unknown"')
+
+    # Skip Shopify duplicates already covered by preferences.
+    if [ "$SOURCE" = "shopify" ] && \
+       { [ -f "$TMPDIR_OPS/shopify-${ALIAS}.json" ] || [ -f "$TMPDIR_OPS/shopify-partner-${ALIAS}.json" ]; }; then
+      continue
+    fi
+
+    (
+      STATUS="unknown"
+      DETAILS="{}"
+
+      case "$SOURCE" in
+        shopify)
+          STORE_URL=$(echo "$PROJECT" | jq -r '.shopify.store_url // empty')
+          CRED_KEY=$(echo "$PROJECT" | jq -r '.shopify.credential_key // "SHOPIFY_TOKEN"')
+          TOKEN="${!CRED_KEY:-}"
+          probe_shopify_admin "$ALIAS" "$STORE_URL" "$TOKEN" "registry"
+          continue
+          ;;
+
+        linear)
+          TEAM_KEY=$(echo "$PROJECT" | jq -r '.linear.team_key // empty')
+          LINEAR_KEY="${LINEAR_API_KEY:-}"
+          if [ -n "$LINEAR_KEY" ] && [ -n "$TEAM_KEY" ]; then
+            RESP=$(curl -gsS --max-time 5 -w "\n%{http_code}" -X POST \
+              -H "Authorization: $LINEAR_KEY" \
+              -H "Content-Type: application/json" \
+              -d "{\"query\":\"{ team(id: \\\"$TEAM_KEY\\\") { name issueCount } }\"}" \
+              "https://api.linear.app/graphql" 2>/dev/null || echo -e "\n000")
+            HTTP_CODE=$(echo "$RESP" | tail -1); BODY=$(echo "$RESP" | sed '$d')
+            if [ "$HTTP_CODE" = "200" ]; then
+              ERRORS=$(echo "$BODY" | jq '.errors' 2>/dev/null)
+              if [ "$ERRORS" = "null" ] || [ -z "$ERRORS" ]; then
+                STATUS="healthy"
+                TEAM_NAME=$(echo "$BODY" | jq -r '.data.team.name // "unknown"')
+                ISSUES=$(echo "$BODY"  | jq -r '.data.team.issueCount // 0')
+                DETAILS=$(jq -n --arg n "$TEAM_NAME" --arg c "$ISSUES" '{team_name:$n,issue_count:($c|tonumber)}')
+              else STATUS="error"; fi
+            else STATUS="unreachable"; fi
+          else STATUS="not_configured"; fi
+          ;;
+
+        slack)
+          WORKSPACE=$(echo "$PROJECT" | jq -r '.slack.workspace // "unknown"')
+          STATUS="discovered"
+          DETAILS=$(jq -n --arg w "$WORKSPACE" '{workspace:$w,note:"use Slack MCP for details"}')
+          ;;
+
+        notion)
+          WORKSPACE=$(echo "$PROJECT" | jq -r '.notion.workspace // "unknown"')
+          STATUS="discovered"
+          DETAILS=$(jq -n --arg w "$WORKSPACE" '{workspace:$w,note:"use Notion MCP for details"}')
+          ;;
+
+        custom)
+          HEALTH_URL=$(echo "$PROJECT" | jq -r '.custom.health_endpoint // empty')
+          CRED_KEY=$(echo "$PROJECT" | jq -r '.custom.credential_key // empty')
+          TOKEN="${CRED_KEY:+${!CRED_KEY:-}}"
+          if [ -n "$HEALTH_URL" ]; then
+            AUTH_HEADER=""
+            [ -n "$TOKEN" ] && AUTH_HEADER="-H \"Authorization: Bearer $TOKEN\""
+            HTTP_CODE=$(curl -gsS --max-time 5 -o /dev/null -w "%{http_code}" $AUTH_HEADER "$HEALTH_URL" 2>/dev/null || echo "000")
+            case "$HTTP_CODE" in
+              200) STATUS="healthy" ;;
+              401|403) STATUS="auth_expired" ;;
+              *) STATUS="degraded" ;;
+            esac
+            DETAILS=$(jq -n --arg u "$HEALTH_URL" --arg c "$HTTP_CODE" '{health_url:$u,http_status:$c}')
+          else STATUS="not_configured"; fi
+          ;;
+
+        *) STATUS="unknown_source" ;;
+      esac
+
+      REVENUE_STAGE=$(echo "$PROJECT" | jq -r '.revenue.stage // "unknown"')
+      REVENUE_MODEL=$(echo "$PROJECT" | jq -r '.revenue.model // "unknown"')
+      PRIORITY=$(echo "$PROJECT" | jq -r '.priority // 99')
+
+      jq -n \
+        --arg a "$ALIAS" --arg s "$SOURCE" --arg st "$STATUS" \
+        --arg rs "$REVENUE_STAGE" --arg rm "$REVENUE_MODEL" --arg p "$PRIORITY" \
+        --argjson d "$DETAILS" \
+        '{alias:$a, source:$s, status:$st, origin:"registry", revenue_stage:$rs, revenue_model:$rm, priority:($p|tonumber), details:$d}' \
+        > "$TMPDIR_OPS/registry-${ALIAS}.json"
+    ) &
+   done
+  fi
+fi
+
 wait
 
 # Assemble array

--- a/claude-ops/bin/ops-marketing-dash
+++ b/claude-ops/bin/ops-marketing-dash
@@ -1,38 +1,105 @@
 #!/usr/bin/env bash
 # ops-marketing-dash — pre-gathers data from all configured marketing channels
 # Output: JSON object with data from each channel (null for unconfigured)
-# v1.5: adds Instagram, blended_roas, marketing_health_score
+# v1.6: project-aware — reads preferences.json marketing.{default_project,projects.<name>.<channel>}
+#       and resolves cred refs (env:VAR | doppler:project/config/SECRET | inline)
 
 set -euo pipefail
 
-# Credential resolution
-KLAVIYO_KEY="${KLAVIYO_PRIVATE_KEY:-$(claude plugin config get klaviyo_private_key 2>/dev/null || echo "")}"
-META_TOKEN="${META_ADS_TOKEN:-$(claude plugin config get meta_ads_token 2>/dev/null || echo "")}"
-META_ACCOUNT="${META_AD_ACCOUNT_ID:-$(claude plugin config get meta_ad_account_id 2>/dev/null || echo "")}"
-GA4_PROPERTY="${GA4_PROPERTY_ID:-$(claude plugin config get ga4_property_id 2>/dev/null || echo "")}"
-GSC_SITE="${GOOGLE_SEARCH_CONSOLE_SITE:-$(claude plugin config get google_search_console_site 2>/dev/null || echo "")}"
-GADS_DEV_TOKEN="${GOOGLE_ADS_DEVELOPER_TOKEN:-$(claude plugin config get google_ads_developer_token 2>/dev/null || echo "")}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OPS_PLUGIN_ROOT_FALLBACK="${SCRIPT_DIR}/.." . "${SCRIPT_DIR}/../lib/registry-path.sh"
+PREFS="${OPS_DATA_DIR}/preferences.json"
+
+# Resolve a cred reference value.
+#   env:VAR_NAME                   -> $VAR_NAME from environment
+#   doppler:project/config/SECRET  -> doppler secrets get SECRET --project P --config C --plain
+#   <anything else>                -> treated as inline literal
+# Empty input -> empty output. Never fails.
+resolve_cred() {
+  local ref="${1:-}"
+  [ -z "$ref" ] || [ "$ref" = "null" ] && return 0
+  case "$ref" in
+    env:*)
+      local var="${ref#env:}"
+      printf '%s' "${!var:-}"
+      ;;
+    doppler:*)
+      local path="${ref#doppler:}"
+      local proj="${path%%/*}"
+      local rest="${path#*/}"
+      local cfg="${rest%%/*}"
+      local secret="${rest#*/}"
+      [ -z "$proj" ] || [ -z "$cfg" ] || [ -z "$secret" ] && return 0
+      doppler secrets get "$secret" --project "$proj" --config "$cfg" --plain 2>/dev/null || true
+      ;;
+    *)
+      printf '%s' "$ref"
+      ;;
+  esac
+}
+
+# Pull a value from preferences.json marketing.projects.<project>.<channel>.<field>.
+# $1 project, $2 channel, $3 field. Echoes nothing if missing or prefs absent.
+prefs_get() {
+  [ -f "$PREFS" ] || return 0
+  jq -r --arg p "$1" --arg c "$2" --arg f "$3" \
+    '.marketing.projects[$p][$c][$f] // empty' "$PREFS" 2>/dev/null
+}
+
+# Project selection: --project <name> arg, OPS_MARKETING_PROJECT env, or
+# marketing.default_project from prefs. Empty if no project context.
+PROJECT=""
+for ((i=1; i<=$#; i++)); do
+  if [ "${!i}" = "--project" ]; then
+    j=$((i+1))
+    PROJECT="${!j:-}"
+    break
+  fi
+done
+PROJECT="${PROJECT:-${OPS_MARKETING_PROJECT:-}}"
+if [ -z "$PROJECT" ] && [ -f "$PREFS" ]; then
+  PROJECT="$(jq -r '.marketing.default_project // empty' "$PREFS" 2>/dev/null || true)"
+fi
+
+# Credential resolution — three-tier:
+#   1. Project config in preferences.json (NEW, primary)
+#   2. Flat env / `claude plugin config get` (legacy)
+#   3. Doppler with bare key name (legacy)
+get_cred() {
+  local proj_channel="$1"  # e.g. "klaviyo.private_key"
+  local env_var="$2"
+  local plugin_key="$3"
+  local doppler_key="${4:-}"
+
+  local val=""
+  if [ -n "$PROJECT" ]; then
+    local channel="${proj_channel%%.*}"
+    local field="${proj_channel#*.}"
+    val="$(resolve_cred "$(prefs_get "$PROJECT" "$channel" "$field")")"
+  fi
+  if [ -z "$val" ]; then val="${!env_var:-}"; fi
+  if [ -z "$val" ]; then val="$(claude plugin config get "$plugin_key" 2>/dev/null || echo "")"; fi
+  if [ -z "$val" ] && [ -n "$doppler_key" ]; then
+    val="$(doppler secrets get "$doppler_key" --plain 2>/dev/null || echo "")"
+  fi
+  printf '%s' "$val"
+}
+
+KLAVIYO_KEY="$(get_cred 'klaviyo.private_key' KLAVIYO_PRIVATE_KEY klaviyo_private_key KLAVIYO_PRIVATE_KEY)"
+META_TOKEN="$(get_cred 'meta.access_token' META_ADS_TOKEN meta_ads_token META_ADS_TOKEN)"
+META_ACCOUNT="$(get_cred 'meta.ad_account_id' META_AD_ACCOUNT_ID meta_ad_account_id META_AD_ACCOUNT_ID)"
+GA4_PROPERTY="$(get_cred 'ga4.property_id' GA4_PROPERTY_ID ga4_property_id)"
+GSC_SITE="$(get_cred 'gsc.site_url' GOOGLE_SEARCH_CONSOLE_SITE google_search_console_site)"
+GADS_DEV_TOKEN="$(get_cred 'google_ads.developer_token' GOOGLE_ADS_DEVELOPER_TOKEN google_ads_developer_token)"
 GADS_CLIENT_ID="${GOOGLE_ADS_CLIENT_ID:-$(claude plugin config get google_ads_client_id 2>/dev/null || echo "")}"
 GADS_CLIENT_SECRET="${GOOGLE_ADS_CLIENT_SECRET:-$(claude plugin config get google_ads_client_secret 2>/dev/null || echo "")}"
-GADS_REFRESH_TOKEN="${GOOGLE_ADS_REFRESH_TOKEN:-$(claude plugin config get google_ads_refresh_token 2>/dev/null || echo "")}"
-GADS_CUSTOMER_ID="${GOOGLE_ADS_CUSTOMER_ID:-$(claude plugin config get google_ads_customer_id 2>/dev/null || echo "")}"
+GADS_REFRESH_TOKEN="$(get_cred 'google_ads.refresh_token' GOOGLE_ADS_REFRESH_TOKEN google_ads_refresh_token GOOGLE_ADS_REFRESH_TOKEN)"
+GADS_CUSTOMER_ID="$(get_cred 'google_ads.customer_id' GOOGLE_ADS_CUSTOMER_ID google_ads_customer_id)"
 GADS_LOGIN_CUSTOMER_ID="${GOOGLE_ADS_LOGIN_CUSTOMER_ID:-$(claude plugin config get google_ads_login_customer_id 2>/dev/null || echo "")}"
-
-# Doppler fallback
-if [ -z "$KLAVIYO_KEY" ]; then
-  KLAVIYO_KEY="$(doppler secrets get KLAVIYO_PRIVATE_KEY --plain 2>/dev/null || echo "")"
-fi
-if [ -z "$META_TOKEN" ]; then
-  META_TOKEN="$(doppler secrets get META_ADS_TOKEN --plain 2>/dev/null || echo "")"
-  META_ACCOUNT="$(doppler secrets get META_AD_ACCOUNT_ID --plain 2>/dev/null || echo "")"
-fi
-if [ -z "$GADS_REFRESH_TOKEN" ]; then
-  GADS_REFRESH_TOKEN="$(doppler secrets get GOOGLE_ADS_REFRESH_TOKEN --plain 2>/dev/null || echo "")"
-fi
+INSTAGRAM_ACCOUNT_ID="$(get_cred 'instagram.account_id' INSTAGRAM_ACCOUNT_ID instagram_account_id)"
 
 # Strip dashes from customer ID (API requires no dashes)
 GADS_CUSTOMER_ID="${GADS_CUSTOMER_ID//-/}"
-INSTAGRAM_ACCOUNT_ID="${INSTAGRAM_ACCOUNT_ID:-$(claude plugin config get instagram_account_id 2>/dev/null || echo "")}"
 
 TODAY=$(date +%Y-%m-%d)
 
@@ -44,14 +111,14 @@ gather_klaviyo() {
   fi
 
   # Get total subscriber count across all lists
-  LISTS=$(curl -s "https://a.klaviyo.com/api/lists/?fields[list]=name,id,profile_count" \
+  LISTS=$(curl -gsS --max-time 5 "https://a.klaviyo.com/api/lists/?fields[list]=name,id,profile_count" \
     -H "Authorization: Klaviyo-API-Key ${KLAVIYO_KEY}" \
     -H "revision: 2024-10-15" 2>/dev/null)
 
   TOTAL_SUBS=$(echo "$LISTS" | jq '[.data[].attributes.profile_count // 0] | add // 0' 2>/dev/null || echo "0")
 
   # Get last campaign stats
-  CAMPAIGNS=$(curl -s "https://a.klaviyo.com/api/campaigns/?filter=equals(messages.channel,'email')&sort=-created_at&page[size]=1&fields[campaign]=name,status,send_time" \
+  CAMPAIGNS=$(curl -gsS --max-time 5 "https://a.klaviyo.com/api/campaigns/?filter=equals(messages.channel,'email')&sort=-created_at&page[size]=1&fields[campaign]=name,status,send_time" \
     -H "Authorization: Klaviyo-API-Key ${KLAVIYO_KEY}" \
     -H "revision: 2024-10-15" 2>/dev/null)
 
@@ -62,7 +129,7 @@ gather_klaviyo() {
   # Open rate (0.0-1.0) for last campaign — feeds marketing health score email component.
   OPEN_RATE="0"
   if [ -n "$LAST_CAMPAIGN_ID" ]; then
-    VALUES=$(curl -s -X POST "https://a.klaviyo.com/api/campaign-values-reports/" \
+    VALUES=$(curl -gsS --max-time 5 -X POST "https://a.klaviyo.com/api/campaign-values-reports/" \
       -H "Authorization: Klaviyo-API-Key ${KLAVIYO_KEY}" \
       -H "revision: 2024-10-15" \
       -H "Content-Type: application/json" \
@@ -85,7 +152,7 @@ gather_meta() {
     return
   fi
 
-  INSIGHTS=$(curl -s "https://graph.facebook.com/v18.0/${META_ACCOUNT}/insights?fields=spend,impressions,clicks,ctr,cpc,actions,action_values&date_preset=last_7d&level=account" \
+  INSIGHTS=$(curl -gsS --max-time 5 "https://graph.facebook.com/v18.0/${META_ACCOUNT}/insights?fields=spend,impressions,clicks,ctr,cpc,actions,action_values&date_preset=last_7d&level=account" \
     -H "Authorization: Bearer ${META_TOKEN}" 2>/dev/null)
 
   SPEND=$(echo "$INSIGHTS" | jq -r '.data[0].spend // "0"' 2>/dev/null || echo "0")
@@ -124,7 +191,7 @@ gather_ga4() {
     return
   fi
 
-  REPORT=$(curl -s -X POST "https://analyticsdata.googleapis.com/v1beta/properties/${GA4_PROPERTY}:runReport" \
+  REPORT=$(curl -gsS --max-time 5 -X POST "https://analyticsdata.googleapis.com/v1beta/properties/${GA4_PROPERTY}:runReport" \
     -H "Authorization: Bearer ${GA4_TOKEN}" \
     -H "Content-Type: application/json" \
     -d '{
@@ -176,7 +243,7 @@ gather_gsc() {
     return
   fi
 
-  REPORT=$(curl -s -X POST "https://searchconsole.googleapis.com/webmasters/v3/sites/${GSC_SITE_ENCODED}/searchAnalytics/query" \
+  REPORT=$(curl -gsS --max-time 5 -X POST "https://searchconsole.googleapis.com/webmasters/v3/sites/${GSC_SITE_ENCODED}/searchAnalytics/query" \
     -H "Authorization: Bearer ${GSC_TOKEN}" \
     -H "Content-Type: application/json" \
     -d "{\"startDate\": \"${START_DATE}\", \"endDate\": \"${TODAY}\", \"dimensions\": [], \"rowLimit\": 1}" 2>/dev/null)
@@ -204,7 +271,7 @@ gather_instagram() {
   # Resolve IG account ID if not cached
   IG_ID="$INSTAGRAM_ACCOUNT_ID"
   if [ -z "$IG_ID" ]; then
-    IG_ID=$(curl -s "https://graph.facebook.com/v21.0/me/accounts?fields=instagram_business_account" \
+    IG_ID=$(curl -gsS --max-time 5 "https://graph.facebook.com/v21.0/me/accounts?fields=instagram_business_account" \
       -H "Authorization: Bearer ${META_TOKEN}" 2>/dev/null | jq -r '.data[0].instagram_business_account.id // empty')
     [ -n "$IG_ID" ] && claude plugin config set instagram_account_id "$IG_ID" 2>/dev/null
   fi
@@ -215,7 +282,7 @@ gather_instagram() {
   fi
 
   # Account stats
-  ACCOUNT=$(curl -s "https://graph.facebook.com/v21.0/${IG_ID}?fields=followers_count,media_count" \
+  ACCOUNT=$(curl -gsS --max-time 5 "https://graph.facebook.com/v21.0/${IG_ID}?fields=followers_count,media_count" \
     -H "Authorization: Bearer ${META_TOKEN}" 2>/dev/null)
   FOLLOWERS=$(echo "$ACCOUNT" | jq -r '.followers_count // 0')
   MEDIA_COUNT=$(echo "$ACCOUNT" | jq -r '.media_count // 0')
@@ -225,7 +292,7 @@ gather_instagram() {
   START_DATE=$(date -v-7d +%Y-%m-%d 2>/dev/null || date -d '7 days ago' +%Y-%m-%d 2>/dev/null || echo "")
   REACH=0
   if [ -n "$START_DATE" ]; then
-    INSIGHTS=$(curl -s "https://graph.facebook.com/v21.0/${IG_ID}/insights?metric=reach&period=day&since=${START_DATE}&until=${END_DATE}" \
+    INSIGHTS=$(curl -gsS --max-time 5 "https://graph.facebook.com/v21.0/${IG_ID}/insights?metric=reach&period=day&since=${START_DATE}&until=${END_DATE}" \
       -H "Authorization: Bearer ${META_TOKEN}" 2>/dev/null)
     REACH=$(echo "$INSIGHTS" | jq '[.data[]?.values[]?.value | tonumber] | add // 0' 2>/dev/null || echo "0")
   fi
@@ -245,7 +312,7 @@ gather_google_ads() {
   fi
 
   # Refresh access token
-  GADS_ACCESS_TOKEN=$(curl -s -X POST https://oauth2.googleapis.com/token \
+  GADS_ACCESS_TOKEN=$(curl -gsS --max-time 5 -X POST https://oauth2.googleapis.com/token \
     --data "client_id=${GADS_CLIENT_ID}&client_secret=${GADS_CLIENT_SECRET}&refresh_token=${GADS_REFRESH_TOKEN}&grant_type=refresh_token" \
     | jq -r '.access_token // empty')
   if [ -z "$GADS_ACCESS_TOKEN" ]; then
@@ -254,7 +321,7 @@ gather_google_ads() {
   fi
 
   # Campaign summary (last 7 days)
-  curl -s -X POST \
+  curl -gsS --max-time 5 -X POST \
     "https://googleads.googleapis.com/v23/customers/${GADS_CUSTOMER_ID}/googleAds:searchStream" \
     -H "Content-Type: application/json" \
     -H "Authorization: Bearer ${GADS_ACCESS_TOKEN}" \
@@ -330,6 +397,7 @@ HEALTH_STATUS="Critical"
 
 # Emit unified JSON
 jq -n \
+  --arg project "$PROJECT" \
   --argjson klaviyo "$KLAVIYO_DATA" \
   --argjson meta "$META_DATA" \
   --argjson ga4 "$GA4_DATA" \
@@ -340,4 +408,4 @@ jq -n \
   --argjson health_score "$HEALTH_SCORE" \
   --arg health_status "$HEALTH_STATUS" \
   --arg date "$TODAY" \
-  '{date: $date, klaviyo: $klaviyo, meta: $meta, ga4: $ga4, gsc: $gsc, google_ads: $google_ads, instagram: $instagram, blended_roas: $blended_roas, health_score: $health_score, health_status: $health_status}'
+  '{date: $date, project: (if $project == "" then null else $project end), klaviyo: $klaviyo, meta: $meta, ga4: $ga4, gsc: $gsc, google_ads: $google_ads, instagram: $instagram, blended_roas: $blended_roas, health_score: $health_score, health_status: $health_status}'

--- a/claude-ops/skills/ops-go/SKILL.md
+++ b/claude-ops/skills/ops-go/SKILL.md
@@ -156,6 +156,12 @@ done
 ${CLAUDE_PLUGIN_ROOT}/bin/ops-external 2>/dev/null || echo '[]'
 ```
 
+### Marketing (live channel data per project)
+
+```!
+${CLAUDE_PLUGIN_ROOT}/bin/ops-marketing-dash 2>/dev/null || echo '{}'
+```
+
 ### Calendar (today)
 
 ```!

--- a/claude-ops/skills/ops-yolo/SKILL.md
+++ b/claude-ops/skills/ops-yolo/SKILL.md
@@ -81,7 +81,35 @@ After initial analysis, use `SendMessage(to="cto", content="CFO flagged $400/mo 
 
 If the flag is NOT set, fall back to standard parallel subagents (fire-and-forget, no mid-task steering).
 
-## Phase 1 — Pre-gather ALL data
+## Phase 0 — MANDATORY: Clear cached state, force fresh-state collection
+
+**NEVER reuse a prior YOLO session's reports.** Stale C-suite analyses misinform decisions.
+Before pre-gathering anything, run:
+
+```!
+# Archive any prior YOLO sessions (don't delete — keep history) then start fresh.
+mkdir -p ~/.claude/yolo-archive
+for d in /tmp/yolo-*/; do
+  [ -d "$d" ] || continue
+  ts=$(basename "$d")
+  mv "$d" "$HOME/.claude/yolo-archive/${ts}-$(date +%s)" 2>/dev/null || true
+done
+
+# Allocate this run's session dir.
+SESSION_ID="$(date +%Y%m%d-%H%M%S)-$$"
+SESSION_DIR="/tmp/yolo-${SESSION_ID}"
+mkdir -p "$SESSION_DIR"
+echo "$SESSION_DIR" > /tmp/yolo-current-session
+echo "YOLO session: $SESSION_DIR (prior reports archived to ~/.claude/yolo-archive/)"
+
+# Drop any cached pre-gather artifacts so Phase 1 hits live sources.
+rm -f /tmp/ops-marketing-dash.cache /tmp/ops-external.cache /tmp/ops-infra.cache 2>/dev/null || true
+```
+
+Each C-suite agent prompt MUST include this line verbatim:
+> "Use ONLY the pre-gathered data block in this prompt. Do NOT read prior /tmp/yolo-*/ files, do NOT reference cached reports, do NOT cite earlier session findings. This is a fresh-state run; report what is true RIGHT NOW."
+
+## Phase 1 — Pre-gather ALL data (live, never cached)
 
 Run all of these simultaneously:
 
@@ -115,6 +143,10 @@ cat "${CLAUDE_PLUGIN_ROOT}/scripts/registry.json" 2>/dev/null || echo '{}'
 
 ```!
 ${CLAUDE_PLUGIN_ROOT}/bin/ops-external 2>/dev/null || echo '[]'
+```
+
+```!
+${CLAUDE_PLUGIN_ROOT}/bin/ops-marketing-dash 2>/dev/null || echo '{}'
 ```
 
 ```!


### PR DESCRIPTION
## Summary
- `bin/ops-external` and `bin/ops-marketing-dash` now read `preferences.json` (`.ecom.projects`, `.partner_registry.shopify_admin.stores`, `.marketing.projects`, `.integrations`) instead of returning `[]`/all-null when only `registry.json` is empty.
- Both scripts share a credential-reference grammar: `env:VAR_NAME`, `doppler:project/config/SECRET`, or inline literal — so per-project tokens stored in prefs resolve transparently against env vars and Doppler.
- `ops-marketing-dash` is now project-aware (`marketing.default_project`, overridable via `--project` or `OPS_MARKETING_PROJECT`) and emits a `project` field in its JSON output.
- All curl calls get `-g` (globoff) so bracketed query params (`fields[shop]=…`) work, plus `--max-time 5` to keep both scripts inside the briefing budget.
- `ops-dash` header now prints `marketing N/100 Status (project) | shopify N/N` from those scripts.
- `/ops:ops-go` Phase-1 pre-gather now invokes `ops-marketing-dash` so the briefing's MARKETING section actually renders.
- `/ops:ops-yolo` gets a new **Phase 0**: archives prior `/tmp/yolo-*/` to `~/.claude/yolo-archive/<session>-<epoch>/`, allocates fresh `SESSION_DIR`, drops cached pre-gather files, and adds a verbatim "fresh-state" directive every C-suite agent prompt must include. `ops-marketing-dash` added to Phase-1.
- Bumps plugin to **v2.1.3** in `.claude-plugin/marketplace.json` and `claude-ops/.claude-plugin/plugin.json`. Full notes in CHANGELOG.

## Bug fixes folded in along the way
- BSD `seq 0 -1` quirk in `ops-external` was emitting spurious `alias: null` entries when registry selection was empty — guarded with `[ "$COUNT" -gt 0 ]`.
- Klaviyo / Meta / GSC URLs use `[bracket]` query params; default `curl` globbing was breaking them silently → `-g` everywhere.

## Verified locally
- `ops-external` returns 8 entries (3 Shopify, 4 declared marketing projects, 1 integration). `alwaysbright` shopify_admin reports `healthy` via Doppler-resolved token.
- `ops-marketing-dash` returns `{project: "alwaysbright", klaviyo, meta, instagram (1409 followers), …}` — real data flowing.
- `ops-dash` header shows `marketing 0/100 Critical (alwaysbright) | shopify 1/3`.

## Test plan
- [x] `bin/ops-external` smoke
- [x] `bin/ops-marketing-dash` smoke (default project, `--project alwaysbright`)
- [x] `bin/ops-dash` header lines render
- [ ] `/ops:ops-go` end-to-end on user's account
- [ ] `/ops:ops-yolo` Phase 0 archive flow on user's account

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple runtime surfaces (`ops-external`, `ops-marketing-dash`, `ops-dash`, `ops-go`, `ops-yolo`) and changes how credentials are resolved and live API calls are made, which could impact briefing reliability or inadvertently hit wrong accounts if prefs are misconfigured. Network call behavior is bounded with timeouts but still adds new external probes and state-archiving behavior.
> 
> **Overview**
> Updates the plugin to **v2.1.3** and documents the release in `CHANGELOG.md`.
> 
> Makes `bin/ops-external` merge external targets from `preferences.json` (ecom Shopify stores, partner registry stores, declared marketing projects, integrations) plus legacy `registry.json`, adds shared credential-ref resolution (`env:` / `doppler:` / inline), improves Shopify probing (status classification) and hardens curl usage (`-g`, `--max-time 5`, BSD `seq` guard).
> 
> Makes `bin/ops-marketing-dash` **project-aware** (prefs default project + `--project`/`OPS_MARKETING_PROJECT` override), resolves per-project nested cred refs before legacy fallbacks, adds time-bounded curl calls, and emits the selected `project` in its JSON output.
> 
> Wires the new marketing/external outputs into user-facing flows: `bin/ops-dash` header now shows marketing health and Shopify healthy/total counts, `/ops:ops-go` pre-gather includes `ops-marketing-dash`, and `/ops:ops-yolo` adds a Phase 0 that archives prior `/tmp/yolo-*` sessions and clears cached pre-gather artifacts to force a fresh run (also pre-gathers marketing data).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d72513ba0618d94f5e2595cc2fcce440b390ad6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 2.1.3

* **New Features**
  * Project-aware marketing dashboard with multi-project credential support
  * Live health probing for Shopify and marketing metrics in operational dashboard
  * Fresh session management for YOLO analysis (archives prior sessions, ensures live data)
  * Marketing data integration into briefing skill

* **Documentation**
  * Updated changelog with 2.1.3 release notes documenting preference-aware behavior and health improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->