### PR TITLE
fix(competitor-intel): loosen LLM JSON extraction + always persist report to disk (v2.2.5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 35 skills, 18 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.2.4",
+      "version": "2.2.5",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "Business operations command center for Claude Code — 35 skills, 18 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.2.5] — 2026-05-17
+### Fixed
+- **`competitor-intel` LLM synth dropped to raw Tavily fallback when output didn't include `---REPORT---` marker.** Sonnet was producing valid strategic deltas but the strict marker check threw them away. Three-strategy JSON extraction now: (1) fenced ` ```json ` block, (2) bare `{"competitors":[...]}` regex anywhere in output, (3) bullet-list scrape from "NEW entrants" / "Competitor moves" sections. Report extraction now falls back to stripping JSON blocks from full synthesis instead of dropping to raw Tavily dump.
+- **Weekly reports invisible without Telegram bot configured.** Cron now writes every report to `$DATA_DIR/reports/competitor-intel/YYYY-MM-DD_<brand>.md` and maintains a `latest-<brand>.md` symlink. Telegram push is now additive — disk write happens unconditionally, even when bot creds are missing.
+
 ## [2.2.4] — 2026-05-17
 ### Fixed
 - **Daemon silent crash-loop under launchd.** `scripts/ops-daemon.sh` included `com.claude-ops.daemon` in its own `EXPECTED_SERVICES` self-healing list. On startup the ENSURE loop read its own previous launchctl `exit=1` status (a normal post-install state), called `launchctl kickstart "gui/$UID/com.claude-ops.daemon"`, received SIGTERM, and respawned every ~30s via launchd's `ThrottleInterval`. Net effect: no `daemon-health.json` refresh, no service supervision, no message-listener, but `launchctl list` showed the entry registered with exit=1, no PID. Removed `com.claude-ops.daemon` from `EXPECTED_SERVICES` (launchd's `KeepAlive=true` already handles auto-restart). Also removed the decommissioned `com.claude-ops.wacli-keepalive` entry — it was a v2.0.3 leftover whose plist no longer ships, causing noisy "cannot repair — missing bash or source plist" log entries every monitor cycle. `install_daemon_launchd()` cleaned up to stop trying to install the non-existent wacli plist. (#241)

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/claude-ops/scripts/ops-cron-competitor-intel.sh
+++ b/claude-ops/scripts/ops-cron-competitor-intel.sh
@@ -176,9 +176,30 @@ EOF
   rm -f "$PROMPT_FILE"
 
   if [[ -n "$SYNTHESIS" ]]; then
-    EXTRACTED=$(echo "$SYNTHESIS" | sed -n '/```json/,/```/p' | sed '1d;$d' | jq -r '.competitors // []' 2>/dev/null || echo "")
-    [[ -n "$EXTRACTED" && "$EXTRACTED" != "null" ]] && NEW_STATE_COMPETITORS="$EXTRACTED"
+    # Try three JSON-extraction strategies in order of strictness
+    EXTRACTED=""
+    # 1. Fenced ```json block
+    CAND=$(echo "$SYNTHESIS" | sed -n '/```json/,/```/p' | sed '1d;$d' | jq -r '.competitors // empty' 2>/dev/null || true)
+    [[ -n "$CAND" && "$CAND" != "null" && "$CAND" != "[]" ]] && EXTRACTED="$CAND"
+    # 2. Bare {"competitors":[...]} anywhere in output (no fence)
+    if [[ -z "$EXTRACTED" ]]; then
+      CAND=$(echo "$SYNTHESIS" | grep -oE '\{"competitors":\s*\[[^]]*\][^}]*\}' | head -1 | jq -r '.competitors // empty' 2>/dev/null || true)
+      [[ -n "$CAND" && "$CAND" != "null" && "$CAND" != "[]" ]] && EXTRACTED="$CAND"
+    fi
+    # 3. Greedy bullet-list scrape from "NEW entrants" or "Competitor moves" sections
+    if [[ -z "$EXTRACTED" ]]; then
+      CAND=$(echo "$SYNTHESIS" | awk '/[Cc]ompetitor|[Ee]ntrant/{flag=1} flag && /^\s*[-•*]\s*\*?\*?[A-Z][A-Za-z0-9 .&-]+/' | grep -oE '\*?\*?[A-Z][A-Za-z0-9 .&-]{2,30}\*?\*?' | sed 's/\*//g; s/^[[:space:]]*//; s/[[:space:]]*$//' | sort -u | head -10 | jq -R . | jq -s . 2>/dev/null || true)
+      [[ -n "$CAND" && "$CAND" != "null" && "$CAND" != "[]" ]] && EXTRACTED="$CAND"
+    fi
+    [[ -n "$EXTRACTED" ]] && NEW_STATE_COMPETITORS="$EXTRACTED"
+
+    # Report extraction: prefer ---REPORT--- marker; otherwise strip JSON block
+    # and use whatever LLM produced — do NOT silently fall back to raw Tavily.
     REPORT=$(echo "$SYNTHESIS" | awk '/---REPORT---/{flag=1; next} flag' | sed '/^```/,/^```$/d')
+    if [[ -z "$REPORT" ]]; then
+      REPORT=$(echo "$SYNTHESIS" | sed -E '/^```(json)?$/,/^```$/d')
+      log "WARN: ---REPORT--- marker missing in LLM output — using full synthesis as report"
+    fi
   fi
 else
   log "WARN: claude-invoke.sh not found at $PLUGIN_ROOT — using Tavily-only fallback"
@@ -209,7 +230,16 @@ fi
 mv "$TMP_STATE" "$STATE_PATH"
 log "State persisted: $(echo "$NEW_STATE_COMPETITORS" | jq 'length // 0' 2>/dev/null || echo 0) competitors tracked for $BRAND_NAME"
 
-# ── Stage 6: Send to Telegram ─────────────────────────────────────────────
+# ── Stage 6: Persist report to disk (always) + push to Telegram (if creds) ─
+REPORT_DIR="$DATA_DIR/reports/competitor-intel"
+mkdir -p "$REPORT_DIR"
+REPORT_FILE="$REPORT_DIR/$(date +%Y-%m-%d)_$(echo "$BRAND_NAME" | tr '[:upper:] ' '[:lower:]-').md"
+printf '%s\n' "$REPORT" > "$REPORT_FILE"
+log "Report written to $REPORT_FILE"
+
+# Update latest pointer for easy access
+ln -sf "$REPORT_FILE" "$REPORT_DIR/latest-$(echo "$BRAND_NAME" | tr '[:upper:] ' '[:lower:]-').md"
+
 log "Stage 6: dispatching Telegram digest"
 if [[ -n "$TELEGRAM_TOKEN" && -n "$TELEGRAM_CHAT" ]]; then
   curl -s -X POST "https://api.telegram.org/bot${TELEGRAM_TOKEN}/sendMessage" \
@@ -219,8 +249,7 @@ if [[ -n "$TELEGRAM_TOKEN" && -n "$TELEGRAM_CHAT" ]]; then
     >> "$LOG" 2>&1
   log "Competitor intel sent to Telegram chat=$TELEGRAM_CHAT"
 else
-  log "WARN: TELEGRAM creds not set — printing report to stdout"
-  printf '%s\n' "$REPORT"
+  log "INFO: TELEGRAM creds not set — report saved to disk only ($REPORT_FILE)"
 fi
 
 log "HEARTBEAT_OK"


### PR DESCRIPTION
## Summary
Two follow-up fixes to v2.2.4's self-discovering competitor-intel cron:

1. **LLM JSON extraction was too brittle.** Sonnet was producing valid strategic deltas but the strict marker check (\`\`\`json block + \`---REPORT---\`) threw them away. Three-strategy extraction now: fenced JSON → bare regex → bullet-list scrape. Report extraction degrades gracefully (uses full synthesis if marker missing) instead of dropping to raw Tavily.
2. **Weekly reports invisible without Telegram bot.** Cron now unconditionally writes `$DATA_DIR/reports/competitor-intel/YYYY-MM-DD_<brand>.md` + maintains `latest-<brand>.md` symlink. Telegram push is additive.

## Validation
- ✅ `bash -n` passes
- ✅ `tests/test-no-secrets.sh` 14/14
- ✅ End-to-end run: Tavily key in Doppler → discovery → 12 real competitors found (NutriTracker, MyFitnessPal, HealthifyMe, etc.)
- ⚠ LLM synth hung in test (Claude Code session collision with cron's `claude -p`) — will run clean when daemon fires solo Mon 10am

## v2.3 architecture pending
Research agent produced a concrete v2.3 playbook (page-diff engine for pricing/features, severity-tiered routing high→immediate vs med→daily vs low→weekly, free signal sources via Reddit/HN/App Store APIs, embedding dedup). To be reviewed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the `competitor-intel` cron’s parsing and output handling, which could change weekly competitor state/report generation if the new extraction heuristics mis-parse LLM output. Disk persistence is low risk but introduces new file/symlink writes under `$DATA_DIR` that could fail on permission/path issues.
> 
> **Overview**
> **`competitor-intel` weekly cron is made more robust and auditable.** LLM competitor-list extraction now uses a 3-step fallback (fenced JSON → inline JSON regex → bullet-list scrape) and report generation no longer discards the synthesis when the `---REPORT---` marker is missing (it strips JSON and uses the remaining text with a warning).
> 
> **Reports are now persisted unconditionally.** Every run writes the markdown report to `$DATA_DIR/reports/competitor-intel/` and updates a `latest-<brand>.md` symlink; Telegram delivery becomes optional/additive instead of the only visibility path.
> 
> Also bumps plugin/package/marketplace versions to `2.2.5` and records the fixes in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d5b643d592d23c4440da6b0bfc45dac6c070b86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved competitor intelligence report parsing with additional fallback extraction methods to prevent valid output loss when expected markers are missing.
  * Enhanced weekly competitor report handling to ensure reports are always persisted to disk with quick-access symlinks.
  * Decoupled Telegram delivery from disk write operations for more flexible deployment configurations.

* **Chores**
  * Version bump to 2.2.5.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->