### PR TITLE
fix(ops-home): correct system endpoint + add Plejd-style mass-outage detector (v2.10.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.10.2",
+      "version": "2.10.4",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.10.2",
+  "version": "2.10.4",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/skills/ops-home/SKILL.md
+++ b/claude-ops/skills/ops-home/SKILL.md
@@ -55,7 +55,7 @@ Base URL: `${HOMEY_LOCAL_URL}` (e.g. `http://192.168.1.100`)
 | `/api/manager/energy/report` | GET | Historical energy report (kWh) |
 | `/api/manager/presence` | GET | Presence status (who is home) |
 | `/api/manager/alarms/alarm` | GET | Active alarms (smoke, water, security) |
-| `/api/manager/system/info` | GET | Homey system info |
+| `/api/manager/system` | GET | Homey system info (firmware, name, uptime) |
 
 **Auth header (local)**: `Authorization: Bearer ${HOMEY_LOCAL_TOKEN}`
 
@@ -188,6 +188,7 @@ homey_call() {
 | climate, temp, thermostat, heating        | Climate manager       |
 | presence, who, home                       | Presence              |
 | alarm, alarms, arm, disarm, security      | Alarms / security     |
+| health, diagnose, outage                  | Health / outage scan  |
 | setup, configure, init, token             | Setup flow            |
 
 ---
@@ -556,8 +557,8 @@ homey_call "/alarms/alarm" | jq '[.[] | select(.active == true) | {
   severity: .severity
 }]'
 
-# Security mode
-homey_call "/system/info" | jq '.securityMode // "unknown"'
+# Security mode (fw 13.2.0+: /api/manager/system — NOT /system/info, that returns the Web App HTML)
+homey_call "/system" | jq '.securityMode // "unknown"'
 ```
 
 If `$ARGUMENTS` is `alarm arm` or `alarm disarm`, set security mode (use a flow if Homey exposes it as such — typical Homey setups use a "Security Armed" flow):
@@ -615,6 +616,87 @@ Then `AskUserQuestion` with `[Send]` / `[Edit]` / `[Skip]`.
 
 ---
 
+## HEALTH (`health`, `diagnose`, `outage`)
+
+Plejd-style mass-outage detector. Groups offline devices by `driverUri` (the source app/integration), then flags any driver where > 30% of its devices are offline as a probable single-driver outage — usually an app crash, expired credentials, or hub-side disconnect inside that integration.
+
+```bash
+# Pull devices once, then group/aggregate locally
+DEVICES_JSON=$(homey_call "/devices/device")
+
+echo "$DEVICES_JSON" | jq '{
+  total: (. | length),
+  online: ([.[] | select(.available == true)] | length),
+  offline: ([.[] | select(.available == false)] | length),
+  drivers: (
+    [.[] | {driverUri: (.driverUri // "unknown"), available: .available}]
+    | group_by(.driverUri)
+    | map({
+        driverUri: .[0].driverUri,
+        total: length,
+        offline: ([.[] | select(.available == false)] | length),
+        offline_pct: (([.[] | select(.available == false)] | length) * 100 / length)
+      })
+    | sort_by(-.offline_pct)
+  )
+}'
+```
+
+Driver short-name: strip `homey:app:` prefix and dotted namespace (e.g. `homey:app:com.plejd` → `com.plejd` → `plejd`). Display logic:
+
+- Total banner: `total devices: N (X online, Y offline)`.
+- For each driver where `offline_pct > 30` AND `total >= 2`, surface a `MASS OUTAGE` line with the count, percentage, and a likely-cause hint based on the driver namespace.
+- For drivers where `total == 1` AND offline, label as `likely powered off` (single device — not a mass outage).
+- For drivers where `offline_pct <= 30`, list under a `partial outage` section only if `offline >= 2`.
+
+Likely-cause hints (keyed by driver namespace substring):
+- `plejd`, `hue`, `tradfri`, `lifx`, `tuya`, `smartthings`, `homekit` → `app credentials expired or app crashed. Fix: open Homey app → Apps → [app name] → reconfigure.`
+- `chromecast`, `sonos`, `airplay` → `media device dropped off network. Fix: power-cycle device + check Wi-Fi.`
+- `zwave`, `zigbee`, `433` → `radio congestion or hub-mesh issue. Fix: check Homey → Settings → Z-Wave/Zigbee mesh.`
+- `whisker`, `litter`, `vacuum`, generic single-device → `likely powered off`.
+- Unknown → `unknown integration — check the app's status in Homey app → Apps.`
+
+Render (desktop):
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► HOME ► HEALTH — [timestamp]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+HOMEY ► HEALTH
+  total devices: 181 (82 online, 99 offline)
+
+  ⚠ MASS OUTAGE: com.plejd — 96 / 96 offline (100%)
+    likely: app credentials expired or app crashed.
+    Fix: open Homey app → Apps → Plejd → reconfigure.
+
+  whisker: 1 / 1 offline (100%) — likely powered off
+  chromecast: 2 / 4 offline (50%) — media device dropped off network.
+
+──────────────────────────────────────────────────────
+ Actions:
+ a) Reconfigure flagged app (deep-link to Homey app)
+ b) Power-cycle Homey hub
+ c) Re-run health scan after fix
+ d) Broadcast outage to /ops:ops-comms
+──────────────────────────────────────────────────────
+```
+
+Mobile mode:
+
+```
+home health: 82/181 online.
+⚠ plejd: 96/96 offline (app down — reconfigure in Homey app).
+whisker: 1/1 offline (powered off).
+next: /ops-home devices | reconfigure plejd
+```
+
+If any MASS OUTAGE is flagged, surface it at the top of the default STATUS dashboard as well (after the DEVICES line), so the user sees it without needing to run `/ops-home health` explicitly.
+
+Cross-channel: if `MASS OUTAGE` count > 50 devices OR a security-related integration is down (alarm panel, locks, cameras), suggest piping to `/ops:ops-comms` (Rule 6 — stage draft, never auto-send).
+
+---
+
 ## SETUP FLOW (`setup`, `configure`, `init`, `token`)
 
 Delegate to the central setup wizard with the home section:
@@ -657,7 +739,7 @@ Verify connectivity after acquisition:
 
 ```bash
 curl -s -H "Authorization: Bearer ${PROVIDED_TOKEN}" \
-  "${PROVIDED_LOCAL_URL}/api/manager/system/info" | jq '{name, firmware: .firmwareVersion}'
+  "${PROVIDED_LOCAL_URL}/api/manager/system" | jq '{name, firmware: .firmwareVersion}'
 ```
 
 If 200 — confirm success and write to `preferences.json` under `home_automation.*`. If 401/403 — token invalid, re-prompt via `AskUserQuestion` (`[Paste new token]`, `[Deep hunt — spawn agent]`, `[Skip]`).


### PR DESCRIPTION
## Summary

Real-world testing on Sam's Homey Pro (fw 13.2.0, 181 devices) surfaced two doc bugs and one missing capability in the `/ops:ops-home` skill.

- **Bug 1 — system endpoint:** `/api/manager/system/info` returns the Web App HTML on fw 13.2.0+. Correct path is `/api/manager/system`. Replaced both call sites in `SKILL.md` and the reference table.
- **Bug 2 — device-collection shape:** Re-verified — existing `jq` patterns (`(. | length)`, `[.[] | select(...)]`) work on object-map responses because `.[]` iterates object values in jq. No changes required.
- **Bug 3 — mass-outage detector:** Added a new `health` subcommand (route keywords `health|diagnose|outage`). Groups offline devices by `driverUri`, flags any driver with >30% offline as probable single-app outage with a driver-specific fix hint. Surfaces top mass-outage on the default STATUS dashboard too.

Version bump `2.10.2 → 2.10.4` (skipping `.3` to avoid collision with in-flight `chore/marketplace-v2.10.3`).

## Test plan

- [x] `bash claude-ops/tests/test-no-secrets.sh` — 14/14 pass
- [ ] Smoke `/ops:ops-home health` against Sam's hub — expect MASS OUTAGE on Plejd (96/96 offline)
- [ ] Smoke `/ops:ops-home status` — expect correct firmware/hub name from `/system` endpoint
- [ ] Smoke `/ops:ops-home` (status default) — expect mass-outage banner inline when present

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `ops-home` skill’s Homey local API calls to use `/api/manager/system` (instead of `/system/info`) and adds new health/outage detection behavior, which may affect runtime hub queries and user-facing status output.
> 
> **Overview**
> Bumps the plugin version to `2.10.4` in both marketplace and plugin manifests.
> 
> Updates `ops-home` to use the correct Homey firmware 13.2.0+ system endpoint (`/api/manager/system`) in the endpoint table, security-mode query, and setup connectivity check.
> 
> Adds a new `health`/`diagnose`/`outage` route to `ops-home` that aggregates device availability by `driverUri` to flag probable single-integration mass outages, with guidance text and recommendations to surface mass-outage banners in the default status output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39515da5feab60334444dee76f14fa183a46bab3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->