### PR TITLE
feat(dash): calendar all-calendar aggregation

### DIFF
--- a/claude-ops/CLAUDE.md
+++ b/claude-ops/CLAUDE.md
@@ -195,7 +195,8 @@ gog gmail drafts create --to "user@example.com" --subject "subj" --body "text"
 #### Calendar
 ```bash
 gog calendar calendars -j                                           # List calendars
-gog calendar events primary --today -j                              # Today's events
+gog calendar events --all --today -j --sort start                   # Today's events across ALL calendars (preferred)
+gog calendar events primary --today -j                              # Today's events — primary calendar only
 gog calendar events primary --from "2026-04-14" --to "2026-04-15" -j  # Date range
 gog calendar create primary --summary "Meeting" --from "2026-04-15T10:00:00" --to "2026-04-15T11:00:00"
 gog calendar freebusy --from "2026-04-14T00:00:00Z" --to "2026-04-14T23:59:59Z" -j

--- a/claude-ops/docs/os-compatibility.md
+++ b/claude-ops/docs/os-compatibility.md
@@ -50,7 +50,7 @@ After install: `gog auth credentials /path/to/client_secret.json && gog auth add
 
 ### Calendar — `gog calendar`
 
-Same install as email — gog ships both. `gog cal` is **not** a valid alias; always use `gog calendar`. Probe with `gog calendar calendars --json`. Today's events: `gog calendar events primary --today --json`. The setup wizard auto-detects the calendar scope and prompts for re-auth if missing.
+Same install as email — gog ships both. `gog cal` is **not** a valid alias; always use `gog calendar`. Probe with `gog calendar calendars --json`. Today's events across all calendars: `gog calendar events --all --today --json --sort start`. The setup wizard auto-detects the calendar scope and prompts for re-auth if missing.
 
 If `gog` isn't installed, the wizard falls back to the Google Calendar MCP connector (read-only — write ops require explicit Claude Desktop permission grant).
 

--- a/claude-ops/skills/ops-go/SKILL.md
+++ b/claude-ops/skills/ops-go/SKILL.md
@@ -64,7 +64,7 @@ Before executing, load available context:
 
 | Command | Usage | Output |
 |---------|-------|--------|
-| `gog calendar events primary --today --json` | Today's calendar events | Calendar events |
+| `gog calendar events --all --today --json --sort start` | Today's events across all calendars (sorted by start time) | Calendar events with `CalendarID` field for attribution |
 | `gog gmail search -j --results-only --no-input --max 30 "in:inbox"` | Search inbox | JSON array of threads |
 
 ---
@@ -170,10 +170,19 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ops-external 2>/dev/null || echo '[]'
 ${CLAUDE_PLUGIN_ROOT}/bin/ops-marketing-dash 2>/dev/null || echo '{}'
 ```
 
-### Calendar (today)
+### Calendar (today — all calendars)
 
 ```!
-gog calendar events primary --today --json 2>/dev/null | head -20 || echo "calendar unavailable"
+gog calendar events --all --today --json --sort start 2>/dev/null | head -60 || echo "calendar unavailable"
+```
+
+Events include a `CalendarID` field (e.g. `work@example.com`, `personal@gmail.com`). When rendering the briefing, attribute each event with a short calendar label in parentheses — derive it from the CalendarID domain or summary (e.g. work account → `(work)`, personal Gmail → `(personal)`). Show total count + top 3 events sorted by start time with format: `HH:MM  Title (calendar)`.
+
+Fallback: if `gog` is unavailable and `GOOGLE_CALENDAR_IDS` env var is set (comma-separated calendar IDs), fetch each ID individually:
+```
+for id in $(echo "$GOOGLE_CALENDAR_IDS" | tr ',' '\n'); do
+  gog calendar events "$id" --today --json 2>/dev/null
+done
 ```
 
 ## Your task

--- a/claude-ops/skills/setup/CLI-REFERENCE.md
+++ b/claude-ops/skills/setup/CLI-REFERENCE.md
@@ -51,7 +51,8 @@ gog gmail drafts create --to "user@example.com" --subject "subj" --body "text"
 #### Calendar
 ```bash
 gog calendar calendars -j                                           # List calendars
-gog calendar events primary --today -j                              # Today's events
+gog calendar events --all --today -j --sort start                   # Today's events across ALL calendars (preferred)
+gog calendar events primary --today -j                              # Today's events — primary calendar only
 gog calendar events primary --from "2026-04-14" --to "2026-04-15" -j  # Date range
 gog calendar create primary --summary "Meeting" --from "2026-04-15T10:00:00" --to "2026-04-15T11:00:00"
 gog calendar freebusy --from "2026-04-14T00:00:00Z" --to "2026-04-14T23:59:59Z" -j


### PR DESCRIPTION
## Summary
- Replaces `gog calendar events primary --today` with `gog calendar events --all --today --sort start` in the ops-go briefing probe
- Events attributed by `CalendarID` field — rendered as `(work)` / `(personal)` labels based on domain
- GOOGLE_CALENDAR_IDS env-var fallback documented for multi-account edge cases
- CLI reference updated in CLAUDE.md, setup/CLI-REFERENCE.md, and docs/os-compatibility.md

## Test plan
- [x] `gog calendar events --all --today --json --sort start` confirmed working — 8 events across 2 calendars (<WORK_DOMAIN>=work, gmail.com=personal)
- [ ] Run `/ops:ops-go` and verify CALENDAR section shows events from both accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the `ops-go` calendar probe and related documentation, with no security-sensitive logic; the main risk is minor briefing output/attribution differences if `gog` returns unexpected `CalendarID` values.
> 
> **Overview**
> Updates the `/ops:ops-go` morning briefing to pull **today’s events across all calendars** using `gog calendar events --all --today --json --sort start`, increasing the probe output size and documenting how to attribute events via the returned `CalendarID`.
> 
> Adds a documented fallback for multi-account edge cases via `GOOGLE_CALENDAR_IDS`, and refreshes CLI references in `CLAUDE.md`, `skills/setup/CLI-REFERENCE.md`, and `docs/os-compatibility.md` to prefer the new all-calendars command while still noting `primary` usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fa38df84130af934d275f9ade82bc631a665de7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->