### PR TITLE
chore(release): v2.8.3

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "Business operations command center for Claude Code — 36 skills, 18 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.8.3] — 2026-05-21
+
+`/ops:ops-dash` data completeness pass — every section now reflects the full portfolio across all integrations (PRs #284–#290).
+
+### Added
+
+- **Multi-brand competitor intel** (#285) — competitor probe sources `scripts/lib/competitor/context.sh` and iterates `.brands[]`. One line per brand with 7d high-alert count, last-run date, top alert snippet (truncated 140 chars).
+- **All-project marketing dashboard** (#284) — renders one row per configured project (9 projects), sorted worst-health-first. Each row: project, health score, blended ROAS, top channel. Mobile collapses to single summary line.
+- **Linear multi-workspace + all-teams scan** (#287) — iterates `LINEAR_API_KEY`, `HEALIFY_LINEAR_API_KEY`, `STAGERY_LINEAR_API_KEY`. Enumerates all teams per workspace, de-dupes across keys, prefixes urgent rows with team key (`[HEA] HEA-4246`).
+- **Calendar all-calendar aggregation** (#286, #290) — `gog calendar events --all --today --sort start -j` surfaces events across every calendar. New `render_section_calendar` always renders — events list, "0 events today", or "not configured" + hint.
+- **Standalone FinOps block** (#290) — split from Revenue & Costs into its own `🔥 FINOPS` section: burn 7d / burn 30d / runway / services tracked / top 3 anomalies. Pulls `/api/ops/anomalies`.
+- **Portfolio includes Shopify-only projects** (#288) — extracts `.ecom.projects` from preferences, renders `── shopify ──` subsection. Each row: project, kind, masked store URL, status (🟢/🟡/⚪). Header: `41 projects total — 38 git + 3 shopify, 14 GSD active`.
+
+### Fixed
+
+- **FinOps endpoint mismatch** (#289) — `bin/ops-dash` was calling `/api/summary` (session-auth only). Switched to `/api/ops/snapshot` with proper field mapping and `preferences.finops` as cred fallback. Also fixed `FINOPS_OPS_API_TOKEN` missing from Render env.
+- **FinOps net summation** (#290) — snapshot ingest was summing `{gross, credit_applied, net}` as if per-service map. Now reads `.net` with `.gross` fallback.
+
 ## [2.8.2] — 2026-05-21
 
 `/ops:ops-dash` rewritten as a 2026-aesthetic hybrid live command center — pixel-art hero + 12 section-by-section panels ingesting live data from every `/ops:*` skill (PR #282).

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
## Summary
Dash data-completeness release. Bundles PRs #284–#290.

- Multi-brand competitor intel (#285)
- All 9 marketing projects (#284)
- Linear all workspaces + teams (#287)
- Calendar all calendars (#286)
- Standalone FinOps block (#290) + endpoint fix (#289)
- Shopify-only projects in portfolio (#288)

See CHANGELOG.md for full notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata only (version bumps and changelog); no runtime code changes in this PR.
> 
> **Overview**
> Updates `plugin.json` and `package.json` versions from `2.8.2` to `2.8.3`.
> 
> Adds the `2.8.3` `CHANGELOG.md` entry describing the `/ops:ops-dash` data-completeness bundle (competitor multi-brand lines, full marketing project rollup, multi-workspace Linear scan, all-calendar aggregation, standalone FinOps section + endpoint/net fixes, and Shopify-only portfolio rows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe7bac8d773bdc870e101cee206d8bd4f6b7ad12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->