### PR TITLE
feat(ops-bg): add `send` subcommand to inject input into running bg sessions

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.11.2",
+  "version": "2.11.3",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.11.3] — 2026-05-25
+
 ### Added
+
+- **`ops-bg send <id> "<msg>"`** (#349) — inject a user message into a running `claude --bg` session without attaching its TUI. Useful when a backgrounded session is blocked on an `AskUserQuestion` and you already know the answer, when an orchestrator wants to nudge / ack / close a shipped session from automation, or as a non-UI escape hatch when the dashboard's "awaiting input" panel breaks.
+  - `claude-ops/scripts/bg-send.py` — talks to the supervisor's UNIX control socket at `/tmp/cc-daemon-<uid>/<sha8>/control.sock` (instance dir discovered from `~/.claude/daemon/roster.json`) and issues a newline-delimited JSON `{"proto":1,"op":"reply","short":"<8 hex chars>","text":"..."}\n` message. Protocol reverse-engineered from claude `2.1.150`.
+  - `claude-ops/bin/ops-bg send` — thin shell wrapper that shells out to the helper. Aliases: `reply`, `msg`.
 
 - **`/ops:desktop` skill + `desktop-act` MCP wiring** — autonomous desktop + browser control surfaced as a first-class ops command. Acquires a noVNC desktop session, takes screenshots, clicks, types, scrolls, and runs the autonomous `act()` loop driven by the bundled `claude-agent-sdk` (OAuth via Claude Max, no Anthropic API key). Cross-platform launcher (Linux full / macOS / Windows partial).
 - **`mcp-servers/desktop-act-launcher.py`** — pure-Python cross-platform launcher. Resolves an installed `desktop-act` companion in (1) `$DESKTOP_ACT_COMMAND`, (2) `$DESKTOP_ACT_HOME`, (3) `$CLAUDE_CONFIG_DIR/plugins/marketplaces/desktop-act`, (4) the per-OS Claude config dir, (5) the per-user cache (`$XDG_CACHE_HOME` on Linux, `~/Library/Caches` on macOS, `%LOCALAPPDATA%` on Windows). If none exist it `git clone`s `$DESKTOP_ACT_REPO` (default Lifecycle-Innovations-Limited/desktop-act), bootstraps a venv, `pip install -r requirements.txt`, then `execv`s the runner. Falls back to a clear error message — never hangs the MCP host.

--- a/claude-ops/bin/ops-bg
+++ b/claude-ops/bin/ops-bg
@@ -11,6 +11,8 @@
 #   status                      Supervisor health summary.
 #   attach <id>                 Re-attach an existing session in this terminal.
 #   logs <id>                   Print recent output from a session.
+#   send <id> "<msg>"           Inject a user message into a running session
+#                               without attaching (mimics typing + Enter).
 #   stop <id>                   Stop a session (also: kill).
 #   rm <id>                     Remove a session from the roster.
 #   respawn [<id>|--all]        Restart sessions (e.g. to pick up a CC upgrade).
@@ -26,6 +28,7 @@
 #   ops-bg list
 #   ops-bg list --json | jq '.[] | select(.status=="busy")'
 #   ops-bg logs 7c5dcf5d
+#   ops-bg send  7c5dcf5d "ack — close this session"
 #   ops-bg respawn --all   # after `claude` binary upgrade
 
 set -u
@@ -50,7 +53,7 @@ if [ -z "$CLAUDE_BIN" ] || [ ! -x "$CLAUDE_BIN" ]; then
 fi
 
 USAGE() {
-  sed -n '2,30p' "$0"
+  sed -n '2,32p' "$0"
   exit "${1:-0}"
 }
 
@@ -124,6 +127,22 @@ cmd_passthrough() {
   exec "$CLAUDE_BIN" "$sub" "$@"
 }
 
+cmd_send() {
+  if [ $# -lt 2 ]; then
+    echo "ops-bg send: usage: send <id> \"<message>\"" >&2
+    exit 2
+  fi
+  local id="$1"; shift
+  local msg="$*"
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" && pwd)"
+  if [ ! -x "$script_dir/bg-send.py" ]; then
+    echo "ops-bg send: bg-send.py not found at $script_dir/bg-send.py" >&2
+    exit 127
+  fi
+  exec python3 "$script_dir/bg-send.py" "$id" "$msg"
+}
+
 cmd_respawn() {
   if [ "${1:-}" = "--all" ]; then
     exec "$CLAUDE_BIN" respawn --all
@@ -141,6 +160,7 @@ case "$SUB" in
   status)                cmd_status ;;
   attach|a)              cmd_passthrough attach "$@" ;;
   logs|log|tail)         cmd_passthrough logs "$@" ;;
+  send|reply|msg)        cmd_send "$@" ;;
   stop|kill)             cmd_passthrough stop "$@" ;;
   rm|remove)             cmd_passthrough rm "$@" ;;
   respawn|restart)       cmd_respawn "$@" ;;

--- a/claude-ops/bin/ops-bg
+++ b/claude-ops/bin/ops-bg
@@ -136,7 +136,7 @@ cmd_send() {
   local msg="$*"
   local script_dir
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" && pwd)"
-  if [ ! -x "$script_dir/bg-send.py" ]; then
+  if [ ! -f "$script_dir/bg-send.py" ]; then
     echo "ops-bg send: bg-send.py not found at $script_dir/bg-send.py" >&2
     exit 127
   fi

--- a/claude-ops/scripts/bg-send.py
+++ b/claude-ops/scripts/bg-send.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+bg-send — inject a user message into a running `claude --bg` session.
+
+Talks to the Claude Code background-session supervisor's control socket
+(`/tmp/cc-daemon-<uid>/<sha8>/control.sock`) and issues a `reply` op.
+
+Wire format (reverse-engineered from claude 2.1.150 by stracing
+`claude logs <short>`): newline-delimited JSON. One line per message.
+
+Reply payload:
+  {"proto":1,"op":"reply","short":"<8 hex chars>","text":"<message>"}\\n
+
+Exit codes: 0 ok, 2 usage, 3 socket missing, 4 send failure, 5 supervisor error.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sys
+from pathlib import Path
+
+ROSTER_PATH = Path.home() / ".claude" / "daemon" / "roster.json"
+PROTO = 1
+SHORT_LEN = 8
+
+
+def discover_control_sock() -> Path:
+    """The supervisor's control socket lives at
+    /tmp/cc-daemon-<uid>/<sha8>/control.sock. The instance dir is the SHA-256
+    (first 8 hex) of the supervisor's resolved cwd, but it isn't published on
+    its own — each worker's rendezvousSock starts with the same dir, so we
+    pull it from the roster."""
+    if ROSTER_PATH.exists():
+        try:
+            roster = json.loads(ROSTER_PATH.read_text())
+            for w in (roster.get("workers") or {}).values():
+                rv = w.get("rendezvousSock", "")
+                if "/rv/" in rv:
+                    sock = Path(rv.split("/rv/")[0]) / "control.sock"
+                    if sock.exists():
+                        return sock
+        except (json.JSONDecodeError, OSError):
+            pass
+    uid = os.getuid()
+    base = Path(f"/tmp/cc-daemon-{uid}")
+    if base.is_dir():
+        for inst in base.iterdir():
+            sock = inst / "control.sock"
+            if sock.exists():
+                return sock
+    raise FileNotFoundError("could not discover supervisor control.sock")
+
+
+def normalize_short(session_id: str) -> str:
+    s = session_id.lower().strip().split("-")[0]
+    if len(s) < SHORT_LEN or not all(c in "0123456789abcdef" for c in s[:SHORT_LEN]):
+        raise ValueError(f"session id {session_id!r} does not start with 8 hex chars")
+    return s[:SHORT_LEN]
+
+
+def send_reply(short: str, text: str, timeout: float = 3.0) -> dict:
+    sock_path = discover_control_sock()
+    msg = {"proto": PROTO, "op": "reply", "short": short, "text": text}
+    line = json.dumps(msg, separators=(",", ":")) + "\n"
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
+        s.connect(str(sock_path))
+        s.sendall(line.encode("utf-8"))
+        s.settimeout(timeout)
+        buf = b""
+        try:
+            while b"\n" not in buf and len(buf) < 65536:
+                chunk = s.recv(4096)
+                if not chunk:
+                    break
+                buf += chunk
+        except socket.timeout:
+            pass
+    if not buf:
+        return {
+            "ok": True,
+            "note": "no response (reply ops are typically fire-and-forget)",
+        }
+    first_line = buf.split(b"\n", 1)[0].decode("utf-8", "replace")
+    try:
+        return json.loads(first_line)
+    except json.JSONDecodeError:
+        return {"ok": False, "raw": first_line[:300]}
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print("usage: bg-send <session-id-or-short> <text>", file=sys.stderr)
+        return 2
+    try:
+        short = normalize_short(argv[1])
+    except ValueError as e:
+        print(f"bg-send: {e}", file=sys.stderr)
+        return 2
+    try:
+        result = send_reply(short, argv[2])
+    except FileNotFoundError as e:
+        print(f"bg-send: {e}", file=sys.stderr)
+        return 3
+    except OSError as e:
+        print(f"bg-send: socket error: {e}", file=sys.stderr)
+        return 4
+    print(json.dumps(result))
+    if isinstance(result, dict) and result.get("ok") is False:
+        return 5
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary

Adds `ops-bg send <id> "<msg>"` for injecting a user message into a running `claude --bg` session without attaching the TUI.

Useful when:
- A backgrounded session is blocked on an `AskUserQuestion` and you already know the answer
- An orchestrator wants to nudge / ack / close a shipped session from automation
- The TUI dashboard's "awaiting input" panel breaks and you need a non-UI escape hatch (this is exactly what motivated the work — three idle sessions were invisible in the TUI counter today)

## How it works

- `claude-ops/scripts/bg-send.py` — talks to the supervisor's UNIX control socket at `/tmp/cc-daemon-<uid>/<sha8>/control.sock`. The `<sha8>` instance dir is discovered from `~/.claude/daemon/roster.json` (each worker's `rendezvousSock` field carries the path prefix).
- Wire format is **newline-delimited JSON** (reverse-engineered from claude `2.1.150` by stracing `claude logs <short>`):
  ```
  {"proto":1,"op":"reply","short":"<8 hex chars>","text":"<message>"}\n
  ```
- Supervisor replies with `{"ok":true,"op":"reply"}` on success.
- `claude-ops/bin/ops-bg send` shells out to the helper.

## Smoke test

Targeted an idle session that had already shipped its `result:`:

```
$ ./claude-ops/bin/ops-bg send 4541cbdd "ack — close this session"
{"ok": true, "op": "reply"}
```

Confirmed via session transcript that the message landed as a user-role turn and the session woke up and processed it.

## Test plan

- [x] `tests/test-no-secrets.sh` — 14/14 PASS
- [x] End-to-end smoke against a real idle background session
- [x] `ops-bg help` shows new subcommand in the usage block
- [x] Helper handles missing supervisor socket (exit 3), bad short id (exit 2), socket errors (exit 4)
- [ ] Cross-machine: only validated on Linux (Amazon Linux 2023). macOS path layout should be identical (`/tmp/cc-daemon-<uid>/...`), but unverified.

## Notes

- Targets `main` because this repo has no `dev` branch (workspace CLAUDE.md is stale on that point — sibling PRs land directly on main).
- Protocol is technically internal/undocumented. If `claude` changes the framing (e.g. switches to length-prefixed binary on the control sock), `bg-send.py` will need an update; the symptom would be `{"ok": true, "note": "no response..."}` instead of a real ack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local-only Unix socket messaging to the existing bg supervisor; no auth or network exposure, with minor coupling risk if Claude Code changes the undocumented control protocol.
> 
> **Overview**
> Adds **`ops-bg send <id> "<msg>"`** (aliases `reply`, `msg`) so you can inject a user turn into a running `claude --bg` session **without** attaching the TUI—handy when a session is waiting on `AskUserQuestion`, when automation needs to nudge or close a worker, or when the dashboard’s “awaiting input” UI is wrong.
> 
> **`scripts/bg-send.py`** discovers the supervisor’s Unix socket via `~/.claude/daemon/roster.json` (or `/tmp/cc-daemon-<uid>/…/control.sock`) and sends newline-delimited JSON `{"proto":1,"op":"reply","short":"<8 hex>","text":"..."}`. **`bin/ops-bg`** delegates to that helper. Release notes bump the plugin to **2.11.3** in `plugin.json` and `CHANGELOG.md`.
> 
> **Note:** The control-socket protocol is reverse-engineered from Claude Code 2.1.150 and may need updates if the supervisor changes framing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 809040cca3b642c934986cad4dfff062e0df558a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 2.11.3

* **New Features**
  * Added `ops-bg send <id> "<msg>"` command to inject user messages into backgrounded Claude sessions without attaching to the interactive interface. Particularly useful when a background agent awaits user input. Command also supports convenient aliases: `reply` and `msg`.

* **Chores**
  * Version bumped to 2.11.3.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->