### PR TITLE
feat(voice): native macOS + Twilio + Bland + Zoom voice surface

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.9.0] — 2026-05-21
+
+`/ops:ops-voice` rebuilt as a full voice/phone/video surface. Native macOS Phone.app (Continuity), FaceTime audio/video, and Zoom now work with zero credentials; Twilio voice + SMS and Bland AI agent calls added for programmatic outbound. New `bin/ops-voice` shell wrapper mirrors the `bin/ops-discord` pattern.
+
+### Added
+
+- **`bin/ops-voice`** — single entry point with sub-commands `phone`, `facetime`, `zoom {start|join|schedule}`, `twilio-call`, `twilio-sms`, `bland-call`. JSON output mode via `--json`. Credential resolution: env → `ops_cred_get` (keychain) → `preferences.json` → Doppler.
+- **Native macOS handlers** — `tel:`, `facetime:`, `facetime-audio:`, and `zoommtg:` URL schemes invoked via `/usr/bin/open`. No API keys required.
+- **Twilio voice + SMS** — `twilio-call <to> <from> --twiml <URL>` and `twilio-sms <to> <from> "<body>"` via `api.twilio.com/2010-04-01`. Per-message approval (Rule 6) enforced.
+- **Bland AI agent calls** — `bland-call <number> "<task prompt>"` posts to `api.bland.ai/v1/calls` with recording enabled. Returns call_id + poll URL.
+- **Zoom REST scheduling** — `zoom schedule "<topic>" --start <ISO8601> --duration <min>` via `api.zoom.us/v2/users/me/meetings`. Requires `ZOOM_API_TOKEN` (Server-to-Server OAuth access token).
+- **Routing in `/ops:comms`** — `call <contact>`, `facetime <contact>`, `start a zoom`, `join zoom <id>`, `text <contact> "<body>"`, and `have an AI call <contact>` now resolve to `bin/ops-voice` sub-commands with contact-number lookup via `mcp__whatsapp__search_contacts` and `preferences.json` → `contacts`.
+- **Channel picker** — `voice` added to the empty-args picker batch when `channels.voice` is configured or `default_channels` includes `"voice"`.
+
+### Changed
+
+- **`skills/ops-voice/SKILL.md`** — rewritten from "call (Bland only) / tts / transcribe / setup" to the full 8-subcommand surface above. Existing `tts` (ElevenLabs) and `transcribe` (Groq Whisper) preserved. Rule 6 outbound-comms guardrail and Rule 7 mobile-mode notes added inline.
+
+### Known follow-up
+
+- `bin/ops-voice` calls `/usr/bin/open` directly for native channels — needs Rule 7 adapter via `lib/opener.sh::ops_open_url` so SSH/mobile sessions get a copy-able URL instead of opening on the remote host. Tracked as v2.9.1 patch.
+- Twilio inbound webhook routing (SMS-in → ops daemon) deferred to v2.10.
+
 ## [2.8.3] — 2026-05-21
 
 `/ops:ops-dash` data completeness pass — every section now reflects the full portfolio across all integrations (PRs #284–#290).

--- a/claude-ops/bin/ops-voice
+++ b/claude-ops/bin/ops-voice
@@ -1,0 +1,401 @@
+#!/usr/bin/env bash
+# ops-voice — Voice / call helper (native macOS + Twilio + FaceTime + Zoom + Bland AI)
+#
+# Subcommands:
+#   phone    <number> [--json]                       Native Phone.app via tel: (Continuity)
+#   facetime <number-or-handle> [--audio] [--json]   FaceTime video (default) or audio
+#   zoom     start|join <meeting-id> [--pwd P]       Open zoom.us app to start/join
+#   zoom     schedule "<topic>" [--start ISO8601] [--duration MIN]   Zoom REST schedule
+#   twilio-call <to> <from> --twiml URL [--json]     Programmatic outbound voice
+#   twilio-sms  <to> <from> "<body>" [--json]        Programmatic outbound SMS
+#   bland-call  <number> "<prompt>" [--json]         AI agent phone call
+#   --help | -h
+#
+# Credential resolution order (per channel):
+#   1. Env vars
+#   2. ops_cred_get <service> <account>   (via lib/credential-store.sh)
+#   3. $PREFS_PATH (preferences.json)
+#   4. Doppler CLI fallback
+#
+# Native channels (phone, facetime, zoom start/join) require no credentials —
+# they invoke macOS URL schemes via /usr/bin/open. Twilio / Bland / Zoom-schedule
+# require API keys.
+set -euo pipefail
+
+# ─── Paths & lib sourcing ───────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LIB_OS_DETECT="$SCRIPT_DIR/lib/os-detect.sh"
+LIB_CRED="$SCRIPT_DIR/lib/credential-store.sh"
+
+# shellcheck disable=SC1090
+[ -r "$LIB_OS_DETECT" ] && . "$LIB_OS_DETECT" || true
+# shellcheck disable=SC1090
+[ -r "$LIB_CRED" ] && . "$LIB_CRED" || true
+
+PREFS_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+PREFS_PATH="${PREFS_PATH:-$PREFS_DIR/preferences.json}"
+
+USER_AGENT="ops-voice (claude-ops, v1)"
+
+JSON_MODE=false
+
+# ─── Output helpers ─────────────────────────────────────────────────────────
+emit_err() {
+  local msg="$1"
+  if $JSON_MODE; then
+    printf '{"error":%s}\n' "$(json_escape "$msg")"
+  else
+    printf 'ops-voice: %s\n' "$msg" >&2
+  fi
+}
+
+emit_ok() {
+  local channel="$1" detail="$2"
+  if $JSON_MODE; then
+    printf '{"ok":true,"channel":%s,"detail":%s}\n' \
+      "$(json_escape "$channel")" "$(json_escape "$detail")"
+  else
+    printf 'ops-voice [%s] %s\n' "$channel" "$detail"
+  fi
+}
+
+json_escape() {
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$1" | jq -Rs .
+    return 0
+  fi
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  printf '"%s"' "$s"
+}
+
+require_macos() {
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    emit_err "native channel requires macOS (detected $(uname -s))"
+    exit 1
+  fi
+}
+
+# ─── Number normalisation ───────────────────────────────────────────────────
+# Accept "+31612345678", "0612345678", "612-345-678", "(555) 123-4567".
+# Return canonical E.164 if input starts with +, else digits only.
+normalize_number() {
+  local raw="$1"
+  if [[ "$raw" =~ ^\+ ]]; then
+    printf '+%s' "$(printf '%s' "${raw#+}" | tr -cd '0-9')"
+  else
+    printf '%s' "$(printf '%s' "$raw" | tr -cd '0-9')"
+  fi
+}
+
+# ─── Credential resolvers ───────────────────────────────────────────────────
+get_secret() {
+  # get_secret <service> <account> <env-fallback>
+  local service="$1" account="$2" env_fallback="$3"
+  local val="${!env_fallback:-}"
+  [[ -n "$val" ]] && { printf '%s' "$val"; return 0; }
+
+  if declare -F ops_cred_get >/dev/null 2>&1; then
+    val="$(ops_cred_get "$service" "$account" 2>/dev/null || true)"
+    [[ -n "$val" ]] && { printf '%s' "$val"; return 0; }
+  fi
+
+  if [[ -s "$PREFS_PATH" ]] && command -v jq >/dev/null 2>&1; then
+    val="$(jq -r --arg s "$service" --arg a "$account" \
+      '.[$s][$a] // .[$s].api_key // ""' "$PREFS_PATH" 2>/dev/null || true)"
+    [[ -n "$val" && "$val" != "null" ]] && { printf '%s' "$val"; return 0; }
+  fi
+
+  if command -v doppler >/dev/null 2>&1; then
+    val="$(doppler secrets get "$env_fallback" --plain 2>/dev/null || true)"
+    [[ -n "$val" ]] && { printf '%s' "$val"; return 0; }
+  fi
+
+  return 1
+}
+
+# ─── Subcommand: phone (native Continuity call) ─────────────────────────────
+cmd_phone() {
+  local raw="${1:-}"
+  [[ -z "$raw" ]] && { emit_err "usage: ops-voice phone <number>"; exit 2; }
+  require_macos
+  local number; number="$(normalize_number "$raw")"
+  /usr/bin/open "tel:${number}" >/dev/null 2>&1 || {
+    emit_err "open tel: failed — Continuity / iPhone link may be unavailable"
+    exit 1
+  }
+  emit_ok "phone" "dialing $number via Phone.app (Continuity)"
+}
+
+# ─── Subcommand: facetime ───────────────────────────────────────────────────
+cmd_facetime() {
+  local raw="${1:-}" audio_only=false
+  shift || true
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --audio) audio_only=true ;;
+      --json)  JSON_MODE=true ;;
+      *)       emit_err "unknown flag: $1"; exit 2 ;;
+    esac
+    shift
+  done
+  [[ -z "$raw" ]] && { emit_err "usage: ops-voice facetime <number-or-handle> [--audio]"; exit 2; }
+  require_macos
+  local handle
+  if [[ "$raw" =~ @ ]]; then
+    handle="$raw"
+  else
+    handle="$(normalize_number "$raw")"
+  fi
+  local scheme="facetime"
+  $audio_only && scheme="facetime-audio"
+  /usr/bin/open "${scheme}://${handle}" >/dev/null 2>&1 || {
+    emit_err "open ${scheme}: failed — FaceTime may not be signed in"
+    exit 1
+  }
+  emit_ok "facetime" "starting ${scheme} with $handle"
+}
+
+# ─── Subcommand: zoom ───────────────────────────────────────────────────────
+cmd_zoom() {
+  local action="${1:-}"; shift || true
+  case "$action" in
+    start)
+      require_macos
+      /usr/bin/open "zoommtg://zoom.us/start?confno=" >/dev/null 2>&1 || true
+      # Fallback: open the app directly so user picks "New Meeting".
+      /usr/bin/open -a "zoom.us" >/dev/null 2>&1 || {
+        emit_err "Zoom not installed (expected /Applications/zoom.us.app)"
+        exit 1
+      }
+      emit_ok "zoom" "starting instant meeting in zoom.us"
+      ;;
+    join)
+      local mid="${1:-}" pwd=""
+      shift || true
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --pwd|--password) pwd="$2"; shift 2 ;;
+          --json) JSON_MODE=true; shift ;;
+          *) shift ;;
+        esac
+      done
+      [[ -z "$mid" ]] && { emit_err "usage: ops-voice zoom join <meeting-id> [--pwd P]"; exit 2; }
+      require_macos
+      local url="zoommtg://zoom.us/join?confno=${mid}"
+      [[ -n "$pwd" ]] && url="${url}&pwd=${pwd}"
+      /usr/bin/open "$url" >/dev/null 2>&1 || {
+        emit_err "open zoommtg: failed"
+        exit 1
+      }
+      emit_ok "zoom" "joining meeting $mid"
+      ;;
+    schedule)
+      local topic="${1:-}"; shift || true
+      local start="" duration=30
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --start)    start="$2"; shift 2 ;;
+          --duration) duration="$2"; shift 2 ;;
+          --json)     JSON_MODE=true; shift ;;
+          *) shift ;;
+        esac
+      done
+      [[ -z "$topic" ]] && { emit_err 'usage: ops-voice zoom schedule "<topic>" [--start ISO8601] [--duration MIN]'; exit 2; }
+      local jwt
+      jwt="$(get_secret zoom api-token ZOOM_API_TOKEN)" || {
+        emit_err "no zoom credential — set ZOOM_API_TOKEN (Server-to-Server OAuth access token)"
+        exit 1
+      }
+      local body
+      body="$(jq -n --arg t "$topic" --arg s "$start" --argjson d "$duration" \
+        '{topic:$t, type: (if $s == "" then 1 else 2 end), duration:$d} +
+         (if $s == "" then {} else {start_time:$s, timezone:"UTC"} end)')"
+      local resp
+      resp="$(curl -sS -X POST "https://api.zoom.us/v2/users/me/meetings" \
+        -H "Authorization: Bearer $jwt" \
+        -H "Content-Type: application/json" \
+        -A "$USER_AGENT" \
+        --data "$body")"
+      local join_url id
+      join_url="$(printf '%s' "$resp" | jq -r '.join_url // empty' 2>/dev/null)"
+      id="$(printf '%s' "$resp" | jq -r '.id // empty' 2>/dev/null)"
+      if [[ -z "$join_url" ]]; then
+        emit_err "zoom schedule failed: $resp"
+        exit 1
+      fi
+      emit_ok "zoom" "scheduled meeting $id — $join_url"
+      ;;
+    *)
+      emit_err "usage: ops-voice zoom {start|join <id>|schedule \"<topic>\"}"
+      exit 2
+      ;;
+  esac
+}
+
+# ─── Subcommand: twilio-call ────────────────────────────────────────────────
+cmd_twilio_call() {
+  local to="${1:-}" from="${2:-}" twiml=""
+  shift 2 || true
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --twiml) twiml="$2"; shift 2 ;;
+      --json)  JSON_MODE=true; shift ;;
+      *) shift ;;
+    esac
+  done
+  [[ -z "$to" || -z "$from" || -z "$twiml" ]] && {
+    emit_err "usage: ops-voice twilio-call <to> <from> --twiml <URL>"
+    exit 2
+  }
+  local sid token
+  sid="$(get_secret twilio account-sid TWILIO_ACCOUNT_SID)" || {
+    emit_err "no twilio credential — set TWILIO_ACCOUNT_SID"; exit 1; }
+  token="$(get_secret twilio auth-token TWILIO_AUTH_TOKEN)" || {
+    emit_err "no twilio credential — set TWILIO_AUTH_TOKEN"; exit 1; }
+  local to_n from_n
+  to_n="$(normalize_number "$to")"
+  from_n="$(normalize_number "$from")"
+  local resp
+  resp="$(curl -sS -X POST \
+    "https://api.twilio.com/2010-04-01/Accounts/${sid}/Calls.json" \
+    -u "${sid}:${token}" \
+    -A "$USER_AGENT" \
+    --data-urlencode "To=${to_n}" \
+    --data-urlencode "From=${from_n}" \
+    --data-urlencode "Url=${twiml}")"
+  local call_sid status
+  call_sid="$(printf '%s' "$resp" | jq -r '.sid // empty' 2>/dev/null)"
+  status="$(printf '%s' "$resp" | jq -r '.status // empty' 2>/dev/null)"
+  if [[ -z "$call_sid" ]]; then
+    emit_err "twilio call failed: $resp"
+    exit 1
+  fi
+  emit_ok "twilio-call" "$call_sid status=$status"
+}
+
+# ─── Subcommand: twilio-sms ─────────────────────────────────────────────────
+cmd_twilio_sms() {
+  local to="${1:-}" from="${2:-}" body="${3:-}"
+  shift 3 || true
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json) JSON_MODE=true; shift ;;
+      *) shift ;;
+    esac
+  done
+  [[ -z "$to" || -z "$from" || -z "$body" ]] && {
+    emit_err 'usage: ops-voice twilio-sms <to> <from> "<body>"'
+    exit 2
+  }
+  local sid token
+  sid="$(get_secret twilio account-sid TWILIO_ACCOUNT_SID)" || {
+    emit_err "no twilio credential — set TWILIO_ACCOUNT_SID"; exit 1; }
+  token="$(get_secret twilio auth-token TWILIO_AUTH_TOKEN)" || {
+    emit_err "no twilio credential — set TWILIO_AUTH_TOKEN"; exit 1; }
+  local to_n from_n
+  to_n="$(normalize_number "$to")"
+  from_n="$(normalize_number "$from")"
+  local resp
+  resp="$(curl -sS -X POST \
+    "https://api.twilio.com/2010-04-01/Accounts/${sid}/Messages.json" \
+    -u "${sid}:${token}" \
+    -A "$USER_AGENT" \
+    --data-urlencode "To=${to_n}" \
+    --data-urlencode "From=${from_n}" \
+    --data-urlencode "Body=${body}")"
+  local msg_sid status
+  msg_sid="$(printf '%s' "$resp" | jq -r '.sid // empty' 2>/dev/null)"
+  status="$(printf '%s' "$resp" | jq -r '.status // empty' 2>/dev/null)"
+  if [[ -z "$msg_sid" ]]; then
+    emit_err "twilio sms failed: $resp"
+    exit 1
+  fi
+  emit_ok "twilio-sms" "$msg_sid status=$status"
+}
+
+# ─── Subcommand: bland-call ─────────────────────────────────────────────────
+cmd_bland_call() {
+  local number="${1:-}" prompt="${2:-}"
+  shift 2 || true
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json) JSON_MODE=true; shift ;;
+      *) shift ;;
+    esac
+  done
+  [[ -z "$number" || -z "$prompt" ]] && {
+    emit_err 'usage: ops-voice bland-call <number> "<task prompt>"'
+    exit 2
+  }
+  local key
+  key="$(get_secret bland api-key BLAND_AI_API_KEY)" || {
+    emit_err "no bland credential — set BLAND_AI_API_KEY"; exit 1; }
+  local number_n; number_n="$(normalize_number "$number")"
+  local body
+  body="$(jq -n --arg p "$number_n" --arg t "$prompt" \
+    '{phone_number:$p, task:$t, record:true, max_duration:300}')"
+  local resp
+  resp="$(curl -sS -X POST "https://api.bland.ai/v1/calls" \
+    -H "authorization: $key" \
+    -H "Content-Type: application/json" \
+    -A "$USER_AGENT" \
+    --data "$body")"
+  local call_id
+  call_id="$(printf '%s' "$resp" | jq -r '.call_id // empty' 2>/dev/null)"
+  if [[ -z "$call_id" ]]; then
+    emit_err "bland call failed: $resp"
+    exit 1
+  fi
+  emit_ok "bland-call" "$call_id (poll with: curl -H \"authorization: \$KEY\" https://api.bland.ai/v1/calls/$call_id)"
+}
+
+# ─── Dispatcher ─────────────────────────────────────────────────────────────
+usage() {
+  cat >&2 <<'EOF'
+ops-voice — voice / call helper
+
+usage:
+  ops-voice phone    <number> [--json]
+  ops-voice facetime <number-or-email> [--audio] [--json]
+  ops-voice zoom     start
+  ops-voice zoom     join     <meeting-id> [--pwd P] [--json]
+  ops-voice zoom     schedule "<topic>" [--start ISO8601] [--duration MIN] [--json]
+  ops-voice twilio-call <to> <from> --twiml <URL> [--json]
+  ops-voice twilio-sms  <to> <from> "<body>" [--json]
+  ops-voice bland-call  <number> "<prompt>" [--json]
+
+native channels (phone/facetime/zoom start|join) need no credentials.
+twilio/bland/zoom-schedule resolve via env → keychain → preferences.json → doppler.
+EOF
+}
+
+main() {
+  # Strip a global --json flag if present anywhere.
+  local args=()
+  for a in "$@"; do
+    case "$a" in
+      --json) JSON_MODE=true ;;
+      *) args+=("$a") ;;
+    esac
+  done
+  set -- "${args[@]:-}"
+
+  local cmd="${1:-}"; shift || true
+  case "$cmd" in
+    phone)        cmd_phone "$@" ;;
+    facetime)     cmd_facetime "$@" ;;
+    zoom)         cmd_zoom "$@" ;;
+    twilio-call)  cmd_twilio_call "$@" ;;
+    twilio-sms)   cmd_twilio_sms "$@" ;;
+    bland-call)   cmd_bland_call "$@" ;;
+    -h|--help|"") usage; exit 0 ;;
+    *) emit_err "unknown subcommand: $cmd"; usage; exit 2 ;;
+  esac
+}
+
+main "$@"

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.8.3",
+  "version": "2.9.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/claude-ops/skills/ops-comms/SKILL.md
+++ b/claude-ops/skills/ops-comms/SKILL.md
@@ -91,11 +91,21 @@ Parse `$ARGUMENTS` and route immediately:
 | `telegram`    | Show Telegram recent chats                              |
 | `discord`     | Show recent Discord channel activity (via bin/ops-discord) |
 | `notion`      | Search Notion workspace — pages, comments, tasks          |
+| `voice`       | Voice / phone / video — routes to `/ops:ops-voice` (bin/ops-voice) |
+| `call * `     | Native Phone.app call via `bin/ops-voice phone`           |
+| `facetime *`  | FaceTime audio/video via `bin/ops-voice facetime`         |
+| `zoom`        | Start an instant Zoom meeting via `bin/ops-voice zoom start` |
 | `send * to *` | Parse message and contact, determine best channel, send |
 | `read *`      | Read the specified channel or contact's messages        |
 | (empty)       | Show channel picker menu                                |
 
-Natural-language parsing: phrases like `send "deploy done" to #general on discord` or `to #ops-alerts on Discord` should resolve to the `discord` branch below. Extract the channel token (the word after `#`, case-insensitive) and pass it as the first arg to `bin/ops-discord send`.
+Natural-language parsing:
+- `send "deploy done" to #general on discord` → `bin/ops-discord send general "deploy done"`.
+- `call <contact>` / `dial <contact>` / `phone <contact>` → resolve number, then `bin/ops-voice phone <E.164>`.
+- `facetime <contact>` (with optional `audio`) → `bin/ops-voice facetime <handle> [--audio]`.
+- `start a zoom` / `new zoom meeting` → `bin/ops-voice zoom start`.
+- `join zoom <ID>` → `bin/ops-voice zoom join <ID>`.
+- `text <contact> "<body>"` / `sms <contact> "<body>"` → `bin/ops-voice twilio-sms <to> $TWILIO_FROM_NUMBER "<body>"` (guarded by per-message approval).
 
 ---
 
@@ -225,6 +235,30 @@ If the script exits 1 with `{"error":"no discord credential configured — run /
 
 Note: `DISCORD_WEBHOOK_URL` is shared with the ops-fires notification sink (`scripts/ops-notify.sh`). When pre-existing, prefer it as the default for `/ops:comms discord send` rather than asking the user to set a separate value.
 
+### Voice / phone / video
+
+All voice traffic flows through `bin/ops-voice` (full surface documented in the `ops-voice` skill). Native channels (Phone.app, FaceTime, Zoom start|join) need no credentials; programmatic channels (Twilio voice/SMS, Bland AI, Zoom schedule) follow the standard credential-resolution order.
+
+```bash
+# Native — no creds
+${CLAUDE_PLUGIN_ROOT}/bin/ops-voice phone    "+1234567890" --json
+${CLAUDE_PLUGIN_ROOT}/bin/ops-voice facetime user@example.com --audio --json
+${CLAUDE_PLUGIN_ROOT}/bin/ops-voice zoom     start
+${CLAUDE_PLUGIN_ROOT}/bin/ops-voice zoom     join 1234567890 --pwd <password>
+
+# Programmatic — gated by Rule 6 (per-message approval)
+${CLAUDE_PLUGIN_ROOT}/bin/ops-voice twilio-call "+1234567890" "$TWILIO_FROM_NUMBER" --twiml "<URL>" --json
+${CLAUDE_PLUGIN_ROOT}/bin/ops-voice twilio-sms  "+1234567890" "$TWILIO_FROM_NUMBER" "<body>" --json
+${CLAUDE_PLUGIN_ROOT}/bin/ops-voice bland-call  "+1234567890" "<task prompt>" --json
+```
+
+**Send-flow integration:** when `$ARGUMENTS` looks like `call <contact>`, `facetime <contact>`, `text <contact> "<body>"`, or `have an AI call <contact> and ...`:
+
+1. Resolve the contact's number/handle (`mcp__whatsapp__search_contacts` or `preferences.json` → `contacts`).
+2. For native calls (`phone`, `facetime`, `zoom`): preview `[Place call via <channel> to <contact>] [Cancel]` then invoke.
+3. For Twilio voice/SMS and Bland AI: stage the full draft (recipient, channel, body or task-prompt) and gate behind one `AskUserQuestion` per message (Rule 6). Never batch.
+4. If no credential resolves for a programmatic channel, prompt via `AskUserQuestion` with `[Run /ops:ops-voice setup]` / `[Paste credential now]` / `[Try native instead]` / `[Skip]` (Rule 3 — never silently skip).
+
 ---
 
 ## Empty arguments — channel picker
@@ -250,9 +284,10 @@ AskUserQuestion call 1 — Read channels:
 AskUserQuestion call 2 (only if "More..."):
 ```
   [Read Telegram]
+  [Make a call (voice)]
   [Send a message]
 ```
 
-If all channels are configured, that's 5 options — always batch. If only 3 channels are configured, "Read X" + "Read Y" + "Read Z" + "Send a message" = 4, fits in one call.
+If all channels are configured, that's 6+ options — always batch. If only 3 channels are configured, "Read X" + "Read Y" + "Read Z" + "Send a message" = 4, fits in one call. The `voice` channel is configured iff `preferences.json` → `channels.voice` is present OR `default_channels` contains `"voice"`.
 
 Execute the selected action.

--- a/claude-ops/skills/ops-voice/SKILL.md
+++ b/claude-ops/skills/ops-voice/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ops-voice
-description: Voice operations — make phone calls (Bland AI), text-to-speech (ElevenLabs), transcribe audio (Whisper/Groq). Replace OpenClaw voice capabilities.
-argument-hint: "[call|tts|transcribe|setup]"
+description: Voice operations — native macOS Phone (Continuity), FaceTime, Zoom, Twilio voice + SMS, Bland AI agent calls, ElevenLabs TTS, Whisper transcription. All curl-based, no SDK deps.
+argument-hint: "[phone|facetime|zoom|twilio-call|twilio-sms|bland-call|tts|transcribe|setup]"
 allowed-tools:
   - Bash
   - Read
@@ -12,73 +12,109 @@ allowed-tools:
 
 # OPS:VOICE — Voice Operations
 
-Voice interface commands. All API calls via curl — no SDK dependencies.
+Voice / phone / video interface. All API calls via curl — no SDK dependencies. Native macOS handlers (Phone.app, FaceTime, Zoom) require no credentials; programmatic channels (Twilio, Bland, ElevenLabs, Groq, Zoom schedule) resolve credentials via:
 
-**Credential resolution order:** userConfig → env vars → Doppler MCP tools (`mcp__doppler__*`) → Doppler CLI fallback (`doppler secrets get <KEY> --plain`) → password manager
+**Credential resolution order:** env vars → `ops_cred_get` (lib/credential-store.sh / keychain) → `preferences.json` → Doppler CLI (`doppler secrets get <KEY> --plain`) → password manager.
+
+All sub-commands have a thin bash wrapper at `bin/ops-voice` — prefer it over inline curl when scripting.
+
+**Outbound comms guardrail (Rule 6):** `twilio-call`, `twilio-sms`, and `bland-call` are 1:1 outbound channels and MUST follow the per-message approval gate — stage final draft, show full target+body, wait for explicit approval (`AskUserQuestion` or single-word chat approval), send one, then stage the next. Never batch.
 
 ---
 
 ## Sub-commands
 
-Parse `$ARGUMENTS` for the command keyword, then execute:
+Parse `$ARGUMENTS` for the command keyword, then execute. Native handlers exit fast; API calls report status and (where relevant) a poll command.
 
 ---
 
-### `call [phone] [prompt]` — Bland AI phone call
+### `phone <number>` — Native Phone.app via Continuity
 
-**Requires:** `bland_ai_api_key` in userConfig or `BLAND_AI_API_KEY` env or Doppler.
+Routes through the linked iPhone. Requires macOS + iPhone signed in to the same iCloud account with **Calls on Other Devices** enabled. No credentials.
 
 ```bash
-BLAND_KEY="${BLAND_AI_API_KEY:-$(doppler secrets get BLAND_AI_API_KEY --plain 2>/dev/null || true)}"
-PHONE="<extracted from $ARGUMENTS>"
-PROMPT="<extracted from $ARGUMENTS or ask user>"
-MAX_DURATION="${BLAND_MAX_DURATION:-300}"  # seconds
-VOICE="${BLAND_VOICE:-male}"
-
-# Make the call
-RESPONSE=$(curl -s -X POST "https://api.bland.ai/v1/calls" \
-  -H "authorization: $BLAND_KEY" \
-  -H "Content-Type: application/json" \
-  -d "{
-    \"phone_number\": \"$PHONE\",
-    \"task\": \"$PROMPT\",
-    \"voice\": \"$VOICE\",
-    \"max_duration\": $MAX_DURATION,
-    \"record\": true
-  }")
-
-CALL_ID=$(echo "$RESPONSE" | python3 -c "import json,sys; print(json.load(sys.stdin).get('call_id',''))" 2>/dev/null)
-
-# Poll for completion (up to 5 min)
-if [ -n "$CALL_ID" ]; then
-  echo "Call initiated: $CALL_ID"
-  for i in $(seq 1 30); do
-    sleep 10
-    STATUS=$(curl -s "https://api.bland.ai/v1/calls/$CALL_ID" \
-      -H "authorization: $BLAND_KEY" | \
-      python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('status',''), d.get('transcripts','')[-1].get('text','') if d.get('transcripts') else '')" 2>/dev/null)
-    echo "Status: $STATUS"
-    [[ "$STATUS" == completed* ]] && break
-  done
-fi
+bin/ops-voice phone "+1234567890" --json
+# {"ok":true,"channel":"phone","detail":"dialing +1234567890 via Phone.app (Continuity)"}
 ```
 
-**Output:** Call ID, live status, transcript when complete.
+Under the hood: `open "tel:<E.164>"`.
+
+---
+
+### `facetime <number-or-email> [--audio]` — FaceTime video/audio
+
+Defaults to video. Pass `--audio` for FaceTime Audio (free, Apple↔Apple). Accepts phone numbers or Apple-ID emails.
+
+```bash
+bin/ops-voice facetime user@example.com               # video
+bin/ops-voice facetime "+1234567890" --audio --json   # audio
+```
+
+Under the hood: `open "facetime://<handle>"` or `open "facetime-audio://<handle>"`.
+
+---
+
+### `zoom start|join|schedule` — Zoom meetings
+
+```bash
+# Open zoom.us app and start a new instant meeting
+bin/ops-voice zoom start
+
+# Join an existing meeting
+bin/ops-voice zoom join 1234567890 --pwd <password>
+
+# Schedule a meeting via Zoom REST API (requires ZOOM_API_TOKEN — Server-to-Server OAuth access token)
+bin/ops-voice zoom schedule "<topic>" --start "2026-05-22T15:00:00Z" --duration 30 --json
+# {"ok":true,"channel":"zoom","detail":"scheduled meeting 12345 — https://us05web.zoom.us/j/..."}
+```
+
+Native start/join use `zoommtg://` URL scheme. Schedule requires `ZOOM_API_TOKEN` resolved via the order above. Generate a Server-to-Server OAuth app in your Zoom Marketplace, then exchange for an access token.
+
+---
+
+### `twilio-call <to> <from> --twiml <URL>` — Programmatic outbound voice
+
+Real telco call (per-minute cost). Requires `TWILIO_ACCOUNT_SID` + `TWILIO_AUTH_TOKEN`. The `--twiml` URL must return TwiML XML describing call behavior — e.g. `https://demo.twilio.com/docs/voice.xml` or a custom Function/Studio flow.
+
+```bash
+bin/ops-voice twilio-call "+1234567890" "+15551234567" \
+  --twiml "https://demo.twilio.com/docs/voice.xml" --json
+```
+
+---
+
+### `twilio-sms <to> <from> "<body>"` — Programmatic outbound SMS
+
+```bash
+bin/ops-voice twilio-sms "+1234567890" "+15551234567" "<body>" --json
+```
+
+For inbound SMS / WhatsApp routing, point your Twilio webhook at the ops daemon (out of scope for v1).
+
+---
+
+### `bland-call <number> "<prompt>"` — Bland AI agent phone call
+
+AI agent calls the number and follows the natural-language prompt. Recordings + transcripts available via the poll URL printed on success.
+
+```bash
+bin/ops-voice bland-call "+1234567890" "<task prompt>" --json
+```
+
+Poll with: `curl -H "authorization: $BLAND_AI_API_KEY" https://api.bland.ai/v1/calls/<call_id>`.
 
 ---
 
 ### `tts [text] [--voice voice_id] [--out file.mp3]` — ElevenLabs text-to-speech
 
-**Requires:** `elevenlabs_api_key` in userConfig or `ELEVENLABS_API_KEY` env or Doppler.
+**Requires:** `ELEVENLABS_API_KEY` (env / keychain / Doppler).
 
 ```bash
 EL_KEY="${ELEVENLABS_API_KEY:-$(doppler secrets get ELEVENLABS_API_KEY --plain 2>/dev/null || true)}"
-VOICE_ID="${ELEVENLABS_VOICE_ID:-21m00Tcm4TlvDq8ikWAM}"  # Rachel (default)
-TEXT="<extracted from $ARGUMENTS>"
+VOICE_ID="${ELEVENLABS_VOICE_ID:-21m00Tcm4TlvDq8ikWAM}"  # Rachel
+TEXT="<from $ARGUMENTS>"
 OUT_FILE="${OUT_FILE:-/tmp/ops-tts-$(date +%s).mp3}"
 
-# List voices if voice name provided (not an ID)
-# Synthesize
 curl -s -X POST "https://api.elevenlabs.io/v1/text-to-speech/${VOICE_ID}" \
   -H "xi-api-key: $EL_KEY" \
   -H "Content-Type: application/json" \
@@ -89,85 +125,131 @@ curl -s -X POST "https://api.elevenlabs.io/v1/text-to-speech/${VOICE_ID}" \
   }" \
   --output "$OUT_FILE"
 
+command -v afplay >/dev/null && afplay "$OUT_FILE" &
 echo "Audio saved to: $OUT_FILE"
-# Auto-play on macOS
-command -v afplay &>/dev/null && afplay "$OUT_FILE" &
 ```
-
-**Output:** Audio file path. Auto-plays on macOS via `afplay`.
 
 ---
 
 ### `transcribe [file_path]` — Groq Whisper transcription
 
-**Requires:** `groq_api_key` in userConfig or `GROQ_API_KEY` env or Doppler.
+**Requires:** `GROQ_API_KEY` (env / keychain / Doppler).
 
 ```bash
 GROQ_KEY="${GROQ_API_KEY:-$(doppler secrets get GROQ_API_KEY --plain 2>/dev/null || true)}"
-AUDIO_FILE="<extracted from $ARGUMENTS>"
+AUDIO_FILE="<from $ARGUMENTS>"
 
-if [ ! -f "$AUDIO_FILE" ]; then
-  echo "ERROR: File not found: $AUDIO_FILE"
-  exit 1
-fi
+[ -f "$AUDIO_FILE" ] || { echo "ERROR: $AUDIO_FILE not found"; exit 1; }
 
-TRANSCRIPT=$(curl -s -X POST "https://api.groq.com/openai/v1/audio/transcriptions" \
+curl -s -X POST "https://api.groq.com/openai/v1/audio/transcriptions" \
   -H "Authorization: Bearer $GROQ_KEY" \
   -F "file=@$AUDIO_FILE" \
   -F "model=whisper-large-v3" \
   -F "response_format=json" | \
-  python3 -c "import json,sys; print(json.load(sys.stdin).get('text',''))" 2>/dev/null)
-
-echo "$TRANSCRIPT"
+  jq -r '.text'
 ```
-
-**Output:** Transcript text printed to stdout.
 
 ---
 
-### `setup` — Configure voice API keys
+### `setup` — Configure voice channels
 
-**Before asking for anything**, auto-scan ALL sources in a single background batch:
+Before asking for anything, auto-scan ALL sources in one background batch (Rule 4: `run_in_background: true`):
 
 ```bash
 # Env vars
-printenv BLAND_AI_API_KEY BLAND_API_KEY ELEVENLABS_API_KEY GROQ_API_KEY 2>/dev/null
+printenv \
+  TWILIO_ACCOUNT_SID TWILIO_AUTH_TOKEN TWILIO_FROM_NUMBER \
+  BLAND_AI_API_KEY ELEVENLABS_API_KEY GROQ_API_KEY \
+  ZOOM_API_TOKEN ZOOM_ACCOUNT_ID ZOOM_CLIENT_ID ZOOM_CLIENT_SECRET 2>/dev/null
 
 # Shell profiles
-grep -h 'BLAND\|ELEVENLABS\|GROQ' ~/.zshrc ~/.bashrc ~/.zprofile ~/.envrc 2>/dev/null | grep -v '^#'
+grep -hE 'TWILIO|BLAND|ELEVENLABS|GROQ|ZOOM' \
+  ~/.zshrc ~/.bashrc ~/.zprofile ~/.envrc 2>/dev/null | grep -v '^#'
 
 # Doppler — ALL projects
 for proj in $(doppler projects --json 2>/dev/null | jq -r '.[].slug'); do
   for cfg in dev stg prd; do
     doppler secrets --project "$proj" --config "$cfg" --json 2>/dev/null | \
-      jq -r --arg proj "$proj" --arg cfg "$cfg" 'to_entries[] | select(.key | test("BLAND|ELEVENLABS|GROQ"; "i")) | "\(.key)=\(.value.computed | .[0:12])... (doppler:\($proj)/\($cfg))"'
+      jq -r --arg p "$proj" --arg c "$cfg" \
+        'to_entries[]
+         | select(.key | test("TWILIO|BLAND|ELEVENLABS|GROQ|ZOOM"; "i"))
+         | "\(.key)=\(.value.computed | .[0:12])... (doppler:\($p)/\($c))"'
   done
 done
 
-# Dashlane
-dcli password bland --output json 2>/dev/null | jq -r '.[] | select(.password != null) | "\(.title): key found"'
-dcli password elevenlabs --output json 2>/dev/null | jq -r '.[] | select(.password != null) | "\(.title): key found"'
-dcli password groq --output json 2>/dev/null | jq -r '.[] | select(.password != null) | "\(.title): key found"'
-
 # Keychain
-security find-generic-password -s "bland-ai-api-key" -w 2>/dev/null
-security find-generic-password -s "elevenlabs-api-key" -w 2>/dev/null
-security find-generic-password -s "groq-api-key" -w 2>/dev/null
+for svc in twilio bland-ai elevenlabs groq zoom; do
+  security find-generic-password -s "$svc" -w 2>/dev/null >/dev/null \
+    && echo "[keychain] $svc ✓"
+done
+
+# Native macOS prerequisites
+ls /Applications/zoom.us.app \
+   /System/Applications/FaceTime.app \
+   /System/Applications/Phone.app 2>/dev/null
 ```
 
-Present all findings. Only prompt for keys NOT found in any source. Then validate each found key in background:
+Validate found keys (in parallel):
 
-1. **Bland AI**: `curl -s -H "authorization: $KEY" https://api.bland.ai/v1/me` — check balance
-2. **ElevenLabs**: `curl -s -H "xi-api-key: $KEY" https://api.elevenlabs.io/v1/voices?page_size=1` — list voices
-3. **Groq**: `curl -s -H "Authorization: Bearer $KEY" https://api.groq.com/openai/v1/models` — list models
+| Channel    | Probe                                                                              |
+|------------|------------------------------------------------------------------------------------|
+| Twilio     | `curl -u "$SID:$TOKEN" https://api.twilio.com/2010-04-01/Accounts/$SID.json`       |
+| Bland      | `curl -H "authorization: $KEY" https://api.bland.ai/v1/me`                         |
+| ElevenLabs | `curl -H "xi-api-key: $KEY" "https://api.elevenlabs.io/v1/voices?page_size=1"`     |
+| Groq       | `curl -H "Authorization: Bearer $KEY" https://api.groq.com/openai/v1/models`       |
+| Zoom       | `curl -H "Authorization: Bearer $TOKEN" https://api.zoom.us/v2/users/me`           |
 
-Report: `[service] ✓ connected` or `[service] ✗ invalid key — [error]`
+Report each as `[service] ✓ connected` or `[service] ✗ <error>`. **Rule 3 applies — never silently skip a channel.** For each unset service, present `AskUserQuestion` with `[Paste manually]` / `[Deep hunt — spawn agent]` / `[Skip]`.
+
+Persist to `preferences.json`:
+
+```json
+{
+  "channels": {
+    "voice": {
+      "backend": "native+twilio+zoom+bland",
+      "native": {"phone": true, "facetime": true, "zoom": true},
+      "twilio": {"status": "configured", "from_number": "env:TWILIO_FROM_NUMBER"},
+      "bland":  {"status": "configured"},
+      "zoom":   {"status": "configured"}
+    }
+  },
+  "default_channels": ["whatsapp", "email", "telegram", "slack", "voice"]
+}
+```
+
+---
+
+## Routing from `/ops:comms`
+
+Voice is wired into `/ops:comms` send-flow. The router resolves intent like:
+
+| User says                              | Resolves to                                |
+|----------------------------------------|--------------------------------------------|
+| `call <name>`                          | `ops-voice phone <number>`                 |
+| `facetime <name>`                      | `ops-voice facetime <handle>`              |
+| `start a zoom`                         | `ops-voice zoom start`                     |
+| `text <name> "..."`                    | `ops-voice twilio-sms ... "..."`           |
+| `have an AI call <name> and tell ...`  | `ops-voice bland-call <number> "..."`      |
+
+Contact-number lookup uses the same contact resolver as WhatsApp (`mcp__whatsapp__search_contacts`) plus an optional `contacts.json` map in `preferences.json`.
+
+---
+
+## Mobile / SSH mode (Rule 7)
+
+When `$SSH_CONNECTION$SSH_CLIENT$SSH_TTY` is set or `$OPS_MOBILE=1`:
+- `bin/ops-voice` still works for API channels.
+- Native channels (`phone`, `facetime`, `zoom start|join`) require a local macOS session — the script returns a plain-text instruction to open the URL on the host instead of calling `open` directly. The script must source `lib/opener.sh` and use `ops_open_url` for URL handoff.
+
+(v1 of `bin/ops-voice` calls `/usr/bin/open` directly — Rule 7 adapter is a v1.1 follow-up; tracked in CHANGELOG.)
 
 ---
 
 ## Execution
 
-1. Resolve the sub-command from `$ARGUMENTS` (first word: call / tts / transcribe / setup)
-2. Resolve credentials in order: env → Doppler
-3. Execute the matching curl block above
-4. If a required key is missing and `setup` was not invoked, suggest `/ops:ops-voice setup`
+1. Resolve the sub-command from `$ARGUMENTS` (first word).
+2. For native handlers (phone/facetime/zoom start|join), shell out to `bin/ops-voice` — exit fast.
+3. For API channels (twilio/bland/zoom-schedule/tts/transcribe), resolve credentials in order, then curl.
+4. If a required key is missing, suggest `/ops:ops-voice setup`.
+5. For 1:1 outbound channels (twilio-call/sms, bland-call): stage one draft → `AskUserQuestion` → send → next.


### PR DESCRIPTION
## Summary
- Rebuilds `/ops:ops-voice` into a full voice/phone/video surface: native macOS Phone.app (Continuity), FaceTime audio/video, Zoom (start/join/schedule), Twilio voice + SMS, Bland AI agent calls. Keeps existing ElevenLabs TTS + Groq Whisper.
- Adds `bin/ops-voice` shell wrapper (mirrors `bin/ops-discord` pattern) with JSON output and standard credential-resolution order.
- Wires the new channels into `/ops:comms` routing — `call <contact>`, `facetime <contact>`, `start a zoom`, `text <contact> "..."`, `have an AI call <contact> ...` all resolve through `bin/ops-voice`.
- Bumps version to 2.9.0.

## Why
`/ops:comms` had no voice channel. The only existing voice surface was Bland AI agent calls — no native dialing, no FaceTime, no Zoom, no Twilio direct calls/SMS.

## Outbound-comms safety
`twilio-call`, `twilio-sms`, and `bland-call` are 1:1 outbound channels and follow Rule 6: stage one draft, `AskUserQuestion` per message, never batch. Documented in both `skills/ops-voice/SKILL.md` and `skills/ops-comms/SKILL.md`.

## Test plan
- [x] `bash -n bin/ops-voice` — syntax OK
- [x] `bash tests/test-no-secrets.sh` — 14 passed, 0 failed (Rule 0)
- [x] `bin/ops-voice --help` — usage prints, all 6 sub-commands documented
- [ ] Manual: `bin/ops-voice phone "+1234567890"` opens Phone.app on a macOS box with Continuity enabled
- [ ] Manual: `bin/ops-voice facetime user@example.com --audio` opens FaceTime audio
- [ ] Manual: `bin/ops-voice zoom start` launches zoom.us
- [ ] Manual: `bin/ops-voice twilio-sms` with sandbox creds round-trips an SMS

## Known follow-ups (tracked in CHANGELOG)
- v2.9.1: route native `open` through `lib/opener.sh::ops_open_url` so SSH/mobile sessions get a copy-able URL instead of opening on the remote host (Rule 7 compliance).
- v2.10: Twilio inbound webhook routing (SMS-in → ops daemon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new outbound calling/SMS capabilities and external API integrations (Twilio/Bland/Zoom) plus native URL-scheme launching, which can trigger real-world communications and depends on correct credential/number handling.
> 
> **Overview**
> Rebuilds the `/ops:ops-voice` surface into a single `bin/ops-voice` CLI supporting **native macOS Phone/FaceTime/Zoom launch** plus **programmatic Twilio voice+SMS, Bland AI calls, and Zoom meeting scheduling**, including `--json` output and a standard credential-resolution chain (env → keychain helper → `preferences.json` → Doppler).
> 
> Updates `/ops:comms` docs to route voice-oriented natural language intents (call/facetime/zoom/text/AI call) through `bin/ops-voice`, adds `voice` to the empty-args channel picker rules, and rewrites `skills/ops-voice/SKILL.md` to document the expanded command surface and Rule 6 approval gating for outbound comms. Bumps version to `2.9.0` and records the release notes in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d75dcb725f42283516fe099538dd50296f706a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->