### PR TITLE
fix(voice): allow whatsapp:// in opener allowlist

### DIFF
--- a/claude-ops/lib/opener.sh
+++ b/claude-ops/lib/opener.sh
@@ -129,7 +129,7 @@ ops_open_url() {
     return 1
   fi
   # Allow web, mail, and the voice schemes used by bin/ops-voice.
-  if [[ ! "$url" =~ ^https?://|^mailto:|^tel:|^facetime(-audio)?:|^zoommtg: ]]; then
+  if [[ ! "$url" =~ ^https?://|^mailto:|^tel:|^facetime(-audio)?:|^zoommtg:|^whatsapp: ]]; then
     echo "opener: refusing to open non-URL scheme: $url" >&2
     return 1
   fi


### PR DESCRIPTION
## Summary
- PR #300 added `whatsapp-call` but the URL scheme `whatsapp://` was missing from `lib/opener.sh`'s `ops_open_url` allowlist, causing `opener: refusing to open non-URL scheme` errors.
- One-char regex addition: `|^whatsapp:`.
- `meet` (https) was unaffected.

## Test plan
- [x] `bash -n claude-ops/lib/opener.sh` clean
- [x] `tests/test-no-secrets.sh` 14/14 pass
- [ ] Local: `bin/ops-voice whatsapp-call "+31..."` launches WhatsApp Desktop call sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change that only expands the URL scheme allowlist used by `ops_open_url`, with minimal behavioral impact beyond enabling WhatsApp deep links.
> 
> **Overview**
> Fixes WhatsApp call launching by extending `lib/opener.sh`’s `ops_open_url` scheme allowlist to accept `whatsapp:` URLs.
> 
> This prevents `opener: refusing to open non-URL scheme` errors when `bin/ops-voice` attempts to open WhatsApp-native links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4917a3636c58adad9c9527445dfdbd8256a6ca11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->