### PR TITLE
feat(dash): fix FinOps endpoint + preferences fallback for creds

### DIFF
--- a/claude-ops/bin/ops-dash
+++ b/claude-ops/bin/ops-dash
@@ -301,10 +301,25 @@ TOTAL_PROBES=12
 (
   FINOPS_URL="${FINOPS_DASHBOARD_URL:-}"
   FINOPS_TOKEN="${FINOPS_OPS_API_TOKEN:-}"
+  # Fall back to preferences.json if env vars not set
+  if [[ -z "$FINOPS_URL" || -z "$FINOPS_TOKEN" ]] && [[ -f "$PREFS" ]] && command -v jq &>/dev/null; then
+    FINOPS_URL="${FINOPS_URL:-$(jq -r '.finops.url // empty' "$PREFS" 2>/dev/null)}"
+    FINOPS_TOKEN="${FINOPS_TOKEN:-$(jq -r '.finops.token // empty' "$PREFS" 2>/dev/null)}"
+  fi
   if [[ -n "$FINOPS_URL" && -n "$FINOPS_TOKEN" ]]; then
-    curl -sf -H "Authorization: Bearer $FINOPS_TOKEN" \
-      "${FINOPS_URL}/api/summary" --max-time 5 2>/dev/null \
-      > "$TMPDIR_DASH/revenue.json" \
+    RAW=$(curl -sf -H "Authorization: Bearer $FINOPS_TOKEN" \
+      "${FINOPS_URL}/api/ops/snapshot" --max-time 5 2>/dev/null) \
+      && echo "$RAW" | jq '{
+        mrr: (.revenue_snapshot.total_mrr_usd | tostring),
+        mrr_cents: .revenue_snapshot.total_mrr_cents,
+        aws_burn_30d: (.current_month_spend | to_entries | map(.value) | add // 0 | tostring),
+        aws_burn_7d: "n/a",
+        runway_months: "n/a",
+        anomalies_open: .anomalies_open,
+        services_tracked: .services_tracked,
+        burn_by_service: .burn_by_service,
+        revenue_by_project: .revenue_snapshot.by_project
+      }' 2>/dev/null > "$TMPDIR_DASH/revenue.json" \
       || echo '{}' > "$TMPDIR_DASH/revenue.json"
   else
     echo '{}' > "$TMPDIR_DASH/revenue.json"


### PR DESCRIPTION
## Summary
- Fixes `/api/ops/snapshot` 500 by setting `FINOPS_OPS_API_TOKEN` on Render (redeployed, now live)
- Switches revenue probe from `/api/summary` (session-auth only) to `/api/ops/snapshot` (bearer token)
- Maps response fields to ops-dash expected shape (`mrr`, `aws_burn_30d`, `anomalies_open`)
- Falls back to `preferences.json` for creds when env vars not set

## Config done (local, not committed)
- `~/.zshenv`: `FINOPS_DASHBOARD_URL` + `FINOPS_OPS_API_TOKEN` exports added
- `preferences.json`: `.finops` block written with url + token + enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small bash-only change to how `ops-dash` fetches/normalizes FinOps data, with no persistence or auth logic changes beyond sourcing existing tokens from `preferences.json`. Main risk is a breaking JSON mapping if the `/api/ops/snapshot` response shape differs.
> 
> **Overview**
> Updates `ops-dash`’s FinOps/revenue probe to call the bearer-token endpoint `GET /api/ops/snapshot` (instead of the session-auth `/api/summary`) and normalizes the response into the dashboard’s expected `revenue.json` fields (e.g., `mrr`, `aws_burn_30d`, `anomalies_open`).
> 
> If `FINOPS_DASHBOARD_URL`/`FINOPS_OPS_API_TOKEN` aren’t set, it now falls back to reading `.finops.url` and `.finops.token` from `preferences.json` when `jq` is available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f8fb975bf1f946e90d90fb8f0a38be9b20dc0d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->