### PR TITLE
docs: v2.2.0 final cleanup — README badges, CHANGELOG, wiki sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-2.0.0-blue)
+![Version](https://img.shields.io/badge/version-2.2.0-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
-![Skills](https://img.shields.io/badge/skills-33%2B-success)
+![Skills](https://img.shields.io/badge/skills-35-success)
 ![Agents](https://img.shields.io/badge/agents-18-informational)
 ![Integrations](https://img.shields.io/badge/integrations-22-orange)
 ![Auto-fix](https://img.shields.io/badge/v2-auto--fix%20subsystem-ef4444)

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -3,13 +3,14 @@
 All notable changes to this project will be documented in this file.
 
 ## [2.2.0] — 2026-05-16
-
 ### Fixed
-
-- **Plugin installation blocked by unsupported `enum` keys in plugin.json.** Claude Code's plugin validator rejects `enum` as an unrecognized key in userConfig fields. Removed `enum` from 7 fields (fix_model, max_fixes_per_hour, watcher_timeout_seconds, notify_channel, task_reminder_threshold, aws_region, doppler_config) and moved allowed values into descriptions.
-- **ops-package SKILL.md YAML frontmatter parse error.** Unquoted colon in description field caused YAML parse failure, silently dropping all frontmatter metadata at runtime. Wrapped in quotes.
-- **Version number alignment.** Synchronized version across plugin.json (was 2.0.6), package.json (was 1.7.2), and marketplace.json (was 2.0.6) to 2.2.0.
+- **Plugin installation blocked by unsupported `enum` keys in `plugin.json`.** Claude Code's plugin validator rejects `enum` as an unrecognized key in userConfig fields. Removed `enum` from 7 fields (`fix_model`, `max_fixes_per_hour`, `watcher_timeout_seconds`, `notify_channel`, `task_reminder_threshold`, `aws_region`, `doppler_config`) and moved allowed values into descriptions.
+- **`ops-package` SKILL.md YAML frontmatter parse error.** Unquoted colon in description field caused YAML parse failure, silently dropping all frontmatter metadata at runtime. Wrapped in quotes.
+- **Version number alignment.** Synchronized version across `plugin.json` (was 2.0.6), `package.json` (was 1.7.2), and `marketplace.json` (was 2.0.6) to 2.2.0.
 - **Plugin description counts updated.** Changed "30 skills, 14 agents" to "35 skills, 18 agents" to match actual inventory.
+- **Deploy-fix test suite: 45/45 passing (was 39/45).** Refactored `dispatch_fix_agent` from template-based (`prompts/*.md`) to agent-based dispatch (`claude --agent <name>`). Fixed `is_transient` regex line continuations. Fixed `resolve_health_url`/`resolve_version_url` multi-`local` cross-references. Updated test cases to use real agent names (`build-fixer`, `deploy-fixer`).
+- **`set -e` safety for `locate_repo` and `resolve_*` functions.** Added `|| true` guards so `locate_repo` returning 1 no longer aborts `ops-deploy-fix-build-trigger` under `set -e`. Added explicit `return 0` to `resolve_health_url` and `resolve_version_url`.
+- **Account rotation stdin handling.** Fixed `claude -p` subprocess invocation in `bulk-setup-token.mjs` and `kapture-claim-credits.mjs` to explicitly close stdin via `stdio: ['ignore','pipe','pipe']`, preventing newer CLI versions from warning about missing stdin.
 
 ## [2.0.6] — 2026-04-30
 

--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -1,10 +1,10 @@
 # claude-ops
 
-> **v2.1.0** — Autonomy Layer · Deploy Auto-Fix · Safety Hooks · Specialist Agents · Recap Marquee · Multi-Account Rotator · Multi-Workspace Slack · ops-ci Current-State Filter · Credentials Audit · 35 Skills · 18 Agents
+> **v2.2.0** — Autonomy Layer · Deploy Auto-Fix · Safety Hooks · Specialist Agents · Recap Marquee · Multi-Account Rotator · Multi-Workspace Slack · ops-ci Current-State Filter · Credentials Audit · 35 Skills · 18 Agents
 
-## What's new since v2.0.0
+## What's new in v2.2.0
 
-- **v2.1.0** — Minor release rolling up the v2.0.5–v2.0.9 feature series. Multi-workspace Slack, ops-ci current-state filter, `/ops:credentials` audit, telegram preflight, userConfig schema upgrades — see [CHANGELOG.md](CHANGELOG.md#210--2026-05-02) for the full list.
+- **v2.2.0** — Audit fixes: plugin validation (install unblocked), deploy-fix test suite (45/45 passing), `set -e` safety, account-rotation stdin handling. See [CHANGELOG.md](CHANGELOG.md#220--2026-05-16) for the full list.
 
 A Claude Code plugin that turns Claude into a business operating system **and** an autonomy layer. Run `/ops` for the interactive command center — pixel-art dashboard with instant hotkey access to morning briefings, inbox, fires, deploys, revenue, and YOLO mode. Or just keep working — v2's hooks watch every merge, every build, every commit, every push, and every agent dispatch in the background.
 


### PR DESCRIPTION
## v2.2.0 Documentation Cleanup

### Repo changes
- **Outer README**: version badge 2.0.0 → 2.2.0, skills badge 33+ → 35
- **Inner README**: version header v2.1.0 → v2.2.0, update what's-new section
- **CHANGELOG.md**: expand 2.2.0 entry with full fix list (deploy-fix test suite, set-e safety, stdin handling)

### Wiki changes (committed separately to wiki repo)
- **Home.md**: 30 commands → 35 commands, 14 agents → 18 agents, added 4 new skill tables, updated agent table with 4 new agents
- **Skills-Reference.md**: count 30 → 35, version badge 1.7.0 → 2.2.0, added docs for 8 new skills
- **Agents-Reference.md**: count 14 → 18, version badge 1.7.0 → 2.2.0, added docs for 4 new agents
- **Changelog.md**: current badge 1.7.0 → 2.2.0, added v2.2.0, v2.1.0, and v2.0.0 entries
- **Auto-Fix-Subsystem.md**: test count 39 → 45 assertions
- **_Sidebar.md**: version v2.0.0 → v2.2.0

All CI checks should pass — no code changes, docs only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates (badges/readme copy and changelog entries) with no functional code changes.
> 
> **Overview**
> **Documentation-only v2.2.0 cleanup.** Updates the root `README.md` badges to reflect version `2.2.0` and the current skills count.
> 
> Refreshes `claude-ops/README.md` to label the release as `v2.2.0` and replaces the “what’s new” blurb with a short v2.2.0 summary.
> 
> Expands `claude-ops/CHANGELOG.md`’s `2.2.0` section with a fuller list of fixes (plugin validation/install unblock, deploy-fix test suite, `set -e` guards, and stdin handling adjustments).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64a7407a70b2d762f97d1f40a4853ff6d6ac559d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated version badge to 2.2.0
  * Increased skills count to 35
  * Added v2.2.0 release notes documenting recent bug fixes and improvements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->