### PR TITLE
docs: 2.11.5 features (telegram-bot-send, rotation private-first, Linux browser-auth)

### DIFF
--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -1,10 +1,13 @@
 # claude-ops
 
-> **v2.2.0** — Autonomy Layer · Deploy Auto-Fix · Safety Hooks · Specialist Agents · Recap Marquee · Multi-Account Rotator · Multi-Workspace Slack · ops-ci Current-State Filter · Credentials Audit · 35 Skills · 18 Agents
+> **v2.11.5** — Autonomy Layer · Deploy Auto-Fix · Safety Hooks · Specialist Agents · Recap Marquee · Multi-Account Rotator · Multi-Workspace Slack · Telegram Bot Push · Linux Headless Browser-Auth · 35 Skills · 18 Agents
 
-## What's new in v2.2.0
+## What's new in v2.11.5
 
-- **v2.2.0** — Audit fixes: plugin validation (install unblocked), deploy-fix test suite (45/45 passing), `set -e` safety, account-rotation stdin handling. See [CHANGELOG.md](CHANGELOG.md#220--2026-05-16) for the full list.
+- **v2.11.5** — Linux headless browser-auth for the account rotator (Brave Tier-2, Xvnc 1280×800, per-account `gog`, magic-link-only). See [CHANGELOG.md](CHANGELOG.md) for the full list.
+- **v2.11.4** — Account rotator prefers personal accounts over TEAMS/org accounts to avoid org-chooser + Google push-2FA stalls.
+- **v2.11.3** — [`bin/ops-telegram-bot-send`](docs/telegram-bot-send.md): bot-token push to the operator's own Telegram chat. Lower-cost alternative to the user-account MCP path for one-way notifications. Includes the `block-outbound-comms.py` self-channel exception.
+- Older: **v2.2.0** — Audit fixes: plugin validation (install unblocked), deploy-fix test suite (45/45 passing), `set -e` safety, account-rotation stdin handling. See [CHANGELOG.md](CHANGELOG.md) for the full list.
 
 A Claude Code plugin that turns Claude into a business operating system **and** an autonomy layer. Run `/ops` for the interactive command center — pixel-art dashboard with instant hotkey access to morning briefings, inbox, fires, deploys, revenue, and YOLO mode. Or just keep working — v2's hooks watch every merge, every build, every commit, every push, and every agent dispatch in the background.
 

--- a/claude-ops/docs/notifications.md
+++ b/claude-ops/docs/notifications.md
@@ -58,8 +58,13 @@ env var isn't set), so you don't have to export secrets globally.
 
 ## How to choose a sink
 
-- **Most users →** Telegram. You already set up a Telegram bot to use
-  `/ops:comms`, so this is zero extra work.
+- **Most users →** Telegram bot. Configure `TELEGRAM_BOT_TOKEN` +
+  `TELEGRAM_OWNER_ID` (one token from @BotFather — see
+  [`docs/telegram-bot-send.md`](telegram-bot-send.md)) and this sink is live
+  immediately. `bin/ops-telegram-bot-send` handles the actual delivery; the
+  fires-watcher calls it automatically once both env vars are set. This is
+  separate from the user-account MCP path (`ops-telegram-autolink`) — you do
+  not need a personal-account session to receive fire alerts.
 - **No account, free →** ntfy.sh. Pick a random topic name like
   `claude-ops-fires-<random>`, subscribe from the ntfy mobile app, done.
 - **Premium iOS/Android →** Pushover. ~$5 one-time per platform, fastest and

--- a/claude-ops/docs/os-compatibility.md
+++ b/claude-ops/docs/os-compatibility.md
@@ -167,7 +167,21 @@ Backend names: `security`, `secret-tool`, `wincred`, `keytar`, `enc-json`, `plai
 
 **Verify:** `bash scripts/ops-daemon.sh --os` echoes the detected OS; `--help` lists every flag.
 
-## Browser automation
+## Account rotator browser-auth on Linux (v2.11.5)
+
+The multi-account rotator's browser fallback now works headlessly on aarch64
+and x86-64 Linux. Key differences from the macOS path:
+
+| | macOS | Linux (headless) |
+|---|---|---|
+| Browser | Chrome (real, headed) | Brave (Tier-2 real-Chromium; no ARM Chrome builds) |
+| Display | native | Xvnc virtual display — `DISPLAY=:1`, 1280×800 |
+| Auth method | magic-link or Google OAuth | magic-link only (Google push-2FA not clearable headlessly) |
+| Inbox reads | forwarded to default Gmail account | `gog --account <email>` per-account (no forwarding required) |
+
+Full setup steps are in `scripts/account-rotation/README.md §Linux setup`.
+
+## Browser automation (general)
 
 `bin/ops-slack-autolink.mjs` (and any future browser-driven setup) uses `lib/os-detect.mjs::browserProfileDirs()` to discover Chrome / Chromium / Brave / Arc profile directories that actually exist on the host:
 

--- a/claude-ops/scripts/account-rotation/README.md
+++ b/claude-ops/scripts/account-rotation/README.md
@@ -16,7 +16,7 @@ session can keep working without a manual `/login`.
 This is **off by default**. It requires:
 
 1. Multiple Claude Max accounts you legitimately own.
-2. macOS (uses the system keychain + `launchd` for the background daemon).
+2. macOS (uses the system keychain + `launchd` for the background daemon) **or Linux** (see [Linux setup](#linux-setup) below).
 3. Node 20+ (already required by the plugin).
 4. Optional: Playwright (installed on first browser-fallback use), Dashlane CLI (`dcli`) for credential reads.
 
@@ -90,6 +90,64 @@ launchctl unload ~/Library/LaunchAgents/com.claude-ops.account-rotation.plist
 ```
 
 And toggle `account_rotation_enabled` off in plugin settings.
+
+## Account selection — private-first (v2.11.4)
+
+When multiple accounts are eligible to rotate into, `rotate.mjs` prefers
+**personal/private** accounts over **TEAMS/org** accounts (those with `orgName`
+or `orgUuid` set). Org accounts hit claude.ai's organisation chooser page and
+may trigger Google Workspace push-2FA that headless browser auth cannot clear,
+causing the rotation to stall.
+
+Rule: an account is treated as an org account if it has a non-empty `orgName`
+**or** `orgUuid`. Personal accounts are selected first; org accounts are used
+only when no personal account has sufficient remaining quota.
+
+To opt an account out of this preference (e.g. an org account you know works
+headlessly), add `"preferEvenIfOrg": true` to its config entry.
+
+## Linux setup (v2.11.5)
+
+The browser-auth fallback now works headlessly on aarch64/x86-64 Linux. Extra
+requirements beyond the base list above:
+
+1. **Brave browser** — acts as the Tier-2 real-Chromium fallback (no ARM Chrome
+   builds exist). Install via your distro's package manager or
+   `brave.com/linux/`:
+
+   ```bash
+   # Debian/Ubuntu
+   sudo apt-get install -y brave-browser
+   # Fedora/RHEL
+   sudo dnf install -y brave-browser
+   ```
+
+2. **Xvnc / virtual display** — the auth flow requires a real display
+   (`DISPLAY` must be set). Start a virtual framebuffer before running the
+   rotator daemon:
+
+   ```bash
+   Xvnc :1 -geometry 1280x800 -depth 24 &
+   export DISPLAY=:1
+   ```
+
+   The 1280×800 viewport is required — narrower viewports (e.g. 1×1) break
+   claude.ai's layout and stall the login flow.
+
+3. **Per-account `gog` service accounts** — magic-link auth reads each
+   account's own inbox using `gog --account <email>`. Add a service account
+   for every rotation email:
+
+   ```bash
+   gog auth add you@example.com --services gmail
+   ```
+
+   No Gmail-forwarding setup is needed; `gog` reads each inbox directly.
+
+4. **Magic-link only** — on Linux the rotator uses magic-link login exclusively
+   (no Google OAuth). This avoids Google Workspace push-2FA which cannot be
+   cleared in a headless session. Accounts that require Google OAuth and cannot
+   receive a Claude magic-link email are not supported on Linux.
 
 ## Safety notes
 

--- a/claude-ops/skills/setup/channels/telegram.md
+++ b/claude-ops/skills/setup/channels/telegram.md
@@ -1,4 +1,17 @@
-### 3a — Telegram (user-auth via ops-telegram-autolink)
+### 3a — Telegram
+
+**Two paths available:**
+
+| Path | Auth cost | Reads DMs | Sends to you | Best for |
+|---|---|---|---|---|
+| **User-account** (this section) | phone + 2 login codes + optional 2FA | yes | yes | `/ops-inbox telegram`, bidirectional |
+| **Bot token** (`bin/ops-telegram-bot-send`) | paste one token from @BotFather | no | yes | one-way push notifications, low setup cost |
+
+If all you need is for ops skills to **push notifications to your phone** (briefings, fire alerts, rotation results), the bot-token path is simpler — see [`docs/telegram-bot-send.md`](../../../../docs/telegram-bot-send.md) and skip to step 3n (notifications). Come back here only if you need `/ops-inbox telegram` inbox triage.
+
+---
+
+#### 3a (continued) — User-account via ops-telegram-autolink
 
 **Always ask before starting the Telegram flow** — even when the user selected "all channels". Use `AskUserQuestion`:
 


### PR DESCRIPTION
## Summary

- **`bin/ops-telegram-bot-send`** — updated `docs/notifications.md` to reference `telegram-bot-send.md` as the recommended Telegram sink for fire alerts; updated `skills/setup/channels/telegram.md` with a two-path decision table (user-account MCP vs bot token) and a link to the doc.
- **Rotation private-first selection (v2.11.4)** — added §Account selection to `scripts/account-rotation/README.md` explaining why personal accounts are preferred over org accounts (org-chooser + push-2FA blocker).
- **Linux headless browser-auth (v2.11.5)** — added §Linux setup to `scripts/account-rotation/README.md` (Brave, Xvnc 1280×800, `gog --account`, magic-link-only) and a matching table to `docs/os-compatibility.md`.
- **README** — version badge bumped to v2.11.5, What's new section updated for all three features.

## Test plan

- [x] `tests/test-no-secrets.sh` — 14/14 passed
- [ ] Reviewer: spot-check that placeholder values (`123456789`, `<email>`, env-var names) appear everywhere real values would — no real tokens, chat IDs, or paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes with no runtime, auth, or deployment impact.
> 
> **Overview**
> Documentation-only release notes for **v2.11.3–v2.11.5**, aligned with behavior already in `CHANGELOG` and `bin/ops-telegram-bot-send`.
> 
> The **README** badge and “What’s new” list now highlight **Telegram bot push**, **private-first account rotation**, and **Linux headless rotator browser-auth**, with older v2.2.0 bullets folded under an “Older” line.
> 
> **`docs/notifications.md`** steers most users to the **bot-token** path (`TELEGRAM_BOT_TOKEN` + `TELEGRAM_OWNER_ID`, `ops-telegram-bot-send`, `telegram-bot-send.md`) for fire alerts, explicitly separate from gram.js / `ops-telegram-autolink`.
> 
> **`skills/setup/channels/telegram.md`** adds a **user-account vs bot-token** decision table and points one-way notification users at notifications setup instead of full MCP auth.
> 
> **`scripts/account-rotation/README.md`** documents **private-before-org** selection (`orgName`/`orgUuid`, optional `preferEvenIfOrg`) and a new **Linux setup** section (Brave, Xvnc 1280×800, per-account `gog`, magic-link only); platform support text changes from macOS-only to **macOS or Linux**.
> 
> **`docs/os-compatibility.md`** adds a **macOS vs Linux headless** comparison table for rotator browser-auth and links to the rotation README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9e275f290a27a6d9cb31bb14abf91397f43947c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->