### PR TITLE
chore(release): v2.8.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 36 skills, 18 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Business operations command center for Claude Code — 36 skills, 18 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+## [2.8.1] — 2026-05-21
+
+Hotfix: three production bugs in `/ops:ops-inbox` (PR #280).
+
+### Fixed
+
+- **WhatsApp bridge restart** — bare `launchctl kickstart -k gui/$UID/<label>` fails with `Could not find service` when the LaunchAgent isn't loaded (common after reboot or partial plist edit). Replaced with load-then-kickstart recipe (quoted target + `launchctl load -w "$PLIST"` fallback + `lsof -i :8080` verify). Health check now uses `launchctl print "gui/$(id -u)/<label>"` instead of `launchctl list` (which only shows already-loaded services).
+- **`gog gmail thread get -j` parsing** — agents kept writing naive `d['messages']` or `d['payload']` parsers expecting the search-array shape, then crashing with `KeyError` on the actual `{thread: {messages: [{payload: {headers}}]}}` envelope. Added an explicit shape table for the three read commands and a canonical copy-paste-safe `classify_thread()` Python recipe with graceful empty/error handling. Documented the fast-path: triage from the search envelope's `labels` + `from` fields without per-thread fetches.
+- **Stale plugin-version pin** — when `installed_plugins.json` (source of truth for `ops-plugin-version-heal.sh`) references a cache dir that no longer exists on disk, the heal hook becomes a no-op and downstream files keep their stale path, producing a recurring `Stop hook error: Plugin directory does not exist: …` on every turn. Added a runtime self-heal step at the top of the Runtime Context section that detects the mismatch, patches the source pin to the latest version present in the cache dir, then re-runs the existing heal script.
+
 ## [2.7.0] — 2026-05-20
 
 `/ops:marketing` becomes the marketing control center. Every credential discoverable across Doppler/env/keychain auto-links into every project; live KPI rollup across all projects in one render; ad spend aggregated across every paid surface; Stripe revenue with UTM-attributed ROAS; Sentry crash-rate correlation flags ad-spend-at-risk projects.

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
## Summary

Hotfix release shipping the three `/ops:ops-inbox` fixes from PR #280.

### Changes
- `claude-ops/.claude-plugin/plugin.json`: 2.8.0 → 2.8.1
- `claude-ops/package.json`: 2.8.0 → 2.8.1
- `.claude-plugin/marketplace.json`: 2.8.0 → 2.8.1
- `claude-ops/CHANGELOG.md`: added 2.8.1 entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping: only version bumps and changelog text updates, with no functional code changes included in this diff.
> 
> **Overview**
> Updates the `ops` plugin release metadata to **v2.8.1** by bumping the version in `marketplace.json`, `claude-ops/.claude-plugin/plugin.json`, and `claude-ops/package.json`.
> 
> Adds a `CHANGELOG.md` entry for `2.8.1` describing three `/ops:ops-inbox` production hotfixes (WhatsApp bridge restart reliability, `gog` Gmail thread JSON parsing guidance, and a self-heal for stale plugin-version pins).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee7fac949c6863e69926ec8a8fbe7aebf9920c8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->