### PR TITLE
feat(ops-desktop): /ops:desktop skill + desktop-act MCP wiring

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -728,6 +728,34 @@
       "title": "Enable FedEx shipping",
       "description": "Use FedEx labels via /ops:package. Requires fedex_client_id/secret + account_number.",
       "default": false
+    },
+    "desktop_act_command": {
+      "title": "desktop-act runner path (override)",
+      "description": "Absolute path to a custom desktop-act MCP server executable. Leave blank to auto-discover the desktop-act plugin or bootstrap into the per-user cache.",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
+    },
+    "desktop_act_home": {
+      "title": "desktop-act install directory (override)",
+      "description": "Absolute path to a desktop-act marketplace checkout. Used when the plugin is installed outside the standard Claude Code marketplace tree.",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
+    },
+    "desktop_act_repo": {
+      "title": "desktop-act source repository",
+      "description": "Git URL the launcher clones from when bootstrapping a fresh install. Defaults to the public Lifecycle-Innovations-Limited/desktop-act repo.",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
+    },
+    "desktop_act_branch": {
+      "title": "desktop-act branch / tag",
+      "description": "Branch or tag to clone when bootstrapping. Defaults to main.",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
     }
   }
 }

--- a/claude-ops/.mcp.json
+++ b/claude-ops/.mcp.json
@@ -16,6 +16,16 @@
       "env": {
         "DOPPLER_TOKEN": "${user_config.doppler_token}"
       }
+    },
+    "desktop-act": {
+      "command": "python3",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-servers/desktop-act-launcher.py"],
+      "env": {
+        "DESKTOP_ACT_COMMAND": "${user_config.desktop_act_command}",
+        "DESKTOP_ACT_HOME": "${user_config.desktop_act_home}",
+        "DESKTOP_ACT_REPO": "${user_config.desktop_act_repo}",
+        "DESKTOP_ACT_BRANCH": "${user_config.desktop_act_branch}"
+      }
     }
   }
 }

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **`/ops:desktop` skill + `desktop-act` MCP wiring** — autonomous desktop + browser control surfaced as a first-class ops command. Acquires a noVNC desktop session, takes screenshots, clicks, types, scrolls, and runs the autonomous `act()` loop driven by the bundled `claude-agent-sdk` (OAuth via Claude Max, no Anthropic API key). Cross-platform launcher (Linux full / macOS / Windows partial).
+- **`mcp-servers/desktop-act-launcher.py`** — pure-Python cross-platform launcher. Resolves an installed `desktop-act` companion in (1) `$DESKTOP_ACT_COMMAND`, (2) `$DESKTOP_ACT_HOME`, (3) `$CLAUDE_CONFIG_DIR/plugins/marketplaces/desktop-act`, (4) the per-OS Claude config dir, (5) the per-user cache (`$XDG_CACHE_HOME` on Linux, `~/Library/Caches` on macOS, `%LOCALAPPDATA%` on Windows). If none exist it `git clone`s `$DESKTOP_ACT_REPO` (default Lifecycle-Innovations-Limited/desktop-act), bootstraps a venv, `pip install -r requirements.txt`, then `execv`s the runner. Falls back to a clear error message — never hangs the MCP host.
+- **plugin.json userConfig keys** — `desktop_act_command`, `desktop_act_home`, `desktop_act_repo`, `desktop_act_branch` for per-user overrides.
+- **`.mcp.json` `desktop-act` server registration** — wired via `${CLAUDE_PLUGIN_ROOT}/mcp-servers/desktop-act-launcher.py`. All `mcp__desktop-act__*` tools (`acquire_desktop`, `screenshot`, `click`, `type_text`, `act`, …) are now part of the ops surface.
+
+### Notes
+
+- Linux is the primary supported platform (X11 + Xvnc + websockify + python-xlib). macOS and Windows can launch the server but native X11 calls no-op; browser/Kapture paths still work.
+- First run on a fresh box performs a one-time clone + `pip install`. Subsequent launches `execv` directly into the cached venv with no extra latency.
+
 ## [2.11.0] — 2026-05-22
 
 First-class Linux parity for the background daemon, plus two cross-platform fixes that surfaced during Linux bring-up on Amazon Linux 2023.

--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -89,6 +89,7 @@ Per-repo budget caps (default 3/hour), single-flight locks, content-hash dedup, 
 | `/ops:recap`      | **v2** — Status/tail/configure/restart for the multi-session recap marquee daemon |
 | `/ops:rotate`     | **v2** — Manually rotate the active Claude Max account                         |
 | `/ops:rotate-setup` | **v2** — Multi-account onboarding for the rotator                            |
+| `/ops:desktop`    | Autonomous desktop + browser control via the `desktop-act` MCP companion       |
 
 ### Dashboard hotkeys
 

--- a/claude-ops/mcp-servers/desktop-act-launcher.py
+++ b/claude-ops/mcp-servers/desktop-act-launcher.py
@@ -219,19 +219,35 @@ def _bootstrap() -> Path | None:
 
     py_bin = shutil.which("python3") or shutil.which("python")
     venv_dir = src / ".venv"
-    if not venv_dir.exists():
-        print(f"[desktop-act-launcher] creating venv at {venv_dir}", file=sys.stderr)
-        try:
-            subprocess.run([py_bin, "-m", "venv", str(venv_dir)], check=True)
-        except subprocess.CalledProcessError as e:
+    vpy: str | None = None
+    for attempt in range(2):
+        if not venv_dir.exists():
+            print(f"[desktop-act-launcher] creating venv at {venv_dir}", file=sys.stderr)
+            try:
+                subprocess.run([py_bin, "-m", "venv", str(venv_dir)], check=True)
+            except subprocess.CalledProcessError as e:
+                print(
+                    f"[desktop-act-launcher] venv create failed (exit {e.returncode})",
+                    file=sys.stderr,
+                )
+                return None
+        vpy = _venv_python(src)
+        if vpy:
+            break
+        if attempt == 0 and venv_dir.exists():
             print(
-                f"[desktop-act-launcher] venv create failed (exit {e.returncode})",
+                f"[desktop-act-launcher] removing broken venv at {venv_dir}",
                 file=sys.stderr,
             )
-            return None
-
-    vpy = _venv_python(src)
-    if not vpy:
+            try:
+                shutil.rmtree(venv_dir)
+            except OSError as e:
+                print(
+                    f"[desktop-act-launcher] could not remove broken venv: {e}",
+                    file=sys.stderr,
+                )
+                return None
+            continue
         return None
     req = src / "requirements.txt"
     if req.exists():

--- a/claude-ops/mcp-servers/desktop-act-launcher.py
+++ b/claude-ops/mcp-servers/desktop-act-launcher.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""desktop-act-launcher — locate or bootstrap the desktop-act MCP server.
+
+Cross-platform launcher (Linux / macOS / Windows) used by the claude-ops plugin
+to bring up the `desktop-act` FastMCP server for the /ops:desktop skill.
+
+Resolution order:
+    1. ``$DESKTOP_ACT_COMMAND`` — explicit path to an executable script.
+    2. ``$DESKTOP_ACT_HOME/mcp-server/`` — manual install directory.
+    3. ``$CLAUDE_CONFIG_DIR/plugins/marketplaces/desktop-act/mcp-server/``
+    4. Per-OS default Claude config dir.
+    5. Per-user cache: $XDG_CACHE_HOME/desktop-act-mcp (Linux) /
+       ~/Library/Caches/desktop-act-mcp (macOS) /
+       %LOCALAPPDATA%\\desktop-act-mcp (Windows).
+       If absent and ``DESKTOP_ACT_REPO`` is set, we ``git clone`` it,
+       bootstrap a venv, ``pip install -r requirements.txt``, then exec.
+
+Linux is the only platform with full desktop automation today; macOS and
+Windows currently surface a clear "not supported yet" message so the
+launcher fails loudly instead of hanging the MCP host.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_REPO = os.environ.get(
+    "DESKTOP_ACT_REPO",
+    "https://github.com/Lifecycle-Innovations-Limited/desktop-act.git",
+)
+DEFAULT_BRANCH = os.environ.get("DESKTOP_ACT_BRANCH", "main")
+
+
+def _system() -> str:
+    s = platform.system().lower()
+    if s.startswith("win"):
+        return "windows"
+    if s == "darwin":
+        return "macos"
+    return "linux"
+
+
+def _cache_root() -> Path:
+    sysname = _system()
+    if sysname == "macos":
+        return Path.home() / "Library" / "Caches" / "desktop-act-mcp"
+    if sysname == "windows":
+        base = os.environ.get("LOCALAPPDATA") or str(Path.home() / "AppData" / "Local")
+        return Path(base) / "desktop-act-mcp"
+    base = os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
+    return Path(base) / "desktop-act-mcp"
+
+
+def _claude_config_dirs() -> list[Path]:
+    sysname = _system()
+    explicit = os.environ.get("CLAUDE_CONFIG_DIR")
+    out: list[Path] = []
+    if explicit:
+        out.append(Path(explicit))
+    if sysname == "windows":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            out.append(Path(appdata) / "claude-code")
+    out.append(Path.home() / ".claude")
+    out.append(Path.home() / ".config" / "claude-code")
+    return out
+
+
+def _runner_in(home: Path) -> Path | None:
+    """Pick the platform-appropriate launcher inside a desktop-act install."""
+    if not home.is_dir():
+        return None
+    if _system() == "windows":
+        for cand in (
+            home / "mcp-server" / "run.cmd",
+            home / "mcp-server" / "run.ps1",
+        ):
+            if cand.exists():
+                return cand
+    sh = home / "mcp-server" / "run.sh"
+    if sh.exists() and os.access(sh, os.X_OK):
+        return sh
+    server_py = home / "mcp-server" / "server.py"
+    if server_py.exists():
+        return server_py
+    return None
+
+
+def _resolve_existing() -> Path | None:
+    override = os.environ.get("DESKTOP_ACT_COMMAND")
+    if override and Path(override).exists():
+        return Path(override)
+
+    explicit_home = os.environ.get("DESKTOP_ACT_HOME")
+    if explicit_home:
+        runner = _runner_in(Path(explicit_home))
+        if runner:
+            return runner
+
+    for cfg in _claude_config_dirs():
+        runner = _runner_in(cfg / "plugins" / "marketplaces" / "desktop-act")
+        if runner:
+            return runner
+
+    runner = _runner_in(_cache_root() / "src")
+    if runner:
+        return runner
+    return None
+
+
+def _exec_runner(runner: Path) -> None:
+    if runner.suffix == ".py":
+        py = (
+            _venv_python(runner.parent.parent)
+            or shutil.which("python3")
+            or shutil.which("python")
+        )
+        if not py:
+            print(
+                "[desktop-act-launcher] No python3 available to exec server.py",
+                file=sys.stderr,
+            )
+            sys.exit(127)
+        os.execv(py, [py, str(runner)])
+    if runner.suffix in (".cmd", ".ps1"):
+        if runner.suffix == ".ps1":
+            ps = shutil.which("pwsh") or shutil.which("powershell")
+            if not ps:
+                print("[desktop-act-launcher] PowerShell not found", file=sys.stderr)
+                sys.exit(127)
+            os.execv(ps, [ps, "-ExecutionPolicy", "Bypass", "-File", str(runner)])
+        os.execv(str(runner), [str(runner)])
+    os.execv(str(runner), [str(runner)])
+
+
+def _venv_python(install_root: Path) -> str | None:
+    bin_dir = "Scripts" if _system() == "windows" else "bin"
+    py = (
+        install_root
+        / ".venv"
+        / bin_dir
+        / ("python.exe" if _system() == "windows" else "python")
+    )
+    return str(py) if py.exists() else None
+
+
+def _have(cmd: str) -> bool:
+    return shutil.which(cmd) is not None
+
+
+def _bootstrap() -> Path | None:
+    """Clone desktop-act into the per-user cache and set up its venv.
+
+    Returns the path to the runner once ready, or ``None`` if bootstrap is not
+    possible (missing git/python3 or unsupported platform).
+    """
+    if not _have("git") or not (_have("python3") or _have("python")):
+        print(
+            "[desktop-act-launcher] git + python3 are required to auto-install desktop-act.\n"
+            "  macOS:   brew install git python\n"
+            "  Linux:   sudo apt install -y git python3 python3-venv  # or your distro's equivalent\n"
+            "  Windows: install Git + Python 3.11+ from python.org",
+            file=sys.stderr,
+        )
+        return None
+
+    cache = _cache_root()
+    src = cache / "src"
+    cache.mkdir(parents=True, exist_ok=True)
+
+    if not src.exists():
+        print(f"[desktop-act-launcher] cloning {DEFAULT_REPO} → {src}", file=sys.stderr)
+        try:
+            subprocess.run(
+                [
+                    "git",
+                    "clone",
+                    "--depth",
+                    "1",
+                    "--branch",
+                    DEFAULT_BRANCH,
+                    DEFAULT_REPO,
+                    str(src),
+                ],
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print(
+                f"[desktop-act-launcher] git clone failed (exit {e.returncode}). "
+                f"Set DESKTOP_ACT_REPO to a reachable URL, or install desktop-act manually.",
+                file=sys.stderr,
+            )
+            return None
+
+    py_bin = shutil.which("python3") or shutil.which("python")
+    venv_dir = src / ".venv"
+    if not venv_dir.exists():
+        print(f"[desktop-act-launcher] creating venv at {venv_dir}", file=sys.stderr)
+        try:
+            subprocess.run([py_bin, "-m", "venv", str(venv_dir)], check=True)
+        except subprocess.CalledProcessError as e:
+            print(
+                f"[desktop-act-launcher] venv create failed (exit {e.returncode})",
+                file=sys.stderr,
+            )
+            return None
+
+    vpy = _venv_python(src)
+    if not vpy:
+        return None
+    req = src / "requirements.txt"
+    if req.exists():
+        print(
+            "[desktop-act-launcher] pip install -r requirements.txt (one-time)",
+            file=sys.stderr,
+        )
+        try:
+            subprocess.run(
+                [vpy, "-m", "pip", "install", "--quiet", "-r", str(req)], check=True
+            )
+        except subprocess.CalledProcessError as e:
+            print(
+                f"[desktop-act-launcher] pip install failed (exit {e.returncode})",
+                file=sys.stderr,
+            )
+            return None
+
+    return _runner_in(src)
+
+
+def main() -> int:
+    runner = _resolve_existing()
+    if runner is None:
+        runner = _bootstrap()
+
+    if runner is None:
+        sysname = _system()
+        if sysname != "linux":
+            print(
+                f"[desktop-act-launcher] desktop-act has full desktop-automation support on Linux today; "
+                f"{sysname} support is partial. The MCP server may still expose Kapture / chrome-devtools / "
+                f"Playwright tools but native X11 calls will no-op. Set DESKTOP_ACT_COMMAND to a custom "
+                f"build to override.",
+                file=sys.stderr,
+            )
+        print(
+            "[desktop-act-launcher] Could not locate or bootstrap the desktop-act MCP server.\n"
+            "  Install manually:    /plugin marketplace add <repo-url> && /plugin install desktop-act\n"
+            "  Or pin a custom path: export DESKTOP_ACT_COMMAND=/path/to/run.sh",
+            file=sys.stderr,
+        )
+        return 127
+
+    _exec_runner(runner)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude-ops/mcp-servers/desktop-act-launcher.py
+++ b/claude-ops/mcp-servers/desktop-act-launcher.py
@@ -29,11 +29,13 @@ import subprocess
 import sys
 from pathlib import Path
 
-DEFAULT_REPO = os.environ.get(
-    "DESKTOP_ACT_REPO",
-    "https://github.com/Lifecycle-Innovations-Limited/desktop-act.git",
-)
-DEFAULT_BRANCH = os.environ.get("DESKTOP_ACT_BRANCH", "main")
+_DEFAULT_REPO = "https://github.com/Lifecycle-Innovations-Limited/desktop-act.git"
+_DEFAULT_BRANCH = "main"
+# MCP may inject empty strings from userConfig; treat those as unset so fallbacks apply.
+DEFAULT_REPO = os.environ.get("DESKTOP_ACT_REPO") or _DEFAULT_REPO
+DEFAULT_BRANCH = os.environ.get("DESKTOP_ACT_BRANCH") or _DEFAULT_BRANCH
+
+_CACHE_READY_MARKER = ".desktop-act-launcher-ready"
 
 
 def _system() -> str:
@@ -107,10 +109,33 @@ def _resolve_existing() -> Path | None:
         if runner:
             return runner
 
-    runner = _runner_in(_cache_root() / "src")
+    cache_src = _cache_root() / "src"
+    runner = _runner_in(cache_src)
+    if runner is not None and not _cache_install_usable(cache_src):
+        runner = None
     if runner:
         return runner
     return None
+
+
+def _venv_python(install_root: Path) -> str | None:
+    bin_dir = "Scripts" if _system() == "windows" else "bin"
+    py = (
+        install_root
+        / ".venv"
+        / bin_dir
+        / ("python.exe" if _system() == "windows" else "python")
+    )
+    return str(py) if py.exists() else None
+
+
+def _cache_install_usable(cache_src: Path) -> bool:
+    """True when cached checkout finished bootstrap (venv + deps marker)."""
+    marker = cache_src / _CACHE_READY_MARKER
+    if not marker.is_file():
+        return False
+    vpy = _venv_python(cache_src)
+    return bool(vpy and Path(vpy).is_file())
 
 
 def _exec_runner(runner: Path) -> None:
@@ -134,19 +159,14 @@ def _exec_runner(runner: Path) -> None:
                 print("[desktop-act-launcher] PowerShell not found", file=sys.stderr)
                 sys.exit(127)
             os.execv(ps, [ps, "-ExecutionPolicy", "Bypass", "-File", str(runner)])
-        os.execv(str(runner), [str(runner)])
+        cmd_exe = os.environ.get("ComSpec")
+        if not cmd_exe or not Path(cmd_exe).is_file():
+            cmd_exe = shutil.which("cmd.exe") or shutil.which("cmd") or ""
+        if not cmd_exe:
+            print("[desktop-act-launcher] cmd.exe not found", file=sys.stderr)
+            sys.exit(127)
+        os.execv(cmd_exe, [cmd_exe, "/c", str(runner)])
     os.execv(str(runner), [str(runner)])
-
-
-def _venv_python(install_root: Path) -> str | None:
-    bin_dir = "Scripts" if _system() == "windows" else "bin"
-    py = (
-        install_root
-        / ".venv"
-        / bin_dir
-        / ("python.exe" if _system() == "windows" else "python")
-    )
-    return str(py) if py.exists() else None
 
 
 def _have(cmd: str) -> bool:
@@ -229,6 +249,15 @@ def _bootstrap() -> Path | None:
                 file=sys.stderr,
             )
             return None
+
+    try:
+        (src / _CACHE_READY_MARKER).write_text("ok\n", encoding="ascii")
+    except OSError as e:
+        print(
+            f"[desktop-act-launcher] could not write cache ready marker: {e}",
+            file=sys.stderr,
+        )
+        return None
 
     return _runner_in(src)
 

--- a/claude-ops/skills/ops-desktop/SKILL.md
+++ b/claude-ops/skills/ops-desktop/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: ops-desktop
+description: Autonomous desktop + browser control via the desktop-act MCP companion. Acquires an isolated noVNC desktop session, takes screenshots, clicks, types, scrolls, and runs the optional autonomous act() loop. First run auto-bootstraps the desktop-act server into a per-user cache.
+argument-hint: "[goal text | 'status' | 'list' | 'release [session_id]']"
+allowed-tools:
+  - Bash
+  - Read
+  - AskUserQuestion
+  - ToolSearch
+  - mcp__desktop-act__acquire_desktop
+  - mcp__desktop-act__release_desktop
+  - mcp__desktop-act__list_desktops
+  - mcp__desktop-act__list_windows
+  - mcp__desktop-act__launch_app
+  - mcp__desktop-act__screenshot
+  - mcp__desktop-act__observe
+  - mcp__desktop-act__click
+  - mcp__desktop-act__keypress
+  - mcp__desktop-act__type_text
+  - mcp__desktop-act__scroll
+  - mcp__desktop-act__act
+  - mcp__desktop-act__act_step
+  - mcp__desktop-act__batch
+  - mcp__desktop-act__status
+effort: medium
+maxTurns: 40
+---
+
+# OPS ► DESKTOP
+
+`/ops:desktop` drives a real GUI desktop (Linux noVNC pool, partial macOS / Windows support) through the `desktop-act` FastMCP server. Use it for tasks that browser-only automation can't reach: native dialogs, OS file pickers, multi-window flows, screen-recording verification.
+
+The MCP tool schemas are **deferred**. Load them with `ToolSearch` on demand:
+
+```
+ToolSearch select:mcp__desktop-act__acquire_desktop,mcp__desktop-act__screenshot,mcp__desktop-act__click,mcp__desktop-act__type_text,mcp__desktop-act__release_desktop
+```
+
+## Runtime Context
+
+Before any route runs, resolve:
+
+1. **Plugin root**: `${CLAUDE_PLUGIN_ROOT}` — used to locate the launcher.
+2. **MCP launcher**: `${CLAUDE_PLUGIN_ROOT}/mcp-servers/desktop-act-launcher.py` — auto-discovers an installed desktop-act marketplace or, if absent, clones from `$DESKTOP_ACT_REPO` (default `https://github.com/Lifecycle-Innovations-Limited/desktop-act.git`) and bootstraps a venv on first run.
+3. **noVNC default**: `http://<box-host>:6081` — primary desktop. `acquire_desktop()` provisions extra sessions on `:6082+`.
+4. **Mobile / SSH mode**: if `$SSH_CONNECTION`, `$SSH_CLIENT`, or `$SSH_TTY` is set, emit compact text-only output per Rule 7 (no banners, no tables, plain lines). The noVNC URL is the one piece the user definitely needs — print it once on a copy-able line.
+
+## Routing table
+
+Parse `$ARGUMENTS` and route. First token decides:
+
+| First arg          | Route                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------- |
+| (empty) / `status` | Print MCP status, default noVNC URL, active sessions, and platform support note       |
+| `list`             | `mcp__desktop-act__list_desktops` — show pool state                                   |
+| `release <id>`     | `mcp__desktop-act__release_desktop(session_id)` — free a session                      |
+| `release-all`      | Release every session this skill has open this turn                                   |
+| anything else      | Treat as a **goal** — acquire → observe → drive → verify → release                    |
+
+Anything else: treat the whole argument string as the goal.
+
+---
+
+## Route — `status` (default)
+
+1. Probe the MCP via `mcp__desktop-act__status` (auto-load schema first).
+2. Print compact summary — plugin connected? venv ready? pool size? default URL?
+3. If the MCP is **not reachable**, the launcher likely needs to bootstrap. Show:
+   - one-line install command (`/plugin marketplace add <repo> && /plugin install desktop-act`)
+   - or the env override (`export DESKTOP_ACT_COMMAND=/path/to/run.sh`)
+   - or the bootstrap repo (`export DESKTOP_ACT_REPO=https://...`)
+4. Mobile/SSH mode: drop banners, output 4–6 plain lines.
+
+## Route — `list`
+
+```
+ToolSearch select:mcp__desktop-act__list_desktops
+```
+Call it. Format as `session_id · display · vnc · last_used`. Linux only renders full info; macOS/Windows fall back to a "limited platform" note.
+
+## Route — `release <id>` / `release-all`
+
+Per Rule 5 (destructive actions): `release_desktop` tears down the X server. Ask before bulk release:
+
+```
+AskUserQuestion: Release session abcd1234?
+  [Release]  [Skip]
+```
+
+For `release-all`, batch confirm once.
+
+---
+
+## Route — **goal** (default for free-form $ARGUMENTS)
+
+The autonomous loop. Use this when Sam types `/ops:desktop open the AWS console and screenshot the ECS cluster page`.
+
+### Step 1 — Acquire
+
+```python
+# Load schemas
+ToolSearch select:mcp__desktop-act__acquire_desktop,mcp__desktop-act__screenshot,...
+
+session = mcp__desktop-act__acquire_desktop()
+session_id = session["session_id"]
+display    = session["display"]      # e.g. ":51"
+novnc_url  = session["novnc_url"]    # e.g. http://host:6082
+```
+
+Print the noVNC URL on a line by itself so the user can watch live. On mobile, the URL is the most useful thing — surface it FIRST.
+
+### Step 2 — Observe
+
+```python
+shot = mcp__desktop-act__screenshot(session_id=session_id)
+Read(file_path=shot["path"])   # let Claude see the screen
+```
+
+If you need window-level metadata before clicking blindly:
+
+```python
+windows = mcp__desktop-act__list_windows(session_id=session_id)
+```
+
+### Step 3 — Drive
+
+Two modes:
+
+**A. Streaming primitives** — full reasoning visibility, per-action transparency. Preferred for sensitive flows (anything touching credentials, billing pages, destructive UIs).
+
+```python
+mcp__desktop-act__launch_app(session_id, app="firefox")
+mcp__desktop-act__click(session_id, x=640, y=400)
+mcp__desktop-act__type_text(session_id, text="ECS clusters")
+mcp__desktop-act__keypress(session_id, key="Return")
+mcp__desktop-act__scroll(session_id, direction="down", amount=3)
+mcp__desktop-act__screenshot(session_id)   # verify
+```
+
+**B. Autonomous loop** — hands the goal to `act()` which runs claude-agent-sdk against the OAuth-bundled CLI (no API key needed; rides Claude Max). Faster but less observable.
+
+```python
+result = mcp__desktop-act__act(
+    session_id=session_id,
+    goal="$ARGUMENTS",
+    max_steps=20,
+)
+```
+
+For multi-step macros, prefer `batch` (single round-trip) or `act_step` (one micro-step at a time with explicit verification).
+
+### Step 4 — Verify
+
+Always `screenshot` and `Read` the path once at the end before claiming the goal is done. If the verification screenshot doesn't show the expected state, iterate or escalate to the user.
+
+### Step 5 — Release
+
+**Always** release in the same turn, even on failure:
+
+```python
+mcp__desktop-act__release_desktop(session_id=session_id)
+```
+
+If the user wants to keep the session for follow-up actions, ask first via `AskUserQuestion`:
+
+```
+Keep session abcd1234 alive for follow-up?
+  [Keep]  [Release]
+```
+
+---
+
+## Cross-platform notes
+
+| OS      | Status   | Notes                                                                 |
+| ------- | -------- | --------------------------------------------------------------------- |
+| Linux   | Full     | X11 + Xvnc + websockify + python-xlib. Multi-desktop pool live.       |
+| macOS   | Partial  | Server runs; native X11 calls no-op. Browser tools still work.        |
+| Windows | Partial  | Server runs via Python launcher. Native automation requires manual.   |
+
+On non-Linux platforms, prefer Kapture (`mcp__kapture__*`) or Playwright for browser-only tasks. The launcher prints a clear "limited platform" notice if it can't bring up a full session.
+
+## Safety
+
+- **Outbound comms** (Rule 6): if a goal involves sending email/messages/forms, stage the draft and ask before pressing Send. Per-message approval, never batch.
+- **Destructive UI clicks**: anything that says "Delete", "Terminate", "Force quit" routes through `AskUserQuestion` first per Rule 5.
+- **Credentials**: never type passwords into a goal string — leave it for Sam to fill in the live noVNC viewer.
+- **Session isolation**: each invocation of `/ops:desktop` gets its own `session_id`. Don't pass session IDs between concurrent agents or skills.
+
+## Examples
+
+```
+/ops:desktop                                    # status
+/ops:desktop list                               # pool state
+/ops:desktop release abcd1234                   # free session
+/ops:desktop open the AWS ECS console and screenshot the healify-api cluster
+/ops:desktop launch Firefox and navigate to https://finops.lifecycleinnovations.limited
+```
+
+## $ARGUMENTS
+
+$ARGUMENTS


### PR DESCRIPTION
## Summary

- Surface autonomous desktop + browser control as a first-class ops command (`/ops:desktop`) backed by the **`desktop-act`** FastMCP companion.
- Ship a cross-platform Python launcher that auto-discovers an installed `desktop-act` plugin or bootstraps one (git clone + venv + pip install) into a per-user cache on first run.
- Wire the new MCP into `.mcp.json` and add `userConfig` overrides for path/repo/branch.

## Files

- `claude-ops/mcp-servers/desktop-act-launcher.py` — cross-platform launcher (Linux full, macOS/Windows partial). Resolves an installed desktop-act in: \`\$DESKTOP_ACT_COMMAND\` → \`\$DESKTOP_ACT_HOME\` → \`\$CLAUDE_CONFIG_DIR/plugins/marketplaces/desktop-act\` → per-OS Claude config dir → per-user cache (\`\$XDG_CACHE_HOME\` / \`~/Library/Caches\` / \`%LOCALAPPDATA%\`). Auto-bootstraps via \`git clone \$DESKTOP_ACT_REPO\` + venv + \`pip install -r requirements.txt\` when absent; falls back to a clear error message instead of hanging the MCP host.
- `claude-ops/.mcp.json` — register `desktop-act` server via the launcher.
- `claude-ops/.claude-plugin/plugin.json` — add \`desktop_act_command\`, \`desktop_act_home\`, \`desktop_act_repo\`, \`desktop_act_branch\` userConfig keys.
- `claude-ops/skills/ops-desktop/SKILL.md` — routing table (\`status\`, \`list\`, \`release\`, free-form goal), acquire→observe→drive→verify→release loop, mobile/SSH compact-output handling, Rule 5/6 safety reminders.
- `claude-ops/README.md` + `claude-ops/CHANGELOG.md` — documented.

## Test plan

- [ ] \`/plugin install ops\` on a fresh box → \`/ops:desktop status\` triggers the launcher's auto-bootstrap path.
- [ ] On Linux, \`/ops:desktop launch firefox\` opens a noVNC desktop and the GUI is reachable at \`http://<host>:6081\`.
- [ ] \`tests/test-no-secrets.sh\` clean (passed locally: 14/14).
- [ ] JSON validity: \`.mcp.json\` + \`plugin.json\` parse via \`python3 -c 'import json; json.load(...)'\`.
- [ ] On macOS / Windows the launcher reports the partial-support note but still execs the server; non-X11 calls no-op while browser/Kapture surfaces still work.

## Notes

- Linux is the primary supported platform today. macOS/Windows can run the server but native X11 calls no-op — Kapture / chrome-devtools / Playwright remain the right path for browser-only tasks on those OSes.
- The default \`DESKTOP_ACT_REPO\` is \`https://github.com/Lifecycle-Innovations-Limited/desktop-act.git\` — that repo doesn't exist yet in GH; users can override via the new userConfig until it's published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to the launcher bootstrap flow and only affects the cached `.venv` creation/removal logic when the venv appears broken.
> 
> **Overview**
> Makes the `desktop-act-launcher` bootstrap more resilient by retrying venv setup: after creating (or finding) `.venv`, it now verifies the venv `python` exists and, if not, removes the broken venv once and recreates it before failing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7624521c592e4e063480f77b704b15eadeb75334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/ops:desktop` skill for autonomous desktop and browser control via the desktop-act MCP server integration
  * Introduced four new user configuration options to customize the desktop-act installation path, home directory, repository, and branch/tag

* **Documentation**
  * Updated changelog, README, and added comprehensive skill documentation for desktop automation workflows and safety guidelines

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/330?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->