### PR TITLE
feat(ops:marketing): wire real perf data into autopilot decisions (GA4 + GSC + Klaviyo + Stripe)

### DIFF
--- a/claude-ops/bin/ops-marketing-autopilot
+++ b/claude-ops/bin/ops-marketing-autopilot
@@ -31,6 +31,12 @@ OPS_PLUGIN_ROOT_FALLBACK="${SCRIPT_DIR}/.." . "${SCRIPT_DIR}/../lib/registry-pat
 # resolve_cred canonical implementation — shared lib; local copy below is removed
 # shellcheck disable=SC1091
 . "${SCRIPT_DIR}/../scripts/lib/ga4-resolve.sh"
+# ga4_auth_token + ga4_run_report (shared with ops-marketing-dash)
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/../scripts/lib/ga4-data-api.sh"
+# utm_validate (UTM enforcement, P3 wiring)
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/../scripts/lib/utm-validate.sh"
 
 # Fix B: source analyze.sh once near top (makes extract_json available on ALL paths,
 # including process_onboard, which runs before delegate_claude would source it).
@@ -175,6 +181,51 @@ create_object() {
 
   report ""
   report "### Object creation: ${kind} — ${desc}"
+
+  # P3: UTM enforcement on campaign names. Conforms to scripts/lib/utm-validate.sh.
+  # campaign-kind only — audiences/budgets are not UTM-tagged objects.
+  if [ "$kind" = "campaign" ]; then
+    local _p_channel="" _p_name=""
+    for _kv in "$@"; do
+      case "$_kv" in
+        channel=*) _p_channel="${_kv#channel=}" ;;
+        name=*)    _p_name="${_kv#name=}" ;;
+      esac
+    done
+    # Derive (utm_source, utm_medium, utm_campaign) from channel + name.
+    # Convention: utm_source=channel (meta|google_ads → google),
+    #             utm_medium=paid, utm_campaign=<name>.
+    # If the supplied name is non-conforming, auto-normalize to
+    # <slug>_v1_YYYYMMDD so legacy strategy outputs ("Awareness Campaign")
+    # still pass — but log + report the auto-fix.
+    local _utm_source="$_p_channel" _utm_medium="paid" _utm_campaign="$_p_name"
+    [ "$_utm_source" = "google_ads" ] && _utm_source="google"
+    if ! utm_validate "$_utm_source" "$_utm_medium" "$_utm_campaign" 2>/dev/null; then
+      local _slug
+      _slug="$(printf '%s' "$_p_name" | tr '[:upper:] ' '[:lower:]-' | tr -cd 'a-z0-9-')"
+      [ -z "$_slug" ] && _slug="campaign"
+      _utm_campaign="${_slug}_v1_$(date +%Y%m%d)"
+      if utm_validate "$_utm_source" "$_utm_medium" "$_utm_campaign" 2>/dev/null; then
+        report "- UTM auto-normalize: '${_p_name}' → '${_utm_campaign}'"
+        # Rewrite the name in the args passed to _create_object_execute so the
+        # API call uses the conforming form.
+        local _new_args=()
+        for _kv in "$@"; do
+          case "$_kv" in
+            name=*)    _new_args+=("name=${_utm_campaign}") ;;
+            *)         _new_args+=("$_kv") ;;
+          esac
+        done
+        set -- "${_new_args[@]}"
+        _p_name="$_utm_campaign"
+      else
+        escalate "$proj" "UTM validation failed for ${kind} '${_p_name}' on channel '${_p_channel}' — non-conforming campaign name (expected <token>_<token>_YYYYMMDD)"
+        report "- ⛔ UTM validate FAIL: campaign='${_p_name}' channel='${_p_channel}' — staged only, no API mutation"
+        return 0
+      fi
+    fi
+    report "- UTM validate OK: source=${_utm_source} medium=${_utm_medium} campaign=${_utm_campaign}"
+  fi
 
   # ── Level 1: kill_switch / DRY_RUN / FIRST_RUN → stage only ─────────────
   if [ "$kill_switch" = "true" ]; then
@@ -553,9 +604,18 @@ $(jq -n \
         report "- floor reached (min_live_creatives=${min_live}) — stop pausing"
         break
       fi
-      local ad_id reason
+      local ad_id reason ad_spend
       ad_id="$(echo "$cand" | jq -r ".[$i].ad_id")"
+      ad_spend="$(echo "$cand" | jq -r ".[$i].spend // 0")"
       reason="$(echo "$cand" | jq -r --argjson cpl_disp "${cpl_mult}" ".[$i] | (if .cpl < 1e11 then \"CPL \\(.cpl|floor) (>\\(\$cpl_disp)x adset avg)\" else \"CTR \\(.ctr)% < floor\" end) + \" / spend \\(.spend) / impr \\(.impr)\"")"
+      # P3: stripe-revenue rescue gate — keep ad if its UTM-tagged stripe revenue
+      # ≥ OPS_PAUSE_ROAS_FLOOR (default 1.0) × meta spend on it.
+      local _decision
+      _decision="$(should_pause_ad "$proj" "$ad_id" "$ad_spend")"
+      if [ "$_decision" = "no" ]; then
+        i=$((i+1))
+        continue
+      fi
       mutate "pause Meta ad ${ad_id} (${reason})" \
         -X POST "${GRAPH}/${ad_id}" \
         -d "status=PAUSED&access_token=${META_TOKEN}${META_PROOF:+&appsecret_proof=${META_PROOF}}"
@@ -654,6 +714,331 @@ process_google_ads() {
   fi
 }
 
+# ── P3: real perf-data gatherers (GA4 conv / GSC / Klaviyo / Stripe) ─────────
+# Each helper:
+#   - reads marketing.projects.<proj>.<channel>.* from preferences.json
+#   - skips silently if not configured (no escalation, no error)
+#   - persists a JSON file to ${STATE_DIR}/${proj}-<channel>.json
+#   - respects OPS_DRY_RUN / DRY_RUN (no network calls)
+#   - never raises — failures degrade to a "null"-shaped envelope so the
+#     downstream bandit/dash path treats missing data as absent, not crashed.
+
+# gather_ga4_conversions <project>
+# 7d run-report with dim=(source/medium/campaign), metrics=(conversions,totalRevenue,sessions).
+# Aggregated JSON keyed by "source/medium/campaign".
+gather_ga4_conversions() {
+  local proj="$1"
+  local out="${STATE_DIR}/${proj}-ga4-conversions.json"
+  local prop sa_key
+  prop="$(resolve_cred "$(jq -r --arg p "$proj" '.marketing.projects[$p].ga4.property_id // empty' "$PREFS" 2>/dev/null)")"
+  sa_key="$(resolve_cred "$(jq -r --arg p "$proj" '.marketing.projects[$p].ga4.sa_key_file_ref // empty' "$PREFS" 2>/dev/null)")"
+  [ -n "$sa_key" ] && export GA4_SERVICE_ACCOUNT_KEY_FILE="$sa_key"
+  if [ -z "$prop" ]; then
+    report "- ga4-conversions: property_id not configured — skipped"
+    # Do NOT overwrite an existing file — leave whatever's there for callers/tests.
+    [ -f "$out" ] || printf '%s' '{"rows":[],"by_smc":{}}' > "$out"
+    return 0
+  fi
+  if [ "$DRY_RUN" = "1" ]; then
+    report "- [DRY] would query GA4 :runReport (property=${prop}, 7d, source/medium/campaign)"
+    printf '%s' '{"rows":[],"by_smc":{},"_dry_run":true}' > "$out"
+    return 0
+  fi
+  local body='{
+    "dateRanges":[{"startDate":"7daysAgo","endDate":"today"}],
+    "dimensions":[
+      {"name":"sessionSource"},
+      {"name":"sessionMedium"},
+      {"name":"sessionCampaign"}
+    ],
+    "metrics":[
+      {"name":"conversions"},
+      {"name":"totalRevenue"},
+      {"name":"sessions"}
+    ],
+    "limit":1000
+  }'
+  local raw
+  raw="$(ga4_run_report "$prop" "$body")"
+  if [ -z "$raw" ] || [ "$raw" = "{}" ]; then
+    report "- ga4-conversions: no response or auth failed — empty envelope"
+    printf '%s' '{"rows":[],"by_smc":{}}' > "$out"
+    return 0
+  fi
+  printf '%s' "$raw" | jq '{
+    rows: [(.rows // [])[] | {
+      source:   (.dimensionValues[0].value // "(none)"),
+      medium:   (.dimensionValues[1].value // "(none)"),
+      campaign: (.dimensionValues[2].value // "(none)"),
+      conversions:   (.metricValues[0].value // "0" | tonumber? // 0),
+      revenue:       (.metricValues[1].value // "0" | tonumber? // 0),
+      sessions:      (.metricValues[2].value // "0" | tonumber? // 0)
+    }],
+    by_smc: ((.rows // []) | map({
+      key:   ((.dimensionValues[0].value // "(none)") + "/" + (.dimensionValues[1].value // "(none)") + "/" + (.dimensionValues[2].value // "(none)")),
+      value: {
+        conversions: (.metricValues[0].value // "0" | tonumber? // 0),
+        revenue:     (.metricValues[1].value // "0" | tonumber? // 0),
+        sessions:    (.metricValues[2].value // "0" | tonumber? // 0)
+      }
+    }) | from_entries)
+  }' > "$out" 2>/dev/null || printf '%s' '{"rows":[],"by_smc":{}}' > "$out"
+  local n; n="$(jq '.rows | length' "$out" 2>/dev/null || echo 0)"
+  report "- ga4-conversions: ${n} source/medium/campaign rows captured → ${out##*/}"
+}
+
+# gather_gsc_signal <project>
+# Pulls GSC searchAnalytics last 28d (dim=query,page), bucketed into:
+#   - rescue:   pos 8-30, impressions>50, CTR<5%
+#   - hooks:    pos 1-3,  impressions>200, CTR<30%  (creative-gen seeds)
+gather_gsc_signal() {
+  local proj="$1"
+  local out="${STATE_DIR}/${proj}-gsc-signal.json"
+  local site
+  site="$(resolve_cred "$(jq -r --arg p "$proj" '.marketing.projects[$p].gsc.site_url // empty' "$PREFS" 2>/dev/null)")"
+  if [ -z "$site" ]; then
+    report "- gsc-signal: site_url not configured — skipped"
+    [ -f "$out" ] || printf '%s' '{"rescue":[],"hooks":[]}' > "$out"
+    return 0
+  fi
+  if [ "$DRY_RUN" = "1" ]; then
+    report "- [DRY] would query GSC searchAnalytics (site=${site}, 28d, query/page)"
+    printf '%s' '{"rescue":[],"hooks":[],"_dry_run":true}' > "$out"
+    return 0
+  fi
+  local tok
+  tok="$(ga4_auth_token)"  # GSC + GA4 share the SA scope when granted; ADC fallback works
+  if [ -z "$tok" ]; then
+    report "- gsc-signal: no auth token available — empty envelope"
+    printf '%s' '{"rescue":[],"hooks":[]}' > "$out"
+    return 0
+  fi
+  local site_enc
+  site_enc="$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$site" 2>/dev/null || echo "$site")"
+  local end_d start_d
+  end_d="$(date +%Y-%m-%d)"
+  start_d="$(date -v-28d +%Y-%m-%d 2>/dev/null || date -d '28 days ago' +%Y-%m-%d 2>/dev/null || echo "$end_d")"
+  local body
+  body="$(jq -n --arg s "$start_d" --arg e "$end_d" \
+    '{startDate:$s,endDate:$e,dimensions:["query","page"],rowLimit:1000}')"
+  local raw
+  raw="$(curl -gsS --max-time 15 -X POST \
+    "https://searchconsole.googleapis.com/webmasters/v3/sites/${site_enc}/searchAnalytics/query" \
+    -H "Authorization: Bearer ${tok}" \
+    -H "Content-Type: application/json" \
+    -d "$body" 2>/dev/null || echo '{}')"
+  if [ -z "$raw" ] || [ "$raw" = "{}" ]; then
+    report "- gsc-signal: GSC API empty/failed — empty envelope"
+    printf '%s' '{"rescue":[],"hooks":[]}' > "$out"
+    return 0
+  fi
+  printf '%s' "$raw" | jq '{
+    rescue: [
+      (.rows // [])[] | {
+        query: (.keys[0] // ""), page: (.keys[1] // ""),
+        impressions: (.impressions // 0), clicks: (.clicks // 0),
+        ctr: ((.ctr // 0) * 100), position: (.position // 0)
+      } | select(.position >= 8 and .position <= 30 and .impressions > 50 and .ctr < 5)
+    ],
+    hooks: [
+      (.rows // [])[] | {
+        query: (.keys[0] // ""), page: (.keys[1] // ""),
+        impressions: (.impressions // 0), clicks: (.clicks // 0),
+        ctr: ((.ctr // 0) * 100), position: (.position // 0)
+      } | select(.position >= 1 and .position <= 3 and .impressions > 200 and .ctr < 30)
+    ]
+  }' > "$out" 2>/dev/null || printf '%s' '{"rescue":[],"hooks":[]}' > "$out"
+  local nr nh
+  nr="$(jq '.rescue | length' "$out" 2>/dev/null || echo 0)"
+  nh="$(jq '.hooks  | length' "$out" 2>/dev/null || echo 0)"
+  report "- gsc-signal: ${nr} rescue opp(s), ${nh} ad-copy hook candidate(s) → ${out##*/}"
+}
+
+# gather_klaviyo_metrics <project>
+# Reads marketing.projects.<proj>.klaviyo.{api_key, account_id}, queries
+# /api/metrics → "Placed Order", /api/metric-aggregates last 7d, /api/flows.
+gather_klaviyo_metrics() {
+  local proj="$1"
+  local out="${STATE_DIR}/${proj}-klaviyo.json"
+  local api_key acct
+  api_key="$(resolve_cred "$(jq -r --arg p "$proj" '.marketing.projects[$p].klaviyo.api_key // .marketing.projects[$p].klaviyo.private_key // empty' "$PREFS" 2>/dev/null)")"
+  acct="$(resolve_cred "$(jq -r --arg p "$proj" '.marketing.projects[$p].klaviyo.account_id // empty' "$PREFS" 2>/dev/null)")"
+  if [ -z "$api_key" ]; then
+    report "- klaviyo: api_key not configured — skipped"
+    [ -f "$out" ] || printf '%s' '{"placed_order_revenue_7d":0,"flows":[]}' > "$out"
+    return 0
+  fi
+  if [ "$DRY_RUN" = "1" ]; then
+    report "- [DRY] would query Klaviyo /api/metrics + metric-aggregates + flows (acct=${acct:-n/a})"
+    printf '%s' '{"placed_order_revenue_7d":0,"flows":[],"_dry_run":true}' > "$out"
+    return 0
+  fi
+  local H=(-H "Authorization: Klaviyo-API-Key ${api_key}" -H "revision: 2024-10-15" -H "accept: application/json")
+  local metrics po_metric po_id rev_resp po_rev
+  metrics="$(curl -gsS --max-time 10 "${H[@]}" 'https://a.klaviyo.com/api/metrics' 2>/dev/null || echo '{}')"
+  po_metric="$(printf '%s' "$metrics" | jq -c '.data[]? | select(.attributes.name=="Placed Order") | {id:.id}' 2>/dev/null | head -1)"
+  po_id="$(printf '%s' "$po_metric" | jq -r '.id // empty' 2>/dev/null || true)"
+  po_rev=0
+  if [ -n "$po_id" ]; then
+    local agg_body
+    agg_body="$(jq -n --arg mid "$po_id" '{data:{type:"metric-aggregate",attributes:{metric_id:$mid,interval:"day",measurements:["sum_value"],filter:["greater-or-equal(datetime,2024-01-01T00:00:00)"]}}}')"
+    rev_resp="$(curl -gsS --max-time 12 "${H[@]}" -H 'content-type: application/json' \
+      -X POST 'https://a.klaviyo.com/api/metric-aggregates' \
+      -d "$agg_body" 2>/dev/null || echo '{}')"
+    po_rev="$(printf '%s' "$rev_resp" | jq -r '[.data.attributes.data[]? | .measurements.sum_value // 0] | (.[-7:] // []) | add // 0' 2>/dev/null || echo 0)"
+  fi
+  local flows flows_arr
+  flows="$(curl -gsS --max-time 10 "${H[@]}" 'https://a.klaviyo.com/api/flows/?filter=equals(status,%22live%22)&fields[flow]=name,status,trigger_type' 2>/dev/null || echo '{}')"
+  flows_arr="$(printf '%s' "$flows" | jq -c '[.data[]? | {id:.id,name:.attributes.name,status:.attributes.status,trigger_type:.attributes.trigger_type}]' 2>/dev/null || echo '[]')"
+  jq -n --argjson rev "${po_rev:-0}" --argjson flows "$flows_arr" --arg acct "${acct:-}" \
+    '{placed_order_revenue_7d:$rev,flows:$flows,account_id:$acct}' > "$out" 2>/dev/null \
+    || printf '%s' '{"placed_order_revenue_7d":0,"flows":[]}' > "$out"
+  local nf; nf="$(jq '.flows | length' "$out" 2>/dev/null || echo 0)"
+  report "- klaviyo: \$${po_rev} order revenue 7d, ${nf} live flow(s) → ${out##*/}"
+}
+
+# gather_stripe_revenue <project>
+# Calls /v1/charges last 7d, parses UTM metadata, aggregates by source/medium/campaign.
+gather_stripe_revenue() {
+  local proj="$1"
+  local out="${STATE_DIR}/${proj}-stripe.json"
+  local api_key acct
+  api_key="$(resolve_cred "$(jq -r --arg p "$proj" '.marketing.projects[$p].stripe.api_key // .marketing.projects[$p].stripe.secret_key // empty' "$PREFS" 2>/dev/null)")"
+  acct="$(resolve_cred "$(jq -r --arg p "$proj" '.marketing.projects[$p].stripe.account_id // empty' "$PREFS" 2>/dev/null)")"
+  if [ -z "$api_key" ]; then
+    report "- stripe: api_key not configured — skipped"
+    [ -f "$out" ] || printf '%s' '{"total_revenue_7d":0,"by_smc":{},"by_ad_id":{}}' > "$out"
+    return 0
+  fi
+  if [ "$DRY_RUN" = "1" ]; then
+    report "- [DRY] would query Stripe /v1/charges last 7d (acct=${acct:-default})"
+    printf '%s' '{"total_revenue_7d":0,"by_smc":{},"by_ad_id":{},"_dry_run":true}' > "$out"
+    return 0
+  fi
+  local since
+  since="$(date -v-7d +%s 2>/dev/null || date -d '7 days ago' +%s 2>/dev/null || echo 0)"
+  local H=(-H "Authorization: Bearer ${api_key}")
+  [ -n "$acct" ] && H+=(-H "Stripe-Account: ${acct}")
+  local agg='{"by_smc":{},"by_ad_id":{},"total_revenue_7d":0}'
+  local starting_after="" resp has_more
+  local pages=0
+  while [ "$pages" -lt 10 ]; do
+    pages=$((pages+1))
+    local url="https://api.stripe.com/v1/charges?limit=100&created[gte]=${since}"
+    [ -n "$starting_after" ] && url="${url}&starting_after=${starting_after}"
+    resp="$(curl -gsS --max-time 15 "${H[@]}" "$url" 2>/dev/null || echo '{}')"
+    [ -z "$resp" ] && break
+    has_more="$(printf '%s' "$resp" | jq -r '.has_more // false' 2>/dev/null || echo false)"
+    # Aggregate this page into agg
+    agg="$(printf '%s\n%s' "$agg" "$resp" | jq -sc '
+      .[0] as $acc | .[1] as $page |
+      ($page.data // []) as $charges |
+      reduce $charges[] as $c ($acc;
+        ($c.amount // 0) as $amt_cents |
+        ($amt_cents / 100.0) as $amt_usd |
+        ($c.status == "succeeded") as $ok |
+        if ($ok | not) then . else
+          ($c.metadata.utm_source   // "(none)") as $s |
+          ($c.metadata.utm_medium   // "(none)") as $m |
+          ($c.metadata.utm_campaign // "(none)") as $cmp |
+          ($c.metadata.ad_id // "(none)") as $aid |
+          ($s + "/" + $m + "/" + $cmp) as $k |
+          .total_revenue_7d = ((.total_revenue_7d // 0) + $amt_usd) |
+          .by_smc[$k] = ((.by_smc[$k] // {revenue:0,charges:0}) | .revenue = (.revenue + $amt_usd) | .charges = (.charges + 1)) |
+          .by_ad_id[$aid] = ((.by_ad_id[$aid] // {revenue:0,charges:0}) | .revenue = (.revenue + $amt_usd) | .charges = (.charges + 1))
+        end
+      )' 2>/dev/null || echo "$agg")"
+    [ "$has_more" = "true" ] || break
+    starting_after="$(printf '%s' "$resp" | jq -r '.data[-1].id // empty' 2>/dev/null || true)"
+    [ -z "$starting_after" ] && break
+  done
+  printf '%s' "$agg" > "$out"
+  local tot; tot="$(jq -r '.total_revenue_7d // 0' "$out" 2>/dev/null || echo 0)"
+  report "- stripe: \$${tot} attributed revenue 7d (UTM-tagged charges) → ${out##*/}"
+}
+
+# stripe_revenue_for_ad <project> <ad_id>
+# Returns total stripe-revenue for charges where metadata.ad_id matches.
+# Empty / 0 when stripe data is absent or the ad has no charges.
+stripe_revenue_for_ad() {
+  local proj="$1" ad_id="$2"
+  local f="${STATE_DIR}/${proj}-stripe.json"
+  [ -f "$f" ] || { printf '0'; return 0; }
+  jq -r --arg a "$ad_id" '(.by_ad_id[$a].revenue // 0)' "$f" 2>/dev/null || printf '0'
+}
+
+# surface_perf_signals <project>
+# Renders top GSC rescue/hook entries + Klaviyo underweight flag into the report.
+surface_perf_signals() {
+  local proj="$1"
+  local gsc_f="${STATE_DIR}/${proj}-gsc-signal.json"
+  local klv_f="${STATE_DIR}/${proj}-klaviyo.json"
+  local kpi_ledger="${OPS_DATA_DIR}/autopilot_state/${proj}/kpi.jsonl"
+  local stripe_f="${STATE_DIR}/${proj}-stripe.json"
+
+  # Stripe ground-truth ROAS slice
+  if [ -f "$stripe_f" ] && [ -f "$kpi_ledger" ]; then
+    local meta_spend_7d stripe_rev_7d gt_roas
+    meta_spend_7d="$(tail -n 2000 "$kpi_ledger" 2>/dev/null | jq -sr '[.[].spend // 0] | add // 0' 2>/dev/null || echo 0)"
+    stripe_rev_7d="$(jq -r '.total_revenue_7d // 0' "$stripe_f" 2>/dev/null || echo 0)"
+    gt_roas="$(awk -v r="${stripe_rev_7d:-0}" -v s="${meta_spend_7d:-0}" \
+      'BEGIN{ if (s+0>0) printf "%.2f", r/s; else print 0 }')"
+    report ""
+    report "### Ground-truth ROAS (Stripe-attributed)"
+    report "- meta_spend_7d=\$${meta_spend_7d}  stripe_revenue_7d=\$${stripe_rev_7d}  ROAS=${gt_roas}"
+  fi
+
+  # GSC rescue + hook signals
+  if [ -f "$gsc_f" ]; then
+    local nr nh
+    nr="$(jq '.rescue | length' "$gsc_f" 2>/dev/null || echo 0)"
+    nh="$(jq '.hooks | length' "$gsc_f" 2>/dev/null || echo 0)"
+    if [ "${nr:-0}" -gt 0 ] || [ "${nh:-0}" -gt 0 ]; then
+      report ""
+      report "### GSC opportunity signals"
+      [ "$nr" -gt 0 ] && report "- ${nr} rescue opportunity(ies) (high-impr, low-CTR, ranks 8-30)"
+      [ "$nh" -gt 0 ] && report "- ${nh} ad-copy hook candidate(s) (rank 1-3, CTR<30%)"
+      jq -r '(.hooks // [])[0:5][] | "  - hook seed: \"" + .query + "\" (pos " + (.position|tostring) + ", CTR " + (.ctr|tostring) + "%)"' "$gsc_f" 2>/dev/null >> "$REPORT" || true
+    fi
+  fi
+
+  # Klaviyo underweight signal
+  if [ -f "$klv_f" ]; then
+    local klv_rev meta_spend ratio threshold
+    klv_rev="$(jq -r '.placed_order_revenue_7d // 0' "$klv_f" 2>/dev/null || echo 0)"
+    threshold="${OPS_KLAVIYO_REVENUE_RATIO_FLAG:-0.5}"
+    if [ -f "$kpi_ledger" ]; then
+      meta_spend="$(tail -n 2000 "$kpi_ledger" 2>/dev/null | jq -sr '[.[].spend // 0] | add // 0' 2>/dev/null || echo 0)"
+      ratio="$(awk -v k="${klv_rev:-0}" -v s="${meta_spend:-0}" \
+        'BEGIN{ if (s+0>0) printf "%.2f", k/s; else print 0 }')"
+      if awk "BEGIN{exit !(${ratio:-0} > ${threshold:-0.5})}"; then
+        report ""
+        report "### Channel-mix signal"
+        report "- ⚠️ email channel underweighted: klaviyo_revenue/paid_spend = ${ratio} (> ${threshold} flag)"
+        report "  (do not auto-shift budget — P4 work)"
+      fi
+    fi
+  fi
+}
+
+# ROAS rescue gate: should_pause_ad <project> <ad_id> <meta_spend_per_ad>
+# Echoes "yes" to pause, "no" to keep. Threshold env-overridable.
+should_pause_ad() {
+  local proj="$1" ad_id="$2" meta_spend="${3:-0}"
+  local floor="${OPS_PAUSE_ROAS_FLOOR:-1.0}"
+  local rev; rev="$(stripe_revenue_for_ad "$proj" "$ad_id")"
+  local keep
+  keep="$(awk -v r="${rev:-0}" -v s="${meta_spend:-0}" -v f="${floor}" \
+    'BEGIN{ if (s+0 > 0 && r+0 >= f*s+0) print 1; else print 0 }')"
+  if [ "$keep" = "1" ]; then
+    log "stripe-rescue: kept ad ${ad_id} (revenue=\$${rev} ≥ ${floor}× spend=\$${meta_spend})"
+    report "- stripe-rescue: kept ad ${ad_id} despite meta CPL threshold (\$${rev} ≥ ${floor}× \$${meta_spend})"
+    printf 'no'
+  else
+    printf 'yes'
+  fi
+}
+
 # ── Calibrator + bandit selection ─────────────────────────────────────────────
 apply_calibration_and_bandit() {
   local proj="$1"
@@ -661,9 +1046,61 @@ apply_calibration_and_bandit() {
   local calibrator="${state_dir}/calibrator.json"
   local ledger="${state_dir}/creatives.jsonl"
   local min_live; min_live="$(ap_get "$proj" '.min_live_creatives')"; min_live="${min_live:-2}"
+  local bandit_source="${OPS_BANDIT_SOURCE:-blended}"  # ga4|meta|blended
 
   report ""
   report "### Calibrator + Bandit selection"
+  report "- bandit reward source: ${bandit_source}"
+
+  # ── Blended reward: meta purchase_value + ga4 revenue (per-ad average) ─────
+  # Reads ${STATE_DIR}/${proj}-ga4-conversions.json (written by gather_ga4_conversions)
+  # and the kpi.jsonl meta rows; appends a 'bandit_reward' event per ad to the
+  # creatives.jsonl ledger so downstream tools (calibrator + dashboards) can
+  # train/visualize. Replaces pure-Meta reward when bandit_source != "meta".
+  local ga4_conv_f="${STATE_DIR}/${proj}-ga4-conversions.json"
+  local kpi_ledger="${state_dir}/kpi.jsonl"
+  if [ -f "$kpi_ledger" ] && [ "$DRY_RUN" = "0" ] && [ "$bandit_source" != "meta" ]; then
+    local ga4_total_rev=0
+    if [ -f "$ga4_conv_f" ]; then
+      ga4_total_rev="$(jq -r '[(.rows // [])[] | .revenue] | add // 0' "$ga4_conv_f" 2>/dev/null || echo 0)"
+    fi
+    # Get most-recent meta KPI row per ad (last 24h)
+    local recent_kpi
+    recent_kpi="$(tail -n 500 "$kpi_ledger" 2>/dev/null | jq -sc 'group_by(.ad_id) | map(max_by(.ts // ""))' 2>/dev/null || echo '[]')"
+    local n_ads
+    n_ads="$(printf '%s' "$recent_kpi" | jq 'length' 2>/dev/null || echo 0)"
+    if [ "${n_ads:-0}" -gt 0 ]; then
+      # Allocate ga4 revenue proportionally to meta spend (per-ad) — best linear
+      # attribution we can do without UTM-tagged per-ad GA4 dims.
+      local total_meta_spend
+      total_meta_spend="$(printf '%s' "$recent_kpi" | jq -r '[.[].spend // 0] | add // 0' 2>/dev/null || echo 0)"
+      local ts_now; ts_now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+      while IFS= read -r row; do
+        [ -z "$row" ] && continue
+        local ad_id _spend _leads meta_rev ga4_share blended
+        ad_id="$(printf '%s' "$row" | jq -r '.ad_id // empty' 2>/dev/null || true)"
+        _spend="$(printf '%s' "$row" | jq -r '.spend // 0' 2>/dev/null || echo 0)"
+        _leads="$(printf '%s' "$row" | jq -r '.leads // 0' 2>/dev/null || echo 0)"
+        meta_rev="$(printf '%s' "$row" | jq -r '.purchase_value // 0' 2>/dev/null || echo 0)"
+        ga4_share="$(awk -v g="${ga4_total_rev:-0}" -v s="${_spend:-0}" -v t="${total_meta_spend:-0}" \
+          'BEGIN{ if (t+0>0) printf "%.4f", (g*s)/t; else print 0 }')"
+        case "$bandit_source" in
+          ga4)     blended="$ga4_share" ;;
+          blended)
+            blended="$(awk -v m="${meta_rev:-0}" -v g="${ga4_share:-0}" \
+              'BEGIN{ if (m+0>0 && g+0>0) printf "%.4f", (m+g)/2.0; else if (m+0>0) print m; else print g }')"
+            ;;
+          *)       blended="$meta_rev" ;;
+        esac
+        [ -n "$ad_id" ] && printf '%s\n' "$(jq -n \
+          --arg ts "$ts_now" --arg p "$proj" --arg a "$ad_id" \
+          --arg src "$bandit_source" \
+          --argjson meta "${meta_rev:-0}" --argjson ga4 "${ga4_share:-0}" --argjson blend "${blended:-0}" \
+          '{ts:$ts,project:$p,event:"bandit_reward",ad_id:$a,source:$src,meta_revenue:$meta,ga4_revenue:$ga4,reward:$blend}')" >> "$ledger"
+      done < <(printf '%s' "$recent_kpi" | jq -c '.[]?' 2>/dev/null || true)
+      report "- bandit reward: appended ${n_ads} blended row(s) (ga4_total=\$${ga4_total_rev}, meta_spend=\$${total_meta_spend})"
+    fi
+  fi
 
   if [ ! -f "$ledger" ]; then
     report "- no creatives.jsonl ledger yet — skipping bandit"
@@ -1336,6 +1773,17 @@ for proj in "${PROJECTS[@]}"; do
   done
 
   if [ "$ESCALATED" = "0" ]; then
+    # P3: gather real perf data (GA4 conv + GSC + Klaviyo + Stripe) before bandit.
+    # Each helper is idempotent, OPS_DRY_RUN-safe, and silently skips when
+    # the project hasn't configured that channel.
+    report ""
+    report "### Perf-data gather (P3)"
+    gather_ga4_conversions "$proj"
+    gather_gsc_signal     "$proj"
+    gather_klaviyo_metrics "$proj"
+    gather_stripe_revenue "$proj"
+    surface_perf_signals  "$proj"
+
     apply_calibration_and_bandit "$proj"
     delegate_claude "$proj"
   fi

--- a/claude-ops/bin/ops-marketing-dash
+++ b/claude-ops/bin/ops-marketing-dash
@@ -11,6 +11,9 @@ OPS_PLUGIN_ROOT_FALLBACK="${SCRIPT_DIR}/.." . "${SCRIPT_DIR}/../lib/registry-pat
 # resolve_cred, ga4_resolve, gsc_resolve, marketing_channels_status
 # shellcheck disable=SC1091
 . "${SCRIPT_DIR}/../scripts/lib/ga4-resolve.sh"
+# ga4_auth_token + ga4_run_report (shared with ops-marketing-autopilot)
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/../scripts/lib/ga4-data-api.sh"
 PREFS="${OPS_DATA_DIR}/preferences.json"
 
 # Pull a value from preferences.json marketing.projects.<project>.<channel>.<field>.
@@ -154,39 +157,9 @@ gather_meta() {
 }
 
 # --- GA4 ---
-# Auth: prefer SA key file (GA4_SERVICE_ACCOUNT_KEY_FILE or first ~/.config/gcloud/keys/*ga*.json)
-# over gcloud ADC, so the dash works in daemon context without interactive gcloud auth.
-# If the key file exists but JWT exchange yields no token, fall back to ADC.
-_ga4_auth_token() {
-  local sa_key_file="${GA4_SERVICE_ACCOUNT_KEY_FILE:-}"
-  if [ -z "$sa_key_file" ]; then
-    # Auto-discover first matching SA key
-    sa_key_file="$(ls "$HOME"/.config/gcloud/keys/*ga*.json 2>/dev/null | head -1 || true)"
-  fi
-  if [ -n "$sa_key_file" ] && [ -f "$sa_key_file" ]; then
-    # Exchange SA key for access token via OAuth2
-    local now exp header payload sig jwt resp sa_token
-    now=$(date +%s)
-    exp=$((now + 3600))
-    header=$(printf '{"alg":"RS256","typ":"JWT"}' | base64 | tr -d '=' | tr '+/' '-_' | tr -d '\n')
-    payload=$(printf '{"iss":"%s","scope":"https://www.googleapis.com/auth/analytics.readonly","aud":"https://oauth2.googleapis.com/token","exp":%d,"iat":%d}' \
-      "$(jq -r '.client_email' "$sa_key_file")" "$exp" "$now" \
-      | base64 | tr -d '=' | tr '+/' '-_' | tr -d '\n')
-    sig=$(printf '%s.%s' "$header" "$payload" \
-      | openssl dgst -sha256 -sign <(jq -r '.private_key' "$sa_key_file") 2>/dev/null \
-      | base64 | tr -d '=' | tr '+/' '-_' | tr -d '\n')
-    jwt="${header}.${payload}.${sig}"
-    resp=$(curl -sS --max-time 5 -X POST https://oauth2.googleapis.com/token \
-      --data "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=${jwt}" 2>/dev/null || echo '{}')
-    sa_token="$(printf '%s' "$resp" | jq -r '.access_token // empty' 2>/dev/null || true)"
-    if [ -n "$sa_token" ]; then
-      printf '%s' "$sa_token"
-      return
-    fi
-  fi
-  # Fallback: ADC
-  gcloud auth application-default print-access-token 2>/dev/null || true
-}
+# Auth + transport now live in scripts/lib/ga4-data-api.sh (shared with autopilot).
+# Local wrapper kept as a thin shim for backward compatibility with prior callers.
+_ga4_auth_token() { ga4_auth_token; }
 
 gather_ga4() {
   if [ -z "$GA4_PROPERTY" ] || [ "$GA4_PROPERTY" = "0" ]; then
@@ -194,19 +167,8 @@ gather_ga4() {
     return
   fi
 
-  local GA4_TOKEN
-  GA4_TOKEN=$(_ga4_auth_token)
-  if [ -z "$GA4_TOKEN" ]; then
-    echo "null"
-    return
-  fi
-
   local REPORT
-  REPORT=$(curl -gsS --max-time 10 -X POST \
-    "https://analyticsdata.googleapis.com/v1beta/properties/${GA4_PROPERTY}:runReport" \
-    -H "Authorization: Bearer ${GA4_TOKEN}" \
-    -H "Content-Type: application/json" \
-    -d '{
+  REPORT=$(ga4_run_report "$GA4_PROPERTY" '{
       "dateRanges": [{"startDate": "7daysAgo", "endDate": "today"}],
       "metrics": [
         {"name": "sessions"},
@@ -215,7 +177,11 @@ gather_ga4() {
         {"name": "screenPageViews"},
         {"name": "totalRevenue"}
       ]
-    }' 2>/dev/null)
+    }')
+  if [ -z "$REPORT" ] || [ "$REPORT" = "{}" ]; then
+    echo "null"
+    return
+  fi
 
   local SESSIONS USERS CONVERSIONS PAGEVIEWS REVENUE CVR
   SESSIONS=$(printf '%s' "$REPORT" | jq -r '.rows[0].metricValues[0].value // "0"' 2>/dev/null || echo "0")

--- a/claude-ops/scripts/lib/ga4-data-api.sh
+++ b/claude-ops/scripts/lib/ga4-data-api.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# scripts/lib/ga4-data-api.sh — shared GA4 Data API helpers
+#
+# Source-able library used by both bin/ops-marketing-dash and
+# bin/ops-marketing-autopilot. All network paths honour OPS_DRY_RUN — when set,
+# requests are NOT issued and the helper returns an empty JSON envelope.
+#
+# Exports:
+#   ga4_auth_token [sa_key_file]            — print a fresh GA4 access token
+#   ga4_run_report <property_id> <body_json> — POST :runReport, print response JSON
+#
+# Requires: jq, openssl, curl, base64. ADC fallback uses gcloud if installed.
+
+[ -n "${_GA4_DATA_API_LOADED:-}" ] && return 0
+_GA4_DATA_API_LOADED=1
+
+# ga4_auth_token [sa_key_file]
+# Resolution order:
+#   1) explicit arg
+#   2) $GA4_SERVICE_ACCOUNT_KEY_FILE
+#   3) first ~/.config/gcloud/keys/*ga*.json
+#   4) gcloud ADC
+ga4_auth_token() {
+  local sa_key_file="${1:-${GA4_SERVICE_ACCOUNT_KEY_FILE:-}}"
+  if [ -z "$sa_key_file" ]; then
+    sa_key_file="$(ls "$HOME"/.config/gcloud/keys/*ga*.json 2>/dev/null | head -1 || true)"
+  fi
+  if [ -n "$sa_key_file" ] && [ -f "$sa_key_file" ]; then
+    local now exp header payload sig jwt resp sa_token
+    now=$(date +%s)
+    exp=$((now + 3600))
+    header=$(printf '{"alg":"RS256","typ":"JWT"}' | base64 | tr -d '=' | tr '+/' '-_' | tr -d '\n')
+    payload=$(printf '{"iss":"%s","scope":"https://www.googleapis.com/auth/analytics.readonly","aud":"https://oauth2.googleapis.com/token","exp":%d,"iat":%d}' \
+      "$(jq -r '.client_email' "$sa_key_file")" "$exp" "$now" \
+      | base64 | tr -d '=' | tr '+/' '-_' | tr -d '\n')
+    sig=$(printf '%s.%s' "$header" "$payload" \
+      | openssl dgst -sha256 -sign <(jq -r '.private_key' "$sa_key_file") 2>/dev/null \
+      | base64 | tr -d '=' | tr '+/' '-_' | tr -d '\n')
+    jwt="${header}.${payload}.${sig}"
+    resp=$(curl -sS --max-time 5 -X POST https://oauth2.googleapis.com/token \
+      --data "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=${jwt}" 2>/dev/null || echo '{}')
+    sa_token="$(printf '%s' "$resp" | jq -r '.access_token // empty' 2>/dev/null || true)"
+    if [ -n "$sa_token" ]; then
+      printf '%s' "$sa_token"
+      return 0
+    fi
+  fi
+  if command -v gcloud >/dev/null 2>&1; then
+    gcloud auth application-default print-access-token 2>/dev/null || true
+  fi
+}
+
+# ga4_run_report <property_id> <body_json>
+# Prints raw GA4 :runReport JSON or "{}" on failure / dry-run.
+ga4_run_report() {
+  local prop="${1:-}" body="${2:-}"
+  if [ -z "$prop" ] || [ "$prop" = "0" ] || [ -z "$body" ]; then
+    printf '%s' '{}'
+    return 0
+  fi
+  if [ "${OPS_DRY_RUN:-0}" = "1" ]; then
+    printf '%s' '{}'
+    return 0
+  fi
+  local tok
+  tok="$(ga4_auth_token)"
+  if [ -z "$tok" ]; then
+    printf '%s' '{}'
+    return 0
+  fi
+  curl -gsS --max-time 12 -X POST \
+    "https://analyticsdata.googleapis.com/v1beta/properties/${prop}:runReport" \
+    -H "Authorization: Bearer ${tok}" \
+    -H "Content-Type: application/json" \
+    -d "$body" 2>/dev/null || printf '%s' '{}'
+}

--- a/claude-ops/skills/ops-marketing/SKILL.md
+++ b/claude-ops/skills/ops-marketing/SKILL.md
@@ -84,10 +84,18 @@ The new bin reads project-level config from `$PREFS_PATH` under `marketing.proje
         },
 
         // Cred-refs for individual rows
-        "stripe":  { "secret_key":     "env:STRIPE_SECRET_KEY" },
+        "stripe":  {
+          "secret_key":  "env:STRIPE_SECRET_KEY",  // legacy DNS provisioner key
+          "api_key":     "env:STRIPE_API_KEY",     // P3: used by ops-marketing-autopilot stripe ROAS gate
+          "account_id":  "acct_<id>"                // optional, only when calling on behalf of a connected acct
+        },
         "meta":    { "access_token":   "env:META_ACCESS_TOKEN" },
-        "klaviyo": { "private_key":    "doppler:prd:KLAVIYO_API_KEY",
-                     "sending_subdomain": "em.example.com" }
+        "klaviyo": {
+          "private_key": "doppler:prd:KLAVIYO_API_KEY",  // legacy DNS row
+          "api_key":     "doppler:prd:KLAVIYO_API_KEY",  // P3: used by gather_klaviyo_metrics
+          "account_id":  "<klaviyo-account-id>",         // P3: optional
+          "sending_subdomain": "em.example.com"
+        }
       }
     }
   }
@@ -95,6 +103,27 @@ The new bin reads project-level config from `$PREFS_PATH` under `marketing.proje
 ```
 
 Defaults are applied bash-side via `${var:-default}`, so all values are optional except `domain` (required by `audit` and `provision-all`).
+
+### P3 — perf-data wiring (autopilot)
+
+`bin/ops-marketing-autopilot` reads four perf-data sources per pass and persists them to `${OPS_DATA_DIR}/state/autopilot/<project>-{ga4-conversions,gsc-signal,klaviyo,stripe}.json`:
+
+| Source | Prefs path | Helper | Purpose |
+|---|---|---|---|
+| GA4 conversions | `marketing.projects.<key>.ga4.{property_id, sa_key_file_ref}` | `gather_ga4_conversions` | source/medium/campaign rows for the blended bandit reward |
+| GSC search | `marketing.projects.<key>.gsc.site_url` | `gather_gsc_signal` | rescue + ad-copy-hook candidate buckets |
+| Klaviyo | `marketing.projects.<key>.klaviyo.{api_key, account_id}` | `gather_klaviyo_metrics` | Placed Order revenue + flow inventory |
+| Stripe | `marketing.projects.<key>.stripe.{api_key, account_id}` | `gather_stripe_revenue` | UTM-attributed revenue per `source/medium/campaign` and per `ad_id` — ground-truth ROAS denominator + pause-rescue gate |
+
+Env knobs:
+
+| Env | Default | Effect |
+|---|---|---|
+| `OPS_BANDIT_SOURCE` | `blended` | `meta` → meta-only reward (legacy), `ga4` → GA4 attribution only, `blended` → `(meta + ga4)/2` |
+| `OPS_PAUSE_ROAS_FLOOR` | `1.0` | An ad with `stripe_revenue ≥ floor × meta_spend` is kept despite Meta CPL/CTR pause criteria |
+| `OPS_KLAVIYO_REVENUE_RATIO_FLAG` | `0.5` | When `klaviyo_revenue / paid_spend > flag`, surface "email channel underweighted" in the daily report (no auto-shift) |
+
+UTM enforcement: every `create_object campaign …` call runs `utm_validate` (from `scripts/lib/utm-validate.sh`) on the derived `(utm_source, utm_medium, utm_campaign)` triple before any API mutation. Non-conforming names escalate + stage-only.
 
 ### Quick examples
 

--- a/claude-ops/tests/test-autopilot-bandit-blended.sh
+++ b/claude-ops/tests/test-autopilot-bandit-blended.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# test-autopilot-bandit-blended.sh — assert the bandit blended-reward path.
+#
+# Strategy: source the autopilot's functions (via env trick), seed a tiny
+# kpi.jsonl + ga4-conversions.json under STATE_DIR, then invoke
+# apply_calibration_and_bandit and verify a bandit_reward row is appended to
+# creatives.jsonl with both meta_revenue and ga4_revenue fields.
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$PLUGIN_ROOT/bin/ops-marketing-autopilot"
+
+pass=0; fail=0
+ok()  { echo "  PASS: $1"; pass=$((pass+1)); }
+err() { echo "  FAIL: $1 — $2"; fail=$((fail+1)); }
+
+echo "Testing bandit blended-reward path in $BIN"
+echo ""
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+export OPS_DATA_DIR="$WORK/data"
+export OPS_AUTOPILOT_PREFS="$WORK/preferences.json"
+mkdir -p "$OPS_DATA_DIR"
+
+# Pre-seed prefs with autopilot.enabled + no live channels (so process_meta skips)
+cat > "$OPS_AUTOPILOT_PREFS" <<'JSON'
+{
+  "marketing": {
+    "projects": {
+      "testproj": {
+        "autopilot": {
+          "enabled": true,
+          "daily_spend_cap_usd": 50,
+          "channels": []
+        }
+      }
+    }
+  }
+}
+JSON
+
+STATE_DIR="$OPS_DATA_DIR/state/autopilot"
+AP_STATE_DIR="$OPS_DATA_DIR/autopilot_state/testproj"
+mkdir -p "$STATE_DIR" "$AP_STATE_DIR"
+
+# Pre-mark project as installed so the autopilot runs in LIVE mode (not forced-dry)
+date -u +%Y-%m-%dT%H:%M:%SZ > "$STATE_DIR/testproj.installed"
+
+# Seed kpi.jsonl with two ad rows
+cat > "$AP_STATE_DIR/kpi.jsonl" <<'JSONL'
+{"ts":"2026-05-18T10:00:00Z","project":"testproj","ad_id":"ad_A","spend":10,"impressions":1000,"ctr":0.01,"cpl":5,"leads":2,"purchase_value":50}
+{"ts":"2026-05-18T10:00:00Z","project":"testproj","ad_id":"ad_B","spend":20,"impressions":1500,"ctr":0.008,"cpl":10,"leads":2,"purchase_value":30}
+JSONL
+
+# Seed creatives.jsonl so the bandit has scored candidates
+cat > "$AP_STATE_DIR/creatives.jsonl" <<'JSONL'
+{"ad_id":"ad_A","asset_path":"/tmp/a.png","tier2":{"prior":75,"verdict":"approved"},"deploy_ts":"2026-05-18T10:00:00Z"}
+{"ad_id":"ad_B","asset_path":"/tmp/b.png","tier2":{"prior":40,"verdict":"approved"},"deploy_ts":"2026-05-18T10:00:00Z"}
+JSONL
+
+# Seed ga4-conversions.json with a known revenue total
+cat > "$STATE_DIR/testproj-ga4-conversions.json" <<'JSON'
+{"rows":[
+  {"source":"meta","medium":"paid","campaign":"summer_v1_20260601","conversions":3,"revenue":60,"sessions":100},
+  {"source":"google","medium":"paid","campaign":"q2_v1_20260601","conversions":1,"revenue":20,"sessions":50}
+],"by_smc":{"meta/paid/summer_v1_20260601":{"conversions":3,"revenue":60,"sessions":100}}}
+JSON
+
+# ── 1. Default (blended) source → bandit_reward rows with ga4_revenue > 0 ────
+export OPS_BANDIT_SOURCE="blended"
+"$BIN" --project testproj >/dev/null 2>&1 || true
+
+if [ -f "$AP_STATE_DIR/creatives.jsonl" ]; then
+  reward_rows="$(grep -c 'bandit_reward' "$AP_STATE_DIR/creatives.jsonl" 2>/dev/null || true)"
+reward_rows="${reward_rows:-0}"
+else
+  reward_rows=0
+fi
+[ "${reward_rows:-0}" -ge 1 ] \
+  && ok "blended: bandit_reward rows written (${reward_rows})" \
+  || err "blended: no bandit_reward rows" "creatives.jsonl missing rows"
+
+ga4_present="$(grep -c 'ga4_revenue' "$AP_STATE_DIR/creatives.jsonl" 2>/dev/null || true)"
+ga4_present="${ga4_present:-0}"
+[ "${ga4_present}" -ge 1 ] \
+  && ok "blended: ga4_revenue present in reward row" \
+  || err "blended: ga4_revenue missing" "no ga4_revenue field"
+
+meta_present="$(grep -c 'meta_revenue' "$AP_STATE_DIR/creatives.jsonl" 2>/dev/null || true)"
+meta_present="${meta_present:-0}"
+[ "${meta_present}" -ge 1 ] \
+  && ok "blended: meta_revenue present in reward row" \
+  || err "blended: meta_revenue missing" "no meta_revenue field"
+
+source_blended="$(grep -c 'blended' "$AP_STATE_DIR/creatives.jsonl" 2>/dev/null || true)"
+source_blended="${source_blended:-0}"
+[ "${source_blended}" -ge 1 ] \
+  && ok "blended: source label written" \
+  || err "blended: source label missing" "expected 'source':'blended'"
+
+# ── 2. OPS_BANDIT_SOURCE=meta → no new bandit_reward rows appended ───────────
+# Reset ledger
+cat > "$AP_STATE_DIR/creatives.jsonl" <<'JSONL'
+{"ad_id":"ad_A","asset_path":"/tmp/a.png","tier2":{"prior":75,"verdict":"approved"},"deploy_ts":"2026-05-18T10:00:00Z"}
+{"ad_id":"ad_B","asset_path":"/tmp/b.png","tier2":{"prior":40,"verdict":"approved"},"deploy_ts":"2026-05-18T10:00:00Z"}
+JSONL
+
+export OPS_BANDIT_SOURCE="meta"
+"$BIN" --project testproj >/dev/null 2>&1 || true
+
+reward_rows_meta="$(grep -c 'bandit_reward' "$AP_STATE_DIR/creatives.jsonl" 2>/dev/null || true)"
+reward_rows_meta="${reward_rows_meta:-0}"
+[ "${reward_rows_meta}" -eq 0 ] \
+  && ok "source=meta: no blended reward rows appended" \
+  || err "source=meta: unexpected reward rows" "${reward_rows_meta}"
+
+# ── 3. Report mentions the bandit reward source ──────────────────────────────
+report="$OPS_DATA_DIR/reports/marketing-autopilot/testproj-latest.md"
+if [ -L "$report" ] && [ -f "$report" ]; then
+  grep -q "bandit reward source:" "$report" \
+    && ok "report mentions reward source" \
+    || err "report missing reward source" "expected 'bandit reward source:'"
+else
+  err "report not generated" "$report not found"
+fi
+
+echo ""
+echo "---"
+echo "Results: $pass passed, $fail failed"
+(( fail == 0 )) || { echo "ACTION: fix failing tests above."; exit 1; }
+exit 0

--- a/claude-ops/tests/test-ga4-data-api-lib.sh
+++ b/claude-ops/tests/test-ga4-data-api-lib.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# test-ga4-data-api-lib.sh — smoke tests for scripts/lib/ga4-data-api.sh
+#
+# Hermetic: OPS_DRY_RUN=1 throughout — zero network calls.
+# Asserts:
+#  - the lib sources without error
+#  - ga4_auth_token returns empty without creds (no crash)
+#  - ga4_run_report respects OPS_DRY_RUN (no curl)
+#  - ga4_run_report returns "{}" on empty property
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LIB="$PLUGIN_ROOT/scripts/lib/ga4-data-api.sh"
+
+pass=0; fail=0
+ok()  { echo "  PASS: $1"; pass=$((pass+1)); }
+err() { echo "  FAIL: $1 — $2"; fail=$((fail+1)); }
+
+echo "Testing $LIB"
+echo ""
+
+[ -f "$LIB" ] && ok "lib file exists" || { err "lib missing" "$LIB"; exit 1; }
+
+# Source in a subshell so guard variable doesn't leak
+out="$(
+  set +u
+  unset GA4_SERVICE_ACCOUNT_KEY_FILE
+  export OPS_DRY_RUN=1
+  # shellcheck disable=SC1090
+  . "$LIB"
+  # 1) no property → "{}"
+  r1="$(ga4_run_report '' '{}')"
+  echo "r1=${r1}"
+  # 2) dry-run with property → "{}"
+  r2="$(ga4_run_report '123456789' '{"dateRanges":[{"startDate":"7daysAgo","endDate":"today"}]}')"
+  echo "r2=${r2}"
+  # 3) ga4_auth_token with no creds → empty
+  HOME=/tmp/no-such-home r3="$(HOME=/tmp/no-such-home GA4_SERVICE_ACCOUNT_KEY_FILE='' ga4_auth_token 2>/dev/null)"
+  echo "r3=[${r3}]"
+)"
+
+echo "$out" | grep -q '^r1={}$' \
+  && ok "empty property_id returns '{}'" || err "empty property_id" "got: $(echo "$out" | grep '^r1=')"
+
+echo "$out" | grep -q '^r2={}$' \
+  && ok "OPS_DRY_RUN=1 returns '{}' (no network)" || err "OPS_DRY_RUN=1" "got: $(echo "$out" | grep '^r2=')"
+
+# r3 may be empty or fail; we only check no crash (output present)
+echo "$out" | grep -q '^r3=\[' \
+  && ok "ga4_auth_token does not crash without creds" || err "ga4_auth_token crash" "missing r3"
+
+# 4) Double-source guard
+out2="$(
+  set +u
+  export OPS_DRY_RUN=1
+  # shellcheck disable=SC1090
+  . "$LIB"
+  # shellcheck disable=SC1090
+  . "$LIB"
+  echo "double-sourced ok"
+)"
+echo "$out2" | grep -q 'double-sourced ok' \
+  && ok "double-sourcing is idempotent" || err "double-source" "guard failed"
+
+echo ""
+echo "---"
+echo "Results: $pass passed, $fail failed"
+(( fail == 0 )) || { echo "ACTION: fix failing tests above."; exit 1; }
+exit 0

--- a/claude-ops/tests/test-stripe-rescue-gate.sh
+++ b/claude-ops/tests/test-stripe-rescue-gate.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# test-stripe-rescue-gate.sh — assert that an ad with stripe revenue ≥ spend
+# is NOT paused by the autopilot's deterministic pause sweep.
+#
+# Strategy: spawn a sub-shell that sources the autopilot's helper region by
+# extracting the should_pause_ad function definition. Drive it with a fake
+# STATE_DIR/<proj>-stripe.json and verify decisions for both rescue + non-
+# rescue cases. No network, no real autopilot binary execution.
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$PLUGIN_ROOT/bin/ops-marketing-autopilot"
+
+pass=0; fail=0
+ok()  { echo "  PASS: $1"; pass=$((pass+1)); }
+err() { echo "  FAIL: $1 — $2"; fail=$((fail+1)); }
+
+echo "Testing stripe-rescue gate in $BIN"
+echo ""
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+STATE_DIR="$WORK/state"
+mkdir -p "$STATE_DIR"
+
+# Seed a stripe revenue file: ad_A earned $50 from Stripe charges
+cat > "$STATE_DIR/proj-stripe.json" <<'JSON'
+{
+  "total_revenue_7d": 90,
+  "by_smc": {},
+  "by_ad_id": {
+    "ad_A": {"revenue": 50, "charges": 5},
+    "ad_B": {"revenue":  2, "charges": 1},
+    "ad_C": {"revenue":  0, "charges": 0}
+  }
+}
+JSON
+
+# Extract + source just the helper region (stripe_revenue_for_ad + should_pause_ad)
+HELPERS="$WORK/helpers.sh"
+{
+  echo '#!/usr/bin/env bash'
+  echo 'set -uo pipefail'
+  echo 'STATE_DIR="$1"; shift'
+  echo 'log() { :; }'
+  echo 'report() { :; }'
+  # Pull the two helpers from the binary verbatim
+  awk '
+    /^stripe_revenue_for_ad\(\)/ {p=1}
+    /^should_pause_ad\(\)/        {p=1}
+    p {print}
+    p && /^}/                     {p=0; print ""}
+  ' "$BIN"
+  cat <<'PY'
+ad="$1"; spend="$2"; floor="${3:-1.0}"
+OPS_PAUSE_ROAS_FLOOR="$floor" should_pause_ad proj "$ad" "$spend"
+PY
+} > "$HELPERS"
+chmod +x "$HELPERS"
+
+# Case 1: ad_A — revenue=50, spend=30 → revenue ≥ floor*spend (1.0 * 30 = 30) → KEEP
+d1="$(bash "$HELPERS" "$STATE_DIR" ad_A 30 1.0)"
+[ "$d1" = "no" ] \
+  && ok "ad_A kept: revenue \$50 ≥ \$30 spend × floor 1.0" \
+  || err "ad_A rescue" "expected 'no', got '$d1'"
+
+# Case 2: ad_B — revenue=2, spend=30 → revenue < floor*spend → PAUSE
+d2="$(bash "$HELPERS" "$STATE_DIR" ad_B 30 1.0)"
+[ "$d2" = "yes" ] \
+  && ok "ad_B paused: revenue \$2 < \$30" \
+  || err "ad_B pause" "expected 'yes', got '$d2'"
+
+# Case 3: ad_C — revenue=0, spend=30 → PAUSE
+d3="$(bash "$HELPERS" "$STATE_DIR" ad_C 30 1.0)"
+[ "$d3" = "yes" ] \
+  && ok "ad_C paused: zero stripe revenue" \
+  || err "ad_C pause" "expected 'yes', got '$d3'"
+
+# Case 4: unknown ad → no stripe data → PAUSE (no rescue without data)
+d4="$(bash "$HELPERS" "$STATE_DIR" ad_unknown 30 1.0)"
+[ "$d4" = "yes" ] \
+  && ok "unknown ad paused: no stripe rescue without revenue data" \
+  || err "unknown ad" "expected 'yes', got '$d4'"
+
+# Case 5: ad_A with high floor (3.0) → revenue 50 < 3.0×30=90 → PAUSE
+d5="$(bash "$HELPERS" "$STATE_DIR" ad_A 30 3.0)"
+[ "$d5" = "yes" ] \
+  && ok "ad_A paused at floor 3.0: revenue \$50 < \$90 required" \
+  || err "ad_A high floor" "expected 'yes', got '$d5'"
+
+# Case 6: zero spend ad → PAUSE (rescue requires positive spend baseline)
+d6="$(bash "$HELPERS" "$STATE_DIR" ad_A 0 1.0)"
+[ "$d6" = "yes" ] \
+  && ok "ad with zero spend → no rescue (no baseline)" \
+  || err "zero spend" "expected 'yes', got '$d6'"
+
+# Case 7: missing stripe file → PAUSE
+rm -f "$STATE_DIR/proj-stripe.json"
+d7="$(bash "$HELPERS" "$STATE_DIR" ad_A 30 1.0)"
+[ "$d7" = "yes" ] \
+  && ok "no stripe file → no rescue, ad paused" \
+  || err "no stripe file" "expected 'yes', got '$d7'"
+
+echo ""
+echo "---"
+echo "Results: $pass passed, $fail failed"
+(( fail == 0 )) || { echo "ACTION: fix failing tests above."; exit 1; }
+exit 0


### PR DESCRIPTION
## Summary

Closes the optimizer-blindness audit: autopilot today reads ONLY Meta + Google Ads in-platform metrics. The dash collects GA4 / GSC / Klaviyo / Stripe but none of it ever feeds bandit decisions or pause logic. This PR closes that loop.

**Audit motivation:**
- 8 dormant GA4 MP secrets + half-blind optimizer — every pause/keep decision was Meta-only ground truth
- No ROAS gate before pause — high-revenue ads were being killed on Meta CPL threshold alone
- UTM enforcement library shipped in #257 but never wired into create-campaign paths

**What's in:**
1. `scripts/lib/ga4-data-api.sh` — shared GA4 :runReport helper (auth + transport), used by dash + autopilot
2. `gather_ga4_conversions` — 7d source/medium/campaign rows, persisted to state
3. `gather_gsc_signal` — 28d query/page, bucketed into rescue (pos 8-30, CTR<5%) + ad-copy hooks (pos 1-3, CTR<30%)
4. `gather_klaviyo_metrics` — Placed Order revenue (7d) + live flow inventory
5. `gather_stripe_revenue` — /v1/charges 7d, UTM-aggregated by source/medium/campaign + by ad_id
6. **Blended bandit reward** — `bandit_reward` events with `meta_revenue + ga4_revenue + reward`; env `OPS_BANDIT_SOURCE=ga4|meta|blended` (default blended)
7. **Stripe-rescue pause gate** — before pausing on Meta criteria, check UTM-tagged Stripe revenue per ad; if `revenue ≥ OPS_PAUSE_ROAS_FLOOR (default 1.0) × meta_spend`, keep + log `stripe-rescue: kept ad despite meta CPL threshold`
8. **Klaviyo underweight surface** — `klaviyo_revenue / paid_spend > OPS_KLAVIYO_REVENUE_RATIO_FLAG (default 0.5)` flags in daily report (no auto-shift; P4 work)
9. **Ground-truth ROAS** — surfaced as `stripe_revenue_7d / meta_spend_7d` in the daily report
10. **UTM enforcement** — every `create_object campaign …` runs `utm_validate`; non-conforming names auto-normalize to `<slug>_v1_YYYYMMDD`, hard failures escalate + stage-only

**Schema additions** (all cred-refs):
- `marketing.projects.<key>.stripe.api_key`, `.stripe.account_id`
- `marketing.projects.<key>.klaviyo.api_key`, `.klaviyo.account_id`
- `marketing.projects.<key>.ga4.sa_key_file_ref` (optional override)

**Follow-up (P6 self-healing) blocked on this merge.** P6 needs the ground-truth ROAS denominator + the stripe-attributed per-ad revenue map to make autonomous budget-shift decisions safe.

## Test plan

- [x] `bash tests/test-ga4-data-api-lib.sh` — 5/5 pass
- [x] `bash tests/test-autopilot-bandit-blended.sh` — 6/6 pass
- [x] `bash tests/test-stripe-rescue-gate.sh` — 7/7 pass
- [x] `bash tests/test-autopilot-cap.sh` — 13/13 pass (regression: cap pre-flight + dry-run still hold)
- [x] `bash tests/test-autopilot-autonomy.sh` — zero new regressions vs origin/main (5 pre-existing failures unchanged)
- [x] `bash tests/test-no-secrets.sh` — 14/14 pass (Rule 0 clean)
- [x] `bash tests/test-ops-conversion-send.sh` — 20/20 pass (downstream lib still works)
- [x] `shellcheck -S warning` clean on all touched files (only pre-existing SC2034 outside touched regions)

## Hard constraints met

- ✅ idempotent (`[ -f "$out" ] ||` guards in not-configured branches preserve seeded test data)
- ✅ `set -euo pipefail` throughout
- ✅ OPS_DRY_RUN supported on every new API path (no network mutations under dry-run)
- ✅ Rule 0 clean (no real names/domains/emails/IDs)
- ✅ Never breaks existing Meta / GAds paths — they remain the default channel handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches autonomous pause/keep and bandit-reward logic and adds new integrations (GA4/GSC/Klaviyo/Stripe), so misconfiguration or attribution errors could change optimization decisions despite dry-run/skip safeguards.
> 
> **Overview**
> Autopilot now **collects and persists real performance data** each pass (GA4 conversions by source/medium/campaign, GSC query/page signals, Klaviyo placed-order revenue + live flows, and Stripe charge revenue aggregated by UTM and `ad_id`) and surfaces key signals (Stripe ground-truth ROAS, GSC opportunities, Klaviyo underweight flag) in the daily report.
> 
> Decisioning changes: bandit training can now emit `bandit_reward` events using **Meta-only, GA4-only, or blended** reward (`OPS_BANDIT_SOURCE`), and the Meta pause sweep adds a **Stripe “rescue gate”** to keep ads whose Stripe-attributed revenue meets `OPS_PAUSE_ROAS_FLOOR × spend`.
> 
> Infrastructure/docs: GA4 Data API auth/transport is factored into a new shared `scripts/lib/ga4-data-api.sh` used by both `ops-marketing-dash` and autopilot, `create_object campaign` now enforces/auto-normalizes UTM campaign names via `utm_validate` (escalating on failure), and docs/tests are added/updated for the new prefs fields and behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e477de17613d5d54b4469b16072aa763a7f1392. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Campaign UTM validation with automatic normalization for invalid naming.
  * Stripe-based revenue protection: ads meeting spend-based ROAS thresholds are now retained during underperformance sweeps.
  * Real-time performance data collection from GA4, GSC, Klaviyo, and Stripe sources.

* **Documentation**
  * Expanded configuration schema for Stripe and Klaviyo credentials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->