### PR TITLE
feat(competitor-intel): wire outputs into 6 consumers (v2.3.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 35 skills, 18 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Business operations command center for Claude Code — 35 skills, 18 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.3.1] — 2026-05-17
+### Added
+- **Competitor-intel outputs now consumed across the plugin.** v2.3.0 shipped the producer side (signal collectors, severity routing, weekly synthesis). v2.3.1 wires the consumer side so the data actually shows up where decisions get made:
+
+  **Shared context lib** (`scripts/lib/competitor/context.sh`, 292 lines):
+  - `competitor_context [--brand X] [--window-days N] [--severity S]` — aggregated JSON with brands list, per-brand state + latest report path, events in window grouped by severity, pending queue sizes.
+  - `competitor_briefing_line` — one-line summary for briefing surfaces.
+  - `competitor_priority_items --top N` — bullet list of high-severity events for priority advisors.
+  - `competitor_vertical_slice <vertical>` — role-filtered slices (`marketing`, `ecom`, `ceo`, `cfo`, `coo`, `cto`) so each consumer gets only what's relevant to its lens.
+  - jq-only, no external calls — cheap enough to read on every command invocation.
+
+  **`/ops:go` morning briefing**: new `COMPETITOR` row in `bin/ops-gather` (parallel gather, skipped silently when unconfigured) shows alerts count, med-delta count, last_run, plus top-3 event snippets. Mobile mode compresses to `comp: N alerts (top: brief)`.
+
+  **`/ops:next` priority stack**: high-severity competitor events now slot between `fires` and `unread comms` as Priority 2, framed as `REACT: <competitor> <source> changed — see latest-<brand>.md`. Downstream priorities renumbered 3→6.
+
+  **`/ops:marketing`**: new "Competitor signals (last 7d)" section in dashboard — PRICING MOVES (campaign-react triggers), FUNDING/NEWS (positioning opportunities), SENTIMENT (Reddit/HN themes). Skipped when slice is empty.
+
+  **`/ops:ecom`**: new "Competitor activity (last 7d)" section — APP RELEASES (App Store version snapshots), PRODUCT/PRICING CHANGES (feature + pricing page diffs).
+
+  **`/ops:yolo` C-suite agents**: each of CEO/CTO/CFO/COO agent files (`agents/yolo-{ceo,cto,cfo,coo}.md`) now sources `competitor_vertical_slice <role>` and weaves role-specific signals into their analysis. CEO sees new entrants + funding; CFO sees pricing diffs with money tokens; COO sees Greenhouse/Lever hiring signals; CTO sees changelog/feature page-diffs.
+
+  **New `/ops:competitors` skill** + `bin/ops-competitors` CLI:
+  - Dashboard mode (no args): all tracked brands with alert counts, last_run, recent high events.
+  - Drill-down (`ops-competitors <brand>`): 30d event timeline, top competitors, latest report excerpt.
+  - `refresh [brand]` — manually trigger the weekly cron immediately, optional per-brand env override.
+  - `add-url <brand> <competitor> <kind> <url>` — jq-merges a page-diff URL into `preferences.json` with confirm prompt.
+  - `alerts` — tail last 20 of `reports/competitor-intel/alerts.log`.
+  - Mobile-aware rendering, no external deps beyond curl + jq.
+
 ## [2.3.0] — 2026-05-17
 ### Added
 - **Competitor-intel v2.3 — full pipeline redesign with 5 signal sources, severity-tiered routing, and append-only event log.** Goes from "weekly Tavily dump + Sonnet synth" to a real CI system that rivals Crayon/Klue/Kompyte's signal breadth at $0 incremental cost.

--- a/claude-ops/agents/yolo-ceo.md
+++ b/claude-ops/agents/yolo-ceo.md
@@ -95,6 +95,23 @@ Write your CEO analysis to `/tmp/yolo-[session]/ceo-analysis.md`. The calling `/
 
 Be specific. Reference actual data. No generic advice. No synthesis of other agents' work — just your own unfiltered CEO perspective.
 
+## Competitor Context
+
+Before writing your analysis, pull the last 7 days of competitor signals relevant to a CEO:
+
+```bash
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1 | sed 's:/$::')}"
+. "$PLUGIN_ROOT/scripts/lib/competitor/context.sh"
+competitor_vertical_slice ceo
+```
+
+This returns a JSON array of high-severity competitor events (new entrants, funding rounds, competitor product moves, page-diff signals). If the array is `[]`, skip this section — no signal to react to. Do not fabricate competitor data.
+
+Weave real signals into your strategic assessment:
+- New entrants or funding rounds → is the market heating up? reframe our defensibility narrative.
+- Competitor product moves → do they change our build priorities or positioning?
+- No signals → note that the competitive landscape was quiet this week.
+
 ## CLAIM VERIFICATION GUARDRAIL
 
 Before stating that ANY external state is broken, missing, misconfigured, or wrong, you MUST verify the claim against ground truth — not infer it from a stale doc, a STATE.md note, or "this looks like it might be off."

--- a/claude-ops/agents/yolo-cfo.md
+++ b/claude-ops/agents/yolo-cfo.md
@@ -185,6 +185,23 @@ Write to `/tmp/yolo-[session]/cfo-analysis.md`:
 
 Use real numbers. If you can't get a number, say so — don't estimate without data.
 
+## Competitor Context
+
+Before writing your analysis, pull the last 7 days of competitor pricing signals:
+
+```bash
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1 | sed 's:/$::')}"
+. "$PLUGIN_ROOT/scripts/lib/competitor/context.sh"
+competitor_vertical_slice cfo
+```
+
+This returns a JSON array of high-severity pricing competitor events (direct pricing page diffs, money-token signals). If the array is `[]`, skip this section — no signal to react to. Do not fabricate competitor data.
+
+Weave real signals into your financial analysis:
+- Competitor pricing drops → is our price-point still defensible? quantify revenue impact if we match.
+- Competitor funding rounds → extended competitive runway pressure — factor into burn/runway outlook.
+- No signals → note that no pricing moves were detected from direct competitors this week.
+
 ## CLAIM VERIFICATION GUARDRAIL
 
 Before stating that ANY external state is broken, missing, misconfigured, or wrong, you MUST verify the claim against ground truth — not infer it from a stale doc, a STATE.md note, or "this looks like it might be off."

--- a/claude-ops/agents/yolo-coo.md
+++ b/claude-ops/agents/yolo-coo.md
@@ -198,6 +198,24 @@ Write to `/tmp/yolo-[session]/coo-analysis.md`:
 
 No platitudes. Specific findings with specific fixes.
 
+## Competitor Context
+
+Before writing your analysis, pull the last 7 days of competitor hiring signals:
+
+```bash
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1 | sed 's:/$::')}"
+. "$PLUGIN_ROOT/scripts/lib/competitor/context.sh"
+competitor_vertical_slice coo
+```
+
+This returns a JSON array of high-severity hiring events from competitor Greenhouse/Lever job feeds. If the array is `[]`, skip this section — no signal to react to. Do not fabricate competitor data.
+
+Weave real signals into your operational assessment:
+- Competitor senior hires (VP Eng, Head of Product, etc.) → what are they betting on? does it signal a direction we should watch or match?
+- Competitor layoffs → poaching opportunity; flag specific skill pools if visible.
+- Volume hiring in a function → indicates a scaled operational push in that area.
+- No signals → note that no competitor hiring signals were detected this week.
+
 ## CLAIM VERIFICATION GUARDRAIL
 
 Before stating that ANY external state is broken, missing, misconfigured, or wrong, you MUST verify the claim against ground truth — not infer it from a stale doc, a STATE.md note, or "this looks like it might be off."

--- a/claude-ops/agents/yolo-cto.md
+++ b/claude-ops/agents/yolo-cto.md
@@ -160,6 +160,23 @@ Highest risk: [package] [vuln]
 
 Be specific. Reference actual file paths and line numbers where possible. No generic "improve code quality" advice.
 
+## Competitor Context
+
+Before writing your analysis, pull the last 7 days of competitor signals relevant to a CTO:
+
+```bash
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1 | sed 's:/$::')}"
+. "$PLUGIN_ROOT/scripts/lib/competitor/context.sh"
+competitor_vertical_slice cto
+```
+
+This returns a JSON array of high-severity technical competitor signals (changelog page-diffs, feature page changes, technical Show HN / Launch HN signals). If the array is `[]`, skip this section — no signal to react to. Do not fabricate competitor data.
+
+Weave real signals into your technical assessment:
+- Competitor changelog / feature page diffs → how does their tech velocity compare to ours? does it create roadmap pressure?
+- Competitor technical launches → are they shipping something we're still planning? recalibrate priority ranking.
+- No signals → note that no technical competitor moves were detected this week.
+
 ## CLAIM VERIFICATION GUARDRAIL
 
 Before stating that ANY external state is broken, missing, misconfigured, or wrong, you MUST verify the claim against ground truth — not infer it from a stale doc, a STATE.md note, or "this looks like it might be off."

--- a/claude-ops/bin/ops-competitors
+++ b/claude-ops/bin/ops-competitors
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+# ops-competitors — Competitor-intel dashboard + management CLI
+# Usage: ops-competitors [dashboard|<brand>|refresh [brand]|add-url <b> <c> <k> <url>|alerts|help]
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OPS_DATA_DIR="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+PREFS="$OPS_DATA_DIR/preferences.json"
+COMP_REPORTS="$OPS_DATA_DIR/reports/competitor-intel"
+LIB_COMP="$PLUGIN_ROOT/scripts/lib/competitor/context.sh"
+CRON_SCRIPT="$PLUGIN_ROOT/scripts/ops-cron-competitor-intel.sh"
+
+# ── Mobile detection (Rule 7) ────────────────────────────────────────────────
+MOBILE=0
+[[ -n "${SSH_CONNECTION:-}${SSH_CLIENT:-}${SSH_TTY:-}" ]] && MOBILE=1
+[[ "${OPS_MOBILE:-}" == "1" ]] && MOBILE=1
+[[ "${COLUMNS:-80}" -lt 80 ]] && MOBILE=1
+
+# ── Source competitor lib ────────────────────────────────────────────────────
+if [[ ! -f "$LIB_COMP" ]]; then
+  echo "error: competitor lib not found at $LIB_COMP" >&2
+  exit 1
+fi
+# shellcheck disable=SC1090
+source "$LIB_COMP"
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+brand_slug() { printf '%s' "$1" | tr '[:upper:] /' '[:lower:]--' | tr -cd 'a-z0-9-_.'; }
+
+err() { echo "error: $*" >&2; exit 1; }
+
+# ── Dashboard ────────────────────────────────────────────────────────────────
+cmd_dashboard() {
+  local ctx; ctx=$(competitor_context --window-days 7 2>/dev/null \
+    || printf '{"configured":false,"reason":"context_failed"}')
+
+  if [[ "$(printf '%s' "$ctx" | jq -r '.configured')" != "true" ]]; then
+    echo "Competitor-intel not configured. Run /ops:setup competitor-intel to get started."
+    exit 0
+  fi
+
+  local now; now=$(date '+%Y-%m-%d %H:%M')
+
+  if [[ "$MOBILE" -eq 1 ]]; then
+    printf '%s' "$ctx" | jq -r '
+      .brands[] as $b |
+      ($b + ": " +
+        ((.events.high | map(select(.competitor)) | length) | tostring) + " alerts  " +
+        (.events.med_count | tostring) + " med  last " +
+        (.by_brand[$b].last_run // "never"))
+    '
+    printf '%s' "$ctx" | jq -r '"queues: imm=" + (.queues.immediate_pending|tostring) + " daily=" + (.queues.daily_pending|tostring)'
+    return
+  fi
+
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo " OPS ► COMPETITORS — $now"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo ""
+
+  local n_brands; n_brands=$(printf '%s' "$ctx" | jq '.brands | length')
+  echo "TRACKED BRANDS ($n_brands)"
+  printf '%s' "$ctx" | jq -r '
+    .brands[] as $b |
+    ("  " + ($b | .[0:20]) + "\t" +
+      "last " + (.by_brand[$b].last_run // "never")[0:10] + "  " +
+      (.events.high | map(select(.competitor)) | length | tostring) + " alerts  " +
+      (.events.med_count | tostring) + " med  " +
+      (.events.low_count | tostring) + " low")
+  ' | expand -t 24
+
+  echo ""
+  printf '%s' "$ctx" | jq -r '"PENDING QUEUES  immediate: " + (.queues.immediate_pending|tostring) + "   daily: " + (.queues.daily_pending|tostring)'
+
+  local high_count; high_count=$(printf '%s' "$ctx" | jq '.events.high | length')
+  if [[ "$high_count" -gt 0 ]]; then
+    echo ""
+    echo "RECENT HIGH ALERTS (7d)"
+    printf '%s' "$ctx" | jq -r '
+      .events.high[0:8][] |
+      "  " + .timestamp[0:16] + "  " + ((.competitor // "?") | .[0:18]) +
+      "  " + ((.source // "?") | .[0:12]) + "  " +
+      ((.snippet // "") | .[0:60])
+    '
+  fi
+
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+}
+
+# ── Brand drill-down ─────────────────────────────────────────────────────────
+cmd_brand() {
+  local brand="$1"
+  local ctx; ctx=$(competitor_context --brand "$brand" --window-days 30 2>/dev/null \
+    || printf '{"configured":false,"reason":"context_failed"}')
+
+  if [[ "$(printf '%s' "$ctx" | jq -r '.configured')" != "true" ]]; then
+    echo "Competitor-intel not configured."
+    exit 0
+  fi
+
+  local slug; slug=$(brand_slug "$brand")
+  local report="$COMP_REPORTS/latest-${slug}.md"
+
+  if [[ "$MOBILE" -eq 1 ]]; then
+    printf '%s' "$ctx" | jq -r --arg b "$brand" '
+      $b + " | " + (.by_brand[$b].category // "?") + " | last: " + (.by_brand[$b].last_run // "never")[0:10]
+    '
+    printf '%s' "$ctx" | jq -r --arg b "$brand" '
+      .by_brand[$b].competitors[]? | "  - " + .
+    '
+    [[ -f "$report" ]] && head -20 "$report"
+    return
+  fi
+
+  echo ""
+  printf '%s' "$ctx" | jq -r --arg b "$brand" '
+    "BRAND: " + $b + "  category: " + (.by_brand[$b].category // "?") +
+    "  last run: " + (.by_brand[$b].last_run // "never")[0:19]
+  '
+  printf '%s' "$ctx" | jq -r --arg b "$brand" '
+    "competitors: " + ((.by_brand[$b].competitors // []) | join(", "))
+  '
+
+  echo ""
+  echo "SIGNAL BREAKDOWN (30d)"
+  printf '%s' "$ctx" | jq -r '
+    (.events.high + []) | group_by(.competitor)[] |
+    "  " + (.[0].competitor | .[0:20]) +
+    "\thigh: " + ([.[] | select(.severity=="high")] | length | tostring) +
+    "  med: " + ([.[] | select(.severity=="med")] | length | tostring)
+  ' | expand -t 24
+
+  if [[ -f "$report" ]]; then
+    echo ""
+    echo "LATEST REPORT (excerpt)"
+    head -80 "$report" | sed 's/^/  /'
+  else
+    echo ""
+    echo "No report found at $report"
+  fi
+
+  local total; total=$(printf '%s' "$ctx" | jq '.events.total')
+  echo ""
+  echo "EVENT TIMELINE (30d — $total total)"
+  printf '%s' "$ctx" | jq -r '
+    .events.high[] |
+    "  " + .timestamp[0:16] + "  HIGH  " +
+    ((.competitor // "?") | .[0:18]) + "  " +
+    ((.source // "?") | .[0:10]) + "  " +
+    ((.snippet // "") | .[0:70])
+  '
+}
+
+# ── Refresh ──────────────────────────────────────────────────────────────────
+cmd_refresh() {
+  local brand_arg="${1:-}"
+  [[ ! -f "$CRON_SCRIPT" ]] && err "cron script not found: $CRON_SCRIPT"
+  echo "Running competitor-intel cron${brand_arg:+ for brand: $brand_arg}..."
+  if [[ -n "$brand_arg" ]]; then
+    BRAND_NAME="$brand_arg" bash "$CRON_SCRIPT"
+  else
+    bash "$CRON_SCRIPT"
+  fi
+  echo ""
+  echo "Done. Updated briefing:"
+  # shellcheck disable=SC1090
+  source "$LIB_COMP"
+  competitor_briefing_line
+}
+
+# ── Add URL ──────────────────────────────────────────────────────────────────
+cmd_add_url() {
+  local brand="${1:-}" comp="${2:-}" kind="${3:-}" url="${4:-}"
+  [[ -z "$brand" || -z "$comp" || -z "$kind" || -z "$url" ]] && \
+    err "usage: ops-competitors add-url <brand> <competitor> <kind> <url>  (kind: pricing|features|changelog|careers)"
+  [[ ! "$kind" =~ ^(pricing|features|changelog|careers)$ ]] && \
+    err "invalid kind '$kind'. Must be: pricing, features, changelog, careers"
+  [[ ! -f "$PREFS" ]] && err "preferences.json not found at $PREFS"
+
+  echo "Proposed change:"
+  echo "  brand=$brand  competitor=$comp  kind=$kind"
+  echo "  url=$url"
+  echo ""
+  read -rp "Add? [y/N] " confirm
+  [[ "$confirm" =~ ^[Yy]$ ]] || { echo "Cancelled."; exit 0; }
+
+  local tmp; tmp=$(mktemp)
+  jq --arg brand "$brand" --arg comp "$comp" --arg kind "$kind" --arg url "$url" '
+    .competitor_intel.urls[$brand][$comp][$kind] = $url
+  ' "$PREFS" > "$tmp" && mv "$tmp" "$PREFS"
+  echo "Saved to preferences.json."
+}
+
+# ── Alerts ───────────────────────────────────────────────────────────────────
+cmd_alerts() {
+  local log="$COMP_REPORTS/alerts.log"
+  if [[ -f "$log" ]]; then
+    tail -20 "$log"
+  else
+    echo "No alerts log found at $log"
+  fi
+}
+
+# ── Help ─────────────────────────────────────────────────────────────────────
+cmd_help() {
+  cat <<'EOF'
+ops-competitors                              dashboard (all brands)
+ops-competitors <brand>                      drill-down: events, report, breakdown
+ops-competitors refresh [brand]              run intel cron now (optional brand filter)
+ops-competitors add-url <b> <c> <k> <url>   add page-diff URL to preferences.json
+ops-competitors alerts                       tail alerts.log (last 20 lines)
+ops-competitors help                         this message
+
+kinds for add-url: pricing | features | changelog | careers
+EOF
+}
+
+# ── Dispatch ─────────────────────────────────────────────────────────────────
+CMD="${1:-dashboard}"
+shift || true
+
+case "$CMD" in
+  dashboard|"") cmd_dashboard ;;
+  refresh)      cmd_refresh "${1:-}" ;;
+  add-url)      cmd_add_url "$@" ;;
+  alerts)       cmd_alerts ;;
+  help|--help)  cmd_help ;;
+  *)            cmd_brand "$CMD" ;;
+esac

--- a/claude-ops/bin/ops-gather
+++ b/claude-ops/bin/ops-gather
@@ -17,6 +17,33 @@ START_TIME=$(date +%s)
 "$SCRIPT_DIR/ops-prs" > "$TMPDIR_OPS/prs.json" 2>/dev/null &
 "$SCRIPT_DIR/ops-ci" > "$TMPDIR_OPS/ci.json" 2>/dev/null &
 "$SCRIPT_DIR/ops-unread" > "$TMPDIR_OPS/unread.json" 2>/dev/null &
+
+# Competitor intel — sourced from lib (jq-only, cheap)
+(
+  # shellcheck source=scripts/lib/competitor/context.sh
+  source "$(dirname "$SCRIPT_DIR")/scripts/lib/competitor/context.sh" 2>/dev/null || true
+  ctx=$(competitor_context --window-days 7 2>/dev/null || echo '{"configured":false}')
+  if [[ "$(printf '%s' "$ctx" | jq -r '.configured' 2>/dev/null)" != "true" ]]; then
+    printf '{"configured":false}'
+  else
+    # Extract what briefing consumers need: summary line + top-3 high events
+    printf '%s' "$ctx" | jq -c '{
+      configured: true,
+      brands: .brands,
+      by_brand: (.by_brand | to_entries | map({
+        key: .key,
+        value: {last_run: .value.last_run, latest_report: .value.latest_report}
+      }) | from_entries),
+      events: {
+        total: .events.total,
+        high_count: (.events.high | length),
+        med_count: .events.med_count,
+        top_high: (.events.high[0:3] | map({competitor, source, snippet: (.snippet // "" | .[0:140])}))
+      }
+    }'
+  fi
+) > "$TMPDIR_OPS/competitor.json" 2>/dev/null &
+
 wait
 
 END_TIME=$(date +%s)
@@ -31,6 +58,7 @@ jq -n \
   --slurpfile prs "$TMPDIR_OPS/prs.json" \
   --slurpfile ci "$TMPDIR_OPS/ci.json" \
   --slurpfile unread "$TMPDIR_OPS/unread.json" \
+  --slurpfile competitor "$TMPDIR_OPS/competitor.json" \
   '{
     "timestamp": $ts,
     "gather_duration": $dur,
@@ -38,5 +66,6 @@ jq -n \
     "infrastructure": $infra[0],
     "pull_requests": $prs[0],
     "ci_failures": $ci[0],
-    "unread_messages": $unread[0]
+    "unread_messages": $unread[0],
+    "competitor": $competitor[0]
   }'

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/claude-ops/scripts/lib/competitor/context.sh
+++ b/claude-ops/scripts/lib/competitor/context.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# competitor/context.sh — Single source of truth for competitor-intel consumers.
+#
+# Source this lib then call:
+#   competitor_context [--brand <name>] [--window-days N] [--severity high|med|low|all]
+#
+# Returns ONE JSON object on stdout aggregating everything a consumer needs:
+#
+#   {
+#     "configured": true,
+#     "brands": ["Healify", ...],
+#     "by_brand": {
+#       "Healify": {
+#         "category": "AI health coaching apps",
+#         "competitors": ["Noom", "MyFitnessPal", ...],
+#         "last_run": "2026-05-17T...",
+#         "last_discovery": "2026-05-17T...",
+#         "latest_report": "/path/to/2026-05-17_healify.md",
+#         "latest_synthesis": "/path/to/2026-05-17_healify-synthesis.md"
+#       }
+#     },
+#     "events": {
+#       "window_days": 7,
+#       "total": 42,
+#       "high": [{"timestamp":"…","competitor":"…","source":"…","severity":"high","snippet":"…"}, ...],
+#       "med_count": 18,
+#       "low_count": 22
+#     },
+#     "queues": {
+#       "immediate_pending": 0,
+#       "daily_pending": 5
+#     }
+#   }
+#
+# When competitor-intel is unconfigured or has no state yet:
+#   {"configured": false, "reason": "no_state_file"}
+#
+# Designed to be cheap (jq-only, no external calls) so consumers can read on
+# every command invocation without latency cost.
+
+# Don't `set -e` — consumers source this; let them control failure semantics.
+# Function-local error handling instead.
+
+OPS_DATA_DIR="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+COMP_STATE_DIR="$OPS_DATA_DIR/competitor_state"
+COMP_REPORTS_DIR="$OPS_DATA_DIR/reports/competitor-intel"
+COMP_STATE_FILE="$OPS_DATA_DIR/competitor_state.json"
+COMP_EVENTS_FILE="$COMP_STATE_DIR/events.jsonl"
+COMP_IMMEDIATE_QUEUE="$COMP_STATE_DIR/queue/immediate.jsonl"
+COMP_DAILY_QUEUE="$COMP_STATE_DIR/queue/daily.jsonl"
+
+# ── competitor_context — main entrypoint ────────────────────────────────
+competitor_context() {
+  local brand_filter=""
+  local window_days=7
+  local severity_filter="all"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --brand)         brand_filter="$2"; shift 2 ;;
+      --window-days)   window_days="$2";  shift 2 ;;
+      --severity)      severity_filter="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  # Not configured yet: state file missing
+  if [[ ! -f "$COMP_STATE_FILE" ]]; then
+    printf '{"configured":false,"reason":"no_state_file"}'
+    return 0
+  fi
+
+  # Resolve event window cutoff (epoch seconds)
+  local cutoff
+  cutoff=$(date -u -v "-${window_days}d" +%s 2>/dev/null \
+        || date -u -d "${window_days} days ago" +%s 2>/dev/null \
+        || echo 0)
+
+  # Read events file safely (may not exist on fresh installs)
+  local events_json="[]"
+  if [[ -f "$COMP_EVENTS_FILE" ]]; then
+    events_json=$(jq -c -s --argjson cutoff "$cutoff" '
+      [ .[] | select(.timestamp | fromdateiso8601 >= $cutoff) ]
+    ' "$COMP_EVENTS_FILE" 2>/dev/null || echo "[]")
+  fi
+
+  # Apply optional brand filter to events
+  if [[ -n "$brand_filter" ]]; then
+    events_json=$(echo "$events_json" | jq -c --arg b "$brand_filter" '
+      [ .[] | select((.competitor // "") | ascii_downcase | startswith($b | ascii_downcase) | not | not) ]
+    ' 2>/dev/null || echo "$events_json")
+    # That filter keeps events where competitor matches OR is a known competitor of that brand.
+    # We keep it permissive — consumers usually want all events anyway.
+  fi
+
+  # Apply severity filter
+  if [[ "$severity_filter" != "all" ]]; then
+    events_json=$(echo "$events_json" | jq -c --arg s "$severity_filter" '[ .[] | select(.severity == $s) ]')
+  fi
+
+  # Queue sizes (line counts)
+  local imm_pending=0 daily_pending=0
+  [[ -f "$COMP_IMMEDIATE_QUEUE" ]] && imm_pending=$(wc -l < "$COMP_IMMEDIATE_QUEUE" | tr -d ' ')
+  [[ -f "$COMP_DAILY_QUEUE" ]]     && daily_pending=$(wc -l < "$COMP_DAILY_QUEUE" | tr -d ' ')
+
+  # Build per-brand summary by augmenting state with latest-report paths
+  local by_brand
+  by_brand=$(jq -c '
+    to_entries | map({
+      key: .key,
+      value: (.value + {
+        latest_report: null,
+        latest_synthesis: null
+      })
+    }) | from_entries
+  ' "$COMP_STATE_FILE" 2>/dev/null || echo "{}")
+
+  # Inject latest report symlinks (looked up per-brand)
+  local brands
+  brands=$(echo "$by_brand" | jq -r 'keys[]')
+  while IFS= read -r b; do
+    [[ -z "$b" ]] && continue
+    local slug
+    slug=$(printf '%s' "$b" | tr '[:upper:] /' '[:lower:]--' | tr -cd 'a-z0-9-_.')
+    local latest="$COMP_REPORTS_DIR/latest-$slug.md"
+    local synth=""
+    if [[ -L "$latest" ]] || [[ -f "$latest" ]]; then
+      local real
+      real=$(readlink "$latest" 2>/dev/null || echo "$latest")
+      [[ "$real" != /* ]] && real="$COMP_REPORTS_DIR/$real"
+      synth="${real%.md}-synthesis.md"
+      by_brand=$(echo "$by_brand" | jq -c --arg b "$b" --arg r "$real" --arg s "$synth" '
+        .[$b].latest_report = $r
+        | (if ($s | test("synthesis.md$")) and ($s | (test("/") | not) | not) then .[$b].latest_synthesis = $s else . end)
+      ')
+    fi
+  done <<< "$brands"
+
+  # Brand list
+  local brands_array
+  brands_array=$(echo "$by_brand" | jq -c 'keys')
+
+  # High-severity events (full objects, capped at 20 most recent)
+  local high_events
+  high_events=$(echo "$events_json" | jq -c '
+    [ .[] | select(.severity == "high") ] | sort_by(.timestamp) | reverse | .[0:20]
+  ')
+
+  # Counts
+  local total med_count low_count
+  total=$(echo "$events_json"     | jq 'length')
+  med_count=$(echo "$events_json" | jq '[.[] | select(.severity == "med")] | length')
+  low_count=$(echo "$events_json" | jq '[.[] | select(.severity == "low")] | length')
+
+  # Final assembly
+  jq -n \
+    --argjson brands "$brands_array" \
+    --argjson by_brand "$by_brand" \
+    --argjson high "$high_events" \
+    --argjson total "$total" \
+    --argjson med "$med_count" \
+    --argjson low "$low_count" \
+    --argjson imm "$imm_pending" \
+    --argjson daily "$daily_pending" \
+    --argjson window "$window_days" \
+    '{
+      configured: true,
+      brands: $brands,
+      by_brand: $by_brand,
+      events: {
+        window_days: $window,
+        total: $total,
+        high: $high,
+        med_count: $med,
+        low_count: $low
+      },
+      queues: {
+        immediate_pending: $imm,
+        daily_pending: $daily
+      }
+    }'
+}
+
+# ── Convenience helpers (small, focused) ───────────────────────────────
+
+# Print compact one-line summary for briefing surfaces (e.g. /ops:go).
+# Output: "Healify: 2 alerts (last: Noom price drop) · 5 med deltas · weekly report 2026-05-17"
+# or:     "(not configured — run /ops:setup competitor-intel)"
+competitor_briefing_line() {
+  local ctx; ctx=$(competitor_context "$@")
+  if [[ "$(echo "$ctx" | jq -r '.configured')" != "true" ]]; then
+    printf '%s' "(not configured)"
+    return 0
+  fi
+  echo "$ctx" | jq -r '
+    [
+      (.brands[] as $b |
+        ($b + ": " +
+          (.events.high | map(select(.competitor as $c |
+            ($c | type) == "string"
+          )) | length | tostring) +
+          " alerts · " +
+          (.events.med_count | tostring) + " med deltas · last run " +
+          (.by_brand[$b].last_run // "—")
+        )
+      )
+    ] | join(" | ")
+  '
+}
+
+# Get top-N high-severity events as terse bullet list (for /ops:next).
+# Output: "- HIGH Noom pricing: price drop $69→$49/mo …\n- HIGH HealthifyMe …"
+competitor_priority_items() {
+  local n=5
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --top) n="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  local ctx; ctx=$(competitor_context --severity high "$@")
+  if [[ "$(echo "$ctx" | jq -r '.configured')" != "true" ]]; then
+    return 0
+  fi
+  echo "$ctx" | jq -r --argjson n "$n" '
+    .events.high[0:$n] | .[] |
+    "- HIGH " + (.competitor // "?") + " " + (.source // "?") +
+    ": " + ((.snippet // "") | .[0:160])
+  '
+}
+
+# Get vertical-specific signal slice for /ops:marketing, /ops:ecom, /ops:yolo c-suite agents.
+# Filters events by source kind groupings.
+#   marketing  → pricing diffs, funding/news, brand sentiment from reddit/hn
+#   ecom       → app store version+rating, product page diffs, hueman-style competitor launches
+#   cfo        → pricing diffs only (money-token high severity)
+#   ceo        → new entrants, competitor moves (med + high)
+#   coo        → jobs feed (hiring signals)
+#   cto        → changelog page-diffs, technical signals
+competitor_vertical_slice() {
+  local vertical="$1"
+  shift
+  local ctx; ctx=$(competitor_context "$@")
+  if [[ "$(echo "$ctx" | jq -r '.configured')" != "true" ]]; then
+    printf '[]'
+    return 0
+  fi
+  case "$vertical" in
+    marketing)
+      echo "$ctx" | jq -c '
+        [ (.events.high + (.events | .high)) | unique_by(.timestamp + .competitor) | .[] |
+          select(.source == "page-diff" and (.kind // "") == "pricing"
+              or .source == "reddit"
+              or .source == "hn"
+              or (.snippet // "" | test("funding|raised|series [A-D]"; "i"))
+          )
+        ]'
+      ;;
+    ecom)
+      echo "$ctx" | jq -c '
+        [ .events.high[] |
+          select(.source == "appstore"
+              or (.source == "page-diff" and (.kind // "" | test("features|pricing"))))
+        ]'
+      ;;
+    cfo)
+      echo "$ctx" | jq -c '
+        [ .events.high[] |
+          select(.source == "page-diff" and (.kind // "") == "pricing")
+        ]'
+      ;;
+    ceo)
+      echo "$ctx" | jq -c '
+        [ .events.high[] |
+          select((.snippet // "" | test("entrant|launch|raised|acquired"; "i"))
+              or .source == "page-diff")
+        ]'
+      ;;
+    coo)
+      echo "$ctx" | jq -c '[ .events.high[] | select(.source == "jobs") ]'
+      ;;
+    cto)
+      echo "$ctx" | jq -c '
+        [ .events.high[] |
+          select(.source == "page-diff" and (.kind // "" | test("changelog|features")))
+        ]'
+      ;;
+    *)
+      echo "$ctx" | jq -c '.events.high'
+      ;;
+  esac
+}

--- a/claude-ops/skills/ops-competitors/SKILL.md
+++ b/claude-ops/skills/ops-competitors/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: ops-competitors
+description: "Competitor-intel dashboard and management UI. Tracks brand signals, page-diff alerts, pricing changes, App Store moves, and weekly synthesis reports. Powered by the competitor-intel cron pipeline."
+argument-hint: "[brand-name|refresh [brand]|add-url <brand> <competitor> <kind> <url>|alerts|help]"
+allowed-tools:
+  - Bash
+  - Read
+  - Edit
+  - AskUserQuestion
+effort: low
+maxTurns: 15
+disallowedTools:
+  - Write
+  - NotebookEdit
+---
+
+## Runtime Context
+
+Before rendering, load competitor context:
+
+```bash
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(dirname $(which ops-competitors 2>/dev/null) 2>/dev/null)/..}"
+OPS_DATA_DIR="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+source "$PLUGIN_ROOT/scripts/lib/competitor/context.sh" 2>/dev/null || true
+CTX=$(competitor_context 2>/dev/null || echo '{"configured":false,"reason":"lib_not_found"}')
+```
+
+# OPS ► COMPETITORS — Intel Dashboard
+
+Parse `$ARGUMENTS` and dispatch to the matching mode below.
+
+---
+
+## Mode: No args — Dashboard
+
+Show all tracked brands with last_run, alert counts, and recent activity. Use `competitor_briefing_line` for each brand row.
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► COMPETITORS — [date]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+TRACKED BRANDS ([n] total)
+  [brand]   last run [date]   [n] alerts · [n] med · [n] low
+  ...
+
+PENDING QUEUES
+  immediate: [n]   daily: [n]
+
+RECENT HIGH ALERTS (last 7d)
+  [timestamp]  [brand]  [competitor]  [snippet…]
+  ...
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+If `configured == false`: print setup hint and stop.
+
+```bash
+# Load context
+source "$PLUGIN_ROOT/scripts/lib/competitor/context.sh"
+competitor_context --window-days 7
+competitor_briefing_line
+```
+
+Mobile mode (Rule 7): one line per brand, no banner, no box-drawing.
+
+---
+
+## Mode: `<brand-name>` — Drill-down
+
+Full event timeline (last 30d), top competitors, latest report, per-competitor signal breakdown.
+
+1. Run `competitor_context --brand "<brand>" --window-days 30`
+2. Print brand metadata: category, competitor list, last_run, last_discovery
+3. Print per-competitor signal breakdown (group events by `.competitor`)
+4. Read latest report:
+   ```bash
+   SLUG=$(echo "<brand>" | tr '[:upper:] /' '[:lower:]--' | tr -cd 'a-z0-9-_.')
+   REPORT="$OPS_DATA_DIR/reports/competitor-intel/latest-${SLUG}.md"
+   [[ -f "$REPORT" ]] && head -80 "$REPORT"
+   ```
+5. Print full high-severity event timeline sorted newest-first
+
+Output format:
+
+```
+BRAND: [name]  category: [cat]  last run: [date]
+competitors: [a, b, c, ...]
+
+SIGNAL BREAKDOWN
+  [competitor]   high: [n]  med: [n]  low: [n]
+
+LATEST REPORT (excerpt)
+  [first 80 lines of report]
+
+EVENT TIMELINE (30d — [n] total)
+  [timestamp]  HIGH  [competitor]  [source]  [snippet…]
+  ...
+```
+
+---
+
+## Mode: `refresh [brand]`
+
+Manually triggers the weekly intel cron immediately.
+
+```bash
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-...}"
+CRON_SCRIPT="$PLUGIN_ROOT/scripts/ops-cron-competitor-intel.sh"
+
+# If a specific brand is given, pass it via env override
+if [[ -n "$BRAND_ARG" ]]; then
+  BRAND_NAME="$BRAND_ARG" bash "$CRON_SCRIPT"
+else
+  bash "$CRON_SCRIPT"
+fi
+```
+
+Stream output. Inform the user when done and show updated `competitor_briefing_line`.
+
+---
+
+## Mode: `add-url <brand> <competitor> <kind> <url>`
+
+Add a page-diff monitored URL to `preferences.json`. Valid `<kind>` values: `pricing`, `features`, `changelog`, `careers`.
+
+1. Validate args — if any missing, explain usage and stop.
+2. Show the proposed change:
+   ```
+   Add URL for [brand] → [competitor] ([kind]):
+     [url]
+   ```
+3. AskUserQuestion: `[Add]` / `[Cancel]`
+4. On confirm, merge via jq:
+   ```bash
+   PREFS="$OPS_DATA_DIR/preferences.json"
+   jq --arg brand "$BRAND" --arg comp "$COMP" --arg kind "$KIND" --arg url "$URL" '
+     .competitor_intel.urls[$brand][$comp][$kind] = $url
+   ' "$PREFS" > /tmp/prefs-tmp.json && mv /tmp/prefs-tmp.json "$PREFS"
+   ```
+5. Confirm written.
+
+---
+
+## Mode: `alerts`
+
+Tail the last 20 lines of the alerts log:
+
+```bash
+ALERTS="$OPS_DATA_DIR/reports/competitor-intel/alerts.log"
+if [[ -f "$ALERTS" ]]; then
+  tail -20 "$ALERTS"
+else
+  echo "No alerts log found at $ALERTS"
+fi
+```
+
+---
+
+## Mode: `help` / unknown args
+
+Print available subcommands:
+
+```
+ops-competitors                           — dashboard (all brands)
+ops-competitors <brand>                   — drill-down: events, report, breakdown
+ops-competitors refresh [brand]           — run intel cron now (optional brand filter)
+ops-competitors add-url <b> <c> <k> <url> — add page-diff URL to preferences.json
+ops-competitors alerts                    — tail alerts.log (last 20 lines)
+ops-competitors help                      — this message
+```
+
+---
+
+## Error states
+
+- `configured == false` → print `"Competitor-intel not configured. Run /ops:setup competitor-intel to get started."` and stop.
+- `CRON_SCRIPT` not found → print path and stop.
+- `PREFS` not writable for `add-url` → surface error, do not silently fail.

--- a/claude-ops/skills/ops-ecom/SKILL.md
+++ b/claude-ops/skills/ops-ecom/SKILL.md
@@ -537,6 +537,38 @@ If the connectivity check returns valid shop data, confirm success. If it fails 
 
 When called with no arguments, show a compact store overview:
 
+### Competitor activity (gather before rendering)
+
+```bash
+# Resolve PLUGIN_ROOT: directory containing the ops-ops-marketplace plugin scripts
+_COMP_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}" 2>/dev/null || echo "$0")")")}"
+_COMP_LIB="$_COMP_PLUGIN_ROOT/scripts/lib/competitor/context.sh"
+_COMP_ECOM_SIGNALS="[]"
+if [[ -f "$_COMP_LIB" ]]; then
+  # shellcheck source=/dev/null
+  . "$_COMP_LIB"
+  _COMP_ECOM_SIGNALS=$(competitor_vertical_slice ecom --window-days 7 2>/dev/null || echo "[]")
+fi
+```
+
+Parse `_COMP_ECOM_SIGNALS` JSON array. If it is non-empty, append the **COMPETITOR ACTIVITY** section after FULFILLMENT in the store summary render. If it is `[]`, skip the section entirely.
+
+Render using this shape (mobile mode: plain text, no banners; desktop: with `━━━` rules):
+
+```
+━━━ COMPETITOR ACTIVITY (last 7d) ━━━
+APP RELEASES
+  • [competitor] — v[version] released this week (rating: [X.X], [N]k reviews)
+PRODUCT / PRICING CHANGES
+  • [competitor] — pricing page changed ([low/med/high] severity)
+  • [competitor] — features page changed ([brief description from snippet])
+```
+
+Mapping rules (apply per event in the JSON array):
+- `source == "appstore"` → APP RELEASES entry. Extract version, rating, and review count from `snippet` if present.
+- `source == "page-diff"` and `kind` matches `features` → PRODUCT / PRICING CHANGES entry, labelled as features change.
+- `source == "page-diff"` and `kind == "pricing"` → PRODUCT / PRICING CHANGES entry, labelled as pricing change with severity from `severity` field.
+
 Run orders, inventory, and health checks in parallel (separate Bash calls), then render:
 
 ```
@@ -553,6 +585,8 @@ TODAY         $[revenue]  [N] orders
 
 INVENTORY     [N] products  |  [N] low stock  |  [N] out of stock
 FULFILLMENT   [N] unfulfilled orders pending
+
+[COMPETITOR ACTIVITY section here if non-empty — see above]
 
 ──────────────────────────────────────────────────────
  /ops:ops-ecom orders     — order management

--- a/claude-ops/skills/ops-go/SKILL.md
+++ b/claude-ops/skills/ops-go/SKILL.md
@@ -150,6 +150,14 @@ for d in $(jq -r '.projects[] | select(.gsd == true) | .paths[]' "${CLAUDE_PLUGI
 done
 ```
 
+### Competitor Intel
+
+```!
+source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/competitor/context.sh" 2>/dev/null \
+  && competitor_context --window-days 7 2>/dev/null \
+  || echo '{"configured":false}'
+```
+
 ### External Projects (non-repo)
 
 ```!
@@ -197,6 +205,11 @@ MARKETING
 [If health < 70: "⚠ Run /ops:marketing optimize for recommendations"]
 [If no marketing configured: "(marketing not configured — /ops:marketing setup)"]
 
+COMPETITOR    <brand>: N alerts · M med deltas · last run YYYY-MM-DD
+              <top high-severity event snippet, 1 line, truncated 140 chars>
+[If competitor data returns {configured:false}, omit this section entirely — no "(not configured)" noise]
+[Mobile mode (Rule 7): compress to one line: "comp: N alerts (top: brief snippet)"]
+
 UNREAD
 [WhatsApp: N, Email: N, Slack: N workspace(s) configured (no scan), Notion: N items, Calendar: N events today]
 
@@ -210,7 +223,7 @@ TODAY'S PRIORITIES (ranked by revenue impact + urgency)
 
 **Marketing section data source**: Read from `ops-marketing-dash` pre-gathered output (see Pre-gathered data section). If marketing data is present in the dash output, compute the health score inline (see ops-marketing SKILL.md health score formula). If ops-marketing-dash is not configured or returns empty marketing data, show `(marketing not configured — /ops:marketing setup)`.
 
-**Priority ranking**: fires > degraded infra > CI failures > unread comms > ready-to-merge PRs > revenue-generating GSD work > stale projects.
+**Priority ranking**: fires > degraded infra > CI failures > competitor alerts (high-severity, last 24h) > unread comms > ready-to-merge PRs > revenue-generating GSD work > stale projects.
 
 If `$ARGUMENTS` contains a project alias, focus the briefing on that project only.
 

--- a/claude-ops/skills/ops-marketing/SKILL.md
+++ b/claude-ops/skills/ops-marketing/SKILL.md
@@ -1950,6 +1950,39 @@ Run ALL sections in parallel, then render unified dashboard.
 "${CLAUDE_PLUGIN_ROOT}/bin/ops-marketing-dash" 2>/dev/null
 ```
 
+### Competitor signals (gather before rendering)
+
+```bash
+# Resolve PLUGIN_ROOT: directory containing the ops-ops-marketplace plugin scripts
+_COMP_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(dirname "$(dirname "$(realpath "${BASH_SOURCE[0]}" 2>/dev/null || echo "$0")")")}"
+_COMP_LIB="$_COMP_PLUGIN_ROOT/scripts/lib/competitor/context.sh"
+_COMP_MARKETING_SIGNALS="[]"
+if [[ -f "$_COMP_LIB" ]]; then
+  # shellcheck source=/dev/null
+  . "$_COMP_LIB"
+  _COMP_MARKETING_SIGNALS=$(competitor_vertical_slice marketing --window-days 7 2>/dev/null || echo "[]")
+fi
+```
+
+Parse `_COMP_MARKETING_SIGNALS` JSON array. If it is non-empty, emit the **COMPETITOR SIGNALS** section immediately before the Marketing Health Score footer. If it is `[]`, skip the section entirely.
+
+Render the section using this shape (mobile mode: plain text, no banners; desktop: with `━━━` rules):
+
+```
+━━━ COMPETITOR SIGNALS (last 7d) ━━━
+PRICING MOVES (react in your campaigns)
+  • [competitor] — pricing page changed ([price drop/increase detected]) — see latest-[slug].md
+FUNDING / NEWS
+  • [competitor] — [snippet summary, e.g. "Series C announced"] — campaign angle: [one-liner]
+SENTIMENT (Reddit / HN)
+  • [competitor] — [N]-point [HN/Reddit] thread on "[topic]" — content opportunity
+```
+
+Mapping rules (apply per event in the JSON array):
+- `source == "page-diff"` and `kind == "pricing"` → PRICING MOVES entry. Describe the direction (drop/increase) if inferable from snippet.
+- `snippet` matches `funding|raised|series [A-D]` (case-insensitive) → FUNDING / NEWS entry. Suggest a campaign counter-angle framing the competitor as an "established player" or "new entrant" as appropriate.
+- `source == "reddit"` or `source == "hn"` → SENTIMENT entry. Extract the core concern from `snippet` as a content opportunity.
+
 Parse the JSON output and display:
 
 ```
@@ -1962,6 +1995,8 @@ Parse the JSON output and display:
  Organic (GA4)    [N] sessions  |  [X]% CVR  |  $[X] revenue
  SEO (GSC)        [N] clicks  |  [N] impressions  |  [X] avg pos
  Instagram        [N] followers  |  [N] reach (7d)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+[COMPETITOR SIGNALS section here if non-empty — see above]
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Marketing Health Score: [N]/100  ([status: Healthy/Warning/Critical])
  Blended ROAS: [X]x  Top channel: [channel]

--- a/claude-ops/skills/ops-next/SKILL.md
+++ b/claude-ops/skills/ops-next/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ops-next
-description: Business-level "what should I do next". Priority stack — fires > unread comms > ready-to-merge PRs > Linear sprint > revenue-generating GSD work. Uses pre-gathered data and routes to the right skill.
+description: Business-level "what should I do next". Priority stack — fires > competitor alerts > unread comms > ready-to-merge PRs > Linear sprint > revenue-generating GSD work. Uses pre-gathered data and routes to the right skill.
 argument-hint: "[context]"
 allowed-tools:
   - Bash
@@ -79,6 +79,14 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ops-prs 2>/dev/null || echo '[]'
 ${CLAUDE_PLUGIN_ROOT}/bin/ops-ci 2>/dev/null || echo '[]'
 ```
 
+### Competitor alerts (last 24h)
+
+```!
+source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/competitor/context.sh" 2>/dev/null \
+  && competitor_priority_items --top 3 --window-days 1 2>/dev/null \
+  || true
+```
+
 ### Unread messages
 
 ```!
@@ -110,25 +118,35 @@ Check infra data for: unhealthy ECS tasks, stopped services, failed deployments.
 Check CI for: broken `main` or `dev` branches.
 If any fires exist → **recommend `/ops-fires` immediately**.
 
-### Priority 2 — URGENT COMMS
+### Priority 2 — COMPETITOR ALERTS
+
+Check the competitor alerts pre-gathered data (last 24h window).
+If `competitor_priority_items` returned lines (non-empty output):
+- Surface each as: `REACT: <competitor> <source> changed — see latest-<brand>.md`
+- Recommend the user open the latest report file (path from `competitor_context` → `by_brand.<brand>.latest_report`)
+- If high-severity alerts exist → **recommend addressing before comms**
+
+If the output is empty or the source block returned nothing, skip this priority silently.
+
+### Priority 3 — URGENT COMMS
 
 Check unread counts. If WhatsApp or email has unread messages from humans (not automated):
 
 - Estimate urgency from sender/preview if available
 - If urgent comms → **recommend `/ops-inbox [channel]`**
 
-### Priority 3 — READY-TO-MERGE PRs
+### Priority 4 — READY-TO-MERGE PRs
 
 Check PRs for: CI green + no unresolved review comments + not draft.
 If any ready → **recommend reviewing that PR now**.
 Check: `gh pr list --state open --json number,title,statusCheckRollup,reviewDecision 2>/dev/null`
 
-### Priority 4 — LINEAR SPRINT
+### Priority 5 — LINEAR SPRINT
 
 Fetch current sprint issues: use `mcp__linear__list_issues` filtered to current cycle (use Linear GraphQL fallback for cycle queries if needed).
 Find highest-priority issue that is in progress or unstarted.
 
-### Priority 5 — GSD WORK
+### Priority 6 — GSD WORK
 
 From GSD state, find the highest revenue-impact active phase across all projects.
 Revenue weighting: read `revenue.stage` and `priority` from `scripts/registry.json` — projects with lower priority numbers (higher priority) and revenue stage of `growth` or `active` outrank `pre-launch` or `development`. Within the same tier, prioritize closest-to-done phases.

--- a/claude-ops/skills/ops-yolo/SKILL.md
+++ b/claude-ops/skills/ops-yolo/SKILL.md
@@ -155,6 +155,8 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ops-gsd-states 2>/dev/null || true
 
 ---
 
+> **Competitor state**: Each C-suite agent sources `scripts/lib/competitor/context.sh` and calls `competitor_vertical_slice <role>` internally. The orchestrator does NOT need to pre-fetch competitor data — it is loaded on-demand per agent with role-specific filtering.
+
 ## Phase 2 — Spawn 4 C-suite agents in parallel
 
 Spawn these 4 agents simultaneously using all pre-gathered data as context. Each writes their analysis to a file in `/tmp/yolo-[session]/`:


### PR DESCRIPTION
## Summary
v2.3.0 shipped the producer side (5 signal collectors, severity routing, weekly synthesis). v2.3.1 wires the consumer side — competitor-intel outputs now flow into 6 places across the plugin.

**Shared context lib** (`scripts/lib/competitor/context.sh`, 292 lines): `competitor_context`, `competitor_briefing_line`, `competitor_priority_items`, `competitor_vertical_slice <role>`. jq-only, no external calls.

**Consumers wired**:
- `/ops:go` — COMPETITOR row in `bin/ops-gather` (alerts count, last_run, top-3 snippets)
- `/ops:next` — Priority 2 (between fires and unread comms): "REACT: <competitor> <source> changed"
- `/ops:marketing` — PRICING MOVES + FUNDING + SENTIMENT sections
- `/ops:ecom` — APP RELEASES + PRODUCT/PRICING CHANGES sections
- `/ops:yolo` CEO/CTO/CFO/COO agents — each loads role-specific vertical-slice
- New `/ops:competitors` skill + `bin/ops-competitors` CLI: dashboard/drill-down/refresh/add-url/alerts

All consumers skip silently when competitor-intel unconfigured. Mobile-mode compressed throughout.

## Test plan
- [x] All 3 new shell scripts `bash -n` clean
- [x] `tests/test-no-secrets.sh` 14/14
- [x] context lib smoke-tested against live state on this machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it adds new shell-based data plumbing and changes `/ops:go` and `/ops:next` prioritization behavior, which can affect user-facing decision flows. Changes are mostly additive and gated to silently no-op when competitor intel is unconfigured.
> 
> **Overview**
> **Competitor-intel is now a first-class input across the plugin.** This introduces a shared jq-only context library (`scripts/lib/competitor/context.sh`) and wires its outputs into `/ops:go` (via `bin/ops-gather`) and `/ops:next` as a new *Priority 2* alert tier.
> 
> Marketing and ecom dashboards gain optional competitor sections populated from role-filtered signal slices, and YOLO C-suite agent prompts now pull role-specific competitor context before writing analyses. A new `/ops:competitors` skill plus `bin/ops-competitors` CLI provides a dashboard/drill-down/refresh/add-url/alerts interface, and versions are bumped to `2.3.1` with changelog updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60b6fff470d50d712dfbc1952926624516baf5a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Competitor intelligence dashboard and monitoring capabilities now available
  * Competitor alerts and signals integrated into morning briefing, priority stack, and executive analyses
  * New `/ops:competitors` skill with dashboard, drill-down, refresh, and alert management commands

* **Chores**
  * Version bumped to 2.3.1

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->