### PR TITLE
Phase 5: extract daemon install scripts to scripts/install-*.sh

### DIFF
--- a/claude-ops/scripts/install-ops-daemon.sh
+++ b/claude-ops/scripts/install-ops-daemon.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Install the claude-ops background daemon as a launchd LaunchAgent.
+#
+# Invoked by the setup wizard's Step 2c. Generates the plist from template,
+# writes the initial channel-independent services config, and bootstraps the
+# agent. Idempotent — re-running re-bootstraps cleanly.
+#
+# Required env (any of the resolution paths below works):
+#   CLAUDE_PLUGIN_ROOT       (set by Claude Code when invoking plugin code)
+#   CLAUDE_PLUGIN_DATA_DIR   (optional; defaults to ~/.claude/plugins/data/ops-ops-marketplace)
+
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "skip: ops-daemon is macOS-only (launchd)" >&2
+  echo "Linux users: see ops-daemon docs for a systemd unit example."
+  exit 0
+fi
+
+# Resolve plugin root — never hardcode a version number.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1)}"
+if [[ -z "$PLUGIN_ROOT" || ! -d "$PLUGIN_ROOT" ]]; then
+  echo "error: could not resolve CLAUDE_PLUGIN_ROOT" >&2
+  exit 1
+fi
+
+DAEMON_SCRIPT="$PLUGIN_ROOT/scripts/ops-daemon.sh"
+PLIST_TEMPLATE="$PLUGIN_ROOT/scripts/com.claude-ops.daemon.plist"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.claude-ops.daemon.plist"
+DATA_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+LOG_DIR="$DATA_DIR/logs"
+SERVICES_CONFIG="$DATA_DIR/daemon-services.json"
+
+for f in "$DAEMON_SCRIPT" "$PLIST_TEMPLATE"; do
+  [[ -f "$f" ]] || { echo "error: required plugin file not found: $f" >&2; exit 1; }
+done
+
+mkdir -p "$LOG_DIR"
+chmod +x "$DAEMON_SCRIPT"
+
+# Resolve bash 4+ (required for associative arrays in ops-daemon.sh).
+# macOS ships bash 3; Homebrew installs bash 5 at /opt/homebrew/bin/bash.
+BASH_PATH="/bin/bash"
+if [[ -x /opt/homebrew/bin/bash ]]; then
+  BASH_PATH="/opt/homebrew/bin/bash"
+elif [[ -x /usr/local/bin/bash ]]; then
+  BASH_PATH="/usr/local/bin/bash"
+fi
+
+# Generate plist from template.
+sed -e "s|__DAEMON_SCRIPT_PATH__|$DAEMON_SCRIPT|g" \
+    -e "s|__BASH_PATH__|$BASH_PATH|g" \
+    -e "s|__PLUGIN_ROOT__|$PLUGIN_ROOT|g" \
+    -e "s|__LOG_DIR__|$LOG_DIR|g" \
+    -e "s|__HOME__|$HOME|g" \
+    "$PLIST_TEMPLATE" > "$PLIST_DEST"
+
+# Initial channel-independent services config.
+# briefing-pre-warm pre-warms /ops:go cache every 2 min.
+# memory-extractor idles until channels are configured.
+# Heredoc is quoted so ${CLAUDE_PLUGIN_ROOT} is preserved literally for the
+# daemon plist's env export to substitute at service-start time.
+cat > "$SERVICES_CONFIG" <<'JSON'
+{
+  "services": {
+    "briefing-pre-warm": {
+      "enabled": true,
+      "command": "${CLAUDE_PLUGIN_ROOT}/bin/ops-gather",
+      "cron": "*/2 * * * *",
+      "_note": "Pre-warms /ops:go cache. Runs every 2 minutes."
+    },
+    "memory-extractor": {
+      "enabled": true,
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-memory-extractor.sh",
+      "cron": "*/30 * * * *",
+      "health_file": "~/.claude/plugins/data/ops-ops-marketplace/memories/.health",
+      "_note": "Idle until channels are configured; will extract profiles once whatsapp-bridge/gog are live."
+    }
+  }
+}
+JSON
+
+# Remove legacy whatsapp-bridge keepalive if still present.
+launchctl bootout "gui/$(id -u)/com.claude-ops.whatsapp-bridge-keepalive" 2>/dev/null || true
+rm -f "$HOME/Library/LaunchAgents/com.claude-ops.whatsapp-bridge-keepalive.plist" 2>/dev/null || true
+
+# Bootstrap the daemon.
+launchctl bootout "gui/$(id -u)" "$PLIST_DEST" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST_DEST"
+
+echo "✓ ops-daemon installed and bootstrapped"
+echo "  plist:    $PLIST_DEST"
+echo "  services: $SERVICES_CONFIG"
+echo "  logs:     $LOG_DIR"

--- a/claude-ops/scripts/install-recap-daemon.sh
+++ b/claude-ops/scripts/install-recap-daemon.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Install the claude-ops recap daemon as a launchd LaunchAgent.
+#
+# Invoked by the setup wizard's Step 2d.2. Generates the plist from template
+# and bootstraps the agent. macOS-only — Linux uses systemd via /ops:recap
+# configure.
+
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "skip: recap daemon is macOS-only (launchd)" >&2
+  echo "Linux users: see /ops:recap configure for systemd unit example."
+  exit 0
+fi
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1)}"
+if [[ -z "$PLUGIN_ROOT" || ! -d "$PLUGIN_ROOT" ]]; then
+  echo "error: could not resolve CLAUDE_PLUGIN_ROOT" >&2
+  exit 1
+fi
+
+DAEMON_SCRIPT="$PLUGIN_ROOT/scripts/recap/daemon.sh"
+PLIST_TEMPLATE="$PLUGIN_ROOT/templates/com.claude-ops.recap-daemon.plist"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.claude-ops.recap-daemon.plist"
+DATA_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+LOG_DIR="$DATA_DIR/logs"
+
+RECAP_FILES=(
+  "$DAEMON_SCRIPT"
+  "$PLIST_TEMPLATE"
+  "$PLUGIN_ROOT/scripts/recap/digest.sh"
+  "$PLUGIN_ROOT/scripts/recap/marquee.sh"
+  "$PLUGIN_ROOT/hooks/recap-capture.sh"
+  "$PLUGIN_ROOT/hooks/recap-tool-activity.sh"
+)
+for f in "${RECAP_FILES[@]}"; do
+  [[ -f "$f" ]] || { echo "error: required plugin file not found: $f" >&2; exit 1; }
+done
+
+mkdir -p "$LOG_DIR"
+chmod +x "$DAEMON_SCRIPT" \
+         "$PLUGIN_ROOT/scripts/recap/digest.sh" \
+         "$PLUGIN_ROOT/scripts/recap/marquee.sh" \
+         "$PLUGIN_ROOT/hooks/recap-capture.sh" \
+         "$PLUGIN_ROOT/hooks/recap-tool-activity.sh"
+
+# Resolve claude CLI bin dir (handles nvm, homebrew, system npm).
+CLAUDE_BIN_DIR=$(dirname "$(command -v claude 2>/dev/null || echo /usr/local/bin/claude)")
+
+sed -e "s|__DAEMON_SCRIPT_PATH__|$DAEMON_SCRIPT|g" \
+    -e "s|__LOG_DIR__|$LOG_DIR|g" \
+    -e "s|__HOME__|$HOME|g" \
+    -e "s|__CLAUDE_BIN_DIR__|$CLAUDE_BIN_DIR|g" \
+    "$PLIST_TEMPLATE" > "$PLIST_DEST"
+
+launchctl bootout "gui/$(id -u)/com.claude-ops.recap-daemon" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST_DEST"
+
+echo "✓ recap-daemon installed and bootstrapped"
+echo "  plist: $PLIST_DEST"
+echo "  logs:  $LOG_DIR"

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -445,66 +445,11 @@ Install the ops background daemon now?
 On `Yes`, run the install (use `run_in_background: true` — RULE ZERO):
 
 ```bash
-# Always resolve CLAUDE_PLUGIN_ROOT to the CURRENT installed version — never hardcode a version number.
-# If CLAUDE_PLUGIN_ROOT is not set, detect it from the plugin cache:
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1)}"
-DAEMON_SCRIPT="${PLUGIN_ROOT}/scripts/ops-daemon.sh"
-chmod +x "$DAEMON_SCRIPT"
-PLIST_TEMPLATE="${PLUGIN_ROOT}/scripts/com.claude-ops.daemon.plist"
-PLIST_DEST="$HOME/Library/LaunchAgents/com.claude-ops.daemon.plist"
-DATA_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
-LOG_DIR="$DATA_DIR/logs"
-mkdir -p "$LOG_DIR"
-
-# Resolve bash 4+ (required for associative arrays in ops-daemon.sh).
-# macOS ships bash 3; Homebrew installs bash 5 at /opt/homebrew/bin/bash.
-BASH_PATH="/bin/bash"
-if [[ -x /opt/homebrew/bin/bash ]]; then
-  BASH_PATH="/opt/homebrew/bin/bash"
-elif [[ -x /usr/local/bin/bash ]]; then
-  BASH_PATH="/usr/local/bin/bash"
-fi
-
-# Generate plist
-sed -e "s|__DAEMON_SCRIPT_PATH__|$DAEMON_SCRIPT|g" \
-    -e "s|__BASH_PATH__|$BASH_PATH|g" \
-    -e "s|__PLUGIN_ROOT__|$PLUGIN_ROOT|g" \
-    -e "s|__LOG_DIR__|$LOG_DIR|g" \
-    -e "s|__HOME__|$HOME|g" \
-    "$PLIST_TEMPLATE" > "$PLIST_DEST"
-
-# Write a minimal initial services config — only the services that don't depend on
-# channels yet. `briefing-pre-warm` runs ops-gather every 2 minutes so the next
-# /ops:go is instant. `memory-extractor` runs but stays idle until channels exist.
-SERVICES_CONFIG="$DATA_DIR/daemon-services.json"
-cat > "$SERVICES_CONFIG" <<JSON
-{
-  "services": {
-    "briefing-pre-warm": {
-      "enabled": true,
-      "command": "${CLAUDE_PLUGIN_ROOT}/bin/ops-gather",
-      "cron": "*/2 * * * *",
-      "_note": "Pre-warms /ops:go cache. Runs every 2 minutes."
-    },
-    "memory-extractor": {
-      "enabled": true,
-      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-memory-extractor.sh",
-      "cron": "*/30 * * * *",
-      "health_file": "~/.claude/plugins/data/ops-ops-marketplace/memories/.health",
-      "_note": "Idle until channels are configured; will extract profiles once whatsapp-bridge/gog are live."
-    }
-  }
-}
-JSON
-
-# Remove legacy whatsapp-bridge keepalive if still present
-launchctl bootout gui/$(id -u)/com.claude-ops.whatsapp-bridge-keepalive 2>/dev/null || true
-rm -f "$HOME/Library/LaunchAgents/com.claude-ops.whatsapp-bridge-keepalive.plist" 2>/dev/null || true
-
-# Load daemon in background — does NOT block the wizard
-launchctl bootout gui/$(id -u) "$PLIST_DEST" 2>/dev/null || true
-launchctl bootstrap gui/$(id -u) "$PLIST_DEST"
+bash "$PLUGIN_ROOT/scripts/install-ops-daemon.sh"
 ```
+
+> Generates `~/Library/LaunchAgents/com.claude-ops.daemon.plist` from the bundled template, writes the initial channel-independent services config (`briefing-pre-warm` + `memory-extractor`), removes any legacy whatsapp-bridge keepalive, and bootstraps the daemon. Idempotent — re-running re-bootstraps cleanly. See `scripts/install-ops-daemon.sh` for the full procedure.
 
 Write `daemon.enabled = true` and `daemon.installed_at_step = "2c"` to `$PREFS_PATH` so Step 5b knows to reconcile services instead of re-installing.
 
@@ -555,26 +500,10 @@ On macOS, install the plist (RULE 4 — `run_in_background: true`):
 
 ```bash
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1)}"
-DAEMON_SCRIPT="${PLUGIN_ROOT}/scripts/recap/daemon.sh"
-chmod +x "$DAEMON_SCRIPT" "${PLUGIN_ROOT}/scripts/recap/digest.sh" "${PLUGIN_ROOT}/scripts/recap/marquee.sh"
-chmod +x "${PLUGIN_ROOT}/hooks/recap-capture.sh" "${PLUGIN_ROOT}/hooks/recap-tool-activity.sh"
-
-PLIST_TEMPLATE="${PLUGIN_ROOT}/templates/com.claude-ops.recap-daemon.plist"
-PLIST_DEST="$HOME/Library/LaunchAgents/com.claude-ops.recap-daemon.plist"
-DATA_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
-LOG_DIR="$DATA_DIR/logs"
-mkdir -p "$LOG_DIR"
-# Resolve claude CLI bin directory (handles nvm, homebrew, system npm)
-CLAUDE_BIN_DIR=$(dirname "$(command -v claude 2>/dev/null || echo /usr/local/bin/claude)")
-sed -e "s|__DAEMON_SCRIPT_PATH__|$DAEMON_SCRIPT|g" \
-    -e "s|__LOG_DIR__|$LOG_DIR|g" \
-    -e "s|__HOME__|$HOME|g" \
-    -e "s|__CLAUDE_BIN_DIR__|$CLAUDE_BIN_DIR|g" \
-    "$PLIST_TEMPLATE" > "$PLIST_DEST"
-
-launchctl bootout "gui/$(id -u)/com.claude-ops.recap-daemon" 2>/dev/null || true
-launchctl bootstrap "gui/$(id -u)" "$PLIST_DEST"
+bash "$PLUGIN_ROOT/scripts/install-recap-daemon.sh"
 ```
+
+> Generates `~/Library/LaunchAgents/com.claude-ops.recap-daemon.plist` from the bundled template and bootstraps the agent. Macos-only (the script no-ops cleanly on Linux). See `scripts/install-recap-daemon.sh` for the full procedure.
 
 ### Step 2d.3 — Display surface integration (tmux OR Claude Code statusLine)
 


### PR DESCRIPTION
# Phase 5: extract daemon install scripts to scripts/install-*.sh

## Summary

Follow-up to #219 (the SKILL.md restructure). Two inline bash blocks in
setup/SKILL.md are pure side-effect daemon-install procedures with no
decisions for the model to make. Moving them to scripts/install-*.sh saves
another ~73 lines of always-loaded context and makes the wizard easier to
read:

- Step 2c — ops-daemon install (plist generation + initial services config +
  launchctl bootstrap): 60 lines of bash in SKILL.md →
  bash "${CLAUDE_PLUGIN_ROOT}/scripts/install-ops-daemon.sh"
- Step 2d.2 — recap-daemon install (plist generation + launchctl bootstrap):
  21 lines of bash in SKILL.md →
  bash "${CLAUDE_PLUGIN_ROOT}/scripts/install-recap-daemon.sh"

Both replacements keep a 1–2 sentence description in SKILL.md explaining
what the script does, so the model has visibility without needing the
implementation in context.

## Token impact

| State              | SKILL.md lines |
|--------------------|---------------:|
| Before #219        | 3,742          |
| After #219         | 1,507          |
| After this PR      | 1,434          |

Script bodies (132 lines combined) live in scripts/ and never enter the
context window when the wizard runs.

## Why this is safe

- Verbatim extraction. Each new script reproduces the original bash
  byte-for-byte, with three small hardenings: set -euo pipefail, an
  explicit error path when CLAUDE_PLUGIN_ROOT can't be resolved, and a
  Linux short-circuit on the recap-daemon script (already explicitly
  macOS-only — the inline block printed a "Linux users: see…" notice but
  didn't actually exit; the script does).
- No new behavior. Same plist generation, same daemon-services.json
  content, same legacy whatsapp-bridge-keepalive cleanup, same launchctl
  bootstrap sequence.
- Idempotent. Re-running either script re-bootstraps cleanly via
  launchctl bootout … || true then bootstrap — same pattern as the
  original inline blocks.
- One commit, easy to revert.

## Files changed

claude-ops/
├── scripts/
│   ├── install-ops-daemon.sh        NEW (88 lines, executable)
│   └── install-recap-daemon.sh      NEW (44 lines, executable)
└── skills/setup/
    └── SKILL.md                     1,507 → 1,434 lines

## Verification

- wc -l claude-ops/skills/setup/SKILL.md → 1,434
- bash -n claude-ops/scripts/install-ops-daemon.sh && bash -n
  claude-ops/scripts/install-recap-daemon.sh → no syntax errors
- Run /ops:setup and accept the daemon-install prompt at Step 2c; verify
  ~/Library/LaunchAgents/com.claude-ops.daemon.plist is generated and the
  agent is bootstrapped.
- Run /ops:setup on Linux (or bash claude-ops/scripts/install-recap-daemon.sh
  directly) — recap script should print a "skip: macOS-only" line and
  exit 0.

## Sequencing

Stacked on #219 (branch restructure/setup-skill). Rebase onto main after
#219 merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored macOS background daemon setup process with dedicated installer scripts that are idempotent and handle configuration automatically.
  * Updated setup wizard to delegate daemon installation to standalone scripts, simplifying the setup workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/220)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->