### PR TITLE
feat(reauth): preload provider login tabs in --bootstrap mode

### DIFF
--- a/claude-ops/scripts/ops-mcp-reauth.py
+++ b/claude-ops/scripts/ops-mcp-reauth.py
@@ -259,11 +259,22 @@ def main() -> int:
                 except Exception as e:
                     log(f"failed to load {u}: {e}")
                 pages.append(pg)
-            # Block until user closes the LAST page (or 10 min hard cap)
-            try:
-                pages[-1].wait_for_event("close", timeout=600_000)
-            except Exception:
-                pass
+            # Block until every bootstrap tab is closed (or 10 min total hard cap).
+            # Waiting only on the last-opened tab exits early if the user closes
+            # tabs in a different order, tearing down the context while other
+            # sign-ins are still in progress.
+            deadline = time.monotonic() + 600
+            while True:
+                open_pages = [p for p in pages if not p.is_closed()]
+                if not open_pages:
+                    break
+                remaining_ms = int(max(0, (deadline - time.monotonic()) * 1000))
+                if remaining_ms <= 0:
+                    break
+                try:
+                    open_pages[0].wait_for_event("close", timeout=remaining_ms)
+                except Exception:
+                    break
         return 0
 
     url = sys.argv[1]

--- a/claude-ops/scripts/ops-mcp-reauth.py
+++ b/claude-ops/scripts/ops-mcp-reauth.py
@@ -239,14 +239,31 @@ def main() -> int:
         except ImportError:
             log("playwright not installed")
             return 3
-        log("BOOTSTRAP MODE — sign into each OAuth provider you use, then close the window")
+        # Default bootstrap targets — the providers that watchdog reports as
+        # needs_bootstrap. Override via CLI: --bootstrap <url1> <url2> ...
+        extra_urls = sys.argv[2:]
+        bootstrap_urls = extra_urls or [
+            "https://vercel.com/login",
+            "https://app.eu.amplitude.com/login",
+        ]
+        log("BOOTSTRAP MODE — sign into each tab, then close the window when done")
+        log(f"opening {len(bootstrap_urls)} provider login page(s): {bootstrap_urls}")
         BROWSER_PROFILE.mkdir(parents=True, exist_ok=True)
         with sync_playwright() as p:
             ctx = p.chromium.launch_persistent_context(str(BROWSER_PROFILE), headless=False)
-            page = ctx.new_page()
-            page.goto("about:blank")
-            # Block until user closes the window
-            page.wait_for_event("close", timeout=600_000)
+            pages = []
+            for u in bootstrap_urls:
+                pg = ctx.new_page()
+                try:
+                    pg.goto(u, wait_until="domcontentloaded", timeout=20000)
+                except Exception as e:
+                    log(f"failed to load {u}: {e}")
+                pages.append(pg)
+            # Block until user closes the LAST page (or 10 min hard cap)
+            try:
+                pages[-1].wait_for_event("close", timeout=600_000)
+            except Exception:
+                pass
         return 0
 
     url = sys.argv[1]


### PR DESCRIPTION
## Summary

- \`ops-mcp-reauth.py --bootstrap\` previously opened a blank tab, forcing the user to manually navigate to each OAuth provider.
- Now defaults to opening Vercel + Amplitude EU login tabs — the providers most frequently flagged \`needs_bootstrap\` by \`ops-mcp-watchdog\`.
- Custom URLs still work: \`ops-mcp-reauth.py --bootstrap <url1> <url2> ...\`.

## Test plan

- [ ] \`ops-mcp-reauth.py --bootstrap\` opens Vercel + Amplitude EU tabs by default.
- [ ] \`ops-mcp-reauth.py --bootstrap https://example.com\` opens only example.com.
- [ ] \`tests/test-no-secrets.sh\` passes (verified locally: 14/14).
- [ ] Python syntax: \`python3 -m py_compile claude-ops/scripts/ops-mcp-reauth.py\` clean.

## Notes

- Cherry-picked from \`feat/auto-ip-whitelist-on-network-change\` (commit 12d531e) which mixed multiple unrelated changes. The other commits on that branch are either already on \`main\` (PR #322, #323) or need Rule 0 scrubbing before they can be public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: isolated changes to an ops script’s interactive bootstrap flow (no auth/token logic changes), mainly affecting which pages open and when the Playwright context closes.
> 
> **Overview**
> `ops-mcp-reauth.py --bootstrap` now opens provider login pages (defaulting to Vercel and Amplitude EU) instead of a blank tab, while still allowing custom URLs via `--bootstrap <url...>`.
> 
> Bootstrap mode now keeps the browser context alive until *all* opened tabs are closed (with a 10-minute cap) to avoid exiting early when tabs are closed out of order, and logs which URLs it attempted to open (including per-URL load failures).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 891c16b5dbf40da886af8779de738fac72ee5424. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced bootstrap mode to open multiple provider login pages in configurable separate tabs, replacing the previous single blank page approach.
  * Streamlined authentication initialization with improved tab management and a 10-minute timeout safeguard.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->