### PR TITLE
feat(gh-quota): PreToolUse guard + orphan-killer daemon for gh REST quota protection

### DIFF
--- a/claude-ops/hooks/gh-watch-guard.sh
+++ b/claude-ops/hooks/gh-watch-guard.sh
@@ -7,8 +7,11 @@
 # Source of truth: ~/Projects/claude-ops/claude-ops/hooks/gh-watch-guard.sh
 # Plugin cache copy (auto-installed via plugin update) is read-only.
 
-stdin=$(cat)
-CMD=$(echo "$stdin" | jq -r '.tool_input.command // empty' 2>/dev/null)
+raw="${TOOL_INPUT:-}"
+if [ -z "$raw" ]; then
+  raw=$(cat) || true
+fi
+CMD=$(printf '%s' "$raw" | jq -r '(.tool_input.command // .command // empty)' 2>/dev/null || true)
 
 # Fast path: not a gh command, exit immediately
 case "$CMD" in
@@ -19,7 +22,7 @@ esac
 # --- Pattern 1: --watch flag on gh pr checks / gh run watch ---
 # `gh pr checks <PR> --watch` and `gh run watch` poll every 2-5s.
 # 5000 REST/hr ÷ 2s = exhausted in ~3 hours of one process. Sam saw this in production.
-if echo "$CMD" | grep -qE 'gh\s+pr\s+checks\s+[^|]*--watch|gh\s+run\s+watch'; then
+if echo "$CMD" | grep -qE 'gh[[:space:]]+pr[[:space:]]+checks[[:space:]]+[^|]*--watch|gh[[:space:]]+run[[:space:]]+watch'; then
     cat >&2 <<'EOF'
 BLOCKED: `gh ... --watch` polls every 2-5s and exhausts the 5000/hr REST quota.
 
@@ -40,10 +43,10 @@ EOF
     exit 2
 fi
 
-# --- Pattern 2: tight gh loops (sleep < 10s) ---
-# Catches: `while true; do gh ...; sleep 5; done` style polls.
-if echo "$CMD" | grep -qE '(while|until|for).*gh\s+(api|pr|run|issue)' && \
-   echo "$CMD" | grep -qE 'sleep\s+([0-9]|10)(\s|;|$)'; then
+# --- Pattern 2: tight gh loops (single-digit sleep = under 10s) ---
+# Catches: `while true; do gh ...; sleep 5; done` style polls (not sleep 10+).
+if echo "$CMD" | grep -qE '(while|until|for).*gh[[:space:]]+(api|pr|run|issue)' && \
+   echo "$CMD" | grep -qE 'sleep[[:space:]]+[0-9]([[:space:];]|$)'; then
     cat >&2 <<'EOF'
 BLOCKED: tight gh polling loop (sleep < 10s) detected.
 

--- a/claude-ops/hooks/gh-watch-guard.sh
+++ b/claude-ops/hooks/gh-watch-guard.sh
@@ -27,6 +27,8 @@ if [ -z "$raw" ]; then
   raw=$(cat) || true
 fi
 CMD=$(printf '%s' "$raw" | jq -r '(.tool_input.command // .command // empty)' 2>/dev/null || true)
+# Collapse newlines so --watch / tight-loop patterns cannot be evaded by splitting lines.
+CMD_ONELINE=$(printf '%s' "$CMD" | tr '\n\r' '  ')
 
 # Fast path: not a gh command, exit immediately
 case "$CMD" in
@@ -37,7 +39,7 @@ esac
 # --- Pattern 1: --watch flag on gh pr checks / gh run watch ---
 # `gh pr checks <PR> --watch` and `gh run watch` poll every 2-5s.
 # 5000 REST/hr ÷ 2s = exhausted in ~3 hours of one process. Sam saw this in production.
-if echo "$CMD" | grep -qE 'gh[[:space:]]+pr[[:space:]]+checks[[:space:]]+[^|]*--watch|gh[[:space:]]+run[[:space:]]+watch'; then
+if echo "$CMD_ONELINE" | grep -qE 'gh[[:space:]]+pr[[:space:]]+checks[[:space:]]+[^|]*--watch|gh[[:space:]]+run[[:space:]]+watch'; then
     emit_pre_tool_deny <<'EOF'
 BLOCKED: `gh ... --watch` polls every 2-5s and exhausts the 5000/hr REST quota.
 
@@ -60,8 +62,8 @@ fi
 
 # --- Pattern 2: tight gh loops (single-digit sleep = under 10s) ---
 # Catches: `while true; do gh ...; sleep 5; done` style polls (not sleep 10+).
-if echo "$CMD" | grep -qE '(while|until|for).*gh[[:space:]]+(api|pr|run|issue)' && \
-   echo "$CMD" | grep -qE 'sleep[[:space:]]+[0-9]([[:space:];]|$)'; then
+if echo "$CMD_ONELINE" | grep -qE '(^|[^[:alnum:]_])(while|until|for)([^[:alnum:]_]|$).*gh[[:space:]]+(api|pr|run|issue)' && \
+   echo "$CMD_ONELINE" | grep -qE 'sleep[[:space:]]+[0-9]([[:space:];]|$)'; then
     emit_pre_tool_deny <<'EOF'
 BLOCKED: tight gh polling loop (sleep < 10s) detected.
 

--- a/claude-ops/hooks/gh-watch-guard.sh
+++ b/claude-ops/hooks/gh-watch-guard.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# PreToolUse Bash hook — blocks rate-limit-burning gh patterns.
+#
+# Reads Claude Code hook stdin, exits 0 (allow) or 2 (block + stderr).
+# Pairs with the persistent gh-orphan-killer.sh watchdog.
+#
+# Source of truth: ~/Projects/claude-ops/claude-ops/hooks/gh-watch-guard.sh
+# Plugin cache copy (auto-installed via plugin update) is read-only.
+
+stdin=$(cat)
+CMD=$(echo "$stdin" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+# Fast path: not a gh command, exit immediately
+case "$CMD" in
+    *gh\ *|*gh-*) ;;
+    *) exit 0 ;;
+esac
+
+# --- Pattern 1: --watch flag on gh pr checks / gh run watch ---
+# `gh pr checks <PR> --watch` and `gh run watch` poll every 2-5s.
+# 5000 REST/hr ÷ 2s = exhausted in ~3 hours of one process. Sam saw this in production.
+if echo "$CMD" | grep -qE 'gh\s+pr\s+checks\s+[^|]*--watch|gh\s+run\s+watch'; then
+    cat >&2 <<'EOF'
+BLOCKED: `gh ... --watch` polls every 2-5s and exhausts the 5000/hr REST quota.
+
+Use the Monitor tool with an `until` poll loop at ≥25s instead:
+
+  prev=""
+  while true; do
+    s=$(gh pr view <PR> --repo <REPO> --json mergeStateStatus,statusCheckRollup)
+    state=$(echo "$s" | jq -r .mergeStateStatus)
+    [ "$state" = "CLEAN" ] || [ "$state" = "UNSTABLE" ] && { echo READY; break; }
+    sleep 30
+  done
+
+For multi-PR watching prefer GraphQL (separate 5000/hr bucket) — single query, multiple PRs.
+
+Source: ~/Projects/claude-ops/claude-ops/hooks/gh-watch-guard.sh
+EOF
+    exit 2
+fi
+
+# --- Pattern 2: tight gh loops (sleep < 10s) ---
+# Catches: `while true; do gh ...; sleep 5; done` style polls.
+if echo "$CMD" | grep -qE '(while|until|for).*gh\s+(api|pr|run|issue)' && \
+   echo "$CMD" | grep -qE 'sleep\s+([0-9]|10)(\s|;|$)'; then
+    cat >&2 <<'EOF'
+BLOCKED: tight gh polling loop (sleep < 10s) detected.
+
+The 5000/hr REST quota is shared across this session, background daemons, the overnight
+sync cron, and any other gh process. A loop at sleep 5 burns 720 calls/hr — easy to OOM-cache.
+
+Bump to `sleep 30` (or use Monitor tool — handles ≥25s naturally).
+EOF
+    exit 2
+fi
+
+exit 0

--- a/claude-ops/hooks/gh-watch-guard.sh
+++ b/claude-ops/hooks/gh-watch-guard.sh
@@ -1,11 +1,26 @@
 #!/bin/bash
 # PreToolUse Bash hook — blocks rate-limit-burning gh patterns.
 #
-# Reads Claude Code hook stdin, exits 0 (allow) or 2 (block + stderr).
+# Allow: exit 0 (no stdout JSON). Deny: emit hookSpecificOutput with permissionDecision deny
+# on stdout (same contract as bin/ops-prevent-secret-commit and docs/safety-hooks.md), then exit 0.
 # Pairs with the persistent gh-orphan-killer.sh watchdog.
 #
 # Source of truth: ~/Projects/claude-ops/claude-ops/hooks/gh-watch-guard.sh
 # Plugin cache copy (auto-installed via plugin update) is read-only.
+
+emit_pre_tool_deny() {
+  python3 -c '
+import json, sys
+reason = sys.stdin.read().rstrip("\n")
+print(json.dumps({
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": reason
+  }
+}))
+'
+}
 
 raw="${TOOL_INPUT:-}"
 if [ -z "$raw" ]; then
@@ -23,7 +38,7 @@ esac
 # `gh pr checks <PR> --watch` and `gh run watch` poll every 2-5s.
 # 5000 REST/hr ÷ 2s = exhausted in ~3 hours of one process. Sam saw this in production.
 if echo "$CMD" | grep -qE 'gh[[:space:]]+pr[[:space:]]+checks[[:space:]]+[^|]*--watch|gh[[:space:]]+run[[:space:]]+watch'; then
-    cat >&2 <<'EOF'
+    emit_pre_tool_deny <<'EOF'
 BLOCKED: `gh ... --watch` polls every 2-5s and exhausts the 5000/hr REST quota.
 
 Use the Monitor tool with an `until` poll loop at ≥25s instead:
@@ -40,14 +55,14 @@ For multi-PR watching prefer GraphQL (separate 5000/hr bucket) — single query,
 
 Source: ~/Projects/claude-ops/claude-ops/hooks/gh-watch-guard.sh
 EOF
-    exit 2
+    exit 0
 fi
 
 # --- Pattern 2: tight gh loops (single-digit sleep = under 10s) ---
 # Catches: `while true; do gh ...; sleep 5; done` style polls (not sleep 10+).
 if echo "$CMD" | grep -qE '(while|until|for).*gh[[:space:]]+(api|pr|run|issue)' && \
    echo "$CMD" | grep -qE 'sleep[[:space:]]+[0-9]([[:space:];]|$)'; then
-    cat >&2 <<'EOF'
+    emit_pre_tool_deny <<'EOF'
 BLOCKED: tight gh polling loop (sleep < 10s) detected.
 
 The 5000/hr REST quota is shared across this session, background daemons, the overnight
@@ -55,7 +70,7 @@ sync cron, and any other gh process. A loop at sleep 5 burns 720 calls/hr — ea
 
 Bump to `sleep 30` (or use Monitor tool — handles ≥25s naturally).
 EOF
-    exit 2
+    exit 0
 fi
 
 exit 0

--- a/claude-ops/scripts/gh-orphan-killer.sh
+++ b/claude-ops/scripts/gh-orphan-killer.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# Kills orphan `gh ... --watch` and tight-poll-loop processes older than 5 min.
-# Runs every 60s while it's active. Idempotent. Safe to run in parallel.
+# Kills orphan `gh pr checks ... --watch` after 5 min; `gh run watch` only after
+# 2000s so deploy monitors (default watcher timeout 1800s in ops-deploy-monitor.sh)
+# are not SIGKILL'd mid-watch. Runs every 60s while active. Idempotent.
 #
 # Triggered by: SessionStart hook (foreground guarded by pidfile to avoid duplicates).
 #
@@ -22,20 +23,25 @@ fi
 echo $$ > "$PIDFILE"
 trap 'rm -f "$PIDFILE"' EXIT
 
+PR_CHECKS_WATCH_MAX_AGE=300
+# Above ops-deploy-monitor default watcher_timeout_seconds (1800) with headroom
+GH_RUN_WATCH_MAX_AGE=2000
+
 while true; do
-  # Find `gh ... --watch` and tight-poll loops older than 300s (5 min)
-  # `ps -eo pid,etimes,command` gives etimes = elapsed seconds since process start
+  # `ps -eo pid,etimes,command` — etimes = elapsed seconds since process start
   killed=0
-  while read -r pid etimes command; do
+  while read -r pid etimes max_age command; do
     [ -z "$pid" ] && continue
-    if [ "$etimes" -gt 300 ]; then
-      echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) killing orphan pid=$pid age=${etimes}s: $command" >> "$LOG"
+    [[ "$etimes" =~ ^[0-9]+$ ]] || continue
+    [[ "$max_age" =~ ^[0-9]+$ ]] || continue
+    if [ "$etimes" -gt "$max_age" ]; then
+      echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) killing orphan pid=$pid age=${etimes}s max=${max_age}s: $command" >> "$LOG"
       kill -9 "$pid" 2>/dev/null || true
       killed=$((killed + 1))
     fi
-  done < <(ps -eo pid,etimes,command 2>/dev/null | awk '
-    /gh pr checks .*--watch/ && !/awk|grep/ { print $1, $2, substr($0, index($0,$3)) }
-    /gh run watch/ && !/awk|grep/ { print $1, $2, substr($0, index($0,$3)) }
+  done < <(ps -eo pid,etimes,command 2>/dev/null | awk -v prmax="$PR_CHECKS_WATCH_MAX_AGE" -v runmax="$GH_RUN_WATCH_MAX_AGE" '
+    /gh pr checks .*--watch/ && !/awk|grep/ { print $1, $2, prmax, substr($0, index($0,$3)) }
+    /gh run watch/ && !/awk|grep/ { print $1, $2, runmax, substr($0, index($0,$3)) }
   ')
 
   [ "$killed" -gt 0 ] && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) killed $killed orphan(s)" >> "$LOG"

--- a/claude-ops/scripts/gh-orphan-killer.sh
+++ b/claude-ops/scripts/gh-orphan-killer.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Kills orphan `gh ... --watch` and tight-poll-loop processes older than 5 min.
+# Runs every 60s while it's active. Idempotent. Safe to run in parallel.
+#
+# Triggered by: SessionStart hook (foreground guarded by pidfile to avoid duplicates).
+#
+# Source of truth: ~/Projects/claude-ops/claude-ops/scripts/gh-orphan-killer.sh
+
+set -euo pipefail
+
+PIDFILE="${TMPDIR:-/tmp}/gh-orphan-killer.pid"
+LOG="${HOME}/.claude/logs/gh-orphan-killer.log"
+mkdir -p "$(dirname "$LOG")"
+
+# Singleton: if another instance is running with a fresh pidfile, exit
+if [ -f "$PIDFILE" ]; then
+  prev_pid=$(cat "$PIDFILE" 2>/dev/null || echo "")
+  if [ -n "$prev_pid" ] && kill -0 "$prev_pid" 2>/dev/null; then
+    exit 0
+  fi
+fi
+echo $$ > "$PIDFILE"
+trap 'rm -f "$PIDFILE"' EXIT
+
+while true; do
+  # Find `gh ... --watch` and tight-poll loops older than 300s (5 min)
+  # `ps -eo pid,etimes,command` gives etimes = elapsed seconds since process start
+  killed=0
+  while read -r pid etimes command; do
+    [ -z "$pid" ] && continue
+    if [ "$etimes" -gt 300 ]; then
+      echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) killing orphan pid=$pid age=${etimes}s: $command" >> "$LOG"
+      kill -9 "$pid" 2>/dev/null || true
+      killed=$((killed + 1))
+    fi
+  done < <(ps -eo pid,etimes,command 2>/dev/null | awk '
+    /gh pr checks .*--watch/ && !/awk|grep/ { print $1, $2, substr($0, index($0,$3)) }
+    /gh run watch/ && !/awk|grep/ { print $1, $2, substr($0, index($0,$3)) }
+  ')
+
+  [ "$killed" -gt 0 ] && echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) killed $killed orphan(s)" >> "$LOG"
+
+  sleep 60
+done


### PR DESCRIPTION
## Summary

Two cooperating safeguards against the shared 5000/hr GitHub REST quota burning out from runaway `gh --watch` and tight-polling loops (Sam observed this in production: a stale `gh pr checks --watch` from an earlier session hammered the bucket to 0 multiple times on 2026-05-22).

## Changes

- **`hooks/gh-watch-guard.sh`** — PreToolUse Bash hook. Blocks `gh pr checks --watch`, `gh run watch`, and any `while/until/for ... gh ... sleep <10s` pattern. Exits 2 with a remediation message pointing at the Monitor tool with ≥25s polls and the GraphQL fallback (separate 5000/hr bucket per CLAUDE.md rate-limit doctrine).
- **`scripts/gh-orphan-killer.sh`** — singleton sweeper (pidfile-guarded, foreground loop). Every 60s, SIGKILLs any `gh ... --watch` or `gh run watch` process older than 300s. Logs to `~/.claude/logs/gh-orphan-killer.log`. Trap-clean on exit.

## Why

`gh pr checks <PR> --watch` polls every 2-5s → 5000/hr ÷ 2s = exhausted in ~3 hours per process. The bucket is shared across this session, background daemons, the overnight sync cron, and any other gh process. One stuck `--watch` kills CI visibility for everyone.

## Test plan

- [ ] `echo '{"tool_input":{"command":"gh pr checks 123 --watch"}}' | bash claude-ops/hooks/gh-watch-guard.sh` → exit 2 with block message
- [ ] `echo '{"tool_input":{"command":"gh pr list --json number"}}' | bash claude-ops/hooks/gh-watch-guard.sh` → exit 0 (allows non-watch gh)
- [ ] `bash claude-ops/scripts/gh-orphan-killer.sh &` then re-run → second instance exits 0 via pidfile
- [ ] Spawn fake long `gh pr checks --watch` → killed within 60s once age >300s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds enforcement that can deny `gh` tool invocations and force-kill long-running `gh ... --watch` processes; mis-detection or aggressive thresholds could disrupt legitimate workflows or terminate the wrong process.
> 
> **Overview**
> Adds two safeguards to reduce GitHub REST quota burn from aggressive `gh` polling.
> 
> A new PreToolUse hook (`hooks/gh-watch-guard.sh`) inspects incoming tool commands and **denies** `gh pr checks --watch`, `gh run watch`, and tight shell loops invoking `gh` with *single-digit* `sleep`, returning a remediation message instead of executing.
> 
> A new watchdog script (`scripts/gh-orphan-killer.sh`) runs as a pidfile-guarded singleton and periodically scans `ps` output to **SIGKILL** orphaned `gh pr checks ... --watch` (after 5 minutes) and long-running `gh run watch` (after ~2000s), logging kills to `~/.claude/logs/gh-orphan-killer.log`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aa91bf86bb867c9831dda5007ee4ec573c56197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->