### PR TITLE
fix(daemon): stop self-kickstart crash-loop + drop wacli-keepalive (v2.2.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 35 skills, 18 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.2.3",
+      "version": "2.2.4",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "Business operations command center for Claude Code — 35 skills, 18 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.2.4] — 2026-05-17
+### Fixed
+- **Daemon silent crash-loop under launchd.** `scripts/ops-daemon.sh` included `com.claude-ops.daemon` in its own `EXPECTED_SERVICES` self-healing list. On startup the ENSURE loop read its own previous launchctl `exit=1` status (a normal post-install state), called `launchctl kickstart "gui/$UID/com.claude-ops.daemon"`, received SIGTERM, and respawned every ~30s via launchd's `ThrottleInterval`. Net effect: no `daemon-health.json` refresh, no service supervision, no message-listener, but `launchctl list` showed the entry registered with exit=1, no PID. Removed `com.claude-ops.daemon` from `EXPECTED_SERVICES` (launchd's `KeepAlive=true` already handles auto-restart). Also removed the decommissioned `com.claude-ops.wacli-keepalive` entry — it was a v2.0.3 leftover whose plist no longer ships, causing noisy "cannot repair — missing bash or source plist" log entries every monitor cycle. `install_daemon_launchd()` cleaned up to stop trying to install the non-existent wacli plist. (#241)
+
 ## [2.2.3] — 2026-05-17
 ### Fixed
 - **Doppler MCP server failed to connect on every reload.** Plugin's `.mcp.json` invoked `npx -y @dopplerhq/mcp-server` which tries to run a binary matching the package name. The actual bin is `doppler-mcp` (`bin: { "doppler-mcp": "bin/doppler-mcp" }`), so npx couldn't find a command and exited with `command not found`. Switched to `npx -y -p @dopplerhq/mcp-server doppler-mcp` form which explicitly names the binary, eliminating the `Failed to connect` error from `/reload-plugins`.

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -1154,9 +1154,7 @@ install_daemon_launchd() {
   mkdir -p "$agents_dir"
 
   local daemon_plist_src="$SCRIPT_DIR/scripts/com.claude-ops.daemon.plist"
-  local keepalive_plist_src="$SCRIPT_DIR/scripts/com.claude-ops.wacli-keepalive.plist"
   local daemon_plist_dst="$agents_dir/com.claude-ops.daemon.plist"
-  local keepalive_plist_dst="$agents_dir/com.claude-ops.wacli-keepalive.plist"
 
   local bash_path
   bash_path="$(command -v bash)"
@@ -1172,8 +1170,7 @@ install_daemon_launchd() {
 
   _install_launchd_plist "$daemon_plist_src" "$daemon_plist_dst" \
     "$bash_path" "$plugin_root" "com.claude-ops.daemon"
-  _install_launchd_plist "$keepalive_plist_src" "$keepalive_plist_dst" \
-    "$bash_path" "$plugin_root" "com.claude-ops.wacli-keepalive"
+  # wacli-keepalive decommissioned in v2.0.3 — WhatsApp now uses Baileys MCP.
 }
 
 # Install a single launchd plist: substitute placeholders, copy, bootstrap.
@@ -1387,10 +1384,19 @@ ENSURE_SERVICES_INTERVAL="${ENSURE_SERVICES_INTERVAL:-300}"  # every 5 min
 
 # Expected launchd agents (macOS) / systemd units (Linux).
 # Format: "label|plist_src_basename|description"
-EXPECTED_SERVICES=(
-  "com.claude-ops.daemon|com.claude-ops.daemon.plist|ops daemon"
-  "com.claude-ops.wacli-keepalive|com.claude-ops.wacli-keepalive.plist|wacli keepalive"
-)
+#
+# IMPORTANT: do NOT include com.claude-ops.daemon here. The daemon must not
+# monitor itself — launchd's KeepAlive=true already auto-restarts on crash.
+# Self-monitoring causes the ENSURE loop to read its own stale launchctl
+# exit=1 status during early init, call `launchctl kickstart` on itself,
+# receive SIGTERM, and respawn every ~30s in a silent crash loop (no
+# stderr/stdout, just rapid START log entries).
+#
+# wacli-keepalive was decommissioned in v2.0.3 — WhatsApp ops moved to the
+# Baileys bridge (com.samrenders.whatsapp-bridge) and mcp__whatsapp__* tools.
+# Including it caused noisy "cannot repair — missing bash or source plist"
+# entries every monitor loop because its plist no longer ships in the package.
+EXPECTED_SERVICES=()
 
 ensure_all_services() {
   local now


### PR DESCRIPTION
## Summary
Daemon was crash-looping silently under launchd on every install since 2.2.x.

**Root cause:** `EXPECTED_SERVICES` array in `ops-daemon.sh` included `com.claude-ops.daemon` itself. The ENSURE loop read its own previous `launchctl list` exit=1 status (a benign post-install state), called `launchctl kickstart` on the running daemon, received SIGTERM, and respawned every ~30s via `ThrottleInterval`. Symptom: `launchctl list` shows the entry registered with `1` exit code and no PID; `daemon-health.json` never refreshes; no stderr because the daemon exits cleanly on SIGTERM.

**Fix:** remove `com.claude-ops.daemon` from `EXPECTED_SERVICES`. launchd's `KeepAlive=true` already auto-restarts on real crashes — daemons should never monitor themselves.

**Bonus:** removed `com.claude-ops.wacli-keepalive` (decommissioned in v2.0.3 — Baileys MCP replaced wacli). Its plist hasn't shipped since then, so the ENSURE loop emitted noisy "cannot repair" entries every cycle. `install_daemon_launchd()` cleaned up too.

## Test plan
- [x] `bash -n` passes
- [x] `tests/test-no-secrets.sh` → 14/14 pass
- [ ] Post-merge: `claude plugin update ops@ops-marketplace` + `ops-daemon-manager.sh upgrade` + verify `launchctl list` shows live PID (not `-`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS daemon supervision/installation logic to avoid self-restarts and to stop managing a removed service; mistakes here could prevent the background daemon from staying registered or recovering services on user machines.
> 
> **Overview**
> Fixes a launchd *silent crash-loop* by removing `com.claude-ops.daemon` from `EXPECTED_SERVICES`, so the daemon no longer tries to `kickstart` itself during the self-healing pass.
> 
> Cleans up decommissioned WhatsApp keepalive support by dropping `com.claude-ops.wacli-keepalive` from the expected-services list and no longer attempting to install its plist in `install_daemon_launchd()`.
> 
> Bumps plugin/package/marketplace versions to `2.2.4` and adds a `2.2.4` changelog entry documenting the fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a105d36358c794005d78fc65880778e2e23bae38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved daemon self-healing misconfiguration that caused service restart loops and prevented proper health monitoring
  * Fixed MCP server plugin reload failure with corrected binary invocation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->