### PR TITLE
chore(marketplace): bump ops to v2.8.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 36 skills, 18 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.8.1",
+      "version": "2.8.3",
       "category": "productivity",
       "keywords": [
         "ops",


### PR DESCRIPTION
Tracks v2.8.3 release (#291).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change that just updates the referenced plugin release; behavior changes are limited to whatever is included in `ops` v2.8.3.
> 
> **Overview**
> Updates `.claude-plugin/marketplace.json` to reference `ops` plugin `v2.8.3` instead of `v2.8.1`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ba961bb03b8a3d59e9286093d8fb902f270b549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->