### PR TITLE
fix(pocket-executor): systemd unit KillMode=process so v3 workers survive

### DIFF
--- a/claude-ops/scripts/systemd/pocket-executor.service
+++ b/claude-ops/scripts/systemd/pocket-executor.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Pocket Executor — supervisor watchdog (keeps pocket-exec tmux alive)
+Description=Pocket Executor v3 — stateless Python supervisor (claude -p per task)
 After=network-online.target
 Wants=network-online.target
 
@@ -10,6 +10,18 @@ WorkingDirectory=__HOME__
 Environment=HOME=__HOME__
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
 Environment=POCKET_STATE_DIR=__HOME__/.claude/state/pocket
+Environment=POCKET_CLAUDE_BIN=/usr/local/bin/claude
+Environment=POCKET_EXEC_CWD=__HOME__
+Environment=POCKET_MAX_CONCURRENT=3
+Environment=POCKET_WORKER_MODEL=claude-sonnet-4-6
+Environment=POCKET_WORKER_TIMEOUT=1800
 ExecStart=__HOME__/.venv-pocket/bin/python3 __HOME__/claude-ops/claude-ops/scripts/ops-cron-pocket-executor.py
 StandardOutput=append:__HOME__/.claude/state/pocket/executor-stdout.log
 StandardError=append:__HOME__/.claude/state/pocket/executor-stderr.log
+# v3 requires this: workers are claude -p subprocesses that must outlive
+# the oneshot service unit (they take 30-120s to complete). Without
+# KillMode=process, systemd SIGKILLs the worker process group when the
+# unit transitions to inactive, leaving 0-byte stdout and a bogus
+# completion receipt. process mode kills only the main PID (the python
+# supervisor), letting worker children run to completion under PID 1.
+KillMode=process


### PR DESCRIPTION
## Summary
- v3 `claude -p` workers were SIGKILL'd by systemd when the oneshot supervisor unit went inactive, truncating output to 0 bytes
- `KillMode=process` kills only the main supervisor PID, leaves worker children running under PID 1 reparenting
- Verified on dev-sandbox: 463-byte Outcome where 3 prior runs produced 0 bytes

## Test plan
- [x] test-no-secrets
- [x] live verified on dev-sandbox

(Companion to #309)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk systemd-unit tweak that only changes process-lifecycle behavior and adds config env vars; main concern is leaving orphaned workers running longer if the supervisor exits unexpectedly.
> 
> **Overview**
> Updates the `pocket-executor.service` unit for Pocket Executor v3 by adding explicit environment configuration for the `claude -p` worker subprocesses (binary path, CWD, concurrency, model, timeout).
> 
> Sets `KillMode=process` so systemd only terminates the Python supervisor when the oneshot unit goes inactive, allowing spawned `claude` workers to continue to completion instead of being SIGKILL’d and truncating outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7891b1e4ee5c091310ebcfe8864c95bc68f67807. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->