### PR TITLE
feat(setup): prompt for competitor-intel queries instead of silent placeholder run

### DIFF
--- a/claude-ops/scripts/ops-cron-competitor-intel.sh
+++ b/claude-ops/scripts/ops-cron-competitor-intel.sh
@@ -1,15 +1,37 @@
 #!/usr/bin/env bash
 # ops-cron-competitor-intel.sh — Weekly Competitor Intel cron job
 # Searches competitors and own brand reviews, reports to Telegram
-# Configure via env vars: COMPETITOR_A_QUERY, COMPETITOR_B_QUERY, BRAND_QUERY, REPORT_TIMEZONE
+# Configure via /ops:setup (writes to preferences.json) OR env vars:
+#   COMPETITOR_A_QUERY, COMPETITOR_B_QUERY, BRAND_QUERY, REPORT_TIMEZONE
+# Env vars override preferences.json when both are set.
 set -euo pipefail
 
 DATA_DIR="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
 LOG_DIR="$DATA_DIR/logs"
 LOG="$LOG_DIR/competitor-intel.log"
+PREFS_PATH="$DATA_DIR/preferences.json"
 
 mkdir -p "$LOG_DIR"
 log() { printf '%s [competitor-intel] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" | tee -a "$LOG"; }
+
+# ── Resolve query config from preferences.json (env vars take precedence) ─
+pref_get() {
+  local key="$1"
+  [[ -f "$PREFS_PATH" ]] || { echo ""; return; }
+  jq -r --arg k "$key" '.competitor_intel[$k] // ""' "$PREFS_PATH" 2>/dev/null || echo ""
+}
+
+COMPETITOR_A_QUERY="${COMPETITOR_A_QUERY:-$(pref_get competitor_a_query)}"
+COMPETITOR_B_QUERY="${COMPETITOR_B_QUERY:-$(pref_get competitor_b_query)}"
+BRAND_QUERY="${BRAND_QUERY:-$(pref_get brand_query)}"
+REPORT_TIMEZONE="${REPORT_TIMEZONE:-$(pref_get report_timezone)}"
+
+# ── Refuse to run with placeholder queries ────────────────────────────────
+if [[ -z "$COMPETITOR_A_QUERY" && -z "$COMPETITOR_B_QUERY" && -z "$BRAND_QUERY" ]]; then
+  log "SKIP: no competitor/brand queries configured. Run /ops:setup to configure."
+  log "HEARTBEAT_OK"
+  exit 0
+fi
 
 # ── Resolve credentials ───────────────────────────────────────────────────
 TELEGRAM_TOKEN="${TELEGRAM_BOT_TOKEN:-}"
@@ -67,9 +89,9 @@ print(' | '.join(clean[:2]) if clean else 'No results')
 # ── Run searches ──────────────────────────────────────────────────────────
 log "Running weekly competitor intelligence searches"
 
-COMPETITOR_A_RESULT=$(search_web "${COMPETITOR_A_QUERY:-competitor-a reviews $YEAR}" "Competitor A")
-COMPETITOR_B_RESULT=$(search_web "${COMPETITOR_B_QUERY:-competitor-b new products $YEAR}" "Competitor B")
-BRAND_RESULT=$(search_web "${BRAND_QUERY:-your-brand reviews $YEAR}" "Brand mentions")
+COMPETITOR_A_RESULT=$([[ -n "$COMPETITOR_A_QUERY" ]] && search_web "$COMPETITOR_A_QUERY" "Competitor A" || echo "(not configured)")
+COMPETITOR_B_RESULT=$([[ -n "$COMPETITOR_B_QUERY" ]] && search_web "$COMPETITOR_B_QUERY" "Competitor B" || echo "(not configured)")
+BRAND_RESULT=$([[ -n "$BRAND_QUERY" ]] && search_web "$BRAND_QUERY" "Brand mentions" || echo "(not configured)")
 
 # ── Build report ──────────────────────────────────────────────────────────
 DATE_LABEL=$(TZ="${REPORT_TIMEZONE:-UTC}" date "+%a %d %b %Y")

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -1010,7 +1010,7 @@ Determine which services to enable based on what was configured in earlier steps
 - `memory-extractor` — always include
 - `inbox-digest` — always include (runs every 4h, aggregates all configured channels)
 - `store-health` — include ONLY if ecommerce was configured (`ecom.shopify.store_url` is set in `$PREFS_PATH`)
-- `competitor-intel` — always include (runs weekly Monday 10am)
+- `competitor-intel` — include only if the user configures queries (see step 5b-i below); otherwise enable with `enabled: false` and surface a `[Configure later via /ops:setup]` hint
 - `message-listener` — include if WhatsApp or Telegram is configured (persistent poller)
 
 Build the services array programmatically (starting from the 2c baseline):
@@ -1038,7 +1038,43 @@ Write daemon services config to `$DATA_DIR/daemon-services.json` — merge with 
 - `memory-extractor`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-memory-extractor.sh", "health_file": "~/.claude/plugins/data/ops-ops-marketplace/memories/.health", "cron": "*/30 * * * *" }` — every 30 min (installed in 2c)
 - `inbox-digest`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-cron-inbox-digest.sh", "cron": "0 */4 * * *" }` — every 4h
 - `store-health`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-cron-store-health.sh", "cron": "0 9 * * *" }` — daily 9am, only if ecom configured
-- `competitor-intel`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-cron-competitor-intel.sh", "cron": "0 10 * * 1" }` — weekly Monday 10am
+- `competitor-intel`: `{ "enabled": <bool>, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-cron-competitor-intel.sh", "cron": "0 10 * * 1" }` — weekly Monday 10am. `enabled` is `true` only when queries were configured in step 5b-i; otherwise `false` so the cron doesn't post placeholder garbage to Telegram
+
+#### Step 5b-i — Competitor intel queries (gate before enabling the service)
+
+Per Rule 3, never silently skip a service. Before deciding `competitor-intel.enabled`, ask the user explicitly:
+
+```
+AskUserQuestion({
+  question: "Configure competitor & brand intel queries? (Weekly search → Telegram)",
+  header: "Competitor intel",
+  options: [
+    { label: "Configure now",   description: "Enter competitor A/B + own brand search queries — runs every Mon 10am" },
+    { label: "Skip — disable",  description: "Leave competitor-intel disabled. Re-run /ops:setup later to configure." }
+  ]
+})
+```
+
+If the user chose **Skip — disable**: set `competitor-intel.enabled = false` in `daemon-services.json`. Do not prompt further.
+
+If the user chose **Configure now**: collect four values (one prompt per value — they are free-text, not multiple choice):
+
+1. `competitor_a_query` — e.g. `"acme inc reviews"` or `"competitor-a $YEAR pricing"`
+2. `competitor_b_query` — e.g. `"competitor-b new product launches"`
+3. `brand_query` — e.g. `"yourbrand reviews"` (the user's own brand for reputation monitoring)
+4. `report_timezone` — IANA TZ, e.g. `"Europe/Amsterdam"`. Default: `"UTC"`
+
+Persist to `$PREFS_PATH` under a top-level `competitor_intel` object:
+
+```bash
+jq --arg a "$A" --arg b "$B" --arg brand "$BRAND" --arg tz "$TZ" \
+   '.competitor_intel = {competitor_a_query: $a, competitor_b_query: $b, brand_query: $brand, report_timezone: $tz}' \
+   "$PREFS_PATH" > "$PREFS_PATH.tmp" && mv "$PREFS_PATH.tmp" "$PREFS_PATH"
+```
+
+The cron script (`ops-cron-competitor-intel.sh`) reads from `preferences.json` automatically — no env-var wiring needed in the daemon plist. Env vars still override `preferences.json` when set, for power users.
+
+Now set `competitor-intel.enabled = true` in `daemon-services.json`.
 - `message-listener`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-message-listener.sh" }` — only if WhatsApp or Telegram configured
 
 After rewriting the services config, do a quick health check (foreground, <2s), then background the reload:


### PR DESCRIPTION
## Summary
- `competitor-intel` cron is wired with `enabled:true` during `/ops:setup` but the wizard never collects `COMPETITOR_A_QUERY` / `COMPETITOR_B_QUERY` / `BRAND_QUERY` / `REPORT_TIMEZONE`. Every Monday 10am it posts placeholder garbage (`"competitor-a reviews 2026"`) to Telegram.
- Fix: cron now reads from `preferences.json` (`.competitor_intel.*`) with env override; if nothing is configured it logs `SKIP` and exits 0.
- Setup gains step 5b-i — `AskUserQuestion` with `[Configure now]` / `[Skip — disable]`. Per Rule 3, no silent skip: the service is only enabled when queries are configured.

## Test plan
- [x] `bash -n` passes
- [x] Cron with empty prefs → logs SKIP, no Telegram post
- [x] Cron with `.competitor_intel.competitor_a_query` set → runs search, omits unconfigured slots as `(not configured)`
- [x] `tests/test-no-secrets.sh` → 14/14 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes cron/daemon runtime behavior and introduces new prefs-driven configuration, which could unintentionally disable reporting or alter scheduled outputs if keys are mis-specified.
> 
> **Overview**
> Stops `competitor-intel` from running with hardcoded placeholder searches by loading queries/timezone from `preferences.json` (with env-var override) and exiting early with a logged `SKIP` when nothing is configured.
> 
> Updates the setup wizard docs to explicitly prompt for competitor/brand query configuration and to only enable the `competitor-intel` daemon service when queries are provided (otherwise keep the service present but `enabled: false`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79727353944ad739c581341d5ab3e6fddc7ccf8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->