### PR TITLE
chore(pocket-systemd): migrate watcher + email-bridge unit templates to Doppler

### DIFF
--- a/claude-ops/.gitignore
+++ b/claude-ops/.gitignore
@@ -4,10 +4,12 @@ node_modules/
 !templates/**/.env.example
 !scripts/systemd/secrets.env.example
 
-# Pocket pipeline secrets — installed at /etc/pocket/secrets.env mode 600
-# root-owned. Never check this file (or any copy of it) into the repo.
+# Pocket pipeline secrets — installed at /etc/pocket/{secrets.env,doppler-token}
+# mode 600 root-owned. Never check these files (or any copy of them) into git.
 secrets.env
 pocket-secrets.env
+doppler-token
+pocket-doppler-token*
 .DS_Store
 *.swp
 *.swo

--- a/claude-ops/scripts/systemd/pocket-email-bridge.service
+++ b/claude-ops/scripts/systemd/pocket-email-bridge.service
@@ -6,15 +6,18 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 User=__USER__
+Group=__USER__
 WorkingDirectory=__HOME__
-# Loads GOG_KEYRING_PASSWORD + GOG_ACCOUNT (file-keyring unlock for non-
-# interactive shells) from the operator-managed secrets file. See
-# scripts/systemd/secrets.env.example for the schema.
-EnvironmentFile=/etc/pocket/secrets.env
+# Doppler service token (same scoped token as pocket-watcher.service). Injects
+# GOG_KEYRING_PASSWORD + GOG_ACCOUNT into the bridge's env. Without these, gog
+# returns exit 2: "no TTY available for keyring file backend password prompt"
+# or "missing --account (or set GOG_ACCOUNT)". See pocket-watcher.service
+# operator setup notes.
+LoadCredential=doppler-token:/etc/pocket/doppler-token
 Environment=HOME=__HOME__
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
 Environment=POCKET_STATE_DIR=__HOME__/.claude/state/pocket
 Environment=GOG_BIN=/usr/local/bin/gog
-ExecStart=__HOME__/.venv-pocket/bin/python3 __HOME__/claude-ops/claude-ops/scripts/ops-pocket-email-bridge.py
+ExecStart=/bin/bash -c 'DOPPLER_TOKEN=$(cat $CREDENTIALS_DIRECTORY/doppler-token) /usr/local/bin/doppler run --silent -- __HOME__/.venv-pocket/bin/python3 __HOME__/claude-ops/claude-ops/scripts/ops-pocket-email-bridge.py'
 StandardOutput=append:__HOME__/.claude/state/pocket/email-bridge.log
 StandardError=append:__HOME__/.claude/state/pocket/email-bridge-stderr.log

--- a/claude-ops/scripts/systemd/pocket-watcher.service
+++ b/claude-ops/scripts/systemd/pocket-watcher.service
@@ -6,11 +6,21 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 User=__USER__
+Group=__USER__
 WorkingDirectory=__HOME__
-# Secrets (POCKET_API_KEY, etc.) — see scripts/systemd/secrets.env.example.
-# This file MUST be created by the operator at /etc/pocket/secrets.env
-# with mode 600 owned by root. It is gitignored.
-EnvironmentFile=/etc/pocket/secrets.env
+# Doppler service token, scoped read-only to the operator's secrets config
+# (e.g. claude-ops/dev). The token file is root-owned mode 600; the
+# LoadCredential directive exposes it as $CREDENTIALS_DIRECTORY/doppler-token
+# only to this service unit. doppler run then injects POCKET_API_KEY into
+# the watcher's env at runtime — secrets never sit on disk in plaintext or
+# in `systemctl cat` output.
+#
+# Operator setup:
+#   sudo install -d -m 0750 -o root -g root /etc/pocket
+#   echo "dp.st.dev.YOUR_TOKEN" | sudo tee /etc/pocket/doppler-token >/dev/null
+#   sudo chmod 600 /etc/pocket/doppler-token && sudo chown root:root /etc/pocket/doppler-token
+#   sudo systemctl daemon-reload && sudo systemctl restart pocket-watcher.timer
+LoadCredential=doppler-token:/etc/pocket/doppler-token
 Environment=HOME=__HOME__
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
 Environment=POCKET_STATE_DIR=__HOME__/.claude/state/pocket
@@ -20,6 +30,6 @@ Environment=POCKET_LOOKBACK_HOURS=24
 Environment=GIGA_SYNC=1
 Environment=GIGA_MIND=global
 Environment=GIGA_CONSOLIDATE=1
-ExecStart=__HOME__/.venv-pocket/bin/python3 __HOME__/claude-ops/claude-ops/scripts/ops-cron-pocket-watcher.py
+ExecStart=/bin/bash -c 'DOPPLER_TOKEN=$(cat $CREDENTIALS_DIRECTORY/doppler-token) /usr/local/bin/doppler run --silent -- __HOME__/.venv-pocket/bin/python3 __HOME__/claude-ops/claude-ops/scripts/ops-cron-pocket-watcher.py'
 StandardOutput=append:__HOME__/.claude/state/pocket/watcher-stdout.log
 StandardError=append:__HOME__/.claude/state/pocket/watcher-stderr.log

--- a/claude-ops/scripts/systemd/secrets.env.example
+++ b/claude-ops/scripts/systemd/secrets.env.example
@@ -1,17 +1,41 @@
-# Pocket pipeline secrets — install at /etc/pocket/secrets.env
+# Pocket pipeline secrets — TWO SUPPORTED MODES
 #
-# Operator setup:
+# Recommended (Doppler): the systemd unit templates default to this. Install
+# a service-scoped Doppler token at /etc/pocket/doppler-token (root:root, mode
+# 600). systemd's LoadCredential= exposes it to each pocket service which then
+# uses `doppler run -- python3 …` to inject secrets per-invocation. Secrets
+# never sit on disk and `systemctl cat` reveals nothing.
+#
+#   # 1. Create scoped service token from a workstation
+#   doppler configs tokens create dev-sandbox-ec2 \
+#     --project claude-ops --config dev --plain --max-age 0
+#
+#   # 2. Place it on the host
 #   sudo install -d -m 0750 -o root -g root /etc/pocket
-#   sudo cp scripts/systemd/secrets.env.example /etc/pocket/secrets.env
-#   sudo chmod 600 /etc/pocket/secrets.env
-#   sudo chown root:root /etc/pocket/secrets.env
-#   sudo $EDITOR /etc/pocket/secrets.env   # fill in real values
-#   sudo systemctl daemon-reload
-#   sudo systemctl restart pocket-watcher
+#   echo "dp.st.dev.YOUR_TOKEN" | sudo tee /etc/pocket/doppler-token >/dev/null
+#   sudo chmod 600 /etc/pocket/doppler-token
+#   sudo chown root:root /etc/pocket/doppler-token
 #
-# DO NOT commit this file with real values. The real file is mode 600 and
-# loaded by systemd via EnvironmentFile= so secrets never appear in
-# `systemctl cat` or `systemctl show` output.
+#   # 3. Populate the Doppler config with these secret names:
+#   doppler secrets set \
+#     POCKET_API_KEY=<your_pocket_api_key> \
+#     GOG_KEYRING_PASSWORD=<your_gog_keyring_password> \
+#     GOG_ACCOUNT=<your-gmail@example.com> \
+#     --project claude-ops --config dev
+#
+#   # 4. Reload + restart
+#   sudo systemctl daemon-reload
+#   sudo systemctl restart pocket-watcher.service pocket-email-bridge.service
+#
+# Legacy (EnvironmentFile=, plain .env file): pre-Doppler deployments used
+# /etc/pocket/secrets.env loaded via systemd EnvironmentFile=. The repo's
+# systemd unit templates no longer reference this path; if you're on an
+# old deploy you can keep using it, but new deploys should go Doppler.
+#
+# DO NOT commit a real secrets.env or doppler-token to git — both are in
+# the plugin's .gitignore.
+
+# ── Secret names (same in either mode) ───────────────────────────────────
 
 # Pocket AI MCP — generate at https://heypocketai.com/account
 POCKET_API_KEY=<YOUR_POCKET_API_KEY>
@@ -26,6 +50,3 @@ GOG_KEYRING_PASSWORD=<YOUR_GOG_KEYRING_PASSWORD>
 # Default Gmail account when --account is omitted. Avoids the
 # `missing --account (or set GOG_ACCOUNT, ...)` error.
 GOG_ACCOUNT=<your-gmail-account@example.com>
-
-# Add other secrets below as services need them. Anything in this file
-# is loaded into the systemd unit's env via EnvironmentFile=.


### PR DESCRIPTION
## Summary
- /etc/pocket/doppler-token (root:root mode 600) + systemd LoadCredential= + `doppler run --silent --` wrap → secrets injected per-invocation, never on disk plaintext
- secrets.env.example rewritten with both modes documented (Doppler recommended; EnvironmentFile legacy still works)
- .gitignore: block doppler-token + pocket-doppler-token* at any depth
- Verified live on dev-sandbox EC2: watcher giga=ok, email-bridge out_failed=0 post-swap

## Test plan
- [x] test-no-secrets passes
- [x] verified live on dev-sandbox after live deploy (/etc/pocket/secrets.env deleted, no fallback)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes systemd service startup to fetch secrets via `doppler run` + `LoadCredential`, so misconfiguration (missing token/permissions, missing doppler binary) will prevent the watcher/email bridge from running. No application logic changes, but it touches deployment/secrets plumbing.
> 
> **Overview**
> Switches the `pocket-watcher` and `pocket-email-bridge` systemd unit templates from `EnvironmentFile=/etc/pocket/secrets.env` to **Doppler-based secret injection** using `LoadCredential=doppler-token:/etc/pocket/doppler-token` and an `ExecStart` wrapper that runs the scripts under `doppler run --silent`.
> 
> Updates `.gitignore` to ignore `doppler-token`/`pocket-doppler-token*`, and rewrites `scripts/systemd/secrets.env.example` to document the new recommended Doppler setup while noting the legacy `secrets.env` approach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db3ed0006d3046bbdfe026d3adb2c5048b5c1a9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced systemd service configurations to use token-based credential management for improved security.
  * Updated Git ignore patterns for better secret file handling.

* **Documentation**
  * Updated deployment documentation with dual-mode credential setup options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/314?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->