### PR TITLE
fix: audit fixes — plugin validation, version alignment, deploy-fix tests, stdin handling (v2.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,9 +9,9 @@
   "plugins": [
     {
       "name": "ops",
-      "description": "Business operations command center for Claude Code \u2014 30 skills, 14 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
+      "description": "Business operations command center for Claude Code \u2014 35 skills, 18 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.0.6",
+      "version": "2.2.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ops",
-  "version": "2.0.6",
-  "description": "Business operations command center for Claude Code — 30 skills, 14 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
+  "version": "2.2.0",
+  "description": "Business operations command center for Claude Code — 35 skills, 18 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",
     "url": "https://github.com/Lifecycle-Innovations-Limited"
@@ -121,27 +121,24 @@
     "fix_model": {
       "type": "string",
       "title": "Fix-agent model",
-      "description": "Anthropic model the fixer runs on. Default haiku (fast/cheap). Use sonnet/opus for harder failures.",
-      "default": "haiku",
-      "enum": ["opus", "sonnet", "haiku"]
+      "description": "Anthropic model the fixer runs on. Default haiku (fast/cheap). Use sonnet/opus for harder failures. Allowed values: opus, sonnet, haiku.",
+      "default": "haiku"
     },
     "max_fixes_per_hour": {
       "type": "number",
       "title": "Per-repo fix budget per hour",
-      "description": "Cap on auto-fix dispatches per repo per hour.",
+      "description": "Cap on auto-fix dispatches per repo per hour. Suggested values: 1, 3, 5, 10.",
       "default": 3,
       "min": 0,
-      "max": 20,
-      "enum": [1, 3, 5, 10]
+      "max": 20
     },
     "watcher_timeout_seconds": {
       "type": "number",
       "title": "Deploy watcher timeout (seconds)",
-      "description": "Max wait for deploy workflow completion.",
+      "description": "Max wait for deploy workflow completion. Suggested values: 300, 600, 900, 1800, 3600.",
       "default": 1800,
       "min": 60,
-      "max": 7200,
-      "enum": [300, 600, 900, 1800, 3600]
+      "max": 7200
     },
     "registry_path": {
       "type": "file",
@@ -164,9 +161,8 @@
     "notify_channel": {
       "type": "string",
       "title": "Failure notification channel",
-      "description": "Where to push failure alerts: macos, ntfy, pushover, discord, telegram, or none.",
-      "default": "macos",
-      "enum": ["macos", "ntfy", "pushover", "discord", "telegram", "none"]
+      "description": "Where to push failure alerts. Allowed values: macos, ntfy, pushover, discord, telegram, none.",
+      "default": "macos"
     },
     "recap_marquee_enabled": {
       "type": "boolean",
@@ -201,11 +197,10 @@
     "task_reminder_threshold": {
       "type": "number",
       "title": "Task reminder threshold",
-      "description": "Number of non-Task tool calls before the reminder fires.",
+      "description": "Number of non-Task tool calls before the reminder fires. Suggested values: 5, 10, 20, 50.",
       "default": 10,
       "min": 3,
-      "max": 50,
-      "enum": [5, 10, 20, 50]
+      "max": 50
     },
     "suggest_specialized_agents": {
       "type": "boolean",
@@ -257,28 +252,10 @@
     },
     "aws_region": {
       "title": "AWS Region",
-      "description": "Default AWS region for infra checks. Valid: us-east-1, us-east-2, us-west-1, us-west-2, eu-west-1, eu-central-1, ap-southeast-1, ap-northeast-1.",
+      "description": "Default AWS region for infra checks. Allowed values: us-east-1, us-east-2, us-west-1, us-west-2, eu-west-1, eu-west-2, eu-west-3, eu-central-1, eu-north-1, ap-southeast-1, ap-southeast-2, ap-northeast-1, ap-northeast-2, ap-south-1, sa-east-1, ca-central-1.",
       "type": "string",
       "sensitive": false,
-      "default": "us-east-1",
-      "enum": [
-        "us-east-1",
-        "us-east-2",
-        "us-west-1",
-        "us-west-2",
-        "eu-west-1",
-        "eu-west-2",
-        "eu-west-3",
-        "eu-central-1",
-        "eu-north-1",
-        "ap-southeast-1",
-        "ap-southeast-2",
-        "ap-northeast-1",
-        "ap-northeast-2",
-        "ap-south-1",
-        "sa-east-1",
-        "ca-central-1"
-      ]
+      "default": "us-east-1"
     },
     "klaviyo_private_key": {
       "title": "Klaviyo Private API Key",
@@ -480,11 +457,10 @@
     },
     "doppler_config": {
       "title": "Doppler Default Config",
-      "description": "Default Doppler config name (e.g. 'dev', 'stg', 'prd'). Used by the Doppler MCP server.",
+      "description": "Default Doppler config name. Used by the Doppler MCP server. Allowed values: dev, stg, prd, ci.",
       "type": "string",
       "sensitive": false,
-      "default": "",
-      "enum": ["dev", "stg", "prd", "ci"]
+      "default": ""
     },
     "myparcel_api_key": {
       "title": "MyParcel.nl API Key",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.2.0] — 2026-05-16
+
+### Fixed
+
+- **Plugin installation blocked by unsupported `enum` keys in plugin.json.** Claude Code's plugin validator rejects `enum` as an unrecognized key in userConfig fields. Removed `enum` from 7 fields (fix_model, max_fixes_per_hour, watcher_timeout_seconds, notify_channel, task_reminder_threshold, aws_region, doppler_config) and moved allowed values into descriptions.
+- **ops-package SKILL.md YAML frontmatter parse error.** Unquoted colon in description field caused YAML parse failure, silently dropping all frontmatter metadata at runtime. Wrapped in quotes.
+- **Version number alignment.** Synchronized version across plugin.json (was 2.0.6), package.json (was 1.7.2), and marketplace.json (was 2.0.6) to 2.2.0.
+- **Plugin description counts updated.** Changed "30 skills, 14 agents" to "35 skills, 18 agents" to match actual inventory.
+
 ## [2.0.6] — 2026-04-30
 
 ### Added

--- a/claude-ops/bin/ops-deploy-fix-build-trigger
+++ b/claude-ops/bin/ops-deploy-fix-build-trigger
@@ -61,7 +61,7 @@ if [ "$(config auto_dispatch_fixer true)" != "true" ]; then
 fi
 
 set +e
-fix_log=$(dispatch_fix_agent "build-fix.md" "$repo_slug-build" \
+fix_log=$(dispatch_fix_agent "build-fixer" "$repo_slug-build" \
   "COMMAND=$cmd" "REPO_PATH=$repo_path" "BRANCH=$branch" "LOGS=$last_lines")
 dispatch_status=$?
 set -e

--- a/claude-ops/bin/ops-deploy-fix-build-trigger
+++ b/claude-ops/bin/ops-deploy-fix-build-trigger
@@ -30,7 +30,10 @@ last_lines=$(echo "$output" | tail -120)
 
 # Repo = healify (mobile build hooks always operate against this)
 repo_slug="healify"
-repo_path=$(locate_repo "Lifecycle-Innovations-Limited/healify" 2>/dev/null)
+# `|| true` — locate_repo returns 1 when the checkout is absent. Without it the
+# plain assignment leaks that non-zero status and `set -e` aborts the hook
+# before the fallback below (and the transient/dispatch paths) can run.
+repo_path=$(locate_repo "Lifecycle-Innovations-Limited/healify" 2>/dev/null) || true
 [ -z "$repo_path" ] && repo_path="$HOME/healify"
 branch=$(git -C "$repo_path" branch --show-current 2>/dev/null || echo "unknown")
 

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "1.7.2",
+  "version": "2.2.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/claude-ops/scripts/account-rotation/bulk-setup-token.mjs
+++ b/claude-ops/scripts/account-rotation/bulk-setup-token.mjs
@@ -29,6 +29,14 @@
 //
 //  Required tools on PATH: claude, aws, gog, expect.
 //
+//  NOTE on `claude -p` stdio: the Anthropic CLI (>= v2.1.x) refuses to start
+//  unless stdin is closed or piped. Inheriting the parent stdin (the default
+//  for child_process.spawn) makes the CLI emit
+//      "Warning: no stdin data received in 3s, proceeding without it"
+//  and then exit 1, which breaks the whole loop. Always spawn with
+//  `stdio: ['ignore', 'pipe', 'pipe']` (or pipe + immediate `stdin.end()`).
+//  Regression fix landed after PR #229.
+//
 //  HARD RULES
 //    - Never log plaintext tokens.
 //    - Never write tokens to disk except via `aws secretsmanager update-secret`
@@ -163,7 +171,8 @@ function invokeClaude(prompt, label) {
     };
 
     log(`${label}: invoking claude -p…`);
-    const child = spawn('claude', ['-p', prompt]);
+    // stdio: close stdin so `claude -p` doesn't emit "no stdin data received in 3s" and exit 1.
+    const child = spawn('claude', ['-p', prompt], { stdio: ['ignore', 'pipe', 'pipe'] });
     timer = setTimeout(() => {
       try {
         child.kill('SIGTERM');

--- a/claude-ops/scripts/account-rotation/kapture-claim-credits.mjs
+++ b/claude-ops/scripts/account-rotation/kapture-claim-credits.mjs
@@ -254,7 +254,8 @@ function invokeClaude(prompt) {
       resolve(payload);
     };
 
-    const child = spawn('claude', ['-p', prompt]);
+    // stdio: close stdin so `claude -p` doesn't emit "no stdin data received in 3s" and exit 1.
+    const child = spawn('claude', ['-p', prompt], { stdio: ['ignore', 'pipe', 'pipe'] });
     timer = setTimeout(() => {
       try {
         child.kill('SIGTERM');

--- a/claude-ops/scripts/lib/deploy-fix-common.sh
+++ b/claude-ops/scripts/lib/deploy-fix-common.sh
@@ -148,8 +148,13 @@ resolve_health_url() {
     [ -n "$v" ] && { echo "$v"; return; }
   fi
   if [ -f "$PLUGIN_ROOT/config/post-merge-services.example.json" ]; then
-    jq -r --arg k "$key" '.[$k].health // ""' "$PLUGIN_ROOT/config/post-merge-services.example.json" 2>/dev/null
+    jq -r --arg k "$key" '.[$k].health // ""' "$PLUGIN_ROOT/config/post-merge-services.example.json" 2>/dev/null || true
   fi
+  # Always succeed. When no registry layer matches, the function's last command
+  # is the `[ -f ... ]` test (false → status 1) or a failed jq; either would
+  # abort a `set -e` caller doing `URL=$(resolve_health_url ...)`. The empty
+  # stdout is the intended "not found" signal — return status must stay 0.
+  return 0
 }
 
 resolve_version_url() {
@@ -168,8 +173,10 @@ resolve_version_url() {
     [ -n "$v" ] && { echo "$v"; return; }
   fi
   if [ -f "$PLUGIN_ROOT/config/post-merge-services.example.json" ]; then
-    jq -r --arg k "$key" '.[$k].version // ""' "$PLUGIN_ROOT/config/post-merge-services.example.json" 2>/dev/null
+    jq -r --arg k "$key" '.[$k].version // ""' "$PLUGIN_ROOT/config/post-merge-services.example.json" 2>/dev/null || true
   fi
+  # Always succeed — see resolve_health_url above for the rationale.
+  return 0
 }
 
 dispatch_fix_agent() {

--- a/claude-ops/scripts/lib/deploy-fix-common.sh
+++ b/claude-ops/scripts/lib/deploy-fix-common.sh
@@ -74,13 +74,17 @@ already_seen() {
 
 # Detect transient failure signatures. Returns 0 (transient) or 1.
 is_transient() {
-  printf '%s' "$1" | grep -qE \
-'ECONNRESET|ETIMEDOUT|EAI_AGAIN|EHOSTUNREACH|TLS handshake timeout|unexpected EOF while reading|Could not resolve host|network is unreachable|\
-npm error code E429|npm error 5(0[0-9]|2[0-9])|HTTP(S)?Error:? 429|HTTP(S)?Error:? 5[0-9]{2}|\
-The runner has received a shutdown signal|The hosted runner lost communication|The operation was canceled\.|GH001:|\
-TooManyRequestsException|ThrottlingException|RequestLimitExceeded|Service Unavailable Exception|\
-Apple ID server.*temporarily unavailable|App Store Connect.*timed out|ASC.*5[0-9]{2}|\
-Simulator failed to launch|ECR.*throttle'
+  # Pattern stored in a variable so the regex is one logical token —
+  # the previous inline backslash-continuation produced literal '\' chars
+  # inside single-quoted alternatives and broke matching under set -e.
+  local pat
+  pat='ECONNRESET|ETIMEDOUT|EAI_AGAIN|EHOSTUNREACH|TLS handshake timeout|unexpected EOF while reading|Could not resolve host|network is unreachable'
+  pat="$pat"'|npm error code E429|npm error 5(0[0-9]|2[0-9])|HTTP(S)?Error:? 429|HTTP(S)?Error:? 5[0-9]{2}'
+  pat="$pat"'|The runner has received a shutdown signal|The hosted runner lost communication|The operation was canceled\.|GH001:'
+  pat="$pat"'|TooManyRequestsException|ThrottlingException|RequestLimitExceeded|Service Unavailable Exception'
+  pat="$pat"'|Apple ID server.*temporarily unavailable|App Store Connect.*timed out|ASC.*5[0-9]{2}'
+  pat="$pat"'|Simulator failed to launch|ECR.*throttle'
+  printf '%s' "$1" | grep -qE "$pat"
 }
 
 notify() {
@@ -126,7 +130,12 @@ locate_repo() {
 
 # Resolve health URL via layered registry: project → user → plugin example.
 resolve_health_url() {
-  local slug="$1" base="$2" key="$slug:$base"
+  # Split onto separate `local` lines: bash evaluates each RHS in the parent
+  # scope first, so multi-assignment cross-refs (`key="$slug:$base"`) trip
+  # set -u with "slug: unbound variable".
+  local slug="$1"
+  local base="$2"
+  local key="$slug:$base"
   local proj=$(locate_repo "$slug" 2>/dev/null)
   if [ -n "$proj" ] && [ -f "$proj/.claude/post-merge-services.json" ]; then
     local v=$(jq -r --arg k "$key" '.[$k].health // ""' "$proj/.claude/post-merge-services.json" 2>/dev/null)
@@ -144,7 +153,9 @@ resolve_health_url() {
 }
 
 resolve_version_url() {
-  local slug="$1" base="$2" key="$slug:$base"
+  local slug="$1"
+  local base="$2"
+  local key="$slug:$base"
   local proj=$(locate_repo "$slug" 2>/dev/null)
   if [ -n "$proj" ] && [ -f "$proj/.claude/post-merge-services.json" ]; then
     local v=$(jq -r --arg k "$key" '.[$k].version // ""' "$proj/.claude/post-merge-services.json" 2>/dev/null)
@@ -162,8 +173,13 @@ resolve_version_url() {
 }
 
 dispatch_fix_agent() {
-  # $1 = prompt template path (in $PLUGIN_ROOT/prompts/), $2 = lock_id, rest = template vars as KEY=VAL
-  local template="$1" lock_id="$2"; shift 2
+  # $1 = agent name (resolved via `claude --agent <name>` against agents/<name>.md),
+  # $2 = lock_id, $3.. = context KEY=VAL pairs that become "KEY: VAL" lines in the brief.
+  # Legacy callers passed prompt template paths like "build-fix.md" / "deploy-fix.md";
+  # those are remapped to the new agent names so the contract change is transparent.
+  local agent_name="$1"
+  local lock_id="$2"
+  shift 2
   if ! lock_acquire "$lock_id"; then
     return 2  # already in flight
   fi
@@ -174,19 +190,31 @@ dispatch_fix_agent() {
     return 3
   fi
 
-  local prompt_file="$PLUGIN_ROOT/prompts/$template"
-  if [ ! -f "$prompt_file" ]; then
+  # Legacy → new contract mapping.
+  agent_name="${agent_name%.md}"
+  case "$agent_name" in
+    build-fix) agent_name="build-fixer" ;;
+    deploy-fix) agent_name="deploy-fixer" ;;
+  esac
+
+  # If the agent file is absent, treat as misconfiguration: release the lock
+  # and surface rc=4 so callers can fall back to manual notification.
+  if [ ! -f "$PLUGIN_ROOT/agents/$agent_name.md" ]; then
     lock_release "$lock_id"
     return 4
   fi
-  local prompt=$(cat "$prompt_file")
+
+  # Build the brief from KEY=VAL pairs. One pair per line so downstream parsers
+  # (and the test mock) can match on `REPO: owner/repo` etc.
+  local brief="Context for this fix:"
+  local kv k v
   for kv in "$@"; do
-    local k="${kv%%=*}" v="${kv#*=}"
-    prompt="${prompt//\{\{${k}\}\}/$v}"
+    k="${kv%%=*}"
+    v="${kv#*=}"
+    brief="$brief"$'\n'"$k: $v"
   done
 
   local fix_log="$LOGS_DIR/fix-${lock_id}-$(date +%s).log"
-  local model=$(config fix_model haiku)
   local danger_flag="--permission-mode acceptEdits"
   [ "$(config allow_dangerous false)" = "true" ] && danger_flag="--dangerously-skip-permissions"
 
@@ -198,9 +226,9 @@ dispatch_fix_agent() {
 
   nohup bash -c "
     . '$_invoker'
-    printf '%s' \"\$1\" | claude_invoke -p --model $model $danger_flag --no-session-persistence > '$fix_log' 2>&1
+    printf '%s' \"\$1\" | claude_invoke -p --agent $agent_name $danger_flag --no-session-persistence > '$fix_log' 2>&1
     rm -f '$STATE_DIR/lock-$lock_id'
-  " _ "$prompt" </dev/null >/dev/null 2>&1 &
+  " _ "$brief" </dev/null >/dev/null 2>&1 &
   disown 2>/dev/null || true
   echo "$fix_log"
   return 0

--- a/claude-ops/scripts/ops-deploy-monitor.sh
+++ b/claude-ops/scripts/ops-deploy-monitor.sh
@@ -83,7 +83,7 @@ if [ "$CONCLUSION" != "success" ]; then
   notify "Deploy failed" "$REPO #$PR → $BASE: $CONCLUSION"
 
   if [ "$(config auto_dispatch_fixer true)" = "true" ]; then
-    fix_log=$(dispatch_fix_agent "deploy-fix.md" "$SLUG-deploy" \
+    fix_log=$(dispatch_fix_agent "deploy-fixer" "$SLUG-deploy" \
       "REPO=$REPO" "PR=$PR" "BASE=$BASE" "SHA=$SHA" "RUN_ID=$RUN_ID" \
       "SUMMARY=deploy workflow #$RUN_ID concluded $CONCLUSION" \
       "LOGS=$failed_log")
@@ -110,7 +110,7 @@ if [ "$HTTP" != "200" ]; then
   fire "service $URL → HTTP $HTTP after deploy"
   notify "Service unhealthy" "$REPO $BASE: $URL → HTTP $HTTP"
   if [ "$(config auto_dispatch_fixer true)" = "true" ]; then
-    dispatch_fix_agent "deploy-fix.md" "$SLUG-health" \
+    dispatch_fix_agent "deploy-fixer" "$SLUG-health" \
       "REPO=$REPO" "PR=$PR" "BASE=$BASE" "SHA=$SHA" "RUN_ID=$RUN_ID" \
       "SUMMARY=service health URL $URL returned HTTP $HTTP" \
       "LOGS=(no workflow logs — health check failure)" >/dev/null

--- a/claude-ops/skills/ops-package/SKILL.md
+++ b/claude-ops/skills/ops-package/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ops-package
-description: Ship parcels via any configured carrier — MyParcel, Sendcloud, DHL Parcel NL, PostNL, DPD, UPS, FedEx. Auto-selects the first carrier whose credentials are configured, or pass --carrier <name> to override. Verbs: ship, label, track, list, carriers.
+description: "Ship parcels via any configured carrier — MyParcel, Sendcloud, DHL Parcel NL, PostNL, DPD, UPS, FedEx. Auto-selects the first carrier whose credentials are configured, or pass --carrier <name> to override. Verbs: ship, label, track, list, carriers."
 argument-hint: "[--carrier <name>] <ship|label|track|list|carriers> [args...]"
 allowed-tools:
   - Bash

--- a/claude-ops/tests/test-deploy-fix-hooks.sh
+++ b/claude-ops/tests/test-deploy-fix-hooks.sh
@@ -280,13 +280,10 @@ test_build_trigger_lock_held() {
   export CLAUDE_PLUGIN_OPTION_DEPLOY_FIX_ENABLED=true
   export CLAUDE_PLUGIN_OPTION_MONITOR_BUILD_FAILURES=true
   export CLAUDE_PLUGIN_OPTION_AUTO_DISPATCH_FIXER=true
-  # Pre-create a live lock owned by current PID so dispatch_fix_agent returns 2
-  local slug_full
-  slug_full=$(git -C "$(pwd -P)" config --get remote.origin.url 2>/dev/null | \
-    sed -E 's|.*[:/]([^/]+/[^/]+)(\.git)?$|\1|; s|\.git$||' || true)
-  local repo_slug
-  repo_slug=$(echo "${slug_full:-local-build}" | tr '/' '-')
-  echo $$ > "$TEST_STATE/lock-${repo_slug}-build"
+  # The build trigger pins `repo_slug=healify` (mobile build hooks always
+  # operate against the healify repo), so the lock path is fixed regardless
+  # of the caller's PWD or git remote.
+  echo $$ > "$TEST_STATE/lock-healify-build"
   out=$(cat "$FIXTURES/build-trigger-fail.json" | bash "$PLUGIN_ROOT/bin/ops-deploy-fix-build-trigger" 2>&1)
   rc=$?
   assert_eq "2e.exit-zero-on-lock" "0" "$rc"
@@ -415,7 +412,7 @@ trap 'rm -rf "$SUITE_TMP"' EXIT
 
 # 8a — happy: dispatches, context vars appear in the brief piped to claude
 ( new_isolated_env "case8-happy" ; load_lib
-  out=$(dispatch_fix_agent "test-agent" "myslug-deploy" "REPO=owner/repo" "SHA=abc1234" "BRANCH=dev" "EXTRA=hi")
+  out=$(dispatch_fix_agent "build-fixer" "myslug-deploy" "REPO=owner/repo" "SHA=abc1234" "BRANCH=dev" "EXTRA=hi")
   rc=$?
   [ "$rc" = "0" ] || { echo "  FAIL: 8a.rc=$rc"; exit 1; }
   echo "  PASS: 8a.dispatch-rc-zero"
@@ -438,20 +435,20 @@ trap 'rm -rf "$SUITE_TMP"' EXIT
   # Pre-create a live lock owned by current PID
   echo $$ > "$TEST_STATE/lock-myslug-deploy"
   rc=0
-  dispatch_fix_agent "test-agent" "myslug-deploy" "REPO=x" "SHA=y" "BRANCH=z" "EXTRA=w" >/dev/null 2>&1 || rc=$?
+  dispatch_fix_agent "build-fixer" "myslug-deploy" "REPO=x" "SHA=y" "BRANCH=z" "EXTRA=w" >/dev/null 2>&1 || rc=$?
   [ "$rc" = "2" ] && echo "  PASS: 8b.skips-on-lock-rc2" || { echo "  FAIL: 8b got rc=$rc"; exit 1; }
 ) && PASS=$((PASS+1)) || { fail "case8b" "see above"; }
 
 # 8c — skip on budget exhausted
 ( new_isolated_env "case8-budget" ; load_lib
   export CLAUDE_PLUGIN_OPTION_MAX_FIXES_PER_HOUR=1
-  dispatch_fix_agent "test-agent" "myslug-deploy" "REPO=x" "SHA=y" "BRANCH=z" "EXTRA=w" >/dev/null 2>&1
+  dispatch_fix_agent "build-fixer" "myslug-deploy" "REPO=x" "SHA=y" "BRANCH=z" "EXTRA=w" >/dev/null 2>&1
   # Wait for first to clear the lock (claude mock exits fast, then lock is removed by the bg shell)
   sleep 1
   # Force lock release in case timing leaves it
   rm -f "$TEST_STATE/lock-myslug-deploy"
   rc=0
-  dispatch_fix_agent "test-agent" "myslug-deploy" "REPO=x" "SHA=y" "BRANCH=z" "EXTRA=w" >/dev/null 2>&1 || rc=$?
+  dispatch_fix_agent "build-fixer" "myslug-deploy" "REPO=x" "SHA=y" "BRANCH=z" "EXTRA=w" >/dev/null 2>&1 || rc=$?
   [ "$rc" = "3" ] && echo "  PASS: 8c.skips-on-budget-rc3" || { echo "  FAIL: 8c got rc=$rc"; exit 1; }
 ) && PASS=$((PASS+1)) || { fail "case8c" "see above"; }
 


### PR DESCRIPTION
## Comprehensive audit fixes

### Changes included:
1. **Plugin installation fix**: Removed unsupported `enum` keys from 7 userConfig fields in plugin.json (blocked `claude plugin install`)
2. **YAML frontmatter fix**: Quoted `description` in ops-package SKILL.md to fix YAML parse error
3. **Version alignment**: Synchronized version to 2.2.0 across plugin.json, marketplace.json, package.json
4. **Description counts**: Updated "30 skills, 14 agents" → "35 skills, 18 agents"
5. **Deploy-fix test suite**: Merged PR #231 refactoring dispatch_fix_agent from template-based to agent-based dispatch
6. **set -e safety**: Fixed `locate_repo` and `resolve_*_url` functions to not abort under `set -e`
7. **Account rotation stdin**: Merged PR #230 fixing `claude -p` stdin handling in bulk-setup-token
8. **CHANGELOG**: Added v2.2.0 entry

### Test results:
- test-deploy-fix-hooks.sh: **45 passed, 0 failed** (was 39 passed, 6 failed)
- All other test suites: passing

Supersedes PRs #230 and #231.