### PR TITLE
fix(account-rotation): bulk-setup-token stdin handling (PR #229 follow-up)

### DIFF
--- a/claude-ops/scripts/account-rotation/bulk-setup-token.mjs
+++ b/claude-ops/scripts/account-rotation/bulk-setup-token.mjs
@@ -29,6 +29,14 @@
 //
 //  Required tools on PATH: claude, aws, gog, expect.
 //
+//  NOTE on `claude -p` stdio: the Anthropic CLI (>= v2.1.x) refuses to start
+//  unless stdin is closed or piped. Inheriting the parent stdin (the default
+//  for child_process.spawn) makes the CLI emit
+//      "Warning: no stdin data received in 3s, proceeding without it"
+//  and then exit 1, which breaks the whole loop. Always spawn with
+//  `stdio: ['ignore', 'pipe', 'pipe']` (or pipe + immediate `stdin.end()`).
+//  Regression fix landed after PR #229.
+//
 //  HARD RULES
 //    - Never log plaintext tokens.
 //    - Never write tokens to disk except via `aws secretsmanager update-secret`
@@ -163,7 +171,8 @@ function invokeClaude(prompt, label) {
     };
 
     log(`${label}: invoking claude -p…`);
-    const child = spawn('claude', ['-p', prompt]);
+    // stdio: close stdin so `claude -p` doesn't emit "no stdin data received in 3s" and exit 1.
+    const child = spawn('claude', ['-p', prompt], { stdio: ['ignore', 'pipe', 'pipe'] });
     timer = setTimeout(() => {
       try {
         child.kill('SIGTERM');

--- a/claude-ops/scripts/account-rotation/kapture-claim-credits.mjs
+++ b/claude-ops/scripts/account-rotation/kapture-claim-credits.mjs
@@ -254,7 +254,8 @@ function invokeClaude(prompt) {
       resolve(payload);
     };
 
-    const child = spawn('claude', ['-p', prompt]);
+    // stdio: close stdin so `claude -p` doesn't emit "no stdin data received in 3s" and exit 1.
+    const child = spawn('claude', ['-p', prompt], { stdio: ['ignore', 'pipe', 'pipe'] });
     timer = setTimeout(() => {
       try {
         child.kill('SIGTERM');


### PR DESCRIPTION
## Bug

`scripts/account-rotation/bulk-setup-token.mjs` (merged in #229) fails on every account in the loop.

`invokeClaude()` spawns the CLI via:

```js
const child = spawn('claude', ['-p', prompt]);
```

With no `stdio` option, the child inherits the parent's stdin. Anthropic CLI v2.1.143 then prints:

```
Warning: no stdin data received in 3s, proceeding without it
```

and exits with code 1, breaking the whole loop.

**Real-world repro:** today's run against 6 accounts — all 6 failed identically with that warning before any Kapture work happened.

## Fix

Pass `stdio: ['ignore', 'pipe', 'pipe']` so `claude -p` sees a closed stdin immediately:

```js
const child = spawn('claude', ['-p', prompt], { stdio: ['ignore', 'pipe', 'pipe'] });
```

Same fix applied to `kapture-claim-credits.mjs` — identical `invokeClaude` pattern, same latent bug. Added a regression note to the `bulk-setup-token.mjs` header docstring under "Required tools on PATH".

## Verification

- `node --check scripts/account-rotation/bulk-setup-token.mjs` — passes
- `node --check scripts/account-rotation/kapture-claim-credits.mjs` — passes
- `npx prettier --check "scripts/account-rotation/**/*.mjs"` — all files match
- `node scripts/account-rotation/bulk-setup-token.mjs --dry-run --gmail-account user@example.com` — exits 0, prints DRY/SKIP summary for all 7 ledger slots

## Test plan

- [ ] Run a real (non-dry-run) `bulk-setup-token` pass against one account and confirm `claude -p` no longer logs the stdin warning and the Kapture login step completes.

Co-Authored-By: Claude Opus 4.7 (1M context)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches automation scripts that mint/store OAuth tokens and claim credits; while the change is small, incorrect stdio handling could still break operational loops during live runs.
> 
> **Overview**
> Fixes `claude -p` subprocess invocation in account-rotation scripts to **explicitly close stdin** by spawning with `stdio: ['ignore','pipe','pipe']`, preventing newer Anthropic CLI versions from warning about missing stdin and exiting non-zero.
> 
> Adds a short regression note in `bulk-setup-token.mjs` documenting the `claude -p` stdin requirement, and applies the same spawn fix to `kapture-claim-credits.mjs`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86edcf6b2dc726bf9677a6f0dbb36b86049c9fbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->