### PR TITLE
fix(mcp): doppler MCP — explicit binary name (v2.2.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 35 skills, 18 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.2.1",
+      "version": "2.2.2",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Business operations command center for Claude Code — 35 skills, 18 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/.mcp.json
+++ b/claude-ops/.mcp.json
@@ -12,7 +12,7 @@
     },
     "doppler": {
       "command": "npx",
-      "args": ["-y", "@dopplerhq/mcp-server"],
+      "args": ["-y", "-p", "@dopplerhq/mcp-server", "doppler-mcp"],
       "env": {
         "DOPPLER_TOKEN": "${user_config.doppler_token}"
       }

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.2.2] — 2026-05-17
+### Fixed
+- **Doppler MCP server failed to connect on every reload.** Plugin's `.mcp.json` invoked `npx -y @dopplerhq/mcp-server` which tries to run a binary matching the package name. The actual bin is `doppler-mcp` (`bin: { "doppler-mcp": "bin/doppler-mcp" }`), so npx couldn't find a command and exited with `command not found`. Switched to `npx -y -p @dopplerhq/mcp-server doppler-mcp` form which explicitly names the binary.
+
 ## [2.2.1] — 2026-05-16
 ### Fixed
 - **Plugin load error: `marketplace.json` rejected by validator.** Removed unsupported `screenshots` key from `.claude-plugin/marketplace.json`. `claude plugin validate` was reporting `Unrecognized key: "screenshots"` and the Claude Code loader surfaced this as an error on `/reload-plugins`.

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Doppler MCP fails with `command not found` because `npx -y @dopplerhq/mcp-server` resolves to a non-existent binary. Real binary is `doppler-mcp`. Switched to `npx -y -p @dopplerhq/mcp-server doppler-mcp`.

Surfaces as 'Failed to connect' in `/reload-plugins` and counts toward the load-error tally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small config change to how the Doppler MCP server is launched plus a version bump; main risk is environment-specific `npx` invocation differences if users rely on the previous (broken) command behavior.
> 
> **Overview**
> Fixes Doppler MCP startup by changing `.mcp.json` to invoke the package’s actual binary (`npx -y -p @dopplerhq/mcp-server doppler-mcp`) instead of assuming `npx` can run `@dopplerhq/mcp-server` directly.
> 
> Bumps plugin/package/marketplace versions to `2.2.2` and documents the reload/connectivity fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 739cc3ae8a5632d6b46f83fd28b02e61e43f82a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->