### PR TITLE
fix(pocket-whatsapp-bridge): defensive parse of supervisor-questions.jsonl

### DIFF
--- a/claude-ops/scripts/ops-pocket-whatsapp-bridge.py
+++ b/claude-ops/scripts/ops-pocket-whatsapp-bridge.py
@@ -121,10 +121,16 @@ def open_questions() -> list[dict]:
                 continue
             try:
                 q = json.loads(line)
-                if q.get("status") == "open":
-                    out.append(q)
             except json.JSONDecodeError:
                 continue
+            if not isinstance(q, dict):
+                continue
+            if q.get("status") != "open":
+                continue
+            if not q.get("id"):
+                log(f"skipping malformed open question (no id): {str(q)[:120]}")
+                continue
+            out.append(q)
     except OSError:
         pass
     return out


### PR DESCRIPTION
## Summary
- Skip malformed open-question records (missing \`id\`) instead of crashing the bridge every minute with \`KeyError: 'id'\`
- Observed live on dev-sandbox EC2 2026-05-21 13:16Z–13:23Z (8 consecutive failures); self-cleared once the malformed record aged out but the defensive guard prevents recurrence

## Test plan
- [x] python3 -m py_compile
- [x] test-no-secrets.sh
- [ ] Pull on dev-sandbox, restart pocket-whatsapp-bridge.service, verify no FATAL in next 5 ticks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds validation/logging around reading the questions JSONL, reducing crash potential without altering core routing logic.
> 
> **Overview**
> Prevents the WhatsApp bridge from failing on bad lines in `supervisor-questions.jsonl` by validating each parsed record is a dict, is `status="open"`, and has a non-empty `id`.
> 
> Malformed open-question entries are now skipped with a brief log message (instead of being treated as valid and later causing runtime errors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cca978e2ee45a0e70711dde7165a1626c7f877e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->