### PR TITLE
release: v2.11.2 — autopilot auto-downshift over-cap budgets

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.11.1",
+      "version": "2.11.2",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -21,6 +21,12 @@ All notable changes to this project will be documented in this file.
 - Linux is the primary supported platform for desktop-act (X11 + Xvnc + websockify + python-xlib). macOS and Windows can launch the server but native X11 calls no-op; browser/Kapture paths still work.
 - First run on a fresh box performs a one-time clone + `pip install`. Subsequent launches `execv` directly into the cached venv with no extra latency.
 
+## [2.11.2] — 2026-05-23
+
+### Added
+
+- **feat(autopilot): auto-downshift Meta + Google Ads budgets when over cap** (#337) — autopilot detects when ad spend crosses the configured daily cap and automatically reduces the active budget on both Meta Marketing API and Google Ads API, preventing runaway spend without manual intervention.
+
 ## [2.11.0] — 2026-05-22
 
 First-class Linux parity for the background daemon, plus two cross-platform fixes that surfaced during Linux bring-up on Amazon Linux 2023.

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -25,6 +25,10 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **feat(ops): integrate Claude Code background-server supervisor** (#338) — first-class visibility + dispatch ergonomics for `claude --bg` background sessions across the ops plugin. Claude Code ships a persistent supervisor that hosts `--bg` agents independently of the interactive session (survives terminal close, sleep, CC binary upgrades).
+  - `bin/ops-doctor` — new section 10c probes `claude agents --json` (fallback: `claude daemon status`). Adds `claude_background_server` to JSON output with `supervisor_status` (`running|idle|unreachable`), `bg_sessions`, `interactive_sessions`. Warns when roster claims live sessions but control socket is dead (→ `claude respawn --all`).
+  - `bin/ops-status` — new `Claude bg` row in pretty panel + `claude_bg` field in `--json`. Distinguishes healthy ephemeral idle from broken-supervisor unreachable. Drive-by fix: bash 5.3 parses `${!ARR[*]:-}` as indirect-on-values, causing "invalid variable name" on Voice/Monitoring rows; guarded with array-bound + length check.
+  - `bin/ops-bg` (new) — thin wrapper around `claude --bg | agents --json | attach | logs | stop | rm | respawn` with standardized defaults (`--model opus --effort high --add-dir $PWD`). Subcommands: `dispatch | list | status | attach | logs | stop | rm | respawn`.
 - **feat(autopilot): auto-downshift Meta + Google Ads budgets when over cap** (#337) — autopilot detects when ad spend crosses the configured daily cap and automatically reduces the active budget on both Meta Marketing API and Google Ads API, preventing runaway spend without manual intervention.
 
 ## [2.11.0] — 2026-05-22


### PR DESCRIPTION
## Summary

- Bumps version `2.11.1` → `2.11.2` in `plugin.json` and `marketplace.json`
- Adds CHANGELOG entry for v2.11.2
- Includes feat(autopilot): auto-downshift Meta + Google Ads budgets when over cap (#337)

## Files changed

- `claude-ops/.claude-plugin/plugin.json` — version bump
- `.claude-plugin/marketplace.json` — version bump
- `claude-ops/CHANGELOG.md` — v2.11.2 entry added

## Test plan

- [ ] Confirm `plugin.json` version reads `2.11.2`
- [ ] Confirm `marketplace.json` version reads `2.11.2`
- [ ] Confirm CHANGELOG entry present under `[2.11.2] — 2026-05-23`
- [ ] After merge: `git tag v2.11.2 && git push --tags`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release/metadata update: only manifest version strings and changelog text change, with no runtime code modifications.
> 
> **Overview**
> Updates plugin release metadata by bumping `ops` version `2.11.1` → `2.11.2` in both `claude-ops/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.
> 
> Adds a new `CHANGELOG.md` section for `v2.11.2` documenting the planned features included in this release (Claude Code background-server supervisor integration and autopilot budget downshift behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc32e98fff773787b90fa9fb106d7b56dbedc2d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->