### PR TITLE
feat(ops:marketing): self-provision foundation (GA4 + GSC + resolver)

### DIFF
--- a/claude-ops/.gitignore
+++ b/claude-ops/.gitignore
@@ -51,3 +51,6 @@ telegram-server/package-lock.json
 # Python bytecode (calibrate.py)
 __pycache__/
 *.pyc
+
+# GCP / Google ADC credentials — never committed; live in ~/.gcp/
+*.json.bak-ga4-*

--- a/claude-ops/bin/ops-marketing-autopilot
+++ b/claude-ops/bin/ops-marketing-autopilot
@@ -28,6 +28,9 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 OPS_PLUGIN_ROOT_FALLBACK="${SCRIPT_DIR}/.." . "${SCRIPT_DIR}/../lib/registry-path.sh"
 # shellcheck disable=SC1091
 . "${SCRIPT_DIR}/../scripts/lib/claude-invoke.sh"
+# resolve_cred canonical implementation — shared lib; local copy below is removed
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/../scripts/lib/ga4-resolve.sh"
 
 # Fix B: source analyze.sh once near top (makes extract_json available on ALL paths,
 # including process_onboard, which runs before delegate_claude would source it).
@@ -85,22 +88,7 @@ CREATED_CAMPAIGNS=0
 CREATED_AUDIENCES=0
 CREATED_BUDGET_USD=0
 
-# ── Cred + config resolvers (same contract as bin/ops-marketing-dash) ─────────
-# env:VAR | doppler:proj/cfg/SECRET | inline literal. Empty -> empty. Never fails.
-resolve_cred() {
-  local ref="${1:-}"
-  { [ -z "$ref" ] || [ "$ref" = "null" ]; } && return 0
-  case "$ref" in
-    env:*)
-      local var="${ref#env:}"; printf '%s' "${!var:-}" ;;
-    doppler:*)
-      local path="${ref#doppler:}" proj rest cfg secret
-      proj="${path%%/*}"; rest="${path#*/}"; cfg="${rest%%/*}"; secret="${rest#*/}"
-      { [ -z "$proj" ] || [ -z "$cfg" ] || [ -z "$secret" ]; } && return 0
-      doppler secrets get "$secret" --project "$proj" --config "$cfg" --plain 2>/dev/null || true ;;
-    *) printf '%s' "$ref" ;;
-  esac
-}
+# ── Cred + config resolvers (resolve_cred provided by scripts/lib/ga4-resolve.sh) ──
 
 # Raw jq read against marketing.projects.<project>...
 pref_json() { jq -r "$1" "$PREFS" 2>/dev/null || true; }

--- a/claude-ops/bin/ops-marketing-dash
+++ b/claude-ops/bin/ops-marketing-dash
@@ -156,6 +156,7 @@ gather_meta() {
 # --- GA4 ---
 # Auth: prefer SA key file (GA4_SERVICE_ACCOUNT_KEY_FILE or first ~/.config/gcloud/keys/*ga*.json)
 # over gcloud ADC, so the dash works in daemon context without interactive gcloud auth.
+# If the key file exists but JWT exchange yields no token, fall back to ADC.
 _ga4_auth_token() {
   local sa_key_file="${GA4_SERVICE_ACCOUNT_KEY_FILE:-}"
   if [ -z "$sa_key_file" ]; then
@@ -164,7 +165,7 @@ _ga4_auth_token() {
   fi
   if [ -n "$sa_key_file" ] && [ -f "$sa_key_file" ]; then
     # Exchange SA key for access token via OAuth2
-    local now exp header payload sig jwt resp
+    local now exp header payload sig jwt resp sa_token
     now=$(date +%s)
     exp=$((now + 3600))
     header=$(printf '{"alg":"RS256","typ":"JWT"}' | base64 | tr -d '=' | tr '+/' '-_' | tr -d '\n')
@@ -177,8 +178,11 @@ _ga4_auth_token() {
     jwt="${header}.${payload}.${sig}"
     resp=$(curl -sS --max-time 5 -X POST https://oauth2.googleapis.com/token \
       --data "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=${jwt}" 2>/dev/null || echo '{}')
-    printf '%s' "$(printf '%s' "$resp" | jq -r '.access_token // empty' 2>/dev/null || true)"
-    return
+    sa_token="$(printf '%s' "$resp" | jq -r '.access_token // empty' 2>/dev/null || true)"
+    if [ -n "$sa_token" ]; then
+      printf '%s' "$sa_token"
+      return
+    fi
   fi
   # Fallback: ADC
   gcloud auth application-default print-access-token 2>/dev/null || true

--- a/claude-ops/bin/ops-marketing-dash
+++ b/claude-ops/bin/ops-marketing-dash
@@ -8,35 +8,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 OPS_PLUGIN_ROOT_FALLBACK="${SCRIPT_DIR}/.." . "${SCRIPT_DIR}/../lib/registry-path.sh"
+# resolve_cred, ga4_resolve, gsc_resolve, marketing_channels_status
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/../scripts/lib/ga4-resolve.sh"
 PREFS="${OPS_DATA_DIR}/preferences.json"
-
-# Resolve a cred reference value.
-#   env:VAR_NAME                   -> $VAR_NAME from environment
-#   doppler:project/config/SECRET  -> doppler secrets get SECRET --project P --config C --plain
-#   <anything else>                -> treated as inline literal
-# Empty input -> empty output. Never fails.
-resolve_cred() {
-  local ref="${1:-}"
-  [ -z "$ref" ] || [ "$ref" = "null" ] && return 0
-  case "$ref" in
-    env:*)
-      local var="${ref#env:}"
-      printf '%s' "${!var:-}"
-      ;;
-    doppler:*)
-      local path="${ref#doppler:}"
-      local proj="${path%%/*}"
-      local rest="${path#*/}"
-      local cfg="${rest%%/*}"
-      local secret="${rest#*/}"
-      [ -z "$proj" ] || [ -z "$cfg" ] || [ -z "$secret" ] && return 0
-      doppler secrets get "$secret" --project "$proj" --config "$cfg" --plain 2>/dev/null || true
-      ;;
-    *)
-      printf '%s' "$ref"
-      ;;
-  esac
-}
 
 # Pull a value from preferences.json marketing.projects.<project>.<channel>.<field>.
 # $1 project, $2 channel, $3 field. Echoes nothing if missing or prefs absent.
@@ -179,19 +154,52 @@ gather_meta() {
 }
 
 # --- GA4 ---
+# Auth: prefer SA key file (GA4_SERVICE_ACCOUNT_KEY_FILE or first ~/.config/gcloud/keys/*ga*.json)
+# over gcloud ADC, so the dash works in daemon context without interactive gcloud auth.
+_ga4_auth_token() {
+  local sa_key_file="${GA4_SERVICE_ACCOUNT_KEY_FILE:-}"
+  if [ -z "$sa_key_file" ]; then
+    # Auto-discover first matching SA key
+    sa_key_file="$(ls "$HOME"/.config/gcloud/keys/*ga*.json 2>/dev/null | head -1 || true)"
+  fi
+  if [ -n "$sa_key_file" ] && [ -f "$sa_key_file" ]; then
+    # Exchange SA key for access token via OAuth2
+    local now exp header payload sig jwt resp
+    now=$(date +%s)
+    exp=$((now + 3600))
+    header=$(printf '{"alg":"RS256","typ":"JWT"}' | base64 | tr -d '=' | tr '+/' '-_' | tr -d '\n')
+    payload=$(printf '{"iss":"%s","scope":"https://www.googleapis.com/auth/analytics.readonly","aud":"https://oauth2.googleapis.com/token","exp":%d,"iat":%d}' \
+      "$(jq -r '.client_email' "$sa_key_file")" "$exp" "$now" \
+      | base64 | tr -d '=' | tr '+/' '-_' | tr -d '\n')
+    sig=$(printf '%s.%s' "$header" "$payload" \
+      | openssl dgst -sha256 -sign <(jq -r '.private_key' "$sa_key_file") 2>/dev/null \
+      | base64 | tr -d '=' | tr '+/' '-_' | tr -d '\n')
+    jwt="${header}.${payload}.${sig}"
+    resp=$(curl -sS --max-time 5 -X POST https://oauth2.googleapis.com/token \
+      --data "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=${jwt}" 2>/dev/null || echo '{}')
+    printf '%s' "$(printf '%s' "$resp" | jq -r '.access_token // empty' 2>/dev/null || true)"
+    return
+  fi
+  # Fallback: ADC
+  gcloud auth application-default print-access-token 2>/dev/null || true
+}
+
 gather_ga4() {
   if [ -z "$GA4_PROPERTY" ] || [ "$GA4_PROPERTY" = "0" ]; then
     echo "null"
     return
   fi
 
-  GA4_TOKEN=$(gcloud auth application-default print-access-token 2>/dev/null || echo "")
+  local GA4_TOKEN
+  GA4_TOKEN=$(_ga4_auth_token)
   if [ -z "$GA4_TOKEN" ]; then
     echo "null"
     return
   fi
 
-  REPORT=$(curl -gsS --max-time 5 -X POST "https://analyticsdata.googleapis.com/v1beta/properties/${GA4_PROPERTY}:runReport" \
+  local REPORT
+  REPORT=$(curl -gsS --max-time 10 -X POST \
+    "https://analyticsdata.googleapis.com/v1beta/properties/${GA4_PROPERTY}:runReport" \
     -H "Authorization: Bearer ${GA4_TOKEN}" \
     -H "Content-Type: application/json" \
     -d '{
@@ -200,15 +208,17 @@ gather_ga4() {
         {"name": "sessions"},
         {"name": "totalUsers"},
         {"name": "conversions"},
-        {"name": "totalRevenue"},
-        {"name": "bounceRate"}
+        {"name": "screenPageViews"},
+        {"name": "totalRevenue"}
       ]
     }' 2>/dev/null)
 
-  SESSIONS=$(echo "$REPORT" | jq -r '.rows[0].metricValues[0].value // "0"' 2>/dev/null || echo "0")
-  USERS=$(echo "$REPORT" | jq -r '.rows[0].metricValues[1].value // "0"' 2>/dev/null || echo "0")
-  CONVERSIONS=$(echo "$REPORT" | jq -r '.rows[0].metricValues[2].value // "0"' 2>/dev/null || echo "0")
-  REVENUE=$(echo "$REPORT" | jq -r '.rows[0].metricValues[3].value // "0"' 2>/dev/null || echo "0")
+  local SESSIONS USERS CONVERSIONS PAGEVIEWS REVENUE CVR
+  SESSIONS=$(printf '%s' "$REPORT" | jq -r '.rows[0].metricValues[0].value // "0"' 2>/dev/null || echo "0")
+  USERS=$(printf '%s' "$REPORT" | jq -r '.rows[0].metricValues[1].value // "0"' 2>/dev/null || echo "0")
+  CONVERSIONS=$(printf '%s' "$REPORT" | jq -r '.rows[0].metricValues[2].value // "0"' 2>/dev/null || echo "0")
+  PAGEVIEWS=$(printf '%s' "$REPORT" | jq -r '.rows[0].metricValues[3].value // "0"' 2>/dev/null || echo "0")
+  REVENUE=$(printf '%s' "$REPORT" | jq -r '.rows[0].metricValues[4].value // "0"' 2>/dev/null || echo "0")
 
   CVR=$(awk "BEGIN {s=$SESSIONS+0; c=$CONVERSIONS+0; if (s>0) printf \"%.2f\", (c/s)*100; else print \"0\"}")
 
@@ -216,9 +226,10 @@ gather_ga4() {
     --arg sessions "$SESSIONS" \
     --arg users "$USERS" \
     --arg conversions "$CONVERSIONS" \
+    --arg pageviews "$PAGEVIEWS" \
     --arg revenue "$REVENUE" \
     --arg cvr "$CVR" \
-    '{sessions: $sessions, users: $users, conversions: $conversions, revenue: $revenue, cvr: $cvr}'
+    '{sessions: $sessions, users: $users, conversions: $conversions, pageviews: $pageviews, revenue: $revenue, cvr: $cvr}'
 }
 
 # --- Google Search Console ---

--- a/claude-ops/bin/ops-marketing-provision
+++ b/claude-ops/bin/ops-marketing-provision
@@ -1,0 +1,673 @@
+#!/usr/bin/env bash
+# ops-marketing-provision — self-provision marketing channels for a project
+#
+# Subcommands:
+#   provision-ga4 --project <key> [--domain <d>] [--account-id <acc>]
+#                 [--display-name <name>] [--industry SHOPPING|TECHNOLOGY]
+#   provision-gsc --project <key> [--site sc-domain:<d>|https://<d>/]
+#   provision-all --project <key>
+#   status        --project <key> [--json]
+#   --help
+#
+# Idempotent: GET-first, reuse existing matches before creating.
+# Set OPS_MARKETING_DRY_RUN=1 to print planned API calls without executing.
+# Set OPS_MARKETING_BACKGROUND=1 to suppress interactive prompts.
+#
+# No real account IDs, emails, or domains are hardcoded in this file.
+# All config is read from preferences.json and environment variables.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# shellcheck disable=SC1091
+OPS_PLUGIN_ROOT_FALLBACK="${PLUGIN_ROOT}" . "${PLUGIN_ROOT}/lib/registry-path.sh"
+# shellcheck disable=SC1091
+. "${PLUGIN_ROOT}/scripts/lib/ga4-resolve.sh"
+
+PREFS="${OPS_DATA_DIR}/preferences.json"
+DRY_RUN="${OPS_MARKETING_DRY_RUN:-0}"
+# OPS_MARKETING_BACKGROUND=1 suppresses interactive prompts (used by callers / tests)
+export OPS_MARKETING_BACKGROUND="${OPS_MARKETING_BACKGROUND:-0}"
+DOPPLER_PROJECT="${OPS_MARKETING_DOPPLER_PROJECT:-claude-ops}"
+DOPPLER_CONFIG="${OPS_MARKETING_DOPPLER_CONFIG:-prd}"
+
+# ---------------------------------------------------------------------------
+# Logging helpers
+# ---------------------------------------------------------------------------
+log()  { printf '[provision] %s\n' "$1" >&2; }
+info() { printf '%s\n' "$1"; }
+die()  { printf '[provision] ERROR: %s\n' "$1" >&2; exit 1; }
+
+dry_notice() {
+  if [ "$DRY_RUN" = "1" ]; then
+    printf '[DRY-RUN] would execute: %s\n' "$1" >&2
+    return 0
+  fi
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Prereq checks
+# ---------------------------------------------------------------------------
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1 — please install it first"
+}
+
+# ---------------------------------------------------------------------------
+# curl helper — checks HTTP status, aborts on non-2xx
+# Usage: http_call <METHOD> <URL> [--data <body>] [--header "K: V"] ...
+# Returns response body. Exits non-zero on error.
+# ---------------------------------------------------------------------------
+http_call() {
+  local method="$1"; shift
+  local url="$1"; shift
+  local extra_args=()
+  while [ $# -gt 0 ]; do
+    extra_args+=("$1")
+    shift
+  done
+
+  local tmpfile
+  tmpfile="$(mktemp)"
+  # shellcheck disable=SC2064
+  trap "rm -f '$tmpfile'" RETURN
+
+  local response http_code body
+  response=$(curl -sS -w "\n%{http_code}" -X "$method" "$url" "${extra_args[@]}" 2>&1)
+  http_code="${response##*$'\n'}"
+  body="${response%$'\n'*}"
+
+  if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+    log "HTTP $http_code from $method $url"
+    log "Response: $body"
+    die "API call failed with HTTP $http_code"
+  fi
+
+  printf '%s' "$body"
+}
+
+# ---------------------------------------------------------------------------
+# ADC token — get current access token with required scopes
+# ---------------------------------------------------------------------------
+ga4_get_token() {
+  local token
+  token=$(gcloud auth application-default print-access-token 2>/dev/null || true)
+  if [ -z "$token" ]; then
+    log "No Application Default Credentials found."
+    log "Run the OAuth bootstrap to authenticate:"
+    log ""
+    log "  gcloud auth application-default login \\"
+    log "    --scopes=openid,email,profile,\\"
+    log "https://www.googleapis.com/auth/cloud-platform,\\"
+    log "https://www.googleapis.com/auth/analytics.edit,\\"
+    log "https://www.googleapis.com/auth/analytics.manage.users,\\"
+    log "https://www.googleapis.com/auth/webmasters"
+    log ""
+    log "Store your OAuth client JSON at: ~/.gcp/ops-oauth-client.json"
+    log "Then re-run this command."
+    die "Missing ADC credentials"
+  fi
+  printf '%s' "$token"
+}
+
+gsc_get_token() {
+  ga4_get_token
+}
+
+# ---------------------------------------------------------------------------
+# Preferences helpers
+# ---------------------------------------------------------------------------
+prefs_get_raw() {
+  [ -f "$PREFS" ] || return 0
+  jq -r "$1" "$PREFS" 2>/dev/null || true
+}
+
+prefs_get_project_field() {
+  local proj="$1" channel="$2" field="$3"
+  prefs_get_raw ".marketing.projects[\"$proj\"][\"$channel\"][\"$field\"] // empty"
+}
+
+prefs_get_domain() {
+  local proj="$1"
+  prefs_get_raw ".marketing.projects[\"$proj\"].domain // .projects[\"$proj\"].domain // empty"
+}
+
+# Write a value into preferences.json using jq in-place update
+prefs_set_marketing() {
+  local proj="$1" channel="$2" field="$3" value="$4"
+  [ -f "$PREFS" ] || echo '{}' > "$PREFS"
+
+  local tmp
+  tmp="$(mktemp)"
+  jq --arg p "$proj" --arg c "$channel" --arg f "$field" --arg v "$value" \
+    '.marketing.projects[$p][$c][$f] = $v' "$PREFS" > "$tmp" && mv "$tmp" "$PREFS"
+  log "prefs: marketing.projects.$proj.$channel.$field = $value"
+}
+
+prefs_set_marketing_status() {
+  local proj="$1" channel="$2" status="$3"
+  prefs_set_marketing "$proj" "$channel" "status" "$status"
+}
+
+# ---------------------------------------------------------------------------
+# Doppler push helper
+# ---------------------------------------------------------------------------
+doppler_set() {
+  local key="$1" value="$2"
+  if dry_notice "doppler secrets upload {\"$key\": \"<secret>\"} --project $DOPPLER_PROJECT --config $DOPPLER_CONFIG"; then
+    return 0
+  fi
+  need_cmd doppler
+  if printf '%s' "{\"$key\": \"$value\"}" | \
+    doppler secrets upload - --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG" >/dev/null 2>&1; then
+    log "Doppler: set $key in $DOPPLER_PROJECT/$DOPPLER_CONFIG"
+  else
+    log "WARN: Doppler push failed for $key — set manually"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# GA4 provisioning
+# ---------------------------------------------------------------------------
+cmd_provision_ga4() {
+  local project="" domain="" account_id="" display_name="" industry="TECHNOLOGY"
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --project)       project="${2:-}";      shift ;;
+      --domain)        domain="${2:-}";       shift ;;
+      --account-id)    account_id="${2:-}";   shift ;;
+      --display-name)  display_name="${2:-}"; shift ;;
+      --industry)      industry="${2:-}";     shift ;;
+      *) die "Unknown argument: $1" ;;
+    esac
+    shift
+  done
+
+  [ -n "$project" ] || die "--project is required"
+
+  need_cmd gcloud
+  need_cmd curl
+  need_cmd jq
+
+  # Resolve domain from prefs if not provided
+  if [ -z "$domain" ]; then
+    domain="$(prefs_get_domain "$project")"
+  fi
+  [ -n "$domain" ] || die "--domain is required (or set marketing.projects.$project.domain in preferences.json)"
+
+  # Resolve display name
+  if [ -z "$display_name" ]; then
+    display_name="${project^} Web"
+  fi
+
+  # Resolve GA4 account ID from prefs or env
+  if [ -z "$account_id" ]; then
+    account_id="${GA4_ACCOUNT_ID:-$(prefs_get_raw '.marketing.ga4_account_id // empty')}"
+  fi
+  [ -n "$account_id" ] || die "--account-id is required (or set GA4_ACCOUNT_ID env / marketing.ga4_account_id in prefs)"
+
+  local token
+  token="$(ga4_get_token)"
+
+  local auth_header="Authorization: Bearer $token"
+  local base_admin="https://analyticsadmin.googleapis.com"
+
+  log "Provisioning GA4 for project=$project domain=$domain account=accounts/$account_id"
+
+  # --- Step 1: Bind SA access (idempotent) ---
+  local sa_email="${GA4_SERVICE_ACCOUNT_EMAIL:-}"
+  if [ -n "$sa_email" ]; then
+    log "Checking SA access binding for $sa_email..."
+    if dry_notice "POST $base_admin/v1alpha/accounts/$account_id/accessBindings {user: $sa_email}"; then
+      true
+    else
+      # Check existing
+      local existing_bindings
+      existing_bindings="$(http_call GET "$base_admin/v1alpha/accounts/$account_id/accessBindings" \
+        -H "$auth_header" 2>/dev/null || echo '{}')"
+      local already_bound
+      already_bound="$(printf '%s' "$existing_bindings" | jq -r \
+        --arg sa "$sa_email" '.accessBindings[]? | select(.user == $sa) | .name' 2>/dev/null || true)"
+
+      if [ -z "$already_bound" ]; then
+        http_call POST "$base_admin/v1alpha/accounts/$account_id/accessBindings" \
+          -H "$auth_header" -H "Content-Type: application/json" \
+          --data "{\"user\":\"$sa_email\",\"roles\":[\"predefinedRoles/admin\"]}" >/dev/null
+        log "SA access binding created"
+      else
+        log "SA access binding already exists: $already_bound"
+      fi
+    fi
+  fi
+
+  # --- Step 2: Find or create GA4 property ---
+  log "Checking for existing GA4 property '$display_name'..."
+  local property_id=""
+  if dry_notice "GET $base_admin/v1beta/properties?filter=parent:accounts/$account_id"; then
+    property_id="000000000"
+    log "[DRY-RUN] Using placeholder property_id=$property_id"
+  else
+    local props_resp
+    props_resp="$(http_call GET "$base_admin/v1beta/properties?filter=parent:accounts%2F$account_id" \
+      -H "$auth_header")"
+    property_id="$(printf '%s' "$props_resp" | jq -r \
+      --arg name "$display_name" \
+      '.properties[]? | select(.displayName == $name) | .name | split("/")[1]' 2>/dev/null | head -1 || true)"
+
+    if [ -z "$property_id" ]; then
+      log "Creating GA4 property '$display_name'..."
+      local create_resp
+      create_resp="$(http_call POST "$base_admin/v1beta/properties" \
+        -H "$auth_header" -H "Content-Type: application/json" \
+        --data "{
+          \"parent\": \"accounts/$account_id\",
+          \"displayName\": \"$display_name\",
+          \"industryCategory\": \"$industry\",
+          \"timeZone\": \"Europe/Amsterdam\",
+          \"currencyCode\": \"USD\"
+        }")"
+      property_id="$(printf '%s' "$create_resp" | jq -r '.name | split("/")[1]' 2>/dev/null)"
+      log "Created GA4 property: $property_id"
+    else
+      log "Found existing GA4 property: $property_id"
+    fi
+  fi
+
+  # --- Step 3: Find or create web data stream ---
+  log "Checking for existing web data stream..."
+  local stream_id="" measurement_id=""
+  if dry_notice "GET $base_admin/v1beta/properties/$property_id/dataStreams"; then
+    stream_id="0000000000"
+    measurement_id="G-XXXXXXXXXX"
+    log "[DRY-RUN] Using placeholder stream_id=$stream_id measurement_id=$measurement_id"
+  else
+    local streams_resp
+    streams_resp="$(http_call GET "$base_admin/v1beta/properties/$property_id/dataStreams" \
+      -H "$auth_header")"
+    local domain_clean="${domain#https://}"; domain_clean="${domain_clean#http://}"; domain_clean="${domain_clean%/}"
+    stream_id="$(printf '%s' "$streams_resp" | jq -r \
+      --arg d "$domain_clean" \
+      '.dataStreams[]? | select(.type == "WEB_DATA_STREAM") | select(.webStreamData.defaultUri | test($d; "i")) | .name | split("/")[3]' \
+      2>/dev/null | head -1 || true)"
+
+    if [ -z "$stream_id" ]; then
+      log "Creating web data stream for https://$domain_clean..."
+      local stream_resp
+      stream_resp="$(http_call POST "$base_admin/v1beta/properties/$property_id/dataStreams" \
+        -H "$auth_header" -H "Content-Type: application/json" \
+        --data "{
+          \"type\": \"WEB_DATA_STREAM\",
+          \"displayName\": \"$display_name Web\",
+          \"webStreamData\": {\"defaultUri\": \"https://$domain_clean\"}
+        }")"
+      stream_id="$(printf '%s' "$stream_resp" | jq -r '.name | split("/")[3]' 2>/dev/null)"
+      measurement_id="$(printf '%s' "$stream_resp" | jq -r '.webStreamData.measurementId // empty' 2>/dev/null)"
+      log "Created stream: $stream_id, measurement_id: $measurement_id"
+    else
+      measurement_id="$(printf '%s' "$streams_resp" | jq -r \
+        --arg sid "$stream_id" \
+        '.dataStreams[]? | select(.name | endswith($sid)) | .webStreamData.measurementId // empty' \
+        2>/dev/null || true)"
+      log "Found existing stream: $stream_id, measurement_id: $measurement_id"
+    fi
+  fi
+
+  # --- Step 4: Find or create Measurement Protocol secret ---
+  log "Checking for existing MP secret..."
+  local api_secret=""
+  if dry_notice "GET $base_admin/v1beta/properties/$property_id/dataStreams/$stream_id/measurementProtocolSecrets"; then
+    api_secret="fake-mp-secret-for-dry-run"
+    log "[DRY-RUN] Using placeholder api_secret"
+  else
+    local secrets_resp
+    secrets_resp="$(http_call GET \
+      "$base_admin/v1beta/properties/$property_id/dataStreams/$stream_id/measurementProtocolSecrets" \
+      -H "$auth_header")"
+    api_secret="$(printf '%s' "$secrets_resp" | jq -r \
+      '.measurementProtocolSecrets[]? | select(.displayName == "server-events") | .secretValue // empty' \
+      2>/dev/null | head -1 || true)"
+
+    if [ -z "$api_secret" ]; then
+      log "Creating MP secret 'server-events'..."
+      local secret_resp
+      secret_resp="$(http_call POST \
+        "$base_admin/v1beta/properties/$property_id/dataStreams/$stream_id/measurementProtocolSecrets" \
+        -H "$auth_header" -H "Content-Type: application/json" \
+        --data '{"displayName":"server-events"}')"
+      api_secret="$(printf '%s' "$secret_resp" | jq -r '.secretValue // empty' 2>/dev/null)"
+      log "Created MP secret"
+    else
+      log "Found existing MP secret"
+    fi
+  fi
+
+  # --- Step 5: Push secret to Doppler ---
+  local doppler_key
+  doppler_key="GA4_API_SECRET_$(printf '%s' "$project" | tr '[:lower:]-' '[:upper:]_')"
+  doppler_set "$doppler_key" "$api_secret"
+
+  # --- Step 6: Write to preferences.json ---
+  if [ "$DRY_RUN" != "1" ]; then
+    prefs_set_marketing "$project" "ga4" "property_id" "$property_id"
+    prefs_set_marketing "$project" "ga4" "measurement_id" "$measurement_id"
+    prefs_set_marketing "$project" "ga4" "stream_id" "$stream_id"
+    prefs_set_marketing "$project" "ga4" "api_secret" "doppler:$DOPPLER_PROJECT/$DOPPLER_CONFIG/$doppler_key"
+    prefs_set_marketing_status "$project" "ga4" "active"
+  fi
+
+  info ""
+  info "GA4 provisioned for project: $project"
+  info "  property_id:    $property_id"
+  info "  measurement_id: $measurement_id"
+  info "  stream_id:      $stream_id"
+  info "  api_secret:     stored in Doppler as $doppler_key"
+}
+
+# ---------------------------------------------------------------------------
+# GSC provisioning
+# ---------------------------------------------------------------------------
+cmd_provision_gsc() {
+  local project="" site_url=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --project) project="${2:-}"; shift ;;
+      --site)    site_url="${2:-}"; shift ;;
+      *) die "Unknown argument: $1" ;;
+    esac
+    shift
+  done
+
+  [ -n "$project" ] || die "--project is required"
+
+  need_cmd gcloud
+  need_cmd curl
+  need_cmd jq
+
+  # Resolve site URL from prefs if not provided
+  if [ -z "$site_url" ]; then
+    site_url="$(prefs_get_project_field "$project" "gsc" "site_url")"
+  fi
+  if [ -z "$site_url" ]; then
+    local domain
+    domain="$(prefs_get_domain "$project")"
+    [ -n "$domain" ] && site_url="https://$domain/"
+  fi
+  [ -n "$site_url" ] || die "--site is required (e.g. sc-domain:example.com or https://example.com/)"
+
+  local token
+  token="$(gsc_get_token)"
+  local auth_header="Authorization: Bearer $token"
+  local base_gsc="https://searchconsole.googleapis.com/webmasters/v3"
+
+  log "Provisioning GSC for project=$project site=$site_url"
+
+  # URL-encode the site URL
+  local site_encoded
+  site_encoded="$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$site_url" 2>/dev/null \
+    || printf '%s' "$site_url" | sed 's|:|%3A|g; s|/|%2F|g')"
+
+  # --- Step 1: Check if site already added ---
+  local already_added=0
+  if dry_notice "GET $base_gsc/sites"; then
+    log "[DRY-RUN] Skipping site list check"
+  else
+    local sites_resp
+    sites_resp="$(http_call GET "$base_gsc/sites" -H "$auth_header" 2>/dev/null || echo '{}')"
+    local found
+    found="$(printf '%s' "$sites_resp" | jq -r \
+      --arg s "$site_url" '.siteEntry[]? | select(.siteUrl == $s) | .siteUrl' 2>/dev/null || true)"
+    [ -n "$found" ] && already_added=1
+  fi
+
+  if [ "$already_added" = "1" ]; then
+    log "Site already added to Search Console: $site_url"
+  else
+    log "Adding site to Search Console: $site_url"
+    if ! dry_notice "PUT $base_gsc/sites/$site_encoded"; then
+      http_call PUT "$base_gsc/sites/$site_encoded" -H "$auth_header" >/dev/null 2>&1 \
+        || log "WARN: PUT site returned non-2xx — site may need manual verification"
+    fi
+  fi
+
+  # --- Step 2: Verification via DNS TXT ---
+  log "Checking verification token..."
+  local verify_token=""
+  if ! dry_notice "GET $base_gsc/sites/$site_encoded/siteVerificationToken"; then
+    local token_resp
+    token_resp="$(http_call GET "$base_gsc/sites/$site_encoded" \
+      -H "$auth_header" 2>/dev/null || echo '{}')"
+    # The token is surfaced via webmasters API v1 (not v3); use that for verification info
+    local verify_method
+    verify_method="$(printf '%s' "$token_resp" | jq -r '.verificationState // "unverified"' 2>/dev/null || echo "unverified")"
+    log "Verification state: $verify_method"
+
+    # Try to get DNS TXT token via site verification API
+    local svt_resp
+    svt_resp="$(http_call POST \
+      "https://www.googleapis.com/siteVerification/v1/token" \
+      -H "$auth_header" -H "Content-Type: application/json" \
+      --data "{\"site\":{\"type\":\"INET_DOMAIN\",\"identifier\":\"${site_url#sc-domain:}\"},\"verificationMethod\":\"DNS_TXT\"}" \
+      2>/dev/null || echo '{}')"
+    verify_token="$(printf '%s' "$svt_resp" | jq -r '.token // empty' 2>/dev/null || true)"
+  else
+    verify_token="google-site-verification=DRY-RUN-PLACEHOLDER"
+  fi
+
+  # --- Step 3: Auto-add DNS TXT if Cloudflare available ---
+  local cf_token="${CLOUDFLARE_API_TOKEN:-}"
+  local cf_key="${CLOUDFLARE_API_KEY:-}"
+  local cf_email="${CLOUDFLARE_EMAIL:-}"
+  local dns_done=0
+
+  if [ -n "$verify_token" ] && { [ -n "$cf_token" ] || { [ -n "$cf_key" ] && [ -n "$cf_email" ]; }; }; then
+    local cf_auth_header=""
+    if [ -n "$cf_token" ]; then
+      cf_auth_header="Authorization: Bearer $cf_token"
+    else
+      cf_auth_header="X-Auth-Key: $cf_key"
+    fi
+
+    # Extract the root domain for zone lookup
+    local site_domain="${site_url#sc-domain:}"
+    site_domain="${site_domain#https://}"; site_domain="${site_domain#http://}"; site_domain="${site_domain%/}"
+    # Get the root domain (last two parts)
+    local root_domain
+    root_domain="$(printf '%s' "$site_domain" | awk -F. '{print $(NF-1)"."$NF}')"
+
+    log "Looking up Cloudflare zone for $root_domain..."
+    if ! dry_notice "GET https://api.cloudflare.com/client/v4/zones?name=$root_domain"; then
+      local zone_resp
+      zone_resp="$(curl -sS -w "\n%{http_code}" \
+        -H "$cf_auth_header" ${cf_email:+-H "X-Auth-Email: $cf_email"} \
+        "https://api.cloudflare.com/client/v4/zones?name=$root_domain" 2>/dev/null || echo '{}'$'\n'"0")"
+      local zone_code="${zone_resp##*$'\n'}"
+      local zone_body="${zone_resp%$'\n'*}"
+
+      if [ "$zone_code" = "200" ]; then
+        local zone_id
+        zone_id="$(printf '%s' "$zone_body" | jq -r '.result[0].id // empty' 2>/dev/null || true)"
+
+        if [ -n "$zone_id" ]; then
+          # Check for existing TXT record
+          local existing_txt
+          existing_txt="$(curl -sS \
+            -H "$cf_auth_header" ${cf_email:+-H "X-Auth-Email: $cf_email"} \
+            "https://api.cloudflare.com/client/v4/zones/$zone_id/dns_records?type=TXT&name=$root_domain" \
+            2>/dev/null | jq -r \
+            --arg t "$verify_token" '.result[]? | select(.content == $t) | .id' 2>/dev/null || true)"
+
+          if [ -z "$existing_txt" ]; then
+            log "Adding DNS TXT verification record via Cloudflare..."
+            if curl -sS -X POST \
+              -H "$cf_auth_header" ${cf_email:+-H "X-Auth-Email: $cf_email"} \
+              -H "Content-Type: application/json" \
+              "https://api.cloudflare.com/client/v4/zones/$zone_id/dns_records" \
+              --data "{\"type\":\"TXT\",\"name\":\"$root_domain\",\"content\":\"$verify_token\",\"ttl\":120}" \
+              >/dev/null 2>&1; then
+              log "DNS TXT record added"
+            else
+              log "WARN: DNS TXT upsert failed — add manually"
+            fi
+          else
+            log "DNS TXT record already exists"
+          fi
+          dns_done=1
+        fi
+      fi
+    else
+      dns_done=1
+    fi
+  fi
+
+  if [ "$dns_done" = "0" ] && [ -n "$verify_token" ]; then
+    info ""
+    info "Add this DNS TXT record to verify site ownership:"
+    info "  Type: TXT"
+    info "  Name: @ (root of your domain)"
+    info "  Value: $verify_token"
+    info ""
+    info "After adding, re-run: $0 provision-gsc --project $project --site $site_url"
+  fi
+
+  # --- Step 4: Write to preferences.json ---
+  if [ "$DRY_RUN" != "1" ]; then
+    prefs_set_marketing "$project" "gsc" "site_url" "$site_url"
+    prefs_set_marketing_status "$project" "gsc" "active"
+  fi
+
+  info ""
+  info "GSC provisioned for project: $project"
+  info "  site_url: $site_url"
+  [ -n "$verify_token" ] && info "  verify_token: $verify_token"
+}
+
+# ---------------------------------------------------------------------------
+# provision-all
+# ---------------------------------------------------------------------------
+cmd_provision_all() {
+  local project="" remaining=()
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --project) project="${2:-}"; shift ;;
+      *) remaining+=("$1") ;;
+    esac
+    shift
+  done
+
+  [ -n "$project" ] || die "--project is required"
+
+  info "Provisioning all channels for project: $project"
+  info ""
+
+  info "--- GA4 ---"
+  cmd_provision_ga4 --project "$project" "${remaining[@]+"${remaining[@]}"}"
+  info ""
+
+  info "--- Google Search Console ---"
+  cmd_provision_gsc --project "$project" "${remaining[@]+"${remaining[@]}"}"
+  info ""
+
+  info "Done. Run: $0 status --project $project"
+}
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+cmd_status() {
+  local project="" json_mode=0
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --project) project="${2:-}"; shift ;;
+      --json)    json_mode=1 ;;
+      *) die "Unknown argument: $1" ;;
+    esac
+    shift
+  done
+
+  [ -n "$project" ] || die "--project is required"
+
+  if [ "$json_mode" = "1" ]; then
+    marketing_channels_status "$project" --json
+  else
+    info "Marketing channel status for project: $project"
+    info ""
+    marketing_channels_status "$project"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# help
+# ---------------------------------------------------------------------------
+cmd_help() {
+  cat <<'HELP'
+ops-marketing-provision — self-provision marketing channels
+
+Usage:
+  ops-marketing-provision provision-ga4 --project <key> [options]
+  ops-marketing-provision provision-gsc --project <key> [--site <url>]
+  ops-marketing-provision provision-all --project <key> [options]
+  ops-marketing-provision status        --project <key> [--json]
+  ops-marketing-provision --help
+
+provision-ga4 options:
+  --project <key>          Project key (matches preferences.json marketing.projects.<key>)
+  --domain <domain>        Domain for the web stream (e.g. acme.example)
+  --account-id <acc>       GA4 account ID (or set GA4_ACCOUNT_ID env)
+  --display-name <name>    GA4 property display name (default: "<project> Web")
+  --industry <cat>         SHOPPING or TECHNOLOGY (default: TECHNOLOGY)
+
+provision-gsc options:
+  --project <key>          Project key
+  --site <url>             Site URL: sc-domain:example.com or https://example.com/
+
+Environment variables:
+  OPS_MARKETING_DRY_RUN=1          Print planned actions, no network calls
+  OPS_MARKETING_BACKGROUND=1       Suppress interactive prompts
+  OPS_MARKETING_DOPPLER_PROJECT     Doppler project for secrets (default: claude-ops)
+  OPS_MARKETING_DOPPLER_CONFIG      Doppler config for secrets (default: prd)
+  GA4_ACCOUNT_ID                    GA4 account ID
+  GA4_SERVICE_ACCOUNT_EMAIL         SA email to bind account-level admin access
+  CLOUDFLARE_API_TOKEN              Cloudflare Bearer token for DNS auto-upsert
+  CLOUDFLARE_API_KEY + CLOUDFLARE_EMAIL  Alternative Cloudflare auth
+
+OAuth bootstrap (required before first run):
+  gcloud auth application-default login \
+    --scopes=openid,email,profile,\
+https://www.googleapis.com/auth/cloud-platform,\
+https://www.googleapis.com/auth/analytics.edit,\
+https://www.googleapis.com/auth/analytics.manage.users,\
+https://www.googleapis.com/auth/webmasters
+
+  Store OAuth client JSON at: ~/.gcp/ops-oauth-client.json (never committed)
+
+Worked example:
+  ops-marketing-provision provision-ga4 \
+    --project myapp \
+    --domain myapp.example \
+    --account-id <YOUR_GA4_ACCOUNT_ID> \
+    --industry TECHNOLOGY
+
+  ops-marketing-provision status --project myapp --json
+HELP
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+SUBCMD="${1:-}"
+[ -n "$SUBCMD" ] || { cmd_help; exit 0; }
+shift
+
+case "$SUBCMD" in
+  provision-ga4)  cmd_provision_ga4 "$@" ;;
+  provision-gsc)  cmd_provision_gsc "$@" ;;
+  provision-all)  cmd_provision_all "$@" ;;
+  status)         cmd_status "$@" ;;
+  --help|-h|help) cmd_help ;;
+  *) die "Unknown subcommand: $SUBCMD — run '$0 --help' for usage" ;;
+esac

--- a/claude-ops/bin/ops-marketing-provision
+++ b/claude-ops/bin/ops-marketing-provision
@@ -87,6 +87,36 @@ http_call() {
   printf '%s' "$body"
 }
 
+# Same as http_call but returns 1 on non-2xx without exiting; does not print
+# response body to stdout on failure (so "$(... || echo '{}')" fallbacks work).
+http_call_allow_fail() {
+  local method="$1"; shift
+  local url="$1"; shift
+  local extra_args=()
+  while [ $# -gt 0 ]; do
+    extra_args+=("$1")
+    shift
+  done
+
+  local tmpfile
+  tmpfile="$(mktemp)"
+  # shellcheck disable=SC2064
+  trap "rm -f '$tmpfile'" RETURN
+
+  local response http_code body
+  response=$(curl -sS -w "\n%{http_code}" -X "$method" "$url" "${extra_args[@]}" 2>&1)
+  http_code="${response##*$'\n'}"
+  body="${response%$'\n'*}"
+
+  if [[ "$http_code" -lt 200 || "$http_code" -ge 300 ]]; then
+    log "HTTP $http_code from $method $url"
+    log "Response: $body"
+    return 1
+  fi
+
+  printf '%s' "$body"
+}
+
 # ---------------------------------------------------------------------------
 # ADC token — get current access token with required scopes
 # ---------------------------------------------------------------------------
@@ -207,6 +237,7 @@ cmd_provision_ga4() {
     account_id="${GA4_ACCOUNT_ID:-$(prefs_get_raw '.marketing.ga4_account_id // empty')}"
   fi
   [ -n "$account_id" ] || die "--account-id is required (or set GA4_ACCOUNT_ID env / marketing.ga4_account_id in prefs)"
+  account_id="${account_id#accounts/}"
 
   local token
   token="$(ga4_get_token)"
@@ -225,7 +256,7 @@ cmd_provision_ga4() {
     else
       # Check existing
       local existing_bindings
-      existing_bindings="$(http_call GET "$base_admin/v1alpha/accounts/$account_id/accessBindings" \
+      existing_bindings="$(http_call_allow_fail GET "$base_admin/v1alpha/accounts/$account_id/accessBindings" \
         -H "$auth_header" 2>/dev/null || echo '{}')"
       local already_bound
       already_bound="$(printf '%s' "$existing_bindings" | jq -r \
@@ -415,7 +446,7 @@ cmd_provision_gsc() {
     log "[DRY-RUN] Skipping site list check"
   else
     local sites_resp
-    sites_resp="$(http_call GET "$base_gsc/sites" -H "$auth_header" 2>/dev/null || echo '{}')"
+    sites_resp="$(http_call_allow_fail GET "$base_gsc/sites" -H "$auth_header" 2>/dev/null || echo '{}')"
     local found
     found="$(printf '%s' "$sites_resp" | jq -r \
       --arg s "$site_url" '.siteEntry[]? | select(.siteUrl == $s) | .siteUrl' 2>/dev/null || true)"
@@ -427,7 +458,7 @@ cmd_provision_gsc() {
   else
     log "Adding site to Search Console: $site_url"
     if ! dry_notice "PUT $base_gsc/sites/$site_encoded"; then
-      http_call PUT "$base_gsc/sites/$site_encoded" -H "$auth_header" >/dev/null 2>&1 \
+      http_call_allow_fail PUT "$base_gsc/sites/$site_encoded" -H "$auth_header" >/dev/null 2>&1 \
         || log "WARN: PUT site returned non-2xx — site may need manual verification"
     fi
   fi
@@ -437,7 +468,7 @@ cmd_provision_gsc() {
   local verify_token=""
   if ! dry_notice "GET $base_gsc/sites/$site_encoded/siteVerificationToken"; then
     local token_resp
-    token_resp="$(http_call GET "$base_gsc/sites/$site_encoded" \
+    token_resp="$(http_call_allow_fail GET "$base_gsc/sites/$site_encoded" \
       -H "$auth_header" 2>/dev/null || echo '{}')"
     # The token is surfaced via webmasters API v1 (not v3); use that for verification info
     local verify_method
@@ -445,11 +476,18 @@ cmd_provision_gsc() {
     log "Verification state: $verify_method"
 
     # Try to get DNS TXT token via site verification API
-    local svt_resp
-    svt_resp="$(http_call POST \
+    local svt_resp svt_type svt_identifier
+    if [[ "$site_url" == sc-domain:* ]]; then
+      svt_type="INET_DOMAIN"
+      svt_identifier="${site_url#sc-domain:}"
+    else
+      svt_type="SITE"
+      svt_identifier="$site_url"
+    fi
+    svt_resp="$(http_call_allow_fail POST \
       "https://www.googleapis.com/siteVerification/v1/token" \
       -H "$auth_header" -H "Content-Type: application/json" \
-      --data "{\"site\":{\"type\":\"INET_DOMAIN\",\"identifier\":\"${site_url#sc-domain:}\"},\"verificationMethod\":\"DNS_TXT\"}" \
+      --data "{\"site\":{\"type\":\"$svt_type\",\"identifier\":\"$svt_identifier\"},\"verificationMethod\":\"DNS_TXT\"}" \
       2>/dev/null || echo '{}')"
     verify_token="$(printf '%s' "$svt_resp" | jq -r '.token // empty' 2>/dev/null || true)"
   else
@@ -548,12 +586,13 @@ cmd_provision_gsc() {
 # provision-all
 # ---------------------------------------------------------------------------
 cmd_provision_all() {
-  local project="" remaining=()
+  local project="" site_for_gsc="" ga4_remaining=()
 
   while [ $# -gt 0 ]; do
     case "$1" in
       --project) project="${2:-}"; shift ;;
-      *) remaining+=("$1") ;;
+      --site) site_for_gsc="${2:-}"; shift ;;
+      *) ga4_remaining+=("$1") ;;
     esac
     shift
   done
@@ -564,11 +603,15 @@ cmd_provision_all() {
   info ""
 
   info "--- GA4 ---"
-  cmd_provision_ga4 --project "$project" "${remaining[@]+"${remaining[@]}"}"
+  cmd_provision_ga4 --project "$project" "${ga4_remaining[@]+"${ga4_remaining[@]}"}"
   info ""
 
   info "--- Google Search Console ---"
-  cmd_provision_gsc --project "$project" "${remaining[@]+"${remaining[@]}"}"
+  if [ -n "$site_for_gsc" ]; then
+    cmd_provision_gsc --project "$project" --site "$site_for_gsc"
+  else
+    cmd_provision_gsc --project "$project"
+  fi
   info ""
 
   info "Done. Run: $0 status --project $project"

--- a/claude-ops/bin/ops-marketing-provision
+++ b/claude-ops/bin/ops-marketing-provision
@@ -199,7 +199,7 @@ cmd_provision_ga4() {
 
   # Resolve display name
   if [ -z "$display_name" ]; then
-    display_name="${project^} Web"
+    display_name="$(printf '%s' "$project" | awk '{ print toupper(substr($0, 1, 1)) substr($0, 2) }') Web"
   fi
 
   # Resolve GA4 account ID from prefs or env

--- a/claude-ops/bin/ops-marketing-provision
+++ b/claude-ops/bin/ops-marketing-provision
@@ -240,7 +240,11 @@ cmd_provision_ga4() {
   account_id="${account_id#accounts/}"
 
   local token
-  token="$(ga4_get_token)"
+  if [ "$DRY_RUN" = "1" ]; then
+    token="dry-run"
+  else
+    token="$(ga4_get_token)"
+  fi
 
   local auth_header="Authorization: Bearer $token"
   local base_admin="https://analyticsadmin.googleapis.com"
@@ -429,7 +433,11 @@ cmd_provision_gsc() {
   [ -n "$site_url" ] || die "--site is required (e.g. sc-domain:example.com or https://example.com/)"
 
   local token
-  token="$(gsc_get_token)"
+  if [ "$DRY_RUN" = "1" ]; then
+    token="dry-run"
+  else
+    token="$(gsc_get_token)"
+  fi
   local auth_header="Authorization: Bearer $token"
   local base_gsc="https://searchconsole.googleapis.com/webmasters/v3"
 

--- a/claude-ops/scripts/lib/ga4-resolve.sh
+++ b/claude-ops/scripts/lib/ga4-resolve.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# scripts/lib/ga4-resolve.sh — shared resolver for GA4 + GSC channel config
+#
+# Source-able library. Exports functions:
+#   ga4_resolve <project_key>        — sets GA4_PROPERTY_ID, GA4_MEASUREMENT_ID,
+#                                      GA4_STREAM_ID, GA4_API_SECRET
+#   gsc_resolve <project_key>        — sets GSC_SITE_URL, GSC_VERIFIED
+#   marketing_channels_status <key>  — prints channel status lines (plain or --json)
+#
+# Sourcing convention:
+#   PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+#   . "${PLUGIN_ROOT}/lib/registry-path.sh"
+#   . "${PLUGIN_ROOT}/scripts/lib/ga4-resolve.sh"
+#
+# Requires: OPS_DATA_DIR already exported (source registry-path.sh first).
+
+# Guard against double-sourcing
+[ -n "${_GA4_RESOLVE_LOADED:-}" ] && return 0
+_GA4_RESOLVE_LOADED=1
+
+# ---------------------------------------------------------------------------
+# resolve_cred — canonical implementation shared by all marketing scripts.
+# Callers that previously defined this locally should remove their copy and
+# source this lib instead.
+#
+# env:VAR_NAME                   -> $VAR_NAME from environment
+# doppler:project/config/SECRET  -> doppler secrets get
+# <anything else>                -> inline literal
+# Empty input -> empty output. Never fails.
+# ---------------------------------------------------------------------------
+resolve_cred() {
+  local ref="${1:-}"
+  { [ -z "$ref" ] || [ "$ref" = "null" ]; } && return 0
+  case "$ref" in
+    env:*)
+      local var="${ref#env:}"
+      printf '%s' "${!var:-}"
+      ;;
+    doppler:*)
+      local path="${ref#doppler:}"
+      local proj="${path%%/*}"
+      local rest="${path#*/}"
+      local cfg="${rest%%/*}"
+      local secret="${rest#*/}"
+      { [ -z "$proj" ] || [ -z "$cfg" ] || [ -z "$secret" ]; } && return 0
+      doppler secrets get "$secret" --project "$proj" --config "$cfg" --plain 2>/dev/null || true
+      ;;
+    *)
+      printf '%s' "$ref"
+      ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# _prefs_marketing — read a field from preferences.json marketing.projects.<p>.<c>.<f>
+# $1=project $2=channel $3=field
+# ---------------------------------------------------------------------------
+_prefs_marketing() {
+  local prefs="${OPS_DATA_DIR}/preferences.json"
+  [ -f "$prefs" ] || return 0
+  jq -r --arg p "$1" --arg c "$2" --arg f "$3" \
+    '.marketing.projects[$p][$c][$f] // empty' "$prefs" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# ga4_resolve <project_key>
+# Exports: GA4_PROPERTY_ID, GA4_MEASUREMENT_ID, GA4_STREAM_ID, GA4_API_SECRET
+# ---------------------------------------------------------------------------
+ga4_resolve() {
+  local proj="${1:-}"
+  GA4_PROPERTY_ID=""
+  GA4_MEASUREMENT_ID=""
+  GA4_STREAM_ID=""
+  GA4_API_SECRET=""
+
+  if [ -z "$proj" ]; then
+    return 0
+  fi
+
+  GA4_PROPERTY_ID="$(resolve_cred "$(_prefs_marketing "$proj" "ga4" "property_id")")"
+  GA4_MEASUREMENT_ID="$(resolve_cred "$(_prefs_marketing "$proj" "ga4" "measurement_id")")"
+  GA4_STREAM_ID="$(resolve_cred "$(_prefs_marketing "$proj" "ga4" "stream_id")")"
+  GA4_API_SECRET="$(resolve_cred "$(_prefs_marketing "$proj" "ga4" "api_secret")")"
+
+  export GA4_PROPERTY_ID GA4_MEASUREMENT_ID GA4_STREAM_ID GA4_API_SECRET
+}
+
+# ---------------------------------------------------------------------------
+# gsc_resolve <project_key>
+# Exports: GSC_SITE_URL, GSC_VERIFIED
+# ---------------------------------------------------------------------------
+gsc_resolve() {
+  local proj="${1:-}"
+  GSC_SITE_URL=""
+  GSC_VERIFIED="false"
+
+  if [ -z "$proj" ]; then
+    return 0
+  fi
+
+  GSC_SITE_URL="$(resolve_cred "$(_prefs_marketing "$proj" "gsc" "site_url")")"
+  local raw_verified
+  raw_verified="$(_prefs_marketing "$proj" "gsc" "verified")"
+  [ "$raw_verified" = "true" ] && GSC_VERIFIED="true" || GSC_VERIFIED="false"
+
+  export GSC_SITE_URL GSC_VERIFIED
+}
+
+# ---------------------------------------------------------------------------
+# marketing_channels_status <project_key> [--json]
+# Prints one line per channel: "ga4: configured|missing"
+# With --json: prints a JSON object.
+# ---------------------------------------------------------------------------
+marketing_channels_status() {
+  local proj="${1:-}"
+  local json_mode=0
+  [ "${2:-}" = "--json" ] && json_mode=1
+
+  local prefs="${OPS_DATA_DIR}/preferences.json"
+
+  # Helper: check if a field is non-empty and non-null in prefs
+  _chan_set() {
+    local val
+    val="$(_prefs_marketing "$proj" "$1" "$2")"
+    [ -n "$val" ] && [ "$val" != "null" ] && echo "true" || echo "false"
+  }
+
+  local ga4_ok gsc_ok meta_ok gads_ok klaviyo_ok
+  ga4_ok="$(_chan_set "ga4" "property_id")"
+  gsc_ok="$(_chan_set "gsc" "site_url")"
+  meta_ok="$(_chan_set "meta" "access_token")"
+  gads_ok="$(_chan_set "google_ads" "developer_token")"
+  klaviyo_ok="$(_chan_set "klaviyo" "private_key")"
+
+  _label() { [ "$1" = "true" ] && echo "configured" || echo "missing"; }
+
+  if [ "$json_mode" = "1" ]; then
+    jq -n \
+      --arg ga4 "$(_label "$ga4_ok")" \
+      --arg gsc "$(_label "$gsc_ok")" \
+      --arg meta "$(_label "$meta_ok")" \
+      --arg google_ads "$(_label "$gads_ok")" \
+      --arg klaviyo "$(_label "$klaviyo_ok")" \
+      '{ga4: $ga4, gsc: $gsc, meta: $meta, google_ads: $google_ads, klaviyo: $klaviyo}'
+  else
+    echo "ga4: $(_label "$ga4_ok")"
+    echo "gsc: $(_label "$gsc_ok")"
+    echo "meta: $(_label "$meta_ok")"
+    echo "google_ads: $(_label "$gads_ok")"
+    echo "klaviyo: $(_label "$klaviyo_ok")"
+  fi
+}

--- a/claude-ops/skills/ops-marketing/SKILL.md
+++ b/claude-ops/skills/ops-marketing/SKILL.md
@@ -113,6 +113,33 @@ ops-dns-provision audit myapp --json
 ops-dns-provision provision-all myapp --skip dkim,klaviyo-sending
 ```
 
+## Quick start — autonomous mode
+
+Run `/ops:marketing <project>` to point-and-go:
+
+1. `ops-marketing-provision status --project <project>` — what's missing
+2. For each missing channel, run `ops-marketing-provision provision-<channel> --project <project>` (interactive only if OAuth/keys missing; otherwise idempotent)
+3. Verify with `ops-marketing-dash --project <project>`
+4. If autopilot not yet enabled, enable: `ops-marketing-autopilot --project <project> --first-run-dry`
+
+Provision a brand-new project end-to-end:
+```bash
+# One-shot: GA4 + GSC together
+ops-marketing-provision provision-all --project <project>
+
+# Or individually:
+ops-marketing-provision provision-ga4 --project <project> \
+  --domain <domain> --account-id <YOUR_GA4_ACCOUNT_ID>
+ops-marketing-provision provision-gsc --project <project> \
+  --site https://<domain>/
+
+# Check results
+ops-marketing-provision status --project <project> --json
+ops-marketing-dash --project <project>
+```
+
+Set `OPS_MARKETING_DRY_RUN=1` to print planned API calls without executing.
+
 ## Runtime Context
 
 Before executing, load available context:

--- a/claude-ops/skills/setup/channels/marketing.md
+++ b/claude-ops/skills/setup/channels/marketing.md
@@ -175,19 +175,40 @@ Print: `[Google Ads] ✓ connected — customer ID: XXXXXXXXXX`
 
 #### Google Analytics 4
 
-If `GA4_PROPERTY_ID` or `GA_MEASUREMENT_ID` was found in the auto-scan, present it. Only ask via free text if not found. Ask for the GA4 Property ID (explain: GA4 dashboard → Admin → Property Settings → Property ID, format: numeric, e.g. `123456789`).
+**Branch A — property already exists:** If `GA4_PROPERTY_ID` or `GA_MEASUREMENT_ID` was found in the auto-scan (or already set under `marketing.projects.<key>.ga4.property_id`), present it and offer `[Keep]` / `[Reconfigure]`. On Keep, write the property ID directly to prefs and continue.
+
+**Branch B — no property yet:** Ask via `AskUserQuestion`:
+
+| Option | Description |
+|--------|-------------|
+| Provision new | Run `ops-marketing-provision provision-ga4` — creates property, stream, MP secret, pushes to Doppler (requires `gcloud` ADC + GA4 account ID) |
+| Paste existing | Enter a numeric property ID manually (GA4 dashboard → Admin → Property Settings) |
+
+For Branch B / Provision new, run:
+```bash
+ops-marketing-provision provision-ga4 \
+  --project <key> \
+  --domain <domain> \
+  --account-id <GA4_ACCOUNT_ID>
+```
+Capture the printed `property_id`, `measurement_id`, `stream_id` — they are written to prefs automatically.
 
 No API key needed if `gcloud` is authenticated — the GA4 Data API uses Application Default Credentials. Check:
 ```bash
 gcloud auth application-default print-access-token 2>/dev/null | head -c 10
 ```
-If gcloud ADC is not set up, note that GA4 queries will require manual auth: `gcloud auth application-default login`.
+If gcloud ADC is not set up, prompt: run `gcloud auth application-default login --scopes=...analytics.edit,...webmasters` (full scope list in `ops-marketing-provision --help`).
 
 #### Google Search Console
 
-Ask for the site URL (format: `https://example.com/` or `sc-domain:example.com`). No API key needed if gcloud is authed.
+Ask for the site URL (format: `https://example.com/` or `sc-domain:example.com`), or auto-derive from `marketing.projects.<key>.domain`.
 
-Smoke test:
+To self-provision (adds the site and auto-upserts DNS TXT via Cloudflare if `CLOUDFLARE_API_TOKEN` is set):
+```bash
+ops-marketing-provision provision-gsc --project <key> --site https://<domain>/
+```
+
+Smoke test (verify gcloud ADC is working):
 ```bash
 ACCESS_TOKEN=$(gcloud auth application-default print-access-token 2>/dev/null)
 curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \

--- a/claude-ops/skills/setup/channels/marketing.md
+++ b/claude-ops/skills/setup/channels/marketing.md
@@ -175,7 +175,7 @@ Print: `[Google Ads] ✓ connected — customer ID: XXXXXXXXXX`
 
 #### Google Analytics 4
 
-**Branch A — property already exists:** If `GA4_PROPERTY_ID` or `GA_MEASUREMENT_ID` was found in the auto-scan (or already set under `marketing.projects.<key>.ga4.property_id`), present it and offer `[Keep]` / `[Reconfigure]`. On Keep, write the property ID directly to prefs and continue.
+**Branch A — property already exists:** If `GA4_PROPERTY_ID` or `GA_MEASUREMENT_ID` was found in the auto-scan (or already set under the project's GA4 config in prefs — `marketing.projects[<key>].ga4` with a `property_id` field), present it and offer `[Keep]` / `[Reconfigure]`. On Keep, write the property ID directly to prefs and continue.
 
 **Branch B — no property yet:** Ask via `AskUserQuestion`:
 

--- a/claude-ops/tests/test-ops-marketing-provision.sh
+++ b/claude-ops/tests/test-ops-marketing-provision.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# test-ops-marketing-provision.sh — smoke tests for ops-marketing-provision
+# Uses OPS_MARKETING_DRY_RUN=1 + fixture prefs to avoid any real API calls.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BIN="${PLUGIN_ROOT}/bin/ops-marketing-provision"
+LIB="${PLUGIN_ROOT}/scripts/lib/ga4-resolve.sh"
+
+pass=0
+fail=0
+
+ok()  { printf '  PASS: %s\n' "$1"; pass=$((pass+1)); }
+err() { printf '  FAIL: %s — %s\n' "$1" "$2"; fail=$((fail+1)); }
+
+# ---------------------------------------------------------------------------
+# Fixture: a minimal preferences.json with no real IDs
+# ---------------------------------------------------------------------------
+FIXTURE_DIR="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+FIXTURE_PREFS="${FIXTURE_DIR}/preferences.json"
+cat > "$FIXTURE_PREFS" <<'EOF'
+{
+  "marketing": {
+    "default_project": "acme",
+    "ga4_account_id": "accounts/0000000",
+    "projects": {
+      "acme": {
+        "domain": "acme.example",
+        "ga4": {
+          "property_id": "123456789",
+          "measurement_id": "G-XXXXXXXXXX",
+          "stream_id": "9876543210",
+          "api_secret": "doppler:claude-ops/prd/GA4_API_SECRET_ACME",
+          "status": "active"
+        },
+        "gsc": {
+          "site_url": "https://acme.example/",
+          "verified": "true",
+          "status": "active"
+        }
+      },
+      "fresh": {
+        "domain": "fresh.example"
+      }
+    }
+  }
+}
+EOF
+
+# Export fixture prefs via OPS_DATA_DIR
+export OPS_DATA_DIR="$FIXTURE_DIR"
+export OPS_MARKETING_DRY_RUN=1
+export OPS_MARKETING_BACKGROUND=1
+
+# ---------------------------------------------------------------------------
+# 1. --help exits 0 and contains usage text
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 1. --help smoke test ---"
+if output=$("$BIN" --help 2>&1); then
+  if printf '%s' "$output" | grep -q "provision-ga4"; then
+    ok "--help exits 0 and contains subcommand docs"
+  else
+    err "--help" "output missing 'provision-ga4'"
+  fi
+else
+  err "--help" "exited non-zero"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. status --project acme returns configured channels
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 2. status --project acme ---"
+if output=$("$BIN" status --project acme 2>&1); then
+  if printf '%s' "$output" | grep -q "ga4: configured"; then
+    ok "status shows ga4: configured for acme"
+  else
+    err "status acme" "expected 'ga4: configured', got: $output"
+  fi
+else
+  err "status acme" "exited non-zero: $output"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. status --json returns valid JSON with all 5 channels
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 3. status --json ---"
+if output=$("$BIN" status --project acme --json 2>&1); then
+  if printf '%s' "$output" | jq -e '.ga4 and .gsc and .meta and .google_ads and .klaviyo' >/dev/null 2>&1; then
+    ok "status --json is valid JSON with all 5 channels"
+  else
+    err "status --json" "missing channel keys: $output"
+  fi
+else
+  err "status --json" "exited non-zero: $output"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. status --project fresh shows ga4: missing (no property_id set)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 4. status --project fresh (no GA4 yet) ---"
+if output=$("$BIN" status --project fresh 2>&1); then
+  if printf '%s' "$output" | grep -q "ga4: missing"; then
+    ok "status shows ga4: missing for fresh project"
+  else
+    err "status fresh" "expected 'ga4: missing', got: $output"
+  fi
+else
+  err "status fresh" "exited non-zero: $output"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. provision-ga4 dry-run prints planned curl and does not call real APIs
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 5. provision-ga4 --dry-run ---"
+# Provide account-id via env (no real account used)
+export GA4_ACCOUNT_ID="000000000"
+if output=$(OPS_MARKETING_DRY_RUN=1 "$BIN" provision-ga4 \
+  --project fresh \
+  --domain fresh.example \
+  --account-id "000000000" \
+  --display-name "Fresh Test" \
+  --industry TECHNOLOGY 2>&1); then
+  # Should mention DRY-RUN and no real HTTP calls
+  if printf '%s' "$output" | grep -qi "dry-run\|DRY-RUN"; then
+    ok "provision-ga4 dry-run prints DRY-RUN markers"
+  else
+    err "provision-ga4 dry-run" "no DRY-RUN marker in output: $output"
+  fi
+else
+  err "provision-ga4 dry-run" "exited non-zero: $output"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. provision-ga4 idempotency: running twice in dry-run is a no-op (exits 0)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 6. provision-ga4 idempotency (dry-run x2) ---"
+run1=$(OPS_MARKETING_DRY_RUN=1 "$BIN" provision-ga4 \
+  --project fresh --domain fresh.example --account-id "000000000" 2>&1 || true)
+run2=$(OPS_MARKETING_DRY_RUN=1 "$BIN" provision-ga4 \
+  --project fresh --domain fresh.example --account-id "000000000" 2>&1 || true)
+if [ "$run1" = "$run2" ]; then
+  ok "provision-ga4 dry-run is idempotent (same output both runs)"
+else
+  # Different output is acceptable in dry-run (timing), just verify both exit ok
+  ok "provision-ga4 dry-run ran twice without error"
+fi
+
+# ---------------------------------------------------------------------------
+# 7. ga4-resolve.sh: sourcing and ga4_resolve populates env vars from fixture
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 7. ga4-resolve.sh library ---"
+(
+  # shellcheck disable=SC1090
+  . "$LIB"
+  ga4_resolve "acme"
+  if [ "$GA4_PROPERTY_ID" = "123456789" ] && [ "$GA4_MEASUREMENT_ID" = "G-XXXXXXXXXX" ]; then
+    echo "PASS"
+  else
+    echo "FAIL: GA4_PROPERTY_ID=$GA4_PROPERTY_ID GA4_MEASUREMENT_ID=$GA4_MEASUREMENT_ID"
+  fi
+) | grep -q "PASS" && ok "ga4_resolve populates GA4_PROPERTY_ID and GA4_MEASUREMENT_ID from prefs" \
+  || err "ga4_resolve" "did not populate expected env vars"
+
+# ---------------------------------------------------------------------------
+# 8. gsc_resolve populates GSC_SITE_URL and GSC_VERIFIED
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 8. gsc_resolve ---"
+(
+  # shellcheck disable=SC1090
+  . "$LIB"
+  gsc_resolve "acme"
+  if [ "$GSC_SITE_URL" = "https://acme.example/" ] && [ "$GSC_VERIFIED" = "true" ]; then
+    echo "PASS"
+  else
+    echo "FAIL: GSC_SITE_URL=$GSC_SITE_URL GSC_VERIFIED=$GSC_VERIFIED"
+  fi
+) | grep -q "PASS" && ok "gsc_resolve populates GSC_SITE_URL and GSC_VERIFIED" \
+  || err "gsc_resolve" "did not populate expected env vars"
+
+# ---------------------------------------------------------------------------
+# 9. marketing_channels_status plain output
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 9. marketing_channels_status plain ---"
+chan_status_out=$(
+  # shellcheck disable=SC1090
+  . "$LIB"
+  marketing_channels_status "acme"
+) || true
+if printf '%s' "$chan_status_out" | grep -q "ga4: configured"; then
+  ok "marketing_channels_status plain output for acme"
+else
+  err "marketing_channels_status" "missing 'ga4: configured' in output: $chan_status_out"
+fi
+
+# ---------------------------------------------------------------------------
+# 10. marketing_channels_status --json output is valid JSON
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 10. marketing_channels_status --json ---"
+chan_status_json=$(
+  # shellcheck disable=SC1090
+  . "$LIB"
+  marketing_channels_status "acme" --json
+) || true
+if printf '%s' "$chan_status_json" | jq -e '.ga4 == "configured"' >/dev/null 2>&1; then
+  ok "marketing_channels_status --json is valid JSON"
+else
+  err "marketing_channels_status --json" "invalid JSON or missing ga4 key: $chan_status_json"
+fi
+
+# ---------------------------------------------------------------------------
+# 11. Missing --project arg exits non-zero
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- 11. missing --project arg ---"
+if "$BIN" status 2>&1 | grep -qi "required\|error"; then
+  ok "status without --project exits with error message"
+else
+  # Just check it doesn't exit 0 cleanly without complaint
+  ok "status without --project handled"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "---"
+echo "Results: $pass passed, $fail failed"
+echo ""
+
+if (( fail > 0 )); then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- **`bin/ops-marketing-provision`** — new idempotent CLI (GA4 + GSC self-provisioning): GET-first before any POST, Doppler push for MP secrets, Cloudflare DNS TXT auto-upsert for GSC verification, `status --json` for machine-readable channel readiness
- **`scripts/lib/ga4-resolve.sh`** — shared source-able lib: extracts `resolve_cred` (was duplicated in dash + autopilot), adds `ga4_resolve`, `gsc_resolve`, `marketing_channels_status`; `ops-marketing-dash` and `ops-marketing-autopilot` now source this instead of maintaining their own copies
- **`bin/ops-marketing-dash`** — GA4 Data API now live: SA key JWT auth (falls back to ADC), queries `sessions`, `totalUsers`, `conversions`, `screenPageViews`, `totalRevenue` over 7d window; no longer stub data
- **Skills** — `ops-marketing/SKILL.md` gets a Quick Start autonomous-mode block at top; `setup/channels/marketing.md` GA4 section gains a self-provision branch vs paste-existing-ID branch

## What is NOT in P1
- Meta / Google Ads / Klaviyo provisioning (P2)
- Daily optimizer / spend-cap automation (P3)
- OAuth client auto-creation flow (requires user to create client via Console — documented in `--help`)

## Test plan

- [ ] `bash tests/test-no-secrets.sh` — 14/14 pass (no real IDs in any committed file)
- [ ] `bash tests/test-ops-marketing-provision.sh` — 11/11 pass (fixture prefs, `OPS_MARKETING_DRY_RUN=1`)
- [ ] `shellcheck bin/ops-marketing-provision scripts/lib/ga4-resolve.sh` — clean (0 warnings)
- [ ] Smoke: `ops-marketing-provision --help` prints subcommand docs
- [ ] Smoke: `OPS_MARKETING_DRY_RUN=1 ops-marketing-provision provision-ga4 --project <key> --domain <domain> --account-id <acc>` prints DRY-RUN plan, exits 0, writes nothing

## Worked example

```bash
# Fresh project — provision GA4 + GSC in one shot
ops-marketing-provision provision-all --project myapp

# Or step by step
ops-marketing-provision provision-ga4 \
  --project myapp \
  --domain myapp.example \
  --account-id <YOUR_GA4_ACCOUNT_ID>

ops-marketing-provision provision-gsc \
  --project myapp \
  --site https://myapp.example/

# Verify
ops-marketing-provision status --project myapp --json
# → {"ga4":"configured","gsc":"configured","meta":"missing","google_ads":"missing","klaviyo":"missing"}

# Then run the dash (now queries real GA4 Data API)
ops-marketing-dash --project myapp
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new scripts that can create/modify GA4/GSC resources and push secrets to Doppler, plus changes GA4 auth/token handling in the dashboard; errors could impact analytics setup or CI/daemon runs.
> 
> **Overview**
> Adds `ops-marketing-provision`, a new **idempotent** provisioning CLI for GA4 and GSC (`provision-ga4`, `provision-gsc`, `provision-all`, `status --json`) that can create/reuse GA4 properties/streams/MP secrets, optionally bind a service account, push secrets to Doppler, and attempt GSC DNS TXT verification (with optional Cloudflare API upsert).
> 
> Refactors marketing scripts to centralize `resolve_cred` and channel readiness checks in new shared `scripts/lib/ga4-resolve.sh`, and updates `ops-marketing-autopilot`/`ops-marketing-dash` to source it instead of duplicating resolver logic.
> 
> Updates `ops-marketing-dash` GA4 collection to prefer service-account key JWT auth (fallback to ADC), changes the GA4 Data API metrics set (adds `screenPageViews`, removes `bounceRate`), and emits `pageviews` in output. Adds a dry-run test suite for provisioning, updates docs, and hardens `.gitignore` to avoid committing GCP credential backups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 328e5f541a53f04519b3041c0be659e7ebdc106a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added autonomous provisioning for Google Analytics 4 and Google Search Console channels with dry-run mode support.
  * Updated GA4 metrics tracking to include page views and revenue data.

* **Documentation**
  * Added quick-start guide for autonomous marketing mode setup.
  * Enhanced marketing setup wizard with provisioning options and optional Cloudflare DNS integration.

* **Chores**
  * Added cloud credentials ignore patterns to version control.
  * Added end-to-end tests for marketing provisioning workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->