### PR TITLE
feat(ops-home): /ops:ops-home smart home control via Homey Pro (v2.9.0)

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ops",
-  "version": "2.8.3",
-  "description": "Business operations command center for Claude Code — 36 skills, 18 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, and YOLO mode for autonomous operation with 4 parallel C-suite agents.",
+  "version": "2.9.0",
+  "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",
     "url": "https://github.com/Lifecycle-Innovations-Limited"
@@ -49,7 +49,12 @@
     "postnl",
     "dpd",
     "ups",
-    "fedex"
+    "fedex",
+    "home-automation",
+    "homey",
+    "smart-home",
+    "iot",
+    "athom"
   ],
   "userConfig": {
     "prevent_secret_commit": {

--- a/claude-ops/agents/ops:home-agent.md
+++ b/claude-ops/agents/ops:home-agent.md
@@ -1,0 +1,120 @@
+---
+name: ops:home-agent
+description: Homey Pro probe agent. Queries local/cloud API for devices, flows, energy, presence, alarms. Returns structured JSON. Used by ops-home skill for parallel scans.
+model: claude-sonnet-4-6
+effort: low
+maxTurns: 10
+tools:
+  - Bash
+  - Read
+disallowedTools:
+  - Write
+  - Edit
+  - Agent
+memory: project
+---
+
+# OPS:HOME AGENT — Homey Pro probe
+
+Read-only probe for a Homey Pro hub. Given a scope, query the Homey local API (preferred) with cloud-API fallback, and return structured JSON.
+
+## Input
+
+The calling skill provides:
+
+- `SCOPE`: `devices` | `flows` | `energy` | `presence` | `alarms` | `zones`
+- Credentials are resolved from the same sources as `ops-home`: `preferences.json` → env vars → Doppler (`homey-pro`) → keychain.
+
+## Phase 1 — Resolve credentials
+
+```bash
+PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+HOMEY_LOCAL_URL=$(jq -r '.home_automation.homey_local_url // empty' "$PREFS_PATH" 2>/dev/null)
+HOMEY_LOCAL_TOKEN=$(jq -r '.home_automation.homey_local_token // empty' "$PREFS_PATH" 2>/dev/null)
+HOMEY_CLOUD_TOKEN=$(jq -r '.home_automation.homey_cloud_token // empty' "$PREFS_PATH" 2>/dev/null)
+HOMEY_ID=$(jq -r '.home_automation.homey_id // empty' "$PREFS_PATH" 2>/dev/null)
+
+[ -z "$HOMEY_LOCAL_URL" ] && HOMEY_LOCAL_URL="${HOMEY_LOCAL_URL:-}"
+[ -z "$HOMEY_LOCAL_TOKEN" ] && HOMEY_LOCAL_TOKEN="${HOMEY_LOCAL_TOKEN:-}"
+[ -z "$HOMEY_CLOUD_TOKEN" ] && HOMEY_CLOUD_TOKEN="${HOMEY_CLOUD_TOKEN:-${HOMEY_ACCESS_TOKEN:-}}"
+[ -z "$HOMEY_ID" ] && HOMEY_ID="${HOMEY_ID:-}"
+```
+
+If neither local nor cloud credentials resolve, return:
+
+```json
+{ "scope": "<scope>", "error": "no credentials", "fallback_attempted": false }
+```
+
+## Phase 2 — Probe (try local, fall back to cloud)
+
+```bash
+probe() {
+  local local_path="$1" cloud_path="$2"
+  local resp http_code
+  if [ -n "$HOMEY_LOCAL_URL" ] && [ -n "$HOMEY_LOCAL_TOKEN" ]; then
+    http_code=$(curl -s -o /tmp/homey_resp -w "%{http_code}" \
+      -H "Authorization: Bearer ${HOMEY_LOCAL_TOKEN}" \
+      "${HOMEY_LOCAL_URL}/api/manager${local_path}" --max-time 5 2>/dev/null)
+    if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+      cat /tmp/homey_resp
+      echo "TRANSPORT=local" >&2
+      return 0
+    fi
+  fi
+  if [ -n "$HOMEY_CLOUD_TOKEN" ] && [ -n "$HOMEY_ID" ]; then
+    curl -s -H "Authorization: Bearer ${HOMEY_CLOUD_TOKEN}" \
+      "https://api.athom.com/v2/homey/${HOMEY_ID}${cloud_path}" --max-time 10
+    echo "TRANSPORT=cloud" >&2
+    return 0
+  fi
+  echo '{"error":"no transport"}'
+  return 1
+}
+```
+
+Route by `$SCOPE`:
+
+| SCOPE     | Local path                  | Cloud path        |
+|-----------|-----------------------------|-------------------|
+| devices   | `/devices/device`           | `/devices`        |
+| flows     | `/flow/flow`                | `/flows`          |
+| energy    | `/energy/live`              | `/energy/live`    |
+| presence  | `/presence`                 | `/presence`       |
+| alarms    | `/alarms/alarm`             | `/alarms`         |
+| zones     | `/zones/zone`               | `/zones`          |
+
+## Phase 3 — Shape output
+
+Return a single JSON object on stdout:
+
+```json
+{
+  "scope": "<scope>",
+  "transport": "local|cloud",
+  "count": 0,
+  "items": [],
+  "summary": "<one-line human-readable summary>",
+  "error": null,
+  "fallback_attempted": false
+}
+```
+
+Per-scope summary examples:
+- `devices`: `"N devices, M online, K offline (top zones: …)"`
+- `flows`: `"N flows, M enabled, last fired: <name> <age>"`
+- `energy`: `"<W> live, <kWh> today"`
+- `presence`: `"N home: <name>, <name>"`
+- `alarms`: `"N active alarms (<types>)"`
+- `zones`: `"N zones"`
+
+## Phase 4 — Error handling
+
+- Local 401 → set `error: "local_unauthorized"`, attempt cloud, set `fallback_attempted: true`.
+- Local timeout / connection refused → attempt cloud silently, set `fallback_attempted: true`.
+- Cloud 401 → set `error: "cloud_unauthorized"`.
+- Both fail → return `{ "scope": "<scope>", "error": "both transports failed", "fallback_attempted": true }`.
+
+Never make state-changing calls. Never call `PUT` or `POST`. Read-only.
+
+Print only the JSON object to stdout. Print transport info to stderr.

--- a/claude-ops/scripts/partner-registry.seed.json
+++ b/claude-ops/scripts/partner-registry.seed.json
@@ -57,6 +57,17 @@
       "credential_key_secondary": "FEDEX_CLIENT_SECRET",
       "credential_key_tertiary": "FEDEX_ACCOUNT_NUMBER",
       "docs_url": "https://developer.fedex.com/api/en-us/catalog/ship/v1/docs.html"
+    },
+    "homey": {
+      "category": "home-automation",
+      "auth_type": "bearer-token",
+      "base_url": "https://api.athom.com",
+      "credential_key": "HOMEY_LOCAL_URL",
+      "credential_key_secondary": "HOMEY_LOCAL_TOKEN",
+      "credential_key_tertiary": "HOMEY_CLOUD_TOKEN",
+      "credential_key_quaternary": "HOMEY_ID",
+      "skill": "/ops:ops-home",
+      "docs_url": "https://apps.developer.homey.app/the-basics/web-api"
     }
   }
 }

--- a/claude-ops/skills/ops-comms/SKILL.md
+++ b/claude-ops/skills/ops-comms/SKILL.md
@@ -97,6 +97,7 @@ Parse `$ARGUMENTS` and route immediately:
 | `zoom`        | Start an instant Zoom meeting via `bin/ops-voice zoom start` |
 | `send * to *` | Parse message and contact, determine best channel, send |
 | `read *`      | Read the specified channel or contact's messages        |
+| `home alarm`  | Pipe a Homey alarm event as a WhatsApp/Telegram alert — delegates to `/ops:ops-home alarm --notify` (only if `home_automation` is configured in `$PREFS_PATH`) |
 | (empty)       | Show channel picker menu                                |
 
 Natural-language parsing:

--- a/claude-ops/skills/ops-credentials/SKILL.md
+++ b/claude-ops/skills/ops-credentials/SKILL.md
@@ -57,6 +57,21 @@ Claude Code's plugin settings UI cannot introspect external credential stores. I
 
 `/ops:credentials` solves that — one command, one table, complete picture of which integrations are ready to use vs which still need `/ops:setup`.
 
+## Homey Pro (Home Automation)
+
+| Field | Value |
+|-------|-------|
+| Service name | Homey Pro |
+| Category | Home Automation |
+| Keys | `HOMEY_LOCAL_URL`, `HOMEY_LOCAL_TOKEN`, `HOMEY_CLOUD_TOKEN`, `HOMEY_ID` |
+| Storage | `$PREFS_PATH` → `.home_automation.homey_local_url`, `.homey_local_token`, `.homey_cloud_token`, `.homey_id` |
+| Required | `HOMEY_LOCAL_URL`, `HOMEY_LOCAL_TOKEN` |
+| Optional | `HOMEY_CLOUD_TOKEN` (off-LAN fallback), `HOMEY_ID` (cloud API only) |
+
+**Rotation:** Revoke the current token at `https://my.homey.app/manager/tokens`, generate a new one, then rerun `/ops:setup --section home` to save the replacement.
+
+---
+
 ## Privacy guarantees
 
 - **Never prints raw values.** All output is masked.

--- a/claude-ops/skills/ops-dash/SKILL.md
+++ b/claude-ops/skills/ops-dash/SKILL.md
@@ -60,7 +60,7 @@ The bin script fires all 12 data probes in parallel (background subshells writin
 9. **DEPLOYS** — ECS Fargate desired/running/pending per cluster (requires AWS CLI)
 10. **COMPETITOR INTEL** — latest report from `${OPS_DATA_DIR}/reports/competitor-intel/`
 11. **YOLO REPORTS** — `/tmp/yolo-*/` directories with verdict summaries
-12. **QUICK ACTIONS** — keyboard shortcuts 1-9, 0, a-h
+12. **QUICK ACTIONS** — keyboard shortcuts 1-9, 0, a-h (where `h` = smart-home if `home_automation` is configured in `$PREFS_PATH`; FAQ moves to `?`). Status indicator next to `h`: green if all Homey devices online and no alarms, yellow if any device offline, red if active critical alarm. Hidden entirely if `home_automation` is not configured.
 
 **Schema fixes vs previous version:**
 - Unread: was reading `.whatsapp.count` / `.email.count` (always 0). Now reads `.channels.whatsapp.recent_chats` / `.channels.email.inbox_count`.
@@ -123,8 +123,9 @@ Skip straight to AskUserQuestion for the next action — no preamble, no recap, 
 | `e`, `report`, `csuite` | Read latest YOLO report | C-suite report |
 | `f`, `settings`, `prefs`, `config` | Settings sub-menu | Interactive config |
 | `g`, `share` | Share sub-menu | Share your setup |
-| `h`, `faq`, `help`, `wiki`, `?` | FAQ sub-menu | Help & FAQ |
-| `back`, `dash`, `home` | Re-render dashboard | Return to dash |
+| `h`, `home`, `homey`, `house` | `/ops:ops-home` | Smart-home control (only if `home_automation` configured in `$PREFS_PATH`) |
+| `?`, `faq`, `help`, `wiki` | FAQ sub-menu | Help & FAQ |
+| `back`, `dash` | Re-render dashboard | Return to dash |
 
 ---
 
@@ -285,9 +286,9 @@ Try it: /plugin marketplace add ops-marketplace
 
 ---
 
-## FAQ sub-menu (option h)
+## FAQ sub-menu (option ?)
 
-When user selects `h`:
+When user selects `?` (or `faq`/`help`/`wiki`):
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -335,6 +336,7 @@ When user selects `h`:
 | 8 | WhatsApp | Check bridge liveness: `lsof -i :8080 | grep LISTEN`. If not running, prompt restart: `launchctl kickstart -k gui/$(id -u)/com.${USER}.whatsapp-bridge`. Check `launchctl list com.${USER}.whatsapp-bridge` for status. If store locked: `kill $(pgrep whatsapp-bridge)`. |
 | 9 | Telegram | Needs user-auth (not bot). Run `/ops:setup` → Telegram section. API ID + hash from my.telegram.org. |
 | 10 | Unread | Channel must be configured in `/ops:setup`. Check `ops-unread` script output for errors. |
+| 11 | Smart-home (Homey) | Run `/ops:setup --section home` to configure Homey Pro. Once set, hotkey `h` and `/ops:ops-home` are routable. Status dot on the dashboard: green = all devices online + no alarms, yellow = device offline, red = active critical alarm. |
 
 For links (w, r, i): open in browser via `open` (macOS) or `xdg-open` (Linux).
 

--- a/claude-ops/skills/ops-fires/SKILL.md
+++ b/claude-ops/skills/ops-fires/SKILL.md
@@ -112,6 +112,16 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ops-ci 2>/dev/null || echo '[]'
 ${CLAUDE_PLUGIN_ROOT}/bin/ops-external 2>/dev/null || echo '[]'
 ```
 
+## Home automation (only if `home_automation` is configured in `$PREFS_PATH`)
+
+```!
+if jq -e '.home_automation' "${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json" >/dev/null 2>&1; then
+  ${CLAUDE_PLUGIN_ROOT}/bin/ops-home snapshot 2>/dev/null || echo '{"configured":true,"error":"home probe failed"}'
+else
+  echo '{"configured":false}'
+fi
+```
+
 ## Your task
 
 Analyze the pre-gathered data — including external projects. Then run parallel checks:
@@ -121,6 +131,11 @@ Analyze the pre-gathered data — including external projects. Then run parallel
 3. **CI** — parse CI data for failing pipelines, broken main/dev branches.
 4. **GitHub Actions** — `gh run list --limit 20 --json status,conclusion,name,headBranch,createdAt 2>/dev/null`
 5. **External projects** — parse ops-external data. Flag `auth_expired` as HIGH (credential rotation needed), `unreachable`/`degraded` as MEDIUM, `not_configured` as LOW.
+6. **Home automation** (only if home snapshot returned `configured:true`) — classify Homey incidents:
+   - Active critical alarm (smoke / water leak / security breach) → **P0 / CRITICAL** — cross-reference `/ops:ops-home alarm` for details.
+   - Major device offline (gateway, hub, primary thermostat) → **P1 / HIGH**.
+   - Energy spike > 3× 7-day baseline → **P2 / MEDIUM** — cross-reference `/ops:ops-home status`.
+   If snapshot returned `configured:false`, skip silently.
 
 Classify each issue by severity:
 
@@ -160,6 +175,10 @@ SENTRY (top errors, 24h)
 
 EXTERNAL PROJECTS
 [alias] [source] [status] [details — e.g. auth_expired, unreachable]
+
+HOME (only if `home_automation` is configured)
+[alarm/device] [type — smoke/water/security/offline/energy] [severity] [since]
+[If `configured:false`, omit this section entirely]
 
 ──────────────────────────────────────────────────────
 ```

--- a/claude-ops/skills/ops-go/SKILL.md
+++ b/claude-ops/skills/ops-go/SKILL.md
@@ -170,6 +170,16 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ops-external 2>/dev/null || echo '[]'
 ${CLAUDE_PLUGIN_ROOT}/bin/ops-marketing-dash 2>/dev/null || echo '{}'
 ```
 
+### Home (smart-home — only if `home_automation` is configured)
+
+```!
+if jq -e '.home_automation' "${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json" >/dev/null 2>&1; then
+  ${CLAUDE_PLUGIN_ROOT}/bin/ops-home snapshot 2>/dev/null || echo '{"configured":true,"error":"home probe failed"}'
+else
+  echo '{"configured":false}'
+fi
+```
+
 ### Calendar (today — all calendars)
 
 ```!
@@ -218,6 +228,11 @@ COMPETITOR    <brand>: N alerts · M med deltas · last run YYYY-MM-DD
               <top high-severity event snippet, 1 line, truncated 140 chars>
 [If competitor data returns {configured:false}, omit this section entirely — no "(not configured)" noise]
 [Mobile mode (Rule 7): compress to one line: "comp: N alerts (top: brief snippet)"]
+
+HOME
+ Power: [X]W now · [Y]kWh today  |  Alarms: [N] active ([severity])  |  Presence: [home/empty since HH:MM]  |  Last flow: [name @ HH:MM]
+[If home data returns {configured:false}, omit this section entirely — no clutter]
+[If critical alarm active (smoke/water/security): prepend `⚠ CRITICAL` and route to FIRES at top]
 
 UNREAD
 [WhatsApp: N, Email: N, Slack: N workspace(s) configured (no scan), Notion: N items, Calendar: N events today]

--- a/claude-ops/skills/ops-home/SKILL.md
+++ b/claude-ops/skills/ops-home/SKILL.md
@@ -1,0 +1,706 @@
+---
+name: ops-home
+description: Smart home command center via Homey Pro. Devices, flows, scenes, energy, climate, presence, alarms. Works via Homey local API (preferred) + Athom cloud API fallback. Configure once via /ops:setup.
+argument-hint: "[status|devices|flow|scene|energy|climate|presence|alarm|setup]"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Grep
+  - Glob
+  - Agent
+  - TeamCreate
+  - SendMessage
+  - AskUserQuestion
+  - WebFetch
+  - WebSearch
+effort: medium
+maxTurns: 30
+---
+
+# OPS ► HOME — Smart Home Command Center (Homey Pro)
+
+## Runtime Context
+
+Before executing, load available context:
+
+1. **Preferences**: Read `${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json`
+   - `timezone` — display all timestamps in user's timezone
+   - `home_automation.homey_local_url` — e.g. `http://192.168.1.100` (preferred path, faster, no cloud dependency)
+   - `home_automation.homey_local_token` — Personal Access Token for local API
+   - `home_automation.homey_cloud_token` — Athom OAuth token for cloud fallback
+   - `home_automation.homey_id` — Homey ID (cloud resolution)
+
+2. **Daemon health**: Read `${CLAUDE_PLUGIN_DATA_DIR}/daemon-health.json`
+   - If `action_needed` is not null → surface it before running any Homey operations
+   - On any auth/connectivity failure in this skill, write `action_needed` back to daemon-health.json
+
+3. **Secrets**: Resolve Homey credentials via userConfig → env vars → Doppler → keychain (see Phase 1 below)
+
+## CLI/API Reference
+
+### Homey Pro Web API v3 — LOCAL (preferred)
+
+Base URL: `${HOMEY_LOCAL_URL}` (e.g. `http://192.168.1.100`)
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/manager/devices/device` | GET | List all devices |
+| `/api/manager/devices/device/{id}` | GET | Get one device with capabilities |
+| `/api/manager/devices/device/{id}/capability/{capability}` | PUT | Set capability (onoff, dim, target_temperature, etc.) |
+| `/api/manager/flow/flow` | GET | List all flows |
+| `/api/manager/flow/flow/{id}/trigger` | POST | Run a flow |
+| `/api/manager/zones/zone` | GET | List zones (rooms) |
+| `/api/manager/energy/live` | GET | Live power draw (watts) |
+| `/api/manager/energy/report` | GET | Historical energy report (kWh) |
+| `/api/manager/presence` | GET | Presence status (who is home) |
+| `/api/manager/alarms/alarm` | GET | Active alarms (smoke, water, security) |
+| `/api/manager/system/info` | GET | Homey system info |
+
+**Auth header (local)**: `Authorization: Bearer ${HOMEY_LOCAL_TOKEN}`
+
+### Athom Cloud API — FALLBACK
+
+Base URL: `https://api.athom.com`
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/v2/homey/${HOMEY_ID}/devices` | GET | Devices via cloud |
+| `/v2/homey/${HOMEY_ID}/flows` | GET | Flows via cloud |
+| `/v2/homey/${HOMEY_ID}/flows/{id}/trigger` | POST | Trigger a flow |
+| `/v2/homey/${HOMEY_ID}/zones` | GET | Zones via cloud |
+
+**Auth header (cloud)**: `Authorization: Bearer ${HOMEY_CLOUD_TOKEN}`
+
+### Common capability strings (Homey)
+`onoff`, `dim` (0.0–1.0), `target_temperature`, `measure_temperature`, `measure_humidity`, `measure_power`, `meter_power`, `alarm_motion`, `alarm_smoke`, `alarm_water`, `alarm_contact`, `locked`, `windowcoverings_state`, `light_hue`, `light_saturation`, `volume_set`.
+
+## Agent Teams support
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** for parallel hub probing:
+
+```
+TeamCreate("home-team")
+Agent(team_name="home-team", name="devices-scanner", prompt="List all Homey devices, group by zone, return online/offline state and current capabilities")
+Agent(team_name="home-team", name="flows-scanner", prompt="List all flows and their last-fired timestamps")
+Agent(team_name="home-team", name="energy-scanner", prompt="Pull live power draw + today's kWh + top consumers, flag anomalies vs 7-day baseline")
+Agent(team_name="home-team", name="presence-scanner", prompt="Return presence state and active alarms")
+```
+
+If the flag is NOT set, dispatch `ops:home-agent` as standard fire-and-forget subagents per scope (devices, flows, energy, presence, alarms).
+
+## Phase 1 — Resolve credentials
+
+Resolve Homey credentials in this order. Local path is preferred (faster, works offline, lower latency):
+
+```bash
+PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+
+# 1. Plugin userConfig (preferences.json)
+HOMEY_LOCAL_URL=$(jq -r '.home_automation.homey_local_url // empty' "$PREFS_PATH" 2>/dev/null)
+HOMEY_LOCAL_TOKEN=$(jq -r '.home_automation.homey_local_token // empty' "$PREFS_PATH" 2>/dev/null)
+HOMEY_CLOUD_TOKEN=$(jq -r '.home_automation.homey_cloud_token // empty' "$PREFS_PATH" 2>/dev/null)
+HOMEY_ID=$(jq -r '.home_automation.homey_id // empty' "$PREFS_PATH" 2>/dev/null)
+
+# 2. Environment variables (override userConfig if set)
+[ -n "$HOMEY_LOCAL_URL" ] || HOMEY_LOCAL_URL="${HOMEY_LOCAL_URL:-}"
+[ -n "$HOMEY_LOCAL_TOKEN" ] || HOMEY_LOCAL_TOKEN="${HOMEY_LOCAL_TOKEN:-}"
+[ -n "$HOMEY_CLOUD_TOKEN" ] || HOMEY_CLOUD_TOKEN="${HOMEY_CLOUD_TOKEN:-${HOMEY_ACCESS_TOKEN:-}}"
+[ -n "$HOMEY_ID" ] || HOMEY_ID="${HOMEY_ID:-}"
+
+# 3. Doppler fallback (project: homey-pro)
+if [ -z "$HOMEY_LOCAL_TOKEN" ] && command -v doppler &>/dev/null; then
+  HOMEY_LOCAL_TOKEN=$(doppler secrets get HOMEY_LOCAL_TOKEN --project homey-pro --plain 2>/dev/null)
+fi
+if [ -z "$HOMEY_CLOUD_TOKEN" ] && command -v doppler &>/dev/null; then
+  HOMEY_CLOUD_TOKEN=$(doppler secrets get HOMEY_ACCESS_TOKEN --project homey-pro --plain 2>/dev/null)
+fi
+if [ -z "$HOMEY_LOCAL_URL" ] && command -v doppler &>/dev/null; then
+  HOMEY_LOCAL_URL=$(doppler secrets get HOMEY_LOCAL_URL --project homey-pro --plain 2>/dev/null)
+fi
+if [ -z "$HOMEY_ID" ] && command -v doppler &>/dev/null; then
+  HOMEY_ID=$(doppler secrets get HOMEY_ID --project homey-pro --plain 2>/dev/null)
+fi
+
+# 4. Keychain fallback
+[ -z "$HOMEY_LOCAL_TOKEN" ] && HOMEY_LOCAL_TOKEN=$(security find-generic-password -s "homey-local-token" -w 2>/dev/null)
+[ -z "$HOMEY_CLOUD_TOKEN" ] && HOMEY_CLOUD_TOKEN=$(security find-generic-password -s "homey-cloud-token" -w 2>/dev/null)
+```
+
+If neither a (`HOMEY_LOCAL_URL` + `HOMEY_LOCAL_TOKEN`) pair nor (`HOMEY_CLOUD_TOKEN` + `HOMEY_ID`) is resolvable, tell the user and exit gracefully:
+
+```
+No Homey credentials configured. Run /ops:setup --section home to configure your Homey Pro hub.
+```
+
+Write `action_needed: "configure_homey"` to `daemon-health.json` and exit.
+
+Set helpers used by all phases below:
+
+```bash
+HOMEY_BASE_LOCAL="${HOMEY_LOCAL_URL}/api/manager"
+HOMEY_BASE_CLOUD="https://api.athom.com/v2/homey/${HOMEY_ID}"
+HOMEY_AUTH_LOCAL="Authorization: Bearer ${HOMEY_LOCAL_TOKEN}"
+HOMEY_AUTH_CLOUD="Authorization: Bearer ${HOMEY_CLOUD_TOKEN}"
+
+# homey_call <path> [method] [body] — tries local first, falls back to cloud on failure
+homey_call() {
+  local path="$1" method="${2:-GET}" body="${3:-}"
+  local resp http_code
+  if [ -n "$HOMEY_LOCAL_URL" ] && [ -n "$HOMEY_LOCAL_TOKEN" ]; then
+    resp=$(curl -s -o /tmp/homey_resp -w "%{http_code}" -X "$method" \
+      -H "$HOMEY_AUTH_LOCAL" -H "Content-Type: application/json" \
+      ${body:+--data "$body"} \
+      "${HOMEY_BASE_LOCAL}${path}" 2>/dev/null)
+    if [ "$resp" -ge 200 ] && [ "$resp" -lt 300 ]; then
+      cat /tmp/homey_resp; return 0
+    fi
+  fi
+  # Fallback to cloud
+  if [ -n "$HOMEY_CLOUD_TOKEN" ] && [ -n "$HOMEY_ID" ]; then
+    # Map manager-style local paths to cloud equivalents where possible
+    local cloud_path="${path/\/devices\/device/\/devices}"
+    cloud_path="${cloud_path/\/flow\/flow/\/flows}"
+    cloud_path="${cloud_path/\/zones\/zone/\/zones}"
+    curl -s -X "$method" \
+      -H "$HOMEY_AUTH_CLOUD" -H "Content-Type: application/json" \
+      ${body:+--data "$body"} \
+      "${HOMEY_BASE_CLOUD}${cloud_path}"
+    return $?
+  fi
+  echo '{"error":"no homey transport available"}'
+  return 1
+}
+```
+
+---
+
+## Phase 2 — Route by $ARGUMENTS
+
+| Input                                     | Action                |
+| ----------------------------------------- | --------------------- |
+| (empty)                                   | Home status dashboard |
+| status, dashboard                         | Home status dashboard |
+| devices, device, lights, locks, sensors   | Devices manager       |
+| flow, flows                               | Trigger / list flows  |
+| scene, scenes                             | Trigger scene (alias) |
+| energy, power, kwh                        | Energy dashboard      |
+| climate, temp, thermostat, heating        | Climate manager       |
+| presence, who, home                       | Presence              |
+| alarm, alarms, arm, disarm, security      | Alarms / security     |
+| setup, configure, init, token             | Setup flow            |
+
+---
+
+## STATUS (default — empty $ARGUMENTS)
+
+One-screen home dashboard. Run devices/flows/energy/presence/alarms calls in parallel (separate Bash calls or Agent Team), then render.
+
+```bash
+# Devices online state
+homey_call "/devices/device" | jq '{
+  total: (. | length),
+  online: ([.[] | select(.available == true)] | length),
+  offline: ([.[] | select(.available == false)] | length)
+}'
+
+# Flows
+homey_call "/flow/flow" | jq '{
+  total: (. | length),
+  enabled: ([.[] | select(.enabled == true)] | length),
+  last_fired: ([.[] | select(.lastExecuted != null)] | sort_by(.lastExecuted) | reverse | .[0] | {name, lastExecuted})
+}'
+
+# Live energy
+homey_call "/energy/live" | jq '{watts: .totalPower // 0}'
+
+# Presence
+homey_call "/presence" | jq '[.[] | select(.present == true) | .name]'
+
+# Alarms (active)
+homey_call "/alarms/alarm" | jq '[.[] | select(.active == true)]'
+
+# Zones
+homey_call "/zones/zone" | jq '[.[] | .name]'
+```
+
+Desktop render:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► HOME — [hub-name] — [timestamp]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+HUB          [name]  ([firmware version])
+TRANSPORT    local | cloud  ([latency-ms]ms)
+
+DEVICES      [N online] / [N total]   [N offline]
+FLOWS        [N enabled] / [N total]
+LAST FLOW    [name] fired [N min] ago
+
+POWER        [W] now    [kWh] today
+ZONES        [N rooms]
+PRESENCE     [name1], [name2]   — home
+
+ALARMS       [N active]
+  [type] in [zone] — [device]    (if active)
+
+──────────────────────────────────────────────────────
+ [d] devices   [f] flows   [e] energy
+ [c] climate   [p] presence   [a] alarms
+ /ops:ops-home setup — configure credentials
+──────────────────────────────────────────────────────
+```
+
+Mobile mode (`$SSH_CONNECTION` set or `$OPS_MOBILE=1`): plain text only, 5–8 lines max, no banners.
+
+```
+home: [N]/[N] devices · [W]W now · [kWh] today.
+flows: [N] enabled · last "[name]" [N]m ago.
+presence: [names] home.
+alarms: [N] active.
+next: /ops-home devices | flows | energy
+```
+
+If `[N] alarms active` is non-zero AND any are critical (smoke/leak/security), surface immediately at top of output and suggest piping to `/ops:ops-comms` to broadcast.
+
+Use `AskUserQuestion` for next-action selection (max 4 options per Rule 1).
+
+---
+
+## DEVICES
+
+List devices, group by zone. Support filter and bulk-toggle.
+
+```bash
+# All devices with zone + capabilities
+homey_call "/devices/device" | jq '[.[] | {
+  id: .id,
+  name: .name,
+  zone: .zoneName,
+  driverId: .driverId,
+  class: .class,
+  available: .available,
+  capabilities: .capabilities,
+  capabilityValues: (.capabilitiesObj // {} | to_entries | map({key: .key, value: .value.value}))
+}]'
+
+# Zones for grouping
+homey_call "/zones/zone" | jq '[.[] | {id: .id, name: .name}]'
+```
+
+Apply filter from `$ARGUMENTS`:
+- `devices lights` → filter `class == "light"` or capability includes `dim`/`light_hue`
+- `devices locks` → filter `class == "lock"` or capability includes `locked`
+- `devices climate` → filter capability includes `target_temperature` or `measure_temperature`
+- `devices sensors` → filter capability starts with `measure_` or `alarm_`
+- `devices --off` → set `onoff=false` on filtered set (REQUIRES `AskUserQuestion` confirmation — destructive)
+- `devices --on` → set `onoff=true` on filtered set (REQUIRES `AskUserQuestion` confirmation)
+
+Render grouped by zone:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► HOME ► DEVICES — [filter] — [timestamp]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+[ZONE: Living Room]
+  [Living Room Lamp]      light    on    dim:0.65    online
+  [Sofa Outlet]           socket   off                online
+  [Thermostat]            climate  22.5°C → 21.0°C   online
+
+[ZONE: Kitchen]
+  [Kitchen Ceiling]       light    on    dim:1.0     online
+  ...
+
+OFFLINE
+  [Garage Sensor]         sensor                     offline 2h
+
+──────────────────────────────────────────────────────
+ Actions:
+ a) Toggle a specific device
+ b) Turn all [filter] off
+ c) Filter by zone
+ d) View device capabilities
+──────────────────────────────────────────────────────
+```
+
+For toggle / set capability:
+
+```bash
+# Set onoff
+homey_call "/devices/device/${DEVICE_ID}/capability/onoff" PUT '{"value": false}'
+
+# Set dim (0.0 - 1.0)
+homey_call "/devices/device/${DEVICE_ID}/capability/dim" PUT '{"value": 0.5}'
+
+# Set target temperature
+homey_call "/devices/device/${DEVICE_ID}/capability/target_temperature" PUT '{"value": 21.0}'
+```
+
+Bulk operations REQUIRE `AskUserQuestion` confirmation (Rule 5 — destructive-like behavior). Show device count + sample before executing.
+
+---
+
+## FLOWS (and SCENES — alias)
+
+Homey calls scenes "flows". Both `flow` and `scene` arguments route here.
+
+```bash
+# List flows
+homey_call "/flow/flow" | jq '[.[] | {
+  id: .id,
+  name: .name,
+  enabled: .enabled,
+  lastExecuted: .lastExecuted,
+  triggerable: .triggerable
+}]'
+```
+
+If `$ARGUMENTS` includes a flow name (e.g. `flow movie-time`, `scene good-night`), fuzzy-match by name (case-insensitive substring), then trigger:
+
+```bash
+FLOW_ID="[matched id]"
+homey_call "/flow/flow/${FLOW_ID}/trigger" POST '{}'
+```
+
+If multiple flows match, present top 4 via `AskUserQuestion` (Rule 1) and let user pick.
+
+If `flow list` or no flow name provided, render the list with last-fired age.
+
+Common scene names users may try: `movie-time`, `good-night`, `leaving-home`, `coming-home`, `wake-up`, `dinner`, `away`. Fuzzy match handles variations (`goodnight`, `good night`, `night`).
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► HOME ► FLOWS — [timestamp]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+ENABLED FLOWS ([N])
+  [name]                 fired [N min] ago
+  [name]                 never
+  ...
+
+DISABLED ([N])
+  [name]
+  ...
+
+──────────────────────────────────────────────────────
+ Actions:
+ a) Trigger a flow
+ b) Enable / disable a flow
+ c) View flow definition
+──────────────────────────────────────────────────────
+```
+
+Trigger results: confirm `{"success": true}` or surface the error.
+
+---
+
+## ENERGY
+
+Live power draw + today's kWh + top consumers + anomaly detection.
+
+```bash
+# Live power
+homey_call "/energy/live" | jq '{
+  totalWatts: .totalPower // 0,
+  byDevice: [.devices // {} | to_entries[] | {id: .key, watts: .value.power}] | sort_by(-.watts) | .[:10]
+}'
+
+# Today's energy report
+TODAY=$(date -u +"%Y-%m-%d")
+homey_call "/energy/report?period=today" | jq '{
+  todayKwh: .totalEnergy // 0,
+  byZone: .zones // {}
+}'
+
+# 7-day baseline for anomaly detection
+homey_call "/energy/report?period=last7days" | jq '.dailyAverage // 0'
+```
+
+Compute anomaly: if `todayKwh > 1.5 * dailyAverage`, flag as anomaly.
+
+Render:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► HOME ► ENERGY — [timestamp]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+LIVE         [W] right now
+TODAY        [kWh]    (baseline: [kWh]/day  → [+/-N%])
+
+TOP CONSUMERS (live)
+  1. [device]  [W]
+  2. [device]  [W]
+  ...
+
+ANOMALY      [yes/no]  [reason if yes]
+
+──────────────────────────────────────────────────────
+ Actions:
+ a) View 30-day energy trend
+ b) Estimate monthly cost
+ c) Set energy alert threshold
+──────────────────────────────────────────────────────
+```
+
+If anomaly detected AND cost projection > threshold, route to `/ops:ops-fires` (see Phase 3).
+
+Mobile mode: 3 lines only — `now [W]W · today [kWh] (baseline [kWh]) · top: [device] [W]W`.
+
+---
+
+## CLIMATE
+
+Per-zone temperature, humidity, target temp, heating mode. Allow setting.
+
+```bash
+# Climate devices
+homey_call "/devices/device" | jq '[.[] | select(
+  (.capabilities | index("target_temperature")) or
+  (.capabilities | index("measure_temperature")) or
+  (.capabilities | index("measure_humidity"))
+) | {
+  name: .name,
+  zone: .zoneName,
+  measure_temperature: (.capabilitiesObj.measure_temperature.value // null),
+  target_temperature: (.capabilitiesObj.target_temperature.value // null),
+  measure_humidity: (.capabilitiesObj.measure_humidity.value // null),
+  mode: (.capabilitiesObj.thermostat_mode.value // null)
+}] | group_by(.zone)'
+```
+
+If `$ARGUMENTS` is `climate <zone> <temp>` (e.g. `climate bedroom 19`), find the thermostat in that zone and set target temp via `AskUserQuestion` confirmation:
+
+```bash
+homey_call "/devices/device/${THERMO_ID}/capability/target_temperature" PUT '{"value": 19.0}'
+```
+
+Render:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► HOME ► CLIMATE — [timestamp]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+[ZONE: Living Room]
+  Temperature   21.5°C   target 21.0°C   mode: heat
+  Humidity      45%
+
+[ZONE: Bedroom]
+  Temperature   19.0°C   target 19.0°C   mode: heat
+  Humidity      52%
+
+──────────────────────────────────────────────────────
+ Actions:
+ a) Set temperature for a zone
+ b) Switch mode (heat/cool/off/auto)
+ c) View 24h history
+──────────────────────────────────────────────────────
+```
+
+---
+
+## PRESENCE
+
+Who is home, based on Homey presence detection.
+
+```bash
+homey_call "/presence" | jq '[.[] | {
+  id: .id,
+  name: .name,
+  present: .present,
+  lastSeen: .lastSeen
+}]'
+```
+
+Render:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► HOME ► PRESENCE — [timestamp]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+HOME ([N])
+  [name]    home since [HH:MM]
+  ...
+
+AWAY ([N])
+  [name]    left [HH:MM]   away [N]h
+  ...
+
+──────────────────────────────────────────────────────
+ Actions:
+ a) Trigger 'leaving-home' flow
+ b) Trigger 'coming-home' flow
+ c) Check presence-linked automations
+──────────────────────────────────────────────────────
+```
+
+If house has been empty for > 1 hour, surface "empty since HH:MM" for cross-reference with `/ops:ops-go` briefing.
+
+---
+
+## ALARMS / SECURITY
+
+Active alarms (smoke, water, motion in armed zone, contact). Allow arm/disarm.
+
+```bash
+# Active alarms
+homey_call "/alarms/alarm" | jq '[.[] | select(.active == true) | {
+  type: .type,
+  zone: .zoneName,
+  device: .deviceName,
+  triggeredAt: .triggeredAt,
+  severity: .severity
+}]'
+
+# Security mode
+homey_call "/system/info" | jq '.securityMode // "unknown"'
+```
+
+If `$ARGUMENTS` is `alarm arm` or `alarm disarm`, set security mode (use a flow if Homey exposes it as such — typical Homey setups use a "Security Armed" flow):
+
+```bash
+# Find the arm/disarm flow by name
+FLOW_ID=$(homey_call "/flow/flow" | jq -r '.[] | select(.name | test("arm|security"; "i")) | .id' | head -1)
+homey_call "/flow/flow/${FLOW_ID}/trigger" POST '{}'
+```
+
+Arm/disarm REQUIRES `AskUserQuestion` confirmation (Rule 5 — security-impacting action).
+
+Render:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► HOME ► ALARMS — [timestamp]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+SECURITY MODE     [armed | disarmed | partial]
+
+ACTIVE ALARMS ([N])
+  CRITICAL  [smoke]  [zone]  [device]  triggered [time]
+  HIGH      [water]  [zone]  [device]  triggered [time]
+  MEDIUM    [motion] [zone]  [device]  triggered [time]
+
+NO ACTIVE ALARMS  (if N == 0)
+
+RECENT (last 24h)
+  [time]  [type]  [zone]  [device]  — cleared
+
+──────────────────────────────────────────────────────
+ Actions:
+ a) Arm security
+ b) Disarm security
+ c) Clear all active alarms
+ d) Broadcast critical alarm to /ops:ops-comms
+──────────────────────────────────────────────────────
+```
+
+**Critical alarm protocol**: If a smoke / water / unauthorized-entry alarm fires, IMMEDIATELY suggest piping a message to `/ops:ops-comms` (WhatsApp + Telegram). Stage the draft and follow Rule 6 (per-message approval). Never auto-send.
+
+Example draft (stage for approval):
+
+```
+Channel: WhatsApp + Telegram
+To: [user's emergency contacts from preferences.json → emergency_contacts]
+Body:
+  [HOMEY ALERT] Smoke alarm triggered in [zone] at [time].
+  Device: [device name].
+  Check the home immediately. Hub: [hub name].
+```
+
+Then `AskUserQuestion` with `[Send]` / `[Edit]` / `[Skip]`.
+
+---
+
+## SETUP FLOW (`setup`, `configure`, `init`, `token`)
+
+Delegate to the central setup wizard with the home section:
+
+```
+/ops:setup --section home
+```
+
+If for any reason the wizard is not available, run the inline credential discovery (background per Rule 4):
+
+```bash
+# 1. Env vars
+printenv HOMEY_LOCAL_URL HOMEY_LOCAL_TOKEN HOMEY_ACCESS_TOKEN HOMEY_CLOUD_TOKEN HOMEY_ID 2>/dev/null
+
+# 2. Shell profiles
+grep -hE 'HOMEY_' ~/.zshrc ~/.bashrc ~/.zprofile ~/.envrc 2>/dev/null | grep -v '^#'
+
+# 3. Doppler — homey-pro project
+doppler secrets --project homey-pro --config prd --json 2>/dev/null | \
+  jq -r 'to_entries[] | select(.key | test("HOMEY"; "i")) | "\(.key)=(present)"'
+
+# 4. Keychain
+security find-generic-password -s "homey-local-token" 2>/dev/null
+security find-generic-password -s "homey-cloud-token" 2>/dev/null
+
+# 5. Local network scan for Homey Pro (mDNS)
+dns-sd -B _homey._tcp 2>/dev/null & sleep 2; kill $! 2>/dev/null
+
+# 6. Existing prefs
+jq -r '.home_automation // empty' "$PREFS_PATH" 2>/dev/null
+```
+
+If local IP discovered but no token, instruct (Rule 3 — never silently skip):
+
+1. Try `https://developer.athom.com/tools/api` Web API playground to generate a Personal Access Token with scopes `homey`, `homey.device`, `homey.flow`, `homey.zone`.
+2. If browser automation is available (Kapture), navigate `https://my.homey.app/account` and automate token creation.
+3. Manual fallback: ask user to paste the token via `AskUserQuestion`.
+
+Verify connectivity after acquisition:
+
+```bash
+curl -s -H "Authorization: Bearer ${PROVIDED_TOKEN}" \
+  "${PROVIDED_LOCAL_URL}/api/manager/system/info" | jq '{name, firmware: .firmwareVersion}'
+```
+
+If 200 — confirm success and write to `preferences.json` under `home_automation.*`. If 401/403 — token invalid, re-prompt via `AskUserQuestion` (`[Paste new token]`, `[Deep hunt — spawn agent]`, `[Skip]`).
+
+---
+
+## Phase 3 — Cross-channel integration
+
+After producing the main output, evaluate cross-channel triggers:
+
+1. **Critical alarm → comms** — If smoke / water leak / unauthorized-entry alarm is active, suggest piping to `/ops:ops-comms` (WhatsApp/Telegram). Stage the draft; follow Rule 6 (per-message approval, never auto-send).
+
+2. **Energy anomaly → fires** — If `todayKwh > 1.5 * 7d_average` AND projected monthly cost spike > $50 / €50, surface as a fire item:
+   - Write the anomaly to `daemon-health.json` under `action_needed`
+   - Suggest running `/ops:ops-fires`
+
+3. **Presence → morning briefing** — If house has been empty > 1 hour during typical wake hours (06:00–10:00 in user's timezone), suggest cross-referencing `/ops:ops-go`:
+   - "Home empty since [HH:MM] — confirm intended for /ops:ops-go briefing?"
+
+4. **Hub offline → status** — If local API fails AND cloud API fails, write `action_needed: "homey_unreachable"` to daemon-health and exit with an action banner.
+
+These integrations are SUGGESTIONS shown in the action footer — never auto-execute Rule-5 / Rule-6 protected actions.
+
+---
+
+## Phase 4 — Error handling
+
+| Failure                                  | Behavior                                                          |
+|------------------------------------------|-------------------------------------------------------------------|
+| Local 401                                | Token expired. Tell user to run `/ops:setup --section home`.      |
+| Local connection refused / timeout       | Fall back to cloud API. Log "transport=cloud (local unreachable)".|
+| Cloud 401                                | Cloud token expired. Tell user to refresh via Athom OAuth.        |
+| Both local + cloud fail                  | Report which channel failed; write `action_needed: "homey_unreachable"` to daemon-health; exit with banner. |
+| jq missing                               | Print raw JSON, suggest `brew install jq`.                        |
+| No credentials at all                    | Exit gracefully with `/ops:setup --section home` instruction.     |
+
+Audit log every state-changing call (PUT capability, POST flow trigger, arm/disarm) to `${CLAUDE_PLUGIN_DATA_DIR}/ops-home-audit.log` with timestamp, action, device/flow id, result.
+
+---
+
+## Output style
+
+- Terse-direct. Plain text in mobile mode (Rule 7). Tables only on desktop.
+- Always show a hotkey footer (`[d] devices [f] flows [e] energy [c] climate [p] presence [a] alarms`) on desktop.
+- Use `AskUserQuestion` (max 4 options per Rule 1) for any state-changing action.
+- Never auto-send messages — always stage drafts per Rule 6.

--- a/claude-ops/skills/ops-next/SKILL.md
+++ b/claude-ops/skills/ops-next/SKILL.md
@@ -27,6 +27,7 @@ Before advising, load:
 1. **Preferences**: `cat ${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json` — read `owner`, `primary_project`, `default_channels`
 2. **Daemon health**: `cat ${CLAUDE_PLUGIN_DATA_DIR}/daemon-health.json` — flag any action_needed as priority
 3. **Ops memories**: Check `${CLAUDE_PLUGIN_DATA_DIR}/memories/topics_active.md` for ongoing work context
+4. **Home automation**: If `home_automation` is configured in `$PREFS_PATH`, probe Homey via `/ops:ops-home status` for active alarms before composing the priority stack.
 
 
 # OPS ► NEXT ACTION
@@ -117,6 +118,15 @@ Apply the priority stack to all pre-gathered data:
 Check infra data for: unhealthy ECS tasks, stopped services, failed deployments.
 Check CI for: broken `main` or `dev` branches.
 If any fires exist → **recommend `/ops-fires` immediately**.
+
+### Priority 1.5 — HOME ALARMS (only if `home_automation` is configured in `$PREFS_PATH`)
+
+Probe `/ops:ops-home status` for active alarms.
+- Critical home alarms (smoke, water leak, security breach) → **top priority — recommend `/ops:ops-home alarm` immediately, above all other fires**.
+- Energy anomalies (current draw > 3× 7-day baseline) → near-top, surface before competitor alerts.
+- Routine home tasks (presence changes, flow failures) → low priority — fold into Priority 6 tail.
+
+If `home_automation` is NOT configured, skip this priority silently.
 
 ### Priority 2 — COMPETITOR ALERTS
 

--- a/claude-ops/skills/ops-settings/SKILL.md
+++ b/claude-ops/skills/ops-settings/SKILL.md
@@ -364,6 +364,46 @@ tail -n 5 "$OPS_DATA_DIR/logs/${SERVICE_NAME}.log" 2>/dev/null || echo "(no log 
 
 Always confirm via `AskUserQuestion` (`[Run now]` / `[Cancel]`) before triggering.
 
+## Home Automation (Homey Pro)
+
+Route here when the user runs `/ops:settings home` or selects "Home Automation" from the dashboard.
+
+### View status
+
+```bash
+PREFS="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+jq '.home_automation // empty' "$PREFS" 2>/dev/null
+```
+
+Display as a compact block:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► SETTINGS — Home Automation (Homey Pro)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ Status:        ✅ configured   (or ⚠️  not configured)
+ Local URL:     https://192.168.1.••• (mask all but last octet)
+ Local token:   ••••••••••••abcd  (last 4 chars only)
+ Cloud token:   ✅ present   (or ○ not set)
+ Homey ID:      ✅ present   (or ○ not set)
+──────────────────────────────────────────────────────
+ [r] reconfigure → /ops:setup --section home
+```
+
+URL masking: replace all octets except the last with `•••`, e.g. `https://192.168.1.42` → `https://•••.•••.•••.42`.
+Token masking: show last 4 characters only, prefix with `••••••••••••`.
+
+If `home_automation` key is absent from `preferences.json`, show:
+```
+ Status:  ○ not configured — run /ops:setup --section home
+```
+
+### Reconfigure
+
+When the user selects `[r] reconfigure`, route to `/ops:setup --section home` (invoke the `3k-home` sub-flow of the setup wizard).
+
+---
+
 ## CLI/API Reference
 
 | Command | Purpose |

--- a/claude-ops/skills/ops-yolo/SKILL.md
+++ b/claude-ops/skills/ops-yolo/SKILL.md
@@ -187,6 +187,7 @@ Uses `agents/yolo-cfo.md`. Writes `/tmp/yolo-[session]/cfo-analysis.md`.
 - Which AWS services are waste?
 - When do we hit zero if nothing changes?
 - What's the ROI on current work?
+- If `home_automation` is configured in `$PREFS_PATH`, check energy spend trend via `/ops:ops-home status` — is the kWh/day curve trending up materially? Flag anomalous draw.
 
 ### Agent 4 — COO (Operations)
 
@@ -196,6 +197,7 @@ Uses `agents/yolo-coo.md`. Writes `/tmp/yolo-[session]/coo-analysis.md`.
 - Which processes are broken?
 - What's the top execution risk this week?
 - What should be automated that isn't?
+- If `home_automation` is configured in `$PREFS_PATH`, include home-automation health in operations checks via `/ops:ops-home status`: are smoke/water alarms armed? Energy anomalies? Devices offline? Flow failures?
 
 ---
 

--- a/claude-ops/skills/ops/SKILL.md
+++ b/claude-ops/skills/ops/SKILL.md
@@ -28,7 +28,7 @@ Route `$ARGUMENTS` to the correct ops skill:
 
 | Input                                         | Route to                |
 | --------------------------------------------- | ----------------------- |
-| (empty), dash, home, hq                       | `/ops:ops-dash`         |
+| (empty), dash, hq                             | `/ops:ops-dash`         |
 | go, morning, briefing                         | `/ops-go`               |
 | setup, configure, init, install               | `/ops:setup $ARGUMENTS` |
 | inbox, unread, messages                       | `/ops-inbox`            |
@@ -53,6 +53,7 @@ Route `$ARGUMENTS` to the correct ops skill:
 | speedup, clean, optimize, cleanup             | `/ops:ops-speedup`      |
 | orchestrate, subagents, agents, dispatch, run | `/ops:ops-orchestrate $ARGUMENTS` |
 | secret-sync, secrets, doppler-sync, drift     | `/ops:ops-secret-sync $ARGUMENTS` |
+| home, homey, lights, flow, scene, energy, climate, presence, alarm, smart-home, iot, thermostat, dim, door, lock | `/ops:ops-home $ARGUMENTS` |
 
 If `$ARGUMENTS` is empty, launch the interactive dashboard: invoke `/ops:ops-dash` directly.
 

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -76,7 +76,7 @@ The setup wizard accepts these flags (parsed from `$ARGUMENTS`):
 | Profile | Sections enabled |
 |---------|------------------|
 | developer | 2 (CLIs), 2c (Daemon), 3g (Doppler), 3h (Vault), plus GitHub + AWS + Sentry + Linear integration paths |
-| founder | 2, 2c, 3a (Telegram), 3b (WhatsApp), 3c (Email), 3d (Slack), 3f (Calendar), 3g (Doppler), 3n (Notifications) |
+| founder | 2, 2c, 3a (Telegram), 3b (WhatsApp), 3c (Email), 3d (Slack), 3f (Calendar), 3g (Doppler), 3k-home (Home Automation), 3n (Notifications) |
 | marketer | 2, 2c, 3j (Marketing — Klaviyo/Meta Ads/GA4/GSC), 3i (Shopify), 3c (Email), 3g (Doppler) |
 
 ### Incremental re-setup
@@ -823,6 +823,56 @@ Every channel sub-flow below references "the Universal Credential Auto-Scan" by 
 
 > **Loaded from `channels/notifications.md`** — fires-watcher per-sink capture.
 > Load that file before running this sub-flow.
+
+### 3k-home — Home Automation (Homey Pro)
+
+Scout for credentials in background (RULE ZERO):
+
+```bash
+# Run all scouts simultaneously — run_in_background: true on each
+security find-generic-password -s homey-local-token -w 2>/dev/null
+echo "$HOMEY_LOCAL_TOKEN"
+doppler secrets get HOMEY_LOCAL_TOKEN --project homey-pro --plaintext 2>/dev/null
+op item get "Homey" --fields=token 2>/dev/null
+```
+
+If any scout returns a non-empty value, pre-fill it as the default; present found values alongside `[Use found value]` / `[Paste manually]` / `[Skip]`.
+
+**Required:**
+
+1. `HOMEY_LOCAL_URL` — LAN IP of the Homey Pro, e.g. `https://192.168.1.42`. Ask via `AskUserQuestion` free-text.
+2. `HOMEY_LOCAL_TOKEN` — Personal Access Token from `https://my.homey.app/manager/tokens`. Ask via `AskUserQuestion` with `sensitive: true`.
+
+**Optional:**
+
+Ask via one `AskUserQuestion` call:
+```
+Configure optional Homey cloud credentials?
+  [Yes — paste cloud token + Homey ID]
+  [Skip optional fields]
+```
+If yes, collect `HOMEY_CLOUD_TOKEN` (Athom OAuth token) and `HOMEY_ID` (hub ID) via two follow-up `AskUserQuestion` calls with `sensitive: true`.
+
+**Validate** (smoke test, RULE ZERO):
+```bash
+curl -s -H "Authorization: Bearer $HOMEY_LOCAL_TOKEN" \
+  "$HOMEY_LOCAL_URL/api/manager/system/system/info" 2>/dev/null
+```
+Expect HTTP 200 with JSON containing `homeyVersion`. If the check fails, present `[Retry]` / `[Save anyway — LAN may be offline]` / `[Skip]` via `AskUserQuestion` (Rule 3 — never auto-skip).
+
+**Save** to `$PREFS_PATH` via `jq`:
+```bash
+jq --arg url "$HOMEY_LOCAL_URL" \
+   --arg lt "$HOMEY_LOCAL_TOKEN" \
+   --arg ct "${HOMEY_CLOUD_TOKEN:-}" \
+   --arg id "${HOMEY_ID:-}" \
+   '.home_automation = {provider: "homey", homey_local_url: $url, homey_local_token: $lt, homey_cloud_token: $ct, homey_id: $id}' \
+   "$PREFS_PATH" > "$PREFS_PATH.tmp" && mv "$PREFS_PATH.tmp" "$PREFS_PATH"
+```
+
+Print: `✓ Home automation — Homey Pro configured (local: $HOMEY_LOCAL_URL)`
+
+---
 
 ### 3m — Discord (webhook + optional bot)
 


### PR DESCRIPTION
## Summary
- New `/ops:ops-home` skill: device control, flows, energy, climate, presence, alarms via Homey Pro local Web API v3 (preferred) + Athom cloud fallback.
- Reusable for any user — credentials captured by `/ops:setup --section home` and stored in `preferences.json` under `home_automation.*`.
- Wired into setup, settings, credentials, router, dashboards, fires, ops-next priority stack, ops-yolo C-suite checks, and partner registry.
- Cross-channel triggers: critical alarms pipe to `/ops:ops-comms`, energy spikes to `/ops:ops-fires`, presence to `/ops:ops-go` briefing.
- Wiki: new `Ops-Home` page + Home/_Sidebar updates.

## What's new
- `skills/ops-home/SKILL.md` — `status|devices|flow|scene|energy|climate|presence|alarm|setup` router
- `agents/ops:home-agent.md` — read-only probe agent for parallel scans
- `scripts/partner-registry.seed.json` — `homey` entry under `home-automation`
- `.claude-plugin/plugin.json` — `v2.8.3` → **`v2.9.0`**, +5 keywords (`home-automation`, `homey`, `smart-home`, `iot`, `athom`), updated counts to 37 skills/19 agents

## Touched surfaces (gated on `home_automation` in `$PREFS_PATH`)
- `skills/setup` — section 3k with 4-source credential scan + smoke test
- `skills/ops-settings` + `skills/ops-credentials` — status card + rotation flow
- `skills/ops` — router keywords
- `skills/ops-next` — priority 1.5 home alarms tier
- `skills/ops-go` — HOME briefing section
- `skills/ops-dash` — hotkey `[h]` with traffic-light status
- `skills/ops-yolo` — CFO energy spend + COO alarm/device checks
- `skills/ops-fires` — P0/P1/P2 home incidents
- `skills/ops-comms` — home alarm route

## Test plan
- [ ] `/ops:setup --section home` captures `HOMEY_LOCAL_URL` + `HOMEY_LOCAL_TOKEN`, smoke-tests `/api/manager/system/system/info`
- [ ] `/ops:ops-home` (no args) renders status dashboard
- [ ] `/ops:ops-home devices` lists devices grouped by zone
- [ ] `/ops:ops-home flow <name>` triggers a flow
- [ ] `/ops:ops-home energy` returns live power + anomalies
- [ ] `/ops:ops-home alarm` surfaces active alarms
- [ ] `/ops:ops-credentials` lists Homey credentials
- [ ] `/ops:ops-go` morning briefing shows HOME section when configured
- [ ] `/ops:ops-dash` hotkey `h` routes to `/ops:ops-home`
- [ ] Without `home_automation` configured → zero clutter in other skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Homey-powered smart-home control surface including state-changing device/flow actions and new credential capture paths, which increases the chance of misconfiguration or unintended device operations. Most integration points are gated on `home_automation` being configured, limiting blast radius for existing users.
> 
> **Overview**
> Introduces **smart-home support via Homey Pro** with a new `/ops:ops-home` skill (status/devices/flows/energy/climate/presence/alarms) plus a read-only `ops:home-agent` for parallel probing, using local Homey Web API first with Athom cloud fallback.
> 
> Wires home automation into existing ops workflows when `home_automation` is present: setup adds a `--section home` credential flow, settings/credentials docs add Homey status + rotation guidance, router/dash hotkeys and comms/fires/go/next/yolo incorporate Homey status/alarms as inputs and escalation triggers.
> 
> Updates marketplace/plugin metadata (v`2.9.1`→v`2.10.0`, description/keywords) and extends the partner registry with a `homey` integration entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25b1fee73e3290719e7c00298b189cef4be1b93a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->