### PR TITLE
chore(marketplace): bump ops to v2.10.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.10.2",
+      "version": "2.10.3",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",


### PR DESCRIPTION
## Summary
Patch release covering #304 — the `/ops:ops-inbox` WhatsApp MCP diagnosis fix.

The skill now:
- Probes both layers (whatsmeow bridge :8080 + mcp-proxy SSE :8090) instead of only :8080.
- Retries `ToolSearch` for `mcp__whatsapp__*` up to 3× at 5s spacing before declaring WhatsApp MCP unavailable (handles transient SSE handshake).
- Documents the macOS launchd `maxfiles=256` EMFILE failure mode inline with the exact LaunchAgent plist fix (`SoftResourceLimits.NumberOfFiles=4096` / Hard=8192).

## Test plan
- [ ] After publish + reinstall, `/ops:ops-inbox` correctly lists WhatsApp chats without misreporting "MCP not available" during transient handshake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates plugin version metadata and does not change runtime code paths.
> 
> **Overview**
> Bumps the `ops` plugin version from `2.10.2` to `2.10.3` in both the local marketplace manifest (`.claude-plugin/marketplace.json`) and the plugin manifest (`claude-ops/.claude-plugin/plugin.json`) to publish the new release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de5cc75a6bf10e85fef355a4223397bfb5a65cab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped plugin version from 2.10.2 to 2.10.3

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->