### PR TITLE
fix(deploy-fix-hooks): repair test-suite (9 → 0 failing cases)

### DIFF
--- a/claude-ops/bin/ops-deploy-fix-build-trigger
+++ b/claude-ops/bin/ops-deploy-fix-build-trigger
@@ -61,7 +61,7 @@ if [ "$(config auto_dispatch_fixer true)" != "true" ]; then
 fi
 
 set +e
-fix_log=$(dispatch_fix_agent "build-fix.md" "$repo_slug-build" \
+fix_log=$(dispatch_fix_agent "build-fixer" "$repo_slug-build" \
   "COMMAND=$cmd" "REPO_PATH=$repo_path" "BRANCH=$branch" "LOGS=$last_lines")
 dispatch_status=$?
 set -e

--- a/claude-ops/scripts/lib/deploy-fix-common.sh
+++ b/claude-ops/scripts/lib/deploy-fix-common.sh
@@ -74,13 +74,17 @@ already_seen() {
 
 # Detect transient failure signatures. Returns 0 (transient) or 1.
 is_transient() {
-  printf '%s' "$1" | grep -qE \
-'ECONNRESET|ETIMEDOUT|EAI_AGAIN|EHOSTUNREACH|TLS handshake timeout|unexpected EOF while reading|Could not resolve host|network is unreachable|\
-npm error code E429|npm error 5(0[0-9]|2[0-9])|HTTP(S)?Error:? 429|HTTP(S)?Error:? 5[0-9]{2}|\
-The runner has received a shutdown signal|The hosted runner lost communication|The operation was canceled\.|GH001:|\
-TooManyRequestsException|ThrottlingException|RequestLimitExceeded|Service Unavailable Exception|\
-Apple ID server.*temporarily unavailable|App Store Connect.*timed out|ASC.*5[0-9]{2}|\
-Simulator failed to launch|ECR.*throttle'
+  # Pattern stored in a variable so the regex is one logical token —
+  # the previous inline backslash-continuation produced literal '\' chars
+  # inside single-quoted alternatives and broke matching under set -e.
+  local pat
+  pat='ECONNRESET|ETIMEDOUT|EAI_AGAIN|EHOSTUNREACH|TLS handshake timeout|unexpected EOF while reading|Could not resolve host|network is unreachable'
+  pat="$pat"'|npm error code E429|npm error 5(0[0-9]|2[0-9])|HTTP(S)?Error:? 429|HTTP(S)?Error:? 5[0-9]{2}'
+  pat="$pat"'|The runner has received a shutdown signal|The hosted runner lost communication|The operation was canceled\.|GH001:'
+  pat="$pat"'|TooManyRequestsException|ThrottlingException|RequestLimitExceeded|Service Unavailable Exception'
+  pat="$pat"'|Apple ID server.*temporarily unavailable|App Store Connect.*timed out|ASC.*5[0-9]{2}'
+  pat="$pat"'|Simulator failed to launch|ECR.*throttle'
+  printf '%s' "$1" | grep -qE "$pat"
 }
 
 notify() {
@@ -126,7 +130,12 @@ locate_repo() {
 
 # Resolve health URL via layered registry: project → user → plugin example.
 resolve_health_url() {
-  local slug="$1" base="$2" key="$slug:$base"
+  # Split onto separate `local` lines: bash evaluates each RHS in the parent
+  # scope first, so multi-assignment cross-refs (`key="$slug:$base"`) trip
+  # set -u with "slug: unbound variable".
+  local slug="$1"
+  local base="$2"
+  local key="$slug:$base"
   local proj=$(locate_repo "$slug" 2>/dev/null)
   if [ -n "$proj" ] && [ -f "$proj/.claude/post-merge-services.json" ]; then
     local v=$(jq -r --arg k "$key" '.[$k].health // ""' "$proj/.claude/post-merge-services.json" 2>/dev/null)
@@ -144,7 +153,9 @@ resolve_health_url() {
 }
 
 resolve_version_url() {
-  local slug="$1" base="$2" key="$slug:$base"
+  local slug="$1"
+  local base="$2"
+  local key="$slug:$base"
   local proj=$(locate_repo "$slug" 2>/dev/null)
   if [ -n "$proj" ] && [ -f "$proj/.claude/post-merge-services.json" ]; then
     local v=$(jq -r --arg k "$key" '.[$k].version // ""' "$proj/.claude/post-merge-services.json" 2>/dev/null)
@@ -162,8 +173,13 @@ resolve_version_url() {
 }
 
 dispatch_fix_agent() {
-  # $1 = prompt template path (in $PLUGIN_ROOT/prompts/), $2 = lock_id, rest = template vars as KEY=VAL
-  local template="$1" lock_id="$2"; shift 2
+  # $1 = agent name (resolved via `claude --agent <name>` against agents/<name>.md),
+  # $2 = lock_id, $3.. = context KEY=VAL pairs that become "KEY: VAL" lines in the brief.
+  # Legacy callers passed prompt template paths like "build-fix.md" / "deploy-fix.md";
+  # those are remapped to the new agent names so the contract change is transparent.
+  local agent_name="$1"
+  local lock_id="$2"
+  shift 2
   if ! lock_acquire "$lock_id"; then
     return 2  # already in flight
   fi
@@ -174,19 +190,31 @@ dispatch_fix_agent() {
     return 3
   fi
 
-  local prompt_file="$PLUGIN_ROOT/prompts/$template"
-  if [ ! -f "$prompt_file" ]; then
+  # Legacy → new contract mapping.
+  agent_name="${agent_name%.md}"
+  case "$agent_name" in
+    build-fix) agent_name="build-fixer" ;;
+    deploy-fix) agent_name="deploy-fixer" ;;
+  esac
+
+  # If the agent file is absent, treat as misconfiguration: release the lock
+  # and surface rc=4 so callers can fall back to manual notification.
+  if [ ! -f "$PLUGIN_ROOT/agents/$agent_name.md" ]; then
     lock_release "$lock_id"
     return 4
   fi
-  local prompt=$(cat "$prompt_file")
+
+  # Build the brief from KEY=VAL pairs. One pair per line so downstream parsers
+  # (and the test mock) can match on `REPO: owner/repo` etc.
+  local brief="Context for this fix:"
+  local kv k v
   for kv in "$@"; do
-    local k="${kv%%=*}" v="${kv#*=}"
-    prompt="${prompt//\{\{${k}\}\}/$v}"
+    k="${kv%%=*}"
+    v="${kv#*=}"
+    brief="$brief"$'\n'"$k: $v"
   done
 
   local fix_log="$LOGS_DIR/fix-${lock_id}-$(date +%s).log"
-  local model=$(config fix_model haiku)
   local danger_flag="--permission-mode acceptEdits"
   [ "$(config allow_dangerous false)" = "true" ] && danger_flag="--dangerously-skip-permissions"
 
@@ -198,9 +226,9 @@ dispatch_fix_agent() {
 
   nohup bash -c "
     . '$_invoker'
-    printf '%s' \"\$1\" | claude_invoke -p --model $model $danger_flag --no-session-persistence > '$fix_log' 2>&1
+    printf '%s' \"\$1\" | claude_invoke -p --agent $agent_name $danger_flag --no-session-persistence > '$fix_log' 2>&1
     rm -f '$STATE_DIR/lock-$lock_id'
-  " _ "$prompt" </dev/null >/dev/null 2>&1 &
+  " _ "$brief" </dev/null >/dev/null 2>&1 &
   disown 2>/dev/null || true
   echo "$fix_log"
   return 0

--- a/claude-ops/scripts/ops-deploy-monitor.sh
+++ b/claude-ops/scripts/ops-deploy-monitor.sh
@@ -83,7 +83,7 @@ if [ "$CONCLUSION" != "success" ]; then
   notify "Deploy failed" "$REPO #$PR → $BASE: $CONCLUSION"
 
   if [ "$(config auto_dispatch_fixer true)" = "true" ]; then
-    fix_log=$(dispatch_fix_agent "deploy-fix.md" "$SLUG-deploy" \
+    fix_log=$(dispatch_fix_agent "deploy-fixer" "$SLUG-deploy" \
       "REPO=$REPO" "PR=$PR" "BASE=$BASE" "SHA=$SHA" "RUN_ID=$RUN_ID" \
       "SUMMARY=deploy workflow #$RUN_ID concluded $CONCLUSION" \
       "LOGS=$failed_log")
@@ -110,7 +110,7 @@ if [ "$HTTP" != "200" ]; then
   fire "service $URL → HTTP $HTTP after deploy"
   notify "Service unhealthy" "$REPO $BASE: $URL → HTTP $HTTP"
   if [ "$(config auto_dispatch_fixer true)" = "true" ]; then
-    dispatch_fix_agent "deploy-fix.md" "$SLUG-health" \
+    dispatch_fix_agent "deploy-fixer" "$SLUG-health" \
       "REPO=$REPO" "PR=$PR" "BASE=$BASE" "SHA=$SHA" "RUN_ID=$RUN_ID" \
       "SUMMARY=service health URL $URL returned HTTP $HTTP" \
       "LOGS=(no workflow logs — health check failure)" >/dev/null

--- a/claude-ops/tests/test-deploy-fix-hooks.sh
+++ b/claude-ops/tests/test-deploy-fix-hooks.sh
@@ -280,13 +280,10 @@ test_build_trigger_lock_held() {
   export CLAUDE_PLUGIN_OPTION_DEPLOY_FIX_ENABLED=true
   export CLAUDE_PLUGIN_OPTION_MONITOR_BUILD_FAILURES=true
   export CLAUDE_PLUGIN_OPTION_AUTO_DISPATCH_FIXER=true
-  # Pre-create a live lock owned by current PID so dispatch_fix_agent returns 2
-  local slug_full
-  slug_full=$(git -C "$(pwd -P)" config --get remote.origin.url 2>/dev/null | \
-    sed -E 's|.*[:/]([^/]+/[^/]+)(\.git)?$|\1|; s|\.git$||' || true)
-  local repo_slug
-  repo_slug=$(echo "${slug_full:-local-build}" | tr '/' '-')
-  echo $$ > "$TEST_STATE/lock-${repo_slug}-build"
+  # The build trigger pins `repo_slug=healify` (mobile build hooks always
+  # operate against the healify repo), so the lock path is fixed regardless
+  # of the caller's PWD or git remote.
+  echo $$ > "$TEST_STATE/lock-healify-build"
   out=$(cat "$FIXTURES/build-trigger-fail.json" | bash "$PLUGIN_ROOT/bin/ops-deploy-fix-build-trigger" 2>&1)
   rc=$?
   assert_eq "2e.exit-zero-on-lock" "0" "$rc"
@@ -415,7 +412,7 @@ trap 'rm -rf "$SUITE_TMP"' EXIT
 
 # 8a — happy: dispatches, context vars appear in the brief piped to claude
 ( new_isolated_env "case8-happy" ; load_lib
-  out=$(dispatch_fix_agent "test-agent" "myslug-deploy" "REPO=owner/repo" "SHA=abc1234" "BRANCH=dev" "EXTRA=hi")
+  out=$(dispatch_fix_agent "build-fixer" "myslug-deploy" "REPO=owner/repo" "SHA=abc1234" "BRANCH=dev" "EXTRA=hi")
   rc=$?
   [ "$rc" = "0" ] || { echo "  FAIL: 8a.rc=$rc"; exit 1; }
   echo "  PASS: 8a.dispatch-rc-zero"
@@ -438,20 +435,20 @@ trap 'rm -rf "$SUITE_TMP"' EXIT
   # Pre-create a live lock owned by current PID
   echo $$ > "$TEST_STATE/lock-myslug-deploy"
   rc=0
-  dispatch_fix_agent "test-agent" "myslug-deploy" "REPO=x" "SHA=y" "BRANCH=z" "EXTRA=w" >/dev/null 2>&1 || rc=$?
+  dispatch_fix_agent "build-fixer" "myslug-deploy" "REPO=x" "SHA=y" "BRANCH=z" "EXTRA=w" >/dev/null 2>&1 || rc=$?
   [ "$rc" = "2" ] && echo "  PASS: 8b.skips-on-lock-rc2" || { echo "  FAIL: 8b got rc=$rc"; exit 1; }
 ) && PASS=$((PASS+1)) || { fail "case8b" "see above"; }
 
 # 8c — skip on budget exhausted
 ( new_isolated_env "case8-budget" ; load_lib
   export CLAUDE_PLUGIN_OPTION_MAX_FIXES_PER_HOUR=1
-  dispatch_fix_agent "test-agent" "myslug-deploy" "REPO=x" "SHA=y" "BRANCH=z" "EXTRA=w" >/dev/null 2>&1
+  dispatch_fix_agent "build-fixer" "myslug-deploy" "REPO=x" "SHA=y" "BRANCH=z" "EXTRA=w" >/dev/null 2>&1
   # Wait for first to clear the lock (claude mock exits fast, then lock is removed by the bg shell)
   sleep 1
   # Force lock release in case timing leaves it
   rm -f "$TEST_STATE/lock-myslug-deploy"
   rc=0
-  dispatch_fix_agent "test-agent" "myslug-deploy" "REPO=x" "SHA=y" "BRANCH=z" "EXTRA=w" >/dev/null 2>&1 || rc=$?
+  dispatch_fix_agent "build-fixer" "myslug-deploy" "REPO=x" "SHA=y" "BRANCH=z" "EXTRA=w" >/dev/null 2>&1 || rc=$?
   [ "$rc" = "3" ] && echo "  PASS: 8c.skips-on-budget-rc3" || { echo "  FAIL: 8c got rc=$rc"; exit 1; }
 ) && PASS=$((PASS+1)) || { fail "case8c" "see above"; }
 


### PR DESCRIPTION
## Summary

Repair pre-existing test-suite regression in `tests/test-deploy-fix-hooks.sh` that was blocking every claude-ops PR. Three real script bugs + a tests-vs-impl contract drift.

## Script bugs fixed

- **`is_transient` regex** — backslash line-continuation inside the single-quoted alternation produced literal `\` chars in alternates, so E429 / Service Unavailable / runner-shutdown patterns never matched. Cascaded into cases 2d (transient → notify path), 3 (the unit tests), and 10a (monitor rerun decision).
- **`resolve_health_url` + `resolve_version_url` multi-`local`** — `local slug="$1" base="$2" key="$slug:$base"` trips `set -u` with `slug: unbound variable` because bash evaluates each RHS in the parent scope before any of the locals exist. Split onto separate `local` lines (case 7).

## Contract refactor

The tests describe (and `agents/*.md` already exists for) a newer `dispatch_fix_agent` contract: take an agent name and invoke `claude --agent <name>`, no `prompts/<file>.md` template substitution.

- Rewrote `dispatch_fix_agent` to use the new contract. Legacy callers passing `build-fix.md` / `deploy-fix.md` are remapped to `build-fixer` / `deploy-fixer` so the change is transparent.
- Updated `bin/ops-deploy-fix-build-trigger` and `scripts/ops-deploy-monitor.sh` to the new agent names (cases 8a, 11f).

## Test fixes

- **8a** — used `build-fixer` (which exists in `agents/`) instead of the never-defined `test-agent`.
- **2e** — the build trigger pins `repo_slug=healify`; the test was deriving repo_slug from the PWD's git remote, so the lock path never matched. Hardcoded `lock-healify-build`.

## Test plan

- [x] `bash tests/test-deploy-fix-hooks.sh` — 45 passed, 0 failed (was 36 / 9)
- [x] `bash tests/test-no-secrets.sh` — public-repo gate (14/14)
- [ ] CI cross-OS run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how build/deploy failures dispatch automated fix agents (switching from prompt templates/model flags to `claude --agent`), which could alter when/what gets invoked on real failures. Also adjusts transient detection and service URL resolution under `set -u/-e`, impacting rerun/dispatch decisions.
> 
> **Overview**
> **Repairs the deploy/build auto-fix hooks and unblocks the test suite** by fixing multiple bash edge cases and aligning implementation with the newer agent-based dispatch contract.
> 
> `dispatch_fix_agent` is refactored to take an *agent name* and pipe a structured context brief into `claude --agent`, with legacy `build-fix.md`/`deploy-fix.md` inputs remapped to `build-fixer`/`deploy-fixer`; callers in the build trigger and deploy monitor are updated accordingly.
> 
> Fixes two correctness bugs that affected control flow under `set -e/-u`: `is_transient` now builds its regex without broken line continuations, and `resolve_health_url`/`resolve_version_url` avoid multi-`local` cross-references that triggered “unbound variable”. Tests are updated to match the new dispatch contract and correct the expected lockfile ID for the pinned `healify` build trigger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c4bdf85dc595f9a3890c849bc00d0b3779c5db4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->