### PR TITLE
chore(pocket-email-bridge): EnvironmentFile + GOG_KEYRING_PASSWORD + GOG_ACCOUNT

### DIFF
--- a/claude-ops/scripts/systemd/pocket-email-bridge.service
+++ b/claude-ops/scripts/systemd/pocket-email-bridge.service
@@ -1,11 +1,16 @@
 [Unit]
 Description=Pocket Email Bridge — outbound send + inbound reply parsing via Gmail
 After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=oneshot
 User=__USER__
 WorkingDirectory=__HOME__
+# Loads GOG_KEYRING_PASSWORD + GOG_ACCOUNT (file-keyring unlock for non-
+# interactive shells) from the operator-managed secrets file. See
+# scripts/systemd/secrets.env.example for the schema.
+EnvironmentFile=/etc/pocket/secrets.env
 Environment=HOME=__HOME__
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
 Environment=POCKET_STATE_DIR=__HOME__/.claude/state/pocket

--- a/claude-ops/scripts/systemd/secrets.env.example
+++ b/claude-ops/scripts/systemd/secrets.env.example
@@ -16,5 +16,16 @@
 # Pocket AI MCP — generate at https://heypocketai.com/account
 POCKET_API_KEY=<YOUR_POCKET_API_KEY>
 
+# gog CLI (Gmail/Calendar/Drive/etc.) file-keyring password. Set this
+# when you run `gog auth add <email> --services all-user`. Required by
+# pocket-email-bridge so the systemd-launched gog can unlock its keyring
+# in a non-interactive shell. Without it, every gog call exits with
+# `no TTY available for keyring file backend password prompt`.
+GOG_KEYRING_PASSWORD=<YOUR_GOG_KEYRING_PASSWORD>
+
+# Default Gmail account when --account is omitted. Avoids the
+# `missing --account (or set GOG_ACCOUNT, ...)` error.
+GOG_ACCOUNT=<your-gmail-account@example.com>
+
 # Add other secrets below as services need them. Anything in this file
 # is loaded into the systemd unit's env via EnvironmentFile=.


### PR DESCRIPTION
Verified live on dev-sandbox: out_sent=0 → 8 on first restart

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate operational risk: changes systemd unit startup environment and introduces new required secrets, which could break the email bridge if `/etc/pocket/secrets.env` is missing/misconfigured.
> 
> **Overview**
> Updates the `pocket-email-bridge` systemd unit to **wait for network-online** (`Wants=network-online.target`) and to load operator-managed secrets via `EnvironmentFile=/etc/pocket/secrets.env`.
> 
> Expands `secrets.env.example` to document and require `GOG_KEYRING_PASSWORD` and `GOG_ACCOUNT`, enabling non-interactive `gog` keyring unlock and a default Gmail account for systemd-launched runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa0f57a2a5990d2c74716c603d20ea82fa0c0874. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->