### PR TITLE
fix(pocket-watcher): health status=degraded when upstream Pocket search is down

### DIFF
--- a/claude-ops/scripts/ops-cron-pocket-watcher.py
+++ b/claude-ops/scripts/ops-cron-pocket-watcher.py
@@ -1154,7 +1154,19 @@ def main() -> int:
         giga_status = "failed"
     summary = f"recordings={new_memories} tasks={new_tasks} giga={giga_status}"
     pocket_search_state = "outage" if SEARCH_OUTAGE_MARKER.exists() else "ok"
-    write_health("ok", summary, extra={
+    # Overall watcher status reflects upstream Pocket search availability.
+    # When Pocket's search backend is down, the watcher itself is fine, but
+    # the pipeline is effectively blocked — dashboards/alerts should treat
+    # this as degraded, not green. `degraded` is intentionally distinct from
+    # `error` (which is reserved for watcher-internal failures like an MCP
+    # init crash or unrecoverable exception).
+    overall_status = "degraded" if pocket_search_state == "outage" else "ok"
+    overall_msg = (
+        f"{summary} (upstream Pocket search unavailable)"
+        if pocket_search_state == "outage"
+        else summary
+    )
+    write_health(overall_status, overall_msg, extra={
         "new_memories": new_memories,
         "new_tasks": new_tasks,
         "cursor": run_started if not cap_hit and not recordings_page_cap_hit else cursor,


### PR DESCRIPTION
## Summary
- Earlier change exposed `pocket_search:outage` in health JSON but kept overall `status:"ok"` → dashboards still looked green during outage
- Now: when search-outage-marker exists, status="degraded" + message tagged "(upstream Pocket search unavailable)"
- `degraded` distinct from `error` (reserved for watcher-internal failures)

## Test plan
- [x] py_compile + test-no-secrets
- [ ] live verify on EC2 that status flips degraded→ok when Pocket recovers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change limited to health status/message formatting, but it will change dashboards/alerting behavior during upstream Pocket search outages.
> 
> **Overview**
> Health reporting from `ops-cron-pocket-watcher.py` now reflects upstream Pocket search availability by setting overall `status` to `degraded` (and appending an outage note to the message) whenever the search outage marker is present, instead of always reporting `ok` while only exposing `pocket_search: outage` in the extra JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f799cf0335cd44651791aa5741c310455f238e2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->