### PR TITLE
daemon: auto-upgrade on plugin version drift

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.10.1",
+      "version": "2.10.2",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/bin/ops-dash
+++ b/claude-ops/bin/ops-dash
@@ -1271,10 +1271,13 @@ render_section_actions() {
 
   YOLO_LIST_NONEMPTY=""
   echo "$YOLO_LIST" | grep -q '[^[:space:]]' && YOLO_LIST_NONEMPTY="1" || true
+  # Pad YOLO_IND to a fixed visible width (15 cols) so the a/d row aligns
+  # regardless of whether reports exist. "🤖 REPORT READY" = 15 visible cols
+  # (emoji renders as 2 cols). "no reports" = 10 cols, needs 5 trailing spaces.
   if [[ -n "$YOLO_LIST_NONEMPTY" ]]; then
     YOLO_IND="${BCYN}🤖 REPORT READY${RST}"
   else
-    YOLO_IND="${DIM2}no reports${RST}"
+    YOLO_IND="${DIM2}no reports${RST}     "
   fi
 
   p ""
@@ -1289,7 +1292,7 @@ render_section_actions() {
   sp "  ${DIMX}│${RST}                                                              ${DIMX}│${RST}"
   sp "  ${DIMX}│${RST}   ${BWHT}POWER${RST}                            ${BWHT}COMMS${RST}               ${DIMX}│${RST}"
   sp "  ${DIMX}│${RST}                                                              ${DIMX}│${RST}"
-  sp "  ${DIMX}│${RST}   ${BMAG}a${RST} ${WHT}YOLO mode${RST}  ${YOLO_IND}   ${BCYN}d${RST} ${WHT}Send message${RST}        ${DIMX}│${RST}"
+  sp "  ${DIMX}│${RST}   ${BMAG}a${RST} ${WHT}YOLO mode${RST}  ${YOLO_IND}   ${BCYN}d${RST} ${WHT}Send message${RST}   ${DIMX}│${RST}"
   sp "  ${DIMX}│${RST}   ${BMAG}b${RST} ${WHT}Auto-merge PRs${RST}                ${BCYN}e${RST} ${WHT}C-suite reports${RST}     ${DIMX}│${RST}"
   sp "  ${DIMX}│${RST}   ${BMAG}c${RST} ${WHT}Setup wizard${RST}                                       ${DIMX}│${RST}"
   sp "  ${DIMX}│${RST}                                                              ${DIMX}│${RST}"

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -1052,6 +1052,55 @@ PY
 
 # ── Phase 16: credential expiry (offline) ────────────────────────────────
 # Reads *_expires_at / *_created_at from preferences.json and warns:
+# ── Self-upgrade on plugin version drift ──────────────────────────────────
+# Detects when a newer plugin cache version has been installed (e.g. via
+# `/plugin upgrade`) but the running daemon is still on the old version.
+# When drift is detected, calls ops-daemon-manager.sh upgrade — which rewrites
+# the plist + reloads launchd, causing this daemon process to exit and a
+# fresh one to start from the new cache. Idempotent. macOS-only.
+#
+# Runs every 5 minutes to keep cost low. Safe under SessionStart hook race
+# (manager script's mac_unload/load are themselves idempotent).
+check_self_upgrade() {
+  [[ "$(uname -s)" == "Darwin" ]] || return 0
+  local LAST_CHECK="$DATA_DIR/cache/.self_upgrade_ts"
+  local now; now=$(date +%s)
+  mkdir -p "$DATA_DIR/cache" 2>/dev/null || true
+  if [[ -f "$LAST_CHECK" ]]; then
+    local last; last=$(cat "$LAST_CHECK" 2>/dev/null || echo 0)
+    if (( now - last < 300 )); then return 0; fi
+  fi
+  date +%s > "$LAST_CHECK"
+
+  local cache_dir="$HOME/.claude/plugins/cache/ops-marketplace/ops"
+  [[ -d "$cache_dir" ]] || return 0
+
+  # Resolve newest installed version via lexicographic sort (semver-safe enough
+  # for our 2.x line; major bumps are rare and would trigger anyway).
+  local newest
+  newest=$(ls -1 "$cache_dir" 2>/dev/null | sort -V | tail -1)
+  [[ -n "$newest" ]] || return 0
+
+  local newest_root="$cache_dir/$newest"
+  local current_root="${CLAUDE_PLUGIN_ROOT:-}"
+  [[ -d "$newest_root/scripts" ]] || return 0
+
+  # No drift if we're already on newest
+  if [[ "$current_root" == "$newest_root" ]]; then return 0; fi
+
+  log "SELF-UPGRADE: drift detected — running=$current_root newest=$newest_root"
+  local mgr="$newest_root/scripts/ops-daemon-manager.sh"
+  if [[ -x "$mgr" ]]; then
+    # Fire-and-forget — manager will SIGTERM us via mac_unload. We exit on
+    # signal; launchd reloads us from the new plist path.
+    CLAUDE_PLUGIN_ROOT="$newest_root" bash "$mgr" upgrade --plugin-root "$newest_root" >> "$LOG_FILE" 2>&1 &
+    log "SELF-UPGRADE: triggered manager upgrade to $newest"
+  else
+    log "SELF-UPGRADE: manager not executable at $mgr — skipping"
+  fi
+}
+
+# Credential expiry & rotation alerts. Warns when a stored key:
 #   - expires within WARN_DAYS (7)
 #   - keys older than MAX_KEY_AGE_DAYS (180) — rotation recommended
 # Strictly offline — never makes a network call. Dedups per (credential, day).
@@ -1712,6 +1761,7 @@ while true; do
   # ── Phase 16: infrastructure hardening ───────────────────────────────────
   check_rate_limits                # Every 5 min: reset rollover windows + warnings
   check_credential_expiry          # Hourly: offline check of *_expires_at / *_created_at
+  check_self_upgrade               # Every 5 min: auto-upgrade plist on version drift
 
   write_daemon_health
 


### PR DESCRIPTION
## Summary
- Daemon now self-heals plist version drift every 5 min in its monitor loop
- When newer cache version detected vs `$CLAUDE_PLUGIN_ROOT`, fires `ops-daemon-manager.sh upgrade` from the newest install — launchd reloads with the fresh path
- Closes the gap where `/plugin upgrade ops` leaves the running daemon pointing at the old script (the `SessionStart` `ensure-current` hook fires `2>/dev/null` and can fail silently)

## Why
This morning's `/ops:doctor` run found plist still pointing at `2.8.3/scripts/ops-daemon.sh` while cache was at `2.9.1`. Manual `ops-daemon-manager.sh upgrade` fixed it — but the daemon should detect this on its own clock, not wait for a session to start or a doctor invocation.

## Test plan
- [x] `bash -n scripts/ops-daemon.sh` clean
- [ ] Manual: install a fake newer cache version dir, watch `daemon.log` for `SELF-UPGRADE: drift detected` within 5 min
- [ ] Manual: verify no-op when versions match (no extra log lines, sentinel honored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a macOS-only monitor-loop check that can trigger a launchd plist rewrite/reload and restart the running daemon when a newer cached plugin version is detected; mis-detection or path issues could cause unexpected daemon restarts or upgrade loops.
> 
> **Overview**
> **Daemon now self-heals plugin version drift on macOS.** `ops-daemon.sh` adds `check_self_upgrade`, which every 5 minutes compares the running `$CLAUDE_PLUGIN_ROOT` to the newest installed cache version and, if different, invokes the newest `ops-daemon-manager.sh upgrade` to reload launchd and restart onto the new version.
> 
> Also bumps plugin version to `2.10.2` and makes a small `ops-dash` UI tweak to keep the Quick Actions menu aligned when there are no YOLO reports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e9e2b56d42ec4d1b65837588b97963bd47512d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->