### PR TITLE
chore(marketplace): bump ops to v2.9.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 36 skills, 18 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), and voice. Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.8.3",
+      "version": "2.9.1",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.8.3",
+  "version": "2.9.1",
   "description": "Business operations command center for Claude Code — 36 skills, 18 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
   "author": {
     "name": "Lifecycle Innovations Limited",


### PR DESCRIPTION
## Summary
Surfaces v2.9.0 (voice surface: native + Twilio + Bland + Zoom) and v2.9.1 (smart calendar join + Rule 7 opener + cross-OS) in the local marketplace so `/plugin install` picks them up.

- `.claude-plugin/marketplace.json` — `ops` version 2.8.3 → 2.9.1
- `claude-ops/.claude-plugin/plugin.json` — version 2.8.3 → 2.9.1

Follows the pattern of #294 (bump to 2.8.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: metadata-only version bumps in marketplace/plugin manifests with no runtime code changes.
> 
> **Overview**
> Updates the `ops` plugin version from `2.8.3` to `2.9.1` in both the local marketplace manifest (`.claude-plugin/marketplace.json`) and the plugin manifest (`claude-ops/.claude-plugin/plugin.json`) so `/plugin install` resolves the newer release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4044e9bc924802b23a17ed06595b94f97436ed48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->