### PR TITLE
feat(pocket): real-time webhook ingest → pending-triage

### DIFF
--- a/claude-ops/scripts/ops-cron-pocket-watcher.py
+++ b/claude-ops/scripts/ops-cron-pocket-watcher.py
@@ -413,21 +413,24 @@ def _transcript_for_infer_length_gate(recording: dict) -> str:
     return transcript
 
 
-def infer_tasks_from_recording(recording: dict) -> list[dict]:
+def infer_tasks_from_recording(recording: dict) -> tuple[list[dict], bool]:
     """Call Haiku to extract implicit tasks from a recording's transcript.
 
-    Returns a list of {title, context, priority, confidence} dicts.
-    Filtered by INFER_CONFIDENCE threshold. Empty list if recording is too
-    short, no auth, or Haiku returns nothing actionable.
+    Returns ``(tasks, api_ok)`` where *tasks* is a list of
+    {title, context, priority, confidence} dicts (filtered by INFER_CONFIDENCE).
+    *api_ok* is True only when a Haiku HTTP request completed and the model
+    reply was parsed as a JSON array (possibly empty after filtering) — so
+    callers can persist dedupe markers and infer-budget without treating transport
+    or parse failures as a successful empty extraction.
     """
     if not INFER_TASKS:
-        return []
+        return [], True
     duration = recording.get("durationSec") or recording.get("duration") or 0
     if duration and duration < INFER_MIN_SECS:
-        return []
+        return [], True
     transcript = _transcript_for_infer_length_gate(recording)
     if len(transcript) < 200:
-        return []
+        return [], True
 
     summary = recording.get("summary") or {}
     if isinstance(summary, dict):
@@ -438,7 +441,7 @@ def infer_tasks_from_recording(recording: dict) -> list[dict]:
     auth_header, extras = _resolve_anthropic_auth()
     if not auth_header and not (extras or {}).get("_apikey"):
         log("infer: no Anthropic auth — skipping implicit-task extraction")
-        return []
+        return [], False
 
     system_prompt = (
         "You extract implicit actionable tasks from a voice-memo transcript. "
@@ -486,10 +489,10 @@ def infer_tasks_from_recording(recording: dict) -> list[dict]:
     except urlerr.HTTPError as e:
         err = e.read().decode("utf-8", errors="replace")[:200] if e.fp else ""
         log(f"infer: Haiku HTTP {e.code}: {err}")
-        return []
+        return [], False
     except Exception as e:
         log(f"infer: Haiku call failed: {type(e).__name__}: {e}")
-        return []
+        return [], False
 
     text = ""
     for block in body.get("content", []):
@@ -505,9 +508,9 @@ def infer_tasks_from_recording(recording: dict) -> list[dict]:
         items = json.loads(text)
     except json.JSONDecodeError:
         log(f"infer: bad JSON from Haiku: {text[:200]}")
-        return []
+        return [], False
     if not isinstance(items, list):
-        return []
+        return [], False
     out = []
     for it in items:
         if not isinstance(it, dict):
@@ -524,7 +527,7 @@ def infer_tasks_from_recording(recording: dict) -> list[dict]:
             "priority": (it.get("priority") or "low").lower(),
             "confidence": conf,
         })
-    return out
+    return out, True
 
 
 # ── Giga client (reuses mcp-remote OAuth token cache) ────────────────────────
@@ -1012,43 +1015,51 @@ def main() -> int:
         seen = load_seen()
         log(f"cursor={cursor} seen={len(seen)}")
 
-        # 1) Pull recordings since cursor
-        new_memories = 0
-        new_recordings: list[str] = []
-        recordings_page_cap_hit = False
-        next_before: str | None = load_recordings_pagination_resume(cursor)
+    # 1) Pull recordings since cursor (MCP + Haiku outside pocket_state_lock so
+    # webhook ingest can make progress; seen/pending updates are short critical
+    # sections below).
+    new_memories = 0
+    new_recordings: list[str] = []
+    recordings_page_cap_hit = False
+    next_before: str | None = load_recordings_pagination_resume(cursor)
+    if next_before:
+        log("resuming pocket recordings pagination (nextRecordingDateBeforeExclusive set)")
+    page = 0
+    infer_calls = 0  # Haiku calls made this run; capped by MAX_INFER_PER_RUN
+    cap_hit = False  # set when MAX_INFER_PER_RUN reached — breaks page loop too
+    while True:
+        page += 1
+        args = {"recordingDateAfter": cursor}
         if next_before:
-            log("resuming pocket recordings pagination (nextRecordingDateBeforeExclusive set)")
-        page = 0
-        infer_calls = 0  # Haiku calls made this run; capped by MAX_INFER_PER_RUN
-        cap_hit = False  # set when MAX_INFER_PER_RUN reached — breaks page loop too
-        while True:
-            page += 1
-            args = {"recordingDateAfter": cursor}
-            if next_before:
-                args["recordingDateBeforeExclusive"] = next_before
-            result, err = client.call_tool("search_pocket_conversations_timerange", args, timeout=30)
-            if err:
-                log(f"recordings page {page} error: {err}")
-                # Distinguish "Pocket search backend is down" from other errors
-                # so we can fire a recovery alert when it comes back. Only mark
-                # outage on the first page (later pages may fail mid-pagination
-                # for unrelated reasons and shouldn't trigger the global flag).
-                if page == 1 and _is_search_unavailable(err):
-                    _on_search_outage_detected(err)
-                break
-            # Successful call — if we had a recorded outage, fire recovery
-            # notification (one-shot, marker is cleared inside the helper).
-            if page == 1:
-                _on_search_outage_resolved()
-            data = (result or {}).get("data", result or {})
-            recordings = data.get("results") or data.get("recordings") or data.get("conversations") or []
-            meta = data.get("meta") or {}
-            if not recordings:
-                clear_recordings_pagination_resume()
-                break
-            for rec in recordings:
-                rid = rec.get("id") or rec.get("recordingId") or ""
+            args["recordingDateBeforeExclusive"] = next_before
+        result, err = client.call_tool("search_pocket_conversations_timerange", args, timeout=30)
+        if err:
+            log(f"recordings page {page} error: {err}")
+            # Distinguish "Pocket search backend is down" from other errors
+            # so we can fire a recovery alert when it comes back. Only mark
+            # outage on the first page (later pages may fail mid-pagination
+            # for unrelated reasons and shouldn't trigger the global flag).
+            if page == 1 and _is_search_unavailable(err):
+                _on_search_outage_detected(err)
+            break
+        # Successful call — if we had a recorded outage, fire recovery
+        # notification (one-shot, marker is cleared inside the helper).
+        if page == 1:
+            _on_search_outage_resolved()
+        data = (result or {}).get("data", result or {})
+        recordings = data.get("results") or data.get("recordings") or data.get("conversations") or []
+        meta = data.get("meta") or {}
+        if not recordings:
+            clear_recordings_pagination_resume()
+            break
+        for rec in recordings:
+            rid = rec.get("id") or rec.get("recordingId") or ""
+            would_infer = False
+            wh_infer = ""
+            webhook_already_inferred = False
+
+            with pocket_state_lock():
+                seen = load_seen()
                 if not rid or rid in seen:
                     continue
                 # Skip very short, transcript-less recordings (likely noise)
@@ -1059,6 +1070,7 @@ def main() -> int:
                 if duration and duration < 20 and not has_content:
                     log(f"skip noise recording {rid} (dur={duration}s, no transcript)")
                     _seen_add(seen, rid)
+                    save_seen(seen)
                     continue
 
                 # Money-leak guard: if a Haiku inference would fire for THIS
@@ -1074,6 +1086,8 @@ def main() -> int:
                     and (not duration or duration >= INFER_MIN_SECS)
                     and len(gate_transcript) >= 200
                 )
+                wh_infer = f"wh-infer:{rid}"
+                webhook_already_inferred = wh_infer in seen
                 if (
                     MAX_INFER_PER_RUN > 0
                     and would_infer
@@ -1086,19 +1100,22 @@ def main() -> int:
                     cap_hit = True
                     break
 
-                write_memory(rec, giga=giga)
-                new_memories += 1
-                new_recordings.append(rid)
-                _seen_add(seen, rid)
+            write_memory(rec, giga=giga)
 
-                # Implicit-task inference (Haiku) — only on substantive recordings
-                wh_infer = f"wh-infer:{rid}"
-                webhook_already_inferred = wh_infer in seen
-                inferred = (
-                    [] if webhook_already_inferred else infer_tasks_from_recording(rec)
-                )
-                if would_infer and not webhook_already_inferred:
-                    infer_calls += 1
+            if webhook_already_inferred:
+                inferred: list[dict] = []
+                infer_api_ok = True
+            else:
+                inferred, infer_api_ok = infer_tasks_from_recording(rec)
+            if would_infer and not webhook_already_inferred:
+                infer_calls += 1
+
+            with pocket_state_lock():
+                seen = load_seen()
+                if rid not in seen:
+                    _seen_add(seen, rid)
+                    new_memories += 1
+                    new_recordings.append(rid)
                 for idx, t in enumerate(inferred):
                     inferred_id = f"inferred-{rid[:12]}-{idx}"
                     if inferred_id in seen:
@@ -1128,58 +1145,69 @@ def main() -> int:
                             f.write(json.dumps(payload) + "\n")
                         log(f"queued for triage: {t['title'][:60]} (conf={t['confidence']:.2f})")
                     _seen_add(seen, inferred_id)
-            if cap_hit:
-                break
-            if meta.get("hasMore") and meta.get("nextRecordingDateBeforeExclusive"):
-                next_before = meta["nextRecordingDateBeforeExclusive"]
-                if page >= 10:
-                    log("hit page cap (10) — leaving cursor unchanged; saved pagination resume for next run")
-                    save_recordings_pagination_resume(cursor, next_before)
-                    recordings_page_cap_hit = True
-                    break
-            else:
-                clear_recordings_pagination_resume()
-                break
+                if would_infer and not webhook_already_inferred and infer_api_ok:
+                    _seen_add(seen, wh_infer)
+                save_seen(seen)
 
-        # 2) Pull action items since cursor (TODO only)
-        new_tasks = 0
-        result, err = client.call_tool("search_pocket_actionitems", {
-            "status": "TODO",
-            "recordingDateFrom": cursor,
-        }, timeout=30)
-        if err:
-            log(f"actionitems error: {err}")
+        if cap_hit:
+            break
+        if meta.get("hasMore") and meta.get("nextRecordingDateBeforeExclusive"):
+            next_before = meta["nextRecordingDateBeforeExclusive"]
+            if page >= 10:
+                log("hit page cap (10) — leaving cursor unchanged; saved pagination resume for next run")
+                save_recordings_pagination_resume(cursor, next_before)
+                recordings_page_cap_hit = True
+                break
         else:
-            data = (result or {}).get("data", result or {})
-            items = data.get("results") or data.get("items") or data.get("actionItems") or []
-            for item in items:
-                iid = item.get("id") or item.get("actionItemId")
-                if not iid:
-                    continue
-                seen_key = f"action:{iid}"
+            clear_recordings_pagination_resume()
+            break
+
+    # 2) Pull action items since cursor (TODO only)
+    new_tasks = 0
+    result, err = client.call_tool("search_pocket_actionitems", {
+        "status": "TODO",
+        "recordingDateFrom": cursor,
+    }, timeout=30)
+    if err:
+        log(f"actionitems error: {err}")
+    else:
+        data = (result or {}).get("data", result or {})
+        items = data.get("results") or data.get("items") or data.get("actionItems") or []
+        for item in items:
+            iid = item.get("id") or item.get("actionItemId")
+            if not iid:
+                continue
+            seen_key = f"action:{iid}"
+            with pocket_state_lock():
+                seen = load_seen()
                 if seen_key in seen:
                     continue
-                route_actionitem(item, giga=giga)
+            route_actionitem(item, giga=giga)
+            with pocket_state_lock():
+                seen = load_seen()
+                if seen_key in seen:
+                    continue
                 new_tasks += 1
                 _seen_add(seen, seen_key)
+                save_seen(seen)
 
-        # 3) Optional consolidate pass (Giga merges adjacent neurons)
-        if giga and giga.ok and GIGA_CONSOLIDATE and (new_memories + new_tasks) > 0:
-            giga.consolidate()
+    # 3) Optional consolidate pass (Giga merges adjacent neurons)
+    if giga and giga.ok and GIGA_CONSOLIDATE and (new_memories + new_tasks) > 0:
+        giga.consolidate()
 
-        # 3.5) Flush buffered Giga neurons via claude -p subprocess (uses Claude Code auth)
-        giga_flush_ok = True
-        if giga and giga.ok:
-            giga_flush_ok = giga.flush()
+    # 3.5) Flush buffered Giga neurons via claude -p subprocess (uses Claude Code auth)
+    giga_flush_ok = True
+    if giga and giga.ok:
+        giga_flush_ok = giga.flush()
 
-        # 4) Advance cursor & persist.
-        # Do not advance if either the Haiku-inference cap or pagination cap was hit —
-        # both mean there are deferred recordings that need the same window next run.
+    # 4) Advance cursor & persist.
+    # Do not advance if either the Haiku-inference cap or pagination cap was hit —
+    # both mean there are deferred recordings that need the same window next run.
+    with pocket_state_lock():
         if cap_hit:
             log(f"cap hit: holding cursor at {cursor} (not advancing to {run_started})")
         elif not recordings_page_cap_hit:
             save_cursor(run_started)
-        save_seen(seen)
 
     if giga and giga.ok and not giga_flush_ok:
         giga_status = "flush_failed"

--- a/claude-ops/scripts/ops-cron-pocket-watcher.py
+++ b/claude-ops/scripts/ops-cron-pocket-watcher.py
@@ -819,6 +819,15 @@ def slugify(text: str, maxlen: int = 60) -> str:
     return (s or "untitled")[:maxlen]
 
 
+def actionitem_webhook_triage_dedupe_key(recording_id: str, title: str) -> str | None:
+    """Matches ops-pocket-webhook-ingest keys for action items without MCP ids."""
+    rid = (recording_id or "").strip()
+    tit = (title or "").strip()
+    if not rid or not tit:
+        return None
+    return f"action-todo:{rid}:{slugify(tit, 40)}"
+
+
 def write_memory(recording: dict, giga: "GigaClient | None" = None) -> Path | None:
     """Persist a recording as a memory file. One file per recording_id.
 
@@ -1056,7 +1065,8 @@ def main() -> int:
             rid = rec.get("id") or rec.get("recordingId") or ""
             would_infer = False
             wh_infer = ""
-            webhook_already_inferred = False
+            infer_done_elsewhere = False
+            run_infer = False
 
             with pocket_state_lock():
                 seen = load_seen()
@@ -1087,7 +1097,7 @@ def main() -> int:
                     and len(gate_transcript) >= 200
                 )
                 wh_infer = f"wh-infer:{rid}"
-                webhook_already_inferred = wh_infer in seen
+                infer_done_elsewhere = wh_infer in seen
                 if (
                     MAX_INFER_PER_RUN > 0
                     and would_infer
@@ -1100,18 +1110,25 @@ def main() -> int:
                     cap_hit = True
                     break
 
+                if would_infer and not infer_done_elsewhere:
+                    _seen_add(seen, wh_infer)
+                    save_seen(seen)
+                    run_infer = True
+
             write_memory(rec, giga=giga)
 
-            if webhook_already_inferred:
+            if infer_done_elsewhere:
                 inferred: list[dict] = []
                 infer_api_ok = True
             else:
                 inferred, infer_api_ok = infer_tasks_from_recording(rec)
-            if would_infer and not webhook_already_inferred:
+            if would_infer and not infer_done_elsewhere and run_infer:
                 infer_calls += 1
 
             with pocket_state_lock():
                 seen = load_seen()
+                if run_infer and not infer_api_ok:
+                    seen.pop(wh_infer, None)
                 if rid not in seen:
                     _seen_add(seen, rid)
                     new_memories += 1
@@ -1145,8 +1162,6 @@ def main() -> int:
                             f.write(json.dumps(payload) + "\n")
                         log(f"queued for triage: {t['title'][:60]} (conf={t['confidence']:.2f})")
                     _seen_add(seen, inferred_id)
-                if would_infer and not webhook_already_inferred and infer_api_ok:
-                    _seen_add(seen, wh_infer)
                 save_seen(seen)
 
         if cap_hit:
@@ -1178,9 +1193,14 @@ def main() -> int:
             if not iid:
                 continue
             seen_key = f"action:{iid}"
+            rec_id = str(item.get("recordingId") or item.get("recording_id") or "").strip()
+            title = (item.get("title") or item.get("label") or "").strip()
+            webhook_triage_key = actionitem_webhook_triage_dedupe_key(rec_id, title)
             with pocket_state_lock():
                 seen = load_seen()
                 if seen_key in seen:
+                    continue
+                if webhook_triage_key and webhook_triage_key in seen:
                     continue
             route_actionitem(item, giga=giga)
             with pocket_state_lock():

--- a/claude-ops/scripts/ops-cron-pocket-watcher.py
+++ b/claude-ops/scripts/ops-cron-pocket-watcher.py
@@ -59,10 +59,12 @@ Giga sync (optional but on-by-default):
 """
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import json
 import os
 from collections import OrderedDict
+from contextlib import contextmanager
 import re
 import subprocess
 import sys
@@ -621,6 +623,22 @@ class GigaClient:
 
 
 # ── State ────────────────────────────────────────────────────────────────────
+@contextmanager
+def pocket_state_lock() -> None:
+    """Serialize updates to seen.json and pending-triage.jsonl (watcher + webhook)."""
+    if DRY_RUN:
+        yield
+        return
+    STATE_DIR.mkdir(parents=True, exist_ok=True)
+    lock_path = STATE_DIR / ".pocket-webhook-state.lock"
+    with open(lock_path, "a+b") as lock_f:
+        fcntl.flock(lock_f.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_f.fileno(), fcntl.LOCK_UN)
+
+
 def load_cursor() -> str:
     if CURSOR_FILE.exists():
         return CURSOR_FILE.read_text().strip()
@@ -974,9 +992,7 @@ def main() -> int:
 
     api_key = resolve_api_key()
     cursor = load_cursor()
-    seen = load_seen()
     run_started = now_iso()
-    log(f"cursor={cursor} seen={len(seen)}")
 
     client = MCPClient(MCP_URL, api_key)
     if not client.initialize():
@@ -992,170 +1008,178 @@ def main() -> int:
             log("giga sync disabled (init failed)")
             giga = None
 
-    # 1) Pull recordings since cursor
-    new_memories = 0
-    new_recordings: list[str] = []
-    recordings_page_cap_hit = False
-    next_before: str | None = load_recordings_pagination_resume(cursor)
-    if next_before:
-        log("resuming pocket recordings pagination (nextRecordingDateBeforeExclusive set)")
-    page = 0
-    infer_calls = 0  # Haiku calls made this run; capped by MAX_INFER_PER_RUN
-    cap_hit = False  # set when MAX_INFER_PER_RUN reached — breaks page loop too
-    while True:
-        page += 1
-        args = {"recordingDateAfter": cursor}
+    with pocket_state_lock():
+        seen = load_seen()
+        log(f"cursor={cursor} seen={len(seen)}")
+
+        # 1) Pull recordings since cursor
+        new_memories = 0
+        new_recordings: list[str] = []
+        recordings_page_cap_hit = False
+        next_before: str | None = load_recordings_pagination_resume(cursor)
         if next_before:
-            args["recordingDateBeforeExclusive"] = next_before
-        result, err = client.call_tool("search_pocket_conversations_timerange", args, timeout=30)
-        if err:
-            log(f"recordings page {page} error: {err}")
-            # Distinguish "Pocket search backend is down" from other errors
-            # so we can fire a recovery alert when it comes back. Only mark
-            # outage on the first page (later pages may fail mid-pagination
-            # for unrelated reasons and shouldn't trigger the global flag).
-            if page == 1 and _is_search_unavailable(err):
-                _on_search_outage_detected(err)
-            break
-        # Successful call — if we had a recorded outage, fire recovery
-        # notification (one-shot, marker is cleared inside the helper).
-        if page == 1:
-            _on_search_outage_resolved()
-        data = (result or {}).get("data", result or {})
-        recordings = data.get("results") or data.get("recordings") or data.get("conversations") or []
-        meta = data.get("meta") or {}
-        if not recordings:
-            clear_recordings_pagination_resume()
-            break
-        for rec in recordings:
-            rid = rec.get("id") or rec.get("recordingId") or ""
-            if not rid or rid in seen:
-                continue
-            # Skip very short, transcript-less recordings (likely noise)
-            duration = rec.get("durationSec") or rec.get("duration") or 0
-            transcript = rec.get("transcript") or ""
-            segs = rec.get("transcriptSegments") or []
-            has_content = bool(transcript or segs)
-            if duration and duration < 20 and not has_content:
-                log(f"skip noise recording {rid} (dur={duration}s, no transcript)")
-                _seen_add(seen, rid)
-                continue
-
-            # Money-leak guard: if a Haiku inference would fire for THIS
-            # recording and we've already hit the per-run cap, STOP the loop
-            # entirely — do NOT write_memory and do NOT mark seen, so the
-            # recording rolls over to the next run untouched. We pre-check
-            # the same gating logic infer_tasks_from_recording uses so we
-            # don't artificially skip recordings that wouldn't trigger Haiku
-            # anyway (too-short, INFER_TASKS=0, etc).
-            gate_transcript = _transcript_for_infer_length_gate(rec)
-            would_infer = (
-                INFER_TASKS
-                and (not duration or duration >= INFER_MIN_SECS)
-                and len(gate_transcript) >= 200
-            )
-            if (
-                MAX_INFER_PER_RUN > 0
-                and would_infer
-                and infer_calls >= MAX_INFER_PER_RUN
-            ):
-                log(
-                    f"infer cap hit: {infer_calls}/{MAX_INFER_PER_RUN} Haiku "
-                    f"calls this run — deferring recording {rid} to next run"
-                )
-                cap_hit = True
+            log("resuming pocket recordings pagination (nextRecordingDateBeforeExclusive set)")
+        page = 0
+        infer_calls = 0  # Haiku calls made this run; capped by MAX_INFER_PER_RUN
+        cap_hit = False  # set when MAX_INFER_PER_RUN reached — breaks page loop too
+        while True:
+            page += 1
+            args = {"recordingDateAfter": cursor}
+            if next_before:
+                args["recordingDateBeforeExclusive"] = next_before
+            result, err = client.call_tool("search_pocket_conversations_timerange", args, timeout=30)
+            if err:
+                log(f"recordings page {page} error: {err}")
+                # Distinguish "Pocket search backend is down" from other errors
+                # so we can fire a recovery alert when it comes back. Only mark
+                # outage on the first page (later pages may fail mid-pagination
+                # for unrelated reasons and shouldn't trigger the global flag).
+                if page == 1 and _is_search_unavailable(err):
+                    _on_search_outage_detected(err)
                 break
-
-            write_memory(rec, giga=giga)
-            new_memories += 1
-            new_recordings.append(rid)
-            _seen_add(seen, rid)
-
-            # Implicit-task inference (Haiku) — only on substantive recordings
-            inferred = infer_tasks_from_recording(rec)
-            if would_infer:
-                infer_calls += 1
-            for idx, t in enumerate(inferred):
-                inferred_id = f"inferred-{rid[:12]}-{idx}"
-                if inferred_id in seen:
+            # Successful call — if we had a recorded outage, fire recovery
+            # notification (one-shot, marker is cleared inside the helper).
+            if page == 1:
+                _on_search_outage_resolved()
+            data = (result or {}).get("data", result or {})
+            recordings = data.get("results") or data.get("recordings") or data.get("conversations") or []
+            meta = data.get("meta") or {}
+            if not recordings:
+                clear_recordings_pagination_resume()
+                break
+            for rec in recordings:
+                rid = rec.get("id") or rec.get("recordingId") or ""
+                if not rid or rid in seen:
                     continue
-                payload = {
-                    "id": inferred_id,
-                    "kind": "inferred",
-                    "title": t["title"],
-                    "context": t["context"],
-                    "priority": t["priority"],
-                    "due": None,
-                    "recording_id": rid,
-                    "source": "pocket-haiku-inferred",
-                    "confidence": t["confidence"],
-                    "captured_at": now_iso(),
-                }
-                if DRY_RUN:
-                    log(f"(dry-run) would queue inferred task for triage: {t['title'][:60]} (conf={t['confidence']:.2f})")
-                else:
-                    # Inferred tasks go to pending-triage.jsonl, NOT directly to
-                    # the live tasks.jsonl. The Opus triage agent must classify
-                    # them (ACT / DRAFT / DROP / ASK) before any can reach the
-                    # supervisor. This is the mandated safety guardrail:
-                    # no autonomous work without a verdict.
-                    PENDING_TRIAGE.parent.mkdir(parents=True, exist_ok=True)
-                    with PENDING_TRIAGE.open("a") as f:
-                        f.write(json.dumps(payload) + "\n")
-                    log(f"queued for triage: {t['title'][:60]} (conf={t['confidence']:.2f})")
-                _seen_add(seen, inferred_id)
-        if cap_hit:
-            break
-        if meta.get("hasMore") and meta.get("nextRecordingDateBeforeExclusive"):
-            next_before = meta["nextRecordingDateBeforeExclusive"]
-            if page >= 10:
-                log("hit page cap (10) — leaving cursor unchanged; saved pagination resume for next run")
-                save_recordings_pagination_resume(cursor, next_before)
-                recordings_page_cap_hit = True
+                # Skip very short, transcript-less recordings (likely noise)
+                duration = rec.get("durationSec") or rec.get("duration") or 0
+                transcript = rec.get("transcript") or ""
+                segs = rec.get("transcriptSegments") or []
+                has_content = bool(transcript or segs)
+                if duration and duration < 20 and not has_content:
+                    log(f"skip noise recording {rid} (dur={duration}s, no transcript)")
+                    _seen_add(seen, rid)
+                    continue
+
+                # Money-leak guard: if a Haiku inference would fire for THIS
+                # recording and we've already hit the per-run cap, STOP the loop
+                # entirely — do NOT write_memory and do NOT mark seen, so the
+                # recording rolls over to the next run untouched. We pre-check
+                # the same gating logic infer_tasks_from_recording uses so we
+                # don't artificially skip recordings that wouldn't trigger Haiku
+                # anyway (too-short, INFER_TASKS=0, etc).
+                gate_transcript = _transcript_for_infer_length_gate(rec)
+                would_infer = (
+                    INFER_TASKS
+                    and (not duration or duration >= INFER_MIN_SECS)
+                    and len(gate_transcript) >= 200
+                )
+                if (
+                    MAX_INFER_PER_RUN > 0
+                    and would_infer
+                    and infer_calls >= MAX_INFER_PER_RUN
+                ):
+                    log(
+                        f"infer cap hit: {infer_calls}/{MAX_INFER_PER_RUN} Haiku "
+                        f"calls this run — deferring recording {rid} to next run"
+                    )
+                    cap_hit = True
+                    break
+
+                write_memory(rec, giga=giga)
+                new_memories += 1
+                new_recordings.append(rid)
+                _seen_add(seen, rid)
+
+                # Implicit-task inference (Haiku) — only on substantive recordings
+                wh_infer = f"wh-infer:{rid}"
+                webhook_already_inferred = wh_infer in seen
+                inferred = (
+                    [] if webhook_already_inferred else infer_tasks_from_recording(rec)
+                )
+                if would_infer and not webhook_already_inferred:
+                    infer_calls += 1
+                for idx, t in enumerate(inferred):
+                    inferred_id = f"inferred-{rid[:12]}-{idx}"
+                    if inferred_id in seen:
+                        continue
+                    payload = {
+                        "id": inferred_id,
+                        "kind": "inferred",
+                        "title": t["title"],
+                        "context": t["context"],
+                        "priority": t["priority"],
+                        "due": None,
+                        "recording_id": rid,
+                        "source": "pocket-haiku-inferred",
+                        "confidence": t["confidence"],
+                        "captured_at": now_iso(),
+                    }
+                    if DRY_RUN:
+                        log(f"(dry-run) would queue inferred task for triage: {t['title'][:60]} (conf={t['confidence']:.2f})")
+                    else:
+                        # Inferred tasks go to pending-triage.jsonl, NOT directly to
+                        # the live tasks.jsonl. The Opus triage agent must classify
+                        # them (ACT / DRAFT / DROP / ASK) before any can reach the
+                        # supervisor. This is the mandated safety guardrail:
+                        # no autonomous work without a verdict.
+                        PENDING_TRIAGE.parent.mkdir(parents=True, exist_ok=True)
+                        with PENDING_TRIAGE.open("a") as f:
+                            f.write(json.dumps(payload) + "\n")
+                        log(f"queued for triage: {t['title'][:60]} (conf={t['confidence']:.2f})")
+                    _seen_add(seen, inferred_id)
+            if cap_hit:
                 break
+            if meta.get("hasMore") and meta.get("nextRecordingDateBeforeExclusive"):
+                next_before = meta["nextRecordingDateBeforeExclusive"]
+                if page >= 10:
+                    log("hit page cap (10) — leaving cursor unchanged; saved pagination resume for next run")
+                    save_recordings_pagination_resume(cursor, next_before)
+                    recordings_page_cap_hit = True
+                    break
+            else:
+                clear_recordings_pagination_resume()
+                break
+
+        # 2) Pull action items since cursor (TODO only)
+        new_tasks = 0
+        result, err = client.call_tool("search_pocket_actionitems", {
+            "status": "TODO",
+            "recordingDateFrom": cursor,
+        }, timeout=30)
+        if err:
+            log(f"actionitems error: {err}")
         else:
-            clear_recordings_pagination_resume()
-            break
+            data = (result or {}).get("data", result or {})
+            items = data.get("results") or data.get("items") or data.get("actionItems") or []
+            for item in items:
+                iid = item.get("id") or item.get("actionItemId")
+                if not iid:
+                    continue
+                seen_key = f"action:{iid}"
+                if seen_key in seen:
+                    continue
+                route_actionitem(item, giga=giga)
+                new_tasks += 1
+                _seen_add(seen, seen_key)
 
-    # 2) Pull action items since cursor (TODO only)
-    new_tasks = 0
-    result, err = client.call_tool("search_pocket_actionitems", {
-        "status": "TODO",
-        "recordingDateFrom": cursor,
-    }, timeout=30)
-    if err:
-        log(f"actionitems error: {err}")
-    else:
-        data = (result or {}).get("data", result or {})
-        items = data.get("results") or data.get("items") or data.get("actionItems") or []
-        for item in items:
-            iid = item.get("id") or item.get("actionItemId")
-            if not iid:
-                continue
-            seen_key = f"action:{iid}"
-            if seen_key in seen:
-                continue
-            route_actionitem(item, giga=giga)
-            new_tasks += 1
-            _seen_add(seen, seen_key)
+        # 3) Optional consolidate pass (Giga merges adjacent neurons)
+        if giga and giga.ok and GIGA_CONSOLIDATE and (new_memories + new_tasks) > 0:
+            giga.consolidate()
 
-    # 3) Optional consolidate pass (Giga merges adjacent neurons)
-    if giga and giga.ok and GIGA_CONSOLIDATE and (new_memories + new_tasks) > 0:
-        giga.consolidate()
+        # 3.5) Flush buffered Giga neurons via claude -p subprocess (uses Claude Code auth)
+        giga_flush_ok = True
+        if giga and giga.ok:
+            giga_flush_ok = giga.flush()
 
-    # 3.5) Flush buffered Giga neurons via claude -p subprocess (uses Claude Code auth)
-    giga_flush_ok = True
-    if giga and giga.ok:
-        giga_flush_ok = giga.flush()
-
-    # 4) Advance cursor & persist.
-    # Do not advance if either the Haiku-inference cap or pagination cap was hit —
-    # both mean there are deferred recordings that need the same window next run.
-    if cap_hit:
-        log(f"cap hit: holding cursor at {cursor} (not advancing to {run_started})")
-    elif not recordings_page_cap_hit:
-        save_cursor(run_started)
-    save_seen(seen)
+        # 4) Advance cursor & persist.
+        # Do not advance if either the Haiku-inference cap or pagination cap was hit —
+        # both mean there are deferred recordings that need the same window next run.
+        if cap_hit:
+            log(f"cap hit: holding cursor at {cursor} (not advancing to {run_started})")
+        elif not recordings_page_cap_hit:
+            save_cursor(run_started)
+        save_seen(seen)
 
     if giga and giga.ok and not giga_flush_ok:
         giga_status = "flush_failed"

--- a/claude-ops/scripts/ops-pocket-webhook-ingest.py
+++ b/claude-ops/scripts/ops-pocket-webhook-ingest.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""ops-pocket-webhook-ingest — real-time push entrypoint for the Pocket pipeline.
+
+The cron watcher (`ops-cron-pocket-watcher.py`) polls the Pocket MCP every few
+minutes and writes `pending-triage.jsonl` rows for the Opus triage gate. This
+script does the same thing, but driven by a HeyPocket **webhook** delivery —
+so a recording is triaged seconds after it finishes processing instead of on
+the next poll. It is an *alternate trigger*, not a replacement: the watcher
+stays as the catch-up/backstop path.
+
+Input: a webhook envelope on stdin (or a file arg), shaped like the receiver's
+journal rows:
+
+    {"ts": "...", "event": "summary.completed", "payload": { <HeyPocket body> }}
+
+The HeyPocket body (see their webhook docs) carries the recording, the
+pre-extracted action items, and the transcript:
+
+    payload.recording        = {id, title, duration, language, createdAt}
+    payload.summarizations.*  = {v2: {summary:{markdown,bulletPoints,title},
+                                       actionItems:{actionItems:[{title,dueDate,
+                                                    status,isCompleted}]}}}
+    payload.transcript        = [{speaker, text, start, end}]
+
+Output: appends canonical rows to `pending-triage.jsonl` — exactly the schema
+`ops-pocket-triage.py` consumes — one row per *pending* (not-completed) action
+item HeyPocket pre-extracted, plus (optionally) implicit tasks inferred from the
+transcript via the watcher's existing Haiku gate. The Opus triage gate still
+classifies every row (ACT / DRAFT / DROP / ASK); nothing reaches the supervisor
+without a verdict.
+
+Idempotency: webhooks are at-least-once (HeyPocket retries 3×). Every emitted
+row carries a deterministic id and is deduped against `seen.json`, so repeated
+deliveries of the same recording never double-queue.
+
+Cost: pre-extracted action items cost zero LLM calls. The optional implicit-task
+pass reuses the watcher's Haiku gate (skips transcripts < 200 chars), so there
+is no unbounded spend.
+
+Env:
+  POCKET_STATE_DIR            default ~/.claude/state/pocket (shared with watcher)
+  POCKET_WEBHOOK_INFER        "1" (default) to also run the Haiku implicit-task
+                              pass; "0" to rely only on HeyPocket's pre-extracted
+                              action items (cheapest).
+  POCKET_DRY_RUN=1            log what would be written, write nothing.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+LOG_PREFIX = "[ops-pocket-webhook-ingest]"
+
+# Events that carry actionable content worth triaging. Everything else
+# (transcription.completed, mind_map.completed, speakers.labeled,
+# recording.deleted/merged, translation.completed) is memory-only — the watcher
+# already persists those; the webhook path does not re-queue them for triage.
+ACTIONABLE_EVENTS = {
+    "summary.completed",
+    "summary.regenerated",
+    "action_items.regenerated",
+    "action_items.updated",
+    "recording.created",
+}
+
+INFER = os.environ.get("POCKET_WEBHOOK_INFER", "1") != "0"
+DRY_RUN = os.environ.get("POCKET_DRY_RUN") == "1"
+
+
+def log(msg: str) -> None:
+    print(f"{LOG_PREFIX} {msg}", file=sys.stderr)
+
+
+def _load_watcher():
+    """Import the sibling watcher module (hyphenated name → importlib by path)
+    so we reuse its exact row sink, dedup set, id/slug helpers, and the Haiku
+    implicit-task gate. The watcher has a `__main__` guard, so importing it runs
+    only module-level constant assignments (no polling, no side effects)."""
+    path = SCRIPT_DIR / "ops-cron-pocket-watcher.py"
+    spec = importlib.util.spec_from_file_location("ops_cron_pocket_watcher", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load watcher module at {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _read_envelope() -> dict:
+    raw = ""
+    if len(sys.argv) > 1 and sys.argv[1] not in ("-", "--stdin"):
+        raw = Path(sys.argv[1]).read_text()
+    else:
+        raw = sys.stdin.read()
+    try:
+        env = json.loads(raw or "{}")
+    except json.JSONDecodeError as e:
+        log(f"bad JSON envelope: {e}")
+        return {}
+    # Accept either the {ts,event,payload} journal envelope or a bare body.
+    if isinstance(env, dict) and "payload" in env and "event" in env:
+        return {"event": env.get("event", "unknown"), "payload": env.get("payload") or {}}
+    if isinstance(env, dict):
+        return {"event": env.get("event", "unknown"), "payload": env}
+    return {}
+
+
+def _first_summarization(payload: dict) -> dict:
+    sums = payload.get("summarizations") or {}
+    if isinstance(sums, dict) and sums:
+        return next(iter(sums.values())) or {}
+    return {}
+
+
+def _to_recording(payload: dict) -> dict:
+    """Map a HeyPocket webhook body onto the recording dict the watcher's
+    helpers (infer_tasks_from_recording, write_memory) already understand."""
+    rec = payload.get("recording") or {}
+    s = _first_summarization(payload)
+    v2 = s.get("v2") or {}
+    summary = v2.get("summary") or {}
+    segs = [
+        {"speaker": seg.get("speaker"), "text": seg.get("text", "")}
+        for seg in (payload.get("transcript") or [])
+        if seg.get("text")
+    ]
+    transcript_text = "\n".join(
+        f"{seg['speaker'] or 'Speaker'}: {seg['text'].strip()}" for seg in segs
+    )
+    return {
+        "id": rec.get("id") or rec.get("recordingId") or "",
+        "title": rec.get("title") or summary.get("title") or "",
+        "summary": {"text": summary.get("markdown") or ""},
+        "transcript": transcript_text,
+        "transcriptSegments": segs,
+        "durationSec": rec.get("duration") or 0,
+        "createdAt": rec.get("createdAt") or "",
+        "_bullets": summary.get("bulletPoints") or [],
+    }
+
+
+def _pending_action_items(payload: dict) -> list[dict]:
+    s = _first_summarization(payload)
+    items = ((s.get("v2") or {}).get("actionItems") or {}).get("actionItems") or []
+    out = []
+    for it in items:
+        if not isinstance(it, dict):
+            continue
+        if it.get("isCompleted") or it.get("is_completed") or it.get("status") == "DONE":
+            continue
+        title = (it.get("title") or "").strip()
+        if title:
+            out.append({"title": title, "due": it.get("dueDate"), "status": it.get("status")})
+    return out
+
+
+def main() -> int:
+    env = _read_envelope()
+    event = env.get("event", "unknown")
+    payload = env.get("payload") or {}
+
+    if event not in ACTIONABLE_EVENTS:
+        log(f"memory-only event '{event}' — no triage rows (watcher persists memory)")
+        return 0
+
+    w = _load_watcher()
+    recording = _to_recording(payload)
+    rid = recording["id"]
+    if not rid:
+        log("no recording id in payload — nothing to queue")
+        return 0
+
+    seen = w.load_seen()  # OrderedDict[str, None]; membership test works on keys
+    pending = w.PENDING_TRIAGE
+    context_md = (recording["summary"].get("text") or "").strip()
+    bullets = recording.get("_bullets") or []
+    context_base = context_md or ("; ".join(bullets) if bullets else recording["title"])
+
+    rows: list[dict] = []
+
+    # 1) HeyPocket pre-extracted action items — zero LLM cost.
+    for idx, ai in enumerate(_pending_action_items(payload)):
+        row_id = f"pocket-action-{rid[:16]}-{w.slugify(ai['title'], 24)}"
+        if row_id in seen:
+            continue
+        rows.append({
+            "id": row_id,
+            "kind": "action_item",
+            "title": ai["title"],
+            "context": (context_base or "")[:500],
+            "priority": "medium",
+            "due": ai.get("due"),
+            "recording_id": rid,
+            "source": "pocket-webhook",
+            "confidence": 1.0,  # HeyPocket explicitly extracted it
+            "captured_at": w.now_iso(),
+        })
+
+    # 2) Optional implicit-task pass — reuses the watcher's Haiku gate
+    #    (skips transcripts < 200 chars, honours POCKET_INFER_* env).
+    if INFER:
+        try:
+            for idx, t in enumerate(w.infer_tasks_from_recording(recording)):
+                row_id = f"inferred-{rid[:12]}-{idx}"
+                if row_id in seen:
+                    continue
+                rows.append({
+                    "id": row_id,
+                    "kind": "inferred",
+                    "title": t["title"],
+                    "context": t.get("context", ""),
+                    "priority": t.get("priority", "low"),
+                    "due": None,
+                    "recording_id": rid,
+                    "source": "pocket-webhook-inferred",
+                    "confidence": t.get("confidence", 0.0),
+                    "captured_at": w.now_iso(),
+                })
+        except Exception as e:  # noqa: BLE001 — inference must never block ingest
+            log(f"implicit-task inference skipped ({type(e).__name__}: {e})")
+
+    if not rows:
+        log(f"event={event} rid={rid}: no new pending action items to queue")
+        return 0
+
+    if DRY_RUN:
+        for r in rows:
+            log(f"(dry-run) would queue [{r['kind']}] {r['title'][:60]} (conf={r['confidence']})")
+        return 0
+
+    pending.parent.mkdir(parents=True, exist_ok=True)
+    with pending.open("a") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+    # Mark seen (watcher's helpers keep the cap/format identical) and persist,
+    # so retried at-least-once deliveries never re-queue the same items.
+    for r in rows:
+        w._seen_add(seen, r["id"])
+    w.save_seen(seen)
+    log(f"event={event} rid={rid}: queued {len(rows)} row(s) for triage")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude-ops/scripts/ops-pocket-webhook-ingest.py
+++ b/claude-ops/scripts/ops-pocket-webhook-ingest.py
@@ -252,7 +252,7 @@ def main() -> int:
 
     rows: list[tuple[dict, str | None]] = []
     wh_infer = f"wh-infer:{rid}"
-    infer_eligible = False
+    infer_claimed = False
 
     with _pocket_state_lock(w):
         seen = w.load_seen()
@@ -262,13 +262,14 @@ def main() -> int:
         # 1) HeyPocket pre-extracted action items — zero LLM cost.
         for idx, ai in enumerate(_pending_action_items(payload)):
             aid = ai.get("action_item_id")
-            watcher_key = f"action:{aid}" if aid else None
-            if watcher_key and watcher_key in seen:
-                continue
             if aid:
                 row_id = f"pocket-action-{aid}"
+                watcher_key = f"action:{aid}"
             else:
                 row_id = f"pocket-action-{rid[:16]}-{idx}-{w.slugify(ai['title'], 40)}"
+                watcher_key = f"action-todo:{rid}:{w.slugify(ai['title'], 40)}"
+            if watcher_key in seen:
+                continue
             if row_id in seen or row_id in emitted_action_ids:
                 continue
             emitted_action_ids.add(row_id)
@@ -288,7 +289,8 @@ def main() -> int:
                 watcher_key,
             ))
 
-        # 2) Optional implicit-task pass — eligibility only (Haiku runs outside lock).
+        # 2) Optional implicit-task pass — claim wh-infer under lock before Haiku so
+        # webhook and watcher cannot both pay for the same recording.
         if INFER and (not DRY_RUN) and _would_infer_haiku(w, recording):
             if wh_infer not in seen:
                 if not _infer_budget_room(w):
@@ -297,11 +299,13 @@ def main() -> int:
                         f"{w.MAX_INFER_PER_RUN}, POCKET_MAX_INFER_PER_RUN)"
                     )
                 else:
-                    infer_eligible = True
+                    w._seen_add(seen, wh_infer)
+                    w.save_seen(seen)
+                    infer_claimed = True
 
     inferred_list: list[dict] = []
     infer_api_ok = False
-    if infer_eligible:
+    if infer_claimed:
         try:
             inferred_list, infer_api_ok = w.infer_tasks_from_recording(recording)
         except Exception as e:  # noqa: BLE001 — inference must never block ingest
@@ -340,6 +344,8 @@ def main() -> int:
 
     with _pocket_state_lock(w):
         seen = w.load_seen()
+        if infer_claimed and not infer_api_ok:
+            seen.pop(wh_infer, None)
         to_write: list[tuple[dict, str | None]] = []
         for r, wk in rows:
             if r["id"] in seen:
@@ -355,9 +361,8 @@ def main() -> int:
             for r, _wk in to_write:
                 f.write(json.dumps(r) + "\n")
 
-        if infer_api_ok and infer_eligible:
+        if infer_claimed and infer_api_ok:
             _infer_budget_commit(w)
-            w._seen_add(seen, wh_infer)
 
         for r, wk in to_write:
             w._seen_add(seen, r["id"])

--- a/claude-ops/scripts/ops-pocket-webhook-ingest.py
+++ b/claude-ops/scripts/ops-pocket-webhook-ingest.py
@@ -47,7 +47,6 @@ Env:
 """
 from __future__ import annotations
 
-import fcntl
 import importlib.util
 import json
 import os
@@ -82,17 +81,8 @@ def log(msg: str) -> None:
 @contextmanager
 def _pocket_state_lock(w):
     """Serialize webhook ingest against itself and the watcher's seen/pending writes."""
-    if DRY_RUN:
+    with w.pocket_state_lock():
         yield
-        return
-    w.STATE_DIR.mkdir(parents=True, exist_ok=True)
-    lock_path = w.STATE_DIR / ".pocket-webhook-state.lock"
-    with open(lock_path, "a+b") as lock_f:
-        fcntl.flock(lock_f.fileno(), fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
-            fcntl.flock(lock_f.fileno(), fcntl.LOCK_UN)
 
 
 def _infer_budget_read(w) -> tuple[str, int]:
@@ -307,6 +297,7 @@ def main() -> int:
                     else:
                         _infer_budget_commit(w)
                         w._seen_add(seen, wh_infer)
+                        w.save_seen(seen)
                         for idx, t in enumerate(inferred_list):
                             row_id = f"inferred-{rid[:12]}-{idx}"
                             if row_id in seen:

--- a/claude-ops/scripts/ops-pocket-webhook-ingest.py
+++ b/claude-ops/scripts/ops-pocket-webhook-ingest.py
@@ -103,7 +103,10 @@ def _infer_budget_read(w) -> tuple[str, int]:
 
 
 def _infer_budget_room(w) -> bool:
-    """Under _pocket_state_lock. True if another Haiku infer call is allowed this UTC hour."""
+    """True if another Haiku infer call is allowed this UTC hour.
+
+    Caller must hold ``pocket_state_lock`` when this races with ingest commits.
+    """
     if DRY_RUN or w.MAX_INFER_PER_RUN <= 0:
         return True
     _hour, n = _infer_budget_read(w)
@@ -111,7 +114,11 @@ def _infer_budget_room(w) -> bool:
 
 
 def _infer_budget_commit(w) -> None:
-    """Record one successful Haiku infer call for the current UTC hour."""
+    """Record one successful Haiku infer call for the current UTC hour.
+
+    Caller must hold ``pocket_state_lock`` — this mutates the hourly budget file
+    alongside seen.json / pending-triage.jsonl in the same critical section.
+    """
     if DRY_RUN or w.MAX_INFER_PER_RUN <= 0:
         return
     path = w.STATE_DIR / ".webhook_infer_hourly.json"
@@ -243,8 +250,9 @@ def main() -> int:
     bullets = recording.get("_bullets") or []
     context_base = context_md or ("; ".join(bullets) if bullets else recording["title"])
 
-    rows: list[dict] = []
-    watcher_seen_keys: list[str] = []
+    rows: list[tuple[dict, str | None]] = []
+    wh_infer = f"wh-infer:{rid}"
+    infer_eligible = False
 
     with _pocket_state_lock(w):
         seen = w.load_seen()
@@ -264,25 +272,24 @@ def main() -> int:
             if row_id in seen or row_id in emitted_action_ids:
                 continue
             emitted_action_ids.add(row_id)
-            rows.append({
-                "id": row_id,
-                "kind": "action_item",
-                "title": ai["title"],
-                "context": (context_base or "")[:500],
-                "priority": "medium",
-                "due": ai.get("due"),
-                "recording_id": rid,
-                "source": "pocket-webhook",
-                "confidence": 1.0,  # HeyPocket explicitly extracted it
-                "captured_at": w.now_iso(),
-            })
-            if watcher_key:
-                watcher_seen_keys.append(watcher_key)
+            rows.append((
+                {
+                    "id": row_id,
+                    "kind": "action_item",
+                    "title": ai["title"],
+                    "context": (context_base or "")[:500],
+                    "priority": "medium",
+                    "due": ai.get("due"),
+                    "recording_id": rid,
+                    "source": "pocket-webhook",
+                    "confidence": 1.0,  # HeyPocket explicitly extracted it
+                    "captured_at": w.now_iso(),
+                },
+                watcher_key,
+            ))
 
-        # 2) Optional implicit-task pass — reuses the watcher's Haiku gate
-        #    (skips transcripts < 200 chars, honours POCKET_INFER_* env).
+        # 2) Optional implicit-task pass — eligibility only (Haiku runs outside lock).
         if INFER and (not DRY_RUN) and _would_infer_haiku(w, recording):
-            wh_infer = f"wh-infer:{rid}"
             if wh_infer not in seen:
                 if not _infer_budget_room(w):
                     log(
@@ -290,55 +297,76 @@ def main() -> int:
                         f"{w.MAX_INFER_PER_RUN}, POCKET_MAX_INFER_PER_RUN)"
                     )
                 else:
-                    try:
-                        inferred_list = list(w.infer_tasks_from_recording(recording))
-                    except Exception as e:  # noqa: BLE001 — inference must never block ingest
-                        log(f"implicit-task inference skipped ({type(e).__name__}: {e})")
-                    else:
-                        _infer_budget_commit(w)
-                        w._seen_add(seen, wh_infer)
-                        w.save_seen(seen)
-                        for idx, t in enumerate(inferred_list):
-                            row_id = f"inferred-{rid[:12]}-{idx}"
-                            if row_id in seen:
-                                continue
-                            rows.append({
-                                "id": row_id,
-                                "kind": "inferred",
-                                "title": t["title"],
-                                "context": t.get("context", ""),
-                                "priority": t.get("priority", "low"),
-                                "due": None,
-                                "recording_id": rid,
-                                "source": "pocket-webhook-inferred",
-                                "confidence": t.get("confidence", 0.0),
-                                "captured_at": w.now_iso(),
-                            })
+                    infer_eligible = True
 
-        if not rows:
+    inferred_list: list[dict] = []
+    infer_api_ok = False
+    if infer_eligible:
+        try:
+            inferred_list, infer_api_ok = w.infer_tasks_from_recording(recording)
+        except Exception as e:  # noqa: BLE001 — inference must never block ingest
+            log(f"implicit-task inference skipped ({type(e).__name__}: {e})")
+
+    if infer_api_ok:
+        for idx, t in enumerate(inferred_list):
+            row_id = f"inferred-{rid[:12]}-{idx}"
+            rows.append((
+                {
+                    "id": row_id,
+                    "kind": "inferred",
+                    "title": t["title"],
+                    "context": t.get("context", ""),
+                    "priority": t.get("priority", "low"),
+                    "due": None,
+                    "recording_id": rid,
+                    "source": "pocket-webhook-inferred",
+                    "confidence": t.get("confidence", 0.0),
+                    "captured_at": w.now_iso(),
+                },
+                None,
+            ))
+
+    if not rows:
+        log(f"event={event} rid={rid}: no new pending action items to queue")
+        return 0
+
+    if DRY_RUN:
+        for r, _wk in rows:
+            log(
+                f"(dry-run) would queue [{r['kind']}] "
+                f"{r['title'][:60]} (conf={r['confidence']})"
+            )
+        return 0
+
+    with _pocket_state_lock(w):
+        seen = w.load_seen()
+        to_write: list[tuple[dict, str | None]] = []
+        for r, wk in rows:
+            if r["id"] in seen:
+                continue
+            to_write.append((r, wk))
+
+        if not to_write:
             log(f"event={event} rid={rid}: no new pending action items to queue")
             return 0
 
-        if DRY_RUN:
-            for r in rows:
-                log(
-                    f"(dry-run) would queue [{r['kind']}] "
-                    f"{r['title'][:60]} (conf={r['confidence']})"
-                )
-            return 0
-
-        for r in rows:
-            w._seen_add(seen, r["id"])
-        for wk in watcher_seen_keys:
-            w._seen_add(seen, wk)
-        w.save_seen(seen)
-
         pending.parent.mkdir(parents=True, exist_ok=True)
         with pending.open("a") as f:
-            for r in rows:
+            for r, _wk in to_write:
                 f.write(json.dumps(r) + "\n")
 
-    log(f"event={event} rid={rid}: queued {len(rows)} row(s) for triage")
+        if infer_api_ok and infer_eligible:
+            _infer_budget_commit(w)
+            w._seen_add(seen, wh_infer)
+
+        for r, wk in to_write:
+            w._seen_add(seen, r["id"])
+            if wk:
+                w._seen_add(seen, wk)
+
+        w.save_seen(seen)
+
+    log(f"event={event} rid={rid}: queued {len(to_write)} row(s) for triage")
     return 0
 
 

--- a/claude-ops/scripts/ops-pocket-webhook-ingest.py
+++ b/claude-ops/scripts/ops-pocket-webhook-ingest.py
@@ -34,8 +34,9 @@ row carries a deterministic id and is deduped against `seen.json`, so repeated
 deliveries of the same recording never double-queue.
 
 Cost: pre-extracted action items cost zero LLM calls. The optional implicit-task
-pass reuses the watcher's Haiku gate (skips transcripts < 200 chars), so there
-is no unbounded spend.
+pass reuses the watcher's Haiku gate (skips transcripts < 200 chars) and the
+same POCKET_MAX_INFER_PER_RUN budget as a rolling per-UTC-hour cap (see
+.webhook_infer_hourly.json), so webhook bursts cannot exceed that Haiku rate.
 
 Env:
   POCKET_STATE_DIR            default ~/.claude/state/pocket (shared with watcher)
@@ -46,10 +47,13 @@ Env:
 """
 from __future__ import annotations
 
+import fcntl
 import importlib.util
 import json
 import os
 import sys
+from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
@@ -75,6 +79,67 @@ def log(msg: str) -> None:
     print(f"{LOG_PREFIX} {msg}", file=sys.stderr)
 
 
+@contextmanager
+def _pocket_state_lock(w):
+    """Serialize webhook ingest against itself and the watcher's seen/pending writes."""
+    if DRY_RUN:
+        yield
+        return
+    w.STATE_DIR.mkdir(parents=True, exist_ok=True)
+    lock_path = w.STATE_DIR / ".pocket-webhook-state.lock"
+    with open(lock_path, "a+b") as lock_f:
+        fcntl.flock(lock_f.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_f.fileno(), fcntl.LOCK_UN)
+
+
+def _infer_budget_read(w) -> tuple[str, int]:
+    """Current UTC hour bucket and Haiku infer count for that bucket."""
+    hour = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H")
+    path = w.STATE_DIR / ".webhook_infer_hourly.json"
+    rec: dict = {}
+    if path.exists():
+        try:
+            raw = json.loads(path.read_text())
+            if isinstance(raw, dict):
+                rec = raw
+        except json.JSONDecodeError:
+            rec = {}
+    if rec.get("hour") != hour:
+        return hour, 0
+    return hour, int(rec.get("n", 0))
+
+
+def _infer_budget_room(w) -> bool:
+    """Under _pocket_state_lock. True if another Haiku infer call is allowed this UTC hour."""
+    if DRY_RUN or w.MAX_INFER_PER_RUN <= 0:
+        return True
+    _hour, n = _infer_budget_read(w)
+    return n < w.MAX_INFER_PER_RUN
+
+
+def _infer_budget_commit(w) -> None:
+    """Record one successful Haiku infer call for the current UTC hour."""
+    if DRY_RUN or w.MAX_INFER_PER_RUN <= 0:
+        return
+    path = w.STATE_DIR / ".webhook_infer_hourly.json"
+    hour, n = _infer_budget_read(w)
+    path.write_text(json.dumps({"hour": hour, "n": n + 1}))
+
+
+def _would_infer_haiku(w, recording: dict) -> bool:
+    """Same preconditions as the watcher's would_infer (no network)."""
+    duration = recording.get("durationSec") or recording.get("duration") or 0
+    gate = w._transcript_for_infer_length_gate(recording)
+    if not w.INFER_TASKS:
+        return False
+    if duration and duration < w.INFER_MIN_SECS:
+        return False
+    return len(gate) >= 200
+
+
 def _load_watcher():
     """Import the sibling watcher module (hyphenated name → importlib by path)
     so we reuse its exact row sink, dedup set, id/slug helpers, and the Haiku
@@ -89,7 +154,7 @@ def _load_watcher():
     return mod
 
 
-def _read_envelope() -> dict:
+def _read_envelope() -> dict | None:
     raw = ""
     if len(sys.argv) > 1 and sys.argv[1] not in ("-", "--stdin"):
         raw = Path(sys.argv[1]).read_text()
@@ -99,7 +164,7 @@ def _read_envelope() -> dict:
         env = json.loads(raw or "{}")
     except json.JSONDecodeError as e:
         log(f"bad JSON envelope: {e}")
-        return {}
+        return None
     # Accept either the {ts,event,payload} journal envelope or a bare body.
     if isinstance(env, dict) and "payload" in env and "event" in env:
         return {"event": env.get("event", "unknown"), "payload": env.get("payload") or {}}
@@ -152,13 +217,23 @@ def _pending_action_items(payload: dict) -> list[dict]:
         if it.get("isCompleted") or it.get("is_completed") or it.get("status") == "DONE":
             continue
         title = (it.get("title") or "").strip()
-        if title:
-            out.append({"title": title, "due": it.get("dueDate"), "status": it.get("status")})
+        if not title:
+            continue
+        aid = it.get("id") or it.get("actionItemId")
+        aid_s = str(aid).strip() if aid else ""
+        out.append({
+            "title": title,
+            "due": it.get("dueDate"),
+            "status": it.get("status"),
+            "action_item_id": aid_s or None,
+        })
     return out
 
 
 def main() -> int:
     env = _read_envelope()
+    if env is None:
+        return 1
     event = env.get("event", "unknown")
     payload = env.get("payload") or {}
 
@@ -173,73 +248,105 @@ def main() -> int:
         log("no recording id in payload — nothing to queue")
         return 0
 
-    seen = w.load_seen()  # OrderedDict[str, None]; membership test works on keys
     pending = w.PENDING_TRIAGE
     context_md = (recording["summary"].get("text") or "").strip()
     bullets = recording.get("_bullets") or []
     context_base = context_md or ("; ".join(bullets) if bullets else recording["title"])
 
     rows: list[dict] = []
+    watcher_seen_keys: list[str] = []
 
-    # 1) HeyPocket pre-extracted action items — zero LLM cost.
-    for idx, ai in enumerate(_pending_action_items(payload)):
-        row_id = f"pocket-action-{rid[:16]}-{w.slugify(ai['title'], 24)}"
-        if row_id in seen:
-            continue
-        rows.append({
-            "id": row_id,
-            "kind": "action_item",
-            "title": ai["title"],
-            "context": (context_base or "")[:500],
-            "priority": "medium",
-            "due": ai.get("due"),
-            "recording_id": rid,
-            "source": "pocket-webhook",
-            "confidence": 1.0,  # HeyPocket explicitly extracted it
-            "captured_at": w.now_iso(),
-        })
+    with _pocket_state_lock(w):
+        seen = w.load_seen()
 
-    # 2) Optional implicit-task pass — reuses the watcher's Haiku gate
-    #    (skips transcripts < 200 chars, honours POCKET_INFER_* env).
-    if INFER:
-        try:
-            for idx, t in enumerate(w.infer_tasks_from_recording(recording)):
-                row_id = f"inferred-{rid[:12]}-{idx}"
-                if row_id in seen:
-                    continue
-                rows.append({
-                    "id": row_id,
-                    "kind": "inferred",
-                    "title": t["title"],
-                    "context": t.get("context", ""),
-                    "priority": t.get("priority", "low"),
-                    "due": None,
-                    "recording_id": rid,
-                    "source": "pocket-webhook-inferred",
-                    "confidence": t.get("confidence", 0.0),
-                    "captured_at": w.now_iso(),
-                })
-        except Exception as e:  # noqa: BLE001 — inference must never block ingest
-            log(f"implicit-task inference skipped ({type(e).__name__}: {e})")
+        emitted_action_ids: set[str] = set()
 
-    if not rows:
-        log(f"event={event} rid={rid}: no new pending action items to queue")
-        return 0
+        # 1) HeyPocket pre-extracted action items — zero LLM cost.
+        for idx, ai in enumerate(_pending_action_items(payload)):
+            aid = ai.get("action_item_id")
+            watcher_key = f"action:{aid}" if aid else None
+            if watcher_key and watcher_key in seen:
+                continue
+            if aid:
+                row_id = f"pocket-action-{aid}"
+            else:
+                row_id = f"pocket-action-{rid[:16]}-{idx}-{w.slugify(ai['title'], 40)}"
+            if row_id in seen or row_id in emitted_action_ids:
+                continue
+            emitted_action_ids.add(row_id)
+            rows.append({
+                "id": row_id,
+                "kind": "action_item",
+                "title": ai["title"],
+                "context": (context_base or "")[:500],
+                "priority": "medium",
+                "due": ai.get("due"),
+                "recording_id": rid,
+                "source": "pocket-webhook",
+                "confidence": 1.0,  # HeyPocket explicitly extracted it
+                "captured_at": w.now_iso(),
+            })
+            if watcher_key:
+                watcher_seen_keys.append(watcher_key)
 
-    if DRY_RUN:
+        # 2) Optional implicit-task pass — reuses the watcher's Haiku gate
+        #    (skips transcripts < 200 chars, honours POCKET_INFER_* env).
+        if INFER and (not DRY_RUN) and _would_infer_haiku(w, recording):
+            wh_infer = f"wh-infer:{rid}"
+            if wh_infer not in seen:
+                if not _infer_budget_room(w):
+                    log(
+                        "implicit-task inference skipped (hourly Haiku cap: "
+                        f"{w.MAX_INFER_PER_RUN}, POCKET_MAX_INFER_PER_RUN)"
+                    )
+                else:
+                    try:
+                        inferred_list = list(w.infer_tasks_from_recording(recording))
+                    except Exception as e:  # noqa: BLE001 — inference must never block ingest
+                        log(f"implicit-task inference skipped ({type(e).__name__}: {e})")
+                    else:
+                        _infer_budget_commit(w)
+                        w._seen_add(seen, wh_infer)
+                        for idx, t in enumerate(inferred_list):
+                            row_id = f"inferred-{rid[:12]}-{idx}"
+                            if row_id in seen:
+                                continue
+                            rows.append({
+                                "id": row_id,
+                                "kind": "inferred",
+                                "title": t["title"],
+                                "context": t.get("context", ""),
+                                "priority": t.get("priority", "low"),
+                                "due": None,
+                                "recording_id": rid,
+                                "source": "pocket-webhook-inferred",
+                                "confidence": t.get("confidence", 0.0),
+                                "captured_at": w.now_iso(),
+                            })
+
+        if not rows:
+            log(f"event={event} rid={rid}: no new pending action items to queue")
+            return 0
+
+        if DRY_RUN:
+            for r in rows:
+                log(
+                    f"(dry-run) would queue [{r['kind']}] "
+                    f"{r['title'][:60]} (conf={r['confidence']})"
+                )
+            return 0
+
         for r in rows:
-            log(f"(dry-run) would queue [{r['kind']}] {r['title'][:60]} (conf={r['confidence']})")
-        return 0
+            w._seen_add(seen, r["id"])
+        for wk in watcher_seen_keys:
+            w._seen_add(seen, wk)
+        w.save_seen(seen)
 
-    pending.parent.mkdir(parents=True, exist_ok=True)
-    with pending.open("a") as f:
-        for r in rows:
-            f.write(json.dumps(r) + "\n")
-    # Mark seen (watcher's helpers keep the cap/format identical) and persist,
-    # so retried at-least-once deliveries never re-queue the same items.
-    for r in rows:
-        w._seen_add(seen, r["id"])
-    w.save_seen(seen)
+        pending.parent.mkdir(parents=True, exist_ok=True)
+        with pending.open("a") as f:
+            for r in rows:
+                f.write(json.dumps(r) + "\n")
+
     log(f"event={event} rid={rid}: queued {len(rows)} row(s) for triage")
     return 0
 

--- a/claude-ops/skills/ops-pocket/STATUS.md
+++ b/claude-ops/skills/ops-pocket/STATUS.md
@@ -6,15 +6,23 @@ The pipeline turns voice memos recorded into Pocket (or any external memo source
 
 ## Pipeline overview
 
+Two triggers feed `pending-triage.jsonl` — a polling watcher (catch-up /
+backstop) and a real-time webhook ingest. Both append the **same** row schema;
+everything downstream of `pending-triage.jsonl` is identical.
+
 ```
- ┌─────────────────────────┐
- │ Pocket API              │
- └─────────┬───────────────┘
-           │ poll (cron)
-           ▼
- [1] ops-cron-pocket-watcher.py
-           │ writes pending-triage.jsonl
-           ▼
+ ┌─────────────────────────┐     ┌────────────────────────────────────┐
+ │ Pocket API              │     │ HeyPocket webhook (push, real-time) │
+ └─────────┬───────────────┘     │ POST https://<host>/webhook → HMAC  │
+           │ poll (cron ~5 min)  └────────────────────┬─────────────────┘
+           ▼                                          │ on-memory.sh "$EVENT" "$PAYLOAD"
+ [1] ops-cron-pocket-watcher.py        [1b] ops-pocket-webhook-ingest.py
+           │                                          │ (reuses watcher's row
+           │ writes pending-triage.jsonl              │  schema + Haiku gate)
+           └───────────────┬──────────────────────────┘
+                           ▼  (same canonical row schema)
+                    pending-triage.jsonl
+                           ▼
  [2] ops-pocket-triage.py            (Opus + extended thinking)
            │ ACT ⇒ tasks.jsonl
            │ SKIP ⇒ logged, discarded

--- a/claude-ops/skills/ops-pocket/STATUS.md
+++ b/claude-ops/skills/ops-pocket/STATUS.md
@@ -56,6 +56,47 @@ everything downstream of `pending-triage.jsonl` is identical.
 
 `ops-pocket-whatsapp-bridge.py` is the **inbound** counterpart in the 7-script set — it polls the operator's own self-chat for replies that should be threaded back into the supervisor's async question/reply protocol. The notifier handles **outbound**; this script handles **inbound** (user replying to a question the supervisor asked).
 
+## Real-time webhook trigger (`ops-pocket-webhook-ingest.py`)
+
+`[1b]` is an alternate, push-based trigger that feeds the same
+`pending-triage.jsonl` as the cron watcher. It's for deployments where the
+provider (e.g. HeyPocket) can POST a webhook the instant a recording finishes
+processing — triage runs in seconds instead of waiting up to a poll interval.
+
+- The webhook receiver (a small FastAPI app, HMAC-verified) invokes a handler
+  script that pipes the `{ts,event,payload}` envelope to
+  `ops-pocket-webhook-ingest.py` **as a file arg** (file-arg avoids stdin
+  quirks with `sudo -u` / backgrounded subshells).
+- The ingest reuses the watcher's helpers via `importlib`
+  (`load_seen`/`_seen_add`/`save_seen`/`slugify`/`now_iso`/
+  `infer_tasks_from_recording`) so the row schema, dedup set, and Haiku gate
+  are identical to the polling path.
+- Pre-extracted action items cost zero LLM calls; the optional implicit-task
+  pass reuses the watcher's Haiku gate (`POCKET_WEBHOOK_INFER=0` disables it).
+- Idempotent: deterministic row ids deduped against `seen.json`, so
+  at-least-once webhook retries never double-queue.
+
+### Deploy on an always-online box (service mode)
+
+When the pipeline runs as a system service (e.g. on an always-online VM)
+rather than from an interactive login, **do not** point `POCKET_STATE_DIR` at
+a `0700` home directory — a service-spawned process (even after `sudo -u`)
+can be blocked from traversing it (SELinux home labeling / restrictive home
+perms). Use a neutral, service-readable state dir owned by the pipeline user,
+and set it for **both** the webhook handler and the cron/triage/supervisor
+units so they share one state dir:
+
+```bash
+# one-time
+sudo mkdir -p /var/lib/pocket-pipeline
+sudo chown <pipeline-user>:<pipeline-user> /var/lib/pocket-pipeline
+sudo chmod 755 /var/lib/pocket-pipeline
+export POCKET_STATE_DIR=/var/lib/pocket-pipeline
+```
+
+The webhook handler runs the ingest as the pipeline user (`sudo -u`) so every
+state file stays owned by that user and consistent with the cron watcher.
+
 ## Scripts (eight, including the install helper)
 
 All paths relative to `$CLAUDE_PLUGIN_ROOT/scripts/`.

--- a/claude-ops/tests/test-pocket-infer-cap.py
+++ b/claude-ops/tests/test-pocket-infer-cap.py
@@ -89,7 +89,7 @@ class PocketInferCapTest(unittest.TestCase):
 
     def _run_watcher_with_cap(self, n_recordings: int, cap: str) -> tuple[int, int, str]:
         """Invoke watcher.main() with N mocked recordings + cap. Returns
-        (haiku_call_count, seen_count, final_cursor)."""
+        (haiku_call_count, n_recordings_marked_seen, final_cursor)."""
         mod = _load_watcher(self.state_dir, self.memory_dir, cap)
         recordings = _make_recordings(n_recordings)
 
@@ -97,7 +97,7 @@ class PocketInferCapTest(unittest.TestCase):
 
         def fake_infer(rec):
             haiku_calls["n"] += 1
-            return []  # no inferred tasks; we only care about call count
+            return [], True  # no inferred tasks; we only care about call count
 
         def fake_call_tool(self_, tool_name, args, timeout=30):
             if tool_name == "search_pocket_conversations_timerange":
@@ -115,22 +115,26 @@ class PocketInferCapTest(unittest.TestCase):
         self.assertEqual(rc, 0, "watcher main() should exit 0")
 
         seen_path = self.state_dir / "seen.json"
-        seen = json.loads(seen_path.read_text()) if seen_path.exists() else []
+        seen_list = json.loads(seen_path.read_text()) if seen_path.exists() else []
+        n_rec_seen = sum(
+            1 for k in seen_list
+            if isinstance(k, str) and k.startswith("rec-")
+        )
         cursor_path = self.state_dir / "cursor.txt"
         cursor = cursor_path.read_text().strip() if cursor_path.exists() else ""
-        return haiku_calls["n"], len(seen), cursor
+        return haiku_calls["n"], n_rec_seen, cursor
 
     def test_cap_respected_under_50_recordings(self):
         """50 unseen recordings × cap=10 → exactly 10 Haiku calls, 10 seen."""
-        n_calls, n_seen, cursor = self._run_watcher_with_cap(50, "10")
+        n_calls, n_rec_seen, cursor = self._run_watcher_with_cap(50, "10")
         self.assertEqual(n_calls, 10, f"Haiku should fire exactly 10 times under cap=10, got {n_calls}")
-        self.assertEqual(n_seen, 10, f"seen.json should have exactly 10 entries, got {n_seen}")
+        self.assertEqual(n_rec_seen, 10, f"expected 10 recording ids in seen.json, got {n_rec_seen}")
 
     def test_cap_zero_disables_cap(self):
         """cap=0 → all 50 fire (counter-factual: without guard, money leaks)."""
-        n_calls, n_seen, _ = self._run_watcher_with_cap(50, "0")
+        n_calls, n_rec_seen, _ = self._run_watcher_with_cap(50, "0")
         self.assertEqual(n_calls, 50, f"cap=0 should disable cap; expected 50 calls, got {n_calls}")
-        self.assertEqual(n_seen, 50)
+        self.assertEqual(n_rec_seen, 50)
 
     def test_cap_hit_holds_cursor(self):
         """When cap is hit, cursor must NOT advance — else deferred recordings
@@ -150,7 +154,7 @@ class PocketInferCapTest(unittest.TestCase):
 
         with mock.patch.object(mod.MCPClient, "initialize", return_value=True), \
                 mock.patch.object(mod.MCPClient, "call_tool", new=fake_call_tool), \
-                mock.patch.object(mod, "infer_tasks_from_recording", new=lambda r: []), \
+                mock.patch.object(mod, "infer_tasks_from_recording", new=lambda r: ([], True)), \
                 mock.patch.object(mod, "write_memory", new=lambda rec, giga=None: None), \
                 mock.patch.object(mod, "resolve_api_key", return_value="pk_test"):
             rc = mod.main()
@@ -177,7 +181,7 @@ class PocketInferCapTest(unittest.TestCase):
 
         with mock.patch.object(mod.MCPClient, "initialize", return_value=True), \
                 mock.patch.object(mod.MCPClient, "call_tool", new=fake_call_tool), \
-                mock.patch.object(mod, "infer_tasks_from_recording", new=lambda r: []), \
+                mock.patch.object(mod, "infer_tasks_from_recording", new=lambda r: ([], True)), \
                 mock.patch.object(mod, "write_memory", new=lambda rec, giga=None: None), \
                 mock.patch.object(mod, "resolve_api_key", return_value="pk_test"):
             mod.main()

--- a/claude-ops/tests/test-pocket-webhook-ingest.py
+++ b/claude-ops/tests/test-pocket-webhook-ingest.py
@@ -76,6 +76,7 @@ def main() -> int:
         r = rows[0]
         assert REQUIRED_FIELDS.issubset(r.keys()), f"missing fields: {REQUIRED_FIELDS - set(r.keys())}"
         assert r["recording_id"] == "rec_test_001"
+        assert r["id"] == "pocket-action-rec_test_001-0-ship_v2_by_friday"
         assert r["title"] == "Ship v2 by Friday"
         assert r["source"] == "pocket-webhook"
         assert r["due"] == "2026-05-29"
@@ -95,6 +96,21 @@ def main() -> int:
             n = len(pending2.read_text().splitlines()) if pending2.exists() else 0
             assert n == 0, f"memory-only event produced {n} rows (expected 0)"
             print("PASS: memory-only event (transcription.completed) → 0 triage rows")
+
+        # 4) invalid JSON envelope → non-zero exit (caller can retry).
+        with tempfile.TemporaryDirectory() as td3:
+            bad_path = Path(td3) / "bad.json"
+            bad_path.write_text("{not json")
+            env_bad = dict(os.environ)
+            env_bad["POCKET_STATE_DIR"] = str(Path(td3) / "state")
+            env_bad["POCKET_WEBHOOK_INFER"] = "0"
+            env_bad["GIGA_SYNC"] = "0"
+            proc_bad = subprocess.run(
+                [sys.executable, str(INGEST), str(bad_path)],
+                capture_output=True, text=True, env=env_bad, timeout=60,
+            )
+            assert proc_bad.returncode == 1, f"expected exit 1 for bad JSON, got {proc_bad.returncode}"
+        print("PASS: malformed JSON envelope exits 1")
 
     print("\nALL TESTS PASSED")
     return 0

--- a/claude-ops/tests/test-pocket-webhook-ingest.py
+++ b/claude-ops/tests/test-pocket-webhook-ingest.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Test ops-pocket-webhook-ingest: a summary.completed payload yields correctly
+shaped pending-triage rows; a memory-only event yields none.
+
+Hermetic: sets POCKET_STATE_DIR to a temp dir and POCKET_WEBHOOK_INFER=0 so no
+Anthropic/network call happens (relies on HeyPocket's pre-extracted action
+items only). Run: python3 tests/test-pocket-webhook-ingest.py
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+INGEST = SCRIPTS / "ops-pocket-webhook-ingest.py"
+
+REQUIRED_FIELDS = {
+    "id", "kind", "title", "context", "priority",
+    "due", "recording_id", "source", "confidence", "captured_at",
+}
+
+SUMMARY_COMPLETED = {
+    "ts": "2026-05-25T10:00:00Z",
+    "event": "summary.completed",
+    "payload": {
+        "event": "summary.completed",
+        "recording": {"id": "rec_test_001", "title": "Standup", "duration": 120,
+                       "createdAt": "2026-05-25T09:58:00Z"},
+        "summarizations": {
+            "sum_1": {"v2": {
+                "summary": {"title": "Standup", "markdown": "## Notes\nShip v2.",
+                            "bulletPoints": ["Ship v2 by Friday"]},
+                "actionItems": {"actionItems": [
+                    {"title": "Ship v2 by Friday", "dueDate": "2026-05-29",
+                     "status": "TODO", "isCompleted": False},
+                    {"title": "Archive old logs", "status": "DONE", "isCompleted": True},
+                ]},
+            }},
+        },
+        "transcript": [{"speaker": "A", "text": "Let's ship.", "start": 0, "end": 2}],
+    },
+}
+
+MEMORY_ONLY = {
+    "ts": "2026-05-25T10:01:00Z",
+    "event": "transcription.completed",
+    "payload": {"event": "transcription.completed",
+                "recording": {"id": "rec_test_002", "title": "x"}},
+}
+
+
+def run(envelope: dict, state_dir: Path) -> Path:
+    env = dict(os.environ)
+    env["POCKET_STATE_DIR"] = str(state_dir)
+    env["POCKET_WEBHOOK_INFER"] = "0"  # no LLM/network
+    env["GIGA_SYNC"] = "0"
+    proc = subprocess.run(
+        [sys.executable, str(INGEST)],
+        input=json.dumps(envelope), capture_output=True, text=True, env=env, timeout=60,
+    )
+    assert proc.returncode == 0, f"ingest exited {proc.returncode}: {proc.stderr}"
+    return state_dir / "pending-triage.jsonl"
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        sd = Path(td)
+
+        # 1) summary.completed → exactly ONE row (the pending item; DONE skipped).
+        pending = run(SUMMARY_COMPLETED, sd)
+        assert pending.exists(), "pending-triage.jsonl was not created"
+        rows = [json.loads(l) for l in pending.read_text().splitlines() if l.strip()]
+        assert len(rows) == 1, f"expected 1 pending row, got {len(rows)}: {rows}"
+        r = rows[0]
+        assert REQUIRED_FIELDS.issubset(r.keys()), f"missing fields: {REQUIRED_FIELDS - set(r.keys())}"
+        assert r["recording_id"] == "rec_test_001"
+        assert r["title"] == "Ship v2 by Friday"
+        assert r["source"] == "pocket-webhook"
+        assert r["due"] == "2026-05-29"
+        assert r["confidence"] == 1.0
+        print("PASS: summary.completed → 1 correctly-shaped pending row (DONE item skipped)")
+
+        # 2) idempotency — same delivery again adds no new rows.
+        run(SUMMARY_COMPLETED, sd)
+        rows2 = [l for l in pending.read_text().splitlines() if l.strip()]
+        assert len(rows2) == 1, f"idempotency broken: {len(rows2)} rows after replay"
+        print("PASS: replayed delivery is idempotent (no duplicate row)")
+
+        # 3) memory-only event → no rows.
+        with tempfile.TemporaryDirectory() as td2:
+            sd2 = Path(td2)
+            pending2 = run(MEMORY_ONLY, sd2)
+            n = len(pending2.read_text().splitlines()) if pending2.exists() else 0
+            assert n == 0, f"memory-only event produced {n} rows (expected 0)"
+            print("PASS: memory-only event (transcription.completed) → 0 triage rows")
+
+    print("\nALL TESTS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds `ops-pocket-webhook-ingest.py` — a **real-time push trigger** for the existing Pocket pipeline, complementing (not replacing) the cron watcher.

Today: `ops-cron-pocket-watcher.py` polls the Pocket MCP every ~5 min → writes `pending-triage.jsonl`. This PR lets a **HeyPocket webhook** feed the same queue the moment a recording finishes processing (seconds, not minutes).

## How it wires in

```
HeyPocket webhook → POST /webhook (HMAC-verified receiver)
  → on-memory.sh "$EVENT" "$PAYLOAD"
    → ops-pocket-webhook-ingest.py   (pipes the {ts,event,payload} envelope)
      → pending-triage.jsonl          (same canonical row schema)
        → ops-pocket-triage.py (Opus ACT/DRAFT/DROP/ASK) → supervisor → workers → notifier
```

- **Reuses the watcher's internals** via `importlib` (`load_seen`, `_seen_add`, `save_seen`, `slugify`, `now_iso`, `infer_tasks_from_recording`) so the row schema, dedup set (`seen.json`), and Haiku inference gate are byte-identical to the polling path.
- **Zero-LLM-cost path**: emits one `pending-triage` row per *pending* (not-completed) action item HeyPocket already pre-extracted. Optional implicit-task pass reuses the watcher's Haiku gate (skips transcripts < 200 chars); disable with `POCKET_WEBHOOK_INFER=0`.
- **Idempotent**: deterministic row ids deduped against `seen.json` — HeyPocket's at-least-once 3× retries never double-queue.
- **Memory-only events** (`transcription.completed`, `mind_map.completed`, …) produce no triage rows.
- The Opus triage gate still classifies every row; **nothing reaches the supervisor without a verdict** — the safety guardrail is unchanged.

## Deploy (always-online FRA dev box)

The pipeline runs on the always-online dev box rather than a laptop. `on-memory.sh` pipes its webhook envelope to `ops-pocket-webhook-ingest.py`; `STATUS.md` pipeline diagram updated to show the dual trigger.

## Test

`tests/test-pocket-webhook-ingest.py` (hermetic, `POCKET_WEBHOOK_INFER=0`, no network):
- `summary.completed` → exactly one correctly-shaped `pending-triage` row (completed item skipped)
- replayed delivery → idempotent (no duplicate)
- `transcription.completed` → zero triage rows

```
PASS: summary.completed → 1 correctly-shaped pending row (DONE item skipped)
PASS: replayed delivery is idempotent (no duplicate row)
PASS: memory-only event (transcription.completed) → 0 triage rows
ALL TESTS PASSED
```

No-secrets check: 14 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Concurrent updates to shared `seen.json` and Haiku spend are new operational surfaces, though the Opus triage gate before the supervisor is unchanged and failures can roll back infer claims.
> 
> **Overview**
> Adds **`ops-pocket-webhook-ingest.py`** as a push path into the same **`pending-triage.jsonl`** queue the cron watcher uses, so HeyPocket **`summary.completed`** (and related actionable events) can triage in seconds instead of waiting for the ~5 min poll.
> 
> The watcher is refactored for **safe dual triggers**: a **`fcntl`** lock on **`seen.json`** / pending writes, **`wh-infer:{rid}`** so webhook and watcher don’t both pay for Haiku, **`infer_tasks_from_recording` → `(tasks, api_ok)`** so failed inference rolls back the infer claim, and **`action-todo:`** keys so MCP action items don’t duplicate webhook rows. Webhook ingest reuses the watcher via **`importlib`**, maps HeyPocket payloads to the existing recording shape, queues pre-extracted action items with **no LLM**, and optionally applies a **per-UTC-hour** Haiku cap via **`.webhook_infer_hourly.json`**.
> 
> **`STATUS.md`** documents the dual-trigger diagram and **service-mode** **`POCKET_STATE_DIR`** (e.g. **`/var/lib/pocket-pipeline`**). Tests cover webhook row shape, idempotency, and updated infer-cap mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6ce439a60b1badaa0e22ccd0d1c7a14da3b336c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real-time Pocket webhook ingestion now enables immediate triage item processing, complementing the existing polling-based ingestion backstop.

* **Documentation**
  * Updated pipeline architecture documentation to describe the new webhook ingestion path and its integration with triage workflows.

* **Tests**
  * Added integration tests for webhook ingestion, verifying correct triage queuing, deduplication, and idempotency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/343?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->