### PR TITLE
fix(ops-comms-scanner): correct is_from_me direction, time_ago math, name resolution

### DIFF
--- a/claude-ops/agents/comms-scanner.md
+++ b/claude-ops/agents/comms-scanner.md
@@ -32,7 +32,7 @@ mcp__whatsapp__list_chats sort_by=last_active
 #
 # NAME RESOLUTION — contacts.db is PRIMARY source; giga memory is fallback only.
 #   DB="${WHATSAPP_BRIDGE_DB:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db}"
-#   sqlite3 "$DB" "SELECT name FROM contacts WHERE jid=? LIMIT 1;" "$JID"
+#   sqlite3 "$DB" "SELECT name FROM contacts WHERE jid='$JID' LIMIT 1;"
 #   If empty → use the name field from list_chats response.
 #   Only consult giga memory (mcp__giga__evoke) when both DB lookup and list_chats name are empty.
 #

--- a/claude-ops/agents/comms-scanner.md
+++ b/claude-ops/agents/comms-scanner.md
@@ -25,11 +25,31 @@ Run all channel scans in parallel:
 
 ```bash
 # WhatsApp — ALL non-archived chats (not just unread)
-# WhatsApp via bridge MCP tools
-mcp__whatsapp__list_chats sort_by=last_active  # or via sqlite3 direct query
-# Then for each chat with recent activity (last 7 days):
-# mcp__whatsapp__list_messages chat_jid="<JID>" limit=5
-# Check FromMe on last message to classify NEEDS_REPLY vs WAITING
+# Step 1: list chats — the response includes last_is_from_me (int 0/1) and last_message_time (RFC3339+TZ string)
+mcp__whatsapp__list_chats sort_by=last_active
+
+# Step 2: for each chat active in last 7 days, resolve contact name and compute time_ago:
+#
+# NAME RESOLUTION — contacts.db is PRIMARY source; giga memory is fallback only.
+#   DB="${WHATSAPP_BRIDGE_DB:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db}"
+#   sqlite3 "$DB" "SELECT name FROM contacts WHERE jid=? LIMIT 1;" "$JID"
+#   If empty → use the name field from list_chats response.
+#   Only consult giga memory (mcp__giga__evoke) when both DB lookup and list_chats name are empty.
+#
+# TIME_AGO — last_message_time is RFC3339 with timezone offset (e.g. "2026-05-24T14:55:06+02:00").
+#   Parse with full TZ awareness. In Python:
+#     from datetime import datetime, timezone
+#     dt = datetime.fromisoformat(last_message_time)   # preserves tz offset
+#     delta = datetime.now(timezone.utc) - dt.astimezone(timezone.utc)
+#   Never strip the timezone suffix before parsing — doing so causes wrong "now" delta.
+#
+# DIRECTION — use last_is_from_me from list_chats directly (do NOT re-derive from last message).
+#   last_is_from_me == 1  →  WAITING  (you sent last; no reply needed)
+#   last_is_from_me == 0  →  NEEDS_REPLY  (they sent last)
+#
+# For chats where last_is_from_me is absent or null, fall back to fetching the thread:
+#   mcp__whatsapp__list_messages chat_jid="<JID>" limit=5
+#   Check is_from_me on the LAST element of the returned array.
 ```
 
 ```bash

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -391,12 +391,7 @@ If only 3 channels are configured, "All channels" + 3 channel options = 4, fits 
 5. For chats where `last_is_from_me` is absent or null, fetch the thread as fallback:
    `mcp__whatsapp__list_messages` with `{chat_jid: "<JID>", limit: 20}` — check `is_from_me` on the **last element** of the returned array.
 
-6. Parse full message array — fields: `is_from_me`, `content`, `timestamp`, `sender`
-7. For EVERY chat, understand the conversation:
-   - Read ALL messages in order. Know which have `is_from_me: true` (user sent) vs `is_from_me: false` (contact sent)
-   - Understand what the conversation is about, what was discussed, what's pending
-   - Identify the user's tone and style in their sent messages
-8. Classify each chat (same direction rule as step 4 — use `last_is_from_me` on the chat object; only after the step 5 thread fallback use the last element's `is_from_me`):
+6. Classify each chat (same direction rule as step 4 — use `last_is_from_me` on the chat object; only after the step 5 thread fallback use the last element's `is_from_me`):
    - **NEEDS REPLY**: `last_is_from_me == 0`, or (fallback only) last thread message `is_from_me: false`
    - **WAITING**: `last_is_from_me == 1`, or (fallback only) last thread message `is_from_me: true`
    - **ARCHIVE**: Newsletters (`@newsletter` JIDs), dead group chats with no recent activity, one-word reactions, or concluded conversations. Bulk-archive these via `mcp__whatsapp__archive_chat {chat_jid, archive: true}` after user confirmation. If the call fails with `LTHash mismatch`, run `mcp__whatsapp__resync_app_state {name: "regular_low", full_sync: true}` first, then retry.

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -321,7 +321,7 @@ For each channel, detect availability at runtime:
 
 2. **For each channel, run a FULL scan** (not just unread):
    - **Email**: Search `in:inbox` (not `is:unread`) via `gog gmail search -a $GMAIL_ACCOUNT -j --results-only --no-input --max 30 "in:inbox"`. For each thread, read the last message to determine who sent it last. Check for DRAFT or SENT labels. **Before suggesting to send a draft, verify no reply was already sent in the thread.**
-   - **WhatsApp**: Call `mcp__whatsapp__list_chats {sort_by: "last_active"}` to get all chats. Filter to chats with `last_message_time` in the last 7 days. For each, fetch the FULL conversation via `mcp__whatsapp__list_messages {chat_jid, limit: 20}` (20 messages, not 5 — you need the full thread). Parse message array with fields `is_from_me`, `content`, `timestamp`, `sender`. Classify by last message `is_from_me` field.
+   - **WhatsApp**: Call `mcp__whatsapp__list_chats {sort_by: "last_active"}` to get all chats. Filter to chats with `last_message_time` in the last 7 days (`last_message_time` is RFC3339+TZ — parse with timezone awareness, never strip the offset). Resolve display name from contacts.db first (`SELECT name FROM contacts WHERE jid=?`), fall back to the chat's `name` field, and only call giga memory when both are empty. Classify direction using `last_is_from_me` on the chat object (`1` = WAITING, `0` = NEEDS_REPLY). Only fetch the full thread via `mcp__whatsapp__list_messages {chat_jid, limit: 20}` when `last_is_from_me` is absent/null or when building reply context for NEEDS_REPLY chats.
    - **Slack**: Search via Slack MCP tools. Check who sent last message in each thread.
    - **Telegram**: Use user-auth MCP (NOT bot API) to read recent conversations.
 
@@ -368,13 +368,35 @@ If only 3 channels are configured, "All channels" + 3 channel options = 4, fits 
 **Phase 1 — Classify:**
 1. Get all chats: `mcp__whatsapp__list_chats` with `{sort_by: "last_active"}`
 2. Filter to chats with `last_message_time` in the last 7 days
-3. For each, fetch the FULL recent conversation: `mcp__whatsapp__list_messages` with `{chat_jid: "<JID>", limit: 20}` — get 20 messages, NOT 5.
-4. Parse message array — fields: `is_from_me`, `content`, `timestamp`, `sender`
-5. For EVERY chat, understand the conversation:
+
+   **TIME_AGO — `last_message_time` is an RFC3339 string with timezone offset** (e.g. `"2026-05-24T14:55:06+02:00"`), NOT a unix epoch integer. Parse with full TZ awareness:
+   ```python
+   from datetime import datetime, timezone
+   dt = datetime.fromisoformat(last_message_time)   # preserves offset
+   delta = datetime.now(timezone.utc) - dt.astimezone(timezone.utc)
+   ```
+   Never strip the timezone suffix before parsing — that produces a naive datetime and wrong deltas.
+
+3. **NAME RESOLUTION — contacts.db is PRIMARY, giga memory is fallback only.**
+   ```bash
+   DB="${WHATSAPP_BRIDGE_DB:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db}"
+   sqlite3 "$DB" "SELECT name FROM contacts WHERE jid='$JID' LIMIT 1;"
+   ```
+   Use the DB result as the display name. If the DB returns empty, fall back to the `name` field in the `list_chats` response. Only call `mcp__giga__evoke` when both are empty.
+
+4. **DIRECTION — classify from `last_is_from_me` on the chat object itself.** Do NOT re-derive from the last message in a fetched thread unless `last_is_from_me` is absent or null:
+   - `last_is_from_me == 1` → **WAITING** (you sent last; no reply needed)
+   - `last_is_from_me == 0` → **NEEDS REPLY** (they sent last)
+
+5. For chats where `last_is_from_me` is absent or null, fetch the thread as fallback:
+   `mcp__whatsapp__list_messages` with `{chat_jid: "<JID>", limit: 20}` — check `is_from_me` on the **last element** of the returned array.
+
+6. Parse full message array — fields: `is_from_me`, `content`, `timestamp`, `sender`
+7. For EVERY chat, understand the conversation:
    - Read ALL messages in order. Know which have `is_from_me: true` (user sent) vs `is_from_me: false` (contact sent)
    - Understand what the conversation is about, what was discussed, what's pending
    - Identify the user's tone and style in their sent messages
-6. Classify each chat:
+8. Classify each chat:
    - **NEEDS REPLY**: Last message has `is_from_me: false` (they sent last)
    - **WAITING**: Last message has `is_from_me: true` (you sent last)
    - **ARCHIVE**: Newsletters (`@newsletter` JIDs), dead group chats with no recent activity, one-word reactions, or concluded conversations. Bulk-archive these via `mcp__whatsapp__archive_chat {chat_jid, archive: true}` after user confirmation. If the call fails with `LTHash mismatch`, run `mcp__whatsapp__resync_app_state {name: "regular_low", full_sync: true}` first, then retry.

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -396,9 +396,9 @@ If only 3 channels are configured, "All channels" + 3 channel options = 4, fits 
    - Read ALL messages in order. Know which have `is_from_me: true` (user sent) vs `is_from_me: false` (contact sent)
    - Understand what the conversation is about, what was discussed, what's pending
    - Identify the user's tone and style in their sent messages
-8. Classify each chat:
-   - **NEEDS REPLY**: Last message has `is_from_me: false` (they sent last)
-   - **WAITING**: Last message has `is_from_me: true` (you sent last)
+8. Classify each chat (same direction rule as step 4 — use `last_is_from_me` on the chat object; only after the step 5 thread fallback use the last element's `is_from_me`):
+   - **NEEDS REPLY**: `last_is_from_me == 0`, or (fallback only) last thread message `is_from_me: false`
+   - **WAITING**: `last_is_from_me == 1`, or (fallback only) last thread message `is_from_me: true`
    - **ARCHIVE**: Newsletters (`@newsletter` JIDs), dead group chats with no recent activity, one-word reactions, or concluded conversations. Bulk-archive these via `mcp__whatsapp__archive_chat {chat_jid, archive: true}` after user confirmation. If the call fails with `LTHash mismatch`, run `mcp__whatsapp__resync_app_state {name: "regular_low", full_sync: true}` first, then retry.
 
 **Phase 2 — Build context for NEEDS REPLY chats (run in parallel):**


### PR DESCRIPTION
## Summary

- **Bug 1 — direction misclassification**: scanner was re-deriving direction from fetched thread messages instead of using `last_is_from_me` (int 0/1) directly from `list_chats`. `last_is_from_me == 1` must classify as WAITING, not NEEDS_REPLY. Thread fetch is now only used as fallback when the field is absent/null.
- **Bug 2 — time_ago math**: `last_message_time` from the bridge is an RFC3339 string with timezone offset (e.g. `"2026-05-24T14:55:06+02:00"`), not a unix epoch integer. Parsing without preserving the offset produced a naive datetime and wrong deltas. Fixed to use `datetime.fromisoformat()` + `.astimezone(timezone.utc)` for correct wall-clock delta.
- **Bug 3 — name resolution**: giga memory was being used as primary name source, overriding the contacts.db lookup. Corrected priority: contacts.db `SELECT name FROM contacts WHERE jid=?` → `list_chats` name field → giga memory only as last resort.

## Files changed

- `claude-ops/agents/comms-scanner.md` — rewrote WhatsApp scan block with all three corrections
- `claude-ops/skills/ops-inbox/SKILL.md` — updated Phase 1 classify block and "Your task" WhatsApp bullet with matching corrections

## Test plan

- [x] `tests/test-no-secrets.sh` — 14 passed, 0 failed
- [x] `tests/test-agents-lint.sh` — 171 passed, 0 failed
- [x] `tests/test-skills-lint.sh` — 344 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes, but they steer operational behavior for WhatsApp triage; incorrect guidance could still cause misclassification or wasted API calls.
> 
> **Overview**
> Updates WhatsApp scanning instructions for `comms-scanner` and `ops-inbox` to **classify chats using `last_is_from_me` from `mcp__whatsapp__list_chats`**, only falling back to `list_messages` when that field is missing/null.
> 
> Clarifies **timezone-aware parsing** for `last_message_time` (RFC3339 with offset) when computing `time_ago`, and tightens **display-name resolution order** to `contacts.db` → chat `name` → `mcp__giga__evoke` as a last resort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c397c62a5a3cb589ff64775fe32e8731b723661f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded WhatsApp inbox scanning guidance to cover scanning all non-archived chats and a step-by-step, tool-by-tool plan.
  * Optimize classification to use chat-level metadata (including a message-origin flag) before fetching full threads; fetch full threads only when necessary.
  * Improved contact-name resolution with primary/fallback sources.
  * Clarified timezone-aware timestamp parsing and requirement to read messages in order for accurate context and classification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->