### PR TITLE
fix(rotation): prefer private accounts over teams/org (2.11.4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.11.2",
+      "version": "2.11.4",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.11.3",
+  "version": "2.11.4",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.11.4] — 2026-05-27
+
+### Fixed
+
+- **Rotation prefers PRIVATE accounts over TEAMS/org accounts** — `scripts/account-rotation/rotate.mjs` account selection now treats team-ness (accounts carrying `orgName`/`orgUuid`) as the PRIMARY sort key and utilization as secondary, so a personal Max account is always chosen over an org/Teams account when viable. Org accounts route through claude.ai's org chooser + Google Workspace push-2FA, which headless browser auth cannot clear — picking one on raw utilization (e.g. a low-util Teams account) caused rotation to stall on 2FA and fail. A team account is now only ever selected when no private account is viable.
+
 ### Added
 
 - **`ops-telegram-bot-send`** — lightweight bot-token push to the operator's own Telegram chat, the companion to the user-account MCP server. Reads `TELEGRAM_BOT_TOKEN` + `TELEGRAM_OWNER_ID` from env or `preferences.json .channels.telegram.*` (zero hardcoded ids, Rule 0). Default recipient is the operator; `--to <chat_id>` overrides; `OPS_DRY_RUN=1` previews without sending.

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -409,6 +409,21 @@ function pickNextAccount(config, state, liveUtil = {}, opts = {}) {
   const excludeKey = (a) =>
     a.disabled === true || accountKey(a) === activeKey || (!allowExtraUsage && hasExtraUsageEnabled(a));
 
+  // Prefer PRIVATE (personal) accounts over TEAMS/org accounts. Org accounts
+  // (those carrying orgName/orgUuid) route through claude.ai's org chooser and
+  // Google Workspace push-2FA, which headless browser auth cannot clear — so a
+  // team account that wins on raw utilization still fails to rotate. Treat
+  // team-ness as the PRIMARY sort key (private first), utilization secondary,
+  // so a team account is only ever picked when no private account is viable.
+  const isTeamAccount = (a) =>
+    !!(a.orgUuid || (a.orgName && String(a.orgName).toLowerCase() !== String(a.email || '').toLowerCase()));
+  const byPrivateThenScore = (a, b) => {
+    const ta = isTeamAccount(a) ? 1 : 0;
+    const tb = isTeamAccount(b) ? 1 : 0;
+    if (ta !== tb) return ta - tb; // private (0) before team (1)
+    return score(a) - score(b);
+  };
+
   // Separate normal and low-priority, excluding current active + extra-usage accounts
   const normal = config.accounts.filter((a) => a.priority !== 'low' && !excludeKey(a));
   const low = config.accounts.filter((a) => a.priority === 'low' && !excludeKey(a));
@@ -422,8 +437,8 @@ function pickNextAccount(config, state, liveUtil = {}, opts = {}) {
     for (const candidates of [fresh, exhausted]) {
       const viable = candidates.filter((a) => score(a) < UTIL_HARD_BLOCK);
       const blocked = candidates.filter((a) => score(a) >= UTIL_HARD_BLOCK);
-      const sorted = [...viable].sort((a, b) => score(a) - score(b));
-      const pool2 = sorted.length ? sorted : [...blocked].sort((a, b) => score(a) - score(b));
+      const sorted = [...viable].sort(byPrivateThenScore);
+      const pool2 = sorted.length ? sorted : [...blocked].sort(byPrivateThenScore);
 
       if (pool2.length > 0) {
         const best = pool2[0];


### PR DESCRIPTION
## What
`rotate.mjs` auto-selection now prefers **private/personal** Max accounts over **Teams/org** accounts. Bumps to **2.11.4**.

## Why
Team accounts (those carrying `orgName`/`orgUuid`) route through claude.ai's org chooser + Google Workspace push-2FA, which the headless browser fallback **cannot clear**. The old selection picked purely by lowest utilization, so a low-util Teams account would win — then stall on 2FA and fail the rotation entirely.

## How
- Adds `isTeamAccount(a)` (`orgUuid` or an `orgName` distinct from the email).
- New `byPrivateThenScore` comparator: team-ness is the **primary** sort key (private first), utilization secondary. A team account is only ever selected when no private account is viable.
- Applied to both the viable and the blocked-fallback candidate pools.

## Verification
- `node --check` OK.
- **Live**: with the same fix on the running copy, rotation skipped the Teams account (`…<OWNER_BRAND>.org`, which had failed on 2FA) and instantly VERIFIED-rotated to a private account.
- `tests/test-no-secrets.sh`: 14 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which Claude credentials rotation selects; wrong choice blocks headless login, but scope is limited to `rotate.mjs` sort logic with no API or billing changes.
> 
> **Overview**
> **Release 2.11.4** bumps plugin/marketplace versions and documents the rotation fix in `CHANGELOG.md`.
> 
> **Account rotation** in `scripts/account-rotation/rotate.mjs` no longer picks the lowest-utilization account only. It adds `isTeamAccount` (org via `orgUuid` or `orgName` distinct from email) and sorts candidates with **`byPrivateThenScore`**: personal accounts first, then utilization. That applies to both viable and high-util fallback pools. Org/Teams accounts that would win on quota alone are avoided because headless auth cannot complete org chooser + Google Workspace push-2FA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a563350b5c6bedd628fd56318f3b3d4766494c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->