### PR TITLE
chore(release): bump to v2.2.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 35 skills, 18 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Business operations command center for Claude Code — 35 skills, 18 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.2.2] — 2026-05-16
+### Changed
+- **`competitor-intel` cron rewritten as self-discovering LLM-driven analyzer.** Previous version posted Telegram digests from 2 hardcoded queries (`COMPETITOR_A_QUERY`, `COMPETITOR_B_QUERY`, `BRAND_QUERY`) that `/ops:setup` never collected — every Monday at 10am the cron broadcast placeholder garbage like `"competitor-a reviews 2026"`. New pipeline: Tavily discovery pass auto-surfaces the current competitor landscape for `{brand_name}` in `{category}`; diffs against persisted `competitor_state.json` to flag NEW entrants week-over-week; runs per-competitor news searches (pricing/launches/funding/layoffs, last 7d); brand-mention pass; Sonnet synthesis (`claude_invoke`, ~5–10k tokens/week against Max-OAuth, no API billing) produces a one-page strategic delta with NEW entrants / competitor moves / brand signal / threats & opportunities. Graceful degradation: missing `TAVILY_API_KEY` → SKIP and exit 0; missing `claude_invoke` or empty LLM response → raw Tavily fallback. (#237)
+- **`/ops:setup` gates `competitor-intel` per Rule 3.** Step 5b-i now asks `[Configure now]` / `[Skip — disable]` instead of always-enabling. Configure path collects 2 free-text values (`brand_name`, `category`) — system auto-discovers competitors instead of hardcoding them. Skip path sets `enabled: false` in `daemon-services.json`. (#234, #237)
+
+### Schema
+- `preferences.json` `.competitor_intel` shape changed:
+  - **Before:** `{competitor_a_query, competitor_b_query, brand_query, report_timezone}`
+  - **After:** `{brand_name, category, max_competitors, report_timezone}` (cron auto-discovers; state persisted at `$DATA_DIR/competitor_state.json`)
+
 ## [2.2.1] — 2026-05-16
 ### Fixed
 - **Plugin load error: `marketplace.json` rejected by validator.** Removed unsupported `screenshots` key from `.claude-plugin/marketplace.json`. `claude plugin validate` was reporting `Unrecognized key: "screenshots"` and the Claude Code loader surfaced this as an error on `/reload-plugins`.

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
## Summary
Version bump for competitor-intel self-discovering redesign (#237) on top of setup gating (#234).

Bumps `plugin.json`, `package.json`, `marketplace.json` to 2.2.2 + adds CHANGELOG entry.

## Test plan
- [x] All 3 version locations aligned at 2.2.2
- [x] CHANGELOG entry written under [2.2.2]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping: only version metadata and changelog text are updated; no runtime code paths change in this diff.
> 
> **Overview**
> Bumps the plugin/package versions to `2.2.2` across `marketplace.json`, `claude-ops/.claude-plugin/plugin.json`, and `claude-ops/package.json`.
> 
> Adds a `2.2.2` CHANGELOG entry documenting the `competitor-intel` redesign and associated `/ops:setup` gating and `preferences.json` schema change (documentation only in this PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 968bf4a797b483cf192ff3f1cdab1cc6cb99cdce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->