### PR TITLE
fix(marketplace): remove unrecognized 'screenshots' key

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,12 +29,6 @@
         "yolo",
         "revenue",
         "gtm"
-      ],
-      "screenshots": [
-        "docs/screenshots/dashboard.png",
-        "docs/screenshots/briefing.png",
-        "docs/screenshots/inbox.png",
-        "docs/screenshots/yolo.png"
       ]
     }
   ]


### PR DESCRIPTION
Plugin loader rejects manifest with `Unrecognized key: "screenshots"` causing plugin load failure (`/reload-plugins` reports errors). Removes the unsupported field from `.claude-plugin/marketplace.json`.

Confirmed via `claude plugin validate ~/Projects/claude-ops` — passes after removal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk schema-only change: removes an unrecognized `screenshots` key to prevent plugin manifest validation/load failures.
> 
> **Overview**
> Fixes plugin loading/validation by removing the unsupported `screenshots` field from `.claude-plugin/marketplace.json`, leaving only schema-recognized metadata (e.g., `keywords`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bae3ea4250f2e58a8b650520860cde5b0d199597. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->