### PR TITLE
fix(pocket-watcher): support Linux/WSL Claude Code OAuth credentials

### DIFF
--- a/claude-ops/scripts/ops-cron-pocket-watcher.py
+++ b/claude-ops/scripts/ops-cron-pocket-watcher.py
@@ -347,10 +347,11 @@ class MCPClient:
 def _resolve_anthropic_auth() -> tuple[str, dict] | tuple[None, None]:
     """Returns (header_value, extra_headers) or (None, None) if no auth.
 
-    Prefers Claude Code OAuth from keychain so subscription users don't pay
-    metered rates. Falls back to ANTHROPIC_API_KEY env / keychain.
+    Prefers Claude Code OAuth (macOS keychain or Linux/WSL file-backed
+    credentials at ~/.claude/.credentials.json) so subscription users don't
+    pay metered rates. Falls back to ANTHROPIC_API_KEY env / keychain.
     """
-    # Try Claude Code OAuth first
+    # Try Claude Code OAuth — macOS keychain
     try:
         blob = subprocess.run(
             ["security", "find-generic-password", "-s", "Claude Code-credentials", "-w"],
@@ -364,6 +365,18 @@ def _resolve_anthropic_auth() -> tuple[str, dict] | tuple[None, None]:
             if tok and exp > int(time.time() * 1000) + 60000:
                 return (f"Bearer {tok}", {"anthropic-beta": "oauth-2025-04-20"})
     except (FileNotFoundError, subprocess.TimeoutExpired, json.JSONDecodeError):
+        pass
+    # Try Claude Code OAuth — Linux/WSL file-backed credentials
+    try:
+        creds_path = Path(os.path.expanduser("~")) / ".claude" / ".credentials.json"
+        if creds_path.exists():
+            data = json.loads(creds_path.read_text())
+            o = data.get("claudeAiOauth") or {}
+            tok = o.get("accessToken") or ""
+            exp = o.get("expiresAt") or 0
+            if tok and exp > int(time.time() * 1000) + 60000:
+                return (f"Bearer {tok}", {"anthropic-beta": "oauth-2025-04-20"})
+    except (OSError, json.JSONDecodeError):
         pass
     # API key fallback
     key = os.environ.get("ANTHROPIC_API_KEY", "").strip()


### PR DESCRIPTION
## Summary
- `_resolve_anthropic_auth()` previously only checked the macOS `security` keychain. On Linux/WSL hosts the OAuth lookup silently failed, the watcher fell through to `ANTHROPIC_API_KEY` (usually unset on subscription-only boxes), and Haiku implicit-task inference was skipped — every recording logged `infer: no Anthropic auth — skipping implicit-task extraction` and `tasks=0`.
- Add a second OAuth lookup that reads `~/.claude/.credentials.json` — the file-backed credentials store Claude Code uses on Linux/WSL. Same payload shape (`claudeAiOauth.accessToken` / `.expiresAt`), same Bearer + `anthropic-beta` header, same expiry safety margin.
- Order preserved: macOS keychain → Linux file → API-key env → API-key keychain. macOS users unaffected.

## Test plan
- [x] On Amazon Linux 2023 (arm64) with Claude Code OAuth at `~/.claude/.credentials.json`, ran the watcher against 13 backfilled recordings — Haiku inference fires cleanly, multiple high-confidence tasks land in `pending-triage.jsonl` (e.g. Bussum mortgage, Amsterdam sale, ETF-backed loan).
- [x] macOS keychain path still tried first and short-circuits when present (unchanged code).
- [ ] (reviewer) confirm no metered API-key usage when the file path resolves OAuth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication/credential resolution for Anthropic calls; a mistake could cause inference to fail or unintentionally fall back to metered API-key usage. Scope is small and gated to an additional fallback path.
> 
> **Overview**
> Enables Haiku implicit-task inference on Linux/WSL hosts by extending `_resolve_anthropic_auth()` to load Claude Code OAuth tokens from `~/.claude/.credentials.json` when the macOS keychain lookup isn’t available.
> 
> The auth resolution order remains **macOS keychain → Linux/WSL credentials file → `ANTHROPIC_API_KEY` env/keychain**, preserving existing macOS behavior while reducing “no auth” skips on non-macOS machines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d66614258af657c96d155171fd412f08308248c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->