### PR TITLE
fix(ci): allowlist macOS daemon-name regex in ops-speedup (unblocks #317)

### DIFF
--- a/claude-ops/.gitleaks.toml
+++ b/claude-ops/.gitleaks.toml
@@ -18,6 +18,16 @@ id = "telegram-session-string"
 description = "Telegram Session String (gram.js)"
 regex = '''[A-Za-z0-9+/=]{100,}'''
 keywords = ["session", "StringSession", "TELEGRAM_SESSION"]
+[rules.allowlist]
+description = "macOS daemon-name pipe-separated regex strings in ops-speedup are not session secrets"
+regexes = [
+  '''bird/cloudd/akd''',
+  '''PROTECTED_RE=''',
+  '''MACOS_DEMOTE_RE=''',
+]
+paths = [
+  '''claude-ops/bin/ops-speedup$''',
+]
 [[rules]]
 id = "slack-xoxc-token"
 description = "Slack XOXC Token"


### PR DESCRIPTION
## Summary
Unblock PR #317's gitleaks check. The telegram-session-string rule false-positives on the pipe-separated macOS daemon-name regex in \`ops-speedup:327\` (\`bird/cloudd/akd/itunescloudd/...\`).

## Test plan
- [x] gitleaks rule now scoped to exclude the daemon list
- [ ] CI green
- [ ] Unblocks #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change; it slightly narrows secret scanning by allowlisting specific regex fragments in `claude-ops/bin/ops-speedup`, which could hide a real secret if it matched those exact patterns.
> 
> **Overview**
> Unblocks CI secret scanning by adding a **targeted allowlist** under the `telegram-session-string` gitleaks rule.
> 
> The allowlist is scoped to `claude-ops/bin/ops-speedup` and exempts specific daemon-name/variable patterns (e.g., `bird/cloudd/akd`, `PROTECTED_RE=`, `MACOS_DEMOTE_RE=`) that were being misidentified as Telegram session strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf92f55243934ccae71666b679d974b2848d6bab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->