### PR TITLE
feat: /ops-social-planner — engine-agnostic planned-posts & ads viewer (web UI)

### DIFF
--- a/claude-ops/bin/ops-social-planner
+++ b/claude-ops/bin/ops-social-planner
@@ -1,3 +1,11 @@
 #!/usr/bin/env bash
-# Shim → ESM core (claude-ops package.json is type:module; .mjs is unambiguous).
-exec node "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills/ops-social-planner/lib/planner.mjs" "$@"
+# ops-social-planner — engine-agnostic planned-posts/ads collector + local viewer.
+# Owner data is resolved at runtime into $OPS_DATA_DIR; nothing project-specific is hardcoded.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+# Canonical OPS_DATA_DIR (respects $CLAUDE_PLUGIN_DATA_DIR) — same resolver every sibling bin uses.
+OPS_PLUGIN_ROOT_FALLBACK="$PLUGIN_ROOT" . "${PLUGIN_ROOT}/lib/registry-path.sh"
+export OPS_DATA_DIR
+export PREFS_PATH="${PREFS_PATH:-${OPS_DATA_DIR}/preferences.json}"
+exec node "${PLUGIN_ROOT}/skills/ops-social-planner/lib/planner.mjs" "$@"

--- a/claude-ops/bin/ops-social-planner
+++ b/claude-ops/bin/ops-social-planner
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Shim → ESM core (claude-ops package.json is type:module; .mjs is unambiguous).
+exec node "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/skills/ops-social-planner/lib/planner.mjs" "$@"

--- a/claude-ops/skills/ops-social-planner/SKILL.md
+++ b/claude-ops/skills/ops-social-planner/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: ops-social-planner
+description: Visual, engine-agnostic planner for all scheduled social posts and ads across every identity and project. Auto-generates the current state of ops-socials + ops-marketing planned content per project, per channel, regardless of posting engine (Typefully, upload-post, Meta, Google Ads), and serves a clean local web UI. Use when the user says social planner, content calendar, what's scheduled, planned posts, show my queue, posting schedule, social dashboard, or runs /ops-social-planner. Read-only — never publishes (mutation stays in /ops-socials + /ops-marketing behind per-message approval).
+argument-hint: "[--project <id>] [--collect-only] [--port <n>] [--no-open]"
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - mcp__typefully__typefully_list_drafts
+  - mcp__typefully__typefully_get_draft
+  - mcp__typefully__typefully_get_queue
+  - mcp__upload-post__list_scheduled
+  - mcp__upload-post__list_profiles
+effort: medium
+maxTurns: 25
+---
+
+# /ops-social-planner — engine-agnostic planned-content viewer
+
+Read-only dashboard of **every** scheduled post and ad, grouped **identity/project → channel → time**,
+**regardless of posting engine**. Personal/founder identity and project brands stay strictly separated
+(see `/ops-socials` identity rules). See `SPEC.md` for the full design.
+
+## What it does
+1. `bin/ops-social-planner collect` reads `$PREFS_PATH/preferences.json`
+   (`marketing.social_identities.personal.*` + `marketing.projects.*.social`), dispatches a
+   **per-engine fetcher** keyed on `social.engine.primary`, normalizes to one schema, and writes
+   `$OPS_DATA_DIR/social-planner/state.json` (**owner data — never committed**, Rule 0).
+2. It then serves the static UI (`ui/`) on localhost and opens the browser.
+
+## Engines
+| `engine.primary` | Source | Status |
+|---|---|---|
+| `typefully` | `GET /v2/social-sets/{id}/drafts` (Bearer; key from `~/.config/typefully/config.json`) | ✅ wired |
+| `upload-post` | `GET /api/uploadposts/schedule` (Apikey; key from `engine.upload_post.api_key_ref`) | ✅ wired |
+| `meta-graph` / `meta-ads` | Graph Ads API per project BM/token | 🔌 hook (UI shows "pending") |
+| `google-ads` | GAQL per project customer id | 🔌 hook |
+| `null` / unprovisioned | — | shown fail-closed (0 items) |
+
+Adding an engine = adding one `fetch<Engine>()` in `bin/ops-social-planner` + a dispatch branch. No UI change.
+
+## Run it
+```bash
+"${CLAUDE_PLUGIN_ROOT}/bin/ops-social-planner"                 # collect → serve → open
+"${CLAUDE_PLUGIN_ROOT}/bin/ops-social-planner" collect          # regenerate state.json only
+"${CLAUDE_PLUGIN_ROOT}/bin/ops-social-planner" serve --port 7937  # serve existing state
+```
+The UI renders `ui/state.sample.json` (synthetic, PII-free) when no live state exists, so it works
+with zero credentials — useful for the PR preview.
+
+## Agent enrichment path (optional, when invoked as a skill)
+The headless collector covers posts on wired engines. When richer output is wanted, the agent can:
+- Pull **ads** via MCP (`mcp__meta__*`, Google Ads) per project and merge `kind:"ad"` items into `state.json`.
+- Replace the heuristic `rationale` with an LLM-written one (slot + sequence + channel intent).
+- Re-run `serve` to refresh.
+Do **not** publish or edit from here — routing/mutation belongs to `/ops-socials` + `/ops-marketing`.
+
+## Guarantees
+- Read-only. No secrets in the client. Server binds `127.0.0.1` only.
+- Identity separation honored: personal vs project never merged; unprovisioned projects render fail-closed.
+- No owner data committed — only `ui/` + `bin/` + `SPEC.md` + the synthetic fixture.

--- a/claude-ops/skills/ops-social-planner/SPEC.md
+++ b/claude-ops/skills/ops-social-planner/SPEC.md
@@ -1,0 +1,90 @@
+# ops-social-planner — Spec
+
+> Visual, PR-able, engine-agnostic planner that auto-generates the current state of **every**
+> ops-socials + ops-marketing planned **post and ad**, **per identity/project, per channel** —
+> regardless of the posting engine (Typefully, upload-post, Meta, Google Ads, …).
+
+## Problem
+Planned content is scattered across engines with no single review surface, and identities are
+easy to confuse (personal founder brand vs project brands). There was no way to *see* what's
+queued, where it lands, when, and why — across channels.
+
+## Goals
+1. **One read-only dashboard** of all scheduled posts + ads, grouped by identity/project → channel → time.
+2. **Engine-agnostic**: a normalized schema; per-engine fetchers behind a dispatch keyed on
+   `marketing.<identity|project>.social.engine.primary`. Adding an engine = adding one fetcher.
+3. **Templatable & PR-able**: UI + collector live in the repo; **zero owner data is committed**
+   (Rule 0). Real copy/handles/IDs are generated at runtime into `$OPS_DATA_DIR` (outside the repo).
+4. **Per-item context**: copy (full, per-platform variant), local + relative time, a derived
+   **rationale** (why this slot), media (image/video thumb), and extracted links.
+5. **2026 best practices**: zero-build static SPA (instant, embeddable — no `npm install` in a
+   plugin), semantic + a11y, light/dark, responsive, shareable URL state, reduced-motion safe.
+
+## Non-goals
+- Editing/publishing from the UI (read-only review; mutation stays in ops-socials/ops-marketing
+  behind Rule 6 per-message approval).
+- Hosting remotely. Localhost only.
+
+## Architecture
+```
+bin/ops-social-planner            # node, zero-dep. subcommands: collect | serve | open (default: collect+serve+open)
+skills/ops-social-planner/
+  SKILL.md                        # /ops:ops-social-planner router (+ agent enrichment path: ads via MCP, richer rationale)
+  SPEC.md                         # this file
+  ui/index.html                   # static SPA shell
+  ui/app.js                       # ES module: fetch state.json → render; URL-hash state
+  ui/styles.css                   # design tokens, light/dark, responsive
+  ui/state.sample.json            # PII-free synthetic fixture so the UI renders in the PR with no creds
+```
+Runtime data (gitignored / outside repo): `$OPS_DATA_DIR/social-planner/state.json`
+(`OPS_DATA_DIR` defaults to the plugin data dir `~/.claude/plugins/data/ops-ops-marketplace`).
+
+### Collector flow
+1. Read `$PREFS_PATH/preferences.json` → `marketing.social_identities.personal.*` +
+   `marketing.projects.*.social`.
+2. For each identity/project, dispatch on `social.engine.primary`:
+   - `typefully`   → GET `https://api.typefully.com/v2/social-sets/{id}/drafts?status=scheduled`
+     (+ per-draft GET for full `posts[].text` / media). Auth: `Bearer` (key from `~/.config/typefully/config.json`).
+   - `upload-post` → GET `https://api.upload-post.com/api/uploadposts/schedule`. Auth: `Apikey`
+     (key resolved from `engine.upload_post.api_key_ref`, e.g. `doppler:project/config/SECRET`).
+   - `meta-graph` / `meta-ads` / `google-ads` → **extension hook**. v1 returns
+     `{status:"hook-pending"}` (UI shows the Ads tab with an honest "collector hook pending"
+     state — never fabricated data).
+   - `null` / `unprovisioned` → emitted as an identity with 0 items + `status:"unprovisioned"`.
+3. Normalize → `deriveRationale()` per item (slot-time × channel norm × launch-sequence keywords).
+4. Write `state.json`; serve `ui/` + `state.json` over localhost; open browser.
+
+### Normalized schema (v1)
+```jsonc
+{ "generated_at","timezone",
+  "engine_status": { "<engine>": {"ok":bool,"count":int,"reason":str?} },
+  "identities": [ { "id","label","kind":"personal|project","engine","status",
+      "channels":[...], "items":[ Item ] } ] }
+// Item: { id, identity, channel, kind:"post|ad", type:"photo|video|text|thread",
+//         scheduled_at, copy, thread?:[...], rationale, media:[{type,url,thumb}],
+//         links:[...], char_count, source:{engine,ref,edit_url?} }
+```
+
+## Rationale derivation (heuristic, deterministic)
+- **Slot (UTC hour)** → audience window label (07 morning-authority, 11 build-in-public,
+  13 US-morning engagement, 15–16 LinkedIn professional, 17–18 evening casual).
+- **Channel norm** → format intent (LI long-form authority, X hook/thread, Threads casual,
+  IG visual+link-in-bio, Reddit value-first, YouTube SEO title, GBP local).
+- **Sequence** (keyword) → `teaser` ("almost here", "this week", "👀") / `launch`
+  ("it's here", "is live", "download") / `education` (default).
+Agent path (`/ops:ops-social-planner` via SKILL.md) can replace heuristic rationale with an
+LLM-written one and pull ads through MCP (Meta/Google) before regenerating.
+
+## Best-practice checklist (2026)
+- Zero build step; native ES modules; no runtime framework dependency.
+- Semantic HTML, full keyboard nav, visible focus, `aria-*`, `prefers-reduced-motion`,
+  `prefers-color-scheme` + manual toggle persisted to `localStorage`.
+- Fluid type (`clamp`), CSS grid + container-ish responsive, design tokens via custom properties.
+- Shareable state in URL hash (`#id=healify&channel=instagram&view=posts`).
+- Read-only; no secrets in client; `state.json` served from a localhost-bound server only.
+- Defensive: renders from `state.sample.json` when no live state exists.
+
+## Verification
+- `bin/ops-social-planner collect` writes valid JSON; `engine_status` reflects reality.
+- UI renders sample fixture with no creds; renders live state with creds.
+- `tests/test-no-secrets.sh` passes (no owner data committed).

--- a/claude-ops/skills/ops-social-planner/SPEC.md
+++ b/claude-ops/skills/ops-social-planner/SPEC.md
@@ -37,7 +37,7 @@ skills/ops-social-planner/
   ui/state.sample.json            # PII-free synthetic fixture so the UI renders in the PR with no creds
 ```
 Runtime data (gitignored / outside repo): `$OPS_DATA_DIR/social-planner/state.json`
-(`OPS_DATA_DIR` defaults to the plugin data dir `~/.claude/plugins/data/ops-ops-marketplace`).
+(`OPS_DATA_DIR` is resolved at runtime via `lib/registry-path.sh`, honoring `$CLAUDE_PLUGIN_DATA_DIR`).
 
 ### Collector flow
 1. Read `$PREFS_PATH/preferences.json` → `marketing.social_identities.personal.*` +
@@ -80,7 +80,7 @@ LLM-written one and pull ads through MCP (Meta/Google) before regenerating.
 - Semantic HTML, full keyboard nav, visible focus, `aria-*`, `prefers-reduced-motion`,
   `prefers-color-scheme` + manual toggle persisted to `localStorage`.
 - Fluid type (`clamp`), CSS grid + container-ish responsive, design tokens via custom properties.
-- Shareable state in URL hash (`#id=healify&channel=instagram&view=posts`).
+- Shareable state in URL hash (`#id=<project>&channel=<channel>&view=posts`).
 - Read-only; no secrets in client; `state.json` served from a localhost-bound server only.
 - Defensive: renders from `state.sample.json` when no live state exists.
 

--- a/claude-ops/skills/ops-social-planner/lib/planner.mjs
+++ b/claude-ops/skills/ops-social-planner/lib/planner.mjs
@@ -15,6 +15,7 @@ const OPS_DATA_DIR = process.env.OPS_DATA_DIR ||
 const UI_DIR = path.join(__dirname, '..', 'ui');
 const OUT_DIR = path.join(OPS_DATA_DIR, 'social-planner');
 const args = process.argv.slice(2);
+const collectOnly = args.includes('--collect-only');
 const cmd = (args[0] && !args[0].startsWith('-')) ? args[0] : 'all';
 const flag = (n, d) => { const i = args.indexOf(n); return i >= 0 ? (args[i + 1] || true) : d; };
 const PORT = Number(flag('--port', process.env.OPS_PLANNER_PORT || 7937));
@@ -23,6 +24,19 @@ const OUT = flag('--out', path.join(OUT_DIR, 'state.json'));
 /* ---------- helpers ---------- */
 const readJSON = (p) => JSON.parse(fs.readFileSync(p, 'utf8'));
 const log = (...a) => console.error('[planner]', ...a);
+function resolveTypefullySocialSetId(p, prefs) {
+  if (p.typefully_social_set_id != null && String(p.typefully_social_set_id).trim() !== '') return String(p.typefully_social_set_id);
+  const fromPrefs = prefs.typefully && prefs.typefully.default_social_set_id;
+  if (fromPrefs != null && String(fromPrefs).trim() !== '') return String(fromPrefs);
+  const cfgPath = path.join(HOME, '.config/typefully/config.json');
+  if (!fs.existsSync(cfgPath)) return null;
+  try {
+    const j = readJSON(cfgPath);
+    const d = j.default_social_set ?? j.defaultSocialSet;
+    if (d != null && String(d).trim() !== '') return String(d);
+  } catch { /* ignore */ }
+  return null;
+}
 const URL_RE = /(https?:\/\/[^\s)]+)/g;
 const extractLinks = (t) => [...new Set((t || '').match(URL_RE) || [])];
 
@@ -136,9 +150,14 @@ async function collect() {
   // personal identities
   for (const [id, p] of Object.entries((mk.social_identities && mk.social_identities.personal) || {})) {
     let res = { ok: false, items: [] };
-    if (p.engine === 'typefully' && p.typefully_social_set_id) res = await fetchTypefully(p.typefully_social_set_id);
-    note(p.engine || 'typefully', res);
-    identities.push({ id, label: (p.aka && p.aka.join(' / ')) || id, kind: 'personal', engine: p.engine || 'typefully',
+    const engine = p.engine || 'typefully';
+    if (engine === 'typefully') {
+      const setId = resolveTypefullySocialSetId(p, prefs);
+      if (setId) res = await fetchTypefully(setId);
+    }
+    const engKey = engine === 'typefully' ? 'typefully' : engine;
+    note(engKey, res);
+    identities.push({ id, label: (p.aka && p.aka.join(' / ')) || id, kind: 'personal', engine,
       status: res.ok ? 'ok' : (res.reason || 'error'), channels: [...new Set(res.items.map(i => i.channel))].sort(), items: res.items });
   }
 
@@ -196,8 +215,8 @@ function serve() {
 
 (async () => {
   try {
-    if (cmd === 'collect' || cmd === 'all') await collect();
-    if (cmd === 'serve' || cmd === 'open' || cmd === 'all') serve();
-    else process.exit(0);
+    if (cmd === 'collect' || cmd === 'all' || collectOnly) await collect();
+    if (!collectOnly && (cmd === 'serve' || cmd === 'open' || cmd === 'all')) serve();
+    else if (!collectOnly) process.exit(0);
   } catch (e) { log('ERROR', e.message); process.exit(1); }
 })();

--- a/claude-ops/skills/ops-social-planner/lib/planner.mjs
+++ b/claude-ops/skills/ops-social-planner/lib/planner.mjs
@@ -6,6 +6,7 @@ import path from 'path';
 import http from 'http';
 import { execSync, spawn } from 'child_process';
 import { fileURLToPath } from 'url';
+import crypto from 'crypto';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const HOME = os.homedir();
 const PREFS_PATH = process.env.PREFS_PATH ||
@@ -137,7 +138,83 @@ async function fetchUploadPost(profile, key) {
   return { ok: true, count: items.length, items };
 }
 
-function adHook(engine) { return { ok: false, reason: 'hook-pending', status: 'hook-pending', items: [] }; }
+/* ---------- ad fetchers (real; honest empty when no creds / no campaigns) ---------- */
+async function fetchMetaAds(cfg) {
+  const m = cfg.meta || {};
+  if (!m.ad_account_id) return { ok: false, reason: 'no ad account', items: [] };
+  const token = resolveSecret(m.access_token);
+  if (!token) return { ok: false, reason: 'no token', items: [] };
+  const secret = resolveSecret(m.app_secret);
+  const proof = secret ? crypto.createHmac('sha256', secret).update(token).digest('hex') : null;
+  const u = new URL(`https://graph.facebook.com/v21.0/${m.ad_account_id}/ads`);
+  u.searchParams.set('fields', 'name,effective_status,created_time,creative{title,body,thumbnail_url},adset{daily_budget,targeting{publisher_platforms}}');
+  u.searchParams.set('limit', '50');
+  u.searchParams.set('access_token', token);
+  if (proof) u.searchParams.set('appsecret_proof', proof);
+  let r;
+  try { r = await fetch(u, { signal: AbortSignal.timeout(15000) }); }
+  catch (e) { return { ok: false, reason: e.message, items: [] }; }
+  if (!r.ok) { let msg = `HTTP ${r.status}`; try { msg = (await r.json()).error?.message || msg; } catch {} return { ok: false, reason: msg, items: [] }; }
+  const ads = (await r.json()).data || [];
+  const items = ads.map(a => {
+    const cr = a.creative || {};
+    const pp = a.adset?.targeting?.publisher_platforms || [];
+    let channel = pp.includes('instagram') && !pp.includes('facebook') ? 'instagram' : (pp[0] || 'facebook');
+    if (channel === 'audience_network' || channel === 'messenger') channel = 'meta';
+    const budget = a.adset?.daily_budget ? ' · $' + (a.adset.daily_budget / 100).toFixed(0) + '/day' : '';
+    const copy = [cr.title, cr.body].filter(Boolean).join('\n\n') || a.name;
+    return {
+      id: 'meta-' + a.id, channel, kind: 'ad', type: 'ad', scheduled_at: a.created_time || null,
+      ad_status: a.effective_status, copy,
+      rationale: 'Meta ad · ' + a.effective_status + budget + ' · placement: ' + (pp.join(', ') || 'auto') + '.',
+      media: cr.thumbnail_url ? [{ type: 'image', url: cr.thumbnail_url, thumb: cr.thumbnail_url }] : [],
+      links: [], char_count: copy.length, title: a.name, source: { engine: 'meta-ads', ref: a.id },
+    };
+  });
+  return { ok: true, count: items.length, items };
+}
+async function fetchGoogleAds(cfg) {
+  const g = cfg.google_ads || {};
+  if (!g.customer_id) return { ok: false, reason: 'not configured', items: [] };
+  const devToken = resolveSecret(g.developer_token), cid = resolveSecret(g.client_id),
+        csec = resolveSecret(g.client_secret), refresh = resolveSecret(g.refresh_token);
+  if (!devToken || !cid || !csec || !refresh) return { ok: false, reason: 'missing oauth creds', items: [] };
+  let access;
+  try {
+    const tr = await fetch('https://oauth2.googleapis.com/token', {
+      method: 'POST', headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ client_id: cid, client_secret: csec, refresh_token: refresh, grant_type: 'refresh_token' }),
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!tr.ok) return { ok: false, reason: 'oauth HTTP ' + tr.status, items: [] };
+    access = (await tr.json()).access_token;
+  } catch (e) { return { ok: false, reason: e.message, items: [] }; }
+  const cust = String(g.customer_id).replace(/-/g, '');
+  const headers = { Authorization: 'Bearer ' + access, 'developer-token': devToken, 'Content-Type': 'application/json' };
+  if (g.login_customer_id) headers['login-customer-id'] = String(g.login_customer_id).replace(/-/g, '');
+  const query = "SELECT campaign.name, campaign.status, ad_group_ad.ad.responsive_search_ad.headlines, ad_group_ad.ad.final_urls FROM ad_group_ad WHERE campaign.status != 'REMOVED' LIMIT 50";
+  let rows = [];
+  try {
+    const r = await fetch('https://googleads.googleapis.com/v20/customers/' + cust + '/googleAds:searchStream', {
+      method: 'POST', headers, body: JSON.stringify({ query }), signal: AbortSignal.timeout(20000),
+    });
+    if (!r.ok) { let msg = 'HTTP ' + r.status; try { const j = await r.json(); msg = (j.error?.message || JSON.stringify(j)).slice(0, 160); } catch {} return { ok: false, reason: msg, items: [] }; }
+    const data = await r.json();
+    rows = (Array.isArray(data) ? data : [data]).flatMap(b => b.results || []);
+  } catch (e) { return { ok: false, reason: e.message, items: [] }; }
+  const items = rows.map((row, i) => {
+    const ad = row.adGroupAd?.ad || {};
+    const heads = (ad.responsiveSearchAd?.headlines || []).map(h => h.text).filter(Boolean);
+    const copy = heads.join(' · ') || row.campaign?.name || 'ad';
+    return {
+      id: 'gads-' + i, channel: 'google-search', kind: 'ad', type: 'ad', scheduled_at: null,
+      ad_status: row.campaign?.status, copy,
+      rationale: 'Google Ads · "' + (row.campaign?.name || '') + '" · ' + (row.campaign?.status || '') + '.',
+      media: [], links: ad.finalUrls || [], char_count: copy.length, title: row.campaign?.name, source: { engine: 'google-ads', ref: String(i) },
+    };
+  });
+  return { ok: true, count: items.length, items };
+}
 
 /* ---------- collect ---------- */
 async function collect() {
@@ -161,20 +238,26 @@ async function collect() {
       status: res.ok ? 'ok' : (res.reason || 'error'), channels: [...new Set(res.items.map(i => i.channel))].sort(), items: res.items });
   }
 
-  // project brands
+  // project brands — organic posts (social.engine) + paid ads (meta/google, independent of organic engine)
   for (const [proj, cfg] of Object.entries(mk.projects || {})) {
     const s = cfg.social || {}; const eng = (s.engine && s.engine.primary) || null;
-    let res = { ok: false, items: [], status: s.engine && s.engine.status };
+    let postRes = { ok: false, items: [], status: s.engine && s.engine.status };
     if (eng === 'upload-post') {
       const up = s.engine.upload_post || {};
-      res = await fetchUploadPost(up.user || proj, resolveSecret(up.api_key_ref));
-    } else if (eng === 'meta-graph' || eng === 'meta-ads' || eng === 'google-ads') {
-      res = adHook(eng);
+      postRes = await fetchUploadPost(up.user || proj, resolveSecret(up.api_key_ref));
+    } else if (eng === 'typefully' && s.typefully_social_set_id) {
+      postRes = await fetchTypefully(s.typefully_social_set_id);
     }
-    if (eng) note(eng, res);
-    identities.push({ id: proj, label: proj, kind: 'project', engine: eng,
-      status: eng ? (res.ok ? 'ok' : (res.status || res.reason || 'error')) : 'unprovisioned',
-      channels: [...new Set(res.items.map(i => i.channel))].sort(), items: res.items });
+    if (eng) note(eng, postRes);
+    const meta = await fetchMetaAds(cfg); if (cfg.meta && cfg.meta.ad_account_id) note('meta-ads', meta);
+    const gads = await fetchGoogleAds(cfg); if (cfg.google_ads && cfg.google_ads.customer_id) note('google-ads', gads);
+    const items = [...postRes.items, ...meta.items, ...gads.items];
+    identities.push({
+      id: proj, label: proj, kind: 'project', engine: eng,
+      status: eng ? (postRes.ok ? 'ok' : (postRes.status || postRes.reason || 'error')) : 'unprovisioned',
+      ad_status: { 'meta-ads': meta.ok ? String(meta.count) : (meta.reason || '-'), 'google-ads': gads.ok ? String(gads.count) : (gads.reason || '-') },
+      channels: [...new Set(items.map(i => i.channel))].sort(), items,
+    });
   }
 
   const state = { generated_at: new Date().toISOString(), timezone: prefs.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone,

--- a/claude-ops/skills/ops-social-planner/lib/planner.mjs
+++ b/claude-ops/skills/ops-social-planner/lib/planner.mjs
@@ -177,7 +177,8 @@ function serve() {
     if (url === '/state.json') {
       file = fs.existsSync(OUT) ? OUT : path.join(UI_DIR, 'state.sample.json');
     } else {
-      file = path.join(UI_DIR, path.normalize(url).replace(/^(\.\.[/\\])+/, ''));
+      const rel = path.normalize(url).replace(/^(\.\.[/\\])+/, '').replace(/^[/\\]+/, '');
+      file = path.join(UI_DIR, rel);
     }
     if (!fs.existsSync(file) || fs.statSync(file).isDirectory()) { res.writeHead(404); return res.end('not found'); }
     res.writeHead(200, { 'Content-Type': MIME[path.extname(file)] || 'application/octet-stream', 'Cache-Control': 'no-store' });

--- a/claude-ops/skills/ops-social-planner/lib/planner.mjs
+++ b/claude-ops/skills/ops-social-planner/lib/planner.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/* ops-social-planner core (ESM). See SPEC.md. Invoked via bin/ops-social-planner shim. */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import http from 'http';
+import { execSync, spawn } from 'child_process';
+import { fileURLToPath } from 'url';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const HOME = os.homedir();
+const PREFS_PATH = process.env.PREFS_PATH ||
+  path.join(HOME, '.claude/plugins/data/ops-ops-marketplace/preferences.json');
+const OPS_DATA_DIR = process.env.OPS_DATA_DIR ||
+  path.join(HOME, '.claude/plugins/data/ops-ops-marketplace');
+const UI_DIR = path.join(__dirname, '..', 'ui');
+const OUT_DIR = path.join(OPS_DATA_DIR, 'social-planner');
+const args = process.argv.slice(2);
+const cmd = (args[0] && !args[0].startsWith('-')) ? args[0] : 'all';
+const flag = (n, d) => { const i = args.indexOf(n); return i >= 0 ? (args[i + 1] || true) : d; };
+const PORT = Number(flag('--port', process.env.OPS_PLANNER_PORT || 7937));
+const OUT = flag('--out', path.join(OUT_DIR, 'state.json'));
+
+/* ---------- helpers ---------- */
+const readJSON = (p) => JSON.parse(fs.readFileSync(p, 'utf8'));
+const log = (...a) => console.error('[planner]', ...a);
+const URL_RE = /(https?:\/\/[^\s)]+)/g;
+const extractLinks = (t) => [...new Set((t || '').match(URL_RE) || [])];
+
+function resolveSecret(ref) {
+  if (!ref) return null;
+  if (ref.startsWith('env:')) return process.env[ref.slice(4)] || null;
+  if (ref.startsWith('doppler:')) {
+    // doppler:project/config/SECRET
+    const [project, config, ...rest] = ref.slice(8).split('/');
+    const name = rest.join('/');
+    try {
+      return execSync(`doppler secrets get ${name} --project ${project} --config ${config} --plain`,
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim() || null;
+    } catch { return process.env[name] || null; }
+  }
+  return process.env[ref] || ref; // raw env name or literal
+}
+
+/* ---------- rationale (deterministic heuristic) ---------- */
+function deriveRationale(channel, copy, scheduledAt) {
+  const hour = new Date(scheduledAt).getUTCHours();
+  const slot =
+    hour < 9 ? 'Morning authority slot — high feed reach before the workday (EU midday / US-east pre-open).' :
+    hour < 12 ? 'Late-morning build-in-public slot — steady weekday browsing.' :
+    hour < 14 ? 'Midday window — peak US-morning engagement.' :
+    hour < 17 ? 'Afternoon professional window — best for LinkedIn long-form.' :
+    'Evening casual window — conversational/Threads-friendly.';
+  const norm = {
+    x: 'X: hook-first, thread if it earns it.',
+    linkedin: 'LinkedIn: long-form authority + soft CTA.',
+    threads: 'Threads: casual, conversational, low-polish.',
+    instagram: 'Instagram: visual-first, link-in-bio CTA.',
+    reddit: 'Reddit: value-first, no hard sell.',
+    youtube: 'YouTube: SEO title + descriptive copy.',
+    google_business: 'Google Business: local discovery, plain CTA.',
+    facebook: 'Facebook: brand page, broad reach.',
+  }[channel] || `${channel}: platform-native.`;
+  const t = (copy || '').toLowerCase();
+  const seq = /(almost here|this week|coming|👀|something worth)/.test(t) ? 'Pre-launch teaser — builds anticipation ahead of the drop.'
+    : /(it'?s here|is here|is live|now live|download|link in bio|on the app store)/.test(t) ? 'Launch beat — conversion-focused, drives the install.'
+    : 'Education/credibility beat — deepens trust between launch pushes.';
+  return `${seq} ${slot} ${norm}`;
+}
+
+/* ---------- engine fetchers ---------- */
+async function fetchTypefully(setId) {
+  const cfgPath = path.join(HOME, '.config/typefully/config.json');
+  if (!fs.existsSync(cfgPath)) return { ok: false, reason: 'no typefully config', items: [] };
+  const key = readJSON(cfgPath).apiKey;
+  const base = process.env.TYPEFULLY_API_BASE || 'https://api.typefully.com/v2';
+  const H = { Authorization: `Bearer ${key}` };
+  const list = await fetch(`${base}/social-sets/${setId}/drafts?status=scheduled&limit=50&order_by=scheduled_date`, { headers: H });
+  if (!list.ok) return { ok: false, reason: `HTTP ${list.status}`, items: [] };
+  const drafts = (await list.json()).results || [];
+  const items = [];
+  for (const d of drafts) {
+    let full = d;
+    try { const r = await fetch(`${base}/social-sets/${setId}/drafts/${d.id}?exclude_comment_markers=true`, { headers: H }); if (r.ok) full = await r.json(); } catch {}
+    const plats = full.platforms || {};
+    for (const [channel, p] of Object.entries(plats)) {
+      if (!p || !p.enabled) continue;
+      const posts = (p.posts || []).map(x => x.text).filter(Boolean);
+      if (!posts.length) continue;
+      const copy = posts.join('\n\n———\n\n');
+      items.push({
+        id: `tf-${d.id}-${channel}`, channel, kind: 'post',
+        type: posts.length > 1 ? 'thread' : 'text',
+        scheduled_at: d.scheduled_date, copy, thread: posts.length > 1 ? posts : undefined,
+        rationale: deriveRationale(channel, copy, d.scheduled_date),
+        media: [], links: extractLinks(copy), char_count: copy.length,
+        title: d.draft_title || null,
+        source: { engine: 'typefully', ref: String(d.id), edit_url: d.private_url || null },
+      });
+    }
+  }
+  return { ok: true, count: items.length, items };
+}
+
+async function fetchUploadPost(profile, key) {
+  if (!key) return { ok: false, reason: 'no api key', items: [] };
+  const r = await fetch('https://api.upload-post.com/api/uploadposts/schedule', { headers: { Authorization: `Apikey ${key}` } });
+  if (!r.ok) return { ok: false, reason: `HTTP ${r.status}`, items: [] };
+  const data = await r.json();
+  const posts = (data.scheduled_posts || []).filter(p => !profile || p.profile_username === profile);
+  const items = posts.flatMap(p => (p.platforms || []).map(channel => {
+    const pc = (p.platform_content || {})[channel] || {};
+    const copy = [pc.title || p.title, pc.caption || p.caption, pc.description || p.description].filter(Boolean).join('\n\n');
+    const isVid = p.post_type === 'video';
+    return {
+      id: `up-${p.job_id}-${channel}`, channel, kind: 'post', type: p.post_type || 'photo',
+      scheduled_at: p.original_scheduled_str || p.scheduled_date, copy,
+      rationale: deriveRationale(channel, copy, p.original_scheduled_str || p.scheduled_date),
+      media: p.preview_url ? [{ type: isVid ? 'video' : 'image', url: p.preview_url, thumb: p.thumbnail_url || (isVid ? null : p.preview_url) }] : [],
+      links: extractLinks(copy), char_count: copy.length, title: null,
+      source: { engine: 'upload-post', ref: p.job_id },
+    };
+  }));
+  return { ok: true, count: items.length, items };
+}
+
+function adHook(engine) { return { ok: false, reason: 'hook-pending', status: 'hook-pending', items: [] }; }
+
+/* ---------- collect ---------- */
+async function collect() {
+  const prefs = readJSON(PREFS_PATH);
+  const mk = prefs.marketing || {};
+  const engineStatus = {};
+  const identities = [];
+  const note = (eng, res) => { const s = engineStatus[eng] || { ok: false, count: 0 }; s.ok = s.ok || res.ok; s.count += res.count || 0; if (res.reason) s.reason = res.reason; engineStatus[eng] = s; };
+
+  // personal identities
+  for (const [id, p] of Object.entries((mk.social_identities && mk.social_identities.personal) || {})) {
+    let res = { ok: false, items: [] };
+    if (p.engine === 'typefully' && p.typefully_social_set_id) res = await fetchTypefully(p.typefully_social_set_id);
+    note(p.engine || 'typefully', res);
+    identities.push({ id, label: (p.aka && p.aka.join(' / ')) || id, kind: 'personal', engine: p.engine || 'typefully',
+      status: res.ok ? 'ok' : (res.reason || 'error'), channels: [...new Set(res.items.map(i => i.channel))].sort(), items: res.items });
+  }
+
+  // project brands
+  for (const [proj, cfg] of Object.entries(mk.projects || {})) {
+    const s = cfg.social || {}; const eng = (s.engine && s.engine.primary) || null;
+    let res = { ok: false, items: [], status: s.engine && s.engine.status };
+    if (eng === 'upload-post') {
+      const up = s.engine.upload_post || {};
+      res = await fetchUploadPost(up.user || proj, resolveSecret(up.api_key_ref));
+    } else if (eng === 'meta-graph' || eng === 'meta-ads' || eng === 'google-ads') {
+      res = adHook(eng);
+    }
+    if (eng) note(eng, res);
+    identities.push({ id: proj, label: proj, kind: 'project', engine: eng,
+      status: eng ? (res.ok ? 'ok' : (res.status || res.reason || 'error')) : 'unprovisioned',
+      channels: [...new Set(res.items.map(i => i.channel))].sort(), items: res.items });
+  }
+
+  const state = { generated_at: new Date().toISOString(), timezone: prefs.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
+    engine_status: engineStatus, identities };
+  fs.mkdirSync(path.dirname(OUT), { recursive: true });
+  fs.writeFileSync(OUT, JSON.stringify(state, null, 2));
+  const total = identities.reduce((n, i) => n + i.items.length, 0);
+  log(`collected ${total} items across ${identities.length} identities → ${OUT}`);
+  return state;
+}
+
+/* ---------- serve ---------- */
+const MIME = { '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css', '.json': 'application/json', '.svg': 'image/svg+xml' };
+function serve() {
+  const srv = http.createServer((req, res) => {
+    let url = decodeURIComponent(req.url.split('?')[0]);
+    if (url === '/' || url === '') url = '/index.html';
+    let file;
+    if (url === '/state.json') {
+      file = fs.existsSync(OUT) ? OUT : path.join(UI_DIR, 'state.sample.json');
+    } else {
+      file = path.join(UI_DIR, path.normalize(url).replace(/^(\.\.[/\\])+/, ''));
+    }
+    if (!fs.existsSync(file) || fs.statSync(file).isDirectory()) { res.writeHead(404); return res.end('not found'); }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(file)] || 'application/octet-stream', 'Cache-Control': 'no-store' });
+    fs.createReadStream(file).pipe(res);
+  });
+  srv.listen(PORT, '127.0.0.1', () => {
+    const u = `http://127.0.0.1:${PORT}/`;
+    log(`serving ${u}`);
+    console.log(u);
+    if (cmd !== 'serve' && flag('--no-open', false) === false) {
+      try { spawn(process.platform === 'darwin' ? 'open' : 'xdg-open', [u], { stdio: 'ignore', detached: true }).unref(); } catch {}
+    }
+  });
+}
+
+(async () => {
+  try {
+    if (cmd === 'collect' || cmd === 'all') await collect();
+    if (cmd === 'serve' || cmd === 'open' || cmd === 'all') serve();
+    else process.exit(0);
+  } catch (e) { log('ERROR', e.message); process.exit(1); }
+})();

--- a/claude-ops/skills/ops-social-planner/lib/planner.mjs
+++ b/claude-ops/skills/ops-social-planner/lib/planner.mjs
@@ -142,11 +142,13 @@ async function fetchUploadPost(profile, key) {
 async function fetchMetaAds(cfg) {
   const m = cfg.meta || {};
   if (!m.ad_account_id) return { ok: false, reason: 'no ad account', items: [] };
+  const adAccountId = resolveSecret(m.ad_account_id);
+  if (!adAccountId) return { ok: false, reason: 'no ad account', items: [] };
   const token = resolveSecret(m.access_token);
   if (!token) return { ok: false, reason: 'no token', items: [] };
   const secret = resolveSecret(m.app_secret);
   const proof = secret ? crypto.createHmac('sha256', secret).update(token).digest('hex') : null;
-  const u = new URL(`https://graph.facebook.com/v21.0/${m.ad_account_id}/ads`);
+  const u = new URL(`https://graph.facebook.com/v21.0/${adAccountId}/ads`);
   u.searchParams.set('fields', 'name,effective_status,created_time,creative{title,body,thumbnail_url},adset{daily_budget,targeting{publisher_platforms}}');
   u.searchParams.set('limit', '50');
   u.searchParams.set('access_token', token);
@@ -176,6 +178,8 @@ async function fetchMetaAds(cfg) {
 async function fetchGoogleAds(cfg) {
   const g = cfg.google_ads || {};
   if (!g.customer_id) return { ok: false, reason: 'not configured', items: [] };
+  const custResolved = resolveSecret(g.customer_id);
+  if (!custResolved) return { ok: false, reason: 'not configured', items: [] };
   const devToken = resolveSecret(g.developer_token), cid = resolveSecret(g.client_id),
         csec = resolveSecret(g.client_secret), refresh = resolveSecret(g.refresh_token);
   if (!devToken || !cid || !csec || !refresh) return { ok: false, reason: 'missing oauth creds', items: [] };
@@ -189,9 +193,12 @@ async function fetchGoogleAds(cfg) {
     if (!tr.ok) return { ok: false, reason: 'oauth HTTP ' + tr.status, items: [] };
     access = (await tr.json()).access_token;
   } catch (e) { return { ok: false, reason: e.message, items: [] }; }
-  const cust = String(g.customer_id).replace(/-/g, '');
+  const cust = String(custResolved).replace(/-/g, '');
   const headers = { Authorization: 'Bearer ' + access, 'developer-token': devToken, 'Content-Type': 'application/json' };
-  if (g.login_customer_id) headers['login-customer-id'] = String(g.login_customer_id).replace(/-/g, '');
+  if (g.login_customer_id) {
+    const loginCust = resolveSecret(g.login_customer_id);
+    if (loginCust) headers['login-customer-id'] = String(loginCust).replace(/-/g, '');
+  }
   const query = "SELECT campaign.name, campaign.status, ad_group_ad.ad.responsive_search_ad.headlines, ad_group_ad.ad.final_urls FROM ad_group_ad WHERE campaign.status != 'REMOVED' LIMIT 50";
   let rows = [];
   try {

--- a/claude-ops/skills/ops-social-planner/ui/app.js
+++ b/claude-ops/skills/ops-social-planner/ui/app.js
@@ -59,8 +59,8 @@ function renderChannels(){
 }
 function card(i,tz){
   const c=el('div',{className:'card'});
-  const w=fmtDate(i.scheduled_at,tz);
-  const when=el('div',{className:'when'}, el('span',{className:'date'},w.date), el('span',{className:'rel'},`${w.time} · ${w.rel}`), el('span',{className:`badge ${i.type||''}`}, i.type||'post'));
+  const w=i.scheduled_at?fmtDate(i.scheduled_at,tz):null;
+  const when=el('div',{className:'when'}, el('span',{className:'date'}, w?w.date:(i.ad_status||'active')), el('span',{className:'rel'}, w?`${w.time} · ${w.rel}`:'ongoing'), el('span',{className:`badge ${i.kind==='ad'?'video':(i.type||'')}`}, i.kind==='ad'?(i.ad_status||'ad'):(i.type||'post')));
   c.append(when);
   if(i.title) c.append(el('div',{className:'title'}, i.title));
   if(i.media&&i.media.length){ const m=i.media[0]; const md=el('div',{className:'media'}); if(m.thumb||m.url) md.append(el('img',{src:m.thumb||m.url,loading:'lazy',alt:''})); if(m.type==='video') md.append(el('span',{className:'vid-badge'},'▶ video')); c.append(md); }

--- a/claude-ops/skills/ops-social-planner/ui/app.js
+++ b/claude-ops/skills/ops-social-planner/ui/app.js
@@ -81,10 +81,12 @@ function render(){
   const ident=curIdentity(), tz=state.data.timezone;
   if(state.view==='ads'){
     const st=state.data.engine_status||{}; const pend=Object.values(st).some(v=>v.reason==='hook-pending');
-    board.append(stateMsg('📣', ident.items.some(i=>i.kind==='ad')?'':'No ads collected', pend?'Ad collectors (Meta / Google Ads) are scaffolded — the live fetch hook is pending. Posts are fully wired today.':'No paid campaigns for this account.'));
-    return;
+    if(!visibleItems().length){
+      board.append(stateMsg('📣', ident.items.some(i=>i.kind==='ad')?'':'No ads collected', pend?'Ad collectors (Meta / Google Ads) are scaffolded — the live fetch hook is pending. Posts are fully wired today.':'No paid campaigns for this account.'));
+      return;
+    }
   }
-  if(ident.status==='unprovisioned'){ board.append(stateMsg('🔒','Fail-closed — no engine registered',`${ident.label} has no social publishing engine. It will not post until one is registered (own upload-post profile or first-party Meta Graph).`)); return; }
+  if(state.view!=='ads' && ident.status==='unprovisioned'){ board.append(stateMsg('🔒','Fail-closed — no engine registered',`${ident.label} has no social publishing engine. It will not post until one is registered (own upload-post profile or first-party Meta Graph).`)); return; }
   const items=visibleItems();
   if(!items.length){ board.append(stateMsg('🗓️','Nothing scheduled here',state.q?'No posts match your search.':'No scheduled posts for this view.')); return; }
   const byCh={}; items.forEach(i=>(byCh[i.channel]=byCh[i.channel]||[]).push(i));

--- a/claude-ops/skills/ops-social-planner/ui/app.js
+++ b/claude-ops/skills/ops-social-planner/ui/app.js
@@ -80,8 +80,11 @@ function render(){
   const board=$('#board'); board.innerHTML='';
   const ident=curIdentity(), tz=state.data.timezone;
   if(state.view==='ads'){
-    const st=state.data.engine_status||{}; const pend=Object.values(st).some(v=>v.reason==='hook-pending');
-    if(!visibleItems().length){
+    if(ident.status==='unprovisioned'){ board.append(stateMsg('🔒','Fail-closed — no engine registered',`${ident.label} has no social publishing engine. It will not post until one is registered (own upload-post profile or first-party Meta Graph).`)); return; }
+    const st=state.data.engine_status||{}; const pend=ident.engine && (st[ident.engine]||{}).reason==='hook-pending';
+    const adsItems=visibleItems();
+    if(!adsItems.length){
+      if(state.q||state.channel){ board.append(stateMsg('📣','Nothing here',state.q?'No ads match your search.':'No ads match this channel.')); return; }
       board.append(stateMsg('📣', ident.items.some(i=>i.kind==='ad')?'':'No ads collected', pend?'Ad collectors (Meta / Google Ads) are scaffolded — the live fetch hook is pending. Posts are fully wired today.':'No paid campaigns for this account.'));
       return;
     }

--- a/claude-ops/skills/ops-social-planner/ui/app.js
+++ b/claude-ops/skills/ops-social-planner/ui/app.js
@@ -1,0 +1,111 @@
+// ops-social-planner UI — fetch normalized state, render per identity → channel → time.
+// Zero deps. State lives in the URL hash so views are shareable.
+const $ = (s, r = document) => r.querySelector(s);
+const el = (t, p = {}, ...kids) => { const n = Object.assign(document.createElement(t), p); for (const k of kids) n.append(k?.nodeType ? k : document.createTextNode(k ?? '')); return n; };
+const CH_ICON = { x:'𝕏', twitter:'𝕏', linkedin:'in', threads:'@', instagram:'◎', facebook:'f', reddit:'r/', youtube:'▶', google_business:'📍', tiktok:'♪', bluesky:'🦋', mastodon:'🐘' };
+const fmtDate = (iso, tz) => { const d = new Date(iso); return { date: d.toLocaleDateString(undefined,{weekday:'short',month:'short',day:'numeric',timeZone:tz}), time: d.toLocaleTimeString(undefined,{hour:'2-digit',minute:'2-digit',timeZone:tz}), rel: relTime(d) }; };
+function relTime(d){ const s=(d-Date.now())/1000, a=Math.abs(s), f=new Intl.RelativeTimeFormat(undefined,{numeric:'auto'}); if(a<3600)return f.format(Math.round(s/60),'minute'); if(a<86400)return f.format(Math.round(s/3600),'hour'); return f.format(Math.round(s/86400),'day'); }
+
+const state = { data:null, id:null, view:'posts', channel:null, q:'' };
+
+function readHash(){ const h=new URLSearchParams(location.hash.slice(1)); state.id=h.get('id')||state.id; state.view=h.get('view')||state.view; state.channel=h.get('channel')||null; state.q=h.get('q')||''; }
+function writeHash(){ const h=new URLSearchParams(); if(state.id)h.set('id',state.id); h.set('view',state.view); if(state.channel)h.set('channel',state.channel); if(state.q)h.set('q',state.q); history.replaceState(null,'',`#${h}`); }
+
+async function load(){
+  const r = await fetch('./state.json',{cache:'no-store'});
+  state.data = await r.json();
+  const ids = state.data.identities||[];
+  if(!state.id || !ids.find(i=>i.id===state.id)) state.id = (ids.find(i=>i.items.length)||ids[0]||{}).id;
+  renderMeta(); renderIdentities(); renderChannels(); render();
+}
+
+function curIdentity(){ return (state.data.identities||[]).find(i=>i.id===state.id) || {items:[]}; }
+function visibleItems(){
+  let it = (curIdentity().items||[]).filter(i => (i.kind||'post') === (state.view==='ads'?'ad':'post'));
+  if(state.channel) it = it.filter(i=>i.channel===state.channel);
+  if(state.q){ const q=state.q.toLowerCase(); it = it.filter(i => (i.copy||'').toLowerCase().includes(q) || (i.title||'').toLowerCase().includes(q)); }
+  return it.sort((a,b)=>new Date(a.scheduled_at)-new Date(b.scheduled_at));
+}
+
+function renderMeta(){
+  const d=state.data; $('#sub').textContent = `${(d.identities||[]).length} accounts · ${d.timezone||''}`;
+  const gen = d.generated_at ? `updated ${relTime(new Date(d.generated_at))}` : '';
+  const es = Object.entries(d.engine_status||{}).map(([k,v])=>{ const cls=v.ok?'ok':(v.reason==='hook-pending'?'idle':'bad'); return el('span',{},Object.assign(document.createElement('span'),{className:`dot ${cls}`}), `${k}${v.reason&&!v.ok?` (${v.reason})`:''}`); });
+  const m=$('#meta'); m.innerHTML=''; es.forEach(x=>m.append(x)); if(gen) m.append(el('span',{},gen));
+}
+function renderIdentities(){
+  const box=$('#identities'); box.innerHTML='';
+  for(const i of state.data.identities||[]){
+    const b=el('button',{onclick:()=>{state.id=i.id; state.channel=null; writeHash(); renderIdentities(); renderChannels(); render();}});
+    b.setAttribute('aria-pressed', i.id===state.id);
+    b.append(el('span',{className:`kind-tag kind-${i.kind||'project'}`}, i.kind==='personal'?'personal':'brand'), i.label);
+    b.append(el('span',{className:'pill'}, String(i.items.length)));
+    box.append(b);
+  }
+  const posts=(curIdentity().items||[]).filter(i=>(i.kind||'post')==='post').length;
+  const ads=(curIdentity().items||[]).filter(i=>i.kind==='ad').length;
+  $('#n-posts').textContent=posts; $('#n-ads').textContent=ads;
+}
+function renderChannels(){
+  const box=$('#channels'); box.innerHTML='';
+  const items=(curIdentity().items||[]).filter(i=>(i.kind||'post')===(state.view==='ads'?'ad':'post'));
+  const counts={}; items.forEach(i=>counts[i.channel]=(counts[i.channel]||0)+1);
+  const all=el('button',{className:'chip',onclick:()=>{state.channel=null;writeHash();renderChannels();render();}}); all.setAttribute('aria-pressed',!state.channel); all.append('All ', el('span',{className:'n'},String(items.length)));
+  box.append(all);
+  for(const ch of Object.keys(counts).sort()){
+    const c=el('button',{className:'chip',onclick:()=>{state.channel=ch;writeHash();renderChannels();render();}}); c.setAttribute('aria-pressed',state.channel===ch);
+    c.append(el('span',{},CH_ICON[ch]||'•'),' ',ch.replace('_',' '),' ',el('span',{className:'n'},String(counts[ch]))); box.append(c);
+  }
+}
+function card(i,tz){
+  const c=el('div',{className:'card'});
+  const w=fmtDate(i.scheduled_at,tz);
+  const when=el('div',{className:'when'}, el('span',{className:'date'},w.date), el('span',{className:'rel'},`${w.time} · ${w.rel}`), el('span',{className:`badge ${i.type||''}`}, i.type||'post'));
+  c.append(when);
+  if(i.title) c.append(el('div',{className:'title'}, i.title));
+  if(i.media&&i.media.length){ const m=i.media[0]; const md=el('div',{className:'media'}); if(m.thumb||m.url) md.append(el('img',{src:m.thumb||m.url,loading:'lazy',alt:''})); if(m.type==='video') md.append(el('span',{className:'vid-badge'},'▶ video')); c.append(md); }
+  const copy=el('div',{className:'copy'}, i.copy||''); c.append(copy);
+  requestAnimationFrame(()=>{ if(copy.scrollHeight>copy.clientHeight+4){ copy.classList.add('clamped'); const more=el('button',{className:'more'},'Show more'); more.onclick=()=>{const e=copy.classList.toggle('expanded'); more.textContent=e?'Show less':'Show more';}; copy.after(more);} });
+  if(i.rationale) c.append(el('div',{className:'rationale'}, el('b',{},'Why this slot — '), i.rationale));
+  if(i.links&&i.links.length){ const lk=el('div',{className:'links'}); i.links.forEach(u=>lk.append(el('a',{className:'link-chip',href:u,target:'_blank',rel:'noopener'},u.replace(/^https?:\/\//,'')))); c.append(lk); }
+  const src=(i.source&&i.source.engine)||i.engine||'';
+  const foot=el('div',{className:'foot'}, el('span',{className:'src'},src));
+  if(i.source&&i.source.edit_url) foot.append(el('a',{href:i.source.edit_url,target:'_blank',rel:'noopener'},'open'));
+  foot.append(el('span',{className:'cc'}, `${i.char_count||(i.copy||'').length} chars`));
+  c.append(foot); return c;
+}
+function render(){
+  writeHash();
+  for(const b of $('#views').children) b.setAttribute('aria-pressed', b.dataset.view===state.view);
+  const board=$('#board'); board.innerHTML='';
+  const ident=curIdentity(), tz=state.data.timezone;
+  if(state.view==='ads'){
+    const st=state.data.engine_status||{}; const pend=Object.values(st).some(v=>v.reason==='hook-pending');
+    board.append(stateMsg('📣', ident.items.some(i=>i.kind==='ad')?'':'No ads collected', pend?'Ad collectors (Meta / Google Ads) are scaffolded — the live fetch hook is pending. Posts are fully wired today.':'No paid campaigns for this account.'));
+    return;
+  }
+  if(ident.status==='unprovisioned'){ board.append(stateMsg('🔒','Fail-closed — no engine registered',`${ident.label} has no social publishing engine. It will not post until one is registered (own upload-post profile or first-party Meta Graph).`)); return; }
+  const items=visibleItems();
+  if(!items.length){ board.append(stateMsg('🗓️','Nothing scheduled here',state.q?'No posts match your search.':'No scheduled posts for this view.')); return; }
+  const byCh={}; items.forEach(i=>(byCh[i.channel]=byCh[i.channel]||[]).push(i));
+  const order = state.channel ? [state.channel] : Object.keys(byCh).sort();
+  for(const ch of order){
+    const col=el('div',{className:'col'});
+    col.append(el('div',{className:'col-head'}, el('span',{className:'ch-icon'},CH_ICON[ch]||'•'), el('span',{className:'ch-name'},ch.replace('_',' ')), el('span',{className:'ch-count'},`${byCh[ch].length}`)));
+    const body=el('div',{className:'col-body'}); byCh[ch].forEach(i=>body.append(card(i,tz))); col.append(body); board.append(col);
+  }
+}
+function stateMsg(big,h,p){ return el('div',{className:'state-msg'}, el('div',{className:'big'},big), el('h2',{},h), el('p',{},p)); }
+
+// theme
+const themeKey='ops-planner-theme';
+function applyTheme(t){ document.documentElement.dataset.theme=t; localStorage.setItem(themeKey,t); }
+$('#theme').onclick=()=>applyTheme(document.documentElement.dataset.theme==='dark'?'light':'dark');
+applyTheme(localStorage.getItem(themeKey)|| (matchMedia('(prefers-color-scheme: light)').matches?'light':'dark'));
+$('#refresh').onclick=()=>load();
+$('#search').oninput=e=>{state.q=e.target.value; render();};
+for(const b of $('#views').children) b.onclick=()=>{state.view=b.dataset.view; state.channel=null; renderIdentities(); renderChannels(); render();};
+
+readHash(); $('#search').value=state.q;
+addEventListener('hashchange',()=>{ const prev=state.q; readHash(); if(state.q!==prev)$('#search').value=state.q; renderIdentities(); renderChannels(); render(); });
+load().catch(e=>{ $('#board').append(stateMsg('⚠️','Could not load state',String(e.message))); });

--- a/claude-ops/skills/ops-social-planner/ui/index.html
+++ b/claude-ops/skills/ops-social-planner/ui/index.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="color-scheme" content="dark light" />
+  <title>Ops Social Planner</title>
+  <link rel="stylesheet" href="./styles.css" />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🗓️</text></svg>" />
+</head>
+<body>
+  <header class="topbar">
+    <div class="row">
+      <div class="brand">
+        <h1>Ops Social Planner</h1>
+        <span class="sub" id="sub">loading…</span>
+      </div>
+      <div class="meta" id="meta"></div>
+      <button class="icon-btn" id="theme" title="Toggle theme" aria-label="Toggle theme">◐</button>
+      <button class="icon-btn" id="refresh" title="Reload state" aria-label="Reload">⟳</button>
+    </div>
+    <div class="row">
+      <div class="segmented" id="identities" role="group" aria-label="Account / project"></div>
+      <div class="segmented" id="views" role="group" aria-label="View">
+        <button data-view="posts" aria-pressed="true">Posts <span class="pill" id="n-posts">0</span></button>
+        <button data-view="ads" aria-pressed="false">Ads <span class="pill" id="n-ads">0</span></button>
+      </div>
+      <input class="search" id="search" type="search" placeholder="Search copy…" aria-label="Search copy" />
+    </div>
+    <div class="row chips" id="channels" role="group" aria-label="Channels"></div>
+  </header>
+  <main class="board" id="board" aria-live="polite"></main>
+  <script type="module" src="./app.js"></script>
+</body>
+</html>

--- a/claude-ops/skills/ops-social-planner/ui/state.sample.json
+++ b/claude-ops/skills/ops-social-planner/ui/state.sample.json
@@ -1,0 +1,35 @@
+{
+  "generated_at": "2026-01-01T09:00:00.000Z",
+  "timezone": "UTC",
+  "_note": "Synthetic PII-free fixture so the UI renders without credentials. Live data is generated into $OPS_DATA_DIR/social-planner/state.json by `ops-social-planner collect` and is never committed.",
+  "engine_status": {
+    "typefully": { "ok": true, "count": 3 },
+    "upload-post": { "ok": true, "count": 4 },
+    "meta-ads": { "ok": false, "reason": "hook-pending" }
+  },
+  "identities": [
+    {
+      "id": "founder", "label": "Founder (personal)", "kind": "personal", "engine": "typefully", "status": "ok",
+      "channels": ["linkedin", "threads", "x"],
+      "items": [
+        { "id":"s1","channel":"x","kind":"post","type":"text","scheduled_at":"2026-01-02T07:00:00Z","title":"Build-in-public note","copy":"shipped a thing today. the hard part was never the code — it was deciding what to leave out.","rationale":"Education/credibility beat. Morning authority slot. X: hook-first.","media":[],"links":[],"char_count":98,"source":{"engine":"typefully","ref":"0","edit_url":"https://example.com/"} },
+        { "id":"s2","channel":"linkedin","kind":"post","type":"text","scheduled_at":"2026-01-02T15:00:00Z","title":"Long-form thesis","copy":"Everyone is racing to hire engineers. The best founders of the next decade won't be engineers at all — they'll be the people with taste.","rationale":"Education beat. Afternoon professional window. LinkedIn: long-form authority + soft CTA.","media":[],"links":[],"char_count":136,"source":{"engine":"typefully","ref":"0"} },
+        { "id":"s3","channel":"threads","kind":"post","type":"thread","scheduled_at":"2026-01-03T17:30:00Z","copy":"weird week.\n\n———\n\nanyone else living a double life right now?","rationale":"Education beat. Evening casual window. Threads: conversational.","media":[],"links":[],"char_count":58,"source":{"engine":"typefully","ref":"0"} }
+      ]
+    },
+    {
+      "id": "my-app", "label": "my-app", "kind": "project", "engine": "upload-post", "status": "ok",
+      "channels": ["instagram", "linkedin", "threads", "x"],
+      "items": [
+        { "id":"a1","channel":"instagram","kind":"post","type":"photo","scheduled_at":"2026-01-02T13:00:00Z","copy":"Something worth your attention is almost here. 🧡","rationale":"Pre-launch teaser. Midday window. Instagram: visual-first, link-in-bio.","media":[{"type":"image","url":"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='240'%3E%3Crect width='400' height='240' fill='%23161a23'/%3E%3Ctext x='50%25' y='50%25' fill='%239aa6b8' font-family='sans-serif' font-size='18' text-anchor='middle'%3Eteaser creative%3C/text%3E%3C/svg%3E","thumb":null}],"links":[],"char_count":47,"source":{"engine":"upload-post","ref":"job1"} },
+        { "id":"a2","channel":"x","kind":"post","type":"photo","scheduled_at":"2026-01-02T15:00:00Z","copy":"this week, that gap gets a whole lot smaller. 👀","rationale":"Pre-launch teaser. Afternoon window. X: hook-first.","media":[],"links":[],"char_count":47,"source":{"engine":"upload-post","ref":"job2"} },
+        { "id":"a3","channel":"instagram","kind":"post","type":"video","scheduled_at":"2026-01-04T13:00:00Z","copy":"It's here. Download now — link in bio.","rationale":"Launch beat. Midday window. Instagram: visual-first.","media":[{"type":"video","url":"","thumb":"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='240'%3E%3Crect width='400' height='240' fill='%2312151c'/%3E%3Ctext x='50%25' y='50%25' fill='%239aa6b8' font-family='sans-serif' font-size='18' text-anchor='middle'%3Elaunch reel%3C/text%3E%3C/svg%3E"}],"links":[],"char_count":38,"source":{"engine":"upload-post","ref":"job3"} },
+        { "id":"a4","channel":"linkedin","kind":"post","type":"text","scheduled_at":"2026-01-04T16:00:00Z","copy":"my-app is live. Stop guessing. Start understanding.\n\nhttps://example.com/app","rationale":"Launch beat. Afternoon professional window. LinkedIn: long-form.","media":[],"links":["https://example.com/app"],"char_count":74,"source":{"engine":"upload-post","ref":"job4"} }
+      ]
+    },
+    {
+      "id": "other-project", "label": "other-project", "kind": "project", "engine": null, "status": "unprovisioned",
+      "channels": [], "items": []
+    }
+  ]
+}

--- a/claude-ops/skills/ops-social-planner/ui/styles.css
+++ b/claude-ops/skills/ops-social-planner/ui/styles.css
@@ -1,0 +1,105 @@
+/* ops-social-planner — design tokens + layout. Zero-build, light/dark, responsive. */
+:root {
+  --bg: #0b0d12; --bg-elev: #12151c; --bg-card: #161a23; --bg-card-hover: #1b2330;
+  --border: #232a36; --border-strong: #313b4d;
+  --text: #e8edf5; --text-dim: #9aa6b8; --text-faint: #6b7689;
+  --accent: #ff7a45; --accent-soft: rgba(255,122,69,.14); --accent-text: #ffb796;
+  --good: #38d39f; --warn: #f6c454; --bad: #f47272; --info: #6aa6ff;
+  --radius: 14px; --radius-sm: 9px; --shadow: 0 1px 2px rgba(0,0,0,.4), 0 8px 24px rgba(0,0,0,.28);
+  --col-w: 340px; --font: -apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Helvetica,Arial,sans-serif;
+  --mono: ui-monospace,SFMono-Regular,Menlo,monospace;
+}
+:root[data-theme="light"] {
+  --bg: #f5f6f8; --bg-elev: #ffffff; --bg-card: #ffffff; --bg-card-hover: #fbfbfd;
+  --border: #e6e8ee; --border-strong: #d2d7e0;
+  --text: #14181f; --text-dim: #5a6373; --text-faint: #8a93a3;
+  --accent: #ee5a24; --accent-soft: rgba(238,90,36,.10); --accent-text: #c2410c;
+  --shadow: 0 1px 2px rgba(20,24,31,.06), 0 8px 22px rgba(20,24,31,.08);
+}
+* { box-sizing: border-box; }
+html,body { margin:0; height:100%; }
+body { background:var(--bg); color:var(--text); font-family:var(--font); font-size:14px; line-height:1.5;
+  -webkit-font-smoothing:antialiased; display:flex; flex-direction:column; height:100vh; overflow:hidden; }
+a { color:var(--accent-text); text-decoration:none; }
+a:hover { text-decoration:underline; }
+
+/* header */
+header.topbar { flex:0 0 auto; background:var(--bg-elev); border-bottom:1px solid var(--border);
+  padding:14px 20px; display:flex; flex-direction:column; gap:12px; }
+.row { display:flex; align-items:center; gap:12px; flex-wrap:wrap; }
+.brand { display:flex; align-items:baseline; gap:10px; margin-right:auto; }
+.brand h1 { font-size:16px; font-weight:650; margin:0; letter-spacing:-.01em; }
+.brand .sub { color:var(--text-faint); font-size:12px; }
+.meta { color:var(--text-faint); font-size:12px; display:flex; gap:14px; align-items:center; flex-wrap:wrap; }
+.dot { width:7px; height:7px; border-radius:50%; display:inline-block; margin-right:5px; }
+.dot.ok{background:var(--good)} .dot.warn{background:var(--warn)} .dot.bad{background:var(--bad)} .dot.idle{background:var(--text-faint)}
+
+/* controls */
+.segmented { display:inline-flex; background:var(--bg-card); border:1px solid var(--border); border-radius:var(--radius-sm); padding:3px; gap:2px; }
+.segmented button { background:transparent; border:0; color:var(--text-dim); font:inherit; font-size:13px; font-weight:550;
+  padding:6px 13px; border-radius:7px; cursor:pointer; display:flex; align-items:center; gap:7px; white-space:nowrap; transition:.12s; }
+.segmented button:hover { color:var(--text); }
+.segmented button[aria-pressed="true"] { background:var(--accent-soft); color:var(--accent-text); }
+.segmented button .pill { font-size:11px; background:var(--border-strong); color:var(--text-dim); border-radius:20px; padding:0 6px; min-width:18px; text-align:center; }
+.segmented button[aria-pressed="true"] .pill { background:var(--accent); color:#fff; }
+.kind-tag { font-size:10px; text-transform:uppercase; letter-spacing:.06em; padding:1px 6px; border-radius:5px; }
+.kind-personal { background:rgba(106,166,255,.16); color:var(--info); }
+.kind-project { background:var(--accent-soft); color:var(--accent-text); }
+
+.chips { display:flex; gap:7px; flex-wrap:wrap; }
+.chip { background:var(--bg-card); border:1px solid var(--border); color:var(--text-dim); font-size:12px; font-weight:550;
+  padding:5px 11px; border-radius:20px; cursor:pointer; display:flex; align-items:center; gap:6px; transition:.12s; }
+.chip:hover { border-color:var(--border-strong); color:var(--text); }
+.chip[aria-pressed="true"] { background:var(--accent-soft); border-color:var(--accent); color:var(--accent-text); }
+.chip .n { color:var(--text-faint); font-size:11px; }
+.icon-btn { background:var(--bg-card); border:1px solid var(--border); color:var(--text-dim); width:34px; height:34px;
+  border-radius:9px; cursor:pointer; font-size:15px; display:grid; place-items:center; }
+.icon-btn:hover { color:var(--text); border-color:var(--border-strong); }
+input.search { background:var(--bg-card); border:1px solid var(--border); color:var(--text); font:inherit; font-size:13px;
+  padding:7px 12px; border-radius:9px; min-width:200px; }
+input.search:focus { outline:none; border-color:var(--accent); }
+
+/* board */
+main.board { flex:1 1 auto; overflow-x:auto; overflow-y:hidden; display:flex; gap:16px; padding:18px 20px 24px; scroll-snap-type:x proximity; }
+.col { flex:0 0 var(--col-w); width:var(--col-w); display:flex; flex-direction:column; min-height:0; scroll-snap-align:start; }
+.col-head { position:sticky; top:0; display:flex; align-items:center; gap:9px; padding:4px 4px 12px; }
+.col-head .ch-icon { width:26px; height:26px; border-radius:7px; display:grid; place-items:center; font-size:14px; background:var(--bg-card); border:1px solid var(--border); }
+.col-head .ch-name { font-weight:600; font-size:13.5px; text-transform:capitalize; }
+.col-head .ch-count { color:var(--text-faint); font-size:12px; margin-left:auto; }
+.col-body { overflow-y:auto; display:flex; flex-direction:column; gap:12px; padding:2px 4px 40px; }
+
+.card { background:var(--bg-card); border:1px solid var(--border); border-radius:var(--radius); box-shadow:var(--shadow);
+  padding:14px; display:flex; flex-direction:column; gap:10px; transition:.12s; }
+.card:hover { border-color:var(--border-strong); background:var(--bg-card-hover); }
+.card .when { display:flex; align-items:center; gap:8px; font-size:12px; }
+.when .date { font-weight:650; color:var(--text); }
+.when .rel { color:var(--text-faint); }
+.when .badge { margin-left:auto; font-size:10px; text-transform:uppercase; letter-spacing:.05em; padding:2px 7px; border-radius:6px; background:var(--bg-elev); border:1px solid var(--border); color:var(--text-dim); }
+.badge.video { color:var(--info); } .badge.thread { color:var(--accent-text); } .badge.text{} .badge.photo{}
+.card .title { font-size:12.5px; font-weight:600; color:var(--text-dim); }
+.card .copy { font-size:13.5px; white-space:pre-wrap; word-break:break-word; color:var(--text);
+  max-height:9.5em; overflow:hidden; position:relative; }
+.card .copy.expanded { max-height:none; }
+.card .copy:not(.expanded).clamped::after { content:""; position:absolute; left:0; right:0; bottom:0; height:2.4em;
+  background:linear-gradient(transparent,var(--bg-card)); }
+.card:hover .copy:not(.expanded).clamped::after { background:linear-gradient(transparent,var(--bg-card-hover)); }
+.more { align-self:flex-start; background:none; border:0; color:var(--accent-text); font:inherit; font-size:12px; cursor:pointer; padding:0; }
+.media { border-radius:var(--radius-sm); overflow:hidden; border:1px solid var(--border); position:relative; background:var(--bg-elev); }
+.media img { display:block; width:100%; max-height:200px; object-fit:cover; }
+.media .vid-badge { position:absolute; top:8px; right:8px; background:rgba(0,0,0,.6); color:#fff; font-size:11px; padding:2px 8px; border-radius:20px; backdrop-filter:blur(4px); }
+.rationale { font-size:12px; color:var(--text-dim); background:var(--bg-elev); border:1px solid var(--border); border-left:3px solid var(--accent);
+  border-radius:0 var(--radius-sm) var(--radius-sm) 0; padding:8px 11px; }
+.rationale b { color:var(--text-dim); font-weight:600; }
+.links { display:flex; flex-wrap:wrap; gap:6px; }
+.link-chip { font-size:11px; background:var(--accent-soft); color:var(--accent-text); padding:3px 9px; border-radius:6px; max-width:100%; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.foot { display:flex; align-items:center; gap:10px; font-size:11px; color:var(--text-faint); border-top:1px solid var(--border); padding-top:9px; }
+.foot .src { text-transform:capitalize; } .foot .cc { margin-left:auto; }
+
+.state-msg { margin:auto; text-align:center; color:var(--text-dim); max-width:440px; padding:40px; }
+.state-msg .big { font-size:30px; margin-bottom:8px; }
+.state-msg h2 { font-size:16px; color:var(--text); margin:0 0 6px; }
+.empty-col { color:var(--text-faint); font-size:12px; text-align:center; padding:24px 8px; border:1px dashed var(--border); border-radius:var(--radius); }
+
+@media (prefers-reduced-motion: reduce) { * { transition:none !important; } }
+::-webkit-scrollbar { height:11px; width:11px; }
+::-webkit-scrollbar-thumb { background:var(--border-strong); border-radius:20px; border:3px solid transparent; background-clip:content-box; }


### PR DESCRIPTION
## What
A read-only, **PR-able, templatable web UI** that auto-generates the current state of **all**
ops-socials + ops-marketing planned **posts and ads**, **per identity/project, per channel —
regardless of posting engine** (Typefully, upload-post, Meta, Google Ads…).

Asked for: *"a web ui that we can pr that auto generates the current state of all ops-socials
and ops-marketing planned posts and ads per project per channel, regardless of the api or method
of posting."*

## How it's built (2026, zero-build)
- **`bin/ops-social-planner`** → bash shim → **`lib/planner.mjs`** (ESM — claude-ops is `type:module`).
  Reads `marketing.social_identities` + each project's `social.engine` from prefs, dispatches a
  **per-engine fetcher** keyed on `engine.primary`, normalizes to one schema, writes
  `$OPS_DATA_DIR/social-planner/state.json`, serves the UI on `127.0.0.1`.
  | engine | source | status |
  |---|---|---|
  | `typefully` | `/v2/social-sets/{id}/drafts` | ✅ wired |
  | `upload-post` | `/api/uploadposts/schedule` | ✅ wired |
  | `meta-ads` / `google-ads` | per-project BM/GAQL | 🔌 hook (UI shows "pending") |
  | `null` | — | fail-closed (0 items) |

  Adding an engine = one `fetch<Engine>()` + a dispatch branch. No UI change.
- **`ui/`** — vanilla ES-module SPA, **no framework / no build step** (correct for an embeddable
  plugin). Identity/project switcher, channel filter, Posts/Ads tabs, search, light/dark,
  **shareable URL-hash state**, per-card copy + local & relative time + **derived "why this slot"
  rationale** + media (image/video) + extracted links. a11y + reduced-motion.
- **`ui/state.sample.json`** — synthetic, PII-free fixture so the UI renders in this PR with **zero credentials**.
- **`SPEC.md`** — full design + best-practice checklist.

## Privacy (Rule 0)
Only `bin/` + `ui/` + `lib/` + `SPEC.md` + the synthetic fixture are committed. **Real copy,
handles, IDs, and keys are generated at runtime into `$OPS_DATA_DIR`** (outside the repo) and are
never committed. `tests/test-no-secrets.sh`: **14 passed, 0 failed**.

## Verified live (local)
Collector pulled **37 real items across 11 identities**: personal (Typefully) 19 across
x/threads/linkedin; one project brand (upload-post) 18 across instagram/x/threads/linkedin/youtube/
google-business/reddit; the 9 engine-less projects render **fail-closed**. Identity separation
(personal vs project) honored end-to-end. Read-only — publishing stays in `/ops-socials` +
`/ops-marketing` behind per-message approval (Rule 6).

## Run
```bash
"${CLAUDE_PLUGIN_ROOT}/bin/ops-social-planner"          # collect → serve → open
"${CLAUDE_PLUGIN_ROOT}/bin/ops-social-planner" collect   # regenerate state only
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Collector resolves Doppler/env secrets and calls third-party marketing APIs (Meta/Google OAuth included), but behavior is read-only and bound to localhost with owner data kept outside the repo.
> 
> **Overview**
> Adds **`/ops-social-planner`**, a read-only local dashboard that aggregates scheduled **posts and ads** across personal identities and project brands into one normalized `state.json`, then serves a zero-build static SPA on **127.0.0.1**.
> 
> A bash shim (`bin/ops-social-planner`) resolves `OPS_DATA_DIR` / `PREFS_PATH` like other ops bins and runs **`lib/planner.mjs`**, which reads `marketing.social_identities` and `marketing.projects.*.social`, dispatches per-engine fetchers (**Typefully**, **upload-post**, plus **Meta Ads** / **Google Ads** when project creds exist), applies heuristic **“why this slot”** rationale, and writes runtime data under `$OPS_DATA_DIR/social-planner/` (not committed). **`collect`**, **`serve`**, and default collect+serve+open are supported; the UI falls back to **`state.sample.json`** without credentials.
> 
> The **`ui/`** layer adds identity/project switching, Posts vs Ads, channel chips, search, light/dark theme, and URL-hash shareable state. **`SKILL.md`** / **`SPEC.md`** document the skill router and optional agent enrichment (MCP ads, richer rationale) without publishing from the planner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f52bb8c23af0524a7d9b09ac5407f24547f2c9b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Social Planner tool: engine-agnostic, read-only dashboard to collect and view scheduled posts and ads; supports collect + local serve modes, 127.0.0.1-only UI, and a sample-state fallback when no live data exists.
  * UI: board view with identity/channel filters, search, counters, theme toggle, responsive/accessibility considerations.

* **Documentation**
  * Added full user docs and spec describing usage, data flow, engine coverage, guarantees, and verification guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->