### PR TITLE
fix(ops-speedup): never demote iCloud/App Store/APNs daemons

### DIFF
--- a/claude-ops/bin/ops-speedup
+++ b/claude-ops/bin/ops-speedup
@@ -323,11 +323,14 @@ run_parallel_scan() {
 # ACTIONS — os-agnostic dispatcher
 # ═════════════════════════════════════════════════════════════════
 
-# Protected processes — never kill
-PROTECTED_RE="kernel_task|launchd|WindowServer|loginwindow|Finder|SystemUIServer|Dock|systemd|init|sshd|ssh|mosh|bash|zsh|fish|tmux|screen|cursor|Cursor|comet|Comet|Shortwave|shortwave|claude|Claude|node|npm|python|Xcode|xcodebuild"
+# Protected processes — never kill, never demote
+# Spotlight stack (mds/mdworker) + iCloud/App Store sync (bird/cloudd/akd/itunescloudd/appstoreagent/storeagent/storeaccountd/commerce/storedownloadd/identityservicesd/apsd) must stay at normal priority.
+# Demoting them via taskpolicy -b starves CloudKit/StoreKit traffic and surfaces as "Cannot Connect" in App Store / iCloud / iCloud Drive sync stalls.
+PROTECTED_RE="kernel_task|launchd|WindowServer|loginwindow|Finder|SystemUIServer|Dock|systemd|init|sshd|ssh|mosh|bash|zsh|fish|tmux|screen|cursor|Cursor|comet|Comet|Shortwave|shortwave|claude|Claude|node|npm|python|Xcode|xcodebuild|mds|mds_stores|mdworker|mdworker_shared|mdbulkimport|Spotlight|bird|cloudd|akd|itunescloudd|appstoreagent|storeagent|storeaccountd|storedownloadd|commerce|identityservicesd|apsd|nsurlsessiond|fmfd|callservicesd|imagent|softwareupdated|nsurlstoraged|trustd|networkd|symptomsd|locationd|dasd|powerd"
 
-# Safe to demote to background priority (not kill)
-MACOS_DEMOTE_RE="bird|cloudd|suggestd|knowledge-agent|photoanalysisd|mediaanalysisd|parsecd|tipsd|AMPLibraryAgent|cloudphotod|identityservicesd"
+# Safe to demote to background priority (not kill).
+# Excludes: bird/cloudd (iCloud/CloudKit), identityservicesd (iMessage/FaceTime/iCloud auth) — demoting these breaks App Store + iCloud sync.
+MACOS_DEMOTE_RE="suggestd|knowledge-agent|photoanalysisd|mediaanalysisd|parsecd|tipsd|AMPLibraryAgent|cloudphotod"
 
 # ─────────────────────────────────────────────────────────────────
 # Windows / WSL helpers


### PR DESCRIPTION
## Summary
- Demoting `bird`/`cloudd`/`identityservicesd` via `taskpolicy -b` parked iCloud, CloudKit, StoreKit, and APNs traffic on E-cores — surfacing as "Cannot Connect" in Mac App Store and stalled iCloud Drive sync.
- Removed those daemons from `MACOS_DEMOTE_RE`, added the Spotlight stack + iCloud + App Store + StoreKit + APNs + Find My + location/network daemons to `PROTECTED_RE` so future runs leave them alone.

## Test plan
- [x] Restored task priority on currently demoted daemons (`taskpolicy -B`) — App Store reconnects, iCloud sync resumes
- [x] `grep -E "bird|cloudd" bin/ops-speedup` shows them only in PROTECTED_RE, not DEMOTE_RE
- [ ] Next `/ops:ops-speedup` run leaves App Store + iCloud functioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes process allow/deny regexes that control which macOS system daemons can be `taskpolicy`-demoted or killed, which can affect system performance and cleanup behavior if the patterns are too broad or miss critical processes.
> 
> **Overview**
> Prevents `ops-speedup` from interfering with macOS connectivity/sync services by **expanding `PROTECTED_RE`** to cover Spotlight (`mds`/`mdworker`) and a broader set of iCloud/App Store/StoreKit/APNs and related networking/location daemons.
> 
> Also **removes iCloud-related daemons from `MACOS_DEMOTE_RE`**, so `action_demote_background` no longer pushes them to background priority where it previously caused App Store “Cannot Connect” and iCloud Drive sync stalls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55fa3eef86c05fec3e734d0717abfe83a1e9201c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->