### PR TITLE
fix(dash): suppress plain-text re-render of colored dashboard

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "Business operations command center for Claude Code — 36 skills, 18 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.8.3] — 2026-05-21
+
+`/ops:ops-dash` data completeness pass — every section now reflects the full portfolio across all integrations (PRs #284–#290).
+
+### Added
+
+- **Multi-brand competitor intel** (#285) — competitor probe sources `scripts/lib/competitor/context.sh` and iterates `.brands[]`. One line per brand with 7d high-alert count, last-run date, top alert snippet (truncated 140 chars).
+- **All-project marketing dashboard** (#284) — renders one row per configured project (9 projects), sorted worst-health-first. Each row: project, health score, blended ROAS, top channel. Mobile collapses to single summary line.
+- **Linear multi-workspace + all-teams scan** (#287) — iterates `LINEAR_API_KEY`, `HEALIFY_LINEAR_API_KEY`, `STAGERY_LINEAR_API_KEY`. Enumerates all teams per workspace, de-dupes across keys, prefixes urgent rows with team key (`[HEA] HEA-4246`).
+- **Calendar all-calendar aggregation** (#286, #290) — `gog calendar events --all --today --sort start -j` surfaces events across every calendar. New `render_section_calendar` always renders — events list, "0 events today", or "not configured" + hint.
+- **Standalone FinOps block** (#290) — split from Revenue & Costs into its own `🔥 FINOPS` section: burn 7d / burn 30d / runway / services tracked / top 3 anomalies. Pulls `/api/ops/anomalies`.
+- **Portfolio includes Shopify-only projects** (#288) — extracts `.ecom.projects` from preferences, renders `── shopify ──` subsection. Each row: project, kind, masked store URL, status (🟢/🟡/⚪). Header: `41 projects total — 38 git + 3 shopify, 14 GSD active`.
+
+### Fixed
+
+- **FinOps endpoint mismatch** (#289) — `bin/ops-dash` was calling `/api/summary` (session-auth only). Switched to `/api/ops/snapshot` with proper field mapping and `preferences.finops` as cred fallback. Also fixed `FINOPS_OPS_API_TOKEN` missing from Render env.
+- **FinOps net summation** (#290) — snapshot ingest was summing `{gross, credit_applied, net}` as if per-service map. Now reads `.net` with `.gross` fallback.
+
 ## [2.8.2] — 2026-05-21
 
 `/ops:ops-dash` rewritten as a 2026-aesthetic hybrid live command center — pixel-art hero + 12 section-by-section panels ingesting live data from every `/ops:*` skill (PR #282).

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/claude-ops/skills/ops-dash/SKILL.md
+++ b/claude-ops/skills/ops-dash/SKILL.md
@@ -96,13 +96,11 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ops-dash 2>/dev/null || echo "DASH_RENDER_FAILED"
 
 ## Your task
 
-The dashboard has already rendered above via the shell script. Your job is to **route user input** to the right skill.
+The dashboard has **already rendered above** via the shell script — the user can see the full colored ANSI output directly. Your job is to **route user input** to the right skill.
 
-**Present the dashboard output as-is** (it's already formatted). Then immediately use AskUserQuestion:
+**DO NOT re-render, re-print, summarize, transcribe, or describe the dashboard output.** The user sees the rich colored render above; any plain-text re-statement is duplicate noise and destroys the visual quality.
 
-```
-  Type a number (1-9, 0), letter (a-j), or describe what you need
-```
+Skip straight to AskUserQuestion for the next action — no preamble, no recap, no "vitals" summary line. The dashboard speaks for itself.
 
 ## Routing table
 


### PR DESCRIPTION
## Summary
- Dashboard shell script outputs rich ANSI-colored render directly into the conversation.
- SKILL.md said "Present the dashboard output as-is" → Claude re-stated dashboard contents in plain markdown, destroying visual quality and producing duplicate noise.
- Fix: explicitly forbid re-rendering, summarizing, transcribing. Route straight to AskUserQuestion.

## Test plan
- [ ] Run `/ops:ops` in fresh session → verify only one colored render appears, no plain-text echo
- [ ] Confirm AskUserQuestion fires immediately after render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/metadata-only change that alters how the `ops-dash` skill instructs the model to respond; no runtime code paths are modified.
> 
> **Overview**
> Updates `/ops:ops-dash` instructions to **explicitly forbid re-printing/summarizing** the already-rendered ANSI dashboard and to jump directly to `AskUserQuestion` for routing.
> 
> Bumps plugin/package versions to `2.8.3` and adds a `2.8.3` changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a4a310553a1a6546d4fc67c09ec52558acc2290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->