### PR TITLE
feat(pocket): SES email backend for notifier self-notify

### DIFF
--- a/claude-ops/scripts/ops-pocket-email-bridge.py
+++ b/claude-ops/scripts/ops-pocket-email-bridge.py
@@ -20,7 +20,12 @@ Config (~/.claude/state/pocket/email-config.json):
     "from_account": "you@example.com",
     "subject_prefix": "[Pocket]",
     "label": "Pocket",
-    "last_processed_id": ""        # auto-managed
+    "last_processed_id": "",       # auto-managed
+    # Outbound backend (default "gog"). Set "ses" on hosts with no gog auth
+    # but an IAM role allowing ses:SendEmail (e.g. an always-on EC2 box):
+    "backend": "gog",              # "gog" | "ses"
+    "region": "us-east-1",         # SES region (backend=ses)
+    "from": "alerts@example.com"   # verified SES sender (backend=ses)
   }
 
 Cron: every 1 minute.
@@ -133,12 +138,80 @@ def open_questions() -> list[dict]:
 # ── OUTBOUND ────────────────────────────────────────────────────────────────
 
 
-def send_email(to: str, subject: str, body: str, attachments: list[str] | None = None) -> tuple[bool, str]:
-    """Send via gog gmail send. Returns (ok, info).
+def _inline_attachments(body: str, attachments: list[str] | None) -> str:
+    """SES simple send is body-only (no MIME parts). Inline readable text
+    reports (.md/.txt) into the body so the notification still carries the
+    worker's output; binaries are noted, not attached."""
+    if not attachments:
+        return body
+    extra = []
+    for a in attachments:
+        if not a:
+            continue
+        expanded = os.path.expanduser(a)
+        if not os.path.isfile(expanded):
+            log(f"attachment missing, skipped: {a}")
+            continue
+        if expanded.lower().endswith((".md", ".txt", ".log", ".json")):
+            try:
+                content = Path(expanded).read_text()[:20000]
+                extra.append(f"\n\n--- {os.path.basename(expanded)} ---\n{content}")
+            except OSError:
+                extra.append(f"\n\n[attachment unreadable: {os.path.basename(expanded)}]")
+        else:
+            extra.append(f"\n\n[binary attachment omitted: {os.path.basename(expanded)}]")
+    return body + "".join(extra)
 
-    attachments: list of file paths to attach (each is expanded with ~ and
-    silently skipped if missing — we never fail the whole send because of
-    a missing report file)."""
+
+def _send_via_ses(to: str, subject: str, body: str, ses_cfg: dict) -> tuple[bool, str]:
+    """Send via AWS SES (aws CLI shell-out — no boto3 dependency).
+
+    ses_cfg: {"region": ..., "from": "alerts@example.com"}. Recipient is
+    already locked to self by the caller. Used when the box has no gog auth
+    but an instance role with ses:SendEmail."""
+    region = ses_cfg.get("region", "us-east-1")
+    from_addr = ses_cfg.get("from", "")
+    if not from_addr:
+        return (False, "ses backend: no 'from' configured")
+    aws_bin = os.environ.get("AWS_BIN", "aws")
+    cmd = [
+        aws_bin, "ses", "send-email", "--region", region,
+        "--from", from_addr,
+        "--destination", f"ToAddresses={to}",
+        "--message", json.dumps({
+            "Subject": {"Data": subject, "Charset": "UTF-8"},
+            "Body": {"Text": {"Data": body, "Charset": "UTF-8"}},
+        }),
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=TIMEOUT)
+    except subprocess.TimeoutExpired:
+        return (False, "ses timeout")
+    except FileNotFoundError:
+        return (False, f"aws binary not found: {aws_bin}")
+    except Exception as e:
+        return (False, f"{type(e).__name__}: {e}")
+    if proc.returncode != 0:
+        return (False, f"ses exit={proc.returncode}: {(proc.stderr or proc.stdout)[:200]}")
+    msg_id = ""
+    try:
+        msg_id = json.loads(proc.stdout or "{}").get("MessageId", "")
+    except json.JSONDecodeError:
+        pass
+    return (True, f"ses MessageId={msg_id}" if msg_id else "ses ok")
+
+
+def send_email(to: str, subject: str, body: str, attachments: list[str] | None = None,
+               backend: str = "gog", ses_cfg: dict | None = None) -> tuple[bool, str]:
+    """Send a self-notification. Returns (ok, info).
+
+    backend="gog" (default): `gog gmail send` with native attachments.
+    backend="ses": AWS SES via aws CLI (body-only; text reports inlined).
+    attachments: file paths (expanded with ~; missing ones skipped silently —
+    a missing report never fails the whole send)."""
+    if backend == "ses":
+        return _send_via_ses(to, subject, _inline_attachments(body, attachments), ses_cfg or {})
+
     cmd = [GOG_BIN, "gmail", "send",
            "--to", to,
            "--subject", subject,
@@ -170,6 +243,8 @@ def drain_outbound(cfg: dict) -> tuple[int, int, int]:
     (sent, failed, skipped)."""
     self_addr = cfg.get("self_address", "")
     prefix = cfg.get("subject_prefix", "[Pocket]")
+    backend = cfg.get("backend", "gog")
+    ses_cfg = {"region": cfg.get("region", "us-east-1"), "from": cfg.get("from", "")}
     if not self_addr or not QUEUE.exists():
         return (0, 0, 0)
     cursor = 0
@@ -228,7 +303,8 @@ def drain_outbound(cfg: dict) -> tuple[int, int, int]:
                 attachments = entry.get("attachments") or []
                 if not isinstance(attachments, list):
                     attachments = []
-                ok, info = send_email(to, subject[:200], body, attachments)
+                ok, info = send_email(to, subject[:200], body, attachments,
+                                      backend=backend, ses_cfg=ses_cfg)
                 if ok:
                     sent += 1
                     try:

--- a/claude-ops/scripts/ops-pocket-email-bridge.py
+++ b/claude-ops/scripts/ops-pocket-email-bridge.py
@@ -154,7 +154,7 @@ def _inline_attachments(body: str, attachments: list[str] | None) -> str:
             continue
         if expanded.lower().endswith((".md", ".txt", ".log", ".json")):
             try:
-                content = Path(expanded).read_text()[:20000]
+                content = Path(expanded).read_text(encoding="utf-8", errors="replace")[:20000]
                 extra.append(f"\n\n--- {os.path.basename(expanded)} ---\n{content}")
             except OSError:
                 extra.append(f"\n\n[attachment unreadable: {os.path.basename(expanded)}]")


### PR DESCRIPTION
## What

Adds an opt-in **AWS SES backend** to `ops-pocket-email-bridge.py`, alongside the existing default `gog` backend.

## Why

The Pocket notifier delivers start/done self-notifications. On an **always-on host** (e.g. the EC2 dev box that runs the pipeline 24/7), `gog` Gmail OAuth isn't set up and can't be done headlessly. SES lets the box deliver from a verified domain identity via its IAM `ses:SendEmail` role — no OAuth, no QR.

## How

- Backend selected in `email-config.json`: `"backend": "ses"`, `"region"`, `"from"` (default stays `gog`).
- SES path uses `aws ses send-email` (no boto3 dep). SES simple-send is body-only, so readable text reports (.md/.txt/.log/.json) are **inlined** into the body; binaries are noted.
- Recipient stays **locked to `self_address`** — self-notifications only, never third-party (Rule 6 preserved).
- `gog` path unchanged; fully backward compatible.

## Deploy (always-online FRA box)

`email-config.json`: `{"enabled":true,"backend":"ses","region":"<region>","from":"alerts@<verified-domain>","self_address":"<you>"}` + an IAM role allowing `ses:SendEmail` on the sender identity. Sender domain verified via SES DKIM; in SES sandbox the recipient must also be verified (one-click).

Complements PR #343 (webhook ingest). Together: webhook → pending-triage → triage → supervisor → worker → **SES self-notify**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new outbound email path (SES/IAM) but keeps recipients locked to self_address and leaves the default gog behavior unchanged.
> 
> **Overview**
> Adds an optional **AWS SES** outbound path to the Pocket email bridge so always-on hosts without `gog` Gmail OAuth can still send **self-only** supervisor notifications via IAM (`aws ses send-email`).
> 
> `email-config.json` can set `"backend": "ses"` with `"region"` and a verified `"from"`; default remains **`gog`**. SES uses plain text only, so `.md`/`.txt`/`.log`/`.json` attachments are **inlined** in the body and binaries are noted. **`drain_outbound`** passes the chosen backend into `send_email`; the **`self_address`** recipient lock and audit behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d388120298263f64a8af791387d0b7f27e8beb0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->