### PR TITLE
feat(plugin): doctor health-walker + settings daemon-services UI + stale-note cleanup

### DIFF
--- a/claude-ops/bin/ops-doctor
+++ b/claude-ops/bin/ops-doctor
@@ -611,14 +611,18 @@ else
     AGE_SEC=$(( NOW_EPOCH - LAST_RUN_EPOCH ))
     AGE_MIN=$(( AGE_SEC / 60 ))
 
-    # Staleness threshold: */N with N<=10 → 5m; larger N → N minutes (one cycle) so mid-cycle gaps are not false positives
+    # Staleness threshold: */N with N<=10 → 5m; larger N → N minutes (one cycle) so mid-cycle gaps are not false positives.
+    # Non-*/N minute patterns need hour/day/month/dow-aware bounds (e.g. 0 17 * * * is daily, not "15m").
     CRON_EXPR=$(jq -r ".services[\"$svc\"].cron // empty" "$DAEMON_SERVICES_FILE" 2>/dev/null || true)
     if [ -z "$CRON_EXPR" ]; then
       # continuous / no cron — use 15m threshold
       STALE_THRESHOLD=15
     else
-      # Parse the minute field: if it's */N, use N; treat as frequent if N<=10
       MINUTE_FIELD=$(echo "$CRON_EXPR" | awk '{print $1}')
+      HOUR_FIELD=$(echo "$CRON_EXPR" | awk '{print $2}')
+      DOM_FIELD=$(echo "$CRON_EXPR" | awk '{if (NF>=3) print $3; else print "*"}')
+      MONTH_FIELD=$(echo "$CRON_EXPR" | awk '{if (NF>=4) print $4; else print "*"}')
+      DOW_FIELD=$(echo "$CRON_EXPR" | awk '{if (NF>=5) print $5; else print "*"}')
       if echo "$MINUTE_FIELD" | grep -qE '^\*/([0-9]+)$'; then
         CRON_INTERVAL=$(echo "$MINUTE_FIELD" | grep -oE '[0-9]+')
         if [ "$CRON_INTERVAL" -le 10 ]; then
@@ -626,9 +630,35 @@ else
         else
           STALE_THRESHOLD="$CRON_INTERVAL"
         fi
+      elif echo "$HOUR_FIELD" | grep -qE '^\*/([0-9]+)$'; then
+        CRON_HOURS=$(echo "$HOUR_FIELD" | grep -oE '[0-9]+')
+        STALE_THRESHOLD=$(( CRON_HOURS * 60 ))
+      elif [ "$DOW_FIELD" != "*" ]; then
+        # Weekday-specific (e.g. weekly): allow a full week between runs plus slack
+        STALE_THRESHOLD=$(( 7 * 24 * 60 + 120 ))
+      elif [ "$DOM_FIELD" != "*" ] || [ "$MONTH_FIELD" != "*" ]; then
+        STALE_THRESHOLD=$(( 35 * 24 * 60 ))
+      elif [ "$HOUR_FIELD" = "*" ]; then
+        # e.g. `0 * * * *` — at least hourly
+        STALE_THRESHOLD=120
+      elif echo "$HOUR_FIELD" | grep -qE '^[0-9]+(,[0-9]+)*$'; then
+        STALE_THRESHOLD=$(echo "$HOUR_FIELD" | tr ',' '\n' | sort -n | awk '
+          { n++; a[n] = $1 }
+          END {
+            if (n < 1) { print 1500; exit }
+            if (n == 1) { print 25 * 60; exit }
+            max = 0
+            for (i = 2; i <= n; i++) {
+              d = a[i] - a[i - 1]
+              if (d > max) max = d
+            }
+            wrap = (24 - a[n]) + a[1]
+            if (wrap > max) max = wrap
+            print max * 60 + 60
+          }
+        ')
       else
-        # Hourly or less frequent — 15m threshold
-        STALE_THRESHOLD=15
+        STALE_THRESHOLD=1500
       fi
     fi
 

--- a/claude-ops/bin/ops-doctor
+++ b/claude-ops/bin/ops-doctor
@@ -602,10 +602,10 @@ else
     if echo "$LAST_RUN_RAW" | grep -qE '^[0-9]+$'; then
       LAST_RUN_EPOCH="$LAST_RUN_RAW"
     else
-      # macOS date -jf is strict: strip fractional seconds and trailing Z (UTC).
-      LAST_RUN_PARSE="${LAST_RUN_RAW%%.*}"
-      LAST_RUN_PARSE="${LAST_RUN_PARSE%Z}"
-      LAST_RUN_EPOCH=$(date -d "$LAST_RUN_RAW" +%s 2>/dev/null || date -jf "%Y-%m-%dT%H:%M:%S" "$LAST_RUN_PARSE" +%s 2>/dev/null || echo "0")
+      LAST_RUN_TRIM="${LAST_RUN_RAW%Z}"
+      LAST_RUN_TRIM="${LAST_RUN_TRIM%%.*}"
+      # GNU date first; on macOS, date -jf treats bare timestamps as local time — force UTC to match Z-stripped ISO instants.
+      LAST_RUN_EPOCH=$(date -d "$LAST_RUN_RAW" +%s 2>/dev/null || TZ=UTC date -jf "%Y-%m-%dT%H:%M:%S" "$LAST_RUN_TRIM" +%s 2>/dev/null || echo "0")
     fi
 
     AGE_SEC=$(( NOW_EPOCH - LAST_RUN_EPOCH ))

--- a/claude-ops/bin/ops-doctor
+++ b/claude-ops/bin/ops-doctor
@@ -611,7 +611,7 @@ else
     AGE_SEC=$(( NOW_EPOCH - LAST_RUN_EPOCH ))
     AGE_MIN=$(( AGE_SEC / 60 ))
 
-    # Determine staleness threshold: services with cron >= 30m use 15m warning, else 5m
+    # Staleness threshold: */N with N<=10 → 5m; larger N → N minutes (one cycle) so mid-cycle gaps are not false positives
     CRON_EXPR=$(jq -r ".services[\"$svc\"].cron // empty" "$DAEMON_SERVICES_FILE" 2>/dev/null || true)
     if [ -z "$CRON_EXPR" ]; then
       # continuous / no cron — use 15m threshold
@@ -624,7 +624,7 @@ else
         if [ "$CRON_INTERVAL" -le 10 ]; then
           STALE_THRESHOLD=5
         else
-          STALE_THRESHOLD=15
+          STALE_THRESHOLD="$CRON_INTERVAL"
         fi
       else
         # Hourly or less frequent — 15m threshold

--- a/claude-ops/scripts/ops-cron-pocket-watcher.py
+++ b/claude-ops/scripts/ops-cron-pocket-watcher.py
@@ -60,6 +60,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+from collections import OrderedDict
 import re
 import subprocess
 import sys
@@ -86,6 +87,7 @@ DRY_RUN = os.environ.get("POCKET_DRY_RUN") == "1"
 
 CURSOR_FILE = STATE_DIR / "cursor.txt"
 SEEN_FILE = STATE_DIR / "seen.json"
+SEEN_CAP = 5000
 HEALTH_FILE = STATE_DIR / ".health"
 
 # Giga sync
@@ -597,23 +599,41 @@ def save_cursor(ts: str) -> None:
     CURSOR_FILE.write_text(ts)
 
 
-def load_seen() -> set[str]:
-    if SEEN_FILE.exists():
-        try:
-            return set(json.loads(SEEN_FILE.read_text()))
-        except json.JSONDecodeError:
-            return set()
-    return set()
+def load_seen() -> OrderedDict[str, None]:
+    """Most-recently touched ids last (LRU tail); matches save_seen capping."""
+    od: OrderedDict[str, None] = OrderedDict()
+    if not SEEN_FILE.exists():
+        return od
+    try:
+        raw = json.loads(SEEN_FILE.read_text())
+    except json.JSONDecodeError:
+        return od
+    if not isinstance(raw, list):
+        return od
+    for x in raw:
+        if isinstance(x, str) and x:
+            od.pop(x, None)
+            od[x] = None
+    return od
 
 
-def save_seen(seen: set[str]) -> None:
+def _seen_add(seen: OrderedDict[str, None], key: str) -> None:
+    """Record id as most recently seen so capped persistence keeps newest entries."""
+    seen.pop(key, None)
+    seen[key] = None
+
+
+def save_seen(seen: OrderedDict[str, None]) -> None:
     if DRY_RUN:
         return
     STATE_DIR.mkdir(parents=True, exist_ok=True)
-    # Cap at 5000 ids to bound file size
-    if len(seen) > 5000:
-        seen = set(list(seen)[-5000:])
-    SEEN_FILE.write_text(json.dumps(sorted(seen)))
+    # Cap at SEEN_CAP ids to bound file size (keep LRU tail deterministically)
+    if len(seen) > SEEN_CAP:
+        kept = list(seen.keys())[-SEEN_CAP:]
+        seen.clear()
+        for k in kept:
+            seen[k] = None
+    SEEN_FILE.write_text(json.dumps(list(seen.keys())))
 
 
 # ── Output sinks ─────────────────────────────────────────────────────────────
@@ -848,7 +868,7 @@ def main() -> int:
             has_content = bool(transcript or segs)
             if duration and duration < 20 and not has_content:
                 log(f"skip noise recording {rid} (dur={duration}s, no transcript)")
-                seen.add(rid)
+                _seen_add(seen, rid)
                 continue
 
             # Money-leak guard: if a Haiku inference would fire for THIS
@@ -879,7 +899,7 @@ def main() -> int:
             write_memory(rec, giga=giga)
             new_memories += 1
             new_recordings.append(rid)
-            seen.add(rid)
+            _seen_add(seen, rid)
 
             # Implicit-task inference (Haiku) — only on substantive recordings
             inferred = infer_tasks_from_recording(rec)
@@ -913,7 +933,7 @@ def main() -> int:
                     with PENDING_TRIAGE.open("a") as f:
                         f.write(json.dumps(payload) + "\n")
                     log(f"queued for triage: {t['title'][:60]} (conf={t['confidence']:.2f})")
-                seen.add(inferred_id)
+                _seen_add(seen, inferred_id)
         if cap_hit:
             break
         if meta.get("hasMore") and meta.get("nextRecordingDateBeforeExclusive"):
@@ -944,7 +964,7 @@ def main() -> int:
                 continue
             route_actionitem(item, giga=giga)
             new_tasks += 1
-            seen.add(seen_key)
+            _seen_add(seen, seen_key)
 
     # 3) Optional consolidate pass (Giga merges adjacent neurons)
     if giga and giga.ok and GIGA_CONSOLIDATE and (new_memories + new_tasks) > 0:

--- a/claude-ops/scripts/ops-cron-pocket-watcher.py
+++ b/claude-ops/scripts/ops-cron-pocket-watcher.py
@@ -629,7 +629,8 @@ def write_memory(recording: dict, giga: "GigaClient | None" = None) -> Path | No
     the configured Giga mind with a back-reference to the local file.
     """
     rid = recording.get("id") or recording.get("recordingId") or ""
-    title = recording.get("title") or recording.get("summary", {}).get("title") or ""
+    summary = recording.get("summary") or {}
+    title = recording.get("title") or (summary.get("title") if isinstance(summary, dict) else "") or ""
     if not title:
         # Derive from first transcript line
         segs = recording.get("transcriptSegments") or []
@@ -637,7 +638,6 @@ def write_memory(recording: dict, giga: "GigaClient | None" = None) -> Path | No
     title = title.strip() or "voice memo"
 
     # Build body from summary + first chunk of transcript
-    summary = recording.get("summary") or {}
     if isinstance(summary, dict):
         summary_text = summary.get("text") or summary.get("body") or summary.get("summary") or ""
     else:

--- a/claude-ops/skills/ops-marketing/SKILL.md
+++ b/claude-ops/skills/ops-marketing/SKILL.md
@@ -2639,3 +2639,41 @@ a 190 error triggers a manual-rotation escalation instead. No existing behaviour
 ```
 
 `healthy` at the top level is `true` only when all checks pass. Pipe to `jq '.[] | select(.healthy==false)'` to filter unhealthy projects.
+
+---
+
+## Cron-driven autopilot
+
+Five cron wrapper scripts drive `bin/ops-marketing-autopilot` on schedule. They live in `${CLAUDE_PLUGIN_ROOT}/scripts/` and are registered as daemon-services entries (toggle via `/ops:settings` → Daemon Services):
+
+| Script | Daemon-service key | Schedule | Purpose |
+|--------|--------------------|----------|---------|
+| `ops-cron-marketing-autopilot.sh` | `marketing-autopilot` | Daily 08:00 UTC | Main daily ad-optimization pass (pause underperformers, regen fatigued creatives, cap pre-flight). First run is forced dry. |
+| `ops-cron-marketing-autopilot-calibrate.sh` | `marketing-autopilot-calibrate` | Monday 09:00 UTC | Self-learning calibration: joins pre-scores to realized KPIs, writes `calibrator.json` for the next daily pass. No metered calls. |
+| `ops-cron-marketing-prewarm.sh` | `marketing-prewarm` | Every 15 min | Pre-warms `/ops:marketing` credential and data cache so the dashboard opens instantly. Requires Klaviyo, Meta, GA4, GSC, Google Ads credentials. |
+| `ops-cron-marketing-auth-prewarm.sh` | `marketing-auth-prewarm` | Nightly 04:23 UTC | Scans Doppler + env + keychain for marketing creds; writes `marketing-auth-prewarm.json` so `/ops:marketing setup` can auto-link projects without per-credential prompts. |
+| `ops-cron-marketing-health-check.sh` | `marketing-health-check` | Sunday 08:00 UTC | Read-only weekly probe: Meta token TTL, Google Ads OAuth, ad account status, Doppler secret freshness, GA4 SA key, GSC site auth. Outputs per-project JSON to `reports/marketing-autopilot/`. No mutations. |
+
+### Inspect last-run for a cron wrapper
+
+```bash
+OPS_DATA_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+# Logs written by cron wrappers (stdout + stderr):
+tail -20 "$OPS_DATA_DIR/logs/marketing-autopilot.log"
+tail -20 "$OPS_DATA_DIR/logs/marketing-autopilot-calibrate.log"
+tail -20 "$OPS_DATA_DIR/logs/marketing-prewarm.log"
+tail -20 "$OPS_DATA_DIR/logs/marketing-auth-prewarm.log"
+tail -20 "$OPS_DATA_DIR/logs/marketing-health-check.log"
+```
+
+### Toggle a cron wrapper
+
+Use `/ops:settings` → Daemon Services to enable or disable any of the five wrappers. Writes to the override file; never edits `daemon-services.default.json`.
+
+All five are **disabled by default**. Enable order:
+1. Configure credentials via `/ops:setup marketing`.
+2. Enable `marketing-prewarm` (optional but recommended — warms the cache).
+3. Enable `marketing-auth-prewarm` (nightly credential scan — low-cost, safe to enable early).
+4. Enable `marketing-autopilot` — first run will be a forced dry-run regardless of `autonomy_level`.
+5. Enable `marketing-autopilot-calibrate` after ≥7 days of autopilot data.
+6. Enable `marketing-health-check` as a weekly safety net once the above are stable.

--- a/claude-ops/skills/ops-settings/SKILL.md
+++ b/claude-ops/skills/ops-settings/SKILL.md
@@ -181,6 +181,189 @@ jq --arg p "$P" --argjson v false \
 - Setting `envelope.kill_switch: true` **hard-stops all mutations** on the next pass (stage-only, zero writes) regardless of `autonomy_level`.
 - The Credential Status Dashboard MUST surface `autonomy_level` and `kill_switch` for every project with `autopilot.enabled == true`.
 
+## Pocket
+
+Manages the voice-journal activity notifier (POCKET_API_KEY watcher + WhatsApp/email bridges + launchd agent).
+
+Route here when the user runs `/ops:settings pocket` or selects "Pocket" from the dashboard.
+
+### View status
+
+Read all four health files and print a compact status block:
+
+```bash
+STATE_DIR="$HOME/.claude/state/pocket"
+for f in .activity-notifier-health .out-queue-health .email-bridge-health .whatsapp-bridge-health; do
+  label="${f#.}"
+  label="${label%-health}"
+  content=$(cat "$STATE_DIR/$f" 2>/dev/null)
+  if [ -z "$content" ]; then
+    echo "$label: missing"
+  else
+    status=$(echo "$content" | jq -r '.status // "unknown"' 2>/dev/null)
+    msg=$(echo "$content"    | jq -r '.message // ""'       2>/dev/null)
+    last=$(echo "$content"   | jq -r '.last_run // ""'      2>/dev/null)
+    echo "$label: $status  $msg  ($last)"
+  fi
+done
+```
+
+For each service whose status is not `"ok"`, flag it:
+
+```
+activity-notifier: ok  (2026-05-20T12:34:56Z)
+out-queue:         ok  sent=3  (2026-05-20T12:34:55Z)
+email-bridge:      disabled  (2026-05-20T12:34:50Z)
+whatsapp-bridge:   ok  scanned=12 routed=1  (2026-05-20T12:34:54Z)
+```
+
+Show `✗ missing` for any health file that does not exist.
+
+### View task counts
+
+```bash
+STATE_DIR="$HOME/.claude/state/pocket"
+echo "tasks.jsonl:          $(wc -l < "$STATE_DIR/tasks.jsonl"         2>/dev/null || echo 0) lines"
+echo "pending-triage.jsonl: $(wc -l < "$STATE_DIR/pending-triage.jsonl" 2>/dev/null || echo 0) lines"
+echo "executor-results/:    $(ls "$STATE_DIR/executor-results/" 2>/dev/null | wc -l | tr -d ' ') files"
+```
+
+### Toggle channels
+
+Ask `AskUserQuestion`:
+
+```
+Which Pocket notification channel setting would you like to change?
+  [Toggle WhatsApp]  [Toggle Email]  [Edit self-address]  [Back]
+```
+
+**Toggle WhatsApp** — read `~/.claude/state/pocket/whatsapp-config.json`, flip `.enabled`, write back:
+
+```bash
+F="$HOME/.claude/state/pocket/whatsapp-config.json"
+CUR=$(jq -r '.enabled' "$F" 2>/dev/null || echo false)
+NEW=$([ "$CUR" = "true" ] && echo false || echo true)
+jq --argjson v "$NEW" '.enabled = $v' "$F" > "${F}.tmp" && mv "${F}.tmp" "$F"
+echo "WhatsApp notifications: $NEW"
+```
+
+**Toggle Email** — same pattern with `~/.claude/state/pocket/email-config.json`.
+
+**Edit self-address** — show current `email-config.json:.self_address`, ask for new value via `AskUserQuestion` text input, write back:
+
+```bash
+F="$HOME/.claude/state/pocket/email-config.json"
+jq --arg v "$NEW_ADDR" '.self_address = $v | .from_account = $v' "$F" > "${F}.tmp" && mv "${F}.tmp" "$F"
+```
+
+### Force a fresh Pocket pull
+
+Run the watcher directly (picks up POCKET_API_KEY from keychain/env):
+
+```bash
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1)}"
+python3 "$PLUGIN_ROOT/scripts/ops-cron-pocket-watcher.py"
+```
+
+Report exit code and last line of `~/.claude/state/pocket/run.log`.
+
+### Restart notifier
+
+```bash
+launchctl kickstart -k "gui/$(id -u)/com.claude-ops.pocket-activity-notifier"
+```
+
+Wait 3 seconds then print the updated `.activity-notifier-health` status.
+
+### View last 3 outbound notifications
+
+```bash
+STATE_DIR="$HOME/.claude/state/pocket"
+echo "=== WhatsApp (out-queue-sent.jsonl) ==="
+tail -3 "$STATE_DIR/out-queue-sent.jsonl" 2>/dev/null | jq -r '"\(.sent_at // .ts // "?")  \(.message // .body // "" | .[0:80])"' 2>/dev/null || echo "(none)"
+echo "=== Email (email-sent.jsonl) ==="
+tail -3 "$STATE_DIR/email-sent.jsonl"     2>/dev/null | jq -r '"\(.sent_at // .ts // "?")  \(.subject // "" | .[0:80])"'                2>/dev/null || echo "(none)"
+```
+
+## Daemon Services
+
+Manage background daemon services declared in `daemon-services.default.json`. Route here when the user runs `/ops:settings daemons` or selects "Daemon services" from the dashboard.
+
+### Display the daemon services table
+
+```bash
+DAEMON_DEFAULT="${CLAUDE_PLUGIN_ROOT}/scripts/daemon-services.default.json"
+DAEMON_OVERRIDE="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/daemon-services.override.json"
+
+# Merge: override file wins on matching service keys
+if [ -f "$DAEMON_OVERRIDE" ]; then
+  jq -s '.[0].services * .[1].services' "$DAEMON_DEFAULT" "$DAEMON_OVERRIDE" 2>/dev/null
+else
+  jq '.services' "$DAEMON_DEFAULT" 2>/dev/null
+fi
+```
+
+Display as a table (for each service, show enabled state, last_run age, and health status from the `health_file` if declared):
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► SETTINGS — Daemon Services
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+ Service                   Enabled   Last Run      Health
+ ──────────────────────── ───────── ────────────  ────────────
+ briefing-pre-warm          ✅ on    2m ago        ✓ ok
+ memory-extractor           ✅ on    18m ago       ✓ ok
+ message-listener           ⏸ off   —             —
+ competitor-intel           ⏸ off   —             —
+ marketing-autopilot        ⏸ off   —             —
+
+──────────────────────────────────────────────────────────────────
+```
+
+For each `enabled: true` service with a `health_file`, expand `~` → `$HOME`, read the JSON file, extract `.last_run` and `.status`. Services with no `health_file` show `—`.
+
+### Toggle a service on or off
+
+Writes to the **override file only** — never edits `daemon-services.default.json`.
+
+Confirm each toggle via `AskUserQuestion` (`[Enable]` / `[Disable]` / `[Cancel]`) before writing.
+
+```bash
+DAEMON_OVERRIDE="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/daemon-services.override.json"
+tmp=$(mktemp)
+# Enable:
+jq --arg svc "$SERVICE_NAME" '.services[$svc].enabled = true' \
+  "${DAEMON_OVERRIDE}" > "$tmp" 2>/dev/null \
+  || echo "{\"services\":{\"$SERVICE_NAME\":{\"enabled\":true}}}" > "$tmp"
+mv "$tmp" "$DAEMON_OVERRIDE"
+# Disable: same pattern with `= false`
+```
+
+If the override file does not exist yet, initialise it with `{"services":{}}` before writing.
+
+### View last 5 log lines for a service
+
+```bash
+OPS_DATA_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+tail -n 5 "$OPS_DATA_DIR/logs/${SERVICE_NAME}.log" 2>/dev/null || echo "(no log file found)"
+```
+
+### Manually trigger a service
+
+- **launchd-registered** (plist-backed, e.g. `whatsapp-bridge`):
+  ```bash
+  launchctl kickstart -k "gui/$UID/com.samrenders.${SERVICE_NAME}"
+  ```
+- **Cron-style / script-based** (have a `command` pointing to a `.sh` file):
+  ```bash
+  COMMAND=$(jq -r ".services[\"$SERVICE_NAME\"].command" "$DAEMON_DEFAULT" \
+    | sed "s|\${CLAUDE_PLUGIN_ROOT}|${CLAUDE_PLUGIN_ROOT}|g")
+  bash "$COMMAND"
+  ```
+
+Always confirm via `AskUserQuestion` (`[Run now]` / `[Cancel]`) before triggering.
+
 ## CLI/API Reference
 
 | Command | Purpose |

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -736,6 +736,12 @@ If the user selects "Pick individually", ask which channels using `AskUserQuesti
 | Doppler  | doppler  | Secrets manager — set default project + config for all ops skills       |
 | Vault    | vault    | Password manager — 1Password, Dashlane, Bitwarden, or macOS Keychain    |
 
+**Batch 3 — Voice journal & integrations (show only if not already configured):**
+
+| Option   | Header   | Description                                                                    |
+| -------- | -------- | ------------------------------------------------------------------------------ |
+| Pocket   | pocket   | Voice journal notifier — POCKET_API_KEY + WhatsApp/email delivery + launchd agent |
+
 Present each batch as a separate `AskUserQuestion` call. Skip batches where all items are already configured. For each selected channel, run the matching sub-flow below.
 
 ---
@@ -826,6 +832,11 @@ Every channel sub-flow below references "the Universal Credential Auto-Scan" by 
 ### 3o — Claude account rotator OAuth (if selected)
 
 > **Loaded from `channels/claude-rotator.md`** — Account rotator OAuth — delegates to /ops:rotate-setup.
+> Load that file before running this sub-flow.
+
+### 3p — Pocket (voice journal activity notifier)
+
+> **Loaded from `channels/pocket.md`** — POCKET_API_KEY credential + WhatsApp/email channel config + launchd notifier install + smoke test.
 > Load that file before running this sub-flow.
 
 ## Step 4 — Configure MCPs (if selected)

--- a/claude-ops/skills/setup/channels/pocket.md
+++ b/claude-ops/skills/setup/channels/pocket.md
@@ -1,0 +1,234 @@
+### 3p — Pocket (voice journal activity notifier)
+
+The Pocket subsystem watches your voice journal recordings via the Pocket AI MCP, infers tasks with Haiku, and sends activity notifications (task spawned / task done) to WhatsApp and/or email. This step installs the credential, writes the channel config files, registers the launchd notifier, and smoke-tests delivery.
+
+#### Step 3p.1 — Prerequisites
+
+Before configuring Pocket, check which notification channels are already set up:
+
+```bash
+PREFS="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+WA_OK=false; EMAIL_OK=false
+jq -e '.channels.whatsapp' "$PREFS" >/dev/null 2>&1 && WA_OK=true
+jq -e '.channels.email'    "$PREFS" >/dev/null 2>&1 && EMAIL_OK=true
+echo "whatsapp=$WA_OK email=$EMAIL_OK"
+```
+
+If **both** are false, ask via `AskUserQuestion`:
+
+```
+Pocket notifications require at least one delivery channel. Set one up first:
+  [Configure WhatsApp — go to channel 3b]
+  [Configure Email — go to channel 3c]
+  [Skip Pocket for now]
+```
+
+Route accordingly. Do NOT proceed with Pocket setup until at least one channel is confirmed green.
+
+#### Step 3p.2 — Pocket API key
+
+The watcher script reads `POCKET_API_KEY` from three sources in order:
+1. `POCKET_API_KEY` environment variable
+2. macOS Keychain: service `POCKET_API_KEY`, account `ops-daemon`
+3. Doppler: key `POCKET_API_KEY`
+
+Run the Universal Credential Auto-Scan (see SHARED.md) for `POCKET_API_KEY` across all three sources. If found, show it masked (last 4 chars) and ask:
+
+```
+Found POCKET_API_KEY. Use this?
+  [Yes — use found key]  [No — enter a different key]  [Skip Pocket]
+```
+
+If not found, ask:
+
+```
+POCKET_API_KEY not found. Where would you like to get one?
+  [Open Pocket dev portal — https://public.heypocketai.com]
+  [Paste key manually]
+  [Skip Pocket for now]
+```
+
+On "Open Pocket dev portal": run `bash "${CLAUDE_PLUGIN_ROOT}/lib/opener.sh" "https://public.heypocketai.com"` (or `open "https://public.heypocketai.com"` on macOS) then ask `AskUserQuestion`: `[Paste key now]` / `[Skip]`.
+
+Once a key is provided, save to macOS Keychain and shell profile:
+
+```bash
+# Keychain (preferred — avoids env leakage in shell history)
+security add-generic-password -U \
+  -s POCKET_API_KEY -a ops-daemon \
+  -w "$POCKET_API_KEY"
+
+# Also export in shell profile so the launchd plist inherits it via EnvironmentVariables
+PROFILE="${ZDOTDIR:-$HOME}/.zshrc"
+grep -q "POCKET_API_KEY" "$PROFILE" 2>/dev/null || \
+  echo 'export POCKET_API_KEY="$(security find-generic-password -s POCKET_API_KEY -a ops-daemon -w 2>/dev/null)"' >> "$PROFILE"
+```
+
+#### Step 3p.3 — Choose notification channels
+
+Use `AskUserQuestion` with `multiSelect: true`. Only show channels that are already configured (from Step 3p.1 check):
+
+```
+Which channels should Pocket send notifications to?
+  [WhatsApp self-chat]   (requires channel 3b — WhatsApp bridge running)
+  [Email self-send]      (requires channel 3c — gog gmail authenticated)
+```
+
+If only one channel is configured, skip the question and auto-select it, then print:
+
+```
+Auto-selected <channel> (only configured channel).
+```
+
+#### Step 3p.4 — WhatsApp config
+
+If WhatsApp was selected:
+
+Resolve the user's own WhatsApp JID. Try the Baileys bridge DB first:
+
+```bash
+DB="$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db"
+# The user's own JID is typically stored as the sender in their own messages
+sqlite3 "$DB" \
+  "SELECT DISTINCT sender FROM messages WHERE sender LIKE '%@s.whatsapp.net' LIMIT 5;" \
+  2>/dev/null || true
+```
+
+If the query returns results, present up to 4 JIDs via `AskUserQuestion`:
+
+```
+Select your WhatsApp JID for self-notifications:
+  [<jid-1>]  [<jid-2>]  [Enter manually]  [Skip WhatsApp]
+```
+
+If the query returns nothing, ask `AskUserQuestion`: `[Enter JID manually]` / `[Skip WhatsApp]`.
+
+On manual entry: ask for JID in format `1234567890@s.whatsapp.net`.
+
+Write `~/.claude/state/pocket/whatsapp-config.json`:
+
+```bash
+mkdir -p "$HOME/.claude/state/pocket"
+jq -n --arg jid "$CHAT_JID" \
+  '{"enabled": true, "chat_jid": $jid}' \
+  > "$HOME/.claude/state/pocket/whatsapp-config.json"
+```
+
+#### Step 3p.5 — Email config
+
+If Email was selected:
+
+Resolve `self_address` and `from_account`. Read from prefs or probe gog:
+
+```bash
+PREFS="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+SELF_EMAIL=$(jq -r '.owner_email // empty' "$PREFS" 2>/dev/null)
+# Fallback: list gog accounts
+[ -z "$SELF_EMAIL" ] && SELF_EMAIL=$(gog auth status --json 2>/dev/null | jq -r '.accounts[0].email // empty')
+```
+
+If found, confirm via `AskUserQuestion`:
+
+```
+Send Pocket notifications to <self_email>?
+  [Yes — use this address]  [Enter a different address]  [Skip email]
+```
+
+Write `~/.claude/state/pocket/email-config.json`:
+
+```bash
+mkdir -p "$HOME/.claude/state/pocket"
+jq -n \
+  --arg addr  "$SELF_EMAIL" \
+  --arg from  "$SELF_EMAIL" \
+  '{"enabled": true, "self_address": $addr, "from_account": $from,
+    "subject_prefix": "[Pocket]", "label": "Pocket",
+    "parser_model": "claude-sonnet-4-6"}' \
+  > "$HOME/.claude/state/pocket/email-config.json"
+```
+
+#### Step 3p.6 — Install the launchd notifier
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/install-pocket-notifier.sh"
+```
+
+This generates `~/Library/LaunchAgents/com.claude-ops.pocket-activity-notifier.plist` from the bundled template, resolves Python 3, substitutes paths, and bootstraps the agent. Idempotent — re-running re-bootstraps cleanly.
+
+Verify the agent loaded:
+
+```bash
+launchctl list | grep com.claude-ops.pocket-activity-notifier
+```
+
+If the grep returns nothing, surface the error via `AskUserQuestion`: `[Retry install]` / `[Skip]`.
+
+#### Step 3p.7 — Smoke test
+
+Drop a synthetic `.done.json` into `executor-results/` to trigger the notifier:
+
+```bash
+STATE_DIR="$HOME/.claude/state/pocket"
+EXEC_DIR="$STATE_DIR/executor-results"
+mkdir -p "$EXEC_DIR"
+TASK_ID="smoke-$(date +%s)"
+
+# Write a synthetic completion file matching what the executor produces
+cat > "$EXEC_DIR/${TASK_ID}.done.json" <<SMOKE_EOF
+{
+  "task_id": "${TASK_ID}",
+  "title": "Smoke test — Pocket notifier",
+  "completed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "status": "ok",
+  "summary": "This is a synthetic test event from /ops:setup. If you received this, the Pocket notifier is working."
+}
+SMOKE_EOF
+
+echo "Dropped smoke-test file: ${EXEC_DIR}/${TASK_ID}.done.json"
+echo "Waiting up to 90s for notifier to fire (runs every 60s)..."
+```
+
+Wait up to 90 seconds for the notifier to process the file (runs on a 60s launchd interval). Check health:
+
+```bash
+cat "$HOME/.claude/state/pocket/.activity-notifier-health" 2>/dev/null
+```
+
+Ask `AskUserQuestion`:
+
+```
+Did you receive the Pocket smoke-test notification?
+  [Yes — it arrived on WhatsApp / email]
+  [No — I didn't receive it]
+  [Skip verification]
+```
+
+If "No": show the stderr log for diagnosis:
+
+```bash
+tail -30 "$HOME/.claude/state/pocket/activity-notifier.stderr.log" 2>/dev/null
+```
+
+Offer `[Retry smoke test]` / `[Continue anyway]` / `[Re-run setup]`.
+
+#### Step 3p.8 — Record state
+
+Write to `$PREFS_PATH`:
+
+```bash
+PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+TMP=$(mktemp)
+jq --argjson wa "$WA_ENABLED" --argjson em "$EMAIL_ENABLED" \
+  '.pocket = {"enabled": true, "whatsapp": $wa, "email": $em, "notifier": "com.claude-ops.pocket-activity-notifier"}' \
+  "$PREFS_PATH" > "$TMP" && mv "$TMP" "$PREFS_PATH"
+```
+
+Print:
+
+```
+✓ Pocket — notifier installed (com.claude-ops.pocket-activity-notifier).
+  Activity events routed to: <channels>.
+  Manage: /ops:settings pocket | /ops:pocket status | /ops:ops-doctor
+```
+
+> **Deep-dive:** see `${CLAUDE_PLUGIN_ROOT}/skills/ops-pocket/SKILL.md` for full operational instructions and `${CLAUDE_PLUGIN_ROOT}/skills/ops-pocket/STATUS.md` for the health contract.


### PR DESCRIPTION
## Summary
- `bin/ops-doctor`: new section 10 walks every `enabled: true` service in `daemon-services.default.json`, resolves `health_file` paths, reads `.status`/`.last_run`, computes age, warns if stale (5 min threshold for fast crons, 15 min for slow/continuous), emits `daemon_services_health` array in JSON output
- `skills/ops-settings/SKILL.md`: new **Daemon Services** section — table display, toggle on/off (writes override file, never default), log tail, manual trigger via launchctl or direct script invocation
- `scripts/daemon-services.default.json`: removed "Script not yet landed" from `inbox-digest`, `message-listener`, `competitor-intel`; replaced with real descriptions
- `skills/ops-marketing/SKILL.md`: new **Cron-driven autopilot** section documenting all 5 cron wrappers, their schedules, log paths, and enable-order guide

## Test plan
- [x] `bash bin/ops-doctor` outputs valid JSON with `daemon_services_health` array — no crash
- [x] Doctor correctly emits `?` for services without health_file, `✗ stale` for memory-extractor (125m > 15m threshold)
- [x] `tests/test-no-secrets.sh` — 14/14 passed
- [x] `tests/test-skills-lint.sh` — 312/312 passed
- [x] `tests/test-bin-scripts.sh` — 167/167 passed
- [x] `jq empty daemon-services.default.json` — valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes daemon staleness/last-run parsing in `bin/ops-doctor` and alters Pocket watcher dedupe persistence to an LRU-capped structure, which could affect alerting and reprocessing behavior if edge cases are wrong.
> 
> **Overview**
> **Improves daemon-service health reporting** in `bin/ops-doctor` by fixing macOS UTC parsing for ISO timestamps and making staleness thresholds cron-aware (minute/hour/day/week patterns) to reduce false stale warnings.
> 
> **Makes Pocket watcher dedupe deterministic and bounded** by switching `seen.json` from an unordered set to an LRU-style `OrderedDict` capped at 5k ids, and hardens title extraction when `summary` isn’t a dict.
> 
> **Expands operational docs**: adds a marketing cron-wrapper overview in `ops-marketing/SKILL.md`, adds `/ops:settings` guidance for Pocket status/channel toggles and a daemon-services management UI flow in `ops-settings/SKILL.md`, and introduces a new `setup/channels/pocket.md` Pocket setup flow (API key + channel config + launchd install + smoke test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3516a75892b98bdfacb321f92a9db964c0c410bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->