### PR TITLE
feat(pocket): templatize pocket-activity-notifier for fresh installs

### DIFF
--- a/claude-ops/bin/ops-marketing-portfolio
+++ b/claude-ops/bin/ops-marketing-portfolio
@@ -31,7 +31,6 @@ for ((i=1; i<=$#; i++)); do
     --json) JSON_OUT=1 ;;
     --project)
       j=$((i+1)); FILTER_PROJECT="${!j:-}"
-      i=$((i+1))
       ;;
   esac
 done

--- a/claude-ops/bin/ops-marketing-portfolio
+++ b/claude-ops/bin/ops-marketing-portfolio
@@ -31,6 +31,7 @@ for ((i=1; i<=$#; i++)); do
     --json) JSON_OUT=1 ;;
     --project)
       j=$((i+1)); FILTER_PROJECT="${!j:-}"
+      i=$((i+1)) # skip value so it is not parsed as a flag on the next iteration
       ;;
   esac
 done

--- a/claude-ops/scripts/com.claude-ops.daemon.plist
+++ b/claude-ops/scripts/com.claude-ops.daemon.plist
@@ -32,6 +32,8 @@
         <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
         <key>HOME</key>
         <string>__HOME__</string>
+        <key>CLAUDE_PLUGIN_ROOT</key>
+        <string>__PLUGIN_ROOT__</string>
     </dict>
 </dict>
 </plist>

--- a/claude-ops/scripts/com.claude-ops.pocket-activity-notifier.plist
+++ b/claude-ops/scripts/com.claude-ops.pocket-activity-notifier.plist
@@ -7,8 +7,8 @@
 
     <key>ProgramArguments</key>
     <array>
-        <string>__PYTHON_PATH__</string>
-        <string>__SCRIPT_PATH__</string>
+        <string>__BASH_PATH__</string>
+        <string>__POCKET_NOTIFIER_LAUNCHER_PATH__</string>
     </array>
 
     <key>StartInterval</key>

--- a/claude-ops/scripts/com.claude-ops.pocket-activity-notifier.plist
+++ b/claude-ops/scripts/com.claude-ops.pocket-activity-notifier.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude-ops.pocket-activity-notifier</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__PYTHON_PATH__</string>
+        <string>__SCRIPT_PATH__</string>
+    </array>
+
+    <key>StartInterval</key>
+    <integer>60</integer>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/.claude/state/pocket/activity-notifier.stdout.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/.claude/state/pocket/activity-notifier.stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>USER</key>
+        <string>__USER__</string>
+    </dict>
+</dict>
+</plist>

--- a/claude-ops/scripts/daemon-services.default.json
+++ b/claude-ops/scripts/daemon-services.default.json
@@ -20,6 +20,14 @@
       "restart_delay": 3600,
       "cron": "*/30 * * * *"
     },
+    "pocket-activity-notifier": {
+      "enabled": false,
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-pocket-activity-notifier.py",
+      "cron": "* * * * *",
+      "health_file": "~/.claude/state/pocket/.activity-notifier-health",
+      "restart_delay": 60,
+      "_note": "Watches pocket spawn-ledger + executor-results dir; emits START + DONE events to WhatsApp self-chat + email with the report attached. Requires whatsapp-config.json and/or email-config.json under ~/.claude/state/pocket/. Run `bash scripts/install-pocket-notifier.sh` to register the launchd job (preferred over the cron-via-daemon path for sub-minute latency)."
+    },
     "fires-watcher": {
       "enabled": false,
       "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-fires-watcher.sh",

--- a/claude-ops/scripts/install-pocket-notifier.sh
+++ b/claude-ops/scripts/install-pocket-notifier.sh
@@ -32,6 +32,9 @@ if [[ -z "$PLUGIN_ROOT" || ! -d "$PLUGIN_ROOT" ]]; then
 fi
 
 NOTIFIER_SCRIPT="$PLUGIN_ROOT/scripts/ops-pocket-activity-notifier.py"
+LAUNCHER_SCRIPT="$PLUGIN_ROOT/scripts/ops-pocket-activity-notifier-launcher.sh"
+LAUNCHER_DEST_DIR="$HOME/.claude/plugins/data/ops-ops-marketplace/bin"
+LAUNCHER_DEST="$LAUNCHER_DEST_DIR/ops-pocket-activity-notifier-launcher.sh"
 PLIST_TEMPLATE="$PLUGIN_ROOT/scripts/com.claude-ops.pocket-activity-notifier.plist"
 PLIST_DEST="$HOME/Library/LaunchAgents/com.claude-ops.pocket-activity-notifier.plist"
 STATE_DIR="$HOME/.claude/state/pocket"
@@ -39,36 +42,37 @@ STATE_DIR="$HOME/.claude/state/pocket"
 # Fall back to script-dir-relative paths when invoked from a fresh checkout
 # where the plugin root resolution above lands somewhere unexpected.
 [[ -f "$NOTIFIER_SCRIPT" ]] || NOTIFIER_SCRIPT="$SCRIPT_DIR/ops-pocket-activity-notifier.py"
+[[ -f "$LAUNCHER_SCRIPT" ]] || LAUNCHER_SCRIPT="$SCRIPT_DIR/ops-pocket-activity-notifier-launcher.sh"
 [[ -f "$PLIST_TEMPLATE"  ]] || PLIST_TEMPLATE="$SCRIPT_DIR/com.claude-ops.pocket-activity-notifier.plist"
 
-for f in "$NOTIFIER_SCRIPT" "$PLIST_TEMPLATE"; do
+for f in "$NOTIFIER_SCRIPT" "$LAUNCHER_SCRIPT" "$PLIST_TEMPLATE"; do
   [[ -f "$f" ]] || { echo "error: required plugin file not found: $f" >&2; exit 1; }
 done
 
-mkdir -p "$STATE_DIR"
+mkdir -p "$STATE_DIR" "$LAUNCHER_DEST_DIR"
 chmod +x "$NOTIFIER_SCRIPT"
 
-# Resolve python3. Prefer Homebrew on Apple Silicon, then Intel Homebrew,
-# then fall back to whichever python3 is first on PATH.
-PYTHON_PATH=""
-if [[ -x /opt/homebrew/bin/python3 ]]; then
-  PYTHON_PATH="/opt/homebrew/bin/python3"
-elif [[ -x /usr/local/bin/python3 ]]; then
-  PYTHON_PATH="/usr/local/bin/python3"
-else
-  PYTHON_PATH="$(command -v python3 || true)"
-fi
-if [[ -z "$PYTHON_PATH" || ! -x "$PYTHON_PATH" ]]; then
-  echo "error: could not find python3 — install via 'brew install python' and retry" >&2
-  exit 1
+# Install the version-agnostic launcher to a stable location outside the
+# version-pinned cache dir. The plist points at THIS path forever — the
+# launcher resolves the latest installed ops version at run time.
+cp "$LAUNCHER_SCRIPT" "$LAUNCHER_DEST"
+chmod +x "$LAUNCHER_DEST"
+
+# macOS ships bash 3; Homebrew installs bash 5 at /opt/homebrew/bin/bash.
+BASH_PATH="/bin/bash"
+if [[ -x /opt/homebrew/bin/bash ]]; then
+  BASH_PATH="/opt/homebrew/bin/bash"
+elif [[ -x /usr/local/bin/bash ]]; then
+  BASH_PATH="/usr/local/bin/bash"
 fi
 
-# Generate plist from template.
+# Generate plist from template. Point at the stable launcher path so plugin
+# upgrades don't strand the plist on a deleted version dir.
 TMP_PLIST="$(mktemp -t pocket-activity-notifier.XXXXXX.plist)"
 trap 'rm -f "$TMP_PLIST"' EXIT
 
-sed -e "s|__PYTHON_PATH__|$PYTHON_PATH|g" \
-    -e "s|__SCRIPT_PATH__|$NOTIFIER_SCRIPT|g" \
+sed -e "s|__BASH_PATH__|$BASH_PATH|g" \
+    -e "s|__POCKET_NOTIFIER_LAUNCHER_PATH__|$LAUNCHER_DEST|g" \
     -e "s|__HOME__|$HOME|g" \
     -e "s|__USER__|$USER|g" \
     "$PLIST_TEMPLATE" > "$TMP_PLIST"
@@ -85,8 +89,8 @@ launchctl enable "gui/$(id -u)/com.claude-ops.pocket-activity-notifier"
 if launchctl list | grep -q "com.claude-ops.pocket-activity-notifier"; then
   echo "✓ pocket-activity-notifier installed and bootstrapped"
   echo "  plist:    $PLIST_DEST"
-  echo "  script:   $NOTIFIER_SCRIPT"
-  echo "  python:   $PYTHON_PATH"
+  echo "  launcher: $LAUNCHER_DEST"
+  echo "  script:   $NOTIFIER_SCRIPT (resolved at run time via launcher)"
   echo "  interval: 60s"
   echo "  logs:     $STATE_DIR/activity-notifier.{stdout,stderr}.log"
 else

--- a/claude-ops/scripts/install-pocket-notifier.sh
+++ b/claude-ops/scripts/install-pocket-notifier.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Install the pocket-activity-notifier as a launchd LaunchAgent.
+#
+# Generates the plist from the bundled template, sed-substitutes user-local
+# paths, and bootstraps the agent. Idempotent — re-running re-bootstraps
+# cleanly.
+#
+# Trigger: invoked from /ops:setup when the user opts in to pocket activity
+# notifications (requires whatsapp-config.json and/or email-config.json under
+# ~/.claude/state/pocket/). Can also be run standalone:
+#
+#   bash scripts/install-pocket-notifier.sh
+#
+# Required env (any of the resolution paths below works):
+#   CLAUDE_PLUGIN_ROOT       (set by Claude Code when invoking plugin code)
+
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "skip: pocket-activity-notifier is macOS-only (launchd)" >&2
+  echo "Linux users: wire scripts/ops-pocket-activity-notifier.py into systemd/cron with a 60s interval."
+  exit 0
+fi
+
+# Resolve plugin root — never hardcode a version number.
+# Fall back to the directory containing THIS script if CLAUDE_PLUGIN_ROOT is unset
+# (lets the script work when invoked directly from a checkout).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1)}"
+if [[ -z "$PLUGIN_ROOT" || ! -d "$PLUGIN_ROOT" ]]; then
+  PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
+
+NOTIFIER_SCRIPT="$PLUGIN_ROOT/scripts/ops-pocket-activity-notifier.py"
+PLIST_TEMPLATE="$PLUGIN_ROOT/scripts/com.claude-ops.pocket-activity-notifier.plist"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.claude-ops.pocket-activity-notifier.plist"
+STATE_DIR="$HOME/.claude/state/pocket"
+
+# Fall back to script-dir-relative paths when invoked from a fresh checkout
+# where the plugin root resolution above lands somewhere unexpected.
+[[ -f "$NOTIFIER_SCRIPT" ]] || NOTIFIER_SCRIPT="$SCRIPT_DIR/ops-pocket-activity-notifier.py"
+[[ -f "$PLIST_TEMPLATE"  ]] || PLIST_TEMPLATE="$SCRIPT_DIR/com.claude-ops.pocket-activity-notifier.plist"
+
+for f in "$NOTIFIER_SCRIPT" "$PLIST_TEMPLATE"; do
+  [[ -f "$f" ]] || { echo "error: required plugin file not found: $f" >&2; exit 1; }
+done
+
+mkdir -p "$STATE_DIR"
+chmod +x "$NOTIFIER_SCRIPT"
+
+# Resolve python3. Prefer Homebrew on Apple Silicon, then Intel Homebrew,
+# then fall back to whichever python3 is first on PATH.
+PYTHON_PATH=""
+if [[ -x /opt/homebrew/bin/python3 ]]; then
+  PYTHON_PATH="/opt/homebrew/bin/python3"
+elif [[ -x /usr/local/bin/python3 ]]; then
+  PYTHON_PATH="/usr/local/bin/python3"
+else
+  PYTHON_PATH="$(command -v python3 || true)"
+fi
+if [[ -z "$PYTHON_PATH" || ! -x "$PYTHON_PATH" ]]; then
+  echo "error: could not find python3 — install via 'brew install python' and retry" >&2
+  exit 1
+fi
+
+# Generate plist from template.
+TMP_PLIST="$(mktemp -t pocket-activity-notifier.XXXXXX.plist)"
+trap 'rm -f "$TMP_PLIST"' EXIT
+
+sed -e "s|__PYTHON_PATH__|$PYTHON_PATH|g" \
+    -e "s|__SCRIPT_PATH__|$NOTIFIER_SCRIPT|g" \
+    -e "s|__HOME__|$HOME|g" \
+    -e "s|__USER__|$USER|g" \
+    "$PLIST_TEMPLATE" > "$TMP_PLIST"
+
+mv "$TMP_PLIST" "$PLIST_DEST"
+trap - EXIT
+
+# Bootstrap the agent. bootout is best-effort (no-op if not loaded).
+launchctl bootout "gui/$(id -u)/com.claude-ops.pocket-activity-notifier" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST_DEST"
+launchctl enable "gui/$(id -u)/com.claude-ops.pocket-activity-notifier"
+
+# Verify.
+if launchctl list | grep -q "com.claude-ops.pocket-activity-notifier"; then
+  echo "✓ pocket-activity-notifier installed and bootstrapped"
+  echo "  plist:    $PLIST_DEST"
+  echo "  script:   $NOTIFIER_SCRIPT"
+  echo "  python:   $PYTHON_PATH"
+  echo "  interval: 60s"
+  echo "  logs:     $STATE_DIR/activity-notifier.{stdout,stderr}.log"
+else
+  echo "✗ pocket-activity-notifier failed to load — check $STATE_DIR/activity-notifier.stderr.log" >&2
+  exit 1
+fi

--- a/claude-ops/scripts/ops-daemon-launcher.sh
+++ b/claude-ops/scripts/ops-daemon-launcher.sh
@@ -1,4 +1,4 @@
-#!/opt/homebrew/bin/bash
+#!/usr/bin/env bash
 # ops-daemon-launcher.sh — version-agnostic launcher for the claude-ops daemon.
 # Resolves the highest installed ops plugin version at run time, then execs its
 # ops-daemon.sh. Survives plugin upgrades without plist edits.
@@ -16,7 +16,8 @@ LATEST_VERSION="$(
   find "$CACHE_ROOT" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null \
     | awk -F/ '{print $NF}' \
     | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
-    | sort -rn -t. -k1,1 -k2,2 -k3,3 \
+    | sort -V \
+    | tac \
     | while read -r v; do
         if [[ -x "$CACHE_ROOT/$v/scripts/ops-daemon.sh" ]]; then
           echo "$v"; break
@@ -33,6 +34,11 @@ DAEMON="$CACHE_ROOT/$LATEST_VERSION/scripts/ops-daemon.sh"
 export CLAUDE_PLUGIN_ROOT="$CACHE_ROOT/$LATEST_VERSION"
 
 echo "[ops-daemon-launcher] resolved ops $LATEST_VERSION → $DAEMON"
-# Re-exec under the same bash that is running this script (plist/installer may
-# use /opt/homebrew or /usr/local on Intel Mac); avoid hardcoding Homebrew path.
-exec "${OPS_DAEMON_LAUNCHER_BASH:-$BASH}" "$DAEMON" "$@"
+# Match install-ops-daemon.sh: Apple Silicon Homebrew → Intel Homebrew → system bash
+BASH_PATH="/bin/bash"
+if [[ -x /opt/homebrew/bin/bash ]]; then
+  BASH_PATH="/opt/homebrew/bin/bash"
+elif [[ -x /usr/local/bin/bash ]]; then
+  BASH_PATH="/usr/local/bin/bash"
+fi
+exec "$BASH_PATH" "$DAEMON" "$@"

--- a/claude-ops/scripts/ops-daemon-launcher.sh
+++ b/claude-ops/scripts/ops-daemon-launcher.sh
@@ -15,7 +15,7 @@ fi
 LATEST_VERSION="$(
   find "$CACHE_ROOT" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null \
     | awk -F/ '{print $NF}' \
-    | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+    | awk '/^[0-9]+\.[0-9]+\.[0-9]+$/ { print }' \
     | sort -V \
     | tac \
     | while read -r v; do

--- a/claude-ops/scripts/ops-pocket-activity-notifier-launcher.sh
+++ b/claude-ops/scripts/ops-pocket-activity-notifier-launcher.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# ops-pocket-activity-notifier-launcher.sh — version-agnostic launcher for the
+# pocket activity notifier. Resolves the highest installed ops plugin version
+# at run time, then execs scripts/ops-pocket-activity-notifier.py with python3.
+# Survives plugin upgrades without plist edits.
+set -euo pipefail
+
+CACHE_ROOT="${CLAUDE_PLUGIN_CACHE_ROOT:-$HOME/.claude/plugins/cache/ops-marketplace/ops}"
+
+if [[ ! -d "$CACHE_ROOT" ]]; then
+  echo "[ops-pocket-activity-notifier-launcher] FATAL: cache root missing: $CACHE_ROOT" >&2
+  exit 64
+fi
+
+# Highest semver dir that contains scripts/ops-pocket-activity-notifier.py
+LATEST_VERSION="$(
+  find "$CACHE_ROOT" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null \
+    | awk -F/ '{print $NF}' \
+    | awk '/^[0-9]+\.[0-9]+\.[0-9]+$/ { print }' \
+    | sort -V \
+    | tac \
+    | while read -r v; do
+        if [[ -f "$CACHE_ROOT/$v/scripts/ops-pocket-activity-notifier.py" ]]; then
+          echo "$v"; break
+        fi
+      done
+)"
+
+if [[ -z "${LATEST_VERSION:-}" ]]; then
+  echo "[ops-pocket-activity-notifier-launcher] FATAL: no installed ops version has scripts/ops-pocket-activity-notifier.py" >&2
+  exit 65
+fi
+
+NOTIFIER="$CACHE_ROOT/$LATEST_VERSION/scripts/ops-pocket-activity-notifier.py"
+export CLAUDE_PLUGIN_ROOT="$CACHE_ROOT/$LATEST_VERSION"
+
+# Match install-pocket-notifier.sh: Apple Silicon Homebrew → Intel Homebrew → PATH
+PYTHON_PATH=""
+if [[ -x /opt/homebrew/bin/python3 ]]; then
+  PYTHON_PATH="/opt/homebrew/bin/python3"
+elif [[ -x /usr/local/bin/python3 ]]; then
+  PYTHON_PATH="/usr/local/bin/python3"
+else
+  PYTHON_PATH="$(command -v python3 || true)"
+fi
+if [[ -z "$PYTHON_PATH" || ! -x "$PYTHON_PATH" ]]; then
+  echo "[ops-pocket-activity-notifier-launcher] FATAL: could not find python3" >&2
+  exit 66
+fi
+
+echo "[ops-pocket-activity-notifier-launcher] resolved ops $LATEST_VERSION → $NOTIFIER (python: $PYTHON_PATH)"
+exec "$PYTHON_PATH" "$NOTIFIER" "$@"

--- a/claude-ops/scripts/ops-pocket-activity-notifier.py
+++ b/claude-ops/scripts/ops-pocket-activity-notifier.py
@@ -222,16 +222,25 @@ def process_spawns(chat_jid: str | None, email_to: str | None, titles: dict) -> 
                 f"attached when this completes.\n"
             )
             email_subject = f"START — {(title or task_id)[:80]}"
-            try:
-                if chat_jid:
+            enqueue_errors: list[str] = []
+            if chat_jid:
+                try:
                     enqueue_whatsapp(chat_jid, wa_msg)
-                if email_to:
+                except OSError as e:
+                    log(f"enqueue START whatsapp failed: {e}")
+                    enqueue_errors.append("whatsapp")
+            if email_to:
+                try:
                     enqueue_email(email_to, email_subject, email_body)
-                sent += 1
-            except OSError as e:
-                log(f"enqueue START failed: {e}")
-                new_cursor = line_start  # retry next tick
+                except OSError as e:
+                    log(f"enqueue START email failed: {e}")
+                    enqueue_errors.append("email")
+            channels_configured = (1 if chat_jid else 0) + (1 if email_to else 0)
+            if channels_configured and len(enqueue_errors) == channels_configured:
+                log("enqueue START all channels failed; retry next tick")
+                new_cursor = line_start
                 break
+            sent += 1
     try:
         SPAWN_CURSOR.write_text(str(new_cursor))
     except OSError as e:
@@ -331,17 +340,26 @@ def process_completions(chat_jid: str | None, email_to: str | None, titles: dict
         email_body = "\n".join(email_body_parts)
         email_subject = f"DONE — {(title or task_id)[:80]}"
 
-        try:
-            if chat_jid:
+        enqueue_errors: list[str] = []
+        if chat_jid:
+            try:
                 enqueue_whatsapp(chat_jid, wa_msg, media_path=attachment)
-            if email_to:
+            except OSError as e:
+                log(f"enqueue DONE whatsapp failed for {name}: {e}")
+                enqueue_errors.append("whatsapp")
+        if email_to:
+            try:
                 attachments = [attachment] if attachment else []
                 enqueue_email(email_to, email_subject, email_body, attachments)
-            sent += 1
-            new_seen.add(name)
-        except OSError as e:
-            log(f"enqueue DONE failed for {name}: {e}")
-            break  # don't mark seen — retry next tick
+            except OSError as e:
+                log(f"enqueue DONE email failed for {name}: {e}")
+                enqueue_errors.append("email")
+        channels_configured = (1 if chat_jid else 0) + (1 if email_to else 0)
+        if channels_configured and len(enqueue_errors) == channels_configured:
+            log(f"enqueue DONE all channels failed for {name}; retry next tick")
+            break
+        sent += 1
+        new_seen.add(name)
 
     if new_seen != seen:
         save_seen_results(new_seen)

--- a/claude-ops/scripts/ops-pocket-email-bridge.py
+++ b/claude-ops/scripts/ops-pocket-email-bridge.py
@@ -8,8 +8,8 @@ Mirrors ops-pocket-whatsapp-bridge.py but on Gmail. Two duties:
      Each entry includes a question-id (qid) in the subject so replies can be
      correlated back via Gmail's threading.
 
-  2. INBOUND: poll Gmail for messages in a known label/thread set, parse the
-     owner's natural-language replies against the list of currently-open supervisor
+  2. INBOUND: poll Gmail for messages in a known label/thread set, parse Sam's
+     natural-language replies against the list of currently-open supervisor
      questions using `claude -p` (Sonnet 4.6), and append matched answers to
      supervisor-replies.jsonl — same downstream format as the WhatsApp bridge.
 
@@ -53,16 +53,6 @@ REPLIES = STATE_DIR / "supervisor-replies.jsonl"
 LOG_FILE = STATE_DIR / "email-bridge.log"
 HEALTH = STATE_DIR / ".email-bridge-health"
 SENT = STATE_DIR / "email-sent.jsonl"
-
-_USER_CONTEXT_PATH = Path(os.environ.get(
-    "POCKET_USER_CONTEXT",
-    HOME / ".claude/state/pocket/user-context.json",
-))
-try:
-    _uctx = json.loads(_USER_CONTEXT_PATH.read_text())
-    _OWNER_NAME: str = _uctx.get("owner_name") or "the user"
-except (OSError, json.JSONDecodeError):
-    _OWNER_NAME = "the user"
 
 GOG_BIN = os.environ.get("GOG_BIN", "gog")
 TIMEOUT = int(os.environ.get("EMAIL_BRIDGE_TIMEOUT", "60"))
@@ -265,11 +255,11 @@ QID_SUBJECT_RE = re.compile(r"\[qid:([a-zA-Z0-9_-]{4,})\]")
 
 def fetch_recent_replies(cfg: dict) -> list[dict]:
     """Use gog gmail search to find recent messages in the configured label
-    that are NOT from self (so we only get the owner's replies, not echoes).
+    that are NOT from self (so we only get Sam's replies, not echoes).
     Returns list of {messageId, threadId, subject, body, ts, fromMe}.
     """
     label = cfg.get("label", "Pocket")
-    # Look for messages sent by the account owner in the label, within last 24h.
+    # Look for messages SENT BY Sam in the label, within last 24h.
     query = f"label:{label} from:me newer_than:1d"
     try:
         proc = subprocess.run(
@@ -318,21 +308,21 @@ def parse_reply_with_llm(body: str, opens: list[dict], parser_model: str) -> lis
         f"  context: {(q.get('context') or '')[:200]}"
         for q in opens
     )
-    prompt = f"""You are the inbound-reply parser for {_OWNER_NAME}'s Pocket supervisor.
+    prompt = f"""You are the inbound-reply parser for Sam Renders' Pocket supervisor.
 
-{_OWNER_NAME} just sent an EMAIL reply. Your job: figure out which of the currently-open supervisor questions they are replying to (it may be one, several, or none), and extract the answer in a form the worker can use.
+Sam just sent an EMAIL reply. Your job: figure out which of the currently-open supervisor questions he's replying to (it may be one, several, or none), and extract the answer in a form the worker can use.
 
 Currently-open questions:
 {open_descriptions}
 
-Their email body:
+Sam's email body:
 \"\"\"{body[:4000]}\"\"\"
 
 Rules:
-- If their message is clearly not a reply to any open question, return an empty array.
-- If they address one specific question, return one item.
-- If they address multiple, return multiple items.
-- The 'answer' field should be in their voice and natural — the worker reads it as a direct instruction.
+- If Sam's message is clearly not a reply to any open question, return an empty array.
+- If Sam addresses one specific question, return one item.
+- If Sam addresses multiple, return multiple items.
+- The 'answer' field should be in Sam's voice and natural — the worker reads it as a direct instruction.
 - 'confidence' is your honest 0.0-1.0 estimate.
 - Output STRICT JSON array, no markdown fences, no prose.
 
@@ -395,7 +385,7 @@ def drain_inbound(cfg: dict) -> tuple[int, int]:
     messages = fetch_recent_replies(cfg)
     if not messages:
         return (0, 0)
-    # Filter: only NEW messages (strictly after last_processed_id in this window)
+    # Filter: only NEW messages after last_processed_id (skip through cursor, then take rest)
     new_messages: list[dict] = []
     if not last_id:
         new_messages = list(messages)
@@ -406,8 +396,7 @@ def drain_inbound(cfg: dict) -> tuple[int, int]:
                 new_messages.append(m)
             elif m["id"] == last_id:
                 past_cursor = True
-        # If last_id wasn't found in current window, treat all as new (first run / drift)
-        if not any(m["id"] == last_id for m in messages):
+        if not past_cursor:
             new_messages = list(messages)
 
     opens = open_questions()

--- a/claude-ops/scripts/ops-pocket-triage.py
+++ b/claude-ops/scripts/ops-pocket-triage.py
@@ -323,8 +323,16 @@ def main() -> int:
         write_health("ok", "no pending items", extra={"counts": {}})
         return 0
 
+    # Claim file atomically so the watcher can append to a fresh pending-triage.jsonl
+    claim = PENDING.with_name("pending-triage.processing")
+    if not DRY_RUN:
+        PENDING.rename(claim)
+        pending_src = claim
+    else:
+        pending_src = PENDING
+
     tasks = []
-    for raw in PENDING.read_text().splitlines():
+    for raw in pending_src.read_text().splitlines():
         raw = raw.strip()
         if not raw:
             continue
@@ -353,9 +361,9 @@ def main() -> int:
             "routed_to": verdict,
         })
 
-    # Truncate pending if not dry run (consumed)
+    # Drop claimed batch if not dry run (watcher recreated PENDING as needed)
     if not DRY_RUN:
-        PENDING.write_text("")
+        claim.unlink(missing_ok=True)
     log(f"done counts={counts}")
     write_health("ok", f"triaged={sum(counts.values())}", extra={"counts": counts})
     return 0


### PR DESCRIPTION
## Summary
- Add `scripts/com.claude-ops.pocket-activity-notifier.plist` template with `__PYTHON_PATH__`, `__SCRIPT_PATH__`, `__HOME__`, `__USER__` placeholders (mirrors `com.claude-ops.daemon.plist` convention).
- Add `scripts/install-pocket-notifier.sh` — sed-substitutes placeholders, writes to `~/Library/LaunchAgents/`, `launchctl bootout` + `bootstrap` + `enable` + verify. Idempotent; macOS-only (cleanly no-ops on Linux).
- Register `pocket-activity-notifier` in `daemon-services.default.json` (`enabled: false`, `cron: "* * * * *"`) so `/ops:doctor` + `/ops:setup` see it; opt-in once `whatsapp-config.json` and/or `email-config.json` exist under `~/.claude/state/pocket/`.

## How a fresh installer activates the notifier
1. User installs the ops plugin → `daemon-services.default.json` is copied to `~/.claude/plugins/data/.../daemon-services.json` with `pocket-activity-notifier.enabled = false`.
2. User configures pocket whatsapp/email creds via `/ops:setup pocket` (writes `~/.claude/state/pocket/{whatsapp,email}-config.json`).
3. Setup wizard (or user manually) runs `bash $CLAUDE_PLUGIN_ROOT/scripts/install-pocket-notifier.sh` — same explicit-install pattern as `install-ops-daemon.sh` and `install-recap-daemon.sh`. The script detects `python3`, resolves the notifier script path, sed-substitutes the template, and bootstraps the launchd job.
4. `/ops:doctor` flips the `enabled` field in `daemon-services.json` to `true` (or user does manually) so the daemon manager treats it as active and `/ops:setup` skips reinstall.
5. Launchd fires `ops-pocket-activity-notifier.py` every 60s; START/DONE events stream to the WhatsApp self-chat + email with the report attached.

Note: the setup-wizard daemon-services loop respects `enabled: true` + `cron` to drive the daemon-managed code path. The launchd plist is the **preferred** path (sub-minute latency) and is wired via the explicit install script — same pattern as ops-daemon/recap-daemon, no new setup-wizard hook needed.

## Test plan
- [ ] `bash -n scripts/install-pocket-notifier.sh` (syntax) — passes locally
- [ ] `python3 -m json.tool scripts/daemon-services.default.json` — passes locally
- [ ] `tests/test-no-secrets.sh` — 14/14 pass locally
- [ ] Run `bash scripts/install-pocket-notifier.sh` on a clean macOS box and confirm `launchctl list | grep pocket-activity-notifier` returns the entry with a non-`-` PID within 60s
- [ ] Re-run the install script (idempotency check) — `bootout` followed by `bootstrap` should succeed without errors

Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new launchd installation/launcher flow and modifies notifier/triage queue processing, which could affect background job reliability and notification delivery. Risk is moderated by being opt-in/default-disabled, but macOS service bootstrap and cursor/claim logic changes can impact runtime behavior.
> 
> **Overview**
> Adds a macOS `launchd`-based installation path for `pocket-activity-notifier`, including a new plist template plus `install-pocket-notifier.sh` and a version-agnostic launcher that survives plugin upgrades.
> 
> Registers `pocket-activity-notifier` (default **disabled**) in `daemon-services.default.json` and updates the main daemon plist to export `CLAUDE_PLUGIN_ROOT`; also makes `ops-daemon-launcher.sh` more portable (env shebang + semver sorting + explicit bash path selection).
> 
> Hardens Pocket runtime behavior: the activity notifier now retries cursor/seen-state only when *all* configured notification channels fail, and `ops-pocket-triage.py` atomically claims `pending-triage.jsonl` to avoid races with the watcher. Minor CLI parsing fix in `ops-marketing-portfolio` and email-bridge prompt/cursor handling tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9da21a641026be93e4380817971da8e745be535e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->