### PR TITLE
feat(skills): add ops-leadgen skill for Healify B2B leadgen

### DIFF
--- a/claude-ops/skills/ops-leadgen/SKILL.md
+++ b/claude-ops/skills/ops-leadgen/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: ops-leadgen
+description: Healify B2B wholesale leadgen review and send flow. Shows pending cold-email drafts from healify-b2b-leadgen, lets you approve/skip each one, and fires approved drafts one-at-a-time via Rule-6-gated `healify-leadgen send`. Never batches sends.
+argument-hint: "[review | send --draft-id N | usage | scrape | draft]"
+allowed-tools:
+  - Bash
+  - Read
+effort: low
+maxTurns: 20
+---
+
+# ops-leadgen
+
+Wraps `healify-leadgen` CLI for the daily leadgen review-and-send loop.
+
+**Repo:** `~/Projects/healify-b2b-leadgen`
+**DB:** `~/Projects/healify-b2b-leadgen/leads.db` (gitignored)
+**Run with Doppler:** `doppler run --project healify-b2b-leadgen --config dev -- healify-leadgen <cmd>`
+
+## Argument routing
+
+| Argument | Action |
+|---|---|
+| `review` (default) | Show pending drafts one-by-one, approve or skip |
+| `send --draft-id N` | Send a single approved draft (Rule-6 gated) |
+| `usage` | Print today's Apollo reveals + Apify runs |
+| `scrape [--limit N]` | Discover new NL HR contacts via Apollo |
+| `enrich` | Run Apify enrichment on unenriched leads |
+| `draft` | Generate Claude NL/EN drafts for undrafted leads |
+
+## Review + send flow (Rule 6)
+
+**NEVER send multiple drafts in one turn. Each send is a separate staged-draft → approval → send cycle.**
+
+1. Run `healify-leadgen review` (or fetch pending drafts from DB directly)
+2. For each pending draft, show the user:
+   - Lead: name, title, company, email
+   - Language, subject, full body
+3. Ask: `[Send]` / `[Skip]` / `[Stop review]`
+4. On `[Send]`:
+   a. Show complete draft one final time
+   b. Wait for Sam to type `ok` / `send` / `ship it` — this creates `/tmp/.claude-send-ok`
+   c. Run: `doppler run --project healify-b2b-leadgen --config dev -- healify-leadgen send --draft-id N`
+   d. Confirm output shows `Sent OK. Gmail message ID: <id>`
+5. Move to the next draft only after the current one is fully resolved.
+
+## Scrape → enrich → draft (pipeline)
+
+```bash
+# Step 1: discover contacts (costs Apollo reveals — check usage first)
+doppler run --project healify-b2b-leadgen --config dev -- \
+  healify-leadgen usage
+
+doppler run --project healify-b2b-leadgen --config dev -- \
+  healify-leadgen scrape --limit 50
+
+# Step 2: enrich with Apify website crawler
+doppler run --project healify-b2b-leadgen --config dev -- \
+  healify-leadgen enrich
+
+# Step 3: generate Claude drafts
+doppler run --project healify-b2b-leadgen --config dev -- \
+  healify-leadgen draft
+
+# Step 4: review + send (Rule-6 gated, one at a time)
+doppler run --project healify-b2b-leadgen --config dev -- \
+  healify-leadgen review
+```
+
+## Daily usage cap
+
+- Apollo reveals: **200/day** max (tracked in `leads.db daily_usage`)
+- Apify runs: ~$0.02/run (3 pages per domain)
+- Always run `usage` first to check remaining reveals before scraping
+
+## DB queries (read-only diagnostics)
+
+```bash
+# Pending drafts count
+sqlite3 ~/Projects/healify-b2b-leadgen/leads.db \
+  "SELECT count(*) FROM drafts WHERE status='pending';"
+
+# Today's sends
+sqlite3 ~/Projects/healify-b2b-leadgen/leads.db \
+  "SELECT d.subject, l.email, s.sent_at FROM sends s
+   JOIN drafts d ON d.id=s.draft_id
+   JOIN leads l ON l.id=d.lead_id
+   WHERE date(s.sent_at)=date('now');"
+```
+
+## Rule 6 — no exceptions
+
+Per CLAUDE.md Rule 6: every outbound send requires individual staging + approval.
+The `healify-leadgen send` command physically blocks unless `/tmp/.claude-send-ok` exists.
+Sam creates this token by typing `ok` / `send it` / `ship it` in the chat.
+Token is one-shot — consumed on send. Next send needs a new approval.


### PR DESCRIPTION
## Summary
- Adds `/ops:leadgen` skill wrapping `healify-b2b-leadgen` CLI
- Documents scrape -> enrich -> draft -> review -> send pipeline
- Rule-6 per-message approval gate documented and enforced
- Never batches sends

## Test plan
- [ ] `healify-leadgen usage` shows today counts
- [ ] `healify-leadgen review` shows pending drafts
- [ ] Sending without /tmp/.claude-send-ok exits 1
- [ ] Sending with token sends and removes token

Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a new skill spec; no runtime code paths are modified. Primary risk is operational (following the documented send/approval steps correctly), not technical regressions.
> 
> **Overview**
> Adds a new `claude-ops/skills/ops-leadgen/SKILL.md` skill that documents how to run the Healify B2B leadgen pipeline (`usage` → `scrape` → `enrich` → `draft` → `review`) and how to review pending cold-email drafts.
> 
> Emphasizes **Rule 6** compliance by documenting a one-at-a-time send flow that requires explicit user approval via the `/tmp/.claude-send-ok` token before invoking `healify-leadgen send --draft-id N`, plus a few read-only `sqlite3` queries for diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fda7ca04353ded8dd8bcd6e44fedae4ec7893be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->