### PR TITLE
chore(release): v2.8.2

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "Business operations command center for Claude Code — 36 skills, 18 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.8.2] — 2026-05-21
+
+`/ops:ops-dash` rewritten as a 2026-aesthetic hybrid live command center — pixel-art hero + 12 section-by-section panels ingesting live data from every `/ops:*` skill (PR #282).
+
+### Fixed
+
+- **Unread counts always 0** — `bin/ops-dash` was reading `.whatsapp.count` / `.email.count` / `.slack.count` from `ops-unread`, but the actual schema is `.channels.whatsapp.recent_chats` / `.channels.email.inbox_count` / `.channels.slack.workspaces[]`. Smoke test: 90 unread now detected (was 0).
+- **PR count always `?`** — `gh pr list --state open` with no `--repo` flag returns nothing when run outside a repo cwd (the bin script runs from `$HOME`). Replaced with `gh api graphql` cross-org search. Smoke test: 17 PRs now detected (was `?`).
+- **Marketing project name rendered outside its parens** — cosmetic alignment fix.
+
+### Changed
+
+- **`bin/ops-dash` — hybrid live command center.** 12 section panels render top-to-bottom after the hero header: FIRES, INBOX, OPEN PRs, PORTFOLIO, REVENUE, MARKETING, LINEAR, DEPLOYS, COMPETITOR, YOLO, QUICK ACTIONS, footer. All probes fire in parallel via background subshells; render is sequential top-to-bottom once `wait` completes.
+- **2026 visual layer** — pixel-art hero with double-line borders + drop shadow, animated braille spinner + progress bar during probe-wait, emoji icons on every section header and data row (🔥📬🔀🗂️💰📣📊🚀🕵️🤖⚡ / 💬📧💼✈️📓 / ✅⚠️🚨⏳🟢🔴🟡), unicode sparklines on time-series data (`▁▂▃▄▅▆▇█`), truecolor cyan-violet gradient palette (`38;2;R;G;B` when `$COLORTERM=truecolor`, else 256-color fallback), at-a-glance vitals strip, randomized footer one-liner.
+- **Mobile/SSH graceful degradation** — detected via `$SSH_CONNECTION$SSH_CLIENT$SSH_TTY` or `$OPS_MOBILE=1`; falls back to plain-text section list, no ANSI boxes, no animations. `NO_COLOR=1` and `TERM=dumb` also honored.
+
+### Known follow-up
+
+- Portfolio section shows `(no git)` for registry paths stored with literal `~/` prefix (e.g. `~/healify-api`) because `git -C` doesn't expand tildes. Cosmetic — does not affect rolled-up stats. To be fixed by tilde-expanding paths at read time.
+
 ## [2.8.1] — 2026-05-21
 
 Hotfix: three production bugs in `/ops:ops-inbox` (PR #280).

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump version 2.8.1 → 2.8.2
- CHANGELOG entry for PR #282 (ops-dash hybrid live command center rewrite)

## Test plan

- [x] `jq -r '.version' .claude-plugin/plugin.json package.json` both report `2.8.2`
- [x] CHANGELOG.md unreleased section moved into `[2.8.2] — 2026-05-21`
- [x] Smoke test of `bin/ops-dash` post-merge: 90 unread detected, 17 PRs detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release-metadata update only (version bumps and changelog text), with no functional code changes in this diff.
> 
> **Overview**
> **Release bump to `2.8.2`.** Updates the version in `plugin.json` and `package.json`.
> 
> **Changelog update.** Adds a `2.8.2` entry describing the `/ops:ops-dash` rewrite and notes fixes for unread/PR counts and minor rendering alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be102ee1bf33e21669776917b2958f465408fc22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->