### PR TITLE
feat(linux): systemd --user daemon installer + ops-doctor cross-platform fixes + pocket symlink-dependency fix

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.10.5",
+  "version": "2.11.0",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.11.0] — 2026-05-22
+
+First-class Linux parity for the background daemon, plus two cross-platform fixes that surfaced during Linux bring-up on Amazon Linux 2023.
+
+### Added
+
+- **`scripts/install-ops-daemon-linux.sh`** — idempotent Linux installer that mirrors `install-ops-daemon.sh` (macOS launchd). Provisions a `systemd --user` service, enables `loginctl` linger, fixes the cache-permission footgun (chowns `~/.claude/plugins/cache/` back to the invoking user when a prior `sudo` left it root-owned), validates `bash >= 4`, and supports `--dry-run` and `--uninstall`. WSL2 with `systemd=true` in `/etc/wsl.conf` uses the same path; WSL without systemd still gets the legacy `nohup` fallback.
+- **`scripts/systemd/claude-ops-daemon.service`** — unit template using `%h` for HOME, `Type=simple`, `Restart=on-failure (10s)`, `WantedBy=default.target`, env block that explicitly sets `CLAUDE_PLUGIN_ROOT` so the daemon and every child service it spawns resolve scripts even outside the user's interactive shell.
+
+### Changed
+
+- **`skills/setup/SKILL.md` Step 2c** — Linux branch no longer prints "out of scope / skipped"; it invokes `install-ops-daemon-linux.sh` and writes `daemon.platform = "linux-systemd"` to `$PREFS_PATH`. macOS launchd path unchanged.
+- **`scripts/systemd/install-systemd-units.sh` + 6 pocket unit templates** — replaced hard-coded `__HOME__/claude-ops/claude-ops/scripts/` with `__PLUGIN_ROOT__`, resolved at install time to the canonical install path. Eliminates the silent-failure mode where a missing `~/claude-ops` symlink froze all 4 pocket health files.
+
+### Fixed
+
+- **`bin/ops-doctor` GNU `stat` crash** — `_pocket_health_check` used `stat -f '%m' || stat -c '%Y'`. On GNU coreutils `-f` means *filesystem stat* (not BSD's *format string*), so the first invocation succeeds with multi-line FS info and the fallback never fires. `MTIME` then becomes a multi-line blob and `$(( NOW - MTIME ))` parses words like `File:` as variable names under `set -u`. Flipped to try `-c '%Y'` first and defensively trim `MTIME` to its first numeric token.
+- **`bin/ops-doctor` false-positive flood for `unconfigured_sensitive_keys`** — used to warn about every one of the ~29 `sensitive: true` user-config keys declared in `plugin.json` (Datadog, NewRelic, Pushover, ntfy, Discord bot, 7 shipping carriers, etc.), even when no MCP server or skill referenced them. Now: collects env-var names from every `.mcp.json` and `~/.claude.json` mcpServers env block, filters `SENSITIVE_KEYS` to only those actually used, and skips the rest silently.
+
+### Verified on
+
+- Amazon Linux 2023 (aarch64, kernel 6.1, systemd 252) — install, re-run idempotency, `--dry-run`, `--uninstall`, ops-doctor recovery, pocket health refresh, `tests/test-no-secrets.sh` (14/14 pass).
+- macOS launchd path unchanged (no regression touched).
+- WSL2 / Ubuntu / Fedora desktop — not yet exercised; please flag regressions.
+
 ## [2.9.1] — 2026-05-21
 
 Rule 7 compliance for `bin/ops-voice` **plus** a new `join` sub-command that auto-joins the current or next calendar meeting with smart AV defaults. Native open-paths now route through `lib/opener.sh::ops_open_url` so SSH/mobile sessions get a copy-able URL block instead of opening on the remote host.

--- a/claude-ops/bin/ops-doctor
+++ b/claude-ops/bin/ops-doctor
@@ -194,42 +194,63 @@ if [ -f "$PLUGIN_JSON" ] && command -v jq >/dev/null 2>&1; then
     fi
   done
   if [ ${#UNCONFIGURED_SENSITIVE[@]} -gt 0 ]; then
-    # Check if a separate working MCP server already provides the same functionality
-    # by scanning global MCP configs for a matching server name
-    _has_global_mcp_server() {
-      local server_name="$1"
-      for global_cfg in "$HOME/.claude/.mcp.json" "$HOME/.claude.json"; do
-        [ -f "$global_cfg" ] || continue
-        if jq -e ".mcpServers.\"$server_name\"" "$global_cfg" >/dev/null 2>&1; then
-          echo true; return
-        fi
-      done
-      # Also check if plugin cache copies provide a working server
-      for cache_mcp in "$HOME/.claude/plugins/cache"/*/ops/*/.mcp.json; do
-        [ -f "$cache_mcp" ] || continue
-        if jq -e ".mcpServers.\"$server_name\"" "$cache_mcp" >/dev/null 2>&1; then
-          echo true; return
-        fi
-      done
-      echo false
-    }
+    # Collect all env var names referenced by any MCP server across known config files.
+    # Only warn about keys that are actually referenced by an MCP server — keys for
+    # optional/unused integrations (shipping carriers, monitoring, etc.) are intentionally
+    # unconfigured and should not produce noise.
+    MCP_ENV_VARS=""
+    for mcp_cfg in "$MCP_JSON_FILE" "$HOME/.claude/.mcp.json" "$HOME/.claude.json" \
+                   "$HOME/.claude/plugins/cache"/*/ops/*/.mcp.json; do
+      [ -f "$mcp_cfg" ] || continue
+      VARS=$(jq -r '[.mcpServers // {} | to_entries[] | .value.env // {} | keys[]] | unique[]' \
+               "$mcp_cfg" 2>/dev/null || true)
+      MCP_ENV_VARS="$MCP_ENV_VARS $VARS"
+    done
 
-    # Determine which MCP servers the unconfigured keys belong to
-    ALL_COVERED_BY_GLOBAL=true
+    # Filter: only keep keys whose uppercase form appears in MCP env refs
+    MCP_REFERENCED_SENSITIVE=()
     for ukey in "${UNCONFIGURED_SENSITIVE[@]}"; do
-      # Extract server name from the key prefix (e.g. telegram_api_id -> telegram)
-      SERVER_PREFIX="${ukey%%_*}"
-      if [ "$(_has_global_mcp_server "$SERVER_PREFIX")" = false ]; then
-        ALL_COVERED_BY_GLOBAL=false
-        break
+      UPPER_KEY=$(echo "$ukey" | tr '[:lower:]' '[:upper:]')
+      if echo "$MCP_ENV_VARS" | grep -qw "$UPPER_KEY"; then
+        MCP_REFERENCED_SENSITIVE+=("$ukey")
       fi
     done
 
-    if [ "$ALL_COVERED_BY_GLOBAL" = true ]; then
-      INFO+=("unconfigured_sensitive_keys: Sensitive user config values not set in plugin: $(IFS=,; echo "${UNCONFIGURED_SENSITIVE[*]}"), but a separate working MCP server provides equivalent functionality.")
-    else
-      WARNINGS+=("unconfigured_sensitive_keys: Sensitive user config values not set: $(IFS=,; echo "${UNCONFIGURED_SENSITIVE[*]}"). MCP servers depending on these will fail. Run /ops:setup to configure.")
+    if [ ${#MCP_REFERENCED_SENSITIVE[@]} -gt 0 ]; then
+      # Check if a separate working MCP server already provides the same functionality
+      _has_global_mcp_server() {
+        local server_name="$1"
+        for global_cfg in "$HOME/.claude/.mcp.json" "$HOME/.claude.json"; do
+          [ -f "$global_cfg" ] || continue
+          if jq -e ".mcpServers.\"$server_name\"" "$global_cfg" >/dev/null 2>&1; then
+            echo true; return
+          fi
+        done
+        for cache_mcp in "$HOME/.claude/plugins/cache"/*/ops/*/.mcp.json; do
+          [ -f "$cache_mcp" ] || continue
+          if jq -e ".mcpServers.\"$server_name\"" "$cache_mcp" >/dev/null 2>&1; then
+            echo true; return
+          fi
+        done
+        echo false
+      }
+
+      ALL_COVERED_BY_GLOBAL=true
+      for ukey in "${MCP_REFERENCED_SENSITIVE[@]}"; do
+        SERVER_PREFIX="${ukey%%_*}"
+        if [ "$(_has_global_mcp_server "$SERVER_PREFIX")" = false ]; then
+          ALL_COVERED_BY_GLOBAL=false
+          break
+        fi
+      done
+
+      if [ "$ALL_COVERED_BY_GLOBAL" = true ]; then
+        INFO+=("unconfigured_sensitive_keys: Sensitive user config values not set in plugin: $(IFS=,; echo "${MCP_REFERENCED_SENSITIVE[*]}"), but a separate working MCP server provides equivalent functionality.")
+      else
+        WARNINGS+=("unconfigured_sensitive_keys: Sensitive user config values not set: $(IFS=,; echo "${MCP_REFERENCED_SENSITIVE[*]}"). MCP servers depending on these will fail. Run /ops:setup to configure.")
+      fi
     fi
+    # Keys with no MCP server reference are intentionally unconfigured — no warning emitted.
   fi
 fi
 
@@ -345,9 +366,17 @@ if [ "$POCKET_CONFIGURED" = true ]; then
       WARNINGS+=("pocket_health_missing_${svc}: $hf does not exist — service may not be running")
       return
     fi
-    # Staleness check (macOS stat -f or GNU stat -c)
+    # Staleness check (GNU stat -c on Linux, BSD stat -f on macOS).
+    # NOTE: order matters — `stat -f` on GNU coreutils means "filesystem stat" and
+    # *succeeds* with multi-line FS info instead of an mtime, which corrupts MTIME
+    # under `set -u` (the multi-line blob then trips $((NOW - MTIME)) on words like
+    # "File:"). Try GNU first; fall back to BSD; finally `echo 0` so MTIME is always
+    # a clean integer.
     if command -v stat >/dev/null 2>&1; then
-      MTIME=$(stat -f '%m' "$hf" 2>/dev/null || stat -c '%Y' "$hf" 2>/dev/null || echo 0)
+      MTIME=$(stat -c '%Y' "$hf" 2>/dev/null || stat -f '%m' "$hf" 2>/dev/null || echo 0)
+      # Defensive sanitize: keep only the first token if anything multi-line slipped through.
+      MTIME="${MTIME%%[!0-9]*}"
+      MTIME="${MTIME:-0}"
       AGE=$(( NOW - MTIME ))
       if [ "$AGE" -gt "$MAX_HEALTH_AGE" ]; then
         WARNINGS+=("pocket_health_stale_${svc}: $hf last written ${AGE}s ago (threshold: ${MAX_HEALTH_AGE}s)")

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.9.1",
+  "version": "2.11.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/claude-ops/scripts/install-ops-daemon-linux.sh
+++ b/claude-ops/scripts/install-ops-daemon-linux.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# Linux equivalent of scripts/install-ops-daemon.sh (which is launchd/macOS-only).
+#
+# Installs the claude-ops background daemon as a `systemd --user` service so it
+# survives logout and reboot. Idempotent: re-running re-bootstraps cleanly.
+#
+# Requires:
+#   - systemd (any modern Linux distro: Amazon Linux 2023, Ubuntu, Fedora, etc.)
+#   - bash >= 4 (for the daemon script itself)
+#   - sudo access (only used for `loginctl enable-linger`, nothing else)
+#
+# Idempotency:
+#   - If the unit file is already installed, contents are diffed and re-written only on change.
+#   - `daemon-reload` is always safe.
+#   - `enable --now` is a no-op if the service is already running.
+#
+# Cache-permission guard:
+#   The daemon needs to mkdir into ~/.claude/plugins/cache/ — if that dir is
+#   owned by root (from a prior sudo run), the daemon crash-loops with EACCES.
+#   We chown it back to the invoking user before starting.
+#
+# Usage:
+#   bash install-ops-daemon-linux.sh
+#   bash install-ops-daemon-linux.sh --dry-run    # show what would change
+#   bash install-ops-daemon-linux.sh --uninstall  # stop + disable + remove unit
+#
+set -euo pipefail
+
+UNIT_NAME="claude-ops-daemon.service"
+USER_UNIT_DIR="$HOME/.config/systemd/user"
+UNIT_DST="$USER_UNIT_DIR/$UNIT_NAME"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UNIT_SRC="$SCRIPT_DIR/systemd/claude-ops-daemon.service"
+
+DRY_RUN=false
+UNINSTALL=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)   DRY_RUN=true ;;
+    --uninstall) UNINSTALL=true ;;
+    -h|--help)   sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "unknown flag: $arg" >&2; exit 64 ;;
+  esac
+done
+
+log()  { printf '%s\n' "$*"; }
+die()  { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+run()  { if $DRY_RUN; then printf '  DRY: %s\n' "$*"; else eval "$@"; fi; }
+
+# --- Platform gate ----------------------------------------------------------
+case "$(uname -s)" in
+  Linux) : ;;
+  *)     die "this installer is Linux-only. macOS users: run scripts/install-ops-daemon.sh" ;;
+esac
+command -v systemctl >/dev/null 2>&1 || die "systemctl not found — this installer requires systemd"
+
+# --- Uninstall path ---------------------------------------------------------
+if $UNINSTALL; then
+  log "Uninstalling claude-ops daemon"
+  run "systemctl --user disable --now $UNIT_NAME 2>/dev/null || true"
+  run "rm -f '$UNIT_DST'"
+  run "systemctl --user daemon-reload"
+  log "✓ Uninstalled. (linger was NOT disabled — run 'sudo loginctl disable-linger \$USER' if no other user services need it.)"
+  exit 0
+fi
+
+# --- Sanity checks ----------------------------------------------------------
+[ -f "$UNIT_SRC" ] || die "unit template missing: $UNIT_SRC"
+DAEMON_SCRIPT="$HOME/.claude/plugins/marketplaces/ops-marketplace/claude-ops/scripts/ops-daemon.sh"
+[ -f "$DAEMON_SCRIPT" ] || die "daemon script missing: $DAEMON_SCRIPT"
+
+BASH_VER="${BASH_VERSINFO[0]}"
+[ "$BASH_VER" -ge 4 ] || die "ops-daemon.sh requires bash >= 4 (have $BASH_VER)"
+
+# --- Cache-perms guard (the #1 install-time footgun) ------------------------
+CACHE_DIR="$HOME/.claude/plugins/cache"
+if [ -d "$CACHE_DIR" ]; then
+  OWNER=$(stat -c '%U' "$CACHE_DIR" 2>/dev/null || echo unknown)
+  if [ "$OWNER" != "$USER" ]; then
+    log "⚠ $CACHE_DIR is owned by $OWNER (not $USER). The daemon will crash-loop on EACCES."
+    log "  Fixing: sudo chown -R $USER:$USER '$CACHE_DIR'"
+    run "sudo chown -R '$USER':'$USER' '$CACHE_DIR'"
+  fi
+fi
+
+# --- Unit file install ------------------------------------------------------
+mkdir -p "$USER_UNIT_DIR"
+if [ -f "$UNIT_DST" ] && diff -q "$UNIT_SRC" "$UNIT_DST" >/dev/null 2>&1; then
+  log "✓ Unit file unchanged: $UNIT_DST"
+else
+  log "Installing unit: $UNIT_DST"
+  run "cp '$UNIT_SRC' '$UNIT_DST'"
+fi
+
+# --- Linger (so the daemon survives logout) ---------------------------------
+LINGER=$(loginctl show-user "$USER" 2>/dev/null | grep -E '^Linger=' | cut -d= -f2 || echo no)
+if [ "$LINGER" != "yes" ]; then
+  log "Enabling linger so the daemon survives logout"
+  run "sudo loginctl enable-linger '$USER'"
+fi
+
+# --- Reload + enable --------------------------------------------------------
+run "systemctl --user daemon-reload"
+run "systemctl --user enable --now $UNIT_NAME"
+
+# --- Verify -----------------------------------------------------------------
+if $DRY_RUN; then
+  log "✓ Dry-run complete."
+  exit 0
+fi
+
+sleep 2
+if systemctl --user is-active --quiet "$UNIT_NAME"; then
+  PID=$(systemctl --user show -p MainPID --value "$UNIT_NAME")
+  log "✓ claude-ops daemon active (PID $PID)"
+  log "  Logs:    journalctl --user -u $UNIT_NAME -f"
+  log "  Status:  systemctl --user status $UNIT_NAME"
+  log "  Health:  cat ~/.claude/plugins/data/ops-ops-marketplace/daemon-health.json | jq ."
+else
+  log "✗ daemon failed to start. Check logs:"
+  log "    journalctl --user -u $UNIT_NAME -n 50 --no-pager"
+  exit 1
+fi

--- a/claude-ops/scripts/install-ops-daemon-linux.sh
+++ b/claude-ops/scripts/install-ops-daemon-linux.sh
@@ -86,7 +86,7 @@ if [ -d "$CACHE_DIR" ]; then
 fi
 
 # --- Unit file install ------------------------------------------------------
-mkdir -p "$USER_UNIT_DIR"
+run "mkdir -p '$USER_UNIT_DIR'"
 if [ -f "$UNIT_DST" ] && diff -q "$UNIT_SRC" "$UNIT_DST" >/dev/null 2>&1; then
   log "✓ Unit file unchanged: $UNIT_DST"
 else

--- a/claude-ops/scripts/systemd/claude-ops-daemon.service
+++ b/claude-ops/scripts/systemd/claude-ops-daemon.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=claude-ops background daemon (briefing pre-warm, memory extraction, message listener, health monitors)
+Documentation=https://github.com/Lifecycle-Innovations-Limited/claude-ops/blob/main/claude-ops/docs/daemon-guide.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h
+Environment=HOME=%h
+Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
+# CLAUDE_PLUGIN_ROOT is read by ops-daemon.sh and the services it spawns.
+# Override at install time if your marketplace dir lives elsewhere.
+Environment=CLAUDE_PLUGIN_ROOT=%h/.claude/plugins/marketplaces/ops-marketplace/claude-ops
+ExecStart=/bin/bash %h/.claude/plugins/marketplaces/ops-marketplace/claude-ops/scripts/ops-daemon.sh
+Restart=on-failure
+RestartSec=10
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/claude-ops/scripts/systemd/install-systemd-units.sh
+++ b/claude-ops/scripts/systemd/install-systemd-units.sh
@@ -25,7 +25,19 @@ fi
 TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
 TAILSCALE_USER="${TAILSCALE_USER:-$TARGET_USER}"
 
-echo "Installing pocket systemd units for user=$TARGET_USER home=$TARGET_HOME"
+# Canonical plugin root — avoids dependency on the ~/claude-ops symlink, which
+# can drop during plugin reinstalls/upgrades and silently break every pocket
+# timer (each tick raises "No such file or directory" → no health write →
+# ops-doctor flags pocket_health_stale_*). Hard-anchor to the marketplace path.
+PLUGIN_ROOT_DEFAULT="$TARGET_HOME/.claude/plugins/marketplaces/ops-marketplace/claude-ops"
+PLUGIN_ROOT="${PLUGIN_ROOT:-$PLUGIN_ROOT_DEFAULT}"
+if [[ ! -d "$PLUGIN_ROOT/scripts" ]]; then
+  echo "ERROR: PLUGIN_ROOT=$PLUGIN_ROOT/scripts does not exist." >&2
+  echo "       Pass PLUGIN_ROOT=<path-to-claude-ops> as env if the plugin is installed elsewhere." >&2
+  exit 1
+fi
+
+echo "Installing pocket systemd units for user=$TARGET_USER home=$TARGET_HOME plugin_root=$PLUGIN_ROOT"
 
 # ── Copy + substitute units ──────────────────────────────────────────────────
 UNITS=(
@@ -59,6 +71,7 @@ for unit in "${UNITS[@]}"; do
     -e "s|__USER__|$TARGET_USER|g" \
     -e "s|__HOME__|$TARGET_HOME|g" \
     -e "s|__TAILSCALE_USER__|$TAILSCALE_USER|g" \
+    -e "s|__PLUGIN_ROOT__|$PLUGIN_ROOT|g" \
     "$src" > "$dest"
   chmod 644 "$dest"
   echo "  installed $dest"

--- a/claude-ops/scripts/systemd/pocket-activity-notifier.service
+++ b/claude-ops/scripts/systemd/pocket-activity-notifier.service
@@ -9,6 +9,6 @@ WorkingDirectory=__HOME__
 Environment=HOME=__HOME__
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
 Environment=POCKET_STATE_DIR=__HOME__/.claude/state/pocket
-ExecStart=__HOME__/.venv-pocket/bin/python3 __HOME__/claude-ops/claude-ops/scripts/ops-pocket-activity-notifier.py
+ExecStart=__HOME__/.venv-pocket/bin/python3 __PLUGIN_ROOT__/scripts/ops-pocket-activity-notifier.py
 StandardOutput=append:__HOME__/.claude/state/pocket/activity-notifier.stdout.log
 StandardError=append:__HOME__/.claude/state/pocket/activity-notifier.stderr.log

--- a/claude-ops/scripts/systemd/pocket-email-bridge.service
+++ b/claude-ops/scripts/systemd/pocket-email-bridge.service
@@ -18,6 +18,6 @@ Environment=HOME=__HOME__
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
 Environment=POCKET_STATE_DIR=__HOME__/.claude/state/pocket
 Environment=GOG_BIN=/usr/local/bin/gog
-ExecStart=/bin/bash -c 'DOPPLER_TOKEN=$(cat $CREDENTIALS_DIRECTORY/doppler-token) /usr/local/bin/doppler run --silent -- __HOME__/.venv-pocket/bin/python3 __HOME__/claude-ops/claude-ops/scripts/ops-pocket-email-bridge.py'
+ExecStart=/bin/bash -c 'DOPPLER_TOKEN=$(cat $CREDENTIALS_DIRECTORY/doppler-token) /usr/local/bin/doppler run --silent -- __HOME__/.venv-pocket/bin/python3 __PLUGIN_ROOT__/scripts/ops-pocket-email-bridge.py'
 StandardOutput=append:__HOME__/.claude/state/pocket/email-bridge.log
 StandardError=append:__HOME__/.claude/state/pocket/email-bridge-stderr.log

--- a/claude-ops/scripts/systemd/pocket-executor.service
+++ b/claude-ops/scripts/systemd/pocket-executor.service
@@ -15,7 +15,7 @@ Environment=POCKET_EXEC_CWD=__HOME__
 Environment=POCKET_MAX_CONCURRENT=3
 Environment=POCKET_WORKER_MODEL=claude-sonnet-4-6
 Environment=POCKET_WORKER_TIMEOUT=1800
-ExecStart=__HOME__/.venv-pocket/bin/python3 __HOME__/claude-ops/claude-ops/scripts/ops-cron-pocket-executor.py
+ExecStart=__HOME__/.venv-pocket/bin/python3 __PLUGIN_ROOT__/scripts/ops-cron-pocket-executor.py
 StandardOutput=append:__HOME__/.claude/state/pocket/executor-stdout.log
 StandardError=append:__HOME__/.claude/state/pocket/executor-stderr.log
 # v3 requires this: workers are claude -p subprocesses that must outlive

--- a/claude-ops/scripts/systemd/pocket-out-queue.service
+++ b/claude-ops/scripts/systemd/pocket-out-queue.service
@@ -10,6 +10,6 @@ Environment=HOME=__HOME__
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
 Environment=POCKET_STATE_DIR=__HOME__/.claude/state/pocket
 Environment=WHATSAPP_BRIDGE_URL=http://localhost:8080/api/send
-ExecStart=__HOME__/.venv-pocket/bin/python3 __HOME__/claude-ops/claude-ops/scripts/ops-pocket-out-queue.py
+ExecStart=__HOME__/.venv-pocket/bin/python3 __PLUGIN_ROOT__/scripts/ops-pocket-out-queue.py
 StandardOutput=append:__HOME__/.claude/state/pocket/out-queue.log
 StandardError=append:__HOME__/.claude/state/pocket/out-queue-stderr.log

--- a/claude-ops/scripts/systemd/pocket-watcher.service
+++ b/claude-ops/scripts/systemd/pocket-watcher.service
@@ -30,6 +30,6 @@ Environment=POCKET_LOOKBACK_HOURS=24
 Environment=GIGA_SYNC=1
 Environment=GIGA_MIND=global
 Environment=GIGA_CONSOLIDATE=1
-ExecStart=/bin/bash -c 'DOPPLER_TOKEN=$(cat $CREDENTIALS_DIRECTORY/doppler-token) /usr/local/bin/doppler run --silent -- __HOME__/.venv-pocket/bin/python3 __HOME__/claude-ops/claude-ops/scripts/ops-cron-pocket-watcher.py'
+ExecStart=/bin/bash -c 'DOPPLER_TOKEN=$(cat $CREDENTIALS_DIRECTORY/doppler-token) /usr/local/bin/doppler run --silent -- __HOME__/.venv-pocket/bin/python3 __PLUGIN_ROOT__/scripts/ops-cron-pocket-watcher.py'
 StandardOutput=append:__HOME__/.claude/state/pocket/watcher-stdout.log
 StandardError=append:__HOME__/.claude/state/pocket/watcher-stderr.log

--- a/claude-ops/scripts/systemd/pocket-whatsapp-bridge.service
+++ b/claude-ops/scripts/systemd/pocket-whatsapp-bridge.service
@@ -10,6 +10,6 @@ Environment=HOME=__HOME__
 Environment=PATH=/usr/local/bin:/usr/bin:/bin
 Environment=POCKET_STATE_DIR=__HOME__/.claude/state/pocket
 Environment=POCKET_WHATSAPP_DB=__HOME__/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db
-ExecStart=__HOME__/.venv-pocket/bin/python3 __HOME__/claude-ops/claude-ops/scripts/ops-pocket-whatsapp-bridge.py
+ExecStart=__HOME__/.venv-pocket/bin/python3 __PLUGIN_ROOT__/scripts/ops-pocket-whatsapp-bridge.py
 StandardOutput=append:__HOME__/.claude/state/pocket/whatsapp-bridge.log
 StandardError=append:__HOME__/.claude/state/pocket/whatsapp-bridge-stderr.log

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -414,14 +414,24 @@ esac
 ```
 
 - **macOS** (`OS=macos`): proceed with the full `launchctl bootstrap` flow below.
-- **Linux / WSL** (`OS=linux|wsl`): `launchctl` is not available. The daemon script (`${CLAUDE_PLUGIN_ROOT}/scripts/ops-daemon.sh`) runs fine under `bash`, but installing it as a user service requires `systemd --user` (Linux) or a custom cron/at wrapper (WSL). That work is **out of scope for this patch** — track as future work. For now, print:
+- **Linux** (`OS=linux`): use the bundled `systemd --user` installer. Run (RULE ZERO — `run_in_background: true`):
+
+  ```bash
+  bash ${CLAUDE_PLUGIN_ROOT}/scripts/install-ops-daemon-linux.sh
+  ```
+
+  > Generates `~/.config/systemd/user/claude-ops-daemon.service` from `scripts/systemd/claude-ops-daemon.service`, enables linger (so the daemon survives logout), chowns `~/.claude/plugins/cache/` back to the user if it was left root-owned by a prior `sudo` run, then `daemon-reload + enable --now`. Idempotent. See `scripts/install-ops-daemon-linux.sh --help` for `--dry-run` and `--uninstall`.
+
+  Write `daemon.enabled = true`, `daemon.installed_at_step = "2c"`, `daemon.platform = "linux-systemd"` to `$PREFS_PATH` and continue immediately to Step 3 — health verification is deferred to Step 5b.
+
+- **WSL** (`OS=wsl`): `systemd --user` works on WSL2 with `systemd=true` in `/etc/wsl.conf`. If `systemctl --user status` succeeds, run the Linux installer above. Otherwise fall back to:
 
   ```
-  ○ Background daemon — skipped (Linux/WSL install via systemd --user is pending; see docs/daemon-guide.md).
-    You can still launch it manually with:  nohup ${CLAUDE_PLUGIN_ROOT}/scripts/ops-daemon.sh &
+  ○ Background daemon — skipped (WSL without systemd). Launch manually with:
+    nohup ${CLAUDE_PLUGIN_ROOT}/scripts/ops-daemon.sh > /tmp/ops-daemon.log 2>&1 &
   ```
 
-  Write `daemon.enabled = false` and `daemon.skip_reason = "platform:<os>"` to `$PREFS_PATH` and continue to Step 3.
+  Write `daemon.enabled = false` and `daemon.skip_reason = "platform:wsl-no-systemd"` to `$PREFS_PATH` and continue.
 - **Windows** (native, `OS=windows`): the daemon is **not installed**. Print `○ Background daemon — not supported on native Windows. Use WSL or run ops-daemon.sh manually.` and continue.
 
 If `OS=macos`, check whether the daemon is already installed:


### PR DESCRIPTION
## Summary

Brings claude-ops to first-class Linux parity by closing three gaps surfaced while bootstrapping on Amazon Linux 2023 (aarch64, systemd 252). Three independent fixes bundled because the second + third only became visible after the first landed.

### 1. `feat(systemd)` — Linux daemon installer

The setup wizard previously stubbed Step 2c on Linux with `"Background daemon — skipped (Linux/WSL install via systemd --user is pending; out of scope for this patch)"`. This PR ships the missing piece.

- **`scripts/systemd/claude-ops-daemon.service`** — unit template using `%h` for HOME, `Type=simple`, `Restart=on-failure (10s)`, `WantedBy=default.target`, env block sets `CLAUDE_PLUGIN_ROOT`.
- **`scripts/install-ops-daemon-linux.sh`** — idempotent installer with platform gate, cache-perms guard (chowns `~/.claude/plugins/cache/` back to user if a prior sudo left it root-owned — the #1 footgun), `loginctl enable-linger`, `--dry-run` and `--uninstall`.
- **`skills/setup/SKILL.md` Step 2c** — replaces skip-stub with real flow; WSL2 w/ systemd uses same path.

### 2. `fix(ops-doctor)` — make Linux-compatible

`/ops-doctor` crashed on every Linux box with `line 351: File: unbound variable`.

- **GNU stat order**: `stat -f '%m'` on GNU coreutils means *filesystem stat* (succeeds with multi-line FS info, never falls through to `-c '%Y'`). Flipped to try `-c` first; defensively trim `MTIME` to first numeric token.
- **Sensitive-keys flood fix**: was warning about all 29 `sensitive: true` user-config keys. Now only warns for keys actually referenced in an MCP server's env block.

### 3. `fix(systemd-pocket)` — drop fragile `~/claude-ops` symlink dependency

Pocket unit templates hard-coded `__HOME__/claude-ops/claude-ops/scripts/`, depending on a non-plugin-managed symlink. When missing, all 4 pocket health files silently froze. Now use `__PLUGIN_ROOT__` resolved by `install-systemd-units.sh` to the canonical install path.

## Test plan

- [x] `bash install-ops-daemon-linux.sh` on Amazon Linux 2023 (aarch64, kernel 6.1, systemd 252) → daemon active in 10s, all 5 services in health report.
- [x] Re-run → idempotent.
- [x] `--dry-run` → no changes.
- [x] `--uninstall` → clean removal.
- [x] `ops-doctor` no longer crashes; `unconfigured_sensitive_keys` warning gone.
- [x] Pocket health files refresh within 60s after install.
- [x] `tests/test-no-secrets.sh` → 14/14 pass.
- [ ] WSL2 / Ubuntu / Fedora desktop — not yet exercised, please flag regressions.

## Notes

- Per Plugin Rule 0 (public repo): all paths use `$HOME` / `~`, no PII, no real org/store/email values.
- Per Plugin Rule 4: macOS launchd path unchanged.
- Per Plugin Rule 5: installer non-destructive. Only `sudo` uses are `loginctl enable-linger` and the cache-perms `chown -R` rescue (only triggers when needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a Linux `systemd --user` installer that uses `sudo` for `loginctl enable-linger` and potential cache `chown`, and rewires systemd unit paths; misconfiguration could impact daemon/service startup on Linux environments.
> 
> **Overview**
> Delivers **first-class Linux daemon support** by adding `scripts/install-ops-daemon-linux.sh` plus a `systemd --user` unit (`scripts/systemd/claude-ops-daemon.service`), and updates the setup wizard docs to install the daemon on Linux (with WSL fallback guidance).
> 
> Hardens `bin/ops-doctor` for cross-platform use by fixing GNU/BSD `stat` handling in pocket health staleness checks and by reducing noisy `unconfigured_sensitive_keys` warnings to only keys actually referenced by MCP server env blocks.
> 
> Fixes **pocket systemd unit reliability** by removing the fragile `~/claude-ops` symlink dependency: `install-systemd-units.sh` now substitutes a resolved `__PLUGIN_ROOT__` into pocket unit templates. Version bumps to `2.11.0` and adds release notes in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc3bfb7090746bbae16a1b9ead46e7a752624c2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated Linux background daemon installer with systemd user support; setup wizard now auto-installs on Linux/WSL when available.

* **Bug Fixes**
  * Fixed pocket health staleness calculation to handle platform differences in diagnostic tools.
  * Reduced noisy warnings by only flagging sensitive keys that are actually referenced.

* **Chores**
  * Standardized service script paths and updated package/plugin versioning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->