### PR TITLE
feat(pocket): worker browser briefing + KillMode fix + ASK/DRAFT email approvals

### DIFF
--- a/claude-ops/scripts/ops-cron-pocket-executor.py
+++ b/claude-ops/scripts/ops-cron-pocket-executor.py
@@ -278,9 +278,24 @@ Hard rules:
     have done.
   - You are running headless via `claude -p`. You will NOT get
     follow-up turns. Plan your single response carefully.
-  - All read-only investigation tools are available (Bash for reads,
-    Grep, Glob, Read, WebFetch). For writes/edits, use them only on
-    local state files needed to complete the task.
+  - YOU HAVE A REAL HEADLESS BROWSER. For ANY web/dashboard/login/QA
+    task (ManyChat, Meta Business Manager, Stripe, Vercel, etc.) use the
+    gstack browse CLI:
+      BROWSE="$HOME/.claude/skills/gstack/browse/dist/browse"
+      "$BROWSE" goto <url> ; "$BROWSE" text ; "$BROWSE" click "<sel>" ;
+      "$BROWSE" fill "<sel>" "<val>" ; "$BROWSE" screenshot ; "$BROWSE" cookie-import
+    It is HEADLESS and works on a Linux box. The chrome-devtools MCP
+    (mcp__chrome-devtools__*) is also connected as an alternative. Browser
+    tasks are NOT impossible here — never say "Mac-only"; drive the browser.
+  - For authenticated sites, fetch credentials from Dashlane: `dcli`
+    (e.g. `dcli password <site>`). Or import synced cookies via
+    `"$BROWSE" cookie-import`.
+  - Gmail/Calendar are authed via `gog` (account in $GOG_ACCOUNT;
+    GOG_ACCOUNT + GOG_KEYRING_PASSWORD are in the environment): e.g.
+    `gog gmail search "<q>" -j --results-only --no-input`, `gog gmail get <id> -j`.
+  - AWS CLI and the Cloudflare API are available for infra tasks.
+  - Other read tools: Bash, Grep, Glob, Read, WebFetch. For writes/edits,
+    use them as needed to complete the task (respecting the rules above).
   - End with a markdown block titled `## Outcome` describing what you
     did, what (if anything) was blocked, and any follow-up the owner
     should review. Keep it to 4-8 lines.

--- a/claude-ops/scripts/ops-pocket-approvals.py
+++ b/claude-ops/scripts/ops-pocket-approvals.py
@@ -20,7 +20,7 @@ Requires the SES email backend in ops-pocket-email-bridge.py (send_email's
 `backend`/`ses_cfg` kwargs) — see the related "SES email backend" PR.
 """
 from __future__ import annotations
-import json, os, sys, time, subprocess
+import json, os, re, sys, time, subprocess
 from pathlib import Path
 
 STATE = Path(os.environ.get("POCKET_STATE_DIR", str(Path.home() / ".claude/state/pocket")))
@@ -107,6 +107,9 @@ def cmd_digest():
     prev=json.loads(NOTIFIED.read_text()).get("hash") if NOTIFIED.exists() else None
     if h==prev:
         log(f"digest: open set unchanged ({len(items)} items) — not re-emailing")
+        if not CODEMAP.exists():
+            CODEMAP.write_text(json.dumps(codemap, indent=2))
+            log("digest: wrote missing approval-codemap.json for unchanged open set")
         return 0
     ok,info,to=send_via_bridge(f"[Pocket] {len(items)} item(s) need approval", body)
     CODEMAP.write_text(json.dumps(codemap,indent=2))
@@ -118,7 +121,7 @@ def cmd_digest():
 def _gog_search_replies():
     """Find recent emails from the owner replying to approval digests."""
     try:
-        r=subprocess.run([GOG,"gmail","search","subject:[Pocket] newer_than:2d","--max","15","-j","--results-only","--no-input"],
+        r=subprocess.run([GOG,"gmail","search","from:me subject:[Pocket] newer_than:2d","--max","15","-j","--results-only","--no-input"],
                          capture_output=True,text=True,timeout=60,env=os.environ)
         if r.returncode!=0:
             log(f"gog search rc={r.returncode}: {r.stderr[:150]}"); return []
@@ -126,25 +129,33 @@ def _gog_search_replies():
     except Exception as e:
         log(f"gog search err {e}"); return []
 
-def _gog_body(msg_id):
+def _gog_body_and_subject(msg_id):
     try:
         r=subprocess.run([GOG,"gmail","get",msg_id,"-j","--no-input"],capture_output=True,text=True,timeout=60,env=os.environ)
         d=json.loads(r.stdout or "{}")
-        return (d.get("body") or d.get("snippet") or "")
-    except Exception: return ""
+        return (d.get("body") or d.get("snippet") or ""), (d.get("subject") or "")
+    except Exception: return "", ""
+
+def _is_digest_outbound_subject(subject):
+    """Sent digest uses '[Pocket] N item(s) need approval' without a Re: prefix; skip those."""
+    s = (subject or "").strip()
+    if re.match(r"(?i)^re:\s*", s):
+        return False
+    return re.match(r"^\[Pocket\]\s+\d+\s+item\(s\)\s+need\s+approval\s*$", s) is not None
 
 def cmd_replies():
     if not CODEMAP.exists(): log("replies: no codemap yet"); return 0
     codemap=json.loads(CODEMAP.read_text())
     res=_resolved_ids()
-    import re
     acted=0
     self_addr=json.loads(CFG.read_text()).get("self_address","")
     for m in _gog_search_replies():
         frm=(m.get("from") or "").lower()
         if not self_addr or self_addr.lower() not in frm:  # only the owner's own replies
             continue
-        body=_gog_body(m.get("id",""))
+        body, subj = _gog_body_and_subject(m.get("id", ""))
+        if _is_digest_outbound_subject(subj):
+            continue
         for mt in re.finditer(r"\b(APPROVE|REJECT)\s+([A-Za-z]\d+|[a-z0-9\-]{6,})\b", body, re.I):
             verb=mt.group(1).upper(); ref=mt.group(2)
             ent=codemap.get(ref) or codemap.get(ref.upper())

--- a/claude-ops/scripts/ops-pocket-approvals.py
+++ b/claude-ops/scripts/ops-pocket-approvals.py
@@ -110,7 +110,8 @@ def cmd_digest():
         CODEMAP.write_text(json.dumps(codemap,indent=2)); return 0
     ok,info,to=send_via_bridge(f"[Pocket] {len(items)} item(s) need approval", body)
     CODEMAP.write_text(json.dumps(codemap,indent=2))
-    NOTIFIED.write_text(json.dumps({"hash":h,"ts":time.time(),"count":len(items)}))
+    if ok:
+        NOTIFIED.write_text(json.dumps({"hash":h,"ts":time.time(),"count":len(items)}))
     log(f"digest: emailed {len(items)} items to {to} ok={ok} info={info}")
     return 0 if ok else 1
 
@@ -154,7 +155,11 @@ def cmd_replies():
             if ent["id"] in res: continue  # already resolved
             if verb=="APPROVE":
                 task=ent["raw"].get("task",ent["raw"]) if isinstance(ent["raw"],dict) else {}
-                task=dict(task); task["id"]=ent["id"]; task.setdefault("kind","action_item")
+                task=dict(task); task["id"]=ent["id"]
+                if ent.get("bucket")=="DRAFT":
+                    task["kind"]="action_item"
+                else:
+                    task.setdefault("kind","action_item")
                 task["approved_at"]=time.strftime('%Y-%m-%dT%H:%M:%SZ',time.gmtime())
                 open(TASKS,"a").write(json.dumps(task)+"\n")
                 open(RESOLVED,"a").write(json.dumps({"id":ent["id"],"decision":"APPROVE","ts":time.time()})+"\n")

--- a/claude-ops/scripts/ops-pocket-approvals.py
+++ b/claude-ops/scripts/ops-pocket-approvals.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""ops-pocket-approvals — surface ASK/DRAFT items to the owner by email and act
+on their APPROVE/REJECT replies.
+
+Modes:
+  --digest   email the owner the current open ASK (review.jsonl) + DRAFT
+             (drafts.jsonl) items, each with a short code (A1/D1...), via the
+             email-bridge SES backend. Idempotent: only emails when the open
+             set changed.
+  --replies  poll the owner's Gmail (gog) for "APPROVE <code|id>" /
+             "REJECT <code|id>" and act: APPROVE -> append the task to
+             tasks.jsonl (executor runs it; the worker keeps its own Rule-6
+             staging for any 3rd-party send); REJECT -> record dropped.
+             Idempotent via approval-resolved.jsonl.
+
+Recipient is locked to email-config.self_address. Self-notification to the
+owner only.
+
+Requires the SES email backend in ops-pocket-email-bridge.py (send_email's
+`backend`/`ses_cfg` kwargs) — see the related "SES email backend" PR.
+"""
+from __future__ import annotations
+import json, os, sys, time, subprocess
+from pathlib import Path
+
+STATE = Path(os.environ.get("POCKET_STATE_DIR", str(Path.home() / ".claude/state/pocket")))
+REVIEW = STATE / "review.jsonl"
+DRAFTS = STATE / "drafts.jsonl"
+TASKS = STATE / "tasks.jsonl"
+RESOLVED = STATE / "approval-resolved.jsonl"     # ids approved/rejected
+CODEMAP = STATE / "approval-codemap.json"        # code -> {id,kind,title}
+NOTIFIED = STATE / "approval-notified.json"      # hash of last-digested open set
+LOG = STATE / "approvals.log"
+CFG = STATE / "email-config.json"
+# Sibling scripts dir: env override, else this file's own directory.
+SCRIPTS = Path(os.environ.get("POCKET_SCRIPTS_DIR", str(Path(__file__).resolve().parent)))
+GOG = os.environ.get("POCKET_GOG_BIN", "gog")
+
+def log(m):
+    line=f"{time.strftime('%Y-%m-%dT%H:%M:%SZ',time.gmtime())} [approvals] {m}"
+    print(line, file=sys.stderr)
+    try: open(LOG,"a").write(line+"\n")
+    except OSError: pass
+
+def _load_jsonl(p):
+    out=[]
+    if p.exists():
+        for line in p.read_text().splitlines():
+            line=line.strip()
+            if not line: continue
+            try: out.append(json.loads(line))
+            except: pass
+    return out
+
+def _norm(item):
+    """Return (id, kind, title, ctx, raw) from a review/draft row (raw or wrapped)."""
+    t = item.get("task", item)
+    return (t.get("id") or item.get("id"),
+            t.get("kind") or item.get("kind","action_item"),
+            (t.get("title") or item.get("title") or "")[:120],
+            (t.get("context") or item.get("context") or "")[:600], t)
+
+def _resolved_ids():
+    return {r.get("id") for r in _load_jsonl(RESOLVED)}
+
+def open_items():
+    res=_resolved_ids()
+    items=[]
+    for src,tag in ((REVIEW,"ASK"),(DRAFTS,"DRAFT")):
+        for it in _load_jsonl(src):
+            iid,kind,title,ctx,raw=_norm(it)
+            if not iid or iid in res: continue
+            if any(x["id"]==iid for x in items): continue
+            items.append({"id":iid,"bucket":tag,"kind":kind,"title":title,"ctx":ctx,"raw":raw})
+    return items
+
+def send_via_bridge(subject, body):
+    """Reuse email-bridge send_email (SES backend) to mail the owner."""
+    sys.path.insert(0,str(SCRIPTS))
+    import importlib.util
+    spec=importlib.util.spec_from_file_location("ebridge", SCRIPTS/"ops-pocket-email-bridge.py")
+    eb=importlib.util.module_from_spec(spec); spec.loader.exec_module(eb)
+    cfg=json.loads(CFG.read_text())
+    to=cfg.get("self_address")
+    ok,info=eb.send_email(to, subject, body, backend=cfg.get("backend","gog"), ses_cfg=cfg)
+    return ok,info,to
+
+def cmd_digest():
+    items=open_items()
+    if not items:
+        log("digest: no open items"); return 0
+    codemap={}
+    a=d=0
+    lines=["Pending Pocket items need your decision. Reply to this email with one line per item:",
+           "  APPROVE <code>   (run it)","  REJECT <code>    (drop it)","",]
+    for it in items:
+        if it["bucket"]=="ASK": a+=1; code=f"A{a}"
+        else: d+=1; code=f"D{d}"
+        codemap[code]={"id":it["id"],"kind":it["kind"],"title":it["title"],"bucket":it["bucket"],"raw":it["raw"]}
+        lines.append(f"[{code}] ({it['bucket']}) {it['title']}")
+        if it["ctx"]: lines.append(f"      {it['ctx'][:240]}")
+        lines.append("")
+    body="\n".join(lines)
+    # idempotency: skip if same open set already notified
+    import hashlib
+    h=hashlib.sha256(json.dumps(sorted(c['id'] for c in codemap.values())).encode()).hexdigest()
+    prev=json.loads(NOTIFIED.read_text()).get("hash") if NOTIFIED.exists() else None
+    if h==prev:
+        log(f"digest: open set unchanged ({len(items)} items) — not re-emailing")
+        CODEMAP.write_text(json.dumps(codemap,indent=2)); return 0
+    ok,info,to=send_via_bridge(f"[Pocket] {len(items)} item(s) need approval", body)
+    CODEMAP.write_text(json.dumps(codemap,indent=2))
+    NOTIFIED.write_text(json.dumps({"hash":h,"ts":time.time(),"count":len(items)}))
+    log(f"digest: emailed {len(items)} items to {to} ok={ok} info={info}")
+    return 0 if ok else 1
+
+def _gog_search_replies():
+    """Find recent emails from the owner replying to approval digests."""
+    try:
+        r=subprocess.run([GOG,"gmail","search","subject:[Pocket] newer_than:2d","--max","15","-j","--results-only","--no-input"],
+                         capture_output=True,text=True,timeout=60,env=os.environ)
+        if r.returncode!=0:
+            log(f"gog search rc={r.returncode}: {r.stderr[:150]}"); return []
+        return json.loads(r.stdout or "[]")
+    except Exception as e:
+        log(f"gog search err {e}"); return []
+
+def _gog_body(msg_id):
+    try:
+        r=subprocess.run([GOG,"gmail","get",msg_id,"-j","--no-input"],capture_output=True,text=True,timeout=60,env=os.environ)
+        d=json.loads(r.stdout or "{}")
+        return (d.get("body") or d.get("snippet") or "")
+    except Exception: return ""
+
+def cmd_replies():
+    if not CODEMAP.exists(): log("replies: no codemap yet"); return 0
+    codemap=json.loads(CODEMAP.read_text())
+    res=_resolved_ids()
+    import re
+    acted=0
+    self_addr=json.loads(CFG.read_text()).get("self_address","")
+    for m in _gog_search_replies():
+        frm=(m.get("from") or "").lower()
+        if not self_addr or self_addr.lower() not in frm:  # only the owner's own replies
+            continue
+        body=_gog_body(m.get("id",""))
+        for mt in re.finditer(r"\b(APPROVE|REJECT)\s+([A-Za-z]\d+|[a-z0-9\-]{6,})\b", body, re.I):
+            verb=mt.group(1).upper(); ref=mt.group(2)
+            ent=codemap.get(ref) or codemap.get(ref.upper())
+            tid=ent["id"] if ent else (ref if any(c["id"]==ref for c in codemap.values()) else None)
+            if not ent and tid:
+                ent=next((c for c in codemap.values() if c["id"]==tid),None)
+            if not ent: continue
+            if ent["id"] in res: continue  # already resolved
+            if verb=="APPROVE":
+                task=ent["raw"].get("task",ent["raw"]) if isinstance(ent["raw"],dict) else {}
+                task=dict(task); task["id"]=ent["id"]; task.setdefault("kind","action_item")
+                task["approved_at"]=time.strftime('%Y-%m-%dT%H:%M:%SZ',time.gmtime())
+                open(TASKS,"a").write(json.dumps(task)+"\n")
+                open(RESOLVED,"a").write(json.dumps({"id":ent["id"],"decision":"APPROVE","ts":time.time()})+"\n")
+                log(f"APPROVE {ref} -> promoted {ent['id']} to tasks.jsonl"); acted+=1
+            else:
+                open(RESOLVED,"a").write(json.dumps({"id":ent["id"],"decision":"REJECT","ts":time.time()})+"\n")
+                log(f"REJECT {ref} -> dropped {ent['id']}"); acted+=1
+            res.add(ent["id"])
+    log(f"replies: acted={acted}")
+    return 0
+
+if __name__=="__main__":
+    mode=sys.argv[1] if len(sys.argv)>1 else "--digest"
+    sys.exit(cmd_digest() if mode=="--digest" else cmd_replies() if mode=="--replies" else 2)

--- a/claude-ops/scripts/ops-pocket-approvals.py
+++ b/claude-ops/scripts/ops-pocket-approvals.py
@@ -103,11 +103,11 @@ def cmd_digest():
     body="\n".join(lines)
     # idempotency: skip if same open set already notified
     import hashlib
-    h=hashlib.sha256(json.dumps(sorted(c['id'] for c in codemap.values())).encode()).hexdigest()
+    h=hashlib.sha256(json.dumps([(it["id"], it["bucket"]) for it in items]).encode()).hexdigest()
     prev=json.loads(NOTIFIED.read_text()).get("hash") if NOTIFIED.exists() else None
     if h==prev:
         log(f"digest: open set unchanged ({len(items)} items) — not re-emailing")
-        CODEMAP.write_text(json.dumps(codemap,indent=2)); return 0
+        return 0
     ok,info,to=send_via_bridge(f"[Pocket] {len(items)} item(s) need approval", body)
     CODEMAP.write_text(json.dumps(codemap,indent=2))
     if ok:

--- a/claude-ops/scripts/systemd/pocket-approval-digest.service
+++ b/claude-ops/scripts/systemd/pocket-approval-digest.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Pocket Approvals — email the owner pending ASK/DRAFT items (digest)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=__USER__
+Group=__USER__
+WorkingDirectory=__HOME__
+# Doppler service token injects GOG_KEYRING_PASSWORD + GOG_ACCOUNT (same as
+# pocket-email-bridge.service). Digest sends via the email-bridge SES backend.
+LoadCredential=doppler-token:/etc/pocket/doppler-token
+Environment=HOME=__HOME__
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=POCKET_STATE_DIR=__HOME__/.claude/state/pocket
+Environment=POCKET_GOG_BIN=/usr/local/bin/gog
+ExecStart=/bin/bash -c 'DOPPLER_TOKEN=$(cat $CREDENTIALS_DIRECTORY/doppler-token) /usr/local/bin/doppler run --silent -- __HOME__/.venv-pocket/bin/python3 __PLUGIN_ROOT__/scripts/ops-pocket-approvals.py --digest'
+StandardOutput=append:__HOME__/.claude/state/pocket/approvals.log
+StandardError=append:__HOME__/.claude/state/pocket/approvals-stderr.log

--- a/claude-ops/scripts/systemd/pocket-approval-digest.timer
+++ b/claude-ops/scripts/systemd/pocket-approval-digest.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run pocket-approval digest every 10 minutes
+Requires=pocket-approval-digest.service
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=10min
+AccuracySec=30s
+
+[Install]
+WantedBy=timers.target

--- a/claude-ops/scripts/systemd/pocket-approval-replies.service
+++ b/claude-ops/scripts/systemd/pocket-approval-replies.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Pocket Approvals — read the owner's APPROVE/REJECT email replies
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=__USER__
+Group=__USER__
+WorkingDirectory=__HOME__
+LoadCredential=doppler-token:/etc/pocket/doppler-token
+Environment=HOME=__HOME__
+Environment=PATH=/usr/local/bin:/usr/bin:/bin
+Environment=POCKET_STATE_DIR=__HOME__/.claude/state/pocket
+Environment=POCKET_GOG_BIN=/usr/local/bin/gog
+ExecStart=/bin/bash -c 'DOPPLER_TOKEN=$(cat $CREDENTIALS_DIRECTORY/doppler-token) /usr/local/bin/doppler run --silent -- __HOME__/.venv-pocket/bin/python3 __PLUGIN_ROOT__/scripts/ops-pocket-approvals.py --replies'
+StandardOutput=append:__HOME__/.claude/state/pocket/approvals.log
+StandardError=append:__HOME__/.claude/state/pocket/approvals-stderr.log

--- a/claude-ops/scripts/systemd/pocket-approval-replies.timer
+++ b/claude-ops/scripts/systemd/pocket-approval-replies.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run pocket-approval replies poller every 2 minutes
+Requires=pocket-approval-replies.service
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=2min
+AccuracySec=15s
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## What

Upstreams the Pocket pipeline worker-execution + approval fixes made directly on the always-online dev box this session.

### 1. Worker execution — workers can now browse + do real work
- `ops-cron-pocket-executor.py`: rewrote `WORKER_PROMPT_TEMPLATE` so headless `claude -p` workers know they have a **real headless browser** (gstack `browse` CLI — works on Linux, never "Mac-only"), plus `dcli` (Dashlane) / `gog` (Gmail) / AWS CLI / Cloudflare API availability. Paths use `$HOME` + env vars (Rule 0).
- Root cause of the prior 0-byte worker output: the executor systemd oneshot's default `KillMode=control-group` SIGKILLed the spawned worker cgroup on exit. `pocket-executor.service` already carries `KillMode=process` in this repo, so no unit change is needed here — documenting it for traceability.

### 2. ASK/DRAFT email approval loop (NEW)
- `ops-pocket-approvals.py`: 
  - `--digest` emails the owner the open ASK (`review.jsonl`) + DRAFT (`drafts.jsonl`) items as a coded list (A1/D1…) via the email-bridge **SES** backend. Idempotent — only re-emails when the open set changes.
  - `--replies` polls the owner's Gmail (`gog`) for `APPROVE <code>` / `REJECT <code>` (owner-sender-gated), promotes APPROVEd tasks to `tasks.jsonl` (executor runs them; worker keeps its own Rule-6 staging for any 3rd-party send) or records REJECT. Idempotent via `approval-resolved.jsonl`.
  - Key fix: `send_via_bridge` passes `backend=ses` + `ses_cfg` — gog can't send on a headless box, SES can.
- systemd: `pocket-approval-digest` (10 min) + `pocket-approval-replies` (2 min).

## Verified on the box
- Worker exec fixed → real outputs: a real SEO PR shipped from a spoken Pocket note, Framer-migration audit, drip-email audit, `uname` self-test.
- Approval loop: digest email lands in the owner's inbox via SES; APPROVE→promote→run and REJECT→drop both proven.

## Dependencies
- **Requires** the SES email backend PR **#345** (`send_email` `backend`/`ses_cfg` kwargs) — `ops-pocket-approvals.py` imports it.
- Complements the webhook-ingest PR **#343**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automated workers gain browser/credential/infra tooling, and email parsing promotes tasks into the execution queue—mitigated by owner-only replies and idempotent resolution, but still expands what headless agents can attempt.
> 
> **Overview**
> Headless Pocket workers get a much richer **single-shot** briefing: they are told to use **gstack `browse`** (and chrome-devtools MCP) on Linux, **`dcli`** / cookie import for logins, **`gog`** for Gmail/Calendar, plus AWS/Cloudflare—replacing the prior “read-only tools only” framing while keeping outbound-send and destructive-op guardrails.
> 
> A new **`ops-pocket-approvals.py`** loop emails the owner coded **ASK** (`review.jsonl`) and **DRAFT** (`drafts.jsonl`) items via the email-bridge **`send_email`** path (configured `backend` / `ses_cfg`), re-sending only when the open set changes. A **`--replies`** mode polls the owner’s Gmail for `APPROVE` / `REJECT` lines, promotes approvals into **`tasks.jsonl`** for the executor, and records rejects in **`approval-resolved.jsonl`**. **systemd** timers run digest (~10m) and reply polling (~2m) under Doppler, same pattern as other Pocket services.
> 
> Depends on the SES-capable email-bridge changes; complements existing executor **`KillMode=process`** (documented elsewhere) so workers are not SIGKILL’d when the oneshot unit exits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e28311d5596d6f29249ffab9cb5c56f5803215be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->