### PR TITLE
fix(ops-daemon): default CLAUDE_PLUGIN_ROOT to prevent unbound-var crash

### DIFF
--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -20,6 +20,11 @@ fi
 # ── OS detection (sourced) ────────────────────────────────────────────────
 # Resolves to the claude-ops plugin root (parent of scripts/).
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# Default CLAUDE_PLUGIN_ROOT so service `command` strings that reference
+# `${CLAUDE_PLUGIN_ROOT}/...` (expanded via `eval echo` in start_service /
+# run_cron_service below) don't trip `set -u` when this daemon runs outside
+# a plugin context (e.g. directly via launchd/systemd on the host).
+export CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$SCRIPT_DIR}"
 # shellcheck disable=SC1091
 [ -r "$SCRIPT_DIR/lib/os-detect.sh" ] && . "$SCRIPT_DIR/lib/os-detect.sh"
 


### PR DESCRIPTION
## Summary
- The daemon tick was failing on every run with `CLAUDE_PLUGIN_ROOT: unbound variable` (line 504 in `run_cron_service`'s `eval echo "$cmd"`).
- Root cause: `set -u` + service commands that reference `${CLAUDE_PLUGIN_ROOT}/...` + the daemon being launched directly by launchd/systemd (no plugin entrypoint to set the var).
- Fix defaults `CLAUDE_PLUGIN_ROOT` to `SCRIPT_DIR` at script init (where it's already known), matching the defaulting pattern used at lines 642 and 801.

## Evidence
Local stderr `~/.claude/plugins/data/ops-ops-marketplace/logs/ops-daemon-stderr.log` showed:
```
ops/2.10.4/scripts/ops-daemon.sh: line 504: CLAUDE_PLUGIN_ROOT: unbound variable
```
firing every tick across 2.8.x → 2.10.4. `launchctl print` reported `last exit code = 1`.

## Test plan
- [x] `bash -n claude-ops/scripts/ops-daemon.sh` — syntax OK
- [x] `bash claude-ops/tests/test-no-secrets.sh` — 14 passed
- [ ] After merge + plugin upgrade, verify stderr log no longer contains "CLAUDE_PLUGIN_ROOT: unbound variable"
- [ ] `launchctl print gui/$(id -u)/com.claude-ops.daemon | grep "last exit"` shows `last exit code = 0`

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: sets a safe default for an environment variable to avoid `set -u` crashes when expanding service command strings; minimal behavioral impact beyond preventing premature daemon exits.
> 
> **Overview**
> Prevents `ops-daemon.sh` from crashing under `set -u` when launched outside the plugin entrypoint (e.g. `launchd`/`systemd`) by **defaulting and exporting** `CLAUDE_PLUGIN_ROOT` to the resolved `SCRIPT_DIR`.
> 
> This ensures service `command` strings that reference `${CLAUDE_PLUGIN_ROOT}/...` can be expanded safely via `eval echo` in `start_service`/`run_cron_service`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb78c5e40828d3521f4eea613202d5efd70e0f84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->