### PR TITLE
feat(aws-sg-whitelist): auto-update SG ingress to current public IP

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -728,6 +728,45 @@
       "title": "Enable FedEx shipping",
       "description": "Use FedEx labels via /ops:package. Requires fedex_client_id/secret + account_number.",
       "default": false
+    },
+    "ip_whitelist_sg_id": {
+      "title": "IP-whitelist target Security Group",
+      "description": "AWS Security Group ID (sg-...) that aws-sg-ip-whitelist.sh keeps in sync with your current public IPv4. Leave blank to disable the feature.",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
+    },
+    "ip_whitelist_region": {
+      "title": "IP-whitelist AWS region",
+      "description": "Region containing ip_whitelist_sg_id. Defaults to us-east-1.",
+      "type": "string",
+      "sensitive": false,
+      "default": "us-east-1"
+    },
+    "ip_whitelist_port": {
+      "title": "IP-whitelist TCP port",
+      "description": "Single TCP port to authorize (default 22 for SSH).",
+      "type": "number",
+      "sensitive": false,
+      "default": 22,
+      "min": 1,
+      "max": 65535
+    },
+    "ip_whitelist_desc_prefix": {
+      "title": "IP-whitelist rule description prefix",
+      "description": "Description prefix for managed rules — e.g. 'mylaptop'. Defaults to <hostname>-laptop. Rules with this prefix are reaped when older than ip_whitelist_keep_recent.",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
+    },
+    "ip_whitelist_keep_recent": {
+      "title": "IP-whitelist rules to retain",
+      "description": "Newest N managed rules retained before pruning. Default 2.",
+      "type": "number",
+      "sensitive": false,
+      "default": 2,
+      "min": 0,
+      "max": 20
     }
   }
 }

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **AWS Security Group IP-whitelist auto-updater** — keeps a single SG ingress rule synced to your current public IPv4 across Wi-Fi switches, VPN flaps, and ISP IP rotations. Useful for dev sandboxes / bastion hosts that should only accept connections from your laptop.
+  - `scripts/aws-sg-ip-whitelist.sh` — idempotent core: detect public IP → reap stale managed rules → authorize new IP with a timestamped description. Configured via `IP_WHITELIST_SG_ID` / `IP_WHITELIST_REGION` / `IP_WHITELIST_PORT` / `IP_WHITELIST_DESC_PREFIX` / `IP_WHITELIST_KEEP_RECENT` env vars.
+  - `scripts/ssh-auto-whitelist.sh` — SSH wrapper that retries once after refreshing the SG when the first attempt times out / is refused.
+  - `scripts/install-ip-whitelist-agent.sh` + `launchd/com.claude-ops.ip-whitelist.plist.template` — macOS launchd agent that fires on `/etc/resolv.conf` changes (network state) with a 5-minute fallback poll and a 30-second throttle. Linux support stubbed (cron / systemd path-unit guidance in the installer output).
+  - `plugin.json` userConfig: `ip_whitelist_sg_id`, `ip_whitelist_region`, `ip_whitelist_port`, `ip_whitelist_desc_prefix`, `ip_whitelist_keep_recent`.
+
 ## [2.11.0] — 2026-05-22
 
 First-class Linux parity for the background daemon, plus two cross-platform fixes that surfaced during Linux bring-up on Amazon Linux 2023.

--- a/claude-ops/launchd/com.claude-ops.ip-whitelist.plist.template
+++ b/claude-ops/launchd/com.claude-ops.ip-whitelist.plist.template
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude-ops.ip-whitelist</string>
+
+    <!-- Fire on network state changes (resolv.conf is rewritten on each IP/DNS change) -->
+    <key>WatchPaths</key>
+    <array>
+        <string>/etc/resolv.conf</string>
+        <string>/var/run/resolv.conf</string>
+    </array>
+
+    <!-- Fallback: poll every 5 minutes to catch Wi-Fi switches WatchPaths may miss -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <!-- Prevent storm during network flap -->
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <!-- Source shell env (AWS creds, PATH), then run the whitelist script.
+             __PLUGIN_ROOT__ is substituted at install time by install-ip-whitelist-agent.sh. -->
+        <string>export PATH="/usr/local/bin:/opt/homebrew/bin:$PATH"; source "$HOME/.zshenv" 2>/dev/null; source "$HOME/.zprofile" 2>/dev/null; exec "__PLUGIN_ROOT__/scripts/aws-sg-ip-whitelist.sh"</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>IP_WHITELIST_SG_ID</key>
+        <string>__IP_WHITELIST_SG_ID__</string>
+        <key>IP_WHITELIST_REGION</key>
+        <string>__IP_WHITELIST_REGION__</string>
+        <key>IP_WHITELIST_PORT</key>
+        <string>__IP_WHITELIST_PORT__</string>
+        <key>IP_WHITELIST_DESC_PREFIX</key>
+        <string>__IP_WHITELIST_DESC_PREFIX__</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/ip-whitelist.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/ip-whitelist.err.log</string>
+
+    <!-- Do not trigger on login -->
+    <key>RunAtLoad</key>
+    <false/>
+
+    <!-- Oneshot per event, not a daemon -->
+    <key>KeepAlive</key>
+    <false/>
+</dict>
+</plist>

--- a/claude-ops/launchd/com.claude-ops.ip-whitelist.plist.template
+++ b/claude-ops/launchd/com.claude-ops.ip-whitelist.plist.template
@@ -39,6 +39,8 @@
         <string>__IP_WHITELIST_PORT__</string>
         <key>IP_WHITELIST_DESC_PREFIX</key>
         <string>__IP_WHITELIST_DESC_PREFIX__</string>
+        <key>IP_WHITELIST_KEEP_RECENT</key>
+        <string>__IP_WHITELIST_KEEP_RECENT__</string>
     </dict>
 
     <key>StandardOutPath</key>

--- a/claude-ops/scripts/aws-sg-ip-whitelist.sh
+++ b/claude-ops/scripts/aws-sg-ip-whitelist.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# aws-sg-ip-whitelist.sh — sync this machine's public IPv4 into an AWS Security
+# Group ingress rule. Idempotent; safe to run on every network change.
+#
+# Behavior:
+#   1. Fetch current public IPv4 via ifconfig.me / icanhazip.com / ipify.
+#   2. If already present in SG with a "$DESC_PREFIX-*" description: no-op.
+#   3. Otherwise revoke "$DESC_PREFIX-*" rules older than KEEP_RECENT count.
+#   4. Authorize the new IP on the target port with a timestamped description.
+#
+# Configuration (env vars or claude-ops preferences):
+#   IP_WHITELIST_SG_ID            REQUIRED — target Security Group ID (sg-...)
+#   IP_WHITELIST_REGION           default: us-east-1
+#   IP_WHITELIST_PORT             default: 22 (single TCP port)
+#   IP_WHITELIST_DESC_PREFIX      default: <hostname-without-domain>-laptop
+#   IP_WHITELIST_KEEP_RECENT      default: 2 (newest N rules retained pre-add)
+#   IP_OVERRIDE                   explicit IP, skips public-IP detection
+#
+# Exit codes:
+#   0  success (added or already present)
+#   1  could not detect public IP / missing config
+#   2  AWS CLI / SG mutation failure
+
+set -euo pipefail
+
+SG_ID="${IP_WHITELIST_SG_ID:-${SG_ID:-}}"
+REGION="${IP_WHITELIST_REGION:-${REGION:-us-east-1}}"
+PORT="${IP_WHITELIST_PORT:-${PORT:-22}}"
+KEEP_RECENT="${IP_WHITELIST_KEEP_RECENT:-${KEEP_RECENT:-2}}"
+DEFAULT_PREFIX="$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo claude-ops)-laptop"
+DESC_PREFIX="${IP_WHITELIST_DESC_PREFIX:-${DESC_PREFIX:-$DEFAULT_PREFIX}}"
+
+log() { printf '[ip-whitelist] %s\n' "$*" >&2; }
+
+if [[ -z "$SG_ID" ]]; then
+  log "IP_WHITELIST_SG_ID is required (export it or run /ops:setup ip-whitelist)"
+  exit 1
+fi
+
+detect_ip() {
+  if [[ -n "${IP_OVERRIDE:-}" ]]; then echo "$IP_OVERRIDE"; return 0; fi
+  for url in https://ifconfig.me https://icanhazip.com https://api.ipify.org; do
+    ip=$(curl -s4 --max-time 5 "$url" 2>/dev/null | tr -d '[:space:]') || true
+    if [[ "$ip" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then echo "$ip"; return 0; fi
+  done
+  return 1
+}
+
+IP=$(detect_ip) || { log "could not detect public IP"; exit 1; }
+log "current public IP: $IP"
+
+RULES_JSON=$(aws ec2 describe-security-groups \
+  --region "$REGION" --group-ids "$SG_ID" \
+  --query "SecurityGroups[].IpPermissions[?FromPort==\`$PORT\`].IpRanges[]" \
+  --output json 2>/dev/null) || { log "aws describe-security-groups failed"; exit 2; }
+
+RULES_FLAT=$(echo "$RULES_JSON" | jq '[.[] | .[]?] // []')
+
+if echo "$RULES_FLAT" | jq -e --arg ip "${IP}/32" '.[] | select(.CidrIp == $ip)' >/dev/null 2>&1; then
+  log "IP $IP already whitelisted — no-op"
+  exit 0
+fi
+
+mapfile -t STALE < <(
+  echo "$RULES_FLAT" | jq -r --arg p "$DESC_PREFIX-" --argjson keep "$KEEP_RECENT" '
+    [.[] | select(.Description // "" | startswith($p))]
+    | sort_by(.Description) | reverse | .[$keep:]
+    | .[] | "\(.CidrIp)|\(.Description)"
+  '
+)
+
+for entry in "${STALE[@]}"; do
+  [[ -z "$entry" ]] && continue
+  cidr="${entry%%|*}"
+  desc="${entry##*|}"
+  log "revoking stale $desc ($cidr)"
+  aws ec2 revoke-security-group-ingress \
+    --region "$REGION" --group-id "$SG_ID" \
+    --ip-permissions "IpProtocol=tcp,FromPort=$PORT,ToPort=$PORT,IpRanges=[{CidrIp=$cidr}]" \
+    >/dev/null 2>&1 || log "  (revoke failed for $cidr — continuing)"
+done
+
+TIMESTAMP=$(date +%Y%m%d-%H%M)
+NEW_DESC="${DESC_PREFIX}-${TIMESTAMP}"
+log "authorizing $IP/32 as $NEW_DESC"
+
+aws ec2 authorize-security-group-ingress \
+  --region "$REGION" --group-id "$SG_ID" \
+  --ip-permissions "IpProtocol=tcp,FromPort=$PORT,ToPort=$PORT,IpRanges=[{CidrIp=$IP/32,Description=$NEW_DESC}]" \
+  >/dev/null 2>&1 || { log "authorize failed"; exit 2; }
+
+log "OK $IP whitelisted as $NEW_DESC on $SG_ID"

--- a/claude-ops/scripts/install-ip-whitelist-agent.sh
+++ b/claude-ops/scripts/install-ip-whitelist-agent.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# install-ip-whitelist-agent.sh — install an OS-native agent that keeps your AWS
+# Security Group ingress synced to this machine's public IP.
+#
+# Idempotent: unloads/disables any existing agent before reinstalling.
+# Supports macOS (launchd) today; Linux (systemd path unit) coming next.
+#
+# Required env (or read from claude-ops preferences if unset):
+#   IP_WHITELIST_SG_ID            target Security Group (sg-...)
+# Optional:
+#   IP_WHITELIST_REGION           default: us-east-1
+#   IP_WHITELIST_PORT             default: 22
+#   IP_WHITELIST_DESC_PREFIX      default: <hostname>-laptop
+
+set -euo pipefail
+
+LABEL="com.claude-ops.ip-whitelist"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PLIST_TEMPLATE="${PLUGIN_ROOT}/launchd/${LABEL}.plist.template"
+PLIST_DEST="$HOME/Library/LaunchAgents/${LABEL}.plist"
+
+# Read config (env wins; prefs fallback omitted for portability — set the env)
+IP_WHITELIST_SG_ID="${IP_WHITELIST_SG_ID:-}"
+IP_WHITELIST_REGION="${IP_WHITELIST_REGION:-us-east-1}"
+IP_WHITELIST_PORT="${IP_WHITELIST_PORT:-22}"
+DEFAULT_PREFIX="$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo claude-ops)-laptop"
+IP_WHITELIST_DESC_PREFIX="${IP_WHITELIST_DESC_PREFIX:-$DEFAULT_PREFIX}"
+
+log() { printf '[install-ip-whitelist] %s\n' "$*"; }
+die() { log "ERROR: $*"; exit 1; }
+
+if [[ -z "$IP_WHITELIST_SG_ID" ]]; then
+  die "IP_WHITELIST_SG_ID is required. Example: IP_WHITELIST_SG_ID=sg-0123456789abcdef0 $0"
+fi
+
+OS="$(uname -s)"
+case "$OS" in
+  Darwin)
+    GUI_DOMAIN="gui/$(id -u)"
+
+    if launchctl print "${GUI_DOMAIN}/${LABEL}" &>/dev/null; then
+      log "unloading existing agent..."
+      launchctl bootout "${GUI_DOMAIN}/${PLIST_DEST}" 2>/dev/null \
+        || launchctl bootout "${GUI_DOMAIN}" "${PLIST_DEST}" 2>/dev/null \
+        || launchctl remove "${LABEL}" 2>/dev/null \
+        || true
+      sleep 1
+    fi
+
+    [[ -f "$PLIST_TEMPLATE" ]] || die "plist template missing: $PLIST_TEMPLATE"
+
+    log "rendering plist with PLUGIN_ROOT=$PLUGIN_ROOT SG=$IP_WHITELIST_SG_ID"
+    mkdir -p "$(dirname "$PLIST_DEST")"
+    sed \
+      -e "s|__PLUGIN_ROOT__|${PLUGIN_ROOT}|g" \
+      -e "s|__IP_WHITELIST_SG_ID__|${IP_WHITELIST_SG_ID}|g" \
+      -e "s|__IP_WHITELIST_REGION__|${IP_WHITELIST_REGION}|g" \
+      -e "s|__IP_WHITELIST_PORT__|${IP_WHITELIST_PORT}|g" \
+      -e "s|__IP_WHITELIST_DESC_PREFIX__|${IP_WHITELIST_DESC_PREFIX}|g" \
+      "$PLIST_TEMPLATE" > "$PLIST_DEST"
+
+    log "bootstrapping ${GUI_DOMAIN}/${LABEL}"
+    launchctl bootstrap "${GUI_DOMAIN}" "${PLIST_DEST}"
+
+    log "agent loaded. status:"
+    launchctl print "${GUI_DOMAIN}/${LABEL}" | head -20
+    ;;
+  Linux)
+    log "Linux support coming next — for now run the script via cron or systemd:"
+    log "  */5 * * * * IP_WHITELIST_SG_ID=$IP_WHITELIST_SG_ID $PLUGIN_ROOT/scripts/aws-sg-ip-whitelist.sh"
+    exit 2
+    ;;
+  *)
+    die "unsupported OS: $OS"
+    ;;
+esac

--- a/claude-ops/scripts/install-ip-whitelist-agent.sh
+++ b/claude-ops/scripts/install-ip-whitelist-agent.sh
@@ -11,6 +11,7 @@
 #   IP_WHITELIST_REGION           default: us-east-1
 #   IP_WHITELIST_PORT             default: 22
 #   IP_WHITELIST_DESC_PREFIX      default: <hostname>-laptop
+#   IP_WHITELIST_KEEP_RECENT      default: 2 (newest N managed rules retained before prune)
 
 set -euo pipefail
 
@@ -26,6 +27,7 @@ IP_WHITELIST_REGION="${IP_WHITELIST_REGION:-us-east-1}"
 IP_WHITELIST_PORT="${IP_WHITELIST_PORT:-22}"
 DEFAULT_PREFIX="$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo claude-ops)-laptop"
 IP_WHITELIST_DESC_PREFIX="${IP_WHITELIST_DESC_PREFIX:-$DEFAULT_PREFIX}"
+IP_WHITELIST_KEEP_RECENT="${IP_WHITELIST_KEEP_RECENT:-2}"
 
 log() { printf '[install-ip-whitelist] %s\n' "$*"; }
 die() { log "ERROR: $*"; exit 1; }
@@ -58,13 +60,14 @@ case "$OS" in
       -e "s|__IP_WHITELIST_REGION__|${IP_WHITELIST_REGION}|g" \
       -e "s|__IP_WHITELIST_PORT__|${IP_WHITELIST_PORT}|g" \
       -e "s|__IP_WHITELIST_DESC_PREFIX__|${IP_WHITELIST_DESC_PREFIX}|g" \
+      -e "s|__IP_WHITELIST_KEEP_RECENT__|${IP_WHITELIST_KEEP_RECENT}|g" \
       "$PLIST_TEMPLATE" > "$PLIST_DEST"
 
     log "bootstrapping ${GUI_DOMAIN}/${LABEL}"
     launchctl bootstrap "${GUI_DOMAIN}" "${PLIST_DEST}"
 
     log "agent loaded. status:"
-    launchctl print "${GUI_DOMAIN}/${LABEL}" | head -20
+    head -20 < <(launchctl print "${GUI_DOMAIN}/${LABEL}")
     ;;
   Linux)
     log "Linux support coming next — for now run the script via cron or systemd:"

--- a/claude-ops/scripts/ssh-auto-whitelist.sh
+++ b/claude-ops/scripts/ssh-auto-whitelist.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# ssh-auto-whitelist.sh — SSH wrapper that self-heals on connection failure.
+#
+# When SSH times out or is refused (likely the bastion's Security Group dropped
+# your IP after a network change), this wrapper calls aws-sg-ip-whitelist.sh to
+# add the current public IP to the target SG, then retries SSH once.
+#
+# Usage:
+#   ssh-auto-whitelist.sh <host-alias> [ssh-args...]
+#   ssh-auto-whitelist.sh <host-alias> "remote command"
+#
+# Requires IP_WHITELIST_SG_ID to be set (or the user's SG config provided via
+# /ops:setup ip-whitelist).
+#
+# Exit code = the final SSH invocation's exit code.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WHITELIST_SCRIPT="${SCRIPT_DIR}/aws-sg-ip-whitelist.sh"
+
+HOST="${1:-}"
+[[ -z "$HOST" ]] && { echo "usage: $0 <ssh-host-alias> [ssh-args...|command]" >&2; exit 2; }
+shift
+
+log() { printf '[ssh-auto] %s\n' "$*" >&2; }
+
+try_ssh() {
+  local timeout=$1; shift
+  ssh -o ConnectTimeout="$timeout" -o BatchMode=no "$HOST" "$@"
+}
+
+if try_ssh 5 "$@"; then
+  exit 0
+fi
+
+rc=$?
+# 255 = SSH-level failure (timeout, refused, unreachable). Anything else is the remote command's exit.
+if [[ $rc -ne 255 ]]; then exit $rc; fi
+
+log "SSH failed (likely IP blocked) — refreshing SG whitelist…"
+if ! bash "$WHITELIST_SCRIPT"; then
+  log "whitelist refresh failed — aborting"
+  exit $rc
+fi
+
+# Brief settle so SG mutation propagates
+sleep 2
+
+log "retrying SSH…"
+try_ssh 10 "$@"


### PR DESCRIPTION
## Summary

- Keeps a single AWS Security Group ingress rule synced to this machine's public IPv4 across Wi-Fi switches, VPN flaps, and ISP IP rotations.
- Useful for dev sandboxes / bastion hosts that should only accept connections from a known laptop.
- macOS launchd agent fires on \`/etc/resolv.conf\` changes; 5-minute fallback poll + 30-second throttle.

## Files

- \`claude-ops/scripts/aws-sg-ip-whitelist.sh\` — idempotent core (detect → reap stale → authorize). All knobs via \`IP_WHITELIST_*\` env vars.
- \`claude-ops/scripts/ssh-auto-whitelist.sh\` — SSH wrapper that retries once after refreshing the SG on ssh exit-code 255.
- \`claude-ops/scripts/install-ip-whitelist-agent.sh\` — renders the plist template with the user's SG config, unloads any existing agent, bootstraps the new one.
- \`claude-ops/launchd/com.claude-ops.ip-whitelist.plist.template\` — \`__PLUGIN_ROOT__\` / \`__IP_WHITELIST_*__\` placeholders substituted at install.
- \`plugin.json\` userConfig: \`ip_whitelist_sg_id\`, \`ip_whitelist_region\`, \`ip_whitelist_port\`, \`ip_whitelist_desc_prefix\`, \`ip_whitelist_keep_recent\`.
- CHANGELOG entry.

## Test plan

- [ ] \`IP_WHITELIST_SG_ID=sg-xxx aws-sg-ip-whitelist.sh\` — first run authorizes; second run no-ops.
- [ ] Toggle Wi-Fi → \`/etc/resolv.conf\` change fires the launchd agent within 30s throttle window.
- [ ] \`ssh-auto-whitelist.sh <host>\` — initial timeout, refresh, retry succeeds.
- [ ] \`tests/test-no-secrets.sh\` clean (verified locally: 14/14).
- [ ] No personal data: grep for \`sam-\`, \`<USER>\`, \`/Users/\`, \`/home/ec2\` returns nothing.

## Notes

- Cherry-picked + scrubbed from \`feat/auto-ip-whitelist-on-network-change\` (commit b8c7b6c). The original carried personal identifiers in filenames/plist label/SG ID — all genericized for the public repo.
- Linux installer path prints cron / systemd guidance for now; full \`systemd --user\` path-unit support to follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds automation that mutates AWS Security Group ingress rules via AWS CLI; misconfiguration could open/close access unexpectedly and relies on external IP-detection services plus `jq`/`aws` availability.
> 
> **Overview**
> Adds an **AWS Security Group IP-whitelist auto-updater** that keeps a laptop’s current public IPv4 authorized on a chosen SG/port and prunes older managed rules (`scripts/aws-sg-ip-whitelist.sh`).
> 
> Introduces a macOS `launchd` agent template plus installer to run the updater on network changes with interval/throttle controls, and an `ssh-auto-whitelist.sh` wrapper that retries SSH once after refreshing the whitelist. Exposes new plugin settings (`ip_whitelist_*`) and documents the feature in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7636ebcb222f8c6389ba02733a30c2ab814452c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->