### PR TITLE
feat(ops:marketing): entry-point verbs + Rule 0 cleanup + brand-voice defaults fix

### DIFF
--- a/claude-ops/bin/ops-daemon-manager
+++ b/claude-ops/bin/ops-daemon-manager
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# bin/ops-daemon-manager — Thin wrapper that adds `enable` / `disable` subcommands
+# on top of scripts/ops-daemon-manager.sh.
+#
+# New subcommands:
+#   enable  <svc>   Set services[<svc>].enabled = true  in daemon-services.json, then restart daemon.
+#   disable <svc>   Set services[<svc>].enabled = false in daemon-services.json, then restart daemon.
+#
+# All other subcommands (install, upgrade, ensure-current, uninstall, status, restart) are
+# passed through verbatim to scripts/ops-daemon-manager.sh.
+#
+# Exit codes mirror ops-daemon-manager.sh (0 = success, 1 = error, 64 = usage).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Resolve OPS_DATA_DIR via the canonical lib (same as every other bin/).
+# SC2034: OPS_PLUGIN_ROOT_FALLBACK is read by registry-path.sh when sourced
+# shellcheck disable=SC2034
+OPS_PLUGIN_ROOT_FALLBACK="$PLUGIN_ROOT"
+# shellcheck disable=SC1091
+. "${PLUGIN_ROOT}/lib/registry-path.sh"
+
+LOG_DIR="${OPS_DATA_DIR}/logs"
+mkdir -p "$LOG_DIR"
+LOG="${LOG_DIR}/setup.log"
+
+_log() { printf '%s [ops-daemon-manager] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" | tee -a "$LOG" >&2; }
+
+_usage() {
+  cat >&2 <<EOF
+Usage: ops-daemon-manager <enable|disable|install|upgrade|ensure-current|uninstall|status|restart> [svc|options]
+
+  enable  <svc>   Enable a daemon service and restart the daemon
+  disable <svc>   Disable a daemon service and restart the daemon
+  (all other subcommands are forwarded to scripts/ops-daemon-manager.sh)
+EOF
+  exit 64
+}
+
+# ── Subcommand dispatch ────────────────────────────────────────────────────────
+SUBCMD="${1:-}"
+[ -z "$SUBCMD" ] && _usage
+
+case "$SUBCMD" in
+  enable|disable)
+    SVC="${2:-}"
+    if [ -z "$SVC" ]; then
+      _log "ERROR: ${SUBCMD} requires a service name"
+      _usage
+    fi
+
+    DAEMON_SERVICES_JSON="${OPS_DATA_DIR}/daemon-services.json"
+
+    # Bootstrap file from defaults if absent
+    if [ ! -f "$DAEMON_SERVICES_JSON" ]; then
+      if [ -f "${PLUGIN_ROOT}/scripts/daemon-services.default.json" ]; then
+        cp "${PLUGIN_ROOT}/scripts/daemon-services.default.json" "$DAEMON_SERVICES_JSON"
+        _log "bootstrapped daemon-services.json from default"
+      else
+        # Create a minimal skeleton so jq can work
+        printf '{"services":{}}\n' > "$DAEMON_SERVICES_JSON"
+        _log "bootstrapped empty daemon-services.json"
+      fi
+    fi
+
+    # Determine enabled value
+    if [ "$SUBCMD" = "enable" ]; then
+      ENABLED_VAL="true"
+    else
+      ENABLED_VAL="false"
+    fi
+
+    # Atomic write: jq → tmp → mv (idempotent)
+    TMP_FILE="${DAEMON_SERVICES_JSON}.tmp.$$"
+    if jq --arg svc "$SVC" --argjson val "$ENABLED_VAL" \
+        '.services[$svc].enabled = $val' \
+        "$DAEMON_SERVICES_JSON" > "$TMP_FILE" 2>/dev/null; then
+      mv "$TMP_FILE" "$DAEMON_SERVICES_JSON"
+      _log "${SUBCMD} ${SVC}: services.${SVC}.enabled = ${ENABLED_VAL}"
+    else
+      rm -f "$TMP_FILE"
+      _log "ERROR: jq failed writing daemon-services.json"
+      exit 1
+    fi
+
+    # Restart the daemon so the change takes effect immediately.
+    # Tolerate failure (daemon may not be installed yet — first-time setup).
+    if "${PLUGIN_ROOT}/scripts/ops-daemon-manager.sh" restart 2>/dev/null; then
+      _log "daemon restarted after ${SUBCMD} ${SVC}"
+    else
+      _log "WARN: daemon restart returned non-zero — daemon may not be installed yet; service flag persisted"
+    fi
+    ;;
+
+  *)
+    # Pass-through to the full daemon manager
+    exec "${PLUGIN_ROOT}/scripts/ops-daemon-manager.sh" "$@"
+    ;;
+esac

--- a/claude-ops/bin/ops-deploy-fix-build-trigger
+++ b/claude-ops/bin/ops-deploy-fix-build-trigger
@@ -28,13 +28,20 @@ echo "$output" | tail -120 | grep -qE \
 
 last_lines=$(echo "$output" | tail -120)
 
-# Repo = healify (mobile build hooks always operate against this)
-repo_slug="healify"
+# Repo slug and org are read from env (set via Doppler / shell profile) so this
+# hook stays project-agnostic and Rule-0 clean.
+repo_slug="${OPS_DEPLOY_FIX_REPO_SLUG:-}"
+repo_org="${OPS_DEPLOY_FIX_REPO_ORG:-}"
+if [ -z "$repo_slug" ]; then
+  notify "Build failed" "OPS_DEPLOY_FIX_REPO_SLUG not set — cannot dispatch fixer. Set it in your shell profile or Doppler."
+  exit 0
+fi
 # `|| true` — locate_repo returns 1 when the checkout is absent. Without it the
 # plain assignment leaks that non-zero status and `set -e` aborts the hook
 # before the fallback below (and the transient/dispatch paths) can run.
-repo_path=$(locate_repo "Lifecycle-Innovations-Limited/healify" 2>/dev/null) || true
-[ -z "$repo_path" ] && repo_path="$HOME/healify"
+repo_path=""
+[ -n "$repo_org" ] && repo_path=$(locate_repo "${repo_org}/${repo_slug}" 2>/dev/null) || true
+[ -z "$repo_path" ] && repo_path="$HOME/${repo_slug}"
 branch=$(git -C "$repo_path" branch --show-current 2>/dev/null || echo "unknown")
 
 # Transient → tell user to retry, no agent

--- a/claude-ops/bin/ops-marketing-autopilot
+++ b/claude-ops/bin/ops-marketing-autopilot
@@ -1305,6 +1305,7 @@ for proj in "${PROJECTS[@]}"; do
       ln -sf "$REPORT" "${REPORT_DIR}/${proj}-latest.md"
       log "project=$proj onboard REFUSED (no cap)"
       RC=1
+      DRY_RUN="$_SAVED_DRY_RUN"
       continue
     fi
     report "- Daily spend cap: \$${CAP}"
@@ -1315,6 +1316,7 @@ for proj in "${PROJECTS[@]}"; do
     ln -sf "$REPORT" "${REPORT_DIR}/${proj}-latest.md"
     notify "$proj"
     log "project=$proj onboard done (dry=${DRY_RUN} mutations=${MUTATIONS} escalated=${ESCALATED})"
+    DRY_RUN="$_SAVED_DRY_RUN"
     continue
   fi
 
@@ -1325,6 +1327,7 @@ for proj in "${PROJECTS[@]}"; do
     ln -sf "$REPORT" "${REPORT_DIR}/${proj}-latest.md"
     log "project=$proj REFUSED (no cap)"
     RC=1
+    DRY_RUN="$_SAVED_DRY_RUN"
     continue
   fi
   report "- Daily spend cap: \$${CAP}"

--- a/claude-ops/bin/ops-marketing-autopilot
+++ b/claude-ops/bin/ops-marketing-autopilot
@@ -42,7 +42,9 @@ PREFS="${OPS_AUTOPILOT_PREFS:-${OPS_DATA_DIR}/preferences.json}"
 REPORT_DIR="${OPS_DATA_DIR}/reports/marketing-autopilot"
 STATE_DIR="${OPS_DATA_DIR}/state/autopilot"
 LOG_DIR="${OPS_DATA_DIR}/logs"
-INSTALL_MARKER="${STATE_DIR}/.installed"
+# INSTALL_MARKER is now per-project: ${STATE_DIR}/${proj}.installed
+# The legacy single-file marker is intentionally removed so every project gets
+# its own forced-dry first pass regardless of when other projects were onboarded.
 mkdir -p "$REPORT_DIR" "$STATE_DIR" "$LOG_DIR"
 
 LOG="${LOG_DIR}/marketing-autopilot.log"
@@ -71,15 +73,9 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-# First install run is always dry — never mutate before an operator has seen
-# one full dry pass in the report.
-if [ ! -f "$INSTALL_MARKER" ]; then
-  DRY_RUN=1
-  FIRST_RUN=1
-  log "first run detected — forcing --dry-run"
-else
-  FIRST_RUN=0
-fi
+# FIRST_RUN / per-project dry gate is evaluated inside the main loop per project.
+# (Each project has its own install marker: ${STATE_DIR}/${proj}.installed)
+FIRST_RUN=0
 
 TODAY="$(date +%Y-%m-%d)"
 DOW="$(date +%u)"  # 1=Mon .. 7=Sun
@@ -825,13 +821,20 @@ delegate_claude() {
 
     # Build brief via claude_invoke (brand-aware)
     local brand_name; brand_name="$(jq -r --arg p "$proj" '.marketing.projects[$p].brand.name // $p' "$PREFS" 2>/dev/null || echo "$proj")"
-    local brand_voice; brand_voice="$(jq -r --arg p "$proj" '.marketing.projects[$p].brand.voice // "health, wellness, vibrant"' "$PREFS" 2>/dev/null || echo "health, wellness, vibrant")"
+    local brand_voice; brand_voice="$(jq -r --arg p "$proj" '.marketing.projects[$p].brand.voice // empty' "$PREFS" 2>/dev/null || true)"
+    if [ -z "$brand_voice" ]; then
+      escalate "$proj" "brand.voice not configured — run /ops:marketing onboard ${proj} to set brand voice before generating creatives"
+      return 0
+    fi
     local brief_prompt="Generate a brief for a single ad creative for brand '${brand_name}' with voice: ${brand_voice}. Return ONLY JSON: {\"prompt\":\"<vivid 9:16 portrait ad description>\",\"type\":\"video\",\"copy\":\"<headline copy 5-8 words>\"}"
     local brief_raw
     brief_raw="$(claude_invoke -p "$brief_prompt" --model claude-opus-4-7 --no-session-persistence --output-format json 2>/dev/null || echo '')"
     local brief_json
-    brief_json="$(extract_json "$brief_raw" 2>/dev/null || echo '{"prompt":"Compelling health and wellness ad, 9:16 portrait, vibrant lifestyle","type":"video","copy":"Transform Your Health Today"}')"
-    [ -z "$brief_json" ] || [ "$brief_json" = "{}" ] && brief_json='{"prompt":"Compelling health and wellness ad, 9:16 portrait, vibrant lifestyle","type":"video","copy":"Transform Your Health Today"}'
+    brief_json="$(extract_json "$brief_raw" 2>/dev/null || echo '')"
+    if [ -z "$brief_json" ] || [ "$brief_json" = "{}" ]; then
+      escalate "$proj" "brief generation failed — claude_invoke returned empty; check credit pool and model availability"
+      return 0
+    fi
 
     local gen_brief; gen_brief="$(printf '%s' "$brief_json" | jq '{prompt,type}' 2>/dev/null || echo "$brief_json")"
     local copy_text; copy_text="$(printf '%s' "$brief_json" | jq -r '.copy // ""' 2>/dev/null || echo '')"
@@ -1264,6 +1267,24 @@ for proj in "${PROJECTS[@]}"; do
     log "SECURITY: skipping project key '${proj}' — fails [A-Za-z0-9._-] allowlist or is . / .."
     continue
   fi
+
+  # Per-project install marker — first run for THIS project is always dry.
+  PROJ_INSTALL_MARKER="${STATE_DIR}/${proj}.installed"
+  if [ ! -f "$PROJ_INSTALL_MARKER" ]; then
+    PROJ_DRY_RUN=1
+    FIRST_RUN=1
+    log "project=${proj}: first run detected — forcing --dry-run"
+  else
+    PROJ_DRY_RUN="$DRY_RUN"
+    FIRST_RUN=0
+  fi
+  # Effective dry-run for this project (global --dry-run OR per-project first run).
+  # Shadow the global DRY_RUN so all sub-functions (mutate, create_object, etc.)
+  # automatically respect the per-project gate without needing changes.
+  _SAVED_DRY_RUN="$DRY_RUN"
+  DRY_RUN="$PROJ_DRY_RUN"
+  _PROJ_EFFECTIVE_DRY="$DRY_RUN"
+
   REPORT="${REPORT_DIR}/${proj}-${TODAY}.md"
   : > "$REPORT"
   MUTATIONS=0; ESCALATED=0; META_FATIGUE=0
@@ -1272,8 +1293,8 @@ for proj in "${PROJECTS[@]}"; do
   export _CREATE_OBJ_PROJ
   report "# Marketing Autopilot — ${proj} — ${TODAY}"
   report ""
-  report "- Mode: $([ "$DRY_RUN" = "1" ] && echo 'DRY-RUN (no mutations)' || echo 'LIVE')"
-  [ "${FIRST_RUN:-0}" = "1" ] && report "- (first install run — forced dry)"
+  report "- Mode: $([ "$_PROJ_EFFECTIVE_DRY" = "1" ] && echo 'DRY-RUN (no mutations)' || echo 'LIVE')"
+  [ "${FIRST_RUN:-0}" = "1" ] && report "- (first install run for ${proj} — forced dry)"
 
   # Onboarding route
   if [ "$DO_ONBOARD" = "1" ]; then
@@ -1333,10 +1354,13 @@ for proj in "${PROJECTS[@]}"; do
   report "_autopilot pass complete — mutations: ${MUTATIONS}, escalated: ${ESCALATED}, $(date -u +%Y-%m-%dT%H:%M:%SZ)_"
   ln -sf "$REPORT" "${REPORT_DIR}/${proj}-latest.md"
   notify "$proj"
-  log "project=$proj done (dry=${DRY_RUN} mutations=${MUTATIONS} escalated=${ESCALATED})"
-done
+  log "project=$proj done (dry=${_PROJ_EFFECTIVE_DRY} mutations=${MUTATIONS} escalated=${ESCALATED})"
 
-# Mark installed after the first (forced-dry) pass so the next run can go live.
-[ "${FIRST_RUN:-0}" = "1" ] && date -u +%Y-%m-%dT%H:%M:%SZ > "$INSTALL_MARKER"
+  # Mark this project installed after its first (forced-dry) pass.
+  [ "${FIRST_RUN:-0}" = "1" ] && date -u +%Y-%m-%dT%H:%M:%SZ > "$PROJ_INSTALL_MARKER"
+
+  # Restore global DRY_RUN for next iteration (may differ from this project's gate)
+  DRY_RUN="$_SAVED_DRY_RUN"
+done
 
 exit $RC

--- a/claude-ops/prompts/build-fix.md
+++ b/claude-ops/prompts/build-fix.md
@@ -10,10 +10,10 @@ You are headless inside Claude Code with full claude-ops tooling:
 |---|---|
 | Mobile / Expo / RN / iOS Fastlane | spawn the `Mobile App Specialist` subagent |
 | TypeScript / type errors | spawn the `typescript-reviewer` subagent |
-| Healify cross-repo contract breakage | spawn the `fullstack-mobile-architect` subagent |
+| Cross-repo contract breakage | spawn the `fullstack-mobile-architect` subagent |
 | Sentry context for runtime crashes | `mcp__sentry__search_events` |
-| Apple Developer / TestFlight state | `python3 scripts/asc-manage-builds.py` (in healify repo) |
-| Doppler secret resolution | `doppler secrets get <KEY> --project healify --config <env> --plain` |
+| Apple Developer / TestFlight state | `python3 scripts/asc-manage-builds.py` (in your mobile repo) |
+| Doppler secret resolution | `doppler secrets get <KEY> --project <your-project> --config <env> --plain` |
 | Library version drift | `npx expo install --check`, `npm ls <pkg>`, Context7 MCP for docs |
 
 Do NOT invent agent names. Fall back to `general-purpose` if unsure.
@@ -44,7 +44,7 @@ Categorize the failure into ONE bucket — your fix flows from the bucket:
 | **App Store Connect transient** | `503`, `timed out`, `Apple ID server.*temporarily unavailable` | Recommend retry; do NOT open PR. |
 | **Doppler missing** | `DOPPLER_TOKEN`, `secret not found` | Surface the missing key + its required Doppler path; do NOT auto-rotate. |
 | **Dirty working tree** | `prepare-build-branch.sh.*Abort`, `Stash or commit your changes` | Stash the variant artifacts (`app.config.js`, `credentials.json`); recommend retry. |
-| **patch-package mismatch** | `verify-runtime-patches.js`, patch did not apply | Restore the patch invariant; reference `~/healify/CLAUDE.md` Runtime patches section. |
+| **patch-package mismatch** | `verify-runtime-patches.js`, patch did not apply | Restore the patch invariant; reference the repo's `CLAUDE.md` Runtime patches section. |
 
 # Workflow
 
@@ -65,7 +65,7 @@ Categorize the failure into ONE bucket — your fix flows from the bucket:
 - **NEVER re-run `npm run build:all` / `build:*:local` yourself.** That's the operator's call.
 - **NEVER bump major dep versions.** Patch only.
 - **NEVER add `eslint-disable` / `@ts-ignore` to mask errors.** Fix the cause.
-- **NEVER touch `app.config.js` directly** — edit `src/config/app.config.<variant>.js` (per `~/healify/CLAUDE.md`).
+- **NEVER touch `app.config.js` directly** — edit `src/config/app.config.<variant>.js` (per the repo's `CLAUDE.md`).
 - **NEVER invalidate signing material** (`fastlane match nuke`) without explicit confirmation.
 - **NEVER ship dependency upgrades unrelated to the bucket.**
 - **MAX 8 files changed.** If more, STOP and report scope mismatch.

--- a/claude-ops/prompts/deploy-fix.md
+++ b/claude-ops/prompts/deploy-fix.md
@@ -47,9 +47,9 @@ You are running headless inside a Claude Code session with full claude-ops tooli
 4. **Apply the minimal fix.** Surgical changes only.
 
 5. **Run the per-repo quality gate** before committing (per `~/.claude/CLAUDE.md`):
-   - `healify-api`: `npm run type-check && npm run lint && npm run test:unit`
-   - `healify`: `npm run type-check`
-   - `healify-langgraphs` / `healify-agentcore` / `meditation-service`: `source .venv/bin/activate && pytest tests/ -x --ignore=tests/e2e`
+   - Node/TS repos: `npm run type-check && npm run lint && npm run test:unit`
+   - React Native / Expo repos: `npm run type-check`
+   - Python repos: `source .venv/bin/activate && pytest tests/ -x --ignore=tests/e2e`
    - other Node repos: `npm run type-check && npm run lint && npm test`
 
 6. **Commit with `--no-verify`** (project hooks are bugged per Sam's CLAUDE.md). Co-author trailer: `Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>`.

--- a/claude-ops/scripts/account-rotation/bulk-setup-token.mjs
+++ b/claude-ops/scripts/account-rotation/bulk-setup-token.mjs
@@ -8,7 +8,7 @@
 //  is missing an OAuth bearer token, drives the Anthropic web login via
 //  Kapture (delegated to a one-shot `claude -p` subprocess with the kapture
 //  MCP server enabled), then stores the resulting sk-ant-oat01-* token in AWS
-//  Secrets Manager at healify/claude-oauth-token/account-{1..7}.
+//  Secrets Manager at <your-org>/claude-oauth-token/account-{1..N}.
 //
 //  Idempotent: skips accounts whose Secrets Manager entry already contains a
 //  validated sk-ant-oat01-* token AND ledger entry says claimed=true.
@@ -24,7 +24,7 @@
 //  Defaults:
 //     --region          eu-west-1
 //     --ledger          ~/.claude/credits-ledger.json
-//     --secret-prefix   healify/claude-oauth-token/account-
+//     --secret-prefix   <your-org>/claude-oauth-token/account-
 //     --gmail-account   $BULK_SETUP_GMAIL_ACCOUNT (env) or unset
 //
 //  Required tools on PATH: claude, aws, gog, expect.
@@ -70,7 +70,7 @@ const ONLY = value('--only', null);
 const REGION = value('--region', 'eu-west-1');
 const HOME = process.env.HOME || process.env.USERPROFILE;
 const LEDGER_PATH = value('--ledger', join(HOME, '.claude', 'credits-ledger.json'));
-const SECRET_PREFIX = value('--secret-prefix', 'healify/claude-oauth-token/account-');
+const SECRET_PREFIX = value('--secret-prefix', '<your-org>/claude-oauth-token/account-');
 const GMAIL_ACCOUNT = value('--gmail-account', process.env.BULK_SETUP_GMAIL_ACCOUNT || null);
 const SUBPROCESS_TIMEOUT_MS = 8 * 60 * 1000; // 8 min per Kapture step
 

--- a/claude-ops/scripts/lib/competitor/context.sh
+++ b/claude-ops/scripts/lib/competitor/context.sh
@@ -8,15 +8,15 @@
 #
 #   {
 #     "configured": true,
-#     "brands": ["Healify", ...],
+#     "brands": ["your-app", ...],
 #     "by_brand": {
-#       "Healify": {
-#         "category": "AI health coaching apps",
-#         "competitors": ["Noom", "MyFitnessPal", ...],
+#       "your-app": {
+#         "category": "your market category",
+#         "competitors": ["competitor-a", "competitor-b", ...],
 #         "last_run": "2026-05-17T...",
 #         "last_discovery": "2026-05-17T...",
-#         "latest_report": "/path/to/2026-05-17_healify.md",
-#         "latest_synthesis": "/path/to/2026-05-17_healify-synthesis.md"
+#         "latest_report": "/path/to/2026-05-17_your-app.md",
+#         "latest_synthesis": "/path/to/2026-05-17_your-app-synthesis.md"
 #       }
 #     },
 #     "events": {
@@ -184,7 +184,7 @@ competitor_context() {
 # ── Convenience helpers (small, focused) ───────────────────────────────
 
 # Print compact one-line summary for briefing surfaces (e.g. /ops:go).
-# Output: "Healify: 2 alerts (last: Noom price drop) · 5 med deltas · weekly report 2026-05-17"
+# Output: "your-app: 2 alerts (last: competitor-a price drop) · 5 med deltas · weekly report 2026-05-17"
 # or:     "(not configured — run /ops:setup competitor-intel)"
 competitor_briefing_line() {
   local ctx; ctx=$(competitor_context "$@")
@@ -232,7 +232,7 @@ competitor_priority_items() {
 # Get vertical-specific signal slice for /ops:marketing, /ops:ecom, /ops:yolo c-suite agents.
 # Filters events by source kind groupings.
 #   marketing  → pricing diffs, funding/news, brand sentiment from reddit/hn
-#   ecom       → app store version+rating, product page diffs, hueman-style competitor launches
+#   ecom       → app store version+rating, product page diffs, new competitor launches
 #   cfo        → pricing diffs only (money-token high severity)
 #   ceo        → new entrants, competitor moves (med + high)
 #   coo        → jobs feed (hiring signals)

--- a/claude-ops/scripts/lib/creative/context.sh
+++ b/claude-ops/scripts/lib/creative/context.sh
@@ -8,9 +8,9 @@
 # Returns ONE JSON object:
 #   {
 #     "configured": true,
-#     "projects": ["healify", ...],
+#     "projects": ["your-app", ...],
 #     "by_project": {
-#       "healify": {
+#       "your-app": {
 #         "ledger_rows": 12,
 #         "last_gen": "2026-05-17T...",
 #         "last_calibrated": "2026-05-17T...",

--- a/claude-ops/scripts/lib/creative/generate.sh
+++ b/claude-ops/scripts/lib/creative/generate.sh
@@ -5,7 +5,7 @@
 #   creative_generate <project> <brief_json> <out_dir>
 #
 # brief_json example:
-#   '{"prompt":"Woman doing yoga at sunrise, 9:16, vibrant health","type":"video|image"}'
+#   '{"prompt":"Person using your product, 9:16 portrait, vibrant lifestyle","type":"video|image"}'
 #
 # Prints ONE JSON:
 #   {"generated":[{"path":"...","type":"video|image","est_cost_usd":N}],
@@ -358,7 +358,11 @@ creative_generate() {
 
   # ── Parse brief ───────────────────────────────────────────────────────────
   local gen_prompt gen_type
-  gen_prompt="$(printf '%s' "$brief_json" | jq -r '.prompt // "Compelling health and wellness ad creative, 9:16 portrait"' 2>/dev/null)"
+  gen_prompt="$(printf '%s' "$brief_json" | jq -r '.prompt // empty' 2>/dev/null)"
+  if [ -z "$gen_prompt" ]; then
+    printf '{"generated":[],"spend_today":0,"capped":false,"refused":true,"reason":"brand_voice_not_configured — run /ops:marketing onboard <project>"}\n'
+    return 1
+  fi
   gen_type="$(printf '%s' "$brief_json" | jq -r '.type // "video"' 2>/dev/null)"
   [ "$gen_type" != "video" ] && [ "$gen_type" != "image" ] && gen_type="video"
 

--- a/claude-ops/scripts/ops-gsd-registry-sync.sh
+++ b/claude-ops/scripts/ops-gsd-registry-sync.sh
@@ -251,7 +251,7 @@ for planning in unique_planning:
         })
 
 # ── Dedupe: same git remote URL ⇒ same logical project ────────────────────
-# Multiple checkout paths (e.g. ~/healify-api and ~/Projects/healify-api,
+# Multiple checkout paths (e.g. ~/my-api and ~/Projects/my-api,
 # or a clone in gsd-workspaces/) all map to one entry. Canonical path =
 # the one with the most recent commit; other paths land in `aliases`.
 # Projects without a git remote are deduped by resolved filesystem path

--- a/claude-ops/skills/ops-marketing/SKILL.md
+++ b/claude-ops/skills/ops-marketing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ops-marketing
 description: Marketing command center. Email campaigns (Klaviyo), paid ads (Meta/Google), analytics (GA4), SEO, and social media metrics. One dashboard for all marketing channels.
-argument-hint: "[email|ads|analytics|seo|social|campaigns|setup]"
+argument-hint: "<project> [email|ads|analytics|seo|social|campaigns|setup|autopilot ...]"
 allowed-tools:
   - Bash
   - Read
@@ -165,11 +165,15 @@ fi
 
 ## Sub-command Routing
 
+**Argument parsing:** `$ARGUMENTS` is split as `<first-token> [rest...]`.
+If `<first-token>` matches a known verb below, route by verb. If it looks like a project name (alphanumeric + hyphens, not a known verb), treat it as `<project>` and continue routing on `[rest...]`.
+
 Route `$ARGUMENTS` to the correct section below:
 
 | Input | Action |
 |---|---|
 | (empty), dashboard | Run full marketing dashboard |
+| `<project>` | If `marketing.projects.<project>.autopilot.enabled == true` → run live autopilot pass for that project. Otherwise → run `bin/ops-marketing-provision provision-all --project <project>` then `bin/ops-marketing-autopilot --project <project> --first-run-dry` (see ## project entry-point section) |
 | email, klaviyo | Klaviyo email metrics |
 | ads, meta | Meta Ads performance (read-only overview) |
 | meta-manage, meta create-campaign, meta target, meta creative, meta rules, meta audiences, meta advantage | Meta Ads campaign management (see ## meta-manage section) |
@@ -182,7 +186,11 @@ Route `$ARGUMENTS` to the correct section below:
 | campaigns | Cross-channel campaign overview (all platforms) |
 | optimize | Cross-platform ad optimization agent |
 | autopilot | Autonomous per-project daily ad management (see ## autopilot section) |
-| autopilot onboard <url> | Cold-start: scrape URL, derive strategy, scaffold/stage campaigns (see ## autopilot → Autonomous onboarding) |
+| autopilot onboard `<url>` | Cold-start: scrape URL, derive strategy, scaffold/stage campaigns (see ## autopilot → Autonomous onboarding) |
+| `autopilot enable <project> [--cap <usd>]` | Enable autopilot for a project (see ## autopilot-enable section) |
+| `autopilot disable <project>` | Disable autopilot for a project (see ## autopilot-disable section) |
+| `autopilot run <project> [--dry-run]` | Run one autopilot pass directly (see ## autopilot-run section) |
+| `autopilot kill <project>` | Set kill_switch for a project (see ## autopilot-kill section) |
 | attribution | Unified attribution table (Meta + Google + Klaviyo + GA4) |
 | setup | Configure API keys |
 
@@ -2006,6 +2014,78 @@ When `source.url` is set, `autopilot onboard <url>` (or the first pass on an emp
 
 ---
 
+## project entry-point
+
+When `$ARGUMENTS` is a single token that matches a configured project key (i.e. exists under `marketing.projects` in preferences.json), route as follows:
+
+1. Read `marketing.projects.<project>.autopilot.enabled` from preferences.json.
+2. **If `true`**: run a live autopilot pass — equivalent to `autopilot run <project>`.
+3. **If `false` or absent**: provision then dry-run:
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/bin/ops-marketing-provision" provision-all --project "<project>"
+   "${CLAUDE_PLUGIN_ROOT}/bin/ops-marketing-autopilot" --project "<project>" --dry-run
+   ```
+   Show the dry-run report and prompt the user to review before enabling autopilot.
+
+---
+
+## autopilot-enable
+
+Syntax: `autopilot enable <project> [--cap <usd>]`
+
+1. Read `marketing.projects.<project>` from preferences.json — abort with helpful message if project not found.
+2. Write to preferences.json (atomic jq → tmp → mv):
+   ```
+   marketing.projects.<project>.autopilot.enabled = true
+   marketing.projects.<project>.autopilot.daily_spend_cap_usd = <cap>   # only if --cap provided
+   ```
+3. Enable daemon services:
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/bin/ops-daemon-manager" enable marketing-autopilot
+   "${CLAUDE_PLUGIN_ROOT}/bin/ops-daemon-manager" enable marketing-autopilot-calibrate
+   ```
+4. Run one forced-dry pass so the operator sees the first report:
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/bin/ops-marketing-autopilot" --project "<project>" --dry-run
+   ```
+5. Print the report path and inform the operator the next scheduled live run is the daemon's `0 8 * * *` UTC tick.
+
+**Spend-safety:** if `--cap` is omitted and no existing `daily_spend_cap_usd` is configured, refuse and tell the operator to add `--cap <usd>` — autopilot refuses to run without a cap (NEVER LEAK MONEY).
+
+---
+
+## autopilot-disable
+
+Syntax: `autopilot disable <project>`
+
+Write `marketing.projects.<project>.autopilot.enabled = false` to preferences.json (atomic jq → tmp → mv). The daemon services are left running (they iterate only projects with `enabled: true`) so other projects are unaffected. Confirm the write with a one-line status message.
+
+---
+
+## autopilot-run
+
+Syntax: `autopilot run <project> [--dry-run]`
+
+Direct dispatch to the autopilot binary for a single project:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/bin/ops-marketing-autopilot" --project "<project>" ${DRY_RUN_FLAG}
+```
+
+Show the tail of the report (`$OPS_DATA_DIR/reports/marketing-autopilot/<project>-latest.md`) after the pass completes.
+
+---
+
+## autopilot-kill
+
+Syntax: `autopilot kill <project>`
+
+Write `marketing.projects.<project>.autopilot.envelope.kill_switch = true` to preferences.json (atomic jq → tmp → mv). This causes the autopilot binary to stage-only (no mutations, no object creation) on every subsequent pass until the flag is cleared. Confirm with a status message showing the new `kill_switch` value.
+
+To re-enable: `autopilot enable <project>` (which resets `kill_switch` to false along with setting `enabled: true`).
+
+---
+
 ## attribution
 
 Unified attribution table showing spend, conversions, revenue, and ROAS side-by-side across all configured platforms.
@@ -2195,3 +2275,30 @@ Present ALL findings before asking for anything. Only prompt for values NOT foun
 **Google Ads:** More complex than other marketing credentials — requires 3 pieces: (1) developer token from Google Ads MCC → Tools & Settings → API Center, (2) OAuth2 client ID + secret from Google Cloud Console (Desktop app type, Google Ads API enabled), (3) refresh token via browser OAuth flow. Setup flow: collect developer token and client credentials first, then open browser auth URL, user pastes authorization code, exchange for refresh token via curl, then list accessible customer accounts and let user select. Smoke test: `curl -s -X GET "https://googleads.googleapis.com/v23/customers:listAccessibleCustomers" -H "Authorization: Bearer $TOKEN" -H "developer-token: $DEV_TOKEN"` — expect JSON with `resourceNames` array.
 
 Save via userConfig (preferred) or Doppler. Report: `[service] ✓ connected` or `[service] ✗ invalid key — [error]`.
+
+---
+
+## Quick Start — autopilot verbs
+
+```
+# First time: provision + dry-run a project
+/ops:marketing <your-project>
+
+# Enable autopilot with a daily spend cap
+/ops:marketing autopilot enable <your-project> --cap 50
+
+# Run one pass immediately (dry-run to preview)
+/ops:marketing autopilot run <your-project> --dry-run
+
+# Run one live pass
+/ops:marketing autopilot run <your-project>
+
+# Disable autopilot (leaves daemon running for other projects)
+/ops:marketing autopilot disable <your-project>
+
+# Emergency stop — stage-only, no mutations until re-enabled
+/ops:marketing autopilot kill <your-project>
+
+# Full dashboard
+/ops:marketing
+```

--- a/claude-ops/skills/ops-marketing/SKILL.md
+++ b/claude-ops/skills/ops-marketing/SKILL.md
@@ -173,7 +173,7 @@ Route `$ARGUMENTS` to the correct section below:
 | Input | Action |
 |---|---|
 | (empty), dashboard | Run full marketing dashboard |
-| `<project>` | If `marketing.projects.<project>.autopilot.enabled == true` → run live autopilot pass for that project. Otherwise → run `bin/ops-marketing-provision provision-all --project <project>` then `bin/ops-marketing-autopilot --project <project> --first-run-dry` (see ## project entry-point section) |
+| `<project>` | If `marketing.projects.<project>.autopilot.enabled == true` → run live autopilot pass for that project. Otherwise → run `bin/ops-marketing-provision provision-all --project <project>` then `bin/ops-marketing-autopilot --project <project> --dry-run` (see ## project entry-point section) |
 | email, klaviyo | Klaviyo email metrics |
 | ads, meta | Meta Ads performance (read-only overview) |
 | meta-manage, meta create-campaign, meta target, meta creative, meta rules, meta audiences, meta advantage | Meta Ads campaign management (see ## meta-manage section) |

--- a/claude-ops/skills/ops-secret-sync/SKILL.md
+++ b/claude-ops/skills/ops-secret-sync/SKILL.md
@@ -185,17 +185,17 @@ If failures > 0: suggest `doppler run --project <proj> --config <env> -- gh secr
 
 ---
 
-## Real-world example: Stagery Inngest case
+## Example: recurring drift pattern
 
-This skill exists because of a recurring drift pattern:
+This skill exists because of a common drift pattern:
 
 | Project | Secret | Situation |
 |---------|--------|-----------|
-| stagery-api | `INNGEST_SIGNING_KEY` | Rotated in Doppler 2026-04-23 — GH secret was 24 days stale, CI failures started on 2026-05-17 |
-| inboxassist | `CEREBRAS_API_KEY` | Added to Doppler, never propagated to GH secrets — Phase 23 CI gate failed |
-| inboxassist | `OPENROUTER_API_KEY` | Same pattern — GH missing, Doppler current |
+| `<your-api>` | `INNGEST_SIGNING_KEY` | Rotated in Doppler — GH secret was 24 days stale, CI failures started after the grace period |
+| `<your-service>` | `CEREBRAS_API_KEY` | Added to Doppler, never propagated to GH secrets — CI gate failed |
+| `<your-service>` | `OPENROUTER_API_KEY` | Same pattern — GH missing, Doppler current |
 
-Running `/ops:secret-sync --repo your-org/stagery-api --project stagery-api --config prd` would have surfaced `INNGEST_SIGNING_KEY` as DRIFTED 24+ days before CI failed.
+Running `/ops:secret-sync --repo <your-org>/<your-api> --project <your-api> --config prd` would have surfaced `INNGEST_SIGNING_KEY` as DRIFTED before CI failed.
 
 ---
 

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -1059,7 +1059,7 @@ If **Skip — disable**: set `competitor-intel.enabled = false` in `daemon-servi
 
 If **Configure now**: collect two free-text values plus one optional:
 
-1. `brand_name` — e.g. `"Healify"`, `"Stagery"`. The product/company being tracked.
+1. `brand_name` — e.g. `"your-app"`, `"your-brand"`. The product/company being tracked.
 2. `category` — e.g. `"AI health coaching apps"`, `"NL virtual real estate staging"`. The market segment Tavily searches in.
 3. `report_timezone` — IANA TZ. Default: system TZ from previous setup steps, or `"UTC"`.
 

--- a/claude-ops/tests/test-deploy-fix-hooks.sh
+++ b/claude-ops/tests/test-deploy-fix-hooks.sh
@@ -189,10 +189,10 @@ echo ""
 echo "── Case 2: ops-deploy-fix-build-trigger ──────────────────────────"
 
 # The trigger resolves repo from PWD via `git -C "$pwd" config --get remote.origin.url`.
-# To keep tests independent of the reviewer's host (no dependency on ~/healify or
-# any other checkout existing), we cd to a non-git temp dir before each Case 2
-# test. The trigger's `slug_full` resolution falls back to "local-build" when
-# git fails, which is the safe codepath we want under test.
+# To keep tests independent of the reviewer's host (no dependency on any specific
+# checkout existing), we cd to a non-git temp dir before each Case 2 test and
+# export OPS_DEPLOY_FIX_REPO_SLUG so the trigger has a repo identity.
+# The trigger's slug is driven by that env var; the lock path uses it.
 SAVED_PWD="$(pwd)"
 NON_GIT_PWD="$SUITE_TMP/non-git-pwd"
 mkdir -p "$NON_GIT_PWD"
@@ -208,6 +208,7 @@ test_build_trigger_fires_on_failure() {
   export CLAUDE_PLUGIN_OPTION_DEPLOY_FIX_ENABLED=true
   export CLAUDE_PLUGIN_OPTION_MONITOR_BUILD_FAILURES=true
   export CLAUDE_PLUGIN_OPTION_AUTO_DISPATCH_FIXER=true
+  export OPS_DEPLOY_FIX_REPO_SLUG="app-a"
   out=$(cat "$FIXTURES/build-trigger-fail.json" | bash "$PLUGIN_ROOT/bin/ops-deploy-fix-build-trigger" 2>&1)
   rc=$?
   assert_eq "2a.exit-zero" "0" "$rc"
@@ -229,6 +230,7 @@ test_build_trigger_skips_success() {
   new_isolated_env "case2-success"
   export CLAUDE_PLUGIN_OPTION_DEPLOY_FIX_ENABLED=true
   export CLAUDE_PLUGIN_OPTION_MONITOR_BUILD_FAILURES=true
+  export OPS_DEPLOY_FIX_REPO_SLUG="app-a"
   cat "$FIXTURES/build-trigger-success.json" | bash "$PLUGIN_ROOT/bin/ops-deploy-fix-build-trigger" >/dev/null 2>&1
   sleep 0.5
   if [ ! -s "$TEST_LOGS/claude.log" ]; then
@@ -243,6 +245,7 @@ test_build_trigger_skips_test_cmd() {
   new_isolated_env "case2-test-cmd"
   export CLAUDE_PLUGIN_OPTION_DEPLOY_FIX_ENABLED=true
   export CLAUDE_PLUGIN_OPTION_MONITOR_BUILD_FAILURES=true
+  export OPS_DEPLOY_FIX_REPO_SLUG="app-a"
   cat "$FIXTURES/build-trigger-test-cmd.json" | bash "$PLUGIN_ROOT/bin/ops-deploy-fix-build-trigger" >/dev/null 2>&1
   sleep 0.5
   if [ ! -s "$TEST_LOGS/claude.log" ]; then
@@ -260,6 +263,7 @@ test_build_trigger_transient() {
   export CLAUDE_PLUGIN_OPTION_MONITOR_BUILD_FAILURES=true
   export CLAUDE_PLUGIN_OPTION_AUTO_DISPATCH_FIXER=true
   export CLAUDE_PLUGIN_OPTION_AUTO_RERUN_TRANSIENTS=true
+  export OPS_DEPLOY_FIX_REPO_SLUG="app-a"
   out=$(cat "$FIXTURES/build-trigger-transient.json" | bash "$PLUGIN_ROOT/bin/ops-deploy-fix-build-trigger" 2>&1)
   rc=$?
   assert_eq "2d.exit-zero" "0" "$rc"
@@ -280,10 +284,9 @@ test_build_trigger_lock_held() {
   export CLAUDE_PLUGIN_OPTION_DEPLOY_FIX_ENABLED=true
   export CLAUDE_PLUGIN_OPTION_MONITOR_BUILD_FAILURES=true
   export CLAUDE_PLUGIN_OPTION_AUTO_DISPATCH_FIXER=true
-  # The build trigger pins `repo_slug=healify` (mobile build hooks always
-  # operate against the healify repo), so the lock path is fixed regardless
-  # of the caller's PWD or git remote.
-  echo $$ > "$TEST_STATE/lock-healify-build"
+  export OPS_DEPLOY_FIX_REPO_SLUG="app-a"
+  # The lock path is keyed by repo_slug (read from OPS_DEPLOY_FIX_REPO_SLUG).
+  echo $$ > "$TEST_STATE/lock-app-a-build"
   out=$(cat "$FIXTURES/build-trigger-fail.json" | bash "$PLUGIN_ROOT/bin/ops-deploy-fix-build-trigger" 2>&1)
   rc=$?
   assert_eq "2e.exit-zero-on-lock" "0" "$rc"


### PR DESCRIPTION
## Motivation

Audit findings from P1-expand pass:

1. **Rule 0 violations** — multiple committed files contained real project names, Doppler prefixes, and org-specific paths visible to anyone on the internet.
2. **Missing `bin/ops-daemon-manager` `enable`/`disable`** — `setup/channels/marketing.md` called `bin/ops-daemon-manager enable <svc>` which didn't exist (only `scripts/ops-daemon-manager.sh` with `install|upgrade|status|restart`).
3. **Wellness-copy defaults** — `brand.voice` fell back to `"health, wellness, vibrant"`, silently injecting product-specific copy for any non-health project.
4. **Single global install marker** — one `.installed` file meant a second project added later would skip its own forced-dry first pass.
5. **Missing entry-point verbs** — no direct `<project>` shortcut or `autopilot enable/disable/run/kill` verbs in the skill.

## What's in

**Commit 1 — Rule 0 cleanup** (`fix(rule0)`)
- `bin/ops-deploy-fix-build-trigger`: parameterised via `OPS_DEPLOY_FIX_REPO_SLUG` / `OPS_DEPLOY_FIX_REPO_ORG` env vars; no defaults pointing at any real repo
- `prompts/build-fix.md`, `prompts/deploy-fix.md`: replaced concrete project examples with generic placeholders
- `scripts/account-rotation/bulk-setup-token.mjs`: `--secret-prefix` default → `<your-org>/claude-oauth-token/account-`
- `scripts/lib/competitor/context.sh`, `scripts/lib/creative/context.sh`: docstring examples anonymised
- `scripts/lib/creative/generate.sh`: example prompt anonymised; empty `prompt` now refuses instead of defaulting
- `scripts/ops-gsd-registry-sync.sh`, `skills/setup/SKILL.md`, `skills/ops-secret-sync/SKILL.md`: real names → generic placeholders
- `tests/test-deploy-fix-hooks.sh`: updated to export `OPS_DEPLOY_FIX_REPO_SLUG=app-a` and use `lock-app-a-build`; all 45 tests pass

**Commit 2 — `bin/ops-daemon-manager`** (`feat(daemon)`)
- New executable wrapper: `enable <svc>` / `disable <svc>` → atomic jq write to `daemon-services.json` + daemon restart
- All other subcommands pass through to `scripts/ops-daemon-manager.sh`
- Logs to `$OPS_DATA_DIR/logs/setup.log`; tolerates daemon not yet installed
- shellcheck clean; idempotent

**Commit 3 — autopilot fixes** (`fix(autopilot)`)
- Per-project install marker: `${STATE_DIR}/${proj}.installed` — each project gets its own forced-dry first pass
- `brand.voice` guard: escalates instead of defaulting to wellness copy when not configured
- Per-project DRY_RUN shadowing: saves/restores global around each iteration

**Commit 4 — SKILL.md entry-point verbs** (`feat(ops:marketing)`)
- `argument-hint` updated
- Routing table: bare `<project>` token, `autopilot enable/disable/run/kill` rows
- New sections: `## project entry-point`, `## autopilot-enable`, `## autopilot-disable`, `## autopilot-run`, `## autopilot-kill`
- `## Quick Start` with all new verb examples

## Breaking changes

| Change | Migration |
|--------|-----------|
| `ops-deploy-fix-build-trigger` no longer has a built-in repo slug | Export `OPS_DEPLOY_FIX_REPO_SLUG=<your-repo>` (and optionally `OPS_DEPLOY_FIX_REPO_ORG=<your-org>`) in your shell profile or Doppler |
| `brand.voice` no longer defaults to wellness copy | Run `/ops:marketing onboard <project>` to set `marketing.projects.<p>.brand.voice` |

## Test plan

- [ ] `bash tests/test-no-secrets.sh` — 14/14 pass
- [ ] `bash tests/test-deploy-fix-hooks.sh` — 45/45 pass (including case 2e lock test)
- [ ] `shellcheck bin/ops-daemon-manager` — clean
- [ ] `shellcheck bin/ops-marketing-autopilot` — same warning count as main (no regressions)
- [ ] Manual: `bin/ops-daemon-manager enable marketing-autopilot` on a fresh `daemon-services.json`
- [ ] Manual: `/ops:marketing autopilot enable <project> --cap 50` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches automation that can trigger daemon restarts and marketing autopilot behavior; misconfiguration (missing env vars / brand.voice) can now block or change runtime behavior, though changes are mostly guardrail-oriented.
> 
> **Overview**
> **Adds a new `bin/ops-daemon-manager` wrapper** that supports `enable`/`disable` by atomically toggling `services.<svc>.enabled` in `daemon-services.json` (bootstrapping it if missing) and then attempting a daemon restart; all other subcommands are passed through to `scripts/ops-daemon-manager.sh`.
> 
> **Hardens `ops-marketing-autopilot` safety and onboarding flow** by switching the forced first-run dry-run marker to *per-project* (`state/autopilot/<proj>.installed`), shadowing/restoring `DRY_RUN` per project iteration, and requiring `marketing.projects.<proj>.brand.voice` (escalates instead of falling back to generic wellness copy); creative generation now refuses when the brief prompt is missing.
> 
> **Cleans up Rule-0 project/org leakage and makes build-fix hooks project-agnostic** by parameterizing `ops-deploy-fix-build-trigger` repo identity via `OPS_DEPLOY_FIX_REPO_SLUG`/`OPS_DEPLOY_FIX_REPO_ORG`, updating tests accordingly, and replacing real-world names/paths with placeholders across prompts, scripts, and skill docs (including new `/ops:marketing` autopilot verb routing documentation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6d98780ca53c3b96b54a67c83171b7782cfbfde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->