### PR TITLE
feat(cron): monthly Anthropic credit reclaim + consumption summary

### DIFF
--- a/claude-ops/scripts/account-rotation/__tests__/monthly-credit-reclaim.test.mjs
+++ b/claude-ops/scripts/account-rotation/__tests__/monthly-credit-reclaim.test.mjs
@@ -1,0 +1,123 @@
+/**
+ * monthly-credit-reclaim.mjs — summary math tests (HEA-4049).
+ *
+ * Run: node --test claude-ops/scripts/account-rotation/__tests__/monthly-credit-reclaim.test.mjs
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildPriorMonthSummary,
+  summarizePostClaim,
+  formatSlackBody,
+  ymKey,
+  priorMonthKey,
+} from '../monthly-credit-reclaim.mjs';
+import { SCHEMA_VERSION, MAX_PLAN_MONTHLY_USD } from '../ledger.mjs';
+
+function makeLedger(month, accounts) {
+  return { schema_version: SCHEMA_VERSION, month, accounts };
+}
+
+test('buildPriorMonthSummary: all claimed + half consumed → 0% waste', () => {
+  const cfg = [{ email: 'a@x' }, { email: 'b@x' }];
+  const ledger = makeLedger('2026-05', [
+    { email: 'a@x', cycle: '2026-05', claimed: true, remaining_usd: 100 },
+    { email: 'b@x', cycle: '2026-05', claimed: true, remaining_usd: 100 },
+  ]);
+  const s = buildPriorMonthSummary(ledger, cfg);
+  assert.equal(s.poolUsd, 400);
+  assert.equal(s.claimedUsd, 400);
+  assert.equal(s.unclaimedPoolUsd, 0);
+  assert.equal(s.wastePct, 0);
+  assert.equal(s.consumedUsd, 200);
+  assert.equal(s.unclaimedCount, 0);
+});
+
+test('buildPriorMonthSummary: one unclaimed → 50% waste', () => {
+  const cfg = [{ email: 'a@x' }, { email: 'b@x' }];
+  const ledger = makeLedger('2026-05', [
+    { email: 'a@x', cycle: '2026-05', claimed: true, remaining_usd: 50 },
+    { email: 'b@x', cycle: '2026-05', claimed: false, remaining_usd: null },
+  ]);
+  const s = buildPriorMonthSummary(ledger, cfg);
+  assert.equal(s.poolUsd, 400);
+  assert.equal(s.claimedUsd, 200);
+  assert.equal(s.unclaimedPoolUsd, 200);
+  assert.equal(s.wastePct, 50);
+  assert.equal(s.consumedUsd, 150);
+  assert.equal(s.unclaimedCount, 1);
+});
+
+test('buildPriorMonthSummary: 7-account $1400 pool — all unclaimed → 100% waste', () => {
+  const cfg = Array.from({ length: 7 }, (_, i) => ({ email: `acc${i}@x` }));
+  const ledger = makeLedger('2026-05', []);
+  const s = buildPriorMonthSummary(ledger, cfg);
+  assert.equal(s.poolUsd, 7 * MAX_PLAN_MONTHLY_USD);
+  assert.equal(s.poolUsd, 1400);
+  assert.equal(s.claimedUsd, 0);
+  assert.equal(s.unclaimedPoolUsd, 1400);
+  assert.equal(s.wastePct, 100);
+  assert.equal(s.unclaimedCount, 7);
+});
+
+test('buildPriorMonthSummary: 7-account fully optimized → 0% waste', () => {
+  const cfg = Array.from({ length: 7 }, (_, i) => ({ email: `acc${i}@x` }));
+  const ledger = makeLedger(
+    '2026-05',
+    cfg.map(({ email }) => ({ email, cycle: '2026-05', claimed: true, remaining_usd: 0 })),
+  );
+  const s = buildPriorMonthSummary(ledger, cfg);
+  assert.equal(s.claimedUsd, 1400);
+  assert.equal(s.consumedUsd, 1400);
+  assert.equal(s.wastePct, 0);
+});
+
+test('buildPriorMonthSummary: empty pool → 0% waste, no division by zero', () => {
+  const s = buildPriorMonthSummary(makeLedger('2026-05', []), []);
+  assert.equal(s.poolUsd, 0);
+  assert.equal(s.wastePct, 0);
+});
+
+test('summarizePostClaim: counts only entries with current cycle', () => {
+  const cfg = [{ email: 'a@x' }, { email: 'b@x' }, { email: 'c@x' }];
+  const cycle = ymKey();
+  const ledger = makeLedger(cycle, [
+    { email: 'a@x', cycle, claimed: true, remaining_usd: 200 },
+    { email: 'b@x', cycle: '2026-04', claimed: true, remaining_usd: 200 }, // stale cycle
+    { email: 'c@x', cycle, claimed: false, remaining_usd: null },
+  ]);
+  const r = summarizePostClaim(ledger, cfg);
+  assert.equal(r.claimedCount, 1);
+  assert.deepEqual(r.failed.sort(), ['b@x', 'c@x']);
+});
+
+test('formatSlackBody: includes pool, waste %, prior cycle, no secrets', () => {
+  const cfg = [{ email: 'a@x' }, { email: 'b@x' }];
+  const ledger = makeLedger('2026-05', [
+    { email: 'a@x', cycle: '2026-05', claimed: true, remaining_usd: 0 },
+    { email: 'b@x', cycle: '2026-05', claimed: false, remaining_usd: null },
+  ]);
+  const s = buildPriorMonthSummary(ledger, cfg);
+  const body = formatSlackBody(s, { claimedCount: 2, failed: [] });
+  assert.match(body, /Pool: \$400/);
+  assert.match(body, /50% waste/);
+  assert.match(body, /2026-05/);
+  assert.match(body, /2\/2 accounts re-claimed/);
+  // Ensure no API token / webhook leaks
+  assert.doesNotMatch(body, /hooks\.slack\.com/);
+});
+
+test('formatSlackBody: reports failed accounts', () => {
+  const cfg = [{ email: 'a@x' }, { email: 'b@x' }];
+  const ledger = makeLedger('2026-05', []);
+  const s = buildPriorMonthSummary(ledger, cfg);
+  const body = formatSlackBody(s, { claimedCount: 1, failed: ['b@x'] });
+  assert.match(body, /Failed: b@x/);
+});
+
+test('priorMonthKey: returns prior YYYY-MM', () => {
+  assert.equal(priorMonthKey(new Date(Date.UTC(2026, 5, 15))), '2026-05'); // Jun 15 → May
+  assert.equal(priorMonthKey(new Date(Date.UTC(2026, 0, 15))), '2025-12'); // Jan → Dec prev year
+});

--- a/claude-ops/scripts/account-rotation/kapture-claim-credits.mjs
+++ b/claude-ops/scripts/account-rotation/kapture-claim-credits.mjs
@@ -66,6 +66,7 @@ import {
   writeLedger,
   findAccount,
   upsertAccount,
+  ymKey,
 } from './ledger.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -183,10 +184,6 @@ function loadLedger() {
 
 function saveLedger(ledger) {
   writeLedger(LEDGER_PATH, ledger);
-}
-
-function ymKey(date = new Date()) {
-  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
 }
 
 function receiptPath(email) {

--- a/claude-ops/scripts/account-rotation/ledger.mjs
+++ b/claude-ops/scripts/account-rotation/ledger.mjs
@@ -42,7 +42,7 @@ export const SCHEMA_VERSION = 2;
  * @returns {object}
  */
 function migrateV1(v1) {
-  const month = v1.month || _ymKey();
+  const month = v1.month || ymKey();
   const accounts = [];
   const raw = v1.accounts || {};
   for (const [email, cycles] of Object.entries(raw)) {
@@ -69,9 +69,12 @@ function migrateV1(v1) {
 }
 
 /**
- * Returns "YYYY-MM" for the current UTC month.
+ * Returns "YYYY-MM" for the given date's UTC month (default: now).
+ *
+ * @param {Date} [date]
+ * @returns {string}
  */
-function _ymKey(date = new Date()) {
+export function ymKey(date = new Date()) {
   return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
 }
 
@@ -87,7 +90,7 @@ function _ymKey(date = new Date()) {
  */
 export function readLedger(path) {
   if (!existsSync(path)) {
-    return { schema_version: SCHEMA_VERSION, month: _ymKey(), accounts: [] };
+    return { schema_version: SCHEMA_VERSION, month: ymKey(), accounts: [] };
   }
 
   let raw;

--- a/claude-ops/scripts/account-rotation/monthly-credit-reclaim.mjs
+++ b/claude-ops/scripts/account-rotation/monthly-credit-reclaim.mjs
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+// ──────────────────────────────────────────────────────────────────────────────
+//  monthly-credit-reclaim.mjs
+//  Day-1 09:00 monthly cron entrypoint (HEA-4049).
+//
+//  Sequence:
+//    1. Snapshot pre-run ledger so we can compute prior-month consumption.
+//    2. Invoke kapture-claim-credits.mjs --live to re-claim the $200 Agent SDK
+//       credit on each of the ~7 Max accounts registered in config.json.
+//    3. Re-read the ledger and compute the prior-month delta:
+//         claimed_usd  = sum of accounts that successfully claimed last cycle
+//         consumed_usd = sum of (granted − remaining) just before re-claim
+//         waste_pct    = unclaimed_pool / total_pool      (× 100, rounded)
+//       Pool size = MAX_PLAN_MONTHLY_USD × account_count.
+//    4. Post a Slack summary (env: SLACK_WEBHOOK_URL) AND fan-out via
+//       scripts/ops-notify.sh (Discord / ntfy / Telegram / Pushover are picked
+//       up automatically when their env vars are present).
+//
+//  CLI:
+//    --dry-run     Print the planned Slack payload + skip the live claim.
+//                  (Forwards --dry-run intent to kapture-claim-credits.mjs by
+//                  NOT passing --live.)
+//    --skip-claim  Compute + post the summary only; do not invoke the claimer
+//                  (useful for re-posting after a manual claim).
+//    --help        Print this header.
+//
+//  Exit codes:
+//    0  success (claim ran AND summary posted, or dry-run plan printed)
+//    1  partial — claim ran but Slack post failed (logged, do not retry inside
+//                 the same window; cron will catch the next month)
+//    2  hard failure (missing config, ledger schema mismatch, claimer crashed)
+// ──────────────────────────────────────────────────────────────────────────────
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, mkdirSync, appendFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+import { MAX_PLAN_MONTHLY_USD, readLedger, findAccount } from './ledger.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLAIMER = join(__dirname, 'kapture-claim-credits.mjs');
+const CONFIG_PATH = join(__dirname, 'config.json');
+const LEDGER_PATH = join(homedir(), '.claude', 'credits-ledger.json');
+const DATA_DIR =
+  process.env.CLAUDE_PLUGIN_DATA_DIR || join(homedir(), '.claude', 'plugins', 'data', 'ops-ops-marketplace');
+const LOG_DIR = join(DATA_DIR, 'logs');
+const LOG_PATH = join(LOG_DIR, 'monthly-credit-reclaim.log');
+const NOTIFY_SCRIPT = join(__dirname, '..', 'ops-notify.sh');
+
+const args = process.argv.slice(2);
+const flag = (n) => args.includes(n);
+const DRY_RUN = flag('--dry-run');
+const SKIP_CLAIM = flag('--skip-claim');
+
+function log(line) {
+  try {
+    mkdirSync(LOG_DIR, { recursive: true });
+    appendFileSync(LOG_PATH, `${new Date().toISOString()} ${line}\n`);
+  } catch {
+    /* logging is best-effort */
+  }
+  console.log(line);
+}
+
+function ymKey(date = new Date()) {
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+function priorMonthKey(date = new Date()) {
+  const d = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() - 1, 1));
+  return ymKey(d);
+}
+
+function loadAccountsConfig() {
+  if (!existsSync(CONFIG_PATH)) return [];
+  try {
+    const cfg = JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
+    return (cfg.accounts ?? []).filter((a) => a?.email);
+  } catch {
+    return [];
+  }
+}
+
+function snapshotLedger() {
+  // readLedger handles missing file (returns empty v2 ledger) and v1→v2 migration.
+  // Safe to call even when the claimer has never run.
+  try {
+    return readLedger(LEDGER_PATH);
+  } catch (e) {
+    log(`[fatal] ledger read failed: ${e.message}`);
+    process.exit(2);
+  }
+}
+
+function runClaimer() {
+  if (SKIP_CLAIM) {
+    log('[monthly-reclaim] --skip-claim set; not invoking kapture-claim-credits.mjs');
+    return { code: 0, signal: null };
+  }
+  if (DRY_RUN) {
+    log('[monthly-reclaim] DRY RUN — would invoke:');
+    log(`  node ${CLAIMER} --live`);
+    return { code: 0, signal: null, dryRun: true };
+  }
+  log(`[monthly-reclaim] invoking ${CLAIMER} --live`);
+  const res = spawnSync(process.execPath, [CLAIMER, '--live'], {
+    stdio: 'inherit',
+    env: process.env,
+  });
+  return { code: res.status, signal: res.signal };
+}
+
+/**
+ * Build the consumption summary for the prior month from the pre-run ledger.
+ * Pre-run ledger holds last cycle's `claimed` + `remaining_usd` BEFORE the
+ * new month's claim overwrites them.
+ */
+function buildPriorMonthSummary(preLedger, accountsConfig) {
+  // "Prior cycle" = whatever cycle the pre-run ledger holds, UNLESS that cycle
+  // is the current month or later (e.g. ledger was just provisioned, not yet
+  // claimed against), in which case we fall back to "last calendar month".
+  const ledgerCycle = preLedger.month;
+  const currentCycle = ymKey();
+  const priorCycle = ledgerCycle && ledgerCycle < currentCycle ? ledgerCycle : priorMonthKey();
+  const accounts = accountsConfig.length ? accountsConfig : (preLedger.accounts || []).map((a) => ({ email: a.email }));
+  const poolUsd = MAX_PLAN_MONTHLY_USD * accounts.length;
+
+  let claimedUsd = 0;
+  let consumedUsd = 0;
+  let unclaimedCount = 0;
+  const perAccount = [];
+
+  for (const cfg of accounts) {
+    const entry = findAccount(preLedger, cfg.email);
+    const claimed = !!entry?.claimed;
+    const remaining = typeof entry?.remaining_usd === 'number' ? entry.remaining_usd : null;
+    const granted = claimed ? MAX_PLAN_MONTHLY_USD : 0;
+    const consumed = claimed && remaining != null ? Math.max(0, granted - remaining) : null;
+    if (claimed) claimedUsd += granted;
+    else unclaimedCount += 1;
+    if (consumed != null) consumedUsd += consumed;
+    perAccount.push({ email: cfg.email, claimed, remaining_usd: remaining, consumed_usd: consumed });
+  }
+
+  const unclaimedPoolUsd = poolUsd - claimedUsd;
+  const wastePct = poolUsd > 0 ? Math.round((unclaimedPoolUsd / poolUsd) * 100) : 0;
+
+  return {
+    priorCycle,
+    accountCount: accounts.length,
+    poolUsd,
+    claimedUsd,
+    unclaimedPoolUsd,
+    unclaimedCount,
+    consumedUsd,
+    wastePct,
+    perAccount,
+  };
+}
+
+function formatSlackBody(summary, postClaimSummary) {
+  const lines = [];
+  lines.push(`Monthly Anthropic credit reclaim — ${ymKey()} (prior cycle ${summary.priorCycle})`);
+  lines.push('');
+  lines.push(`Pool: $${summary.poolUsd} (${summary.accountCount} × $${MAX_PLAN_MONTHLY_USD})`);
+  lines.push(`Claimed last month: $${summary.claimedUsd}`);
+  lines.push(
+    `Unclaimed pool: $${summary.unclaimedPoolUsd} (${summary.wastePct}% waste, ${summary.unclaimedCount} accounts skipped)`,
+  );
+  lines.push(`Consumed last month: $${summary.consumedUsd}`);
+  lines.push('');
+  if (postClaimSummary) {
+    lines.push(`This cycle: ${postClaimSummary.claimedCount}/${summary.accountCount} accounts re-claimed`);
+    if (postClaimSummary.failed.length) {
+      lines.push(`Failed: ${postClaimSummary.failed.join(', ')}`);
+    }
+  } else if (DRY_RUN) {
+    lines.push('(dry-run — no claim attempted)');
+  } else if (SKIP_CLAIM) {
+    lines.push('(--skip-claim — ledger unchanged this run)');
+  }
+  return lines.join('\n');
+}
+
+function summarizePostClaim(postLedger, accountsConfig) {
+  const cycle = ymKey();
+  const accounts = accountsConfig.length
+    ? accountsConfig
+    : (postLedger.accounts || []).map((a) => ({ email: a.email }));
+  let claimedCount = 0;
+  const failed = [];
+  for (const cfg of accounts) {
+    const e = findAccount(postLedger, cfg.email);
+    if (e?.claimed && e.cycle === cycle) claimedCount += 1;
+    else failed.push(cfg.email);
+  }
+  return { claimedCount, failed };
+}
+
+async function postSlack(body) {
+  const webhook = process.env.SLACK_WEBHOOK_URL;
+  if (!webhook) {
+    log('[monthly-reclaim] SLACK_WEBHOOK_URL not set — skipping Slack post');
+    return { ok: true, skipped: true };
+  }
+  if (DRY_RUN) {
+    log('[monthly-reclaim] DRY RUN — Slack payload below:');
+    log(body);
+    return { ok: true, dryRun: true };
+  }
+  try {
+    const res = await fetch(webhook, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: body }),
+    });
+    if (!res.ok) {
+      const txt = await res.text().catch(() => '');
+      log(`[monthly-reclaim] Slack post failed: ${res.status} ${txt.slice(0, 200)}`);
+      return { ok: false };
+    }
+    log('[monthly-reclaim] Slack post OK');
+    return { ok: true };
+  } catch (e) {
+    log(`[monthly-reclaim] Slack post threw: ${e.message}`);
+    return { ok: false };
+  }
+}
+
+function fanOutNotify(severity, title, body) {
+  if (DRY_RUN) {
+    log(`[monthly-reclaim] DRY RUN — would fan-out via ops-notify (${severity}): ${title}`);
+    return;
+  }
+  if (!existsSync(NOTIFY_SCRIPT)) return;
+  try {
+    spawnSync(NOTIFY_SCRIPT, [severity, title, body], {
+      stdio: 'ignore',
+      env: process.env,
+    });
+  } catch (e) {
+    log(`[monthly-reclaim] ops-notify fan-out failed: ${e.message}`);
+  }
+}
+
+async function main() {
+  log(`[monthly-reclaim] start cycle=${ymKey()} dry-run=${DRY_RUN} skip-claim=${SKIP_CLAIM}`);
+
+  const accountsConfig = loadAccountsConfig();
+  const preLedger = snapshotLedger();
+  const priorSummary = buildPriorMonthSummary(preLedger, accountsConfig);
+
+  const claim = runClaimer();
+  if (claim.code !== 0 && !claim.dryRun) {
+    log(`[monthly-reclaim] claimer exited code=${claim.code} signal=${claim.signal}`);
+    fanOutNotify(
+      'HIGH',
+      'Monthly credit reclaim FAILED',
+      `kapture-claim-credits.mjs exited ${claim.code}. Cycle ${ymKey()} claim incomplete.`,
+    );
+    // Continue to post the prior-month summary anyway — operator still needs visibility.
+  }
+
+  const postLedger = snapshotLedger();
+  const postClaim = SKIP_CLAIM || DRY_RUN ? null : summarizePostClaim(postLedger, accountsConfig);
+
+  const body = formatSlackBody(priorSummary, postClaim);
+  const slack = await postSlack(body);
+
+  const title = `Monthly credit reclaim — ${priorSummary.wastePct}% waste last month`;
+  const severity = priorSummary.wastePct >= 30 ? 'HIGH' : 'LOW';
+  fanOutNotify(severity, title, body);
+
+  if (claim.code !== 0 && !claim.dryRun) process.exit(2);
+  if (!slack.ok && !slack.skipped) process.exit(1);
+  log('[monthly-reclaim] done');
+}
+
+// Only run main() when executed directly (not when imported by tests).
+const _entryPath = fileURLToPath(import.meta.url);
+if (process.argv[1] && process.argv[1] === _entryPath) {
+  if (flag('--help') || flag('-h')) {
+    console.log(readFileSync(_entryPath, 'utf8').split('\n').slice(0, 44).join('\n'));
+    process.exit(0);
+  }
+  main().catch((e) => {
+    log(`[fatal] ${e.stack || e.message}`);
+    process.exit(2);
+  });
+}
+
+// Test exports
+export { buildPriorMonthSummary, summarizePostClaim, formatSlackBody, ymKey, priorMonthKey };

--- a/claude-ops/scripts/account-rotation/monthly-credit-reclaim.mjs
+++ b/claude-ops/scripts/account-rotation/monthly-credit-reclaim.mjs
@@ -39,7 +39,7 @@ import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
-import { MAX_PLAN_MONTHLY_USD, readLedger, findAccount } from './ledger.mjs';
+import { MAX_PLAN_MONTHLY_USD, readLedger, findAccount, ymKey } from './ledger.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLAIMER = join(__dirname, 'kapture-claim-credits.mjs');
@@ -64,10 +64,6 @@ function log(line) {
     /* logging is best-effort */
   }
   console.log(line);
-}
-
-function ymKey(date = new Date()) {
-  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
 }
 
 function priorMonthKey(date = new Date()) {

--- a/claude-ops/scripts/account-rotation/monthly-credit-reclaim.mjs
+++ b/claude-ops/scripts/account-rotation/monthly-credit-reclaim.mjs
@@ -158,7 +158,7 @@ function buildPriorMonthSummary(preLedger, accountsConfig) {
   };
 }
 
-function formatSlackBody(summary, postClaimSummary) {
+function formatSlackBody(summary, postClaimSummary, { dryRun = false, skipClaim = false } = {}) {
   const lines = [];
   lines.push(`Monthly Anthropic credit reclaim — ${ymKey()} (prior cycle ${summary.priorCycle})`);
   lines.push('');
@@ -174,9 +174,9 @@ function formatSlackBody(summary, postClaimSummary) {
     if (postClaimSummary.failed.length) {
       lines.push(`Failed: ${postClaimSummary.failed.join(', ')}`);
     }
-  } else if (DRY_RUN) {
+  } else if (dryRun) {
     lines.push('(dry-run — no claim attempted)');
-  } else if (SKIP_CLAIM) {
+  } else if (skipClaim) {
     lines.push('(--skip-claim — ledger unchanged this run)');
   }
   return lines.join('\n');
@@ -264,7 +264,7 @@ async function main() {
   const postLedger = snapshotLedger();
   const postClaim = SKIP_CLAIM || DRY_RUN ? null : summarizePostClaim(postLedger, accountsConfig);
 
-  const body = formatSlackBody(priorSummary, postClaim);
+  const body = formatSlackBody(priorSummary, postClaim, { dryRun: DRY_RUN, skipClaim: SKIP_CLAIM });
   const slack = await postSlack(body);
 
   const title = `Monthly credit reclaim — ${priorSummary.wastePct}% waste last month`;

--- a/claude-ops/scripts/install-monthly-credit-reclaim.sh
+++ b/claude-ops/scripts/install-monthly-credit-reclaim.sh
@@ -42,7 +42,10 @@ sed -e "s|__SCRIPT_PATH__|$SCRIPT_PATH|g" \
     -e "s|__LOG_DIR__|$LOG_DIR|g" \
     -e "s|__HOME__|$HOME|g" \
     -e "s|__NODE_BIN__|$NODE_BIN|g" \
-    "$PLIST_TEMPLATE" > "$PLIST_DEST"
+    "$PLIST_TEMPLATE" \
+  | SLACK_WEBHOOK_URL="${SLACK_WEBHOOK_URL:-}" "$NODE_BIN" -e \
+    'const fs=require("fs");const t=fs.readFileSync(0,"utf8");const e=s=>s.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");process.stdout.write(t.replace("__SLACK_WEBHOOK_URL__",e(process.env.SLACK_WEBHOOK_URL||"")));' \
+    > "$PLIST_DEST"
 
 launchctl bootout "gui/$(id -u)/com.claude-ops.monthly-credit-reclaim" 2>/dev/null || true
 launchctl bootstrap "gui/$(id -u)" "$PLIST_DEST"
@@ -52,3 +55,6 @@ echo "  plist:  $PLIST_DEST"
 echo "  script: $SCRIPT_PATH"
 echo "  logs:   $LOG_DIR/monthly-credit-reclaim-*.log"
 echo "  next run: day 1 of next month, 09:00 local time"
+if [[ -z "${SLACK_WEBHOOK_URL:-}" ]]; then
+  echo "  note: SLACK_WEBHOOK_URL was unset — Slack summary is skipped unless you export it and re-run this installer."
+fi

--- a/claude-ops/scripts/install-monthly-credit-reclaim.sh
+++ b/claude-ops/scripts/install-monthly-credit-reclaim.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# install-monthly-credit-reclaim.sh — Install the monthly Anthropic credit
+# reclaim cron as a launchd LaunchAgent (HEA-4049).
+#
+# Renders templates/com.claude-ops.monthly-credit-reclaim.plist with the
+# absolute paths to node + the wrapper script, then bootstraps it under the
+# current user's GUI session. macOS-only.
+
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "skip: monthly-credit-reclaim cron is macOS-only (launchd)" >&2
+  echo "Linux users: install equivalent systemd timer (OnCalendar=*-*-01 09:00:00)."
+  exit 0
+fi
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+if [[ -z "$PLUGIN_ROOT" || ! -d "$PLUGIN_ROOT" ]]; then
+  echo "error: could not resolve CLAUDE_PLUGIN_ROOT" >&2
+  exit 1
+fi
+
+SCRIPT_PATH="$PLUGIN_ROOT/scripts/account-rotation/monthly-credit-reclaim.mjs"
+PLIST_TEMPLATE="$PLUGIN_ROOT/templates/com.claude-ops.monthly-credit-reclaim.plist"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.claude-ops.monthly-credit-reclaim.plist"
+DATA_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+LOG_DIR="$DATA_DIR/logs"
+
+for f in "$SCRIPT_PATH" "$PLIST_TEMPLATE"; do
+  [[ -f "$f" ]] || { echo "error: required file not found: $f" >&2; exit 1; }
+done
+
+NODE_BIN="$(command -v node 2>/dev/null || true)"
+if [[ -z "$NODE_BIN" ]]; then
+  echo "error: node not found in PATH" >&2
+  exit 1
+fi
+
+mkdir -p "$LOG_DIR" "$(dirname "$PLIST_DEST")"
+
+sed -e "s|__SCRIPT_PATH__|$SCRIPT_PATH|g" \
+    -e "s|__LOG_DIR__|$LOG_DIR|g" \
+    -e "s|__HOME__|$HOME|g" \
+    -e "s|__NODE_BIN__|$NODE_BIN|g" \
+    "$PLIST_TEMPLATE" > "$PLIST_DEST"
+
+launchctl bootout "gui/$(id -u)/com.claude-ops.monthly-credit-reclaim" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST_DEST"
+
+echo "ok: monthly-credit-reclaim installed"
+echo "  plist:  $PLIST_DEST"
+echo "  script: $SCRIPT_PATH"
+echo "  logs:   $LOG_DIR/monthly-credit-reclaim-*.log"
+echo "  next run: day 1 of next month, 09:00 local time"

--- a/claude-ops/templates/com.claude-ops.monthly-credit-reclaim.plist
+++ b/claude-ops/templates/com.claude-ops.monthly-credit-reclaim.plist
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Monthly Anthropic credit reclaim cron (HEA-4049).
+
+  Schedule: day 1 of each month, 09:00 local time (Europe/Amsterdam for Sam).
+  Equivalent cron: 0 9 1 * *
+
+  The installer (scripts/install-monthly-credit-reclaim.sh) substitutes
+  __SCRIPT_PATH__, __LOG_DIR__, __HOME__, __NODE_BIN__ and writes the
+  rendered copy to ~/Library/LaunchAgents/com.claude-ops.monthly-credit-reclaim.plist
+  before running:
+    launchctl bootstrap "gui/$(id -u)" <plist>
+
+  To uninstall:
+    launchctl bootout "gui/$(id -u)/com.claude-ops.monthly-credit-reclaim"
+    rm ~/Library/LaunchAgents/com.claude-ops.monthly-credit-reclaim.plist
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.claude-ops.monthly-credit-reclaim</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>__NODE_BIN__</string>
+    <string>__SCRIPT_PATH__</string>
+  </array>
+
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Day</key>
+    <integer>1</integer>
+    <key>Hour</key>
+    <integer>9</integer>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>StandardOutPath</key>
+  <string>__LOG_DIR__/monthly-credit-reclaim-stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>__LOG_DIR__/monthly-credit-reclaim-stderr.log</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>HOME</key>
+    <string>__HOME__</string>
+    <key>NODE_NO_WARNINGS</key>
+    <string>1</string>
+  </dict>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>

--- a/claude-ops/templates/com.claude-ops.monthly-credit-reclaim.plist
+++ b/claude-ops/templates/com.claude-ops.monthly-credit-reclaim.plist
@@ -6,7 +6,8 @@
   Equivalent cron: 0 9 1 * *
 
   The installer (scripts/install-monthly-credit-reclaim.sh) substitutes
-  __SCRIPT_PATH__, __LOG_DIR__, __HOME__, __NODE_BIN__ and writes the
+  __SCRIPT_PATH__, __LOG_DIR__, __HOME__, __NODE_BIN__, __SLACK_WEBHOOK_URL__
+  (from SLACK_WEBHOOK_URL at install time; empty if unset) and writes the
   rendered copy to ~/Library/LaunchAgents/com.claude-ops.monthly-credit-reclaim.plist
   before running:
     launchctl bootstrap "gui/$(id -u)" <plist>
@@ -53,6 +54,8 @@
     <string>__HOME__</string>
     <key>NODE_NO_WARNINGS</key>
     <string>1</string>
+    <key>SLACK_WEBHOOK_URL</key>
+    <string>__SLACK_WEBHOOK_URL__</string>
   </dict>
 
   <key>ProcessType</key>


### PR DESCRIPTION
Closes [HEA-4049](https://linear.app/healify/issue/HEA-4049) — schedules `kapture-claim-credits.mjs` for day-1 09:00 monthly, posts Slack summary of prior month's $1,400 credit-pool waste.

## Summary
- New launchd LaunchAgent (`com.claude-ops.monthly-credit-reclaim`) fires at day-1 09:00 local time (`StartCalendarInterval Day=1 Hour=9 Minute=0` — equivalent to `0 9 1 * *`).
- Orchestrator `monthly-credit-reclaim.mjs` snapshots the ledger, invokes `kapture-claim-credits.mjs --live`, then computes prior-cycle delta: claimed_usd / consumed_usd / unclaimed_pool / waste_pct (against `MAX_PLAN_MONTHLY_USD × account_count` pool).
- Posts Slack via `$SLACK_WEBHOOK_URL` AND fans out via `scripts/ops-notify.sh` (Discord/ntfy/Telegram/Pushover pick up automatically when their env vars are present). Severity escalates to HIGH when waste >= 30%.
- `--dry-run` prints the planned Slack payload without touching the browser or the webhook.
- Installer `scripts/install-monthly-credit-reclaim.sh` renders the plist template + bootstraps under `gui/$(id -u)`.

## Files
- `claude-ops/scripts/account-rotation/monthly-credit-reclaim.mjs`
- `claude-ops/scripts/account-rotation/__tests__/monthly-credit-reclaim.test.mjs` (9 tests)
- `claude-ops/templates/com.claude-ops.monthly-credit-reclaim.plist`
- `claude-ops/scripts/install-monthly-credit-reclaim.sh`

## Test plan
- [x] `node --test scripts/account-rotation/__tests__/monthly-credit-reclaim.test.mjs` — 9/9 pass (pool math, waste %, post-claim summary, prior-month rollover, no-secrets in body)
- [x] `shellcheck scripts/install-monthly-credit-reclaim.sh` — clean
- [x] `node --check` on both new .mjs files
- [x] `bash tests/test-no-secrets.sh` — 14/14 pass
- [x] Smoke run `node scripts/account-rotation/monthly-credit-reclaim.mjs --dry-run` — prints planned Slack body without error
- [x] `npx prettier --check` on .mjs files
- [ ] Manual: run installer on macOS, verify `launchctl list | grep monthly-credit-reclaim` shows the agent, then `launchctl kickstart` to trigger an out-of-band test fire

## Constraints honored
- Edited `~/Projects/claude-ops` (worktree), not plugin cache
- Slack webhook from env (`$SLACK_WEBHOOK_URL`), never hard-coded
- No real emails/secrets in committed files (Rule 0)
- Outbound comms guardrail unaffected — this script posts to a webhook (internal billing tooling), not 1:1 messaging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it introduces a scheduled job that triggers browser automation and posts notifications; failures/misconfiguration could cause missed claims or noisy alerts, though changes are isolated to ops scripts.
> 
> **Overview**
> Adds a new `monthly-credit-reclaim.mjs` entrypoint that snapshots the credits ledger, runs `kapture-claim-credits.mjs --live` (unless `--dry-run`/`--skip-claim`), computes prior-cycle pool/claimed/consumed and *waste %*, then posts a Slack summary via `SLACK_WEBHOOK_URL` and fans out via `ops-notify.sh` with severity based on waste.
> 
> Introduces a macOS `launchd` LaunchAgent template plus `install-monthly-credit-reclaim.sh` to render and bootstrap the monthly schedule (day 1 @ 09:00), and adds a Node test suite covering summary math, post-claim validation, prior-month rollover, and Slack body redaction.
> 
> Refactors date key generation by exporting `ymKey()` from `ledger.mjs` and reusing it in `kapture-claim-credits.mjs` (removing the local helper).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84b85bae1b978b6032e544790033f6e85363d7da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated monthly credit reclaim system that runs on the first of each month at 09:00.
  * Generates Slack notifications with credit consumption metrics and reclaim summaries.
  * Includes macOS installer for streamlined setup.

* **Tests**
  * Added comprehensive test suite for credit reclaim calculations and notification formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/255?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->