### PR TITLE
fix(recap-digest): plain-text fallback when Claude auth unavailable in daemon

### DIFF
--- a/claude-ops/scripts/recap/digest.sh
+++ b/claude-ops/scripts/recap/digest.sh
@@ -76,10 +76,20 @@ result=$(printf '%s' "$prompt" | claude -p --model haiku --no-session-persistenc
 # digest OR the rolling log (which feeds back as PRIOR HEADLINES on next run).
 case "$result" in
   ""|"Prompt is too long"*|"Error:"*|"error:"*|"API Error"*|"Credit balance"*|"Invalid API"*|"You've hit your limit"*|"You've reached your"*|"Claude AI usage limit"*|"Usage limit"*|"usage limit"*|"Rate limit"*|"rate limit"*|"resets May"*|"resets at"*|"Please try again"*|"Account is restricted"*|"Not logged in"*|*"Please run /login"*|*"run /login"*|"OAuth"*|"oauth"*|"Authentication"*|"authentication"*)
-    printf '[%s] SKIP bad-result: %s\n' "$(date '+%H:%M')" "$result" >> "${LOG}.errors"
-    exit 0
+    printf '[%s] SKIP bad-result: %s
+' "$(date '+%H:%M')" "$result" >> "${LOG}.errors"
+    result=""
     ;;
 esac
+
+# Fallback: if Claude unavailable, assemble a plain-text digest from session recaps
+if [ -z "$result" ] && [ -n "$sessions" ]; then
+  result=$(printf '%s' "$sessions" \
+    | LC_ALL=C tr '
+' ' ' \
+    | LC_ALL=C sed 's/^- //; s/ - /  /g' \
+    | head -c 240)
+fi
 
 if [ -n "$result" ]; then
   printf '%s' "$result" > "$DIGEST"

--- a/claude-ops/scripts/recap/digest.sh
+++ b/claude-ops/scripts/recap/digest.sh
@@ -75,7 +75,7 @@ result=$(printf '%s' "$prompt" | claude -p --model haiku --no-session-persistenc
 # Reject Claude error / auth / quota strings — never let them pollute the
 # digest OR the rolling log (which feeds back as PRIOR HEADLINES on next run).
 case "$result" in
-  ""|"Prompt is too long"*|"Error:"*|"error:"*|"API Error"*|"Credit balance"*|"Invalid API"*|"You've hit your limit"*|"You've reached your"*|"Claude AI usage limit"*|"Usage limit"*|"usage limit"*|"Rate limit"*|"rate limit"*|"resets May"*|"resets at"*|"Please try again"*|"Account is restricted"*|"Not logged in"*|*"Please run /login"*|*"run /login"*|"OAuth"*|"oauth"*|"Authentication"*|"authentication"*)
+  ""|"Prompt is too long"*|"Error:"*|"error:"*|"API Error"*|"Credit balance"*|"Invalid API"*|"You've hit your limit"*|"You've reached your"*|"Claude AI usage limit"*|"Usage limit"*|"usage limit"*|"Rate limit"*|"rate limit"*|"resets "*|"resets at"*|"Please try again"*|"Account is restricted"*|"Not logged in"*|*"Please run /login"*|*"run /login"*|"OAuth"*|"oauth"*|"Authentication"*|"authentication"*)
     printf '[%s] SKIP bad-result: %s
 ' "$(date '+%H:%M')" "$result" >> "${LOG}.errors"
     result=""


### PR DESCRIPTION
## Summary
- `recap-digest.sh` calls `claude -p --model haiku` which returns "Not logged in" when run from the daemon's non-interactive shell (no Claude auth context)
- Previously: on auth/error result, script exited 0 without writing `/tmp/claude-recap-digest`, leaving tmux status marquee blank
- Fix: on any auth/error string, clear `result` then fall back to assembling plain-text digest directly from the per-session `/tmp/claude-recap-<uuid>` files
- Also ports the error-guard pattern (already in local copy) into the upstream `scripts/recap/digest.sh`

## Test plan
- [ ] `THROTTLE_OVERRIDE=1 bash claude-ops/scripts/recap/digest.sh` writes non-empty `/tmp/claude-recap-digest` even without Claude auth
- [ ] `bash recap-marquee.sh` outputs session recap content
- [ ] When Claude auth IS available the LLM path still runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk shell-script change limited to digest generation; main behavior change is in error handling and fallback output when Claude CLI fails or is unauthenticated.
> 
> **Overview**
> Keeps `scripts/recap/digest.sh` from leaving `/tmp/claude-recap-digest` blank when the `claude` CLI returns auth/quota/rate-limit errors: those outputs are now logged to `${LOG}.errors`, `result` is cleared (instead of exiting), and a plain-text digest is synthesized from the current session recap files.
> 
> Also slightly broadens the rejected error patterns (e.g., `resets *`) to avoid polluting the rolling digest log with transient Claude error strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f7ffe82d41534b21f268d34cb56e52af74faefe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented authentication, rate-limit, and other error messages from appearing in digest logs by sanitizing AI-generated output
  * When AI output is unavailable or cleared, the digest now generates a concise fallback summary from recent session recaps
  * Logging, timestamping, and retention behavior remain unchanged

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/216)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->