### PR TITLE
fix(ops-daemon): bump briefing prefetch TTL 5min → 30min to protect GitHub REST quota

### DIFF
--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -523,13 +523,27 @@ prefetch_briefing_cache() {
   local CACHE="$CACHE_DIR/briefing.json"
   local LAST_FETCH="$CACHE_DIR/.briefing_ts"
 
-  # Throttle: only run every 5 min
+  # Throttle: only run every 30 min by default.
+  #
+  # Why 30 min and not 5: every refresh fires `gh pr list` (line below) which
+  # consumes one GitHub REST API call against the user's personal token. At a
+  # 5-minute TTL that is 12 calls/hr * 24h = 288 calls/day from this single
+  # callsite, on top of any interactive `gh` use. Over a few days that
+  # accumulation alone can exhaust the 5000/hr REST budget that's shared
+  # with every other tool authenticated as the same user (gh CLI, MCP github
+  # server, hosted CI using the same PAT). 30 min keeps morning-briefing
+  # data fresh enough — open PR lists rarely change faster than that — and
+  # cuts the daily call volume to ~48.
+  #
+  # Override with $OPS_BRIEFING_PREFETCH_TTL (seconds) if a deployment
+  # genuinely needs faster cycles.
+  local PREFETCH_TTL="${OPS_BRIEFING_PREFETCH_TTL:-1800}"
   if [[ -f "$LAST_FETCH" ]]; then
     local last
     last=$(cat "$LAST_FETCH")
     local now
     now=$(date +%s)
-    if (( now - last < 300 )); then return 0; fi
+    if (( now - last < PREFETCH_TTL )); then return 0; fi
   fi
 
   log "BRAIN: refreshing briefing cache"


### PR DESCRIPTION
## Summary

`prefetch_briefing_cache` in `ops-daemon.sh` fires `gh pr list --limit 20` on a 5-minute throttle from the 30s daemon loop. Each refresh consumes one REST call against the user's personal GitHub token. At 12 calls/hr × 24h that's **288 calls/day from this single callsite** — stacked with interactive `gh`, MCP github server, and any hosted CI sharing the same PAT, it can silently exhaust the 5000/hr REST budget and surface as rate-limit errors in completely unrelated workflows hours later.

## Fix

Raise the default TTL to 1800s (30 min). Open PR lists rarely change faster than that — briefing data stays fresh for `/ops:ops-go` while this callsite drops to ~48 calls/day. New env var `OPS_BRIEFING_PREFETCH_TTL` (seconds) lets deployments override if they need tighter cycles.

No behavior change beyond the default interval. No new code paths. Single-file diff.

## Repro

Run the daemon for ~24h on a token also used by interactive `gh` work or other tools — REST core remaining drops to 0 and resets only at the rolling hour boundary. Logs in `~/Library/Logs/claude-ops/` show `BRAIN: refreshing briefing cache` every 5 min.

## Test plan
- [x] `tests/test-no-secrets.sh` passes (14/14)
- [x] Manual: with TTL=1800, daemon `BRAIN: refreshing briefing cache` log line appears every 30 min, not every 5
- [x] Manual: setting `OPS_BRIEFING_PREFETCH_TTL=600` restores 10-min refresh for users who want it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes how often `prefetch_briefing_cache` refreshes by default, reducing GitHub API usage without altering the cache contents/format or adding new external calls.
> 
> **Overview**
> In `ops-daemon.sh`, increases the default throttle for `prefetch_briefing_cache` from 5 minutes to 30 minutes to reduce `gh pr list` GitHub REST API consumption.
> 
> Adds `OPS_BRIEFING_PREFETCH_TTL` (seconds) to override the default refresh interval when faster briefing cache updates are needed, and documents the rationale inline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64f75b16499d091e8c96611681dedac1d715713e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default briefing cache refresh interval from 5 to 30 minutes.
  * Briefing cache refresh interval is now customizable via environment variable for flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->