### PR TITLE
feat(account-rotation): env-gated claude-p-as wiring for daemon callers (HEA-4014)

### DIFF
--- a/claude-ops/CLAUDE.md
+++ b/claude-ops/CLAUDE.md
@@ -20,6 +20,10 @@ These rules apply to ALL skills in this plugin. They are non-negotiable and over
 
 Run `tests/test-no-secrets.sh` before every commit to verify.
 
+## Credit-pool gate — `CLAUDE_OPS_USE_CREDIT_POOL`
+
+Daemon scripts that invoke Claude (recap digest, deploy-fix fixer, agent-drafter hook) route through `scripts/lib/claude-invoke.sh`, which provides a `claude_invoke` shell function. When `CLAUDE_OPS_USE_CREDIT_POOL=1` is exported in the environment, `claude_invoke` delegates to `scripts/account-rotation/claude-p-as.mjs`, which selects the highest-credit Max-OAuth account from the shared ledger. When the variable is unset or any other value, `claude_invoke` calls `claude` directly (standard keychain account), preserving existing behaviour. Set `CLAUDE_OPS_USE_CREDIT_POOL=1` only after the credit ledger is activated (target: 2026-06-15); before that date the wrapper exits 2 when the ledger is empty and daemons would fail silently. The gate can be exported in your shell profile or per-launch environment and takes effect immediately without restarting daemons.
+
 ## Rule 1 — Max 4 options per AskUserQuestion
 
 The `AskUserQuestion` tool enforces a hard schema limit of `<=4` items in the `options` array. Passing more than 4 options causes an `InputValidationError` and the skill crashes.

--- a/claude-ops/bin/ops-suggest-specialized-agent
+++ b/claude-ops/bin/ops-suggest-specialized-agent
@@ -10,6 +10,10 @@
 set -e
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 . "$PLUGIN_ROOT/scripts/lib/deploy-fix-common.sh" 2>/dev/null || { config() { echo "${2:-}"; }; }
+# Route claude invocations through the credit-pool wrapper when
+# CLAUDE_OPS_USE_CREDIT_POOL=1; otherwise calls claude directly.
+# shellcheck source=../scripts/lib/claude-invoke.sh
+. "$PLUGIN_ROOT/scripts/lib/claude-invoke.sh"
 
 [ "$(config suggest_specialized_agents true)" = "false" ] && exit 0
 
@@ -103,7 +107,8 @@ model: haiku|sonnet|opus
 Final line of your output: 'NEW: <name>' or 'SKIP: <reason>'."
 
   nohup bash -c "
-    printf '%s' \"\$1\" | claude -p --model haiku --dangerously-skip-permissions --no-session-persistence > '$drafter_log' 2>&1
+    . '$PLUGIN_ROOT/scripts/lib/claude-invoke.sh'
+    printf '%s' \"\$1\" | claude_invoke -p --model haiku --dangerously-skip-permissions --no-session-persistence > '$drafter_log' 2>&1
   " _ "$draft_prompt" </dev/null >/dev/null 2>&1 &
   disown 2>/dev/null || true
 fi

--- a/claude-ops/scripts/lib/claude-invoke.sh
+++ b/claude-ops/scripts/lib/claude-invoke.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# claude-invoke.sh — env-gated wrapper for claude -p daemon callers.
+#
+# Usage (source this file, then call claude_invoke):
+#   . "$PLUGIN_ROOT/scripts/lib/claude-invoke.sh"
+#   claude_invoke --model haiku --no-session-persistence [other claude args]
+#
+# Gate:
+#   CLAUDE_OPS_USE_CREDIT_POOL=1  ->  route through claude-p-as.mjs (credit pool)
+#   unset / 0 / any other value   ->  call `claude` directly (current-keychain account)
+#
+# Repo root resolution order:
+#   1. $CLAUDE_OPS_ROOT env var
+#   2. $PLUGIN_ROOT (set by deploy-fix-common.sh / plugin loader)
+#   3. Walk up from ${BASH_SOURCE[0]} until scripts/account-rotation/claude-p-as.mjs is found
+#      (bash only; silently skipped in /bin/sh)
+
+_claude_invoke_find_root() {
+  # 1. Explicit env override
+  if [ -n "${CLAUDE_OPS_ROOT:-}" ]; then
+    printf '%s' "$CLAUDE_OPS_ROOT"
+    return 0
+  fi
+  # 2. PLUGIN_ROOT set by plugin loader / deploy-fix-common.sh
+  if [ -n "${PLUGIN_ROOT:-}" ] && [ -f "${PLUGIN_ROOT}/scripts/account-rotation/claude-p-as.mjs" ]; then
+    printf '%s' "$PLUGIN_ROOT"
+    return 0
+  fi
+  # 3. Walk up from this file (bash only — BASH_SOURCE is undefined in /bin/sh)
+  if [ -n "${BASH_SOURCE[0]:-}" ]; then
+    local dir
+    dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    while [ "$dir" != "/" ]; do
+      if [ -f "$dir/scripts/account-rotation/claude-p-as.mjs" ]; then
+        printf '%s' "$dir"
+        return 0
+      fi
+      dir="$(dirname "$dir")"
+    done
+  fi
+  printf ''
+  return 1
+}
+
+claude_invoke() {
+  if [ "${CLAUDE_OPS_USE_CREDIT_POOL:-0}" = "1" ]; then
+    local repo_root
+    repo_root="$(_claude_invoke_find_root)" || repo_root=""
+    local wrapper="${repo_root}/scripts/account-rotation/claude-p-as.mjs"
+    if [ -z "$repo_root" ] || [ ! -f "$wrapper" ]; then
+      # Wrapper not found — log a warning and fall back to direct claude so
+      # daemon jobs are never silently dropped due to misconfiguration.
+      printf '[claude-invoke] WARNING: claude-p-as.mjs not found (root=%s) — falling back to direct claude\n' "${repo_root:-unresolved}" >&2
+      claude "$@"
+      return $?
+    fi
+    node "$wrapper" -- "$@"
+  else
+    claude "$@"
+  fi
+}

--- a/claude-ops/scripts/lib/deploy-fix-common.sh
+++ b/claude-ops/scripts/lib/deploy-fix-common.sh
@@ -192,8 +192,13 @@ dispatch_fix_agent() {
 
   command -v claude >/dev/null || { lock_release "$lock_id"; return 5; }
 
+  # Capture invoker path so the nohup subshell can source it without relying
+  # on $PLUGIN_ROOT being exported (it may not be in all caller environments).
+  local _invoker="$PLUGIN_ROOT/scripts/lib/claude-invoke.sh"
+
   nohup bash -c "
-    printf '%s' \"\$1\" | claude -p --model $model $danger_flag --no-session-persistence > '$fix_log' 2>&1
+    . '$_invoker'
+    printf '%s' \"\$1\" | claude_invoke -p --model $model $danger_flag --no-session-persistence > '$fix_log' 2>&1
     rm -f '$STATE_DIR/lock-$lock_id'
   " _ "$prompt" </dev/null >/dev/null 2>&1 &
   disown 2>/dev/null || true

--- a/claude-ops/scripts/recap/digest.sh
+++ b/claude-ops/scripts/recap/digest.sh
@@ -1,9 +1,15 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # AI-generated rolling digest: summarizes the last 10 digests + current session recaps
 # + recent shell activity into one unified ticker line. 20s throttle (bypassable via
 # THROTTLE_OVERRIDE=1 — daemon.sh sets this).
 
 set -e
+
+# Route claude invocations through the credit-pool wrapper when
+# CLAUDE_OPS_USE_CREDIT_POOL=1; otherwise calls claude directly.
+_CI_SH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/claude-invoke.sh
+. "$_CI_SH_DIR/../lib/claude-invoke.sh"
 DIGEST=/tmp/claude-recap-digest
 LOG=/tmp/claude-recap-digest.log
 LOCK=/tmp/claude-recap-digest.lock
@@ -70,7 +76,7 @@ ${shell_activity:-(none)}
 
 Produce ONE single line (max 240 chars) describing the CURRENT state of work, weighted heavily toward the most-recent activity (last 1-2 headlines + current session activity + last few shell commands). DROP themes from older headlines that are no longer mentioned in current activity — assume they are resolved or no longer relevant. Only carry forward an older theme if there is concrete evidence in the current activity that it is still in flight. Translate raw shell commands into plain English (e.g., 'ssh into bastion', 'inspecting prod logs', 'running tests'). Plain English ticker style. No bullets, no quotes, no preface, no markdown."
 
-result=$(printf '%s' "$prompt" | claude -p --model haiku --no-session-persistence --output-format text 2>/dev/null | head -c 260 | LC_ALL=C tr '\n' ' ')
+result=$(printf '%s' "$prompt" | claude_invoke -p --model haiku --no-session-persistence --output-format text 2>/dev/null | head -c 260 | LC_ALL=C tr '\n' ' ')
 
 # Reject Claude error / auth / quota strings — never let them pollute the
 # digest OR the rolling log (which feeds back as PRIOR HEADLINES on next run).

--- a/claude-ops/tests/test-claude-invoke.sh
+++ b/claude-ops/tests/test-claude-invoke.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# test-claude-invoke.sh — unit tests for scripts/lib/claude-invoke.sh
+#
+# Tests:
+#   T1: CLAUDE_OPS_USE_CREDIT_POOL unset  -> calls `claude` directly
+#   T2: CLAUDE_OPS_USE_CREDIT_POOL=0      -> calls `claude` directly
+#   T3: CLAUDE_OPS_USE_CREDIT_POOL=1      -> calls `node .../claude-p-as.mjs --` with same args
+#   T4: CLAUDE_OPS_USE_CREDIT_POOL=1 but wrapper missing -> falls back to `claude`, exits non-zero
+#       (warning printed to stderr, direct claude called)
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HELPER="$PLUGIN_ROOT/scripts/lib/claude-invoke.sh"
+
+pass=0
+fail=0
+
+ok()  { echo "  PASS: $1"; pass=$((pass+1)); }
+err() { echo "  FAIL: $1"; fail=$((fail+1)); }
+
+# ---------------------------------------------------------------------------
+# Helpers — build a temp dir with stub binaries for each test
+# ---------------------------------------------------------------------------
+
+make_stubs() {
+  local tmpdir="$1"
+  # Stub claude: records argv to a capture file and exits 0
+  cat > "$tmpdir/claude" <<'SH'
+#!/usr/bin/env bash
+echo "claude $*" >> "$CAPTURE_FILE"
+exit 0
+SH
+  chmod +x "$tmpdir/claude"
+
+  # Stub node: records argv to a capture file and exits 0
+  cat > "$tmpdir/node" <<'SH'
+#!/usr/bin/env bash
+echo "node $*" >> "$CAPTURE_FILE"
+exit 0
+SH
+  chmod +x "$tmpdir/node"
+}
+
+run_invoke() {
+  # Runs claude_invoke in a clean subshell with PATH restricted to stubs.
+  # Args: env-var assignments (as separate args), then -- then claude_invoke args.
+  local env_args=()
+  while [[ "$1" != "--" ]]; do
+    env_args+=("$1")
+    shift
+  done
+  shift  # consume --
+
+  local tmpdir capture
+  tmpdir="$(mktemp -d)"
+  capture="$(mktemp)"
+  trap 'rm -rf "$tmpdir" "$capture"' RETURN
+
+  make_stubs "$tmpdir"
+
+  # Run in a subshell: set env, prepend stubs to PATH, source helper, call claude_invoke
+  (
+    export PATH="$tmpdir:$PATH"
+    export CAPTURE_FILE="$capture"
+    for kv in "${env_args[@]:-}"; do
+      export "$kv"
+    done
+    # Point PLUGIN_ROOT at the real plugin so wrapper resolution works
+    export PLUGIN_ROOT="$PLUGIN_ROOT"
+    export CLAUDE_OPS_ROOT="$PLUGIN_ROOT"
+    # shellcheck source=../scripts/lib/claude-invoke.sh
+    . "$HELPER"
+    claude_invoke "$@"
+  ) 2>/dev/null || true
+
+  cat "$capture"
+}
+
+# ---------------------------------------------------------------------------
+# T1: gate unset -> direct claude
+# ---------------------------------------------------------------------------
+echo "T1: gate unset -> direct claude"
+result=$(run_invoke -- -p --model haiku --no-session-persistence)
+if [[ "$result" == "claude -p --model haiku --no-session-persistence" ]]; then
+  ok "called claude directly with correct args"
+else
+  err "expected 'claude -p --model haiku --no-session-persistence', got: '$result'"
+fi
+
+# ---------------------------------------------------------------------------
+# T2: gate=0 -> direct claude
+# ---------------------------------------------------------------------------
+echo "T2: gate=0 -> direct claude"
+result=$(run_invoke CLAUDE_OPS_USE_CREDIT_POOL=0 -- -p --model haiku)
+if [[ "$result" == "claude -p --model haiku" ]]; then
+  ok "called claude directly with CREDIT_POOL=0"
+else
+  err "expected 'claude -p --model haiku', got: '$result'"
+fi
+
+# ---------------------------------------------------------------------------
+# T3: gate=1 -> node .../claude-p-as.mjs -- <args>
+# ---------------------------------------------------------------------------
+echo "T3: gate=1 -> node ...claude-p-as.mjs -- <args>"
+result=$(run_invoke CLAUDE_OPS_USE_CREDIT_POOL=1 -- -p --model haiku --no-session-persistence)
+wrapper_path="$PLUGIN_ROOT/scripts/account-rotation/claude-p-as.mjs"
+expected="node $wrapper_path -- -p --model haiku --no-session-persistence"
+if [[ "$result" == "$expected" ]]; then
+  ok "routed through claude-p-as.mjs with correct args after --"
+else
+  err "expected: '$expected'"
+  err "     got: '$result'"
+fi
+
+# ---------------------------------------------------------------------------
+# T4: gate=1, wrapper missing -> warning to stderr, falls back to claude
+# ---------------------------------------------------------------------------
+echo "T4: gate=1, wrapper missing -> fallback to claude"
+tmpdir_missing="$(mktemp -d)"
+capture_missing="$(mktemp)"
+trap 'rm -rf "$tmpdir_missing" "$capture_missing"' EXIT
+
+make_stubs "$tmpdir_missing"
+
+stderr_out=$(
+  (
+    export PATH="$tmpdir_missing:$PATH"
+    export CAPTURE_FILE="$capture_missing"
+    export CLAUDE_OPS_USE_CREDIT_POOL=1
+    # Point to a non-existent root so wrapper lookup fails
+    export CLAUDE_OPS_ROOT="/nonexistent-root-$$"
+    unset PLUGIN_ROOT
+    # shellcheck source=../scripts/lib/claude-invoke.sh
+    . "$HELPER"
+    claude_invoke -p --model haiku
+  ) 2>&1 >/dev/null || true
+)
+
+fallback_result=$(cat "$capture_missing")
+if [[ "$fallback_result" == "claude -p --model haiku" ]]; then
+  ok "fell back to direct claude when wrapper missing"
+else
+  err "fallback: expected 'claude -p --model haiku', got: '$fallback_result'"
+fi
+if echo "$stderr_out" | grep -q "WARNING"; then
+  ok "emitted WARNING to stderr"
+else
+  err "no WARNING in stderr output: '$stderr_out'"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $pass passed, $fail failed"
+[[ $fail -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- Add `scripts/lib/claude-invoke.sh` — shell helper exposing `claude_invoke` function. When `CLAUDE_OPS_USE_CREDIT_POOL=1` it delegates to `node scripts/account-rotation/claude-p-as.mjs --`; otherwise calls `claude` directly. Repo root resolved via `$CLAUDE_OPS_ROOT` → `$PLUGIN_ROOT` → `BASH_SOURCE` walk-up.
- Patch three daemon call sites to source the helper and call `claude_invoke` instead of bare `claude -p`:
  - `scripts/recap/digest.sh` line 73 (shebang promoted to bash)
  - `scripts/lib/deploy-fix-common.sh` line 196 (inside `nohup bash -c` subshell)
  - `bin/ops-suggest-specialized-agent` line 106 (PreToolUse hook, also inside nohup subshell)
- Document `CLAUDE_OPS_USE_CREDIT_POOL` in `CLAUDE.md` with activation date caveat (2026-06-15).
- Add `tests/test-claude-invoke.sh` (5 tests): gate unset, gate=0, gate=1 routes to wrapper, gate=1 with missing wrapper falls back + emits WARNING.

## Gate behaviour

| `CLAUDE_OPS_USE_CREDIT_POOL` | Behaviour |
|---|---|
| unset / `0` | `claude "$@"` — no change from today |
| `1` | `node .../claude-p-as.mjs -- "$@"` — credit pool |

Before ledger activation (pre-2026-06-15), leave the variable unset. After activation, export it in the daemon launch environment.

## Rollback

`unset CLAUDE_OPS_USE_CREDIT_POOL` — instantly reverts all three callers to direct `claude` without any code change.

## Files touched

| File | Change |
|---|---|
| `scripts/lib/claude-invoke.sh` | NEW — helper + `claude_invoke` function |
| `scripts/recap/digest.sh` | L1 shebang bash, L6-10 source helper, L73 `claude_invoke` |
| `scripts/lib/deploy-fix-common.sh` | L193 capture invoker path, L196 source + `claude_invoke` in nohup subshell |
| `bin/ops-suggest-specialized-agent` | L11-14 source helper, L106 source + `claude_invoke` in nohup subshell |
| `CLAUDE.md` | Credit-pool gate paragraph after Rule 0 |
| `tests/test-claude-invoke.sh` | NEW — 5 bash tests |

## Test plan

- [x] `bash tests/test-claude-invoke.sh` — 5/5 pass
- [x] `npx prettier --check "scripts/**/*.{js,mjs,json}"` — clean
- [x] `bash -n scripts/lib/claude-invoke.sh` — syntax OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple daemon/hook call sites and changes how `claude -p` is executed (potentially via account-rotation/keychain swapping) when an env gate is enabled, which could impact background job reliability if misconfigured.
> 
> **Overview**
> Introduces `scripts/lib/claude-invoke.sh`, a sourced helper that adds `claude_invoke` to *optionally* run Claude via `node scripts/account-rotation/claude-p-as.mjs -- ...` when `CLAUDE_OPS_USE_CREDIT_POOL=1`, otherwise falling back to direct `claude`.
> 
> Updates the recap digest, deploy-fix `nohup` runner, and specialized-agent drafter hook to source this helper and replace direct `claude -p` calls with `claude_invoke` (including switching `scripts/recap/digest.sh` to bash and capturing the invoker path for subshell sourcing).
> 
> Documents the new gate in `CLAUDE.md` and adds `tests/test-claude-invoke.sh` to verify routing and fallback behavior (including warning-on-missing-wrapper).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19b597f792b5fb95342880b22d798eb7956f3a9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced an optional credit-pool routing system controlled via an environment variable. When enabled, the system intelligently selects Claude API accounts based on available credits; default direct invocation is preserved when disabled. Routing takes effect immediately upon configuration.

* **Tests**
  * Added comprehensive test suite validating credit-pool routing behavior and account selection across various scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/226)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->