### PR TITLE
release: v2.11.1 — ops-desktop + reauth-preload + sg-ip-whitelist

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.10.4",
+      "version": "2.11.1",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -728,6 +728,34 @@
       "title": "Enable FedEx shipping",
       "description": "Use FedEx labels via /ops:package. Requires fedex_client_id/secret + account_number.",
       "default": false
+    },
+    "desktop_act_command": {
+      "title": "desktop-act runner path (override)",
+      "description": "Absolute path to a custom desktop-act MCP server executable. Leave blank to auto-discover the desktop-act plugin or bootstrap into the per-user cache.",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
+    },
+    "desktop_act_home": {
+      "title": "desktop-act install directory (override)",
+      "description": "Absolute path to a desktop-act marketplace checkout. Used when the plugin is installed outside the standard Claude Code marketplace tree.",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
+    },
+    "desktop_act_repo": {
+      "title": "desktop-act source repository",
+      "description": "Git URL the launcher clones from when bootstrapping a fresh install. Defaults to the public Lifecycle-Innovations-Limited/desktop-act repo.",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
+    },
+    "desktop_act_branch": {
+      "title": "desktop-act branch / tag",
+      "description": "Branch or tag to clone when bootstrapping. Defaults to main.",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
     }
   }
 }

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -728,6 +728,45 @@
       "title": "Enable FedEx shipping",
       "description": "Use FedEx labels via /ops:package. Requires fedex_client_id/secret + account_number.",
       "default": false
+    },
+    "ip_whitelist_sg_id": {
+      "title": "IP-whitelist target Security Group",
+      "description": "AWS Security Group ID (sg-...) that aws-sg-ip-whitelist.sh keeps in sync with your current public IPv4. Leave blank to disable the feature.",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
+    },
+    "ip_whitelist_region": {
+      "title": "IP-whitelist AWS region",
+      "description": "Region containing ip_whitelist_sg_id. Defaults to us-east-1.",
+      "type": "string",
+      "sensitive": false,
+      "default": "us-east-1"
+    },
+    "ip_whitelist_port": {
+      "title": "IP-whitelist TCP port",
+      "description": "Single TCP port to authorize (default 22 for SSH).",
+      "type": "number",
+      "sensitive": false,
+      "default": 22,
+      "min": 1,
+      "max": 65535
+    },
+    "ip_whitelist_desc_prefix": {
+      "title": "IP-whitelist rule description prefix",
+      "description": "Description prefix for managed rules — e.g. 'mylaptop'. Defaults to <hostname>-laptop. Rules with this prefix are reaped when older than ip_whitelist_keep_recent.",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
+    },
+    "ip_whitelist_keep_recent": {
+      "title": "IP-whitelist rules to retain",
+      "description": "Newest N managed rules retained before pruning. Default 2.",
+      "type": "number",
+      "sensitive": false,
+      "default": 2,
+      "min": 0,
+      "max": 20
     }
   }
 }

--- a/claude-ops/.mcp.json
+++ b/claude-ops/.mcp.json
@@ -16,6 +16,16 @@
       "env": {
         "DOPPLER_TOKEN": "${user_config.doppler_token}"
       }
+    },
+    "desktop-act": {
+      "command": "python3",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-servers/desktop-act-launcher.py"],
+      "env": {
+        "DESKTOP_ACT_COMMAND": "${user_config.desktop_act_command}",
+        "DESKTOP_ACT_HOME": "${user_config.desktop_act_home}",
+        "DESKTOP_ACT_REPO": "${user_config.desktop_act_repo}",
+        "DESKTOP_ACT_BRANCH": "${user_config.desktop_act_branch}"
+      }
     }
   }
 }

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **AWS Security Group IP-whitelist auto-updater** — keeps a single SG ingress rule synced to your current public IPv4 across Wi-Fi switches, VPN flaps, and ISP IP rotations. Useful for dev sandboxes / bastion hosts that should only accept connections from your laptop.
+  - `scripts/aws-sg-ip-whitelist.sh` — idempotent core: detect public IP → reap stale managed rules → authorize new IP with a timestamped description. Configured via `IP_WHITELIST_SG_ID` / `IP_WHITELIST_REGION` / `IP_WHITELIST_PORT` / `IP_WHITELIST_DESC_PREFIX` / `IP_WHITELIST_KEEP_RECENT` env vars.
+  - `scripts/ssh-auto-whitelist.sh` — SSH wrapper that retries once after refreshing the SG when the first attempt times out / is refused.
+  - `scripts/install-ip-whitelist-agent.sh` + `launchd/com.claude-ops.ip-whitelist.plist.template` — macOS launchd agent that fires on `/etc/resolv.conf` changes (network state) with a 5-minute fallback poll and a 30-second throttle. Linux support stubbed (cron / systemd path-unit guidance in the installer output).
+  - `plugin.json` userConfig: `ip_whitelist_sg_id`, `ip_whitelist_region`, `ip_whitelist_port`, `ip_whitelist_desc_prefix`, `ip_whitelist_keep_recent`.
+
 ## [2.11.0] — 2026-05-22
 
 First-class Linux parity for the background daemon, plus two cross-platform fixes that surfaced during Linux bring-up on Amazon Linux 2023.

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **`/ops:desktop` skill + `desktop-act` MCP wiring** — autonomous desktop + browser control surfaced as a first-class ops command. Acquires a noVNC desktop session, takes screenshots, clicks, types, scrolls, and runs the autonomous `act()` loop driven by the bundled `claude-agent-sdk` (OAuth via Claude Max, no Anthropic API key). Cross-platform launcher (Linux full / macOS / Windows partial).
+- **`mcp-servers/desktop-act-launcher.py`** — pure-Python cross-platform launcher. Resolves an installed `desktop-act` companion in (1) `$DESKTOP_ACT_COMMAND`, (2) `$DESKTOP_ACT_HOME`, (3) `$CLAUDE_CONFIG_DIR/plugins/marketplaces/desktop-act`, (4) the per-OS Claude config dir, (5) the per-user cache (`$XDG_CACHE_HOME` on Linux, `~/Library/Caches` on macOS, `%LOCALAPPDATA%` on Windows). If none exist it `git clone`s `$DESKTOP_ACT_REPO` (default Lifecycle-Innovations-Limited/desktop-act), bootstraps a venv, `pip install -r requirements.txt`, then `execv`s the runner. Falls back to a clear error message — never hangs the MCP host.
+- **plugin.json userConfig keys** — `desktop_act_command`, `desktop_act_home`, `desktop_act_repo`, `desktop_act_branch` for per-user overrides.
+- **`.mcp.json` `desktop-act` server registration** — wired via `${CLAUDE_PLUGIN_ROOT}/mcp-servers/desktop-act-launcher.py`. All `mcp__desktop-act__*` tools (`acquire_desktop`, `screenshot`, `click`, `type_text`, `act`, …) are now part of the ops surface.
+
+### Notes
+
+- Linux is the primary supported platform (X11 + Xvnc + websockify + python-xlib). macOS and Windows can launch the server but native X11 calls no-op; browser/Kapture paths still work.
+- First run on a fresh box performs a one-time clone + `pip install`. Subsequent launches `execv` directly into the cached venv with no extra latency.
+
 ## [2.11.0] — 2026-05-22
 
 First-class Linux parity for the background daemon, plus two cross-platform fixes that surfaced during Linux bring-up on Amazon Linux 2023.

--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -89,6 +89,7 @@ Per-repo budget caps (default 3/hour), single-flight locks, content-hash dedup, 
 | `/ops:recap`      | **v2** — Status/tail/configure/restart for the multi-session recap marquee daemon |
 | `/ops:rotate`     | **v2** — Manually rotate the active Claude Max account                         |
 | `/ops:rotate-setup` | **v2** — Multi-account onboarding for the rotator                            |
+| `/ops:desktop`    | Autonomous desktop + browser control via the `desktop-act` MCP companion       |
 
 ### Dashboard hotkeys
 

--- a/claude-ops/launchd/com.claude-ops.ip-whitelist.plist.template
+++ b/claude-ops/launchd/com.claude-ops.ip-whitelist.plist.template
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude-ops.ip-whitelist</string>
+
+    <!-- Fire on network state changes (resolv.conf is rewritten on each IP/DNS change) -->
+    <key>WatchPaths</key>
+    <array>
+        <string>/etc/resolv.conf</string>
+        <string>/var/run/resolv.conf</string>
+    </array>
+
+    <!-- Fallback: poll every 5 minutes to catch Wi-Fi switches WatchPaths may miss -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <!-- Prevent storm during network flap -->
+    <key>ThrottleInterval</key>
+    <integer>30</integer>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <!-- Source shell env (AWS creds, PATH), then run the whitelist script.
+             __PLUGIN_ROOT__ is substituted at install time by install-ip-whitelist-agent.sh. -->
+        <string>export PATH="/usr/local/bin:/opt/homebrew/bin:$PATH"; source "$HOME/.zshenv" 2>/dev/null; source "$HOME/.zprofile" 2>/dev/null; exec "__PLUGIN_ROOT__/scripts/aws-sg-ip-whitelist.sh"</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>IP_WHITELIST_SG_ID</key>
+        <string>__IP_WHITELIST_SG_ID__</string>
+        <key>IP_WHITELIST_REGION</key>
+        <string>__IP_WHITELIST_REGION__</string>
+        <key>IP_WHITELIST_PORT</key>
+        <string>__IP_WHITELIST_PORT__</string>
+        <key>IP_WHITELIST_DESC_PREFIX</key>
+        <string>__IP_WHITELIST_DESC_PREFIX__</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/ip-whitelist.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/ip-whitelist.err.log</string>
+
+    <!-- Do not trigger on login -->
+    <key>RunAtLoad</key>
+    <false/>
+
+    <!-- Oneshot per event, not a daemon -->
+    <key>KeepAlive</key>
+    <false/>
+</dict>
+</plist>

--- a/claude-ops/launchd/com.claude-ops.ip-whitelist.plist.template
+++ b/claude-ops/launchd/com.claude-ops.ip-whitelist.plist.template
@@ -39,6 +39,8 @@
         <string>__IP_WHITELIST_PORT__</string>
         <key>IP_WHITELIST_DESC_PREFIX</key>
         <string>__IP_WHITELIST_DESC_PREFIX__</string>
+        <key>IP_WHITELIST_KEEP_RECENT</key>
+        <string>__IP_WHITELIST_KEEP_RECENT__</string>
     </dict>
 
     <key>StandardOutPath</key>

--- a/claude-ops/mcp-servers/desktop-act-launcher.py
+++ b/claude-ops/mcp-servers/desktop-act-launcher.py
@@ -219,19 +219,35 @@ def _bootstrap() -> Path | None:
 
     py_bin = shutil.which("python3") or shutil.which("python")
     venv_dir = src / ".venv"
-    if not venv_dir.exists():
-        print(f"[desktop-act-launcher] creating venv at {venv_dir}", file=sys.stderr)
-        try:
-            subprocess.run([py_bin, "-m", "venv", str(venv_dir)], check=True)
-        except subprocess.CalledProcessError as e:
+    vpy: str | None = None
+    for attempt in range(2):
+        if not venv_dir.exists():
+            print(f"[desktop-act-launcher] creating venv at {venv_dir}", file=sys.stderr)
+            try:
+                subprocess.run([py_bin, "-m", "venv", str(venv_dir)], check=True)
+            except subprocess.CalledProcessError as e:
+                print(
+                    f"[desktop-act-launcher] venv create failed (exit {e.returncode})",
+                    file=sys.stderr,
+                )
+                return None
+        vpy = _venv_python(src)
+        if vpy:
+            break
+        if attempt == 0 and venv_dir.exists():
             print(
-                f"[desktop-act-launcher] venv create failed (exit {e.returncode})",
+                f"[desktop-act-launcher] removing broken venv at {venv_dir}",
                 file=sys.stderr,
             )
-            return None
-
-    vpy = _venv_python(src)
-    if not vpy:
+            try:
+                shutil.rmtree(venv_dir)
+            except OSError as e:
+                print(
+                    f"[desktop-act-launcher] could not remove broken venv: {e}",
+                    file=sys.stderr,
+                )
+                return None
+            continue
         return None
     req = src / "requirements.txt"
     if req.exists():

--- a/claude-ops/mcp-servers/desktop-act-launcher.py
+++ b/claude-ops/mcp-servers/desktop-act-launcher.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""desktop-act-launcher — locate or bootstrap the desktop-act MCP server.
+
+Cross-platform launcher (Linux / macOS / Windows) used by the claude-ops plugin
+to bring up the `desktop-act` FastMCP server for the /ops:desktop skill.
+
+Resolution order:
+    1. ``$DESKTOP_ACT_COMMAND`` — explicit path to an executable script.
+    2. ``$DESKTOP_ACT_HOME/mcp-server/`` — manual install directory.
+    3. ``$CLAUDE_CONFIG_DIR/plugins/marketplaces/desktop-act/mcp-server/``
+    4. Per-OS default Claude config dir.
+    5. Per-user cache: $XDG_CACHE_HOME/desktop-act-mcp (Linux) /
+       ~/Library/Caches/desktop-act-mcp (macOS) /
+       %LOCALAPPDATA%\\desktop-act-mcp (Windows).
+       If absent and ``DESKTOP_ACT_REPO`` is set, we ``git clone`` it,
+       bootstrap a venv, ``pip install -r requirements.txt``, then exec.
+
+Linux is the only platform with full desktop automation today; macOS and
+Windows currently surface a clear "not supported yet" message so the
+launcher fails loudly instead of hanging the MCP host.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+DEFAULT_REPO = os.environ.get(
+    "DESKTOP_ACT_REPO",
+    "https://github.com/Lifecycle-Innovations-Limited/desktop-act.git",
+)
+DEFAULT_BRANCH = os.environ.get("DESKTOP_ACT_BRANCH", "main")
+
+
+def _system() -> str:
+    s = platform.system().lower()
+    if s.startswith("win"):
+        return "windows"
+    if s == "darwin":
+        return "macos"
+    return "linux"
+
+
+def _cache_root() -> Path:
+    sysname = _system()
+    if sysname == "macos":
+        return Path.home() / "Library" / "Caches" / "desktop-act-mcp"
+    if sysname == "windows":
+        base = os.environ.get("LOCALAPPDATA") or str(Path.home() / "AppData" / "Local")
+        return Path(base) / "desktop-act-mcp"
+    base = os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
+    return Path(base) / "desktop-act-mcp"
+
+
+def _claude_config_dirs() -> list[Path]:
+    sysname = _system()
+    explicit = os.environ.get("CLAUDE_CONFIG_DIR")
+    out: list[Path] = []
+    if explicit:
+        out.append(Path(explicit))
+    if sysname == "windows":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            out.append(Path(appdata) / "claude-code")
+    out.append(Path.home() / ".claude")
+    out.append(Path.home() / ".config" / "claude-code")
+    return out
+
+
+def _runner_in(home: Path) -> Path | None:
+    """Pick the platform-appropriate launcher inside a desktop-act install."""
+    if not home.is_dir():
+        return None
+    if _system() == "windows":
+        for cand in (
+            home / "mcp-server" / "run.cmd",
+            home / "mcp-server" / "run.ps1",
+        ):
+            if cand.exists():
+                return cand
+    sh = home / "mcp-server" / "run.sh"
+    if sh.exists() and os.access(sh, os.X_OK):
+        return sh
+    server_py = home / "mcp-server" / "server.py"
+    if server_py.exists():
+        return server_py
+    return None
+
+
+def _resolve_existing() -> Path | None:
+    override = os.environ.get("DESKTOP_ACT_COMMAND")
+    if override and Path(override).exists():
+        return Path(override)
+
+    explicit_home = os.environ.get("DESKTOP_ACT_HOME")
+    if explicit_home:
+        runner = _runner_in(Path(explicit_home))
+        if runner:
+            return runner
+
+    for cfg in _claude_config_dirs():
+        runner = _runner_in(cfg / "plugins" / "marketplaces" / "desktop-act")
+        if runner:
+            return runner
+
+    runner = _runner_in(_cache_root() / "src")
+    if runner:
+        return runner
+    return None
+
+
+def _exec_runner(runner: Path) -> None:
+    if runner.suffix == ".py":
+        py = (
+            _venv_python(runner.parent.parent)
+            or shutil.which("python3")
+            or shutil.which("python")
+        )
+        if not py:
+            print(
+                "[desktop-act-launcher] No python3 available to exec server.py",
+                file=sys.stderr,
+            )
+            sys.exit(127)
+        os.execv(py, [py, str(runner)])
+    if runner.suffix in (".cmd", ".ps1"):
+        if runner.suffix == ".ps1":
+            ps = shutil.which("pwsh") or shutil.which("powershell")
+            if not ps:
+                print("[desktop-act-launcher] PowerShell not found", file=sys.stderr)
+                sys.exit(127)
+            os.execv(ps, [ps, "-ExecutionPolicy", "Bypass", "-File", str(runner)])
+        os.execv(str(runner), [str(runner)])
+    os.execv(str(runner), [str(runner)])
+
+
+def _venv_python(install_root: Path) -> str | None:
+    bin_dir = "Scripts" if _system() == "windows" else "bin"
+    py = (
+        install_root
+        / ".venv"
+        / bin_dir
+        / ("python.exe" if _system() == "windows" else "python")
+    )
+    return str(py) if py.exists() else None
+
+
+def _have(cmd: str) -> bool:
+    return shutil.which(cmd) is not None
+
+
+def _bootstrap() -> Path | None:
+    """Clone desktop-act into the per-user cache and set up its venv.
+
+    Returns the path to the runner once ready, or ``None`` if bootstrap is not
+    possible (missing git/python3 or unsupported platform).
+    """
+    if not _have("git") or not (_have("python3") or _have("python")):
+        print(
+            "[desktop-act-launcher] git + python3 are required to auto-install desktop-act.\n"
+            "  macOS:   brew install git python\n"
+            "  Linux:   sudo apt install -y git python3 python3-venv  # or your distro's equivalent\n"
+            "  Windows: install Git + Python 3.11+ from python.org",
+            file=sys.stderr,
+        )
+        return None
+
+    cache = _cache_root()
+    src = cache / "src"
+    cache.mkdir(parents=True, exist_ok=True)
+
+    if not src.exists():
+        print(f"[desktop-act-launcher] cloning {DEFAULT_REPO} → {src}", file=sys.stderr)
+        try:
+            subprocess.run(
+                [
+                    "git",
+                    "clone",
+                    "--depth",
+                    "1",
+                    "--branch",
+                    DEFAULT_BRANCH,
+                    DEFAULT_REPO,
+                    str(src),
+                ],
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print(
+                f"[desktop-act-launcher] git clone failed (exit {e.returncode}). "
+                f"Set DESKTOP_ACT_REPO to a reachable URL, or install desktop-act manually.",
+                file=sys.stderr,
+            )
+            return None
+
+    py_bin = shutil.which("python3") or shutil.which("python")
+    venv_dir = src / ".venv"
+    if not venv_dir.exists():
+        print(f"[desktop-act-launcher] creating venv at {venv_dir}", file=sys.stderr)
+        try:
+            subprocess.run([py_bin, "-m", "venv", str(venv_dir)], check=True)
+        except subprocess.CalledProcessError as e:
+            print(
+                f"[desktop-act-launcher] venv create failed (exit {e.returncode})",
+                file=sys.stderr,
+            )
+            return None
+
+    vpy = _venv_python(src)
+    if not vpy:
+        return None
+    req = src / "requirements.txt"
+    if req.exists():
+        print(
+            "[desktop-act-launcher] pip install -r requirements.txt (one-time)",
+            file=sys.stderr,
+        )
+        try:
+            subprocess.run(
+                [vpy, "-m", "pip", "install", "--quiet", "-r", str(req)], check=True
+            )
+        except subprocess.CalledProcessError as e:
+            print(
+                f"[desktop-act-launcher] pip install failed (exit {e.returncode})",
+                file=sys.stderr,
+            )
+            return None
+
+    return _runner_in(src)
+
+
+def main() -> int:
+    runner = _resolve_existing()
+    if runner is None:
+        runner = _bootstrap()
+
+    if runner is None:
+        sysname = _system()
+        if sysname != "linux":
+            print(
+                f"[desktop-act-launcher] desktop-act has full desktop-automation support on Linux today; "
+                f"{sysname} support is partial. The MCP server may still expose Kapture / chrome-devtools / "
+                f"Playwright tools but native X11 calls will no-op. Set DESKTOP_ACT_COMMAND to a custom "
+                f"build to override.",
+                file=sys.stderr,
+            )
+        print(
+            "[desktop-act-launcher] Could not locate or bootstrap the desktop-act MCP server.\n"
+            "  Install manually:    /plugin marketplace add <repo-url> && /plugin install desktop-act\n"
+            "  Or pin a custom path: export DESKTOP_ACT_COMMAND=/path/to/run.sh",
+            file=sys.stderr,
+        )
+        return 127
+
+    _exec_runner(runner)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude-ops/mcp-servers/desktop-act-launcher.py
+++ b/claude-ops/mcp-servers/desktop-act-launcher.py
@@ -29,11 +29,13 @@ import subprocess
 import sys
 from pathlib import Path
 
-DEFAULT_REPO = os.environ.get(
-    "DESKTOP_ACT_REPO",
-    "https://github.com/Lifecycle-Innovations-Limited/desktop-act.git",
-)
-DEFAULT_BRANCH = os.environ.get("DESKTOP_ACT_BRANCH", "main")
+_DEFAULT_REPO = "https://github.com/Lifecycle-Innovations-Limited/desktop-act.git"
+_DEFAULT_BRANCH = "main"
+# MCP may inject empty strings from userConfig; treat those as unset so fallbacks apply.
+DEFAULT_REPO = os.environ.get("DESKTOP_ACT_REPO") or _DEFAULT_REPO
+DEFAULT_BRANCH = os.environ.get("DESKTOP_ACT_BRANCH") or _DEFAULT_BRANCH
+
+_CACHE_READY_MARKER = ".desktop-act-launcher-ready"
 
 
 def _system() -> str:
@@ -107,10 +109,33 @@ def _resolve_existing() -> Path | None:
         if runner:
             return runner
 
-    runner = _runner_in(_cache_root() / "src")
+    cache_src = _cache_root() / "src"
+    runner = _runner_in(cache_src)
+    if runner is not None and not _cache_install_usable(cache_src):
+        runner = None
     if runner:
         return runner
     return None
+
+
+def _venv_python(install_root: Path) -> str | None:
+    bin_dir = "Scripts" if _system() == "windows" else "bin"
+    py = (
+        install_root
+        / ".venv"
+        / bin_dir
+        / ("python.exe" if _system() == "windows" else "python")
+    )
+    return str(py) if py.exists() else None
+
+
+def _cache_install_usable(cache_src: Path) -> bool:
+    """True when cached checkout finished bootstrap (venv + deps marker)."""
+    marker = cache_src / _CACHE_READY_MARKER
+    if not marker.is_file():
+        return False
+    vpy = _venv_python(cache_src)
+    return bool(vpy and Path(vpy).is_file())
 
 
 def _exec_runner(runner: Path) -> None:
@@ -134,19 +159,14 @@ def _exec_runner(runner: Path) -> None:
                 print("[desktop-act-launcher] PowerShell not found", file=sys.stderr)
                 sys.exit(127)
             os.execv(ps, [ps, "-ExecutionPolicy", "Bypass", "-File", str(runner)])
-        os.execv(str(runner), [str(runner)])
+        cmd_exe = os.environ.get("ComSpec")
+        if not cmd_exe or not Path(cmd_exe).is_file():
+            cmd_exe = shutil.which("cmd.exe") or shutil.which("cmd") or ""
+        if not cmd_exe:
+            print("[desktop-act-launcher] cmd.exe not found", file=sys.stderr)
+            sys.exit(127)
+        os.execv(cmd_exe, [cmd_exe, "/c", str(runner)])
     os.execv(str(runner), [str(runner)])
-
-
-def _venv_python(install_root: Path) -> str | None:
-    bin_dir = "Scripts" if _system() == "windows" else "bin"
-    py = (
-        install_root
-        / ".venv"
-        / bin_dir
-        / ("python.exe" if _system() == "windows" else "python")
-    )
-    return str(py) if py.exists() else None
 
 
 def _have(cmd: str) -> bool:
@@ -229,6 +249,15 @@ def _bootstrap() -> Path | None:
                 file=sys.stderr,
             )
             return None
+
+    try:
+        (src / _CACHE_READY_MARKER).write_text("ok\n", encoding="ascii")
+    except OSError as e:
+        print(
+            f"[desktop-act-launcher] could not write cache ready marker: {e}",
+            file=sys.stderr,
+        )
+        return None
 
     return _runner_in(src)
 

--- a/claude-ops/scripts/aws-sg-ip-whitelist.sh
+++ b/claude-ops/scripts/aws-sg-ip-whitelist.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# aws-sg-ip-whitelist.sh — sync this machine's public IPv4 into an AWS Security
+# Group ingress rule. Idempotent; safe to run on every network change.
+#
+# Behavior:
+#   1. Fetch current public IPv4 via ifconfig.me / icanhazip.com / ipify.
+#   2. If already present in SG with a "$DESC_PREFIX-*" description: no-op.
+#   3. Otherwise revoke "$DESC_PREFIX-*" rules older than KEEP_RECENT count.
+#   4. Authorize the new IP on the target port with a timestamped description.
+#
+# Configuration (env vars or claude-ops preferences):
+#   IP_WHITELIST_SG_ID            REQUIRED — target Security Group ID (sg-...)
+#   IP_WHITELIST_REGION           default: us-east-1
+#   IP_WHITELIST_PORT             default: 22 (single TCP port)
+#   IP_WHITELIST_DESC_PREFIX      default: <hostname-without-domain>-laptop
+#   IP_WHITELIST_KEEP_RECENT      default: 2 (newest N rules retained pre-add)
+#   IP_OVERRIDE                   explicit IP, skips public-IP detection
+#
+# Exit codes:
+#   0  success (added or already present)
+#   1  could not detect public IP / missing config
+#   2  AWS CLI / SG mutation failure
+
+set -euo pipefail
+
+SG_ID="${IP_WHITELIST_SG_ID:-${SG_ID:-}}"
+REGION="${IP_WHITELIST_REGION:-${REGION:-us-east-1}}"
+PORT="${IP_WHITELIST_PORT:-${PORT:-22}}"
+KEEP_RECENT="${IP_WHITELIST_KEEP_RECENT:-${KEEP_RECENT:-2}}"
+DEFAULT_PREFIX="$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo claude-ops)-laptop"
+DESC_PREFIX="${IP_WHITELIST_DESC_PREFIX:-${DESC_PREFIX:-$DEFAULT_PREFIX}}"
+
+log() { printf '[ip-whitelist] %s\n' "$*" >&2; }
+
+if [[ -z "$SG_ID" ]]; then
+  log "IP_WHITELIST_SG_ID is required (export it or run /ops:setup ip-whitelist)"
+  exit 1
+fi
+
+detect_ip() {
+  if [[ -n "${IP_OVERRIDE:-}" ]]; then echo "$IP_OVERRIDE"; return 0; fi
+  for url in https://ifconfig.me https://icanhazip.com https://api.ipify.org; do
+    ip=$(curl -s4 --max-time 5 "$url" 2>/dev/null | tr -d '[:space:]') || true
+    if [[ "$ip" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then echo "$ip"; return 0; fi
+  done
+  return 1
+}
+
+IP=$(detect_ip) || { log "could not detect public IP"; exit 1; }
+log "current public IP: $IP"
+
+RULES_JSON=$(aws ec2 describe-security-groups \
+  --region "$REGION" --group-ids "$SG_ID" \
+  --query "SecurityGroups[].IpPermissions[?FromPort==\`$PORT\`].IpRanges[]" \
+  --output json 2>/dev/null) || { log "aws describe-security-groups failed"; exit 2; }
+
+RULES_FLAT=$(echo "$RULES_JSON" | jq '[.[] | .[]?] // []')
+
+if echo "$RULES_FLAT" | jq -e --arg ip "${IP}/32" '.[] | select(.CidrIp == $ip)' >/dev/null 2>&1; then
+  log "IP $IP already whitelisted — no-op"
+  exit 0
+fi
+
+mapfile -t STALE < <(
+  echo "$RULES_FLAT" | jq -r --arg p "$DESC_PREFIX-" --argjson keep "$KEEP_RECENT" '
+    [.[] | select(.Description // "" | startswith($p))]
+    | sort_by(.Description) | reverse | .[$keep:]
+    | .[] | "\(.CidrIp)|\(.Description)"
+  '
+)
+
+for entry in "${STALE[@]}"; do
+  [[ -z "$entry" ]] && continue
+  cidr="${entry%%|*}"
+  desc="${entry##*|}"
+  log "revoking stale $desc ($cidr)"
+  aws ec2 revoke-security-group-ingress \
+    --region "$REGION" --group-id "$SG_ID" \
+    --ip-permissions "IpProtocol=tcp,FromPort=$PORT,ToPort=$PORT,IpRanges=[{CidrIp=$cidr}]" \
+    >/dev/null 2>&1 || log "  (revoke failed for $cidr — continuing)"
+done
+
+TIMESTAMP=$(date +%Y%m%d-%H%M)
+NEW_DESC="${DESC_PREFIX}-${TIMESTAMP}"
+log "authorizing $IP/32 as $NEW_DESC"
+
+aws ec2 authorize-security-group-ingress \
+  --region "$REGION" --group-id "$SG_ID" \
+  --ip-permissions "IpProtocol=tcp,FromPort=$PORT,ToPort=$PORT,IpRanges=[{CidrIp=$IP/32,Description=$NEW_DESC}]" \
+  >/dev/null 2>&1 || { log "authorize failed"; exit 2; }
+
+log "OK $IP whitelisted as $NEW_DESC on $SG_ID"

--- a/claude-ops/scripts/install-ip-whitelist-agent.sh
+++ b/claude-ops/scripts/install-ip-whitelist-agent.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# install-ip-whitelist-agent.sh — install an OS-native agent that keeps your AWS
+# Security Group ingress synced to this machine's public IP.
+#
+# Idempotent: unloads/disables any existing agent before reinstalling.
+# Supports macOS (launchd) today; Linux (systemd path unit) coming next.
+#
+# Required env (or read from claude-ops preferences if unset):
+#   IP_WHITELIST_SG_ID            target Security Group (sg-...)
+# Optional:
+#   IP_WHITELIST_REGION           default: us-east-1
+#   IP_WHITELIST_PORT             default: 22
+#   IP_WHITELIST_DESC_PREFIX      default: <hostname>-laptop
+
+set -euo pipefail
+
+LABEL="com.claude-ops.ip-whitelist"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+PLIST_TEMPLATE="${PLUGIN_ROOT}/launchd/${LABEL}.plist.template"
+PLIST_DEST="$HOME/Library/LaunchAgents/${LABEL}.plist"
+
+# Read config (env wins; prefs fallback omitted for portability — set the env)
+IP_WHITELIST_SG_ID="${IP_WHITELIST_SG_ID:-}"
+IP_WHITELIST_REGION="${IP_WHITELIST_REGION:-us-east-1}"
+IP_WHITELIST_PORT="${IP_WHITELIST_PORT:-22}"
+DEFAULT_PREFIX="$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo claude-ops)-laptop"
+IP_WHITELIST_DESC_PREFIX="${IP_WHITELIST_DESC_PREFIX:-$DEFAULT_PREFIX}"
+
+log() { printf '[install-ip-whitelist] %s\n' "$*"; }
+die() { log "ERROR: $*"; exit 1; }
+
+if [[ -z "$IP_WHITELIST_SG_ID" ]]; then
+  die "IP_WHITELIST_SG_ID is required. Example: IP_WHITELIST_SG_ID=sg-0123456789abcdef0 $0"
+fi
+
+OS="$(uname -s)"
+case "$OS" in
+  Darwin)
+    GUI_DOMAIN="gui/$(id -u)"
+
+    if launchctl print "${GUI_DOMAIN}/${LABEL}" &>/dev/null; then
+      log "unloading existing agent..."
+      launchctl bootout "${GUI_DOMAIN}/${PLIST_DEST}" 2>/dev/null \
+        || launchctl bootout "${GUI_DOMAIN}" "${PLIST_DEST}" 2>/dev/null \
+        || launchctl remove "${LABEL}" 2>/dev/null \
+        || true
+      sleep 1
+    fi
+
+    [[ -f "$PLIST_TEMPLATE" ]] || die "plist template missing: $PLIST_TEMPLATE"
+
+    log "rendering plist with PLUGIN_ROOT=$PLUGIN_ROOT SG=$IP_WHITELIST_SG_ID"
+    mkdir -p "$(dirname "$PLIST_DEST")"
+    sed \
+      -e "s|__PLUGIN_ROOT__|${PLUGIN_ROOT}|g" \
+      -e "s|__IP_WHITELIST_SG_ID__|${IP_WHITELIST_SG_ID}|g" \
+      -e "s|__IP_WHITELIST_REGION__|${IP_WHITELIST_REGION}|g" \
+      -e "s|__IP_WHITELIST_PORT__|${IP_WHITELIST_PORT}|g" \
+      -e "s|__IP_WHITELIST_DESC_PREFIX__|${IP_WHITELIST_DESC_PREFIX}|g" \
+      "$PLIST_TEMPLATE" > "$PLIST_DEST"
+
+    log "bootstrapping ${GUI_DOMAIN}/${LABEL}"
+    launchctl bootstrap "${GUI_DOMAIN}" "${PLIST_DEST}"
+
+    log "agent loaded. status:"
+    launchctl print "${GUI_DOMAIN}/${LABEL}" | head -20
+    ;;
+  Linux)
+    log "Linux support coming next — for now run the script via cron or systemd:"
+    log "  */5 * * * * IP_WHITELIST_SG_ID=$IP_WHITELIST_SG_ID $PLUGIN_ROOT/scripts/aws-sg-ip-whitelist.sh"
+    exit 2
+    ;;
+  *)
+    die "unsupported OS: $OS"
+    ;;
+esac

--- a/claude-ops/scripts/install-ip-whitelist-agent.sh
+++ b/claude-ops/scripts/install-ip-whitelist-agent.sh
@@ -11,6 +11,7 @@
 #   IP_WHITELIST_REGION           default: us-east-1
 #   IP_WHITELIST_PORT             default: 22
 #   IP_WHITELIST_DESC_PREFIX      default: <hostname>-laptop
+#   IP_WHITELIST_KEEP_RECENT      default: 2 (newest N managed rules retained before prune)
 
 set -euo pipefail
 
@@ -26,6 +27,7 @@ IP_WHITELIST_REGION="${IP_WHITELIST_REGION:-us-east-1}"
 IP_WHITELIST_PORT="${IP_WHITELIST_PORT:-22}"
 DEFAULT_PREFIX="$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo claude-ops)-laptop"
 IP_WHITELIST_DESC_PREFIX="${IP_WHITELIST_DESC_PREFIX:-$DEFAULT_PREFIX}"
+IP_WHITELIST_KEEP_RECENT="${IP_WHITELIST_KEEP_RECENT:-2}"
 
 log() { printf '[install-ip-whitelist] %s\n' "$*"; }
 die() { log "ERROR: $*"; exit 1; }
@@ -58,13 +60,14 @@ case "$OS" in
       -e "s|__IP_WHITELIST_REGION__|${IP_WHITELIST_REGION}|g" \
       -e "s|__IP_WHITELIST_PORT__|${IP_WHITELIST_PORT}|g" \
       -e "s|__IP_WHITELIST_DESC_PREFIX__|${IP_WHITELIST_DESC_PREFIX}|g" \
+      -e "s|__IP_WHITELIST_KEEP_RECENT__|${IP_WHITELIST_KEEP_RECENT}|g" \
       "$PLIST_TEMPLATE" > "$PLIST_DEST"
 
     log "bootstrapping ${GUI_DOMAIN}/${LABEL}"
     launchctl bootstrap "${GUI_DOMAIN}" "${PLIST_DEST}"
 
     log "agent loaded. status:"
-    launchctl print "${GUI_DOMAIN}/${LABEL}" | head -20
+    head -20 < <(launchctl print "${GUI_DOMAIN}/${LABEL}")
     ;;
   Linux)
     log "Linux support coming next — for now run the script via cron or systemd:"

--- a/claude-ops/scripts/ops-mcp-reauth.py
+++ b/claude-ops/scripts/ops-mcp-reauth.py
@@ -259,11 +259,22 @@ def main() -> int:
                 except Exception as e:
                     log(f"failed to load {u}: {e}")
                 pages.append(pg)
-            # Block until user closes the LAST page (or 10 min hard cap)
-            try:
-                pages[-1].wait_for_event("close", timeout=600_000)
-            except Exception:
-                pass
+            # Block until every bootstrap tab is closed (or 10 min total hard cap).
+            # Waiting only on the last-opened tab exits early if the user closes
+            # tabs in a different order, tearing down the context while other
+            # sign-ins are still in progress.
+            deadline = time.monotonic() + 600
+            while True:
+                open_pages = [p for p in pages if not p.is_closed()]
+                if not open_pages:
+                    break
+                remaining_ms = int(max(0, (deadline - time.monotonic()) * 1000))
+                if remaining_ms <= 0:
+                    break
+                try:
+                    open_pages[0].wait_for_event("close", timeout=remaining_ms)
+                except Exception:
+                    break
         return 0
 
     url = sys.argv[1]

--- a/claude-ops/scripts/ops-mcp-reauth.py
+++ b/claude-ops/scripts/ops-mcp-reauth.py
@@ -239,14 +239,31 @@ def main() -> int:
         except ImportError:
             log("playwright not installed")
             return 3
-        log("BOOTSTRAP MODE — sign into each OAuth provider you use, then close the window")
+        # Default bootstrap targets — the providers that watchdog reports as
+        # needs_bootstrap. Override via CLI: --bootstrap <url1> <url2> ...
+        extra_urls = sys.argv[2:]
+        bootstrap_urls = extra_urls or [
+            "https://vercel.com/login",
+            "https://app.eu.amplitude.com/login",
+        ]
+        log("BOOTSTRAP MODE — sign into each tab, then close the window when done")
+        log(f"opening {len(bootstrap_urls)} provider login page(s): {bootstrap_urls}")
         BROWSER_PROFILE.mkdir(parents=True, exist_ok=True)
         with sync_playwright() as p:
             ctx = p.chromium.launch_persistent_context(str(BROWSER_PROFILE), headless=False)
-            page = ctx.new_page()
-            page.goto("about:blank")
-            # Block until user closes the window
-            page.wait_for_event("close", timeout=600_000)
+            pages = []
+            for u in bootstrap_urls:
+                pg = ctx.new_page()
+                try:
+                    pg.goto(u, wait_until="domcontentloaded", timeout=20000)
+                except Exception as e:
+                    log(f"failed to load {u}: {e}")
+                pages.append(pg)
+            # Block until user closes the LAST page (or 10 min hard cap)
+            try:
+                pages[-1].wait_for_event("close", timeout=600_000)
+            except Exception:
+                pass
         return 0
 
     url = sys.argv[1]

--- a/claude-ops/scripts/ssh-auto-whitelist.sh
+++ b/claude-ops/scripts/ssh-auto-whitelist.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# ssh-auto-whitelist.sh — SSH wrapper that self-heals on connection failure.
+#
+# When SSH times out or is refused (likely the bastion's Security Group dropped
+# your IP after a network change), this wrapper calls aws-sg-ip-whitelist.sh to
+# add the current public IP to the target SG, then retries SSH once.
+#
+# Usage:
+#   ssh-auto-whitelist.sh <host-alias> [ssh-args...]
+#   ssh-auto-whitelist.sh <host-alias> "remote command"
+#
+# Requires IP_WHITELIST_SG_ID to be set (or the user's SG config provided via
+# /ops:setup ip-whitelist).
+#
+# Exit code = the final SSH invocation's exit code.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WHITELIST_SCRIPT="${SCRIPT_DIR}/aws-sg-ip-whitelist.sh"
+
+HOST="${1:-}"
+[[ -z "$HOST" ]] && { echo "usage: $0 <ssh-host-alias> [ssh-args...|command]" >&2; exit 2; }
+shift
+
+log() { printf '[ssh-auto] %s\n' "$*" >&2; }
+
+try_ssh() {
+  local timeout=$1; shift
+  ssh -o ConnectTimeout="$timeout" -o BatchMode=no "$HOST" "$@"
+}
+
+if try_ssh 5 "$@"; then
+  exit 0
+fi
+
+rc=$?
+# 255 = SSH-level failure (timeout, refused, unreachable). Anything else is the remote command's exit.
+if [[ $rc -ne 255 ]]; then exit $rc; fi
+
+log "SSH failed (likely IP blocked) — refreshing SG whitelist…"
+if ! bash "$WHITELIST_SCRIPT"; then
+  log "whitelist refresh failed — aborting"
+  exit $rc
+fi
+
+# Brief settle so SG mutation propagates
+sleep 2
+
+log "retrying SSH…"
+try_ssh 10 "$@"

--- a/claude-ops/skills/ops-desktop/SKILL.md
+++ b/claude-ops/skills/ops-desktop/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: ops-desktop
+description: Autonomous desktop + browser control via the desktop-act MCP companion. Acquires an isolated noVNC desktop session, takes screenshots, clicks, types, scrolls, and runs the optional autonomous act() loop. First run auto-bootstraps the desktop-act server into a per-user cache.
+argument-hint: "[goal text | 'status' | 'list' | 'release [session_id]']"
+allowed-tools:
+  - Bash
+  - Read
+  - AskUserQuestion
+  - ToolSearch
+  - mcp__desktop-act__acquire_desktop
+  - mcp__desktop-act__release_desktop
+  - mcp__desktop-act__list_desktops
+  - mcp__desktop-act__list_windows
+  - mcp__desktop-act__launch_app
+  - mcp__desktop-act__screenshot
+  - mcp__desktop-act__observe
+  - mcp__desktop-act__click
+  - mcp__desktop-act__keypress
+  - mcp__desktop-act__type_text
+  - mcp__desktop-act__scroll
+  - mcp__desktop-act__act
+  - mcp__desktop-act__act_step
+  - mcp__desktop-act__batch
+  - mcp__desktop-act__status
+effort: medium
+maxTurns: 40
+---
+
+# OPS ► DESKTOP
+
+`/ops:desktop` drives a real GUI desktop (Linux noVNC pool, partial macOS / Windows support) through the `desktop-act` FastMCP server. Use it for tasks that browser-only automation can't reach: native dialogs, OS file pickers, multi-window flows, screen-recording verification.
+
+The MCP tool schemas are **deferred**. Load them with `ToolSearch` on demand:
+
+```
+ToolSearch select:mcp__desktop-act__acquire_desktop,mcp__desktop-act__screenshot,mcp__desktop-act__click,mcp__desktop-act__type_text,mcp__desktop-act__release_desktop
+```
+
+## Runtime Context
+
+Before any route runs, resolve:
+
+1. **Plugin root**: `${CLAUDE_PLUGIN_ROOT}` — used to locate the launcher.
+2. **MCP launcher**: `${CLAUDE_PLUGIN_ROOT}/mcp-servers/desktop-act-launcher.py` — auto-discovers an installed desktop-act marketplace or, if absent, clones from `$DESKTOP_ACT_REPO` (default `https://github.com/Lifecycle-Innovations-Limited/desktop-act.git`) and bootstraps a venv on first run.
+3. **noVNC default**: `http://<box-host>:6081` — primary desktop. `acquire_desktop()` provisions extra sessions on `:6082+`.
+4. **Mobile / SSH mode**: if `$SSH_CONNECTION`, `$SSH_CLIENT`, or `$SSH_TTY` is set, emit compact text-only output per Rule 7 (no banners, no tables, plain lines). The noVNC URL is the one piece the user definitely needs — print it once on a copy-able line.
+
+## Routing table
+
+Parse `$ARGUMENTS` and route. First token decides:
+
+| First arg          | Route                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------- |
+| (empty) / `status` | Print MCP status, default noVNC URL, active sessions, and platform support note       |
+| `list`             | `mcp__desktop-act__list_desktops` — show pool state                                   |
+| `release <id>`     | `mcp__desktop-act__release_desktop(session_id)` — free a session                      |
+| `release-all`      | Release every session this skill has open this turn                                   |
+| anything else      | Treat as a **goal** — acquire → observe → drive → verify → release                    |
+
+Anything else: treat the whole argument string as the goal.
+
+---
+
+## Route — `status` (default)
+
+1. Probe the MCP via `mcp__desktop-act__status` (auto-load schema first).
+2. Print compact summary — plugin connected? venv ready? pool size? default URL?
+3. If the MCP is **not reachable**, the launcher likely needs to bootstrap. Show:
+   - one-line install command (`/plugin marketplace add <repo> && /plugin install desktop-act`)
+   - or the env override (`export DESKTOP_ACT_COMMAND=/path/to/run.sh`)
+   - or the bootstrap repo (`export DESKTOP_ACT_REPO=https://...`)
+4. Mobile/SSH mode: drop banners, output 4–6 plain lines.
+
+## Route — `list`
+
+```
+ToolSearch select:mcp__desktop-act__list_desktops
+```
+Call it. Format as `session_id · display · vnc · last_used`. Linux only renders full info; macOS/Windows fall back to a "limited platform" note.
+
+## Route — `release <id>` / `release-all`
+
+Per Rule 5 (destructive actions): `release_desktop` tears down the X server. Ask before bulk release:
+
+```
+AskUserQuestion: Release session abcd1234?
+  [Release]  [Skip]
+```
+
+For `release-all`, batch confirm once.
+
+---
+
+## Route — **goal** (default for free-form $ARGUMENTS)
+
+The autonomous loop. Use this when Sam types `/ops:desktop open the AWS console and screenshot the ECS cluster page`.
+
+### Step 1 — Acquire
+
+```python
+# Load schemas
+ToolSearch select:mcp__desktop-act__acquire_desktop,mcp__desktop-act__screenshot,...
+
+session = mcp__desktop-act__acquire_desktop()
+session_id = session["session_id"]
+display    = session["display"]      # e.g. ":51"
+novnc_url  = session["novnc_url"]    # e.g. http://host:6082
+```
+
+Print the noVNC URL on a line by itself so the user can watch live. On mobile, the URL is the most useful thing — surface it FIRST.
+
+### Step 2 — Observe
+
+```python
+shot = mcp__desktop-act__screenshot(session_id=session_id)
+Read(file_path=shot["path"])   # let Claude see the screen
+```
+
+If you need window-level metadata before clicking blindly:
+
+```python
+windows = mcp__desktop-act__list_windows(session_id=session_id)
+```
+
+### Step 3 — Drive
+
+Two modes:
+
+**A. Streaming primitives** — full reasoning visibility, per-action transparency. Preferred for sensitive flows (anything touching credentials, billing pages, destructive UIs).
+
+```python
+mcp__desktop-act__launch_app(session_id, app="firefox")
+mcp__desktop-act__click(session_id, x=640, y=400)
+mcp__desktop-act__type_text(session_id, text="ECS clusters")
+mcp__desktop-act__keypress(session_id, key="Return")
+mcp__desktop-act__scroll(session_id, direction="down", amount=3)
+mcp__desktop-act__screenshot(session_id)   # verify
+```
+
+**B. Autonomous loop** — hands the goal to `act()` which runs claude-agent-sdk against the OAuth-bundled CLI (no API key needed; rides Claude Max). Faster but less observable.
+
+```python
+result = mcp__desktop-act__act(
+    session_id=session_id,
+    goal="$ARGUMENTS",
+    max_steps=20,
+)
+```
+
+For multi-step macros, prefer `batch` (single round-trip) or `act_step` (one micro-step at a time with explicit verification).
+
+### Step 4 — Verify
+
+Always `screenshot` and `Read` the path once at the end before claiming the goal is done. If the verification screenshot doesn't show the expected state, iterate or escalate to the user.
+
+### Step 5 — Release
+
+**Always** release in the same turn, even on failure:
+
+```python
+mcp__desktop-act__release_desktop(session_id=session_id)
+```
+
+If the user wants to keep the session for follow-up actions, ask first via `AskUserQuestion`:
+
+```
+Keep session abcd1234 alive for follow-up?
+  [Keep]  [Release]
+```
+
+---
+
+## Cross-platform notes
+
+| OS      | Status   | Notes                                                                 |
+| ------- | -------- | --------------------------------------------------------------------- |
+| Linux   | Full     | X11 + Xvnc + websockify + python-xlib. Multi-desktop pool live.       |
+| macOS   | Partial  | Server runs; native X11 calls no-op. Browser tools still work.        |
+| Windows | Partial  | Server runs via Python launcher. Native automation requires manual.   |
+
+On non-Linux platforms, prefer Kapture (`mcp__kapture__*`) or Playwright for browser-only tasks. The launcher prints a clear "limited platform" notice if it can't bring up a full session.
+
+## Safety
+
+- **Outbound comms** (Rule 6): if a goal involves sending email/messages/forms, stage the draft and ask before pressing Send. Per-message approval, never batch.
+- **Destructive UI clicks**: anything that says "Delete", "Terminate", "Force quit" routes through `AskUserQuestion` first per Rule 5.
+- **Credentials**: never type passwords into a goal string — leave it for Sam to fill in the live noVNC viewer.
+- **Session isolation**: each invocation of `/ops:desktop` gets its own `session_id`. Don't pass session IDs between concurrent agents or skills.
+
+## Examples
+
+```
+/ops:desktop                                    # status
+/ops:desktop list                               # pool state
+/ops:desktop release abcd1234                   # free session
+/ops:desktop open the AWS ECS console and screenshot the healify-api cluster
+/ops:desktop launch Firefox and navigate to https://finops.lifecycleinnovations.limited
+```
+
+## $ARGUMENTS
+
+$ARGUMENTS


### PR DESCRIPTION
## Summary
Combined release bundling three feature branches + version bump to **2.11.1** (plugin.json + marketplace.json synced).

- **#330** feat(ops-desktop): /ops:desktop skill + desktop-act MCP wiring
- **#331** feat(reauth): preload provider login tabs in --bootstrap mode
- **#332** feat(aws-sg-whitelist): auto-update SG ingress to current public IP

Supersedes #330, #331, #332 (their commits are included here). Closing those in favor of this combined release.

## Verification
- Secret scan: 14/14 pass (no personal data)
- No conflict markers; gh-watch-guard uses JSON-deny hook contract
- Both version files = 2.11.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new automation surfaces that can control a desktop session and mutate AWS Security Group ingress rules; while opt-in/config-driven, mistakes could impact local security posture or network access.
> 
> **Overview**
> Bumps the plugin/marketplace version to `2.11.1` and introduces a new **`/ops:desktop`** skill wired to a new `desktop-act` MCP server.
> 
> Adds a cross-platform `desktop-act` launcher that auto-discovers an existing install or bootstraps one into a per-user cache (git clone + venv + deps), plus new `userConfig` overrides and `.mcp.json` registration to expose `mcp__desktop-act__*` tools.
> 
> Introduces an **AWS Security Group IP whitelist** feature: scripts to sync the current public IP into an SG ingress rule, an SSH wrapper that refreshes the whitelist and retries once, and a macOS `launchd` agent template + installer to run this on network changes.
> 
> Improves `ops-mcp-reauth.py --bootstrap` to open multiple provider login tabs (configurable URLs) and wait for all tabs to close before exiting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dfde55df58ddbc7f964f650f43357b9d44545dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->