### PR TITLE
feat(ops-merge): Phase 0 salvage — find & finish all loose local work before PR merge

### DIFF
--- a/claude-ops/bin/ops-merge-salvage-scan
+++ b/claude-ops/bin/ops-merge-salvage-scan
@@ -141,7 +141,7 @@ scan_repo() {
           wt_dirty=$(git -C "$wt_path" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
           wt_unpushed=0
           if [ "$wt_branch" != "DETACHED" ] && [ -n "$wt_branch" ]; then
-            wt_unpushed=$(git -C "$wt_path" log "origin/$integration_branch..HEAD" --oneline 2>/dev/null | wc -l | tr -d ' ' || echo 0)
+            wt_unpushed=$(git -C "$wt_path" log '@{u}..' --oneline 2>/dev/null | wc -l | tr -d ' ' || echo 0)
             wt_pr=$(gh pr list --repo "$repo_slug" --head "$wt_branch" --state open --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
             [ -n "$wt_pr" ] && wt_has_pr="true" || wt_has_pr="false"
           else
@@ -166,14 +166,14 @@ scan_repo() {
   # --- Salvage classification ---------------------------------------------
   # A repo has "salvage work" if ANY of:
   #   - dirty/staged/stashed > 0 in main checkout
-  #   - any local feature branch with integrated=false (not yet on integration branch)
+  #   - any local feature branch without an open PR (branch-no-pr or branch-already-merged)
   #   - any worktree with dirty or unpushed > 0 or branch without open PR
   #   - unpushed > 0 on current branch
   local has_salvage="false"
   if [ "$dirty" -gt 0 ] || [ "$staged" -gt 0 ] || [ "$stashed" -gt 0 ] || [ "$unpushed" -gt 0 ]; then
     has_salvage="true"
   fi
-  if [ "$(echo "$BRANCHES_JSON" | jq '[.[] | select(.integrated == false)] | length')" -gt 0 ]; then
+  if [ "$(echo "$BRANCHES_JSON" | jq '[.[] | select(.has_open_pr == false)] | length')" -gt 0 ]; then
     has_salvage="true"
   fi
   if [ "$(echo "$WORKTREES_JSON" | jq '[.[] | select(.dirty_files > 0 or .unpushed_commits > 0 or .has_open_pr == false)] | length')" -gt 0 ]; then
@@ -210,8 +210,10 @@ scan_repo() {
 }
 
 # Iterate projects → repos in parallel (cap at 8 simultaneous git fetches).
+# Use process substitution so the loop runs in the main shell; a pipeline would
+# subshell the while-loop and orphan background jobs from the final wait.
 SEM=0
-echo "$PROJECTS_JSON" | jq -c '.[]' | while read -r project; do
+while IFS= read -r project; do
   PROJECT_PATH=$(echo "$project" | jq -r '.path // empty')
   REPOS=$(echo "$project" | jq -r '.repos[]? // empty')
   [ -z "$REPOS" ] && continue
@@ -239,7 +241,7 @@ echo "$PROJECTS_JSON" | jq -c '.[]' | while read -r project; do
       SEM=0
     fi
   done
-done
+done < <(echo "$PROJECTS_JSON" | jq -c '.[]')
 wait
 
 # Assemble final document

--- a/claude-ops/bin/ops-merge-salvage-scan
+++ b/claude-ops/bin/ops-merge-salvage-scan
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# ops-merge-salvage-scan — Inventory local work NOT yet on dev/main and NOT in an open PR.
+# Surfaces orphan worktrees, feature branches without PRs, uncommitted/staged/stashed work,
+# and unpushed commits across every repo in the project registry.
+#
+# Output: single JSON document consumed by /ops:merge Phase 0 (Salvage).
+# Used by /ops:merge to find and finish all loose local work BEFORE the PR merge pipeline runs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR="${CLAUDE_PLUGIN_ROOT:-${SCRIPT_DIR}/..}"
+OPS_PLUGIN_ROOT_FALLBACK="$PLUGIN_DIR" . "${PLUGIN_DIR}/lib/registry-path.sh"
+
+FILTER_REPO="${1:-}"
+
+if [ ! -f "$REGISTRY" ]; then
+  echo '{"error":"registry.json not found","repos":[]}' && exit 1
+fi
+
+if ! command -v gh &>/dev/null; then
+  echo '{"error":"gh CLI not found","repos":[]}' && exit 0
+fi
+
+# Walk every project in the registry. Each project entry should have a local
+# `path` field (the checkout root) and a `repos` array (owner/name slugs).
+# We pair them up; if a project has multiple repos we trust the path is the
+# parent that contains each as a subdir.
+PROJECTS_JSON=$(jq -c '.projects // []' "$REGISTRY")
+
+TMPDIR_OPS=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_OPS"' EXIT
+
+scan_repo() {
+  local repo_slug="$1"      # owner/name
+  local repo_path="$2"      # absolute path to working tree
+  local safe_name
+  safe_name=$(echo "$repo_slug" | tr '/' '_')
+
+  if [ ! -d "$repo_path/.git" ] && [ ! -f "$repo_path/.git" ]; then
+    return 0
+  fi
+
+  # --- Working tree state -------------------------------------------------
+  local current_branch dirty staged stashed unpushed ahead behind
+  current_branch=$(git -C "$repo_path" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "DETACHED")
+  dirty=$(git -C "$repo_path" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+  staged=$(git -C "$repo_path" diff --cached --name-only 2>/dev/null | wc -l | tr -d ' ')
+  stashed=$(git -C "$repo_path" stash list 2>/dev/null | wc -l | tr -d ' ')
+
+  # Fetch quietly so ahead/behind are accurate. Skip on failure (offline / no remote).
+  git -C "$repo_path" fetch --quiet origin 2>/dev/null || true
+
+  # Detect default integration branches (dev preferred, fallback main/master).
+  local has_dev has_main integration_branch
+  has_dev=$(git -C "$repo_path" rev-parse --verify --quiet origin/dev >/dev/null 2>&1 && echo "true" || echo "false")
+  has_main=$(git -C "$repo_path" rev-parse --verify --quiet origin/main >/dev/null 2>&1 && echo "true" || echo "false")
+  if [ "$has_dev" = "true" ]; then
+    integration_branch="dev"
+  elif [ "$has_main" = "true" ]; then
+    integration_branch="main"
+  else
+    integration_branch=$(git -C "$repo_path" rev-parse --abbrev-ref --symbolic-full-name 'HEAD@{upstream}' 2>/dev/null | sed 's|^origin/||' || echo "main")
+  fi
+
+  # Unpushed commits on current branch (relative to its upstream, if any).
+  unpushed=$(git -C "$repo_path" log '@{u}..' --oneline 2>/dev/null | wc -l | tr -d ' ' || echo 0)
+
+  # --- Local branches not on integration branch ---------------------------
+  # Branches whose tip is NOT an ancestor of origin/<integration_branch> AND
+  # which differ from main/dev/master themselves.
+  local LOCAL_BRANCHES BRANCHES_JSON
+  LOCAL_BRANCHES=$(git -C "$repo_path" for-each-ref --format='%(refname:short)' refs/heads/ 2>/dev/null)
+  BRANCHES_JSON="[]"
+  if [ -n "$LOCAL_BRANCHES" ]; then
+    BRANCHES_JSON=$(
+      while IFS= read -r br; do
+        [ -z "$br" ] && continue
+        case "$br" in dev|main|master) continue ;; esac
+
+        local tip integrated has_remote has_pr pr_number ahead_int
+        tip=$(git -C "$repo_path" rev-parse "$br" 2>/dev/null || echo "")
+        [ -z "$tip" ] && continue
+
+        if git -C "$repo_path" merge-base --is-ancestor "$tip" "origin/$integration_branch" 2>/dev/null; then
+          integrated="true"
+        else
+          integrated="false"
+        fi
+
+        # Is the branch pushed to origin?
+        if git -C "$repo_path" rev-parse --verify --quiet "origin/$br" >/dev/null 2>&1; then
+          has_remote="true"
+        else
+          has_remote="false"
+        fi
+
+        # Open PR for this branch? (cheap check via gh — already authed).
+        pr_number=$(gh pr list --repo "$repo_slug" --head "$br" --state open --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+        if [ -n "$pr_number" ]; then
+          has_pr="true"
+        else
+          has_pr="false"
+        fi
+
+        ahead_int=$(git -C "$repo_path" rev-list --count "origin/$integration_branch..$br" 2>/dev/null || echo 0)
+
+        jq -n \
+          --arg name "$br" \
+          --arg tip "$tip" \
+          --argjson integrated "$integrated" \
+          --argjson has_remote "$has_remote" \
+          --argjson has_pr "$has_pr" \
+          --arg pr "$pr_number" \
+          --argjson ahead "$ahead_int" \
+          '{name:$name,tip:$tip,integrated:$integrated,pushed:$has_remote,has_open_pr:$has_pr,pr_number:($pr|tonumber? // null),commits_ahead_of_integration:$ahead}'
+      done <<< "$LOCAL_BRANCHES" | jq -s '.'
+    )
+  fi
+
+  # --- Worktrees ----------------------------------------------------------
+  # `git worktree list --porcelain` blocks of:
+  #   worktree <path>
+  #   HEAD <sha>
+  #   branch refs/heads/<name>  (or "detached")
+  local WORKTREES_JSON
+  WORKTREES_JSON=$(
+    git -C "$repo_path" worktree list --porcelain 2>/dev/null \
+      | awk 'BEGIN{path="";sha="";branch=""}
+             /^worktree /{if(path!=""){print path"|"sha"|"branch}; path=substr($0,10); sha=""; branch=""}
+             /^HEAD /{sha=substr($0,6)}
+             /^branch /{branch=substr($0,8); sub("refs/heads/","",branch)}
+             /^detached/{branch="DETACHED"}
+             END{if(path!=""){print path"|"sha"|"branch}}' \
+      | while IFS='|' read -r wt_path wt_sha wt_branch; do
+          [ -z "$wt_path" ] && continue
+          # Skip the primary working tree (we report it separately as repo state).
+          if [ "$wt_path" = "$repo_path" ]; then continue; fi
+
+          local wt_dirty wt_unpushed wt_has_pr wt_pr
+          wt_dirty=$(git -C "$wt_path" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+          wt_unpushed=0
+          if [ "$wt_branch" != "DETACHED" ] && [ -n "$wt_branch" ]; then
+            wt_unpushed=$(git -C "$wt_path" log "origin/$integration_branch..HEAD" --oneline 2>/dev/null | wc -l | tr -d ' ' || echo 0)
+            wt_pr=$(gh pr list --repo "$repo_slug" --head "$wt_branch" --state open --json number --jq '.[0].number // empty' 2>/dev/null || echo "")
+            [ -n "$wt_pr" ] && wt_has_pr="true" || wt_has_pr="false"
+          else
+            wt_has_pr="false"
+            wt_pr=""
+          fi
+
+          jq -n \
+            --arg path "$wt_path" \
+            --arg sha "$wt_sha" \
+            --arg branch "$wt_branch" \
+            --argjson dirty "$wt_dirty" \
+            --argjson unpushed "$wt_unpushed" \
+            --argjson has_pr "$wt_has_pr" \
+            --arg pr "$wt_pr" \
+            '{path:$path,sha:$sha,branch:$branch,dirty_files:$dirty,unpushed_commits:$unpushed,has_open_pr:$has_pr,pr_number:($pr|tonumber? // null)}'
+        done \
+      | jq -s '.'
+  )
+  [ -z "$WORKTREES_JSON" ] && WORKTREES_JSON="[]"
+
+  # --- Salvage classification ---------------------------------------------
+  # A repo has "salvage work" if ANY of:
+  #   - dirty/staged/stashed > 0 in main checkout
+  #   - any local feature branch with integrated=false (not yet on integration branch)
+  #   - any worktree with dirty or unpushed > 0 or branch without open PR
+  #   - unpushed > 0 on current branch
+  local has_salvage="false"
+  if [ "$dirty" -gt 0 ] || [ "$staged" -gt 0 ] || [ "$stashed" -gt 0 ] || [ "$unpushed" -gt 0 ]; then
+    has_salvage="true"
+  fi
+  if [ "$(echo "$BRANCHES_JSON" | jq '[.[] | select(.integrated == false)] | length')" -gt 0 ]; then
+    has_salvage="true"
+  fi
+  if [ "$(echo "$WORKTREES_JSON" | jq '[.[] | select(.dirty_files > 0 or .unpushed_commits > 0 or .has_open_pr == false)] | length')" -gt 0 ]; then
+    has_salvage="true"
+  fi
+
+  jq -n \
+    --arg repo "$repo_slug" \
+    --arg path "$repo_path" \
+    --arg branch "$current_branch" \
+    --arg integration "$integration_branch" \
+    --argjson dirty "$dirty" \
+    --argjson staged "$staged" \
+    --argjson stashed "$stashed" \
+    --argjson unpushed "$unpushed" \
+    --argjson branches "$BRANCHES_JSON" \
+    --argjson worktrees "$WORKTREES_JSON" \
+    --argjson has_salvage "$has_salvage" \
+    '{
+      repo:$repo,
+      path:$path,
+      current_branch:$branch,
+      integration_branch:$integration,
+      working_tree:{
+        dirty_files:$dirty,
+        staged_files:$staged,
+        stashed:$stashed,
+        unpushed_commits:$unpushed
+      },
+      local_branches:$branches,
+      worktrees:$worktrees,
+      has_salvage:$has_salvage
+    }' > "$TMPDIR_OPS/$safe_name.json"
+}
+
+# Iterate projects → repos in parallel (cap at 8 simultaneous git fetches).
+SEM=0
+echo "$PROJECTS_JSON" | jq -c '.[]' | while read -r project; do
+  PROJECT_PATH=$(echo "$project" | jq -r '.path // empty')
+  REPOS=$(echo "$project" | jq -r '.repos[]? // empty')
+  [ -z "$REPOS" ] && continue
+
+  for repo in $REPOS; do
+    [ -n "$FILTER_REPO" ] && [ "$repo" != "$FILTER_REPO" ] && continue
+
+    # Resolve path: if project has multiple repos assume <project_path>/<repo-name>;
+    # otherwise use project_path itself.
+    REPO_NAME=$(echo "$repo" | awk -F/ '{print $2}')
+    NUM_REPOS=$(echo "$project" | jq '.repos | length')
+    if [ "$NUM_REPOS" -gt 1 ] && [ -d "$PROJECT_PATH/$REPO_NAME" ]; then
+      REPO_PATH="$PROJECT_PATH/$REPO_NAME"
+    else
+      REPO_PATH="$PROJECT_PATH"
+    fi
+
+    [ ! -d "$REPO_PATH" ] && continue
+
+    scan_repo "$repo" "$REPO_PATH" &
+
+    SEM=$((SEM + 1))
+    if [ "$SEM" -ge 8 ]; then
+      wait
+      SEM=0
+    fi
+  done
+done
+wait
+
+# Assemble final document
+echo -n '{"repos":['
+first=true
+for f in "$TMPDIR_OPS"/*.json; do
+  [ ! -f "$f" ] && continue
+  [ "$first" = true ] && first=false || echo -n ','
+  cat "$f"
+done
+echo '],"scanned_at":"'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}'

--- a/claude-ops/skills/ops-merge/SKILL.md
+++ b/claude-ops/skills/ops-merge/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ops-merge
-description: Autonomous PR merge pipeline. Scans all repos for open PRs, dispatches subagents to fix CI, resolve conflicts, address review comments, then merges. Use --main to also sync dev↔main branches.
-argument-hint: "[--main] [--repo org/repo] [--dry-run]"
+description: Autonomous salvage + PR merge pipeline. FIRST scans every repo in every org for orphan worktrees, feature branches without PRs, uncommitted/staged/stashed work, and unpushed commits — dispatches subagents to finish/PR all loose local work. THEN scans all open PRs, dispatches fixers for CI/conflicts/reviews, and merges. Use --main to also sync dev↔main branches. Use --no-salvage to skip Phase 0 (PR-only mode). Use --salvage-only to stop after Phase 0.
+argument-hint: "[--main] [--repo org/repo] [--dry-run] [--no-salvage] [--salvage-only]"
 allowed-tools:
   - Bash
   - Read
@@ -73,6 +73,12 @@ If the flag is NOT set, fall back to standard parallel subagents with `isolation
 ${CLAUDE_PLUGIN_ROOT}/bin/ops-merge-scan 2>/dev/null || echo '{"prs":[],"error":"merge-scan failed"}'
 ```
 
+## Pre-gathered salvage data (orphan worktrees, branches without PRs, uncommitted/unpushed work)
+
+```!
+${CLAUDE_PLUGIN_ROOT}/bin/ops-merge-salvage-scan 2>/dev/null || echo '{"repos":[],"error":"salvage-scan failed"}'
+```
+
 ## Your task
 
 You are the **merge orchestrator**. Your job is to get every open PR across the owner's repos merged — fixing whatever blocks them first.
@@ -85,7 +91,104 @@ From `$ARGUMENTS`:
 - `--repo <slug>` → scope to one repo only (e.g., `--repo Lifecycle-Innovations-Limited/my-api`)
 - `--dry-run` → report what would happen, don't dispatch agents or merge anything
 - `--force` → skip the confirmation prompt before merging
-- (empty) → process all repos, merge to dev only
+- `--no-salvage` → skip Phase 0 (Salvage). Behaves like the legacy PR-only pipeline.
+- `--salvage-only` → run Phase 0 only and stop. Useful for "find and finish all loose local work" without touching the existing PR queue yet.
+- (empty) → process all repos: salvage local work first, then merge PRs to dev only
+
+### Phase 0 — Salvage scan (run BEFORE the PR queue)
+
+**Goal:** every repo in every org gets a clean slate before the PR merge pipeline runs. Find and finish every piece of local work that isn't already on `dev`/`main` and isn't already in an open PR — orphan worktrees, feature branches without PRs, uncommitted/staged/stashed changes, and unpushed commits.
+
+**Skip this phase only if `--no-salvage` is set.**
+
+Parse the JSON returned by `ops-merge-salvage-scan`. For each repo with `has_salvage: true`, classify each finding into one of:
+
+| Finding                                                            | Classification             | Action                                                                                                |
+| ------------------------------------------------------------------ | -------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Worktree with `dirty_files > 0` or `unpushed_commits > 0`          | `worktree-incomplete`      | Dispatch salvager: finish work in the worktree, commit, push, open PR if missing                      |
+| Worktree on a branch with `has_open_pr: false`                     | `worktree-orphan-pr`       | Dispatch salvager: confirm work is complete (lint/type/test gate), push if needed, open PR            |
+| Local branch with `integrated: false` and `has_open_pr: false`     | `branch-no-pr`             | Dispatch salvager: review state, push if unpushed, open PR targeting integration branch               |
+| Local branch with `integrated: true` and `has_open_pr: false`      | `branch-already-merged`    | Surface to user → `[Delete local branch]` / `[Keep]` (NEVER auto-delete — Safety Rails)               |
+| Main checkout: `dirty_files > 0` or `staged_files > 0` or stash >0 | `checkout-dirty`           | Surface to user → `[Stash & continue]` / `[Open salvage worktree]` / `[Skip]`. Never auto-discard.    |
+| Main checkout: `unpushed_commits > 0` on a non-integration branch  | `checkout-unpushed`        | Dispatch salvager: push the branch, open PR if missing                                                |
+
+**Print the salvage queue:**
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► MERGE — Phase 0: Salvage Queue
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+| Repo | Location | Branch | State | Classification | Action |
+|------|----------|--------|-------|----------------|--------|
+| my-api | .worktrees/feat-x | feat/x | 3 dirty, 2 unpushed | worktree-incomplete | salvage |
+| my-app | (main checkout) | feat/y | 5 unpushed, no PR | checkout-unpushed | salvage |
+| mise | refs/heads/old-experiment | old-experiment | integrated, no PR | branch-already-merged | confirm delete |
+| ... | ... | ... | ... | ... | ... |
+
+Salvageable: N  |  Needs user input: N  |  Clean: M
+──────────────────────────────────────────────────────
+```
+
+If `--dry-run`, print the queue and stop here (skip Phase 1+).
+If `--salvage-only`, run the salvage dispatch loop below, then stop (skip Phase 1+).
+
+**Confirmation gate:** unless `--force`, use `AskUserQuestion` (max 4 options — Plugin Rule 1) to confirm before dispatching salvagers:
+
+```
+N pieces of loose local work found across M repos.
+
+  [Salvage all N — dispatch agents]  [Let me pick which ones]  [Skip Phase 0 — go to PR queue]  [Abort]
+```
+
+**Dispatch salvager subagents** (max 5 concurrent, one repo per agent — never share the main checkout per CLAUDE.md worktree isolation rule). Use `subagent_type: "general-purpose"` for now (or a future `salvage-fixer` agent if one exists). Each salvager gets this brief:
+
+```
+Task: Finish and PR loose local work in <repo>
+Repo path: <path from salvage scan>
+Findings:
+  - <classification>: <branch / worktree path> — <state summary>
+  - ...
+
+Worktree isolation: if the work lives in an existing .worktrees/* dir, work IN that directory.
+If the work lives only on a local branch (no worktree), create one:
+  git -C <repo path> worktree add .worktrees/salvage-<branch> <branch>
+
+For each finding:
+  1. cd into the worktree.
+  2. Inspect state: `git status`, `git log <integration>..HEAD --oneline`, `git diff --stat`.
+  3. Read recent commit messages + any TODOs/HEREs in the diff. Decide whether the work is:
+       (a) complete and just needs commit/push/PR — proceed
+       (b) incomplete but obvious next step — finish it
+       (c) ambiguous or risky → ABORT this finding and return it for human review.
+  4. If finishing work: make the smallest correct commit. Quality gate locally
+     (per-repo: type-check + lint + relevant tests).
+  5. Commit with a clear message. NEVER use --no-verify unless a hook is genuinely
+     broken and unrelated to your change.
+  6. Push: `git push -u origin <branch>` (or `--force-with-lease` if branch already remote).
+  7. Open PR (only if has_open_pr=false in the brief):
+       gh pr create --repo <repo> --base <integration_branch> --head <branch> \
+         --title "<derived from commit messages>" \
+         --body "Salvaged by /ops:merge Phase 0. <commit summary>"
+  8. Return structured JSON:
+       {
+         "repo": "...",
+         "branch": "...",
+         "status": "pr_opened" | "pushed_only" | "aborted_for_review" | "failed",
+         "pr_number": <int or null>,
+         "pr_url": "<or null>",
+         "end_sha": "<remote head>",
+         "notes": "..."
+       }
+
+DO NOT call `gh pr merge` — newly opened PRs flow through Phase 1+ like any other PR.
+DO NOT delete branches, worktrees, or stashes. Salvage = finish + PR, never destroy.
+DO NOT touch files outside the assigned worktree.
+```
+
+**After all salvagers return:** re-run `ops-merge-scan` so the freshly opened PRs join the Phase 1 queue. Surface any `aborted_for_review` findings to the user with a brief explanation and `[Open in editor]` / `[Skip]` options.
+
+**Branches classified `branch-already-merged` and `checkout-dirty`** are surfaced one-by-one to the user via `AskUserQuestion` (never auto-handled — see Safety Rails).
 
 ### Phase 1 — Classify the PR queue
 
@@ -314,9 +417,22 @@ For each repo that has separate `dev` and `main` branches:
  OPS ► MERGE COMPLETE
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+Phase 0 — Salvage
+| Repo | Finding | Result |
+|------|---------|--------|
+| my-api | feat/x worktree | ✓ pushed + PR #2999 opened |
+| my-app | feat/y local-only | ✓ pushed + PR #4470 opened |
+| mise | old-experiment (merged) | ⚠ surfaced for delete confirmation |
+
+Salvaged: N pieces of work → N new PRs opened
+Aborted for review: N
+User-input pending: N (dirty checkouts, already-merged branches)
+
+Phase 1–5 — PR merges
 | Repo | PR | Result |
 |------|----|--------|
 | my-api | #2958 | ✓ merged to dev |
+| my-api | #2999 | ✓ salvaged + merged to dev |
 | my-app | #4456 | ✓ fixed CI + merged |
 | mise | #10 | ✗ 3 critical bugs — skipped |
 
@@ -324,6 +440,7 @@ Merged: N PRs across M repos
 Skipped: N (blocked/draft)
 Failed: N (still need manual attention)
 
+Phase 6 — Main sync
 Main sync: N repos synced (dev → main → dev)
 ──────────────────────────────────────────────────────
 ```
@@ -352,6 +469,18 @@ During this command's execution, invoke the following superpower skills at the s
 - **ALWAYS use `--admin` only for squash merges to dev** (not main, unless `--main` flag)
 - **Max 10 PRs per invocation** to avoid GitHub API throttling
 - **If a PR has > 50 files changed**, flag it for manual review instead of auto-merging
+
+### Phase 0 (Salvage) Safety Rails
+
+- **NEVER auto-delete a local branch, worktree, or stash** — even if classified `branch-already-merged`. Always surface to the user via `AskUserQuestion`.
+- **NEVER `git stash drop` or `git checkout -- <file>` or `git clean`** in any checkout — uncommitted work is the user's, not the agent's, until they confirm.
+- **NEVER auto-commit ambiguous changes.** If a salvager can't tell whether work is complete, it MUST return `aborted_for_review` and let the user decide.
+- **NEVER share the main checkout between salvager subagents.** Per CLAUDE.md worktree isolation: each agent gets its own `.worktrees/salvage-<branch>` dir. Sharing the main checkout causes branch-switch collisions.
+- **NEVER force-push a branch the salvager didn't originate work on** — salvagers may only push with `--force-with-lease` to branches whose tip they fetched at start of work.
+- **NEVER salvage main/master/dev** — those are integration branches; loose work on them surfaces to the user, never auto-pushed.
+- **NEVER touch files outside the assigned worktree.** Salvagers are scoped to one repo + one branch.
+- **ALWAYS run the per-repo quality gate** (type-check + lint + tests) before pushing salvaged work.
+- **ALWAYS open a PR (not direct push to dev/main)** — salvaged work flows through the same review/CI/merge gate as any other PR.
 
 ---
 


### PR DESCRIPTION
## Summary

`/ops:ops-merge` now scans every repo in every org for loose local work BEFORE running the existing PR merge pipeline. Salvager subagents are dispatched (worktree-isolated, max 5 concurrent) to finish + push + open PRs for orphan worktrees, feature branches without PRs, uncommitted/staged/stashed changes, and unpushed commits. Freshly opened PRs then flow through Phase 1+ like any other.

## Changes

- **New `bin/ops-merge-salvage-scan`** — parallel git inventory across the project registry. Per repo: working-tree dirty/staged/stashed/unpushed counts, local branches with `integrated` + `pushed` + `has_open_pr` classification, worktree dirty/unpushed/PR state.
- **`skills/ops-merge/SKILL.md`**:
  - New Phase 0 (Salvage) inserted before Phase 1
  - New flags: `--no-salvage`, `--salvage-only`
  - Phase 0 Safety Rails (no auto-delete branches/stashes, no shared main checkout, must open PR not direct push)
  - Updated final report with Phase 0 section

## Salvage classification

| Finding | Classification | Action |
|---|---|---|
| Worktree dirty/unpushed | `worktree-incomplete` | dispatch salvager |
| Worktree on branch with no PR | `worktree-orphan-pr` | dispatch salvager |
| Local branch not integrated + no PR | `branch-no-pr` | dispatch salvager |
| Local branch integrated + no PR | `branch-already-merged` | surface to user (never auto-delete) |
| Main checkout dirty/staged/stashed | `checkout-dirty` | surface to user |
| Main checkout unpushed on feature branch | `checkout-unpushed` | dispatch salvager |

## Test plan

- [ ] Run `bin/ops-merge-salvage-scan` against the registry — verify JSON shape
- [ ] Run `/ops:ops-merge --salvage-only --dry-run` — verify queue prints without dispatching
- [ ] Verify `--no-salvage` skips Phase 0 entirely (legacy behavior)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how unpushed commits are detected (now relative to each branch’s upstream) and adjusts salvage heuristics, which could affect which repos/branches are flagged for salvage or missed. Concurrency loop restructuring also affects process control and could change scan completeness/timing.
> 
> **Overview**
> Updates `ops-merge-salvage-scan` to compute **unpushed commits** for worktrees against each branch’s configured upstream (`@{u}..`) instead of comparing to `origin/<integration_branch>`.
> 
> Adjusts **salvage detection** to treat any local branch *without an open PR* as salvage-worthy (replacing the prior `integrated == false` check), and refactors the project iteration loop to use process substitution (avoiding a piped `while` subshell) so background `scan_repo` jobs are correctly tracked and waited on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46c75fa1556ff7180c762e2aee02386d4c99891b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->