### PR TITLE
feat(ops): integrate Claude Code background-server supervisor

### DIFF
--- a/claude-ops/bin/ops-bg
+++ b/claude-ops/bin/ops-bg
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# ops-bg — Wrapper around Claude Code background-session supervisor.
+#
+# Standardized entrypoint for dispatching, listing, attaching to, and managing
+# `claude --bg` sessions. Wraps the underlying `claude` CLI with sane defaults
+# and consistent ergonomics across the ops plugin.
+#
+# Subcommands:
+#   dispatch [opts] "<prompt>"  Start a new background session and return the ID.
+#   list                        List active background sessions (pretty or --json).
+#   status                      Supervisor health summary.
+#   attach <id>                 Re-attach an existing session in this terminal.
+#   logs <id>                   Print recent output from a session.
+#   stop <id>                   Stop a session (also: kill).
+#   rm <id>                     Remove a session from the roster.
+#   respawn [<id>|--all]        Restart sessions (e.g. to pick up a CC upgrade).
+#
+# Dispatch defaults (override via flags):
+#   --model      opus
+#   --effort     high
+#   --add-dir    $PWD
+#
+# Examples:
+#   ops-bg dispatch "audit Healify repos for cost-leak gaps"
+#   ops-bg dispatch --agent ops:yolo-cto --model sonnet "analyze prod incidents"
+#   ops-bg list
+#   ops-bg list --json | jq '.[] | select(.status=="busy")'
+#   ops-bg logs 7c5dcf5d
+#   ops-bg respawn --all   # after `claude` binary upgrade
+
+set -u
+
+# Resolve underlying claude binary. If a shell function aliases `claude` for
+# Doppler routing, prefer the raw binary so we don't double-wrap secrets.
+CLAUDE_BIN="${CLAUDE_BIN:-}"
+if [ -z "$CLAUDE_BIN" ]; then
+  for candidate in \
+    "$HOME/.local/bin/claude" \
+    "/opt/homebrew/bin/claude" \
+    "/usr/local/bin/claude"; do
+    if [ -x "$candidate" ]; then
+      CLAUDE_BIN="$candidate"
+      break
+    fi
+  done
+fi
+if [ -z "$CLAUDE_BIN" ] || [ ! -x "$CLAUDE_BIN" ]; then
+  echo "ops-bg: cannot find claude binary (set CLAUDE_BIN=...)" >&2
+  exit 127
+fi
+
+USAGE() {
+  sed -n '2,30p' "$0"
+  exit "${1:-0}"
+}
+
+[ $# -ge 1 ] || USAGE 1
+SUB="$1"; shift
+
+cmd_dispatch() {
+  local model="opus"
+  local effort="high"
+  local add_dir="$PWD"
+  local agent=""
+  local extra=()
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --model)   model="$2"; shift 2 ;;
+      --effort)  effort="$2"; shift 2 ;;
+      --cwd|--add-dir) add_dir="$2"; shift 2 ;;
+      --agent)   agent="$2"; shift 2 ;;
+      --) shift; extra+=("$@"); break ;;
+      --help|-h) USAGE 0 ;;
+      *) break ;;
+    esac
+  done
+  if [ $# -lt 1 ]; then
+    echo "ops-bg dispatch: missing <prompt>" >&2
+    exit 2
+  fi
+  local prompt="$*"
+  local -a args=(--bg --model "$model" --effort "$effort" --add-dir "$add_dir")
+  if [ -n "$agent" ]; then
+    args+=(--agent "$agent")
+  fi
+  args+=("$prompt")
+  args+=("${extra[@]}")
+  exec "$CLAUDE_BIN" "${args[@]}"
+}
+
+cmd_list() {
+  local fmt="pretty"
+  if [ "${1:-}" = "--json" ]; then fmt="json"; fi
+  local raw
+  raw="$("$CLAUDE_BIN" agents --json 2>/dev/null || echo '')"
+  if [ -z "$raw" ]; then
+    echo "ops-bg: claude agents --json returned empty (supervisor unreachable?)" >&2
+    return 1
+  fi
+  if [ "$fmt" = "json" ]; then
+    echo "$raw" | jq '[.[] | select(.kind == "background")]'
+    return
+  fi
+  command -v jq >/dev/null 2>&1 || { echo "$raw"; return; }
+  local n
+  n=$(echo "$raw" | jq '[.[] | select(.kind == "background")] | length')
+  printf 'background sessions: %s\n' "$n"
+  if [ "$n" -gt 0 ]; then
+    echo "$raw" | jq -r '
+      .[] | select(.kind == "background")
+      | "  \(.sessionId[0:8])  \(.status)  pid=\(.pid)  cwd=\(.cwd)"
+    '
+  fi
+}
+
+cmd_status() {
+  local raw
+  raw="$("$CLAUDE_BIN" daemon status 2>&1 || true)"
+  printf '%s\n' "$raw"
+}
+
+cmd_passthrough() {
+  local sub="$1"; shift
+  exec "$CLAUDE_BIN" "$sub" "$@"
+}
+
+cmd_respawn() {
+  if [ "${1:-}" = "--all" ]; then
+    exec "$CLAUDE_BIN" respawn --all
+  fi
+  if [ $# -lt 1 ]; then
+    echo "ops-bg respawn: pass <id> or --all" >&2
+    exit 2
+  fi
+  exec "$CLAUDE_BIN" respawn "$@"
+}
+
+case "$SUB" in
+  dispatch|d|run)        cmd_dispatch "$@" ;;
+  list|ls)               cmd_list "$@" ;;
+  status)                cmd_status ;;
+  attach|a)              cmd_passthrough attach "$@" ;;
+  logs|log|tail)         cmd_passthrough logs "$@" ;;
+  stop|kill)             cmd_passthrough stop "$@" ;;
+  rm|remove)             cmd_passthrough rm "$@" ;;
+  respawn|restart)       cmd_respawn "$@" ;;
+  help|--help|-h)        USAGE 0 ;;
+  *)
+    echo "ops-bg: unknown subcommand '$SUB'" >&2
+    USAGE 2
+    ;;
+esac

--- a/claude-ops/bin/ops-doctor
+++ b/claude-ops/bin/ops-doctor
@@ -703,6 +703,44 @@ else
   done
 fi
 
+# --- 10c. Claude Code background-server supervisor ---
+# Probes `claude agents --json` to detect the persistent bg-session supervisor.
+# Ephemeral (no live bg sessions) is healthy. We only warn if the supervisor
+# is unreachable AND a live bg session is claimed in roster.json.
+CC_BG_SUPERVISOR_STATUS="unknown"
+CC_BG_SESSION_COUNT=0
+CC_INTERACTIVE_SESSION_COUNT=0
+if command -v claude >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+  CC_AGENTS_JSON=$(claude agents --json 2>/dev/null || echo "")
+  if [ -n "$CC_AGENTS_JSON" ] && echo "$CC_AGENTS_JSON" | jq empty 2>/dev/null; then
+    CC_BG_SESSION_COUNT=$(echo "$CC_AGENTS_JSON" | jq '[.[] | select(.kind == "background")] | length' 2>/dev/null || echo 0)
+    CC_INTERACTIVE_SESSION_COUNT=$(echo "$CC_AGENTS_JSON" | jq '[.[] | select(.kind == "interactive")] | length' 2>/dev/null || echo 0)
+    if [ "$CC_BG_SESSION_COUNT" -gt 0 ]; then
+      CC_BG_SUPERVISOR_STATUS="running"
+    else
+      CC_BG_SUPERVISOR_STATUS="idle"
+    fi
+  else
+    # Fall back to `claude daemon status` to distinguish unreachable from idle.
+    CC_DAEMON_RAW=$(claude daemon status 2>&1 || true)
+    if echo "$CC_DAEMON_RAW" | head -1 | grep -qi "^not running"; then
+      CC_BG_SUPERVISOR_STATUS="idle"
+    elif echo "$CC_DAEMON_RAW" | grep -qi "unreachable"; then
+      # Roster claims sessions but socket is dead — real bug.
+      ROSTER_WORKERS=$(echo "$CC_DAEMON_RAW" | grep -oE 'bg workers:[[:space:]]+[0-9]+' | grep -oE '[0-9]+' || echo 0)
+      if [ "${ROSTER_WORKERS:-0}" -gt 0 ]; then
+        CC_BG_SUPERVISOR_STATUS="unreachable"
+        WARNINGS+=("claude_supervisor_unreachable: $ROSTER_WORKERS bg session(s) in roster but control.sock unreachable. Run: claude respawn --all")
+      else
+        CC_BG_SUPERVISOR_STATUS="idle"
+      fi
+    else
+      CC_BG_SUPERVISOR_STATUS="unknown"
+      INFO+=("claude_supervisor_probe_failed: could not parse 'claude agents --json' or 'claude daemon status' output")
+    fi
+  fi
+fi
+
 # --- 10b. Cache copies vs source ---
 CACHE_DIR="$HOME/.claude/plugins/cache/ops-marketplace/ops"
 CACHE_VERSIONS=()
@@ -757,6 +795,11 @@ cat <<EOF
   },
   "cache_versions": $cache_json,
   "daemon_services_health": $daemon_json,
+  "claude_background_server": {
+    "supervisor_status": "$CC_BG_SUPERVISOR_STATUS",
+    "bg_sessions": $CC_BG_SESSION_COUNT,
+    "interactive_sessions": $CC_INTERACTIVE_SESSION_COUNT
+  },
   "skill_count": $(find "$SCRIPT_DIR/skills" -name "SKILL.md" 2>/dev/null | wc -l | tr -d ' '),
   "agent_count": $(find "$SCRIPT_DIR/agents" -name "*.md" 2>/dev/null | wc -l | tr -d ' '),
   "bin_count": $(find "$SCRIPT_DIR/bin" -name "ops-*" 2>/dev/null | wc -l | tr -d ' ')

--- a/claude-ops/bin/ops-status
+++ b/claude-ops/bin/ops-status
@@ -225,6 +225,33 @@ if [ -f "$DAEMON_HEALTH" ]; then
   fi
 fi
 
+# ─── 7b. Claude Code background-server supervisor ──────────────────────────
+# Reports state of `claude --bg` supervisor. Ephemeral (0 bg sessions) is healthy.
+CC_BG_STATE="idle"
+CC_BG_COUNT=0
+CC_BG_INTERACTIVE=0
+if has_cmd claude && has_cmd jq; then
+  cc_agents_json="$(claude agents --json 2>/dev/null || echo '')"
+  if [ -n "$cc_agents_json" ] && echo "$cc_agents_json" | jq empty 2>/dev/null; then
+    CC_BG_COUNT="$(echo "$cc_agents_json" | jq '[.[] | select(.kind == "background")] | length' 2>/dev/null || echo 0)"
+    CC_BG_INTERACTIVE="$(echo "$cc_agents_json" | jq '[.[] | select(.kind == "interactive")] | length' 2>/dev/null || echo 0)"
+    if [ "$CC_BG_COUNT" -gt 0 ]; then
+      CC_BG_STATE="running"
+    else
+      CC_BG_STATE="idle"
+    fi
+  else
+    # Distinguish unreachable from not-installed via daemon status.
+    cc_daemon_raw="$(claude daemon status 2>&1 || true)"
+    if echo "$cc_daemon_raw" | grep -qi "unreachable"; then
+      roster_n="$(echo "$cc_daemon_raw" | grep -oE 'bg workers:[[:space:]]+[0-9]+' | grep -oE '[0-9]+' || echo 0)"
+      if [ "${roster_n:-0}" -gt 0 ]; then
+        CC_BG_STATE="unreachable"
+      fi
+    fi
+  fi
+fi
+
 # ─── 8. Registry ────────────────────────────────────────────────────────────
 REGISTRY_STATE="missing"
 REGISTRY_COUNT=0
@@ -295,7 +322,10 @@ render_pretty() {
   fi
 
   # Voice
-  local v_keys="${!VOICE_STATUS[*]:-}"
+  # Bash 5.3 parses ${!ARR[*]:-} as ${!"ok ok ok"} (indirect-on-values) → invalid var name.
+  # Guard by array-length check, then expand keys directly.
+  local v_keys=""
+  if [ -n "${VOICE_STATUS[*]+x}" ] && [ "${#VOICE_STATUS[@]}" -gt 0 ]; then v_keys="${!VOICE_STATUS[*]}"; fi
   if [ -n "$v_keys" ]; then
     printf ' Voice        '
     for k in $v_keys; do
@@ -307,7 +337,8 @@ render_pretty() {
   fi
 
   # Monitoring
-  local m_keys="${!MON_STATUS[*]:-}"
+  local m_keys=""
+  if [ -n "${MON_STATUS[*]+x}" ] && [ "${#MON_STATUS[@]}" -gt 0 ]; then m_keys="${!MON_STATUS[*]}"; fi
   if [ -n "$m_keys" ]; then
     printf ' Monitoring   '
     for k in $m_keys; do
@@ -325,6 +356,13 @@ render_pretty() {
     invalid)  printf ' Daemon       ✗ invalid daemon-health.json\n' ;;
     unhealthy)printf ' Daemon       ✗ unhealthy\n' ;;
     *)        printf ' Daemon       ○ not running\n' ;;
+  esac
+
+  # Claude Code background-server
+  case "$CC_BG_STATE" in
+    running)     printf ' Claude bg    ✓ %s session(s) (interactive: %s)\n' "$CC_BG_COUNT" "$CC_BG_INTERACTIVE" ;;
+    unreachable) printf ' Claude bg    ✗ supervisor unreachable — run: claude respawn --all\n' ;;
+    *)           printf ' Claude bg    ○ idle (interactive: %s)\n' "$CC_BG_INTERACTIVE" ;;
   esac
 
   # Registry
@@ -398,6 +436,9 @@ render_json() {
       --arg daemon_state "$DAEMON_STATE" \
       --arg daemon_last_sync "$DAEMON_LAST_SYNC" \
       --argjson daemon_services "${DAEMON_SERVICES:-0}" \
+      --arg cc_bg_state "$CC_BG_STATE" \
+      --argjson cc_bg_count "${CC_BG_COUNT:-0}" \
+      --argjson cc_bg_interactive "${CC_BG_INTERACTIVE:-0}" \
       --arg registry_state "$REGISTRY_STATE" \
       --argjson registry_count "${REGISTRY_COUNT:-0}" \
       --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
@@ -409,6 +450,7 @@ render_json() {
         voice: $voice,
         monitoring: $monitoring,
         daemon: {state: $daemon_state, services: $daemon_services, last_sync: $daemon_last_sync},
+        claude_bg: {state: $cc_bg_state, sessions: $cc_bg_count, interactive: $cc_bg_interactive},
         registry: {state: $registry_state, projects: $registry_count},
         generated_at: $generated_at
       }'
@@ -425,6 +467,8 @@ render_json() {
   printf '"monitoring":%s,' "$monitoring"
   printf '"daemon":{"state":"%s","services":%s,"last_sync":"%s"},' \
     "$DAEMON_STATE" "${DAEMON_SERVICES:-0}" "$DAEMON_LAST_SYNC"
+  printf '"claude_bg":{"state":"%s","sessions":%s,"interactive":%s},' \
+    "$CC_BG_STATE" "${CC_BG_COUNT:-0}" "${CC_BG_INTERACTIVE:-0}"
   printf '"registry":{"state":"%s","projects":%s},' \
     "$REGISTRY_STATE" "${REGISTRY_COUNT:-0}"
   printf '"generated_at":"%s"' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"


### PR DESCRIPTION
## Summary

Integrates Claude Code's `claude --bg` background-session supervisor into ops plugin doctor, status, and dispatch surfaces.

**Why:** Claude Code ships a persistent supervisor that hosts `--bg` agents independently of the interactive session — survives terminal close, sleep, and CC upgrades. Previously invisible to ops plugin; now first-class.

## Changes

- **`bin/ops-doctor`** — new section 10c probes `claude agents --json` (fallback: `claude daemon status`). Adds `claude_background_server` to JSON output with `supervisor_status` (`running|idle|unreachable`), `bg_sessions`, `interactive_sessions`. Warns when roster claims live sessions but control socket is dead → `claude respawn --all`.
- **`bin/ops-status`** — adds `Claude bg` row to pretty panel and `claude_bg` field to `--json`. Drive-by fix: bash 5.3 parses `${!ARR[*]:-}` as indirect-on-values, causing `invalid variable name` errors on Voice/Monitoring rows; guarded with array-bound + length check.
- **`bin/ops-bg`** (new) — wrapper around `claude --bg | agents --json | attach | logs | stop | rm | respawn` with standardized defaults (`--model opus --effort high --add-dir $PWD`). Subcommands: `dispatch | list | status | attach | logs | stop | rm | respawn`.

## Test plan

- [x] `tests/test-no-secrets.sh` passes (14/14)
- [x] `shellcheck -S warning` clean on all 3 files
- [x] `bin/ops-doctor | jq .claude_background_server` returns `{supervisor_status, bg_sessions, interactive_sessions}`
- [x] `bin/ops-status` renders new row; ops-status `--json` includes `claude_bg`
- [x] `bin/ops-bg list` returns `background sessions: 0` when idle
- [x] `bin/ops-bg status` proxies through to `claude daemon status`

## Follow-ups (separate PRs)

- Surface bg session count in `/ops:ops-go` morning briefing
- launchd job: `claude respawn --all` on machine wake to refresh bg sessions after CC binary auto-update
- `~/.claude/CLAUDE.md` doctrine added in parallel (user-private — not in this repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new operational probes and new fields/rows to `ops-status`/`ops-doctor` outputs plus a new `ops-bg` CLI wrapper, which could affect scripts that parse these diagnostics and relies on `claude`/`jq` command behaviors.
> 
> **Overview**
> **Integrates Claude Code `--bg` supervision into ops tooling.** `ops-doctor` now probes `claude agents --json` (fallback `claude daemon status`) and emits a new `claude_background_server` JSON section, warning when the roster claims bg sessions but the supervisor socket is unreachable.
> 
> `ops-status` now reports Claude background-supervisor state (pretty panel row + `claude_bg` JSON fields) and hardens associative-array key expansion to avoid Bash 5.3 `${!ARR[*]:-}` parsing errors.
> 
> Adds a new `ops-bg` script that standardizes managing background sessions (`dispatch`, `list`, `status`, `attach`, `logs`, `stop`, `rm`, `respawn`) with default dispatch flags and direct underlying `claude` binary resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5755195d21f4d1774e3492530d835243a8a3de7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->