### PR TITLE
feat(competitor-intel): self-discovering LLM-driven analyzer with weekly delta detection

### DIFF
--- a/claude-ops/scripts/ops-cron-competitor-intel.sh
+++ b/claude-ops/scripts/ops-cron-competitor-intel.sh
@@ -1,34 +1,50 @@
 #!/usr/bin/env bash
-# ops-cron-competitor-intel.sh — Weekly Competitor Intel cron job
-# Searches competitors and own brand reviews, reports to Telegram
-# Configure via /ops:setup (writes to preferences.json) OR env vars:
-#   COMPETITOR_A_QUERY, COMPETITOR_B_QUERY, BRAND_QUERY, REPORT_TIMEZONE
-# Env vars override preferences.json when both are set.
+# ops-cron-competitor-intel.sh — Weekly self-discovering competitor intel
+#
+# Pipeline (per brand seed):
+#   1. Tavily discovery   → top competitors to {brand} in {category}
+#   2. State merge        → diff vs competitor_state.json, flag NEW entrants
+#   3. Tavily news pass   → recent moves per top-5 competitor (last 7d)
+#   4. Tavily brand pass  → own-brand reviews / mentions
+#   5. LLM synthesis      → claude_invoke (Sonnet) one-page strategic delta
+#   6. Telegram digest + persist new state for next week's delta
+#
+# Config (preferences.json → .competitor_intel):
+#   brand_name        — e.g. "Healify"           (REQUIRED)
+#   category          — e.g. "AI health coaching apps"  (REQUIRED)
+#   max_competitors   — int, default 5
+#   report_timezone   — IANA TZ, default UTC
+#
+# Env overrides: BRAND_NAME, BRAND_CATEGORY, MAX_COMPETITORS, REPORT_TIMEZONE
+#
 set -euo pipefail
 
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/ops-marketplace/ops/$(ls -1 "$HOME/.claude/plugins/cache/ops-marketplace/ops/" 2>/dev/null | sort -V | tail -1)}"
 DATA_DIR="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
 LOG_DIR="$DATA_DIR/logs"
 LOG="$LOG_DIR/competitor-intel.log"
 PREFS_PATH="$DATA_DIR/preferences.json"
+STATE_PATH="$DATA_DIR/competitor_state.json"
 
 mkdir -p "$LOG_DIR"
 log() { printf '%s [competitor-intel] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" | tee -a "$LOG"; }
 
-# ── Resolve query config from preferences.json (env vars take precedence) ─
+# ── Resolve config ────────────────────────────────────────────────────────
 pref_get() {
   local key="$1"
   [[ -f "$PREFS_PATH" ]] || { echo ""; return; }
   jq -r --arg k "$key" '.competitor_intel[$k] // ""' "$PREFS_PATH" 2>/dev/null || echo ""
 }
 
-COMPETITOR_A_QUERY="${COMPETITOR_A_QUERY:-$(pref_get competitor_a_query)}"
-COMPETITOR_B_QUERY="${COMPETITOR_B_QUERY:-$(pref_get competitor_b_query)}"
-BRAND_QUERY="${BRAND_QUERY:-$(pref_get brand_query)}"
+BRAND_NAME="${BRAND_NAME:-$(pref_get brand_name)}"
+BRAND_CATEGORY="${BRAND_CATEGORY:-$(pref_get category)}"
+MAX_COMPETITORS="${MAX_COMPETITORS:-$(pref_get max_competitors)}"
 REPORT_TIMEZONE="${REPORT_TIMEZONE:-$(pref_get report_timezone)}"
+MAX_COMPETITORS="${MAX_COMPETITORS:-5}"
+REPORT_TIMEZONE="${REPORT_TIMEZONE:-UTC}"
 
-# ── Refuse to run with placeholder queries ────────────────────────────────
-if [[ -z "$COMPETITOR_A_QUERY" && -z "$COMPETITOR_B_QUERY" && -z "$BRAND_QUERY" ]]; then
-  log "SKIP: no competitor/brand queries configured. Run /ops:setup to configure."
+if [[ -z "$BRAND_NAME" || -z "$BRAND_CATEGORY" ]]; then
+  log "SKIP: brand_name + category not configured in preferences.json. Run /ops:setup."
   log "HEARTBEAT_OK"
   exit 0
 fi
@@ -45,79 +61,166 @@ if [[ -z "$TAVILY_KEY" ]]; then
   TAVILY_KEY=$(doppler secrets get TAVILY_API_KEY --plain 2>/dev/null || true)
 fi
 
+if [[ -z "$TAVILY_KEY" ]]; then
+  log "SKIP: TAVILY_API_KEY not available — can't run intelligent search."
+  log "HEARTBEAT_OK"
+  exit 0
+fi
+
 YEAR=$(date +%Y)
-FINDINGS=()
 
-# ── Search function via Tavily (or fallback curl) ─────────────────────────
-search_web() {
-  local query="$1"
-  local label="$2"
-  local result=""
+# ── Tavily helpers ────────────────────────────────────────────────────────
+tavily_search() {
+  # $1=query, $2=depth(basic|advanced), $3=topic(general|news), $4=days
+  local query="$1" depth="${2:-basic}" topic="${3:-general}" days="${4:-30}"
+  local payload
+  payload=$(jq -n --arg q "$query" --arg d "$depth" --arg t "$topic" --argjson days "$days" \
+    '{query:$q, search_depth:$d, topic:$t, max_results:5, days:$days}')
 
-  if [[ -n "$TAVILY_KEY" ]]; then
-    result=$(curl -s -X POST "https://api.tavily.com/search" \
-      -H "Content-Type: application/json" \
-      -H "Authorization: Bearer ${TAVILY_KEY}" \
-      -d "{\"query\": \"$query\", \"max_results\": 3, \"search_depth\": \"basic\"}" \
-      2>/dev/null | python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-results = data.get('results', [])
-if not results:
-    print('No results found')
-else:
-    snippets = [r.get('title','') + ': ' + r.get('content','')[:120] for r in results[:2]]
-    print(' | '.join(snippets))
-" 2>/dev/null || echo "search unavailable")
-  else
-    # Fallback: SerpAPI-compatible curl search via DuckDuckGo HTML (best-effort)
-    result=$(curl -s -A "Mozilla/5.0" \
-      "https://html.duckduckgo.com/html/?q=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote('$query'))")" \
-      2>/dev/null | python3 -c "
-import sys, re
-html = sys.stdin.read()
-titles = re.findall(r'class=\"result__title\"[^>]*>.*?<a[^>]*>(.*?)</a>', html, re.DOTALL)
-clean = [re.sub('<[^>]+>','',t).strip() for t in titles[:3]]
-print(' | '.join(clean[:2]) if clean else 'No results')
-" 2>/dev/null || echo "search unavailable")
-  fi
-
-  log "Search [$label]: ${result:0:100}..."
-  echo "$result"
+  curl -s -X POST "https://api.tavily.com/search" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${TAVILY_KEY}" \
+    -d "$payload" 2>/dev/null || echo '{"results":[]}'
 }
 
-# ── Run searches ──────────────────────────────────────────────────────────
-log "Running weekly competitor intelligence searches"
+# ── Stage 1: Discovery — surface current competitor landscape ─────────────
+log "Stage 1: discovering competitors to '$BRAND_NAME' in category '$BRAND_CATEGORY'"
+DISCOVERY_QUERY="Top competitors to $BRAND_NAME in $BRAND_CATEGORY market $YEAR — list company names"
+DISCOVERY_JSON=$(tavily_search "$DISCOVERY_QUERY" "advanced" "general" 90)
+DISCOVERY_TEXT=$(echo "$DISCOVERY_JSON" | jq -r '.results[]? | "[\(.title // "?")] \((.content // "")[:400])"' 2>/dev/null | head -c 6000)
 
-COMPETITOR_A_RESULT=$([[ -n "$COMPETITOR_A_QUERY" ]] && search_web "$COMPETITOR_A_QUERY" "Competitor A" || echo "(not configured)")
-COMPETITOR_B_RESULT=$([[ -n "$COMPETITOR_B_QUERY" ]] && search_web "$COMPETITOR_B_QUERY" "Competitor B" || echo "(not configured)")
-BRAND_RESULT=$([[ -n "$BRAND_QUERY" ]] && search_web "$BRAND_QUERY" "Brand mentions" || echo "(not configured)")
+# ── Stage 2: Load prior state ─────────────────────────────────────────────
+KNOWN_COMPETITORS="[]"
+if [[ -f "$STATE_PATH" ]]; then
+  KNOWN_COMPETITORS=$(jq -r --arg b "$BRAND_NAME" '.[$b].competitors // []' "$STATE_PATH" 2>/dev/null || echo "[]")
+fi
+log "Stage 2: $(echo "$KNOWN_COMPETITORS" | jq 'length // 0' 2>/dev/null || echo 0) competitors in prior state"
 
-# ── Build report ──────────────────────────────────────────────────────────
-DATE_LABEL=$(TZ="${REPORT_TIMEZONE:-UTC}" date "+%a %d %b %Y")
-REPORT="*Weekly Competitor Intel* ($DATE_LABEL)
+# ── Stage 3: Brand mentions (own reviews/news) ────────────────────────────
+log "Stage 3: scanning brand mentions for '$BRAND_NAME'"
+BRAND_NEWS_JSON=$(tavily_search "$BRAND_NAME reviews OR mentions OR launch OR funding" "basic" "news" 7)
+BRAND_TEXT=$(echo "$BRAND_NEWS_JSON" | jq -r '.results[]? | "[\(.title // "?")] \((.content // "")[:300])"' 2>/dev/null | head -c 4000)
 
-*Competitor A:*
-$COMPETITOR_A_RESULT
+# ── Stage 4: Recent moves per known competitor (cap at MAX_COMPETITORS) ───
+COMPETITOR_MOVES=""
+if [[ "$KNOWN_COMPETITORS" != "[]" && "$KNOWN_COMPETITORS" != "" ]]; then
+  log "Stage 4: scanning recent moves for known competitors"
+  while IFS= read -r comp; do
+    [[ -z "$comp" ]] && continue
+    NEWS_JSON=$(tavily_search "$comp pricing OR launch OR funding OR product $YEAR" "basic" "news" 7)
+    SNIP=$(echo "$NEWS_JSON" | jq -r '.results[]? | "  • \(.title // "?"): \((.content // "")[:200])"' 2>/dev/null | head -3)
+    [[ -n "$SNIP" ]] && COMPETITOR_MOVES+=$'\n## '"$comp"$'\n'"$SNIP"$'\n'
+  done < <(echo "$KNOWN_COMPETITORS" | jq -r '.[]?' 2>/dev/null | head -n "$MAX_COMPETITORS")
+fi
 
-*Competitor B:*
-$COMPETITOR_B_RESULT
+# ── Stage 5: LLM synthesis — strategic delta report ───────────────────────
+log "Stage 5: LLM synthesis (Sonnet)"
 
-*Brand Mentions:*
-$BRAND_RESULT"
+NEW_STATE_COMPETITORS="$KNOWN_COMPETITORS"
+REPORT=""
 
-log "Report built — sending to Telegram"
+# shellcheck disable=SC1091
+if [[ -f "$PLUGIN_ROOT/scripts/lib/claude-invoke.sh" ]]; then
+  . "$PLUGIN_ROOT/scripts/lib/claude-invoke.sh"
 
-# ── Send to Telegram ──────────────────────────────────────────────────────
-if [[ -n "$TELEGRAM_TOKEN" ]]; then
+  PROMPT_FILE=$(mktemp)
+  cat > "$PROMPT_FILE" <<EOF
+You are a strategic competitor intelligence analyst.
+
+Brand: $BRAND_NAME
+Category: $BRAND_CATEGORY
+Date: $(TZ="$REPORT_TIMEZONE" date '+%Y-%m-%d')
+Previously known competitors: $(echo "$KNOWN_COMPETITORS" | jq -c '.' 2>/dev/null || echo "[]")
+
+## Raw Tavily research
+
+### Discovery pass (current landscape):
+$DISCOVERY_TEXT
+
+### Brand mentions (last 7 days, $BRAND_NAME):
+$BRAND_TEXT
+
+### Recent competitor moves (last 7 days):
+$COMPETITOR_MOVES
+
+## Your tasks
+
+1. Extract the canonical competitor list from the Discovery pass — return ONLY actual product/company names, not generic categories. Cap at $MAX_COMPETITORS.
+2. Identify NEW entrants (in current list but not in "Previously known competitors").
+3. Identify DROPPED competitors (in prior list but absent from current landscape).
+4. Synthesize a one-page strategic delta. Skip filler. Strategic, not generic.
+
+Output format (STRICT — must be parseable):
+
+\`\`\`json
+{"competitors": ["name1","name2"]}
+\`\`\`
+
+---REPORT---
+*$BRAND_NAME Competitor Intel — $(TZ="$REPORT_TIMEZONE" date '+%a %d %b %Y')*
+
+*NEW entrants:*
+...
+
+*Competitor moves this week:*
+...
+
+*Brand signal:*
+...
+
+*Threats & opportunities:*
+...
+EOF
+
+  SYNTHESIS=$(claude_invoke --model claude-sonnet-4-6 --no-session-persistence -p < "$PROMPT_FILE" 2>>"$LOG" || echo "")
+  rm -f "$PROMPT_FILE"
+
+  if [[ -n "$SYNTHESIS" ]]; then
+    EXTRACTED=$(echo "$SYNTHESIS" | sed -n '/```json/,/```/p' | sed '1d;$d' | jq -r '.competitors // []' 2>/dev/null || echo "")
+    [[ -n "$EXTRACTED" && "$EXTRACTED" != "null" ]] && NEW_STATE_COMPETITORS="$EXTRACTED"
+    REPORT=$(echo "$SYNTHESIS" | awk '/---REPORT---/{flag=1; next} flag' | sed '/^```/,/^```$/d')
+  fi
+else
+  log "WARN: claude-invoke.sh not found at $PLUGIN_ROOT — using Tavily-only fallback"
+fi
+
+# Fallback report if LLM unavailable or returned empty
+if [[ -z "$REPORT" ]]; then
+  REPORT="*Weekly Competitor Intel — $(TZ="$REPORT_TIMEZONE" date '+%a %d %b %Y')*
+
+*Discovery (raw):*
+${DISCOVERY_TEXT:0:1200}
+
+*Brand mentions (raw):*
+${BRAND_TEXT:0:1200}"
+fi
+
+# ── Persist state ─────────────────────────────────────────────────────────
+TMP_STATE=$(mktemp)
+if [[ -f "$STATE_PATH" ]]; then
+  jq --arg b "$BRAND_NAME" --argjson c "$NEW_STATE_COMPETITORS" --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '.[$b] = {competitors: $c, last_run: $ts}' "$STATE_PATH" > "$TMP_STATE" 2>/dev/null \
+    || jq -n --arg b "$BRAND_NAME" --argjson c "$NEW_STATE_COMPETITORS" --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+       '{($b): {competitors: $c, last_run: $ts}}' > "$TMP_STATE"
+else
+  jq -n --arg b "$BRAND_NAME" --argjson c "$NEW_STATE_COMPETITORS" --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{($b): {competitors: $c, last_run: $ts}}' > "$TMP_STATE"
+fi
+mv "$TMP_STATE" "$STATE_PATH"
+log "State persisted: $(echo "$NEW_STATE_COMPETITORS" | jq 'length // 0' 2>/dev/null || echo 0) competitors tracked for $BRAND_NAME"
+
+# ── Stage 6: Send to Telegram ─────────────────────────────────────────────
+log "Stage 6: dispatching Telegram digest"
+if [[ -n "$TELEGRAM_TOKEN" && -n "$TELEGRAM_CHAT" ]]; then
   curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage" \
     -H "Content-Type: application/json" \
-    -d "{\"chat_id\": \"$TELEGRAM_CHAT\", \"text\": $(echo "$REPORT" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))'), \"parse_mode\": \"Markdown\"}" \
+    -d "$(jq -n --arg chat "$TELEGRAM_CHAT" --arg text "$REPORT" \
+        '{chat_id: $chat, text: $text, parse_mode: "Markdown"}')" \
     >> "$LOG" 2>&1
   log "Competitor intel sent to Telegram chat=$TELEGRAM_CHAT"
 else
-  log "WARN: TELEGRAM_BOT_TOKEN not set — printing report to stdout"
-  echo "$REPORT"
+  log "WARN: TELEGRAM creds not set — printing report to stdout"
+  printf '%s\n' "$REPORT"
 fi
 
 log "HEARTBEAT_OK"

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -1040,39 +1040,38 @@ Write daemon services config to `$DATA_DIR/daemon-services.json` — merge with 
 - `store-health`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-cron-store-health.sh", "cron": "0 9 * * *" }` — daily 9am, only if ecom configured
 - `competitor-intel`: `{ "enabled": <bool>, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-cron-competitor-intel.sh", "cron": "0 10 * * 1" }` — weekly Monday 10am. `enabled` is `true` only when queries were configured in step 5b-i; otherwise `false` so the cron doesn't post placeholder garbage to Telegram
 
-#### Step 5b-i — Competitor intel queries (gate before enabling the service)
+#### Step 5b-i — Competitor intel (self-discovering, gate before enabling)
 
 Per Rule 3, never silently skip a service. Before deciding `competitor-intel.enabled`, ask the user explicitly:
 
 ```
 AskUserQuestion({
-  question: "Configure competitor & brand intel queries? (Weekly search → Telegram)",
+  question: "Configure competitor intel? (Weekly: Tavily auto-discovers competitors → Sonnet synthesizes strategic delta → Telegram)",
   header: "Competitor intel",
   options: [
-    { label: "Configure now",   description: "Enter competitor A/B + own brand search queries — runs every Mon 10am" },
+    { label: "Configure now",   description: "Provide brand name + category. System auto-discovers competitors every week and detects deltas." },
     { label: "Skip — disable",  description: "Leave competitor-intel disabled. Re-run /ops:setup later to configure." }
   ]
 })
 ```
 
-If the user chose **Skip — disable**: set `competitor-intel.enabled = false` in `daemon-services.json`. Do not prompt further.
+If **Skip — disable**: set `competitor-intel.enabled = false` in `daemon-services.json`. Stop.
 
-If the user chose **Configure now**: collect four values (one prompt per value — they are free-text, not multiple choice):
+If **Configure now**: collect two free-text values plus one optional:
 
-1. `competitor_a_query` — e.g. `"acme inc reviews"` or `"competitor-a $YEAR pricing"`
-2. `competitor_b_query` — e.g. `"competitor-b new product launches"`
-3. `brand_query` — e.g. `"yourbrand reviews"` (the user's own brand for reputation monitoring)
-4. `report_timezone` — IANA TZ, e.g. `"Europe/Amsterdam"`. Default: `"UTC"`
+1. `brand_name` — e.g. `"Healify"`, `"Stagery"`. The product/company being tracked.
+2. `category` — e.g. `"AI health coaching apps"`, `"NL virtual real estate staging"`. The market segment Tavily searches in.
+3. `report_timezone` — IANA TZ. Default: system TZ from previous setup steps, or `"UTC"`.
 
-Persist to `$PREFS_PATH` under a top-level `competitor_intel` object:
+The system handles competitor discovery, news scanning, and synthesis automatically — no hardcoded competitor list to maintain. Tavily API key (`TAVILY_API_KEY` in env or Doppler) is required; if missing, the cron logs SKIP and exits cleanly.
+
+Persist to `$PREFS_PATH`:
 
 ```bash
-jq --arg a "$A" --arg b "$B" --arg brand "$BRAND" --arg tz "$TZ" \
-   '.competitor_intel = {competitor_a_query: $a, competitor_b_query: $b, brand_query: $brand, report_timezone: $tz}' \
+jq --arg brand "$BRAND" --arg cat "$CATEGORY" --arg tz "$TZ" \
+   '.competitor_intel = {brand_name: $brand, category: $cat, max_competitors: 5, report_timezone: $tz}' \
    "$PREFS_PATH" > "$PREFS_PATH.tmp" && mv "$PREFS_PATH.tmp" "$PREFS_PATH"
 ```
-
-The cron script (`ops-cron-competitor-intel.sh`) reads from `preferences.json` automatically — no env-var wiring needed in the daemon plist. Env vars still override `preferences.json` when set, for power users.
 
 Now set `competitor-intel.enabled = true` in `daemon-services.json`.
 - `message-listener`: `{ "enabled": true, "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-message-listener.sh" }` — only if WhatsApp or Telegram configured


### PR DESCRIPTION
## Summary
Replaces the 2-hardcoded-query Google Alert (PR #234) with a real competitor intel pipeline:

1. **Tavily discovery** → auto-discovers competitors to `{brand_name}` in `{category}` (no hardcoded list).
2. **State diff** → flags NEW entrants vs persisted `competitor_state.json` week-over-week.
3. **Tavily news** per top-N known competitor (pricing, launches, funding, layoffs, last 7d).
4. **Brand mentions** pass (own reviews/news, last 7d).
5. **Sonnet synthesis** → extracts canonical competitor list as JSON + writes strategic delta (NEW entrants, moves, brand signal, threats & opportunities).
6. Telegram digest + persist state.

## Schema change
- Before: `{competitor_a_query, competitor_b_query, brand_query, report_timezone}` (PR #234)
- After: `{brand_name, category, max_competitors, report_timezone}` — system auto-discovers competitors.

## Graceful degradation
- No `TAVILY_API_KEY` → log SKIP, exit 0.
- No `claude-invoke.sh` or empty LLM response → raw Tavily research dump fallback.

## Token cost
~5-10k Sonnet tokens / brand / week.

## Test plan
- [x] `bash -n` passes
- [x] `tests/test-no-secrets.sh` → 14/14 pass
- [x] Unconfigured → SKIP, no Telegram
- [x] Configured, no Tavily key → SKIP cleanly
- [ ] End-to-end with live Tavily key (requires deploy + Mon 10am cron)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: rewrites a scheduled cron pipeline to depend on Tavily API + optional LLM synthesis and adds persistent state writes (`competitor_state.json`), so failures/rate limits or parsing issues could change weekly notifications and stored competitor lists.
> 
> **Overview**
> Replaces the competitor-intel cron from hardcoded user-provided search queries to a **self-discovering weekly pipeline** driven by Tavily discovery/news plus optional Sonnet synthesis, producing a strategic delta report and Telegram digest.
> 
> Adds week-over-week delta tracking by persisting per-brand competitor lists to `competitor_state.json`, updates config to `{brand_name, category, max_competitors, report_timezone}` (with env overrides), and introduces clean SKIP/fallback behavior when `TAVILY_API_KEY`/`claude-invoke.sh`/Telegram creds are missing.
> 
> Updates setup docs to gate enabling `competitor-intel` on collecting `brand_name` + `category` (instead of competitor A/B queries) and to persist the new preference schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26700f40c8d2b17d23383f1fcd25bc820b6f5231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->