### PR TITLE
fix(security): purge personal namespace from marketing prewarm + telegram-server (F-008, F-009)

### DIFF
--- a/claude-ops/bin/ops-marketing-link-prewarm
+++ b/claude-ops/bin/ops-marketing-link-prewarm
@@ -72,7 +72,7 @@ category_mappings() {
     analytics_ga4)
       echo "property_id:ga4.property_id"
       echo "measurement_id:ga4.measurement_id"
-      echo "api_secret:ga4.api_secret"
+      echo "api_secret:ga4.api_secret"  # gitleaks:allow — prefs path reference, not a literal secret
       ;;
     analytics_amplitude)
       echo "api_key:amplitude.api_key"

--- a/claude-ops/scripts/ops-marketing-auth-prewarm.sh
+++ b/claude-ops/scripts/ops-marketing-auth-prewarm.sh
@@ -83,24 +83,26 @@ extract_project_hint() {
 
   # look for product name embedded in the key itself
   # e.g. META_HEALIFY_ACCESS_TOKEN → healify, STRIPE_FIBERWIFI_SECRET_KEY → fiberwifi
-  # First try projects already defined in prefs (highest signal — these are
-  # the projects /ops:marketing knows about). Then fall back to a static
-  # known list for projects that exist in Doppler but aren't yet in prefs.
+  # Source of truth: user's configured projects in $PREFS_PATH under
+  # .marketing.projects (and optionally .marketing.account_slugs[]).
+  # No hardcoded project names — those are user PII and must live in config.
   local prefs_path="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
-  local prefs_projects=()
+  local known_products=()
   if [ -f "$prefs_path" ]; then
     while IFS= read -r p; do
-      [ -n "$p" ] && prefs_projects+=("$p")
-    done < <(jq -r '.marketing.projects | keys[]?' "$prefs_path" 2>/dev/null)
+      [ -n "$p" ] && known_products+=("$p")
+    done < <(jq -r '
+      [
+        (.marketing.projects | keys[]?),
+        (.marketing.account_slugs[]?)
+      ] | unique | .[]
+    ' "$prefs_path" 2>/dev/null)
   fi
 
-  local known_products=(
-    "${prefs_projects[@]}"
-    "healify" "alwaysbright" "stagery" "inboxassist" "fiberinternet" "fiberwifi"
-    "shannon" "talktoyourhouse" "claude-ops" "claudeops" "flowrider" "hueman"
-    "upres" "whoopgo" "aurora" "bondmcp" "payfwd" "messo" "manus"
-    "samrenders" "homey" "carrier" "anna" "mango" "hypest" "maitre"
-  )
+  # No configured projects → no hint extraction possible; fall back to the
+  # doppler project base name. Caller-level guard already handles the
+  # zero-config case at script entry, so reaching here with an empty list
+  # is harmless.
   # Dedupe + sort by length descending so longer matches win (e.g. "fiberwifi" before "fiber")
   local sorted_products
   sorted_products=$(printf '%s\n' "${known_products[@]}" | awk 'NF' | sort -u | awk '{ print length, $0 }' | sort -rn | cut -d" " -f2-)
@@ -129,6 +131,27 @@ extract_project_hint() {
   # fall back to base doppler project name
   echo "$base_project"
 }
+
+# ── precondition: at least one marketing project must be configured ──────────
+# Load slugs from the partner registry (preferences.json). If empty, exit 0
+# as a graceful no-op so this script can be safely chained in setup flows.
+PREFS_PATH="$DATA_DIR/preferences.json"
+CONFIGURED_SLUGS=()
+if [ -f "$PREFS_PATH" ]; then
+  while IFS= read -r p; do
+    [ -n "$p" ] && CONFIGURED_SLUGS+=("$p")
+  done < <(jq -r '
+    [
+      (.marketing.projects | keys[]?),
+      (.marketing.account_slugs[]?)
+    ] | unique | .[]
+  ' "$PREFS_PATH" 2>/dev/null)
+fi
+
+if [ "${#CONFIGURED_SLUGS[@]}" -eq 0 ]; then
+  echo "no marketing accounts configured — run /ops:setup marketing"
+  exit 0
+fi
 
 # ── accumulate entries into a temp JSON lines file ────────────────────────────
 TMP_ENTRIES="$(mktemp)"

--- a/claude-ops/scripts/ops-marketing-auth-prewarm.sh
+++ b/claude-ops/scripts/ops-marketing-auth-prewarm.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 #   OPS_PREWARM_DRY_RUN - if set to 1, print output to stderr only (no file write)
 
 DATA_DIR="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+PREFS_PATH="${PREFS_PATH:-${CLAUDE_PLUGIN_DATA_DIR:-$DATA_DIR}/preferences.json}"
 OUTPUT_FILE="$DATA_DIR/marketing-auth-prewarm.json"
 GENERATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
@@ -86,17 +87,16 @@ extract_project_hint() {
   # Source of truth: user's configured projects in $PREFS_PATH under
   # .marketing.projects (and optionally .marketing.account_slugs[]).
   # No hardcoded project names — those are user PII and must live in config.
-  local prefs_path="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
   local known_products=()
-  if [ -f "$prefs_path" ]; then
+  if [ -f "$PREFS_PATH" ]; then
     while IFS= read -r p; do
       [ -n "$p" ] && known_products+=("$p")
     done < <(jq -r '
       [
-        (.marketing.projects | keys[]?),
+        (.marketing.projects // {} | keys[]?),
         (.marketing.account_slugs[]?)
       ] | unique | .[]
-    ' "$prefs_path" 2>/dev/null)
+    ' "$PREFS_PATH" 2>/dev/null)
   fi
 
   # No configured projects → no hint extraction possible; fall back to the
@@ -135,14 +135,13 @@ extract_project_hint() {
 # ── precondition: at least one marketing project must be configured ──────────
 # Load slugs from the partner registry (preferences.json). If empty, exit 0
 # as a graceful no-op so this script can be safely chained in setup flows.
-PREFS_PATH="$DATA_DIR/preferences.json"
 CONFIGURED_SLUGS=()
 if [ -f "$PREFS_PATH" ]; then
   while IFS= read -r p; do
     [ -n "$p" ] && CONFIGURED_SLUGS+=("$p")
   done < <(jq -r '
     [
-      (.marketing.projects | keys[]?),
+      (.marketing.projects // {} | keys[]?),
       (.marketing.account_slugs[]?)
     ] | unique | .[]
   ' "$PREFS_PATH" 2>/dev/null)

--- a/claude-ops/scripts/ops-marketing-auth-prewarm.sh
+++ b/claude-ops/scripts/ops-marketing-auth-prewarm.sh
@@ -84,20 +84,10 @@ extract_project_hint() {
 
   # look for product name embedded in the key itself
   # e.g. META_HEALIFY_ACCESS_TOKEN → healify, STRIPE_FIBERWIFI_SECRET_KEY → fiberwifi
-  # Source of truth: user's configured projects in $PREFS_PATH under
-  # .marketing.projects (and optionally .marketing.account_slugs[]).
+  # Same slugs as CONFIGURED_SLUGS (loaded once from $PREFS_PATH:
+  # .marketing.projects keys and .marketing.account_slugs[]).
   # No hardcoded project names — those are user PII and must live in config.
-  local known_products=()
-  if [ -f "$PREFS_PATH" ]; then
-    while IFS= read -r p; do
-      [ -n "$p" ] && known_products+=("$p")
-    done < <(jq -r '
-      [
-        (.marketing.projects // {} | keys[]?),
-        (.marketing.account_slugs[]?)
-      ] | unique | .[]
-    ' "$PREFS_PATH" 2>/dev/null)
-  fi
+  local known_products=("${CONFIGURED_SLUGS[@]}")
 
   # No configured projects → no hint extraction possible; fall back to the
   # doppler project base name. Caller-level guard already handles the

--- a/claude-ops/skills/setup/channels/marketing.md
+++ b/claude-ops/skills/setup/channels/marketing.md
@@ -1,5 +1,7 @@
 ### 3j — Marketing (Klaviyo, Meta Ads, GA4, Search Console)
 
+> **Project slugs are the entry gate.** Every sub-step below writes under `marketing.projects.<slug>` in `$PREFS_PATH`. Those slugs (plus an optional flat `marketing.account_slugs[]` array) are the canonical source consumed by `ops-marketing-auth-prewarm.sh` for product-hint extraction. The prewarm script no longer ships a hardcoded slug list — if no projects/slugs exist in prefs it prints `no marketing accounts configured — run /ops:setup marketing` and exits 0. Make sure the user has at least one project slug picked before continuing.
+
 **Before showing the service selector**, run the Universal Credential Auto-Scan for all marketing vars simultaneously:
 
 ```bash

--- a/claude-ops/telegram-server/package.json
+++ b/claude-ops/telegram-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-ops-telegram-server",
   "version": "0.2.1",
-  "mcpName": "io.github.auroracapital/claude-ops-telegram-server",
+  "mcpName": "io.github.lifecycle-innovations-limited/claude-ops-telegram-server",
   "description": "Telegram user-auth MCP server for claude-ops plugin (personal account via MTProto, not bots)",
   "license": "MIT",
   "repository": {

--- a/claude-ops/telegram-server/server.json
+++ b/claude-ops/telegram-server/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.auroracapital/claude-ops-telegram-server",
+  "name": "io.github.lifecycle-innovations-limited/claude-ops-telegram-server",
   "description": "Telegram personal-account MCP (MTProto user-auth). Read DMs, send messages, search across chats.",
   "repository": {
     "url": "https://github.com/Lifecycle-Innovations-Limited/claude-ops",


### PR DESCRIPTION
## Summary

Closes two MEDIUM-severity findings from the public-repo PII audit.

- **F-008** `claude-ops/scripts/ops-marketing-auth-prewarm.sh` — replaced the hardcoded array of project slugs (which included the username `<USER>` plus a long list of personal projects) with a `$PREFS_PATH` lookup of `.marketing.projects` keys + optional `.marketing.account_slugs[]`. If no slugs are configured the script now prints `no marketing accounts configured — run /ops:setup marketing` and exits 0 (graceful no-op, not failure).
- **F-009** `claude-ops/telegram-server/{package,server}.json` — renamed the MCP server identifier from `io.github.auroracapital/claude-ops-telegram-server` (private org namespace public users can't claim) to `io.github.lifecycle-innovations-limited/claude-ops-telegram-server` (canonical public org of this repo).
- Added a short note to `claude-ops/skills/setup/channels/marketing.md` explaining that project slugs are the entry gate consumed by the prewarm script and pointing users to `/ops:setup marketing` to populate them.

## Verifications

```
git grep "<USER>" claude-ops/scripts/ops-marketing-auth-prewarm.sh        → 0 matches
git grep "io\.github\.auroracapital" -- ':!CHANGELOG.md'                      → 0 matches
bash -n claude-ops/scripts/ops-marketing-auth-prewarm.sh                      → OK
python3 -m json.tool claude-ops/telegram-server/package.json                  → valid JSON
python3 -m json.tool claude-ops/telegram-server/server.json                   → valid JSON
```

`SECURITY.md` still references `@auroracapital/gog` — that is a different npm scope (a private dependency acknowledged in the security notes section), not the `io.github.auroracapital` MCP namespace, so it is intentionally left alone. `CHANGELOG.md` is also intentionally left alone per audit guidance (historical entries acceptable).

## Test plan

- [ ] Run `bash claude-ops/scripts/ops-marketing-auth-prewarm.sh` on a fresh install with no `marketing.projects` configured → expect graceful no-op message and exit 0.
- [ ] Run the same script on a system with `.marketing.projects` populated by `/ops:setup marketing` → expect normal scan output and a written cache file.
- [ ] Validate the renamed MCP identifier against the MCP registry schema (server.json `$schema` already declared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how the marketing prewarm script derives project hints (now requires configured slugs and can no-op), which could affect credential auto-linking behavior; Telegram changes are identifier-only.
> 
> **Overview**
> Eliminates hardcoded marketing project slug lists from `ops-marketing-auth-prewarm.sh` by loading configured slugs from `$PREFS_PATH` (`.marketing.projects` keys and optional `.marketing.account_slugs[]`), and makes the script a graceful no-op (exit 0) when none are configured.
> 
> Updates docs to make project slugs the required entry gate for marketing setup, adds a `gitleaks:allow` comment for the GA4 `api_secret` prefs-path reference, and renames the Telegram MCP server identifier in `telegram-server/package.json` and `telegram-server/server.json` to the repo’s public org namespace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e9b96c427dde76d6940d6117dc560bb13561271. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated marketing setup documentation with new configuration requirements and setup instructions.

* **Chores**
  * Updated Telegram server identifier across manifests.
  * Marketing authentication script now uses user-configured projects instead of defaults and provides clearer feedback when no marketing accounts are configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->