### PR TITLE
feat(secret-sync): Doppler→GH secrets drift detection and sync skill

### DIFF
--- a/claude-ops/bin/ops-doctor
+++ b/claude-ops/bin/ops-doctor
@@ -281,6 +281,42 @@ if command -v jq >/dev/null 2>&1; then
   esac
 fi
 
+# --- 5d. Stale GH secrets check (Doppler→GH drift, read-only) ---
+# If ops-secret-sync bin is available AND both gh + doppler are installed, run a
+# quick per-project drift scan for projects in the registry that have a
+# doppler_project field. Only emits a WARNING — never reads or writes secret values.
+if command -v jq >/dev/null 2>&1 && \
+   command -v gh >/dev/null 2>&1 && \
+   command -v doppler >/dev/null 2>&1 && \
+   [ -x "$SCRIPT_DIR/bin/ops-secret-sync" ] && \
+   [ -f "$REGISTRY" ] && jq empty "$REGISTRY" >/dev/null 2>&1; then
+
+  STALE_PROJECTS=()
+
+  # Iterate projects that have both github_repo and doppler_project defined
+  PROJ_COUNT=$(jq '.projects | length' "$REGISTRY" 2>/dev/null || echo 0)
+  for i in $(seq 0 $((PROJ_COUNT - 1))); do
+    GH_REPO=$(jq -r ".projects[$i].github_repo // empty" "$REGISTRY" 2>/dev/null)
+    DOP_PROJ=$(jq -r ".projects[$i].doppler_project // empty" "$REGISTRY" 2>/dev/null)
+    DOP_CFG=$(jq -r ".projects[$i].doppler_config // \"prd\"" "$REGISTRY" 2>/dev/null)
+    [ -z "$GH_REPO" ] || [ -z "$DOP_PROJ" ] && continue
+
+    # Run drift check — exit 1 = drift found, exit 0 = in sync, exit 2 = error/skip
+    if "$SCRIPT_DIR/bin/ops-secret-sync" \
+         --repo "$GH_REPO" --project "$DOP_PROJ" --config "$DOP_CFG" \
+         --json >/dev/null 2>&1; then
+      : # in sync
+    elif [ $? -eq 1 ]; then
+      STALE_PROJECTS+=("$GH_REPO ($DOP_PROJ/$DOP_CFG)")
+    fi
+    # exit 2 (error/missing tools) — silently skip
+  done
+
+  if [ ${#STALE_PROJECTS[@]} -gt 0 ]; then
+    WARNINGS+=("stale_gh_secrets: Potentially stale GH secrets detected in: $(IFS=', '; echo "${STALE_PROJECTS[*]}"). Run /ops:secret-sync --repo <repo> --project <proj> to review and sync.")
+  fi
+fi
+
 # --- 6. Registry ---
 REGISTRY_STATUS="missing"
 REGISTRY_COUNT=0

--- a/claude-ops/bin/ops-secret-sync
+++ b/claude-ops/bin/ops-secret-sync
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# ops-secret-sync — Detect Doppler→GitHub secrets drift and report stale secrets.
+#
+# Usage:
+#   ops-secret-sync --repo <owner/repo> --project <doppler-proj> [--config <env>] [--json] [--dry-run]
+#
+# Output:
+#   Human table by default; JSON when --json is passed.
+#   Exit codes: 0=ok/no-drift, 1=drift-found, 2=error
+#
+# This script is READ-ONLY — it never writes secrets. Syncing is done by the
+# ops-secret-sync SKILL.md which calls `gh secret set` after user confirmation.
+
+set -euo pipefail
+
+REPO=""
+PROJECT=""
+CONFIG="prd"
+JSON_OUT=false
+DRY_RUN=false   # kept for compatibility; script is always dry-run (read-only)
+THRESHOLD_SECONDS=86400  # 24h
+
+# ── arg parse ────────────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)      REPO="$2";    shift 2 ;;
+    --project)   PROJECT="$2"; shift 2 ;;
+    --config)    CONFIG="$2";  shift 2 ;;
+    --json)      JSON_OUT=true; shift ;;
+    --dry-run)   DRY_RUN=true;  shift ;;
+    *) shift ;;
+  esac
+done
+
+# ── prereq checks ────────────────────────────────────────────────────────────
+missing_tools=()
+command -v gh      >/dev/null 2>&1 || missing_tools+=("gh")
+command -v doppler >/dev/null 2>&1 || missing_tools+=("doppler")
+command -v jq      >/dev/null 2>&1 || missing_tools+=("jq")
+
+if [[ ${#missing_tools[@]} -gt 0 ]]; then
+  echo '{"error":"missing_tools","tools":'"$(printf '%s\n' "${missing_tools[@]}" | jq -R . | jq -s .)"'}' >&2
+  exit 2
+fi
+
+if [[ -z "$REPO" || -z "$PROJECT" ]]; then
+  echo '{"error":"missing_args","message":"--repo and --project are required"}' >&2
+  exit 2
+fi
+
+# ── fetch GH secrets ─────────────────────────────────────────────────────────
+GH_JSON=$(gh secret list --repo "$REPO" --json name,updatedAt 2>/dev/null || echo "[]")
+
+# ── fetch Doppler secrets ─────────────────────────────────────────────────────
+DOPPLER_JSON=$(doppler secrets --project "$PROJECT" --config "$CONFIG" --json 2>/dev/null || echo "{}")
+
+# ── drift analysis ────────────────────────────────────────────────────────────
+# Build analysis via jq: cross-reference by name, compute delta in seconds.
+ANALYSIS=$(jq -n \
+  --argjson gh "$GH_JSON" \
+  --argjson dop "$DOPPLER_JSON" \
+  --argjson threshold "$THRESHOLD_SECONDS" \
+  '
+  # Build GH lookup: name → updatedAt (epoch)
+  def gh_map: ($gh | map({ (.name): .updatedAt }) | add // {});
+  def to_epoch(s): s | if . == null then 0
+    else gsub("\\.[0-9]+Z$"; "Z") | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime end;
+
+  def gh_epoch(name): (gh_map)[name] | to_epoch(.);
+
+  # Doppler secret names (exclude meta-keys with no updatedAt)
+  ($dop | to_entries | map(select(.value | type == "object"))) as $dop_entries |
+
+  ($dop_entries | map(
+    .key as $name |
+    (.value.updatedAt // null) as $dop_ts |
+    (gh_map | has($name)) as $in_gh |
+    {
+      name: $name,
+      doppler_ts: $dop_ts,
+      gh_ts: (if $in_gh then (gh_map)[$name] else null end),
+      in_gh: $in_gh,
+      delta_seconds: (
+        if $in_gh and $dop_ts != null then
+          (to_epoch($dop_ts) - gh_epoch($name))
+        else null end
+      )
+    }
+  )) as $compared |
+
+  {
+    repo: "'"$REPO"'",
+    project: "'"$PROJECT"'",
+    config: "'"$CONFIG"'",
+    threshold_seconds: $threshold,
+    drifted: ($compared | map(select(.delta_seconds != null and .delta_seconds > $threshold))),
+    missing_from_gh: ($compared | map(select(.in_gh == false))),
+    in_sync: ($compared | map(select(.in_gh == true and (.delta_seconds == null or .delta_seconds <= $threshold)))),
+    doppler_total: ($compared | length),
+    gh_total: ($gh | length)
+  }
+' 2>/dev/null)
+
+if [[ -z "$ANALYSIS" ]]; then
+  echo '{"error":"analysis_failed","message":"jq analysis returned empty — check doppler/gh output"}' >&2
+  exit 2
+fi
+
+DRIFT_COUNT=$(echo "$ANALYSIS" | jq '.drifted | length')
+MISSING_COUNT=$(echo "$ANALYSIS" | jq '.missing_from_gh | length')
+
+# ── output ───────────────────────────────────────────────────────────────────
+if $JSON_OUT; then
+  echo "$ANALYSIS"
+  # Exit 1 if drift found so callers can branch
+  if [[ "$DRIFT_COUNT" -gt 0 || "$MISSING_COUNT" -gt 0 ]]; then exit 1; fi
+  exit 0
+fi
+
+# ── mobile / compact mode ─────────────────────────────────────────────────────
+COMPACT=false
+if [[ -n "${SSH_CONNECTION:-}${SSH_CLIENT:-}${SSH_TTY:-}" || "${OPS_MOBILE:-}" == "1" ]]; then
+  COMPACT=true
+fi
+if [[ -n "${COLUMNS:-}" ]] && (( COLUMNS < 80 )); then COMPACT=true; fi
+
+if $COMPACT; then
+  echo "repo: $REPO  project: $PROJECT/$CONFIG"
+  echo "drifted: $DRIFT_COUNT  missing: $MISSING_COUNT"
+  echo "$ANALYSIS" | jq -r '
+    (.drifted[] | "\(.name)  doppler: \(.doppler_ts // "?")  gh: \(.gh_ts // "?")  DRIFTED"),
+    (.missing_from_gh[] | "\(.name)  gh: MISSING")
+  ' 2>/dev/null || true
+  if [[ "$DRIFT_COUNT" -gt 0 || "$MISSING_COUNT" -gt 0 ]]; then exit 1; fi
+  exit 0
+fi
+
+# ── full table output ─────────────────────────────────────────────────────────
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo " OPS ► SECRET-SYNC — $REPO / $PROJECT/$CONFIG"
+echo " Scanned: $NOW"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "$ANALYSIS" | jq -r '"  Doppler secrets : \(.doppler_total)\n  GH repo secrets : \(.gh_total)\n  Drifted (>24h)  : \(.drifted|length)\n  GH missing      : \(.missing_from_gh|length)\n  In sync         : \(.in_sync|length)"'
+echo ""
+
+if [[ "$DRIFT_COUNT" -gt 0 ]]; then
+  echo " DRIFTED SECRETS (GH is stale vs Doppler)"
+  echo "$ANALYSIS" | jq -r '
+    .drifted[] |
+    "   \(.name)\n     Doppler : \(.doppler_ts // "unknown")\n     GH      : \(.gh_ts // "unknown")\n     delta   : \(if .delta_seconds != null then "\(.delta_seconds / 86400 | floor)d \(.delta_seconds % 86400 / 3600 | floor)h" else "unknown" end)"
+  ' 2>/dev/null
+  echo ""
+fi
+
+if [[ "$MISSING_COUNT" -gt 0 ]]; then
+  echo " GH MISSING (present in Doppler, absent from GH repo)"
+  echo "$ANALYSIS" | jq -r '.missing_from_gh[] | "   \(.name)"' 2>/dev/null
+  echo ""
+fi
+
+IN_SYNC_COUNT=$(echo "$ANALYSIS" | jq '.in_sync | length')
+if [[ "$IN_SYNC_COUNT" -gt 0 ]]; then
+  echo " IN SYNC"
+  echo "$ANALYSIS" | jq -r '.in_sync[] | "   \(.name)  last-gh: \(.gh_ts // "unknown")"' 2>/dev/null
+  echo ""
+fi
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [[ "$DRIFT_COUNT" -gt 0 || "$MISSING_COUNT" -gt 0 ]]; then
+  echo " Action: run /ops:secret-sync to review and sync."
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  exit 1
+fi
+
+echo " All secrets in sync."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+exit 0

--- a/claude-ops/skills/ops-secret-sync/SKILL.md
+++ b/claude-ops/skills/ops-secret-sync/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: ops-secret-sync
+description: Detects and syncs Doppler→GitHub secrets drift. Compares last-updated timestamps between Doppler and GH repo secrets; flags stale GH secrets (>24h behind Doppler); confirms with user before writing any changes. Safe to run in CI or locally.
+argument-hint: "[--repo <owner/repo>] [--project <doppler-proj>] [--config <doppler-env>] [--dry-run]"
+allowed-tools:
+  - Bash
+  - AskUserQuestion
+effort: medium
+maxTurns: 20
+---
+
+# OPS ► SECRET-SYNC
+
+Detect GitHub secrets that are stale relative to Doppler. Confirm before syncing.
+
+## CLI/API Reference
+
+| Command | Purpose |
+|---------|---------|
+| `gh secret list --repo <owner/repo> --json name,updatedAt` | List GH repo secrets with timestamps |
+| `doppler secrets --project <proj> --config <env> --json` | List Doppler secrets with metadata |
+| `doppler secrets get <NAME> --project <proj> --config <env> --plain` | Fetch raw value for sync |
+| `gh secret set <NAME> --repo <owner/repo>` | Write secret to GH (reads stdin) |
+
+---
+
+## Phase 1 — Resolve arguments
+
+Parse `$ARGUMENTS`:
+
+- `--repo <owner/repo>` → target GitHub repo (required unless registry provides default)
+- `--project <proj>` → Doppler project name (required)
+- `--config <env>` → Doppler config/environment, e.g. `prd`, `stg` (default: `prd`)
+- `--dry-run` → report drift only, never write
+
+If `--repo` is missing, load `${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/registry.json` and let the user pick via `AskUserQuestion` (max 4 at a time).
+
+If `--project` is missing, run:
+
+```bash
+doppler projects --json 2>/dev/null | jq -r '.[].slug'
+```
+
+and let the user pick via `AskUserQuestion` (max 4 at a time).
+
+---
+
+## Phase 2 — Fetch secret inventories
+
+Run in parallel (background both, then collect):
+
+```bash
+# GH secrets (names + last-updated timestamps, ISO-8601)
+gh secret list --repo <owner/repo> --json name,updatedAt 2>/dev/null
+```
+
+```bash
+# Doppler secrets (names + metadata including updated_at)
+doppler secrets --project <proj> --config <env> --json 2>/dev/null
+```
+
+Parse outputs:
+
+**GH format** (array):
+```json
+[{"name": "INNGEST_SIGNING_KEY", "updatedAt": "2026-04-23T09:12:00Z"}, ...]
+```
+
+**Doppler format** (object keyed by name):
+```json
+{
+  "INNGEST_SIGNING_KEY": {"computed": "...", "note": "", "rawValue": "...", "updatedAt": "2026-04-23T10:00:00Z"},
+  ...
+}
+```
+
+> Note: Doppler's `--json` flag returns computed values inline. Use `doppler secrets get <NAME> --plain` only at sync time to avoid holding all values in memory.
+
+---
+
+## Phase 3 — Drift detection
+
+For each secret in Doppler:
+
+1. Check if a GH secret with the same name exists.
+2. If yes: compute `delta = doppler_updated_at - gh_updated_at` (seconds).
+3. If `delta > 86400` (24 hours): mark as **DRIFTED**.
+4. If GH secret does NOT exist: mark as **GH_MISSING** (flag but do not auto-create — requires explicit user confirm).
+
+Build drift report:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► SECRET-SYNC — <repo> / <proj>/<config>
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+ Doppler secrets : <N>
+ GH repo secrets : <M>
+ Matched         : <K>
+ DRIFTED (>24h)  : <D>
+ GH missing      : <G>
+
+ DRIFTED SECRETS
+   <NAME>  Doppler: <date>  GH: <date>  delta: <Nd>
+   ...
+
+ GH MISSING (in Doppler but absent from GH)
+   <NAME>
+   ...
+
+ IN SYNC (no action needed)
+   <NAME>  last-synced: <date>
+   ...
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+If `--dry-run` is set or no drift found: stop here and display report.
+
+---
+
+## Phase 4 — Confirm before syncing (REQUIRED — never skip)
+
+> Rule 5 compliance: every secret write requires per-action confirmation.
+
+If drift was found, ask:
+
+```
+AskUserQuestion({
+  title: "Sync stale GH secrets from Doppler?",
+  question: "Found <D> drifted + <G> missing secrets for <repo>.\n\nSync all, pick specific ones, or skip?",
+  options: [
+    { value: "all",    label: "Sync all drifted + missing" },
+    { value: "pick",   label: "Pick which secrets to sync" },
+    { value: "drifted", label: "Sync drifted only (skip missing)" },
+    { value: "skip",   label: "Skip — report only" }
+  ]
+})
+```
+
+**On "Pick"**: present drifted secrets 4-at-a-time via `AskUserQuestion` checkboxes. Collect user selections. Proceed only with confirmed names.
+
+**On "Skip"**: stop. Print report path.
+
+---
+
+## Phase 5 — Sync confirmed secrets
+
+For each confirmed secret name:
+
+```bash
+doppler secrets get <NAME> --project <proj> --config <env> --plain 2>/dev/null \
+  | gh secret set <NAME> --repo <owner/repo>
+```
+
+After each write, verify:
+
+```bash
+gh secret list --repo <owner/repo> --json name,updatedAt \
+  | jq -r '.[] | select(.name == "<NAME>") | .updatedAt'
+```
+
+Confirm the `updatedAt` advanced. If it did not advance: report failure for that secret and continue with the rest.
+
+Print per-secret outcome:
+
+```
+  synced : INNGEST_SIGNING_KEY  (Doppler 2026-04-23 → GH updated)
+  FAILED : SOME_KEY             (gh secret set exited non-zero)
+```
+
+---
+
+## Phase 6 — Summary
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ SYNC COMPLETE — <repo>
+ Synced  : <S> secrets
+ Failed  : <F> secrets
+ Skipped : <K> secrets
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+If failures > 0: suggest `doppler run --project <proj> --config <env> -- gh secret set <NAME> --repo <repo>` as a manual fallback.
+
+---
+
+## Real-world example: Stagery Inngest case
+
+This skill exists because of a recurring drift pattern:
+
+| Project | Secret | Situation |
+|---------|--------|-----------|
+| stagery-api | `INNGEST_SIGNING_KEY` | Rotated in Doppler 2026-04-23 — GH secret was 24 days stale, CI failures started on 2026-05-17 |
+| inboxassist | `CEREBRAS_API_KEY` | Added to Doppler, never propagated to GH secrets — Phase 23 CI gate failed |
+| inboxassist | `OPENROUTER_API_KEY` | Same pattern — GH missing, Doppler current |
+
+Running `/ops:secret-sync --repo your-org/stagery-api --project stagery-api --config prd` would have surfaced `INNGEST_SIGNING_KEY` as DRIFTED 24+ days before CI failed.
+
+---
+
+## Safety rules
+
+- **Never** read or print raw secret values in the summary or logs.
+- **Never** sync without user confirmation (Rule 5).
+- Doppler values flow directly from `doppler secrets get --plain` into `gh secret set` via a pipe — they are never stored in shell variables, temp files, or command substitution.
+- `--dry-run` always safe: no writes, report only.
+
+---
+
+## Mobile / SSH (Rule 7)
+
+When `$SSH_CONNECTION` / `$OPS_MOBILE=1` / `$COLUMNS < 80`: skip the banner, emit compact lines:
+
+```
+repo: your-org/stagery-api  project: stagery-api/prd
+drifted: 2  missing: 1
+INNGEST_SIGNING_KEY  doppler: 2026-04-23  gh: 2026-03-30  (24d stale)
+CEREBRAS_API_KEY     gh: MISSING
+```

--- a/claude-ops/skills/ops/SKILL.md
+++ b/claude-ops/skills/ops/SKILL.md
@@ -52,6 +52,7 @@ Route `$ARGUMENTS` to the correct ops skill:
 | integrate, connect, add-api, saas, partner    | `/ops:ops-integrate $ARGUMENTS` |
 | speedup, clean, optimize, cleanup             | `/ops:ops-speedup`      |
 | orchestrate, subagents, agents, dispatch, run | `/ops:ops-orchestrate $ARGUMENTS` |
+| secret-sync, secrets, doppler-sync, drift     | `/ops:ops-secret-sync $ARGUMENTS` |
 
 If `$ARGUMENTS` is empty, launch the interactive dashboard: invoke `/ops:ops-dash` directly.
 

--- a/claude-ops/tests/mocks/doppler
+++ b/claude-ops/tests/mocks/doppler
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Mock `doppler` CLI for ops-secret-sync tests.
+# Behavior controlled by env vars:
+#   MOCK_DOPPLER_JSON        — JSON object returned by `doppler secrets --json`
+#   MOCK_DOPPLER_PLAIN_VALUE — plain-text value returned by `doppler secrets get <NAME> --plain`
+#   MOCK_DOPPLER_LOG_FILE    — append every invocation (argv) to this file
+set -u
+LOG="${MOCK_DOPPLER_LOG_FILE:-/dev/null}"
+printf '%s\n' "$*" >> "$LOG"
+
+sub="${1:-}"
+shift || true
+
+case "$sub" in
+  secrets)
+    # Scan remaining args for subcommand
+    subcmd=""
+    for a in "$@"; do
+      case "$a" in
+        get) subcmd="get"; break ;;
+      esac
+    done
+
+    if [[ "$subcmd" == "get" ]]; then
+      # `doppler secrets get <NAME> [--plain ...]`
+      printf '%s' "${MOCK_DOPPLER_PLAIN_VALUE:-mock-secret-value}"
+      exit 0
+    fi
+
+    # `doppler secrets [--project X] [--config Y] [--json]`
+    _dop_json="${MOCK_DOPPLER_JSON:-}"
+    printf '%s' "${_dop_json:-{\}}"
+    exit 0
+    ;;
+  projects)
+    printf '%s' '[{"slug":"your-project","name":"your-project"}]'
+    exit 0
+    ;;
+esac
+
+exit 0

--- a/claude-ops/tests/mocks/gh
+++ b/claude-ops/tests/mocks/gh
@@ -27,6 +27,20 @@ case "$sub" in
         ;;
     esac
     ;;
+  secret)
+    case "$sub2" in
+      list)
+        # MOCK_GH_SECRET_JSON — JSON array of {name, updatedAt} for `gh secret list --json name,updatedAt`
+        printf '%s' "${MOCK_GH_SECRET_JSON:-[]}"
+        exit 0
+        ;;
+      set)
+        # Simulate a successful secret write (no-op in tests)
+        echo "[mock-gh] secret set: $*"
+        exit "${MOCK_GH_SECRET_SET_RC:-0}"
+        ;;
+    esac
+    ;;
   run)
     case "$sub2" in
       list)

--- a/claude-ops/tests/test-secret-sync.sh
+++ b/claude-ops/tests/test-secret-sync.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# test-secret-sync.sh — Unit tests for bin/ops-secret-sync using mock gh + doppler
+set -uo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$PLUGIN_ROOT/bin/ops-secret-sync"
+MOCKS_DIR="$PLUGIN_ROOT/tests/mocks"
+
+pass=0
+fail=0
+ok()  { echo "  PASS: $1"; pass=$((pass+1)); }
+err() { echo "  FAIL: $1"; fail=$((fail+1)); }
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+# Run ops-secret-sync with PATH-injected mock binaries.
+# Usage: run_sync [extra args...]
+# Env vars consumed by mocks:
+#   MOCK_GH_SECRET_JSON    — JSON array for `gh secret list`
+#   MOCK_DOPPLER_JSON      — JSON object for `doppler secrets --json`
+run_sync() {
+  PATH="$MOCKS_DIR:$PATH" \
+  MOCK_GH_SECRET_JSON="${MOCK_GH_SECRET_JSON:-}" \
+  MOCK_DOPPLER_JSON="${MOCK_DOPPLER_JSON:-}" \
+    "$BIN" --repo "your-org/your-repo" --project "your-project" --config "prd" "$@" 2>&1 || true
+}
+
+# Returns the exit code of ops-secret-sync as a plain integer on stdout.
+get_rc() {
+  PATH="$MOCKS_DIR:$PATH" \
+  MOCK_GH_SECRET_JSON="${MOCK_GH_SECRET_JSON:-}" \
+  MOCK_DOPPLER_JSON="${MOCK_DOPPLER_JSON:-}" \
+    "$BIN" --repo "your-org/your-repo" --project "your-project" --config "prd" "$@" >/dev/null 2>&1
+  echo $?
+}
+
+# ── prereqs ───────────────────────────────────────────────────────────────────
+
+if [[ ! -x "$BIN" ]]; then
+  echo "FAIL: $BIN not found or not executable"
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq not available — skipping all tests"
+  exit 0
+fi
+
+# Verify mock stubs exist
+for mock in gh doppler; do
+  if [[ ! -x "$MOCKS_DIR/$mock" ]]; then
+    echo "SKIP: mock '$mock' not found at $MOCKS_DIR/$mock — skipping"
+    exit 0
+  fi
+done
+
+echo ""
+echo "Running: ops-secret-sync tests"
+echo ""
+
+# ── test 1: all secrets in sync → exit 0 ─────────────────────────────────────
+echo "Test 1: all secrets in sync"
+
+# GH secret updated AFTER Doppler — no drift
+export MOCK_GH_SECRET_JSON='[
+  {"name":"INNGEST_SIGNING_KEY","updatedAt":"2026-05-01T10:00:00Z"},
+  {"name":"DATABASE_URL","updatedAt":"2026-05-01T10:00:00Z"}
+]'
+export MOCK_DOPPLER_JSON='{
+  "INNGEST_SIGNING_KEY": {"updatedAt":"2026-04-01T09:00:00Z","computed":"v1"},
+  "DATABASE_URL":        {"updatedAt":"2026-04-01T09:00:00Z","computed":"v1"}
+}'
+
+OUTPUT=$(run_sync --json)
+RC=$(get_rc --json)
+
+DRIFTED=$(echo "$OUTPUT" | jq '.drifted | length' 2>/dev/null || echo "ERR")
+MISSING=$(echo "$OUTPUT" | jq '.missing_from_gh | length' 2>/dev/null || echo "ERR")
+
+if [[ "$DRIFTED" == "0" && "$MISSING" == "0" ]]; then
+  ok "no drift detected when GH is current"
+else
+  err "expected drifted=0 missing=0, got drifted=$DRIFTED missing=$MISSING"
+fi
+
+if [[ "$RC" == "0" ]]; then
+  ok "exit 0 when no drift"
+else
+  err "expected exit 0, got $RC"
+fi
+
+echo ""
+
+# ── test 2: stale GH secret → exit 1, shows in drifted ──────────────────────
+echo "Test 2: INNGEST_SIGNING_KEY stale in GH by 25 days"
+
+# Doppler updated 2026-04-23, GH updated 2026-03-30 (delta = 24d 1h stale)
+export MOCK_GH_SECRET_JSON='[
+  {"name":"INNGEST_SIGNING_KEY","updatedAt":"2026-03-29T09:00:00Z"},
+  {"name":"DATABASE_URL","updatedAt":"2026-04-23T10:00:00Z"}
+]'
+export MOCK_DOPPLER_JSON='{
+  "INNGEST_SIGNING_KEY": {"updatedAt":"2026-04-23T10:00:00Z","computed":"new-key"},
+  "DATABASE_URL":        {"updatedAt":"2026-04-23T10:00:00Z","computed":"db-url"}
+}'
+
+OUTPUT=$(run_sync --json)
+RC=$(get_rc --json)
+
+DRIFTED=$(echo "$OUTPUT" | jq '.drifted | length' 2>/dev/null || echo "ERR")
+DRIFTED_NAME=$(echo "$OUTPUT" | jq -r '.drifted[0].name // ""' 2>/dev/null)
+MISSING=$(echo "$OUTPUT" | jq '.missing_from_gh | length' 2>/dev/null || echo "ERR")
+
+if [[ "$DRIFTED" == "1" && "$DRIFTED_NAME" == "INNGEST_SIGNING_KEY" ]]; then
+  ok "INNGEST_SIGNING_KEY flagged as drifted"
+else
+  err "expected drifted=1 (INNGEST_SIGNING_KEY), got drifted=$DRIFTED name=$DRIFTED_NAME"
+fi
+
+if [[ "$RC" == "1" ]]; then
+  ok "exit 1 when drift found"
+else
+  err "expected exit 1, got $RC"
+fi
+
+if [[ "$MISSING" == "0" ]]; then
+  ok "DATABASE_URL not in missing (it exists in GH)"
+else
+  err "expected missing=0, got $MISSING"
+fi
+
+echo ""
+
+# ── test 3: secret in Doppler but absent from GH → missing ──────────────────
+echo "Test 3: CEREBRAS_API_KEY in Doppler but absent from GH"
+
+export MOCK_GH_SECRET_JSON='[
+  {"name":"DATABASE_URL","updatedAt":"2026-05-01T10:00:00Z"}
+]'
+export MOCK_DOPPLER_JSON='{
+  "CEREBRAS_API_KEY": {"updatedAt":"2026-04-01T09:00:00Z","computed":"key"},
+  "DATABASE_URL":     {"updatedAt":"2026-04-01T09:00:00Z","computed":"db"}
+}'
+
+OUTPUT=$(run_sync --json)
+RC=$(get_rc --json)
+
+MISSING=$(echo "$OUTPUT" | jq '.missing_from_gh | length' 2>/dev/null || echo "ERR")
+MISSING_NAME=$(echo "$OUTPUT" | jq -r '.missing_from_gh[0].name // ""' 2>/dev/null)
+
+if [[ "$MISSING" == "1" && "$MISSING_NAME" == "CEREBRAS_API_KEY" ]]; then
+  ok "CEREBRAS_API_KEY flagged as missing from GH"
+else
+  err "expected missing=1 (CEREBRAS_API_KEY), got missing=$MISSING name=$MISSING_NAME"
+fi
+
+if [[ "$RC" == "1" ]]; then
+  ok "exit 1 when missing found"
+else
+  err "expected exit 1 for missing secrets, got $RC"
+fi
+
+echo ""
+
+# ── test 4: delta exactly at threshold (24h) → NOT drifted ──────────────────
+echo "Test 4: delta exactly 24h — should NOT flag as drifted (threshold is >24h)"
+
+# Doppler updated exactly 24h after GH — should be in sync (threshold is strictly >86400s)
+export MOCK_GH_SECRET_JSON='[
+  {"name":"API_KEY","updatedAt":"2026-04-22T10:00:00Z"}
+]'
+export MOCK_DOPPLER_JSON='{
+  "API_KEY": {"updatedAt":"2026-04-23T10:00:00Z","computed":"val"}
+}'
+
+OUTPUT=$(run_sync --json)
+DRIFTED=$(echo "$OUTPUT" | jq '.drifted | length' 2>/dev/null || echo "ERR")
+
+if [[ "$DRIFTED" == "0" ]]; then
+  ok "delta exactly 24h not flagged (threshold is strictly >24h)"
+else
+  err "expected drifted=0 at exactly 24h, got $DRIFTED"
+fi
+
+echo ""
+
+# ── test 5: empty Doppler + empty GH → no drift, exit 0 ─────────────────────
+echo "Test 5: empty project (no secrets on either side)"
+
+export MOCK_GH_SECRET_JSON='[]'
+export MOCK_DOPPLER_JSON='{}'
+
+OUTPUT=$(run_sync --json)
+RC=$(get_rc --json)
+
+DRIFTED=$(echo "$OUTPUT" | jq '.drifted | length' 2>/dev/null || echo "ERR")
+MISSING=$(echo "$OUTPUT" | jq '.missing_from_gh | length' 2>/dev/null || echo "ERR")
+
+if [[ "$DRIFTED" == "0" && "$MISSING" == "0" ]]; then
+  ok "empty project reports no drift"
+else
+  err "expected drifted=0 missing=0, got drifted=$DRIFTED missing=$MISSING"
+fi
+
+if [[ "$RC" == "0" ]]; then
+  ok "exit 0 for empty project"
+else
+  err "expected exit 0 for empty project, got $RC"
+fi
+
+echo ""
+
+# ── test 6: human output contains DRIFTED label ──────────────────────────────
+echo "Test 6: human (non-JSON) output mentions DRIFTED"
+
+export MOCK_GH_SECRET_JSON='[
+  {"name":"OPENROUTER_API_KEY","updatedAt":"2026-03-01T00:00:00Z"}
+]'
+export MOCK_DOPPLER_JSON='{
+  "OPENROUTER_API_KEY": {"updatedAt":"2026-05-01T00:00:00Z","computed":"key"}
+}'
+
+OUTPUT=$(run_sync)  # no --json
+
+if echo "$OUTPUT" | grep -qi "DRIFTED\|stale\|drift"; then
+  ok "human output mentions drift"
+else
+  err "human output should mention DRIFTED/stale, got: $(echo "$OUTPUT" | head -5)"
+fi
+
+echo ""
+
+# ── summary ──────────────────────────────────────────────────────────────────
+echo "---"
+echo "Results: $pass passed, $fail failed"
+echo ""
+
+if (( fail > 0 )); then exit 1; fi
+exit 0


### PR DESCRIPTION
## Summary

- **New skill** `/ops:secret-sync` — compares Doppler secret `updatedAt` vs GH repo secret timestamps; flags secrets >24h stale or absent from GH; confirms via `AskUserQuestion` before any write
- **New bin** `bin/ops-secret-sync` — read-only scanner invocable standalone; JSON (`--json`) and human output; exit 1 on drift, 0 on in-sync
- **ops-doctor** — new section 5d adds a passive `stale_gh_secrets` warning for registry projects that declare `doppler_project`; runs `ops-secret-sync --json` internally, never reads/logs values
- **ops router** — keywords `secret-sync / secrets / doppler-sync / drift` route to `/ops:ops-secret-sync`

## Motivation

Two real incidents in the past 30 days:
- `stagery-api` `INNGEST_SIGNING_KEY` — rotated in Doppler, GH secret was 24 days stale, caused CI failures
- `inboxassist` `CEREBRAS_API_KEY` + `OPENROUTER_API_KEY` — added to Doppler, never propagated to GH, Phase 23 CI gate failed

## Safety

- Sync is **never automatic** — `AskUserQuestion` gate required before any `gh secret set`
- Secret values pipe directly from `doppler secrets get --plain` into `gh secret set` stdin; never stored in variables, files, or logs
- `--dry-run` flag always safe (report only)
- ops-doctor addition is read-only

## Test plan

- [ ] `bash claude-ops/tests/test-secret-sync.sh` — 11 unit tests, all passing (mocked `gh` + `doppler`)
- [ ] `bash claude-ops/tests/test-skills-lint.sh` — 296 passed
- [ ] `bash claude-ops/tests/test-no-secrets.sh` — 14 passed
- [ ] `/ops:secret-sync --repo your-org/your-repo --project your-project --dry-run` — human output with drift table
- [ ] `/ops:doctor` on a registry with `doppler_project` field — verify `stale_gh_secrets` warning appears when drift exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new automation around secret inventory comparison and (via skill workflow) potential secret writes to GitHub, which is operationally sensitive despite explicit confirmation gates and a read-only scanner.
> 
> **Overview**
> Adds a new `/ops:secret-sync` capability to detect drift between Doppler and GitHub repo secrets by comparing `updatedAt` timestamps, flagging secrets that are **stale (>24h)** or **missing** in GitHub.
> 
> Introduces a standalone, read-only `bin/ops-secret-sync` scanner (JSON or human output; exit `1` on drift/missing) and wires it into `ops-doctor` as a passive warning that scans registry projects with `doppler_project` metadata.
> 
> Updates the ops router keywords to route secret-sync requests, and adds test coverage with `gh`/`doppler` CLI mocks plus a new `test-secret-sync.sh` suite validating drift/missing/threshold and output modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90190a92ffd3f91d852720ce6ceb3e4f04b8d3e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->