### PR TITLE
chore(release): label 2.11.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.11.4",
+      "version": "2.11.5",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.11.4",
+  "version": "2.11.5",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.11.5] — 2026-05-27
+
+### Fixed
+
+- **Rotation works headless on Linux (browser-auth)** — `rotate.mjs` gains Brave as a real-Chromium Tier-2 browser on aarch64 Linux (no ARM Chrome ships) in `REAL_BROWSERS` + the bootstrap scan; `gracefullyQuitApp` Linux `pkill -TERM` branch; the Tier-2 spawn uses a real `1280x800` viewport on Linux (the macOS `1x1` hide trick collapses claude.ai's responsive layout so the submit button is unclickable on Xvnc) + `--no-sandbox`; `pollGmailForMagicLink` reads each pool account's OWN inbox via `gog --account` (no Gmail-forwarding dependency); and the magic-link path fails the account cleanly on timeout instead of stalling on Google OAuth push-2FA. Preserves the 2.11.4 private-first selection + extra-usage exclusion.
+
 ## [2.11.4] — 2026-05-27
 
 ### Fixed


### PR DESCRIPTION
Browser-auth code shipped in #356 but its version-bump commit was lost in the squash (stray git-config warning dropped the push). Labels manifests + CHANGELOG to 2.11.5 to match already-shipped code. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only edits; no behavioral changes in the diff.
> 
> **Overview**
> **Release metadata only** — bumps the ops plugin from **2.11.4 → 2.11.5** in `.claude-plugin/marketplace.json` and `claude-ops/.claude-plugin/plugin.json`, and adds a **[2.11.5]** section to `CHANGELOG.md` documenting the Linux headless browser-auth rotation fixes already merged elsewhere (#356).
> 
> There are **no runtime or script changes** in this diff; it realigns version labels and changelog with shipped `rotate.mjs` behavior (Brave on aarch64 Linux, per-account Gmail magic links via `gog --account`, Linux viewport/`--no-sandbox`, etc.) after a lost squash commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 867269c3401e057b4889289e4cd03831244c10dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->