### PR TITLE
docs: sync README + docs + wiki + manifest counts for v2.3.x (v2.3.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,9 +9,9 @@
   "plugins": [
     {
       "name": "ops",
-      "description": "Business operations command center for Claude Code — 35 skills, 18 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
+      "description": "Business operations command center for Claude Code — 36 skills, 18 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ claude --plugin-dir ./claude-ops/claude-ops
 
 ## Commands
 
-All 30 skills, grouped by category:
+All 36 skills, grouped by category:
 
 | 🧭 Navigation | 📊 Daily Ops |
 |---|---|
@@ -120,6 +120,7 @@ All 30 skills, grouped by category:
 | `/ops:fires` — incidents + **all AWS** | `/ops:gtm` — **cross-channel GTM planner** |
 | `/ops:deploy` — ECS/Vercel/Actions | `/ops:voice` — Bland AI/ElevenLabs/Whisper |
 | `/ops:monitor` — Datadog/New Relic/OTEL | `/ops:package` — carrier-agnostic shipping |
+| `/ops:competitors` — **self-discovering competitor intel** (v2.3) | |
 
 | 🤖 Automation | 🧰 Maintenance |
 |---|---|
@@ -284,6 +285,57 @@ SendMessage(to="fix-ecs", content="This is P0, prioritize over CI")
 
 ---
 
+## Competitor Intelligence (v2.3)
+
+A self-discovering competitive-intelligence pipeline that goes well past "weekly Google Alert." Free signals + LLM curation, $0 incremental cost, configurable per brand.
+
+**Pipeline per configured brand:**
+
+1. **Discovery** (Tavily, cached 30d) — surfaces the current competitor landscape for `{brand_name}` in `{category}`.
+2. **Per-competitor signal collectors** run in parallel (`scripts/lib/competitor/`):
+   - `reddit-search.sh` — Reddit JSON API
+   - `hn-search.sh` — HN Algolia API
+   - `appstore-lookup.sh` — iTunes Lookup (opt-in for mobile brands)
+   - `jobs-feed.sh` — Greenhouse + Lever public APIs (senior-hire detection)
+   - `page-diff.sh` — HTML pricing/features/careers SHA snapshots with money-token detection
+3. **Severity routing** via `event-router.sh`:
+   - `high` (price change on direct rival, funding, Show HN going viral) → immediate Telegram push every 10 min via `competitor-alert` cron
+   - `med` → daily 17:00 grouped roll-up via `competitor-daily` cron
+   - `low` → state-only, surfaces in weekly strategic synthesis
+4. **Weekly synthesis** (Mon 10:00) — `claude_invoke` Sonnet 4.6 against 7-day events.jsonl window. Output: `NEW entrants / Competitor moves / Brand signal / Threats & opportunities`.
+
+**Where it shows up:**
+
+| Surface | What you see |
+|---|---|
+| `/ops:go` | `COMPETITOR` row: alerts count, last_run, top-3 event snippets |
+| `/ops:next` | Priority 2 (between fires + comms): `REACT: <competitor> <source> changed` |
+| `/ops:marketing` | PRICING MOVES + FUNDING + SENTIMENT section |
+| `/ops:ecom` | APP RELEASES + PRODUCT/PRICING CHANGES section |
+| `/ops:yolo` | CEO/CTO/CFO/COO agents each load role-specific vertical slice |
+| `/ops:competitors` | Dedicated dashboard + `bin/ops-competitors` CLI |
+| Disk | `$DATA_DIR/reports/competitor-intel/YYYY-MM-DD_<brand>.md` |
+
+**Config** (`preferences.json .competitor_intel`):
+```json
+{
+  "brand_name": "Healify",
+  "category": "AI health coaching apps",
+  "max_competitors": 5,
+  "report_timezone": "Europe/Amsterdam",
+  "app_store": true,
+  "urls": {
+    "Noom": { "pricing": "https://www.noom.com/plans/", "features": "..." }
+  }
+}
+```
+
+**Required env:** `TAVILY_API_KEY` (free tier 1000 searches/mo — covers ~30 brands). **Optional:** `TELEGRAM_BOT_TOKEN` + `TELEGRAM_CHAT_ID` for push delivery (otherwise reports persist to disk only).
+
+**Cost at 10-brand scale:** ~13 Tavily calls/wk + ~320k Sonnet tokens/mo on Max-OAuth = **$0 incremental**.
+
+---
+
 ## Privacy & Security
 
 > [!IMPORTANT]
@@ -305,7 +357,9 @@ SendMessage(to="fix-ecs", content="This is P0, prioritize over CI")
 - `memory-extractor` every 30 min — Haiku summarizes local chats to `memories/`.
 - `inbox-digest` every 4h — aggregates for your configured Telegram bot (if any).
 - `store-health` daily 9am — Shopify Admin API, read-only.
-- `competitor-intel` weekly — your configured competitor feeds.
+- `competitor-intel` weekly Mon 10:00 — full strategic synthesis for each configured brand (see below).
+- `competitor-alert` every 10 min — drains high-severity competitor events to Telegram + `alerts.log`.
+- `competitor-daily` daily 17:00 — drains medium-severity events into a grouped roll-up digest.
 - `message-listener` continuous — local polling, never sends outbound on its own.
 
 **Security measures:** `umask 077` on preferences.json · credentials in Claude Code's encrypted `userConfig` · registry/preferences gitignored · `tests/test-no-secrets.sh` pre-commit · Rule 5 blocks destructive actions without confirmation · append-only shell profile writes.

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ops",
-  "version": "2.3.1",
-  "description": "Business operations command center for Claude Code — 35 skills, 18 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
+  "version": "2.3.2",
+  "description": "Business operations command center for Claude Code — 36 skills, 18 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",
     "url": "https://github.com/Lifecycle-Innovations-Limited"

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.3.2] — 2026-05-17
+### Changed
+- **Docs/wiki/metadata sync for v2.3.x.** Producer side (v2.3.0) and consumer side (v2.3.1) shipped without doc surface updates; v2.3.2 catches everything up.
+  - `README.md`: new "Competitor Intelligence (v2.3)" section with pipeline overview, signal-source matrix, consumer integrations, config schema, cost model. Daemon-services list now reflects `competitor-intel` (Mon 10:00), `competitor-alert` (every 10 min), and `competitor-daily` (17:00). `/ops:competitors` added to the skills table. Skill count bumped 30 → 36.
+  - `claude-ops/docs/daemon-guide.md`: 3 competitor cron services listed with correct cadence + purpose.
+  - `claude-ops/docs/agents-reference.md`: each of `yolo-ceo`/`cto`/`cfo`/`coo` now documents its `competitor_vertical_slice` source and how the slice folds into the analysis.
+  - `claude-ops/docs/skills-reference.md`: `/ops:competitors` entry added with all 6 subcommands.
+  - Wiki: new `Competitor-Intelligence.md` page covering full architecture + signal sources + severity routing + consumer integrations + state/reports layout + cost model + operational commands. Sidebar updated. Version stamp bumped 2.2.0 → 2.3.2.
+  - Skill count drift fixed: `plugin.json` + `marketplace.json` descriptions now say "36 skills, 18 agents" (was "35 skills") to reflect the new `/ops:competitors` skill.
+
 ## [2.3.1] — 2026-05-17
 ### Added
 - **Competitor-intel outputs now consumed across the plugin.** v2.3.0 shipped the producer side (signal collectors, severity routing, weekly synthesis). v2.3.1 wires the consumer side so the data actually shows up where decisions get made:

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -130,25 +130,31 @@ sequenceDiagram
 > [!IMPORTANT]
 > `Hard Truths Merger` in the diagram above is the **main `/ops:yolo` skill orchestrator** running in the Claude Code main agent context — NOT a separate agent. It reads all four parallel analysis files (`ceo-analysis.md`, `cto-analysis.md`, `cfo-analysis.md`, `coo-analysis.md`) and composes the unified report. `yolo-ceo` is a peer agent with its own strategic perspective; it does not synthesize the others' work.
 
+> **v2.3.1 — competitor context auto-loaded.** Each C-suite agent now sources `scripts/lib/competitor/context.sh` at the start of its run and calls `competitor_vertical_slice <role>` to pull a role-filtered slice of last-7d high-severity competitor events. The slice is folded into each agent's analysis. Skipped silently when competitor-intel is unconfigured.
+
 ### `yolo-ceo` · `agents/yolo-ceo.md`
 - **Model**: `claude-opus-4-6`
 - **Effort**: high · **maxTurns**: 20
 - **Purpose**: Strategic priority analysis. Growth blockers, resource allocation, build vs. buy decisions, investor-readiness. No sugar-coating.
+- **Competitor slice**: `competitor_vertical_slice ceo` — NEW entrants, comp funding, strategic moves. Factors into market-positioning recommendations.
 
 ### `yolo-cto` · `agents/yolo-cto.md`
 - **Model**: `claude-opus-4-6`
 - **Effort**: high · **maxTurns**: 25
 - **Purpose**: Technical health analysis. Architecture, tech debt, production risks, scalability limits, and cut corners. Brutally honest about what will break.
+- **Competitor slice**: `competitor_vertical_slice cto` — changelog/feature page-diffs, Show HN / Launch HN. Benchmarks tech velocity.
 
 ### `yolo-cfo` · `agents/yolo-cfo.md`
 - **Model**: `claude-opus-4-6`
 - **Effort**: high · **maxTurns**: 20
 - **Purpose**: Financial analysis. AWS burn rate, runway, ROI on current work, credits expiry, cost anomalies. No optimism without data.
+- **Competitor slice**: `competitor_vertical_slice cfo` — pricing diffs with money tokens (severity:high), comp funding rounds. Quantifies revenue impact of competitor pricing moves.
 
 ### `yolo-coo` · `agents/yolo-coo.md`
 - **Model**: `claude-opus-4-6`
 - **Effort**: high · **maxTurns**: 25
 - **Purpose**: Operations execution analysis. Stale work, broken processes, missing automation, communication failures. What the CEO doesn't see.
+- **Competitor slice**: `competitor_vertical_slice coo` — Greenhouse/Lever hiring signals (especially senior roles), layoff signals. Surfaces operational threats and poaching opportunities.
 
 > [!WARNING]
 > C-suite agents produce unfiltered "Hard Truths" — they will flag risks, dead projects, and wasted spend by name. Review before sharing with investors or teammates.

--- a/claude-ops/docs/daemon-guide.md
+++ b/claude-ops/docs/daemon-guide.md
@@ -34,7 +34,9 @@ The daemon supervises **seven** long-lived services:
 | `memory-extractor` | every 30 min | Spawns `memory-extractor` agent to refresh `memories/` |
 | `inbox-digest` | every 15 min | Pre-classifies comms across channels for `/ops:inbox` |
 | `store-health` | every 10 min | Shopify orders + inventory polling (if configured) |
-| `competitor-intel` | hourly | Background market/competitor monitoring |
+| `competitor-intel` | Mon 10:00 (TZ) | **v2.3**: weekly strategic synthesis. Tavily discovery (cached 30d) + 5 parallel signal collectors (Reddit/HN/AppStore/jobs/page-diff) + 7d events.jsonl window → Sonnet → `reports/competitor-intel/YYYY-MM-DD_<brand>.md` |
+| `competitor-alert` | every 10 min | **v2.3**: drains `queue/immediate.jsonl` (severity:high). Telegram push if configured + always appends to `alerts.log`. Heartbeats on empty queue |
+| `competitor-daily` | daily 17:00 (TZ) | **v2.3**: drains `queue/daily.jsonl` (severity:med). Groups by competitor, emits `daily-YYYY-MM-DD.md` roll-up + Telegram digest |
 | `message-listener` | persistent | Surfaces urgent patterns (your name, "urgent", "ASAP", "fire", "down") |
 
 > [!TIP]

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -87,6 +87,15 @@ Portfolio dashboard. Shows all registered projects with GSD phase, branch state,
 - `/ops:projects` — all projects
 - `/ops:projects my-app` — single project deep-dive
 
+### `/ops:competitors` · `skills/ops-competitors/SKILL.md` · `bin/ops-competitors`
+Dedicated dashboard + management UI for the v2.3 competitor-intelligence subsystem.
+- `/ops:competitors` — dashboard: all tracked brands with alert counts, last_run, recent high-severity events
+- `/ops:competitors <brand>` — drill-down: 30d event timeline, competitor breakdown, latest weekly report excerpt
+- `/ops:competitors refresh [brand]` — manually trigger the weekly cron immediately, optional per-brand env override
+- `/ops:competitors add-url <brand> <competitor> <kind> <url>` — `jq`-merge a page-diff URL into `preferences.json` (kind ∈ pricing/features/careers/blog/changelog) with confirm prompt
+- `/ops:competitors alerts` — tail last 20 of `reports/competitor-intel/alerts.log`
+- `/ops:competitors help` — print subcommand reference
+
 ### `/ops:linear` · `skills/ops-linear/SKILL.md`
 Linear sprint board and issue management. Uses Linear MCP for full sprint visibility and GSD sync.
 - `/ops:linear sprint` — current sprint

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
## Summary
Producer (v2.3.0) and consumer (v2.3.1) shipped without doc surface updates. This catches all of them up.

- `README.md` — new Competitor Intelligence (v2.3) section; daemon-services list now lists all 3 competitor cron services; `/ops:competitors` in skills table; skill count 30→36
- `claude-ops/docs/daemon-guide.md` — competitor-alert + competitor-daily added
- `claude-ops/docs/agents-reference.md` — C-suite agents document their `competitor_vertical_slice` source
- `claude-ops/docs/skills-reference.md` — `/ops:competitors` entry with all 6 subcommands
- Wiki (separate repo, already pushed) — new `Competitor-Intelligence.md` page + sidebar + version stamp 2.3.2
- Skill-count drift fixed in `marketplace.json` + `plugin.json` descriptions (35→36)

## Test plan
- [x] `tests/test-no-secrets.sh` 14/14
- [x] Wiki pushed to https://github.com/Lifecycle-Innovations-Limited/claude-ops/wiki/Competitor-Intelligence
- [x] All 3 manifest version fields aligned at 2.3.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/metadata-only updates plus version bumps; no runtime logic changes, so risk is limited to possible confusion from mismatched docs or manifest metadata.
> 
> **Overview**
> Updates public docs and reference materials to fully reflect the v2.3 competitor-intelligence subsystem, including a new README section, updated daemon service descriptions/cadences, and expanded references for `/ops:competitors` and YOLO agents’ `competitor_vertical_slice` usage.
> 
> Aligns release metadata by bumping plugin/marketplace/package versions to `2.3.2` and correcting the advertised skill count to **36** (was 35).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10565f5e038900b5a5d3e53e1dcd78aab5fe6ed5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->