### PR TITLE
feat(telegram): bot-token push to operator's own chat

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **`ops-telegram-bot-send`** — lightweight bot-token push to the operator's own Telegram chat, the companion to the user-account MCP server. Reads `TELEGRAM_BOT_TOKEN` + `TELEGRAM_OWNER_ID` from env or `preferences.json .channels.telegram.*` (zero hardcoded ids, Rule 0). Default recipient is the operator; `--to <chat_id>` overrides; `OPS_DRY_RUN=1` previews without sending.
+  - For users who want notifications / bidirectional comms without the interactive gram.js phone+code login: provision a @BotFather token, `/start` the bot, grab the numeric chat id from @userinfobot, set the two values, done.
+  - `docs/telegram-bot-send.md` documents setup and the **self-channel exception** for `block-outbound-comms.py` — sends to the operator's own chat are operational self-notifications and skip the approval token (mirroring the existing email / WhatsApp / iMessage self-channel exceptions), while third-party Telegram sends stay gated under Rule 6.
+
 ## [2.11.3] — 2026-05-25
 
 ### Added

--- a/claude-ops/bin/ops-telegram-bot-send
+++ b/claude-ops/bin/ops-telegram-bot-send
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# ops-telegram-bot-send — push a Telegram message to the operator's OWN chat
+# via the Bot API. This is the lightweight, operator-self companion to the
+# user-account MCP server (telegram-server/index.js): the MCP path reads DMs
+# and powers /ops-inbox; this path only ever pushes notifications to YOU.
+#
+# Why a bot, not the user account: a bot token is trivial to provision
+# (@BotFather), needs no phone/2FA login flow, and can only message users who
+# have already /start-ed the bot — so it is the natural channel for one-way
+# operator notifications (fleet check-ins, briefings, fire alerts, rotation
+# results) and for the inbound→outbound round-trip when paired with the
+# polling listener (ops-message-listener.sh).
+#
+# Credentials resolved from env or preferences.json — zero hardcoded values
+# (Rule 0). Nothing here is account-specific; every deployment supplies its
+# own token + chat id.
+#
+#   TELEGRAM_BOT_TOKEN   bot token from @BotFather (e.g. 123456789:AA...)
+#   TELEGRAM_OWNER_ID    numeric chat id of the operator (from @userinfobot)
+#
+# Both also fall back to preferences.json .channels.telegram.{bot_token,owner_id}.
+#
+# Usage:
+#   ops-telegram-bot-send "your message"        # message as arg
+#   echo "your message" | ops-telegram-bot-send  # message on stdin
+#   ops-telegram-bot-send --to <chat_id> "msg"   # override recipient (still gated, see below)
+#
+# Outbound-comms gate (Rule 6): this script shells out to the Telegram Bot API,
+# which a personal `block-outbound-comms.py` hook will block by default. Because
+# the DEFAULT recipient is the operator's own chat, sends to TELEGRAM_OWNER_ID
+# are operational self-notifications, not human-to-human comms. Add the
+# self-channel exception documented in docs/telegram-bot-send.md so sends to
+# your own chat skip the approval token while third-party chats stay gated.
+#
+#   OPS_DRY_RUN=1   Print the planned request (token redacted) and exit 0.
+set -euo pipefail
+
+DATA_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+PREFS="$DATA_DIR/preferences.json"
+
+prefs_get() {
+  # $1 = jq path expression; prints value or empty
+  [ -f "$PREFS" ] || return 0
+  jq -r "${1} // empty" "$PREFS" 2>/dev/null || true
+}
+
+TOKEN="${TELEGRAM_BOT_TOKEN:-$(prefs_get '.channels.telegram.bot_token')}"
+OWNER="${TELEGRAM_OWNER_ID:-$(prefs_get '.channels.telegram.owner_id')}"
+
+# Optional --to override (e.g. a group the operator owns). Parsed before body.
+TO="$OWNER"
+if [ "${1:-}" = "--to" ]; then
+  TO="${2:-}"
+  shift 2
+fi
+
+if [ -z "$TOKEN" ]; then
+  echo "ops-telegram-bot-send: no TELEGRAM_BOT_TOKEN (env or preferences.json .channels.telegram.bot_token)" >&2
+  echo "  See docs/telegram-bot-send.md for setup." >&2
+  exit 2
+fi
+if [ -z "$TO" ]; then
+  echo "ops-telegram-bot-send: no recipient — set TELEGRAM_OWNER_ID or pass --to <chat_id>" >&2
+  exit 2
+fi
+
+# Message body: positional arg wins, else stdin.
+TEXT="${1:-}"
+if [ -z "$TEXT" ] && [ ! -t 0 ]; then
+  TEXT="$(cat)"
+fi
+if [ -z "$TEXT" ]; then
+  echo "ops-telegram-bot-send: empty message (pass as arg or pipe on stdin)" >&2
+  exit 2
+fi
+
+if [ "${OPS_DRY_RUN:-}" = "1" ]; then
+  echo "[dry-run] POST https://api.telegram.org/bot<redacted>/sendMessage"
+  echo "[dry-run]   chat_id=$TO"
+  echo "[dry-run]   text=${TEXT}"
+  exit 0
+fi
+
+curl -sS -X POST \
+  "https://api.telegram.org/bot${TOKEN}/sendMessage" \
+  --data-urlencode "chat_id=${TO}" \
+  --data-urlencode "text=${TEXT}" \
+  --data-urlencode "parse_mode=Markdown" \
+  --data-urlencode "disable_web_page_preview=true" \
+  | jq -e '.ok == true' >/dev/null \
+  && echo "✓ sent to ${TO}" \
+  || { echo "ops-telegram-bot-send: send failed (check token / chat_id / that the recipient has /start-ed the bot)" >&2; exit 1; }

--- a/claude-ops/docs/INDEX.md
+++ b/claude-ops/docs/INDEX.md
@@ -31,6 +31,7 @@
 | [`marketplace-submissions.md`](marketplace-submissions.md) | Publishing your own plugin to the same marketplace. |
 | [`memories-system.md`](memories-system.md) | The cross-session memory system used by agents. |
 | [`notifications.md`](notifications.md) | Notification channel setup (macos/ntfy/pushover/discord/telegram). |
+| [`telegram-bot-send.md`](telegram-bot-send.md) | Bot-token push to the operator's own Telegram chat + the outbound-hook self-channel exception. |
 | [`os-compatibility.md`](os-compatibility.md) | macOS / Linux / WSL feature matrix. |
 
 ## External

--- a/claude-ops/docs/telegram-bot-send.md
+++ b/claude-ops/docs/telegram-bot-send.md
@@ -1,0 +1,112 @@
+# Telegram bot-token push (operator self-notifications)
+
+`bin/ops-telegram-bot-send` pushes a message to **your own** Telegram chat using a
+Bot API token. It is the lightweight companion to the user-account MCP server
+(`telegram-server/index.js`):
+
+| | User-account MCP (`mcp__…telegram…`) | Bot token (`ops-telegram-bot-send`) |
+|---|---|---|
+| Auth | phone + 2 login codes + optional 2FA → gram.js session | one token from @BotFather |
+| Reads your DMs | yes (powers `/ops-inbox telegram`) | no |
+| Pushes to you | yes | yes |
+| Setup cost | high (interactive login, rate-limited) | low (paste token + chat id) |
+| Best for | inbox triage | one-way notifications, bidirectional round-trip with the polling listener |
+
+If all you want is for ops skills (briefings, fire alerts, rotation results) to
+**reach your phone** — and to reply via the bot back into your session through
+`ops-message-listener.sh` — the bot token is the simpler path.
+
+## Setup
+
+1. **Create a bot** — message [@BotFather](https://t.me/BotFather), `/newbot`, copy
+   the token (`123456789:AA...`).
+2. **/start your bot** from your own Telegram account (a bot cannot message a user
+   who has not started it).
+3. **Find your numeric chat id** — message [@userinfobot](https://t.me/userinfobot);
+   it replies with your `Id`.
+4. **Provide the credentials** — either env vars (preferred for daemons) or
+   `preferences.json`:
+
+   ```bash
+   export TELEGRAM_BOT_TOKEN="123456789:AA..."   # from @BotFather
+   export TELEGRAM_OWNER_ID="123456789"          # your numeric chat id
+   ```
+
+   or in `~/.claude/plugins/data/ops-ops-marketplace/preferences.json`:
+
+   ```json
+   { "channels": { "telegram": { "bot_token": "123456789:AA...", "owner_id": "123456789" } } }
+   ```
+
+5. **Send a test:**
+
+   ```bash
+   ops-telegram-bot-send "✅ bot push works"
+   # or
+   echo "from stdin" | ops-telegram-bot-send
+   ```
+
+## Outbound-comms gate (Rule 6) — required self-channel exception
+
+This script calls the Telegram Bot API, which the reference
+`block-outbound-comms.py` PreToolUse hook blocks by default (the `Telegram bot`
+pattern). That is correct: sending to *other people* over Telegram is
+human-to-human comms and must stay gated behind per-message approval.
+
+Sending to **your own** chat (`TELEGRAM_OWNER_ID`) is an operational
+self-notification, not human-to-human comms — the same category as the existing
+email / WhatsApp / iMessage self-channel exceptions. To let those through
+without the one-shot approval token while keeping third-party Telegram gated,
+add a self-channel exception to your personal hook
+(`~/.claude/scripts/hooks/block-outbound-comms.py`):
+
+```python
+# --- with the other SELF_* loaders ---
+def _load_self_telegram_ids() -> set:
+    """Operator's own Telegram chat id(s). Sends here are self-notifications,
+    not human-to-human comms. Sourced from env or preferences.json — never
+    hardcoded (Rule 0)."""
+    out = set()
+    v = (os.environ.get("TELEGRAM_OWNER_ID") or "").strip()
+    if v:
+        out.add(v)
+    try:
+        with open(os.path.join(_HOME, ".claude/plugins/data/ops-ops-marketplace/preferences.json")) as f:
+            oid = ((json.load(f).get("channels") or {}).get("telegram") or {}).get("owner_id")
+        if oid:
+            out.add(str(oid).strip())
+    except (OSError, json.JSONDecodeError):
+        pass
+    return out
+
+SELF_TELEGRAM_IDS = _load_self_telegram_ids()
+
+def _telegram_curl_is_self(cmd: str) -> bool:
+    """True iff every chat_id targeted by a Telegram Bot API call is the
+    operator's own chat. Mixed/third-party recipients stay gated."""
+    if not SELF_TELEGRAM_IDS:
+        return False
+    ids = re.findall(r'chat_id["\s=:&]+(-?\d+)', cmd)
+    return bool(ids) and all(i in SELF_TELEGRAM_IDS for i in ids)
+```
+
+Then, in `main()`, right after `reason = detect_outbound_bash(cmd)`:
+
+```python
+        # Self-channel exception: Telegram Bot API sends to the operator's own
+        # chat are operational notifications, not human-to-human comms.
+        if reason == 'Telegram bot' and _telegram_curl_is_self(cmd):
+            reason = None
+```
+
+With that in place, `ops-telegram-bot-send` (default recipient = owner) flows
+freely; any `--to <other-chat>` or third-party bot send still trips the gate and
+requires the approval token. This mirrors `_bash_recipient_is_self` (email),
+`SELF_JIDS` (WhatsApp), and `_imessage_chat_id_is_self` (iMessage).
+
+## Bidirectional round-trip
+
+Pair this with `ops-message-listener.sh` (polls `getUpdates` with the same bot
+token) for a full loop: you DM the bot → the listener enqueues → your session
+resumes with the message → replies go back out via `ops-telegram-bot-send`. No
+user-account session required.


### PR DESCRIPTION
## What

Adds `bin/ops-telegram-bot-send` — a lightweight bot-token push to the **operator's own** Telegram chat, the companion to the existing user-account MCP server (`telegram-server/index.js`).

| | User-account MCP | Bot token (this PR) |
|---|---|---|
| Auth | phone + 2 codes + 2FA → gram.js session | one @BotFather token |
| Reads DMs | yes (`/ops-inbox`) | no |
| Pushes to operator | yes | yes |
| Setup cost | high (interactive, rate-limited) | low |

For users who just want ops notifications / a bidirectional round-trip (paired with `ops-message-listener.sh`) without the interactive gram.js login.

## How

- Reads `TELEGRAM_BOT_TOKEN` + `TELEGRAM_OWNER_ID` from env or `preferences.json .channels.telegram.*` — **zero hardcoded ids (Rule 0)**.
- Default recipient is the operator; `--to <chat_id>` overrides; `OPS_DRY_RUN=1` previews.
- `docs/telegram-bot-send.md` documents setup + the **self-channel exception** for the personal `block-outbound-comms.py` hook: sends to the operator's own chat are operational self-notifications and skip the approval token, mirroring the existing email / WhatsApp / iMessage self-channel exceptions — **third-party Telegram sends stay gated under Rule 6.**

## Verification

- `bash -n` syntax OK
- `OPS_DRY_RUN=1` smoke: redacts token, correct chat_id/text
- `tests/test-no-secrets.sh`: **14 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an optional outbound notification script and documentation only; no changes to auth, shared hooks in-repo, or default daemon behavior.
> 
> **Overview**
> Adds **`bin/ops-telegram-bot-send`**, a Bot API helper for one-way pushes to the operator’s own Telegram chat (arg or stdin, optional `--to`, `OPS_DRY_RUN=1`), as a lighter alternative to the gram.js user-account MCP path.
> 
> Credentials come from **`TELEGRAM_BOT_TOKEN`** / **`TELEGRAM_OWNER_ID`** or **`preferences.json`** under `.channels.telegram.*` with no hardcoded IDs. The script POSTs to `sendMessage` with Markdown and validates `.ok` via `jq`.
> 
> **`docs/telegram-bot-send.md`** covers @BotFather setup, compares MCP vs bot-token flows, and documents a **personal** `block-outbound-comms.py` self-channel exception so default owner sends count as self-notifications while other `chat_id`s stay Rule 6–gated. **`CHANGELOG.md`** and **`docs/INDEX.md`** index the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e391ff5b8466daa2d23007c07ff136201d8fb7ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telegram bot messaging for operator self-notifications with configurable credentials via environment variables or config file, plus dry-run preview mode.

* **Documentation**
  * Telegram bot setup guide covering configuration steps, test commands, and integration patterns for bidirectional communication flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/354?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->