### PR TITLE
feat(voice): add whatsapp-call + Google Meet subcommands

### DIFF
--- a/claude-ops/bin/ops-voice
+++ b/claude-ops/bin/ops-voice
@@ -6,6 +6,8 @@
 #   facetime <number-or-handle> [--audio] [--json]   FaceTime video (default) or audio
 #   zoom     start|join <meeting-id> [--pwd P]       Open zoom.us app to start/join
 #   zoom     schedule "<topic>" [--start ISO8601] [--duration MIN]   Zoom REST schedule
+#   whatsapp-call <number> [--video] [--json]        Open WhatsApp desktop to call
+#   meet     start|join <code> [--json]              Open Google Meet (new or by code)
 #   twilio-call <to> <from> --twiml URL [--json]     Programmatic outbound voice
 #   twilio-sms  <to> <from> "<body>" [--json]        Programmatic outbound SMS
 #   bland-call  <number> "<prompt>" [--json]         AI agent phone call
@@ -173,6 +175,92 @@ cmd_facetime() {
     exit 1
   }
   emit_ok "facetime" "starting ${scheme} with $handle"
+}
+
+# ─── Subcommand: whatsapp-call ──────────────────────────────────────────────
+# Opens WhatsApp desktop and starts a voice or video call with the contact.
+# Uses the `whatsapp://` URL scheme handled by WhatsApp.app / WhatsApp Desktop.
+cmd_whatsapp_call() {
+  local raw="${1:-}" video=false
+  shift || true
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --video) video=true ;;
+      --json)  JSON_MODE=true ;;
+      *)       emit_err "unknown flag: $1"; exit 2 ;;
+    esac
+    shift
+  done
+  [[ -z "$raw" ]] && { emit_err "usage: ops-voice whatsapp-call <number> [--video]"; exit 2; }
+  local number; number="$(normalize_number "$raw")"
+  # Strip leading + — WhatsApp's scheme expects digits only after `phone=`.
+  local digits="${number#+}"
+  local url
+  if $video; then
+    url="whatsapp://video?phone=${digits}"
+  else
+    url="whatsapp://call?phone=${digits}"
+  fi
+  open_native "$url" || {
+    emit_err "open whatsapp: failed — install WhatsApp Desktop and sign in"
+    exit 1
+  }
+  local kind="voice"; $video && kind="video"
+  emit_ok "whatsapp-call" "starting WhatsApp $kind call to $number"
+}
+
+# ─── Subcommand: meet ───────────────────────────────────────────────────────
+# Google Meet handler.
+#   meet start                — open https://meet.new (new instant meeting)
+#   meet join <code-or-url>   — join existing meeting by code (abc-defg-hij) or full URL
+cmd_meet() {
+  local action="${1:-}"; shift || true
+  case "$action" in
+    start)
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --json) JSON_MODE=true ;;
+          *)      emit_err "unknown flag: $1"; exit 2 ;;
+        esac
+        shift
+      done
+      open_native "https://meet.new" || {
+        emit_err "open https://meet.new failed"
+        exit 1
+      }
+      emit_ok "meet" "starting new Google Meet (meet.new)"
+      ;;
+    join)
+      local target="${1:-}"
+      shift || true
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --json) JSON_MODE=true ;;
+          *)      emit_err "unknown flag: $1"; exit 2 ;;
+        esac
+        shift
+      done
+      [[ -z "$target" ]] && { emit_err "usage: ops-voice meet join <code-or-url>"; exit 2; }
+      local url
+      if [[ "$target" =~ ^https?:// ]]; then
+        url="$target"
+      elif [[ "$target" =~ ^[a-z]{3}-[a-z]{4}-[a-z]{3}$ ]]; then
+        url="https://meet.google.com/${target}"
+      else
+        # Accept bare meeting codes without dashes too; pass through unchanged.
+        url="https://meet.google.com/${target}"
+      fi
+      open_native "$url" || {
+        emit_err "open $url failed"
+        exit 1
+      }
+      emit_ok "meet" "joining $url"
+      ;;
+    *)
+      emit_err "usage: ops-voice meet {start|join <code-or-url>}"
+      exit 2
+      ;;
+  esac
 }
 
 # ─── Subcommand: zoom ───────────────────────────────────────────────────────
@@ -736,6 +824,9 @@ usage:
   ops-voice zoom     start
   ops-voice zoom     join     <meeting-id> [--pwd P] [--json]
   ops-voice zoom     schedule "<topic>" [--start ISO8601] [--duration MIN] [--json]
+  ops-voice whatsapp-call <number> [--video] [--json]
+  ops-voice meet     start [--json]
+  ops-voice meet     join  <code-or-url> [--json]
   ops-voice join     [--at now|next|HH:MM] [--window MIN] [--dry-run] [--json]
   ops-voice twilio-call <to> <from> --twiml <URL> [--json]
   ops-voice twilio-sms  <to> <from> "<body>" [--json]
@@ -766,13 +857,15 @@ main() {
 
   local cmd="${1:-}"; shift || true
   case "$cmd" in
-    phone)        cmd_phone "$@" ;;
-    facetime)     cmd_facetime "$@" ;;
-    zoom)         cmd_zoom "$@" ;;
-    join)         cmd_join "$@" ;;
-    twilio-call)  cmd_twilio_call "$@" ;;
-    twilio-sms)   cmd_twilio_sms "$@" ;;
-    bland-call)   cmd_bland_call "$@" ;;
+    phone)          cmd_phone "$@" ;;
+    facetime)       cmd_facetime "$@" ;;
+    zoom)           cmd_zoom "$@" ;;
+    whatsapp-call)  cmd_whatsapp_call "$@" ;;
+    meet)           cmd_meet "$@" ;;
+    join)           cmd_join "$@" ;;
+    twilio-call)    cmd_twilio_call "$@" ;;
+    twilio-sms)     cmd_twilio_sms "$@" ;;
+    bland-call)     cmd_bland_call "$@" ;;
     -h|--help|"") usage; exit 0 ;;
     *) emit_err "unknown subcommand: $cmd"; usage; exit 2 ;;
   esac

--- a/claude-ops/skills/ops-voice/SKILL.md
+++ b/claude-ops/skills/ops-voice/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ops-voice
-description: Voice operations — native macOS Phone (Continuity), FaceTime, Zoom, Twilio voice + SMS, Bland AI agent calls, ElevenLabs TTS, Whisper transcription. All curl-based, no SDK deps.
-argument-hint: "[phone|facetime|zoom|twilio-call|twilio-sms|bland-call|tts|transcribe|setup]"
+description: Voice operations — native macOS Phone (Continuity), FaceTime, Zoom, Google Meet, WhatsApp call, Twilio voice + SMS, Bland AI agent calls, ElevenLabs TTS, Whisper transcription. All curl-based, no SDK deps.
+argument-hint: "[phone|facetime|zoom|meet|whatsapp-call|twilio-call|twilio-sms|bland-call|tts|transcribe|setup]"
 allowed-tools:
   - Bash
   - Read
@@ -69,6 +69,35 @@ bin/ops-voice zoom schedule "<topic>" --start "2026-05-22T15:00:00Z" --duration 
 ```
 
 Native start/join use `zoommtg://` URL scheme. Schedule requires `ZOOM_API_TOKEN` resolved via the order above. Generate a Server-to-Server OAuth app in your Zoom Marketplace, then exchange for an access token.
+
+---
+
+### `meet start|join` — Google Meet
+
+```bash
+# Open a brand-new instant meeting (https://meet.new)
+bin/ops-voice meet start
+
+# Join by meeting code (xxx-yyyy-zzz) or full URL
+bin/ops-voice meet join abc-defg-hij
+bin/ops-voice meet join https://meet.google.com/abc-defg-hij --json
+```
+
+`meet start` opens `https://meet.new` in the default browser (creates a fresh meeting and lands you in it). `meet join` accepts a 3-4-3 Google Meet code, a bare code, or a full URL — all are normalized to `https://meet.google.com/<code>`. No credentials needed; the user must be signed into Google in the browser.
+
+---
+
+### `whatsapp-call <number> [--video]` — WhatsApp Desktop voice/video call
+
+```bash
+# Voice call (default)
+bin/ops-voice whatsapp-call "+1234567890"
+
+# Video call
+bin/ops-voice whatsapp-call "+1234567890" --video --json
+```
+
+Opens WhatsApp Desktop via the `whatsapp://call?phone=<digits>` or `whatsapp://video?phone=<digits>` URL scheme. Requires WhatsApp Desktop installed and signed in. The leading `+` is stripped — WhatsApp expects digits only after `phone=`. No credentials needed; the WhatsApp session lives in the desktop app.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add `ops-voice whatsapp-call <number> [--video]` — opens WhatsApp Desktop via `whatsapp://call|video?phone=<digits>` URL scheme. No credentials.
- Add `ops-voice meet start` (opens `https://meet.new`) and `ops-voice meet join <code-or-url>` (normalizes code → `https://meet.google.com/<code>`). No credentials.
- Update SKILL.md frontmatter + add two new sub-command sections. Update `bin/ops-voice` usage banner and dispatch.

Both handlers route through `open_native`, so Rule 7 (SSH/mobile) handoff is preserved — URL is printed for the user to open locally instead of launching on the remote host.

## Test plan
- [x] `bash -n bin/ops-voice` — syntax clean
- [x] `tests/test-no-secrets.sh` — 14 passed, 0 failed
- [ ] Local: `bin/ops-voice whatsapp-call "+31..."` → WhatsApp Desktop opens call sheet
- [ ] Local: `bin/ops-voice meet start` → browser opens `meet.new` with new room
- [ ] Local: `bin/ops-voice meet join abc-defg-hij` → joins meeting
- [ ] SSH session: both print URL instead of launching

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new URL-launching subcommands and documentation without changing credentialed/API call flows or existing meeting join logic.
> 
> **Overview**
> Adds two new native subcommands to `bin/ops-voice`: `whatsapp-call` (voice/video via `whatsapp://call|video?phone=` with number normalization) and `meet start|join` (opens `https://meet.new` or normalizes a code/URL to `https://meet.google.com/...`).
> 
> Updates the CLI dispatcher/usage banner and the `ops-voice` skill documentation (`SKILL.md`) to include the new commands and examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10a8de8f08e9d83606fd932d6b7d6bfa17d8a577. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->