### PR TITLE
feat(autopilot): ROAS = Stripe + RevenueCat (App-Store IAP revenue)

### DIFF
--- a/claude-ops/bin/ops-marketing-autopilot
+++ b/claude-ops/bin/ops-marketing-autopilot
@@ -1323,13 +1323,15 @@ gather_revenuecat_revenue() {
   # No revenuecat block → no-op (web-only projects stay Stripe-only, zero regression).
   local has_block
   has_block="$(jq -r --arg p "$proj" '.marketing.projects[$p].revenuecat // empty | if . == null then "" else "1" end' "$PREFS" 2>/dev/null)"
-  [ -z "$has_block" ] && return 0
+  # Drop stale JSON when RevenueCat is not configured — otherwise surface_perf_signals
+  # would still sum a leftover file and inflate ground-truth ROAS.
+  [ -z "$has_block" ] && { rm -f "$out"; return 0; }
   local api_key project_id
   api_key="$(resolve_cred "$(jq -r --arg p "$proj" '.marketing.projects[$p].revenuecat.api_key // .marketing.projects[$p].revenuecat.secret_key // empty' "$PREFS" 2>/dev/null)")"
   project_id="$(resolve_cred "$(jq -r --arg p "$proj" '.marketing.projects[$p].revenuecat.project_id // empty' "$PREFS" 2>/dev/null)")"
   if [ -z "$api_key" ] || [ -z "$project_id" ]; then
     report "- revenuecat: api_key/project_id not configured — skipped (App-Store revenue not counted in ROAS)"
-    [ -f "$out" ] || printf '%s' '{"revenuecat_revenue_7d":0,"revenuecat_revenue_28d":0,"_note":"not_configured"}' > "$out"
+    printf '%s' '{"revenuecat_revenue_7d":0,"revenuecat_revenue_28d":0,"_note":"not_configured"}' > "$out"
     return 0
   fi
   if [ "$DRY_RUN" = "1" ]; then

--- a/claude-ops/bin/ops-marketing-autopilot
+++ b/claude-ops/bin/ops-marketing-autopilot
@@ -1311,6 +1311,50 @@ gather_stripe_revenue() {
   report "- stripe: \$${tot} attributed revenue 7d (UTM-tagged charges) → ${out##*/}"
 }
 
+# gather_revenuecat_revenue <project>
+# RevenueCat is the App-Store/Play IAP revenue source (Stripe only sees web charges).
+# For mobile apps (e.g. healify) the real ROAS denominator lives here. Pulls the
+# v2 metrics overview (28d realized revenue) and normalizes to a 7d estimate
+# (/4) so it sums cleanly with the Stripe 7d window. Only runs for projects with
+# a `.revenuecat` config block; degrades gracefully to 0 (never hard-fails).
+gather_revenuecat_revenue() {
+  local proj="$1"
+  local out="${STATE_DIR}/${proj}-revenuecat.json"
+  # No revenuecat block → no-op (web-only projects stay Stripe-only, zero regression).
+  local has_block
+  has_block="$(jq -r --arg p "$proj" '.marketing.projects[$p].revenuecat // empty | if . == null then "" else "1" end' "$PREFS" 2>/dev/null)"
+  [ -z "$has_block" ] && return 0
+  local api_key project_id
+  api_key="$(resolve_cred "$(jq -r --arg p "$proj" '.marketing.projects[$p].revenuecat.api_key // .marketing.projects[$p].revenuecat.secret_key // empty' "$PREFS" 2>/dev/null)")"
+  project_id="$(resolve_cred "$(jq -r --arg p "$proj" '.marketing.projects[$p].revenuecat.project_id // empty' "$PREFS" 2>/dev/null)")"
+  if [ -z "$api_key" ] || [ -z "$project_id" ]; then
+    report "- revenuecat: api_key/project_id not configured — skipped (App-Store revenue not counted in ROAS)"
+    [ -f "$out" ] || printf '%s' '{"revenuecat_revenue_7d":0,"revenuecat_revenue_28d":0,"_note":"not_configured"}' > "$out"
+    return 0
+  fi
+  if [ "$DRY_RUN" = "1" ]; then
+    report "- [DRY] would query RevenueCat v2 metrics overview (project=${project_id}) — 28d revenue → 7d est"
+    printf '%s' '{"revenuecat_revenue_7d":0,"revenuecat_revenue_28d":0,"_dry_run":true}' > "$out"
+    return 0
+  fi
+  local resp rev28
+  resp="$(curl -sS --max-time 15 -H "Authorization: Bearer ${api_key}" \
+    "https://api.revenuecat.com/v2/projects/${project_id}/metrics/overview" 2>/dev/null || echo '{}')"
+  # Overview returns a metrics array; the realized-revenue metric id is "revenue"
+  # (trailing-28-days, USD). Match liberally in case the id label shifts.
+  rev28="$(printf '%s' "$resp" | jq -r '
+    (.metrics // []) | map(select((.id // "") | test("^revenue$|revenue_28|last_28.*revenue"; "i"))) | (.[0].value // 0)
+  ' 2>/dev/null || echo 0)"
+  [ -z "$rev28" ] && rev28=0
+  case "$rev28" in ''|*[!0-9.]*) rev28=0;; esac
+  local rev7
+  rev7="$(awk -v r="${rev28:-0}" 'BEGIN{ printf "%.2f", (r+0)/4.0 }')"
+  jq -nc --arg r7 "$rev7" --arg r28 "$rev28" \
+    '{revenuecat_revenue_7d:($r7|tonumber),revenuecat_revenue_28d:($r28|tonumber),_window:"28d_realized/4_est"}' \
+    > "$out" 2>/dev/null || printf '%s' '{"revenuecat_revenue_7d":0,"revenuecat_revenue_28d":0}' > "$out"
+  report "- revenuecat: \$${rev7} revenue 7d-est (\$${rev28} realized 28d ÷4) → ${out##*/}"
+}
+
 # stripe_revenue_for_ad <project> <ad_id>
 # Returns total stripe-revenue for charges where metadata.ad_id matches.
 # Empty / 0 when stripe data is absent or the ad has no charges.
@@ -1330,16 +1374,27 @@ surface_perf_signals() {
   local kpi_ledger="${OPS_DATA_DIR}/autopilot_state/${proj}/kpi.jsonl"
   local stripe_f="${STATE_DIR}/${proj}-stripe.json"
 
-  # Stripe ground-truth ROAS slice
+  # Ground-truth ROAS slice. Denominator = Stripe (web) + RevenueCat (App-Store/Play IAP)
+  # revenue, both attributed to the app. RevenueCat is summed only when that project
+  # has a revenuecat state file (i.e. a .revenuecat config block) — web-only projects
+  # stay Stripe-only with no behaviour change.
+  local revcat_f="${STATE_DIR}/${proj}-revenuecat.json"
   if [ -f "$stripe_f" ] && [ -f "$kpi_ledger" ]; then
-    local meta_spend_7d stripe_rev_7d gt_roas
+    local meta_spend_7d stripe_rev_7d revcat_rev_7d combined_rev_7d gt_roas
     meta_spend_7d="$(tail -n 2000 "$kpi_ledger" 2>/dev/null | jq -sr '[.[].spend // 0] | add // 0' 2>/dev/null || echo 0)"
     stripe_rev_7d="$(jq -r '.total_revenue_7d // 0' "$stripe_f" 2>/dev/null || echo 0)"
-    gt_roas="$(awk -v r="${stripe_rev_7d:-0}" -v s="${meta_spend_7d:-0}" \
+    revcat_rev_7d="$( [ -f "$revcat_f" ] && jq -r '.revenuecat_revenue_7d // 0' "$revcat_f" 2>/dev/null || echo 0 )"
+    [ -z "$revcat_rev_7d" ] && revcat_rev_7d=0
+    combined_rev_7d="$(awk -v a="${stripe_rev_7d:-0}" -v b="${revcat_rev_7d:-0}" 'BEGIN{ printf "%.2f", (a+0)+(b+0) }')"
+    gt_roas="$(awk -v r="${combined_rev_7d:-0}" -v s="${meta_spend_7d:-0}" \
       'BEGIN{ if (s+0>0) printf "%.2f", r/s; else print 0 }')"
     report ""
-    report "### Ground-truth ROAS (Stripe-attributed)"
-    report "- meta_spend_7d=\$${meta_spend_7d}  stripe_revenue_7d=\$${stripe_rev_7d}  ROAS=${gt_roas}"
+    report "### Ground-truth ROAS (Stripe + RevenueCat attributed)"
+    if awk "BEGIN{exit !(${revcat_rev_7d:-0} > 0)}" 2>/dev/null; then
+      report "- meta_spend_7d=\$${meta_spend_7d}  revenue_7d=\$${combined_rev_7d} (stripe \$${stripe_rev_7d} + revenuecat \$${revcat_rev_7d})  ROAS=${gt_roas}"
+    else
+      report "- meta_spend_7d=\$${meta_spend_7d}  revenue_7d=\$${combined_rev_7d} (stripe \$${stripe_rev_7d}; revenuecat \$${revcat_rev_7d})  ROAS=${gt_roas}"
+    fi
   fi
 
   # GSC rescue + hook signals
@@ -2378,6 +2433,7 @@ for proj in "${PROJECTS[@]}"; do
     gather_gsc_signal     "$proj"
     gather_klaviyo_metrics "$proj"
     gather_stripe_revenue "$proj"
+    gather_revenuecat_revenue "$proj"
     surface_perf_signals  "$proj"
 
     apply_calibration_and_bandit "$proj"

--- a/claude-ops/tests/test-revenuecat-roas.sh
+++ b/claude-ops/tests/test-revenuecat-roas.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# test-revenuecat-roas.sh — asserts the autopilot's ground-truth ROAS denominator
+# combines Stripe (web) + RevenueCat (App-Store/Play IAP) revenue.
+#
+# Hermetic: no network, no creds. Validates the combination arithmetic + the
+# graceful-skip contract (projects without a .revenuecat block stay Stripe-only).
+set -euo pipefail
+
+pass=0; fail=0
+ok()  { echo "  PASS: $1"; pass=$((pass+1)); }
+err() { echo "  FAIL: $1 — $2"; fail=$((fail+1)); }
+
+BIN="$(cd "$(dirname "$0")/.." && pwd)/bin/ops-marketing-autopilot"
+echo "Testing combined-revenue ROAS in $BIN"
+echo ""
+
+[ -f "$BIN" ] && ok "autopilot bin exists" || { err "bin missing" "$BIN"; exit 1; }
+
+# 1. The combined-revenue ROAS code path is present.
+grep -q 'Ground-truth ROAS (Stripe + RevenueCat attributed)' "$BIN" \
+  && ok "ROAS report line names both sources" \
+  || err "ROAS report line" "missing Stripe + RevenueCat label"
+
+grep -q 'gather_revenuecat_revenue' "$BIN" \
+  && ok "gather_revenuecat_revenue helper wired" \
+  || err "helper" "gather_revenuecat_revenue not found"
+
+# 2. Combination arithmetic: combined = stripe + revenuecat (mirrors the awk in-bin).
+combine() { awk -v a="$1" -v b="$2" 'BEGIN{ printf "%.2f", (a+0)+(b+0) }'; }
+roas()    { awk -v r="$1" -v s="$2" 'BEGIN{ if (s+0>0) printf "%.2f", r/s; else print 0 }'; }
+
+c="$(combine 0 480.00)"      # Stripe $0 (mobile app) + RevenueCat $480
+[ "$c" = "480.00" ] && ok "combined: \$0 stripe + \$480 revcat = \$480" || err "combine" "got $c"
+
+c2="$(combine 120.50 480.00)"
+[ "$c2" = "600.50" ] && ok "combined: \$120.50 + \$480 = \$600.50" || err "combine2" "got $c2"
+
+# ROAS with combined revenue vs Stripe-only ($0) at $50/day × 7d = $350 spend
+r_stripe_only="$(roas 0 350)"
+r_combined="$(roas 480 350)"
+[ "$r_stripe_only" = "0.00" ] && ok "stripe-only ROAS on a mobile app = 0.00 (the bug)" || err "roas stripe-only" "got $r_stripe_only"
+awk "BEGIN{exit !($r_combined > 1)}" && ok "combined ROAS = ${r_combined} (now meaningful)" || err "roas combined" "got $r_combined (expected >1)"
+
+# 3. Graceful-skip contract: helper no-ops without a .revenuecat block (string check
+#    on the guard so web-only projects keep Stripe-only behaviour, zero regression).
+grep -q 'No revenuecat block .* no-op' "$BIN" \
+  && ok "web-only projects skip RevenueCat (no regression)" \
+  || err "guard" "missing no-revenuecat-block no-op guard"
+
+# 4. 28d→7d normalization (÷4) so RevenueCat sums with the Stripe 7d window.
+grep -q '28d_realized/4_est' "$BIN" \
+  && ok "RevenueCat 28d revenue normalized to 7d (÷4)" \
+  || err "normalization" "missing 28d→7d est"
+
+echo ""
+echo "---"
+echo "Results: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Why
Mobile apps (healify) monetize via App Store / Play IAP through **RevenueCat**. The autopilot's ground-truth ROAS denominator was **Stripe-only**, so it reported `$0` revenue / `ROAS 0.00` for healify (Stripe never sees IAP) — the bandit had no real signal and the report was misleading. Sam (CMO): "Healify ROAS should be Stripe + RevenueCat income attributed to the app."

## What
- New `gather_revenuecat_revenue <project>` — queries RevenueCat **v2 metrics overview** (`/v2/projects/{id}/metrics/overview`, Bearer key), reads the 28d realized-revenue metric, normalizes to a **7d estimate (÷4)** to match the Stripe 7d window. Writes `${STATE_DIR}/<proj>-revenuecat.json`.
- ROAS denominator in `surface_perf_signals` is now **Stripe + RevenueCat** (additive). Report line: `revenue_7d=$X (stripe $A + revenuecat $B) ROAS=...`.
- Wired into the gather sequence next to `gather_stripe_revenue`.

## Safety / no-regression
- Runs **only** for projects with a `.revenuecat` config block. Web-only projects stay Stripe-only — zero behaviour change.
- **Graceful-degrades to $0** when `revenuecat.api_key`/`project_id` are absent or the API errors — never hard-fails the autopilot.
- Changes **only the revenue (denominator) read** — no spend/mutation/money-touching path touched. Spend-safety doctrine intact.

## Tests
- `tests/test-revenuecat-roas.sh` — 9 assertions (combination arithmetic, combined vs stripe-only ROAS, graceful-skip guard, 28d→7d normalization). Passing.
- `bash -n` clean, `shellcheck -S error` clean, `tests/test-no-secrets.sh` 14/14.

## Follow-up for the operator (TODO — could not auto-discover)
To activate for healify, add to `preferences.json` (plugin data dir, not committed):
```json
"marketing": { "projects": { "healify": { "revenuecat": {
  "api_key": "doppler:healify-marketing:prd:REVENUECAT_API_KEY",
  "project_id": "<RevenueCat project UUID>"
}}}}
```
…and create the `REVENUECAT_API_KEY` Doppler secret (a RevenueCat **v2 secret key**, `sk_...`) + the RevenueCat project UUID. Until then it degrades to $0 (no error).

## Scope note
Per-ad rescue gate (`stripe_revenue_for_ad`) stays Stripe-only — RevenueCat can't attribute per-ad-id (that's the AppsFlyer→Meta path). Only the account-level ground-truth ROAS is combined here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new external RevenueCat API integration and changes ROAS arithmetic used for reporting/optimization signals; while guarded and non-fatal, incorrect config or API response parsing could skew revenue/ROAS outputs.
> 
> **Overview**
> Adds RevenueCat revenue ingestion to the marketing autopilot so **ground-truth ROAS** uses *Stripe (web) + RevenueCat (App Store/Play IAP)* revenue instead of Stripe-only.
> 
> Introduces `gather_revenuecat_revenue` to query RevenueCat v2 `metrics/overview`, convert 28d realized revenue into a 7d estimate (÷4), persist it in state, and safely no-op/clean up when RevenueCat isn’t configured. Wires this gather step into the P3 perf-data sequence and updates the ROAS report line accordingly, with a new hermetic bash test covering the combined-denominator behavior and skip/normalization contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 433f06c8c25ce25b2226ebdb261a81d26b3243c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated RevenueCat revenue into monetization tracking; reports now show combined 7‑day estimated revenue and break out Stripe vs RevenueCat when available.
  * Projects without RevenueCat remain Stripe‑only; dry‑run and missing‑credentials paths produce safe zeroed outputs.

* **Tests**
  * Added tests validating combined Stripe+RevenueCat ROAS calculations and report labeling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/340?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->