### PR TITLE
feat(pocket): standing-auth promoter daemon — auto-promote ASK→ACT for nudge/fleet patterns

### DIFF
--- a/claude-ops/scripts/ops-pocket-standing-auth-promoter.py
+++ b/claude-ops/scripts/ops-pocket-standing-auth-promoter.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""ops-pocket-standing-auth-promoter — auto-resolve ASKs Sam has pre-authorized.
+
+Sam's 2026-05-25 directive: "you may always auto nudge agents without my
+permission thats your mission" + "babysit pocket workers + nudge stalls. so
+sam has to do nothing but leave pocket notes".
+
+When pocket-triage classifies a task as ASK (high-stakes / ambiguous), this
+script post-processes review.jsonl: if the task matches one of the standing
+authorization rules in standing-auth-rules.json, it's auto-promoted to
+tasks.jsonl (so pocket-executor spawns a worker) and removed from review.jsonl.
+
+The original ASK row is preserved in approval-resolved.jsonl with verdict=
+"auto-approve" + reason citing the matched rule for audit.
+
+Idempotent: tracks promoted task ids in seen.json (shared with watcher).
+
+Env:
+  POCKET_STATE_DIR     default /var/lib/pocket-pipeline
+  POCKET_DRY_RUN=1     log decisions, don't mutate files
+"""
+
+from __future__ import annotations
+import json, os, re, sys
+from pathlib import Path
+from datetime import datetime, timezone
+
+STATE_DIR = Path(os.environ.get("POCKET_STATE_DIR", "/var/lib/pocket-pipeline"))
+REVIEW = STATE_DIR / "review.jsonl"
+TASKS = STATE_DIR / "tasks.jsonl"
+RESOLVED = STATE_DIR / "approval-resolved.jsonl"
+SEEN = STATE_DIR / "seen.json"
+RULES = STATE_DIR / "standing-auth-rules.json"
+PARK_RULES = STATE_DIR / "park-rules.json"
+PARKED = STATE_DIR / "parked.jsonl"
+LOG_PREFIX = "[standing-auth-promoter]"
+DRY_RUN = os.environ.get("POCKET_DRY_RUN") == "1"
+
+
+def log(msg: str) -> None:
+    print(f"{LOG_PREFIX} {msg}", file=sys.stderr)
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def load_rules() -> list[dict]:
+    """Standing-auth rules JSON. Format:
+    [{"id":"nudge-agents","match_any":["nudge","monitor.*fleet","fleet.*agents"],"reason":"..."}]
+    Match against title + context (case-insensitive)."""
+    if not RULES.exists():
+        # Seed with Sam's initial standing auth — nudging the agent fleet.
+        default = [
+            {
+                "id": "agent-nudge-and-fleet-supervision",
+                "match_any": [
+                    r"\bnudge\b",
+                    r"\bmonitor.*(fleet|agents?)\b",
+                    r"\b(fleet|agents?).*(monitor|supervis)",
+                    r"\bagent.*list\b",
+                    r"send.*messages.*(agents?|workers?|subagents?)",
+                ],
+                "reason": "Sam standing-authorized agent nudging/fleet supervision 2026-05-25",
+            },
+        ]
+        if not DRY_RUN:
+            RULES.parent.mkdir(parents=True, exist_ok=True)
+            RULES.write_text(json.dumps(default, indent=2))
+        return default
+    try:
+        return json.loads(RULES.read_text())
+    except Exception as e:
+        log(f"rules load err: {e}")
+        return []
+
+
+def load_park_rules() -> list[dict]:
+    """Deny-list: tasks matching these patterns are PARKED (kept out of the
+    executor) because another owner (e.g. the orchestrator working a dedicated
+    worktree) already owns them. Park beats promote — checked first."""
+    if not PARK_RULES.exists():
+        default = [
+            {
+                "id": "healify-prod-fires-owned-by-orchestrator",
+                "match_any": [
+                    r"dedup.*(loop|duplicate|retry)",
+                    r"anna.*(503|empty.?answer)",
+                    r"/api/goals",
+                    r"P3012",
+                    r"prisma.*migrat",
+                    r"cloudwatch:putmetricdata",
+                    r"headbucket",
+                    r"meditation.*s3|s3.*meditation",
+                ],
+                "reason": "Healify prod/staging fires owned by orchestrator in dedicated worktree (2026-05-25). Do not auto-spawn duplicate workers.",
+            },
+        ]
+        if not DRY_RUN:
+            PARK_RULES.parent.mkdir(parents=True, exist_ok=True)
+            PARK_RULES.write_text(json.dumps(default, indent=2))
+        return default
+    try:
+        return json.loads(PARK_RULES.read_text())
+    except Exception as e:
+        log(f"park rules load err: {e}")
+        return []
+
+
+def match_rule(rules: list[dict], task: dict) -> dict | None:
+    hay = (
+        task.get("title", "")
+        + "\n"
+        + task.get("context", "")
+        + "\n"
+        + task.get("summary", "")
+        + "\n"
+        + task.get("transcript", "")
+    ).lower()
+    for r in rules:
+        for pat in r.get("match_any", []):
+            try:
+                if re.search(pat.lower(), hay):
+                    return r
+            except re.error:
+                continue
+    return None
+
+
+def main() -> int:
+    if not REVIEW.exists():
+        log("no review.jsonl — nothing to promote")
+        return 0
+    rules = load_rules()
+    park_rules = load_park_rules()
+    if not rules:
+        log("no standing-auth rules configured")
+        return 0
+
+    review_rows = []
+    promoted = []
+    parked = []
+    kept = []
+
+    for line in REVIEW.read_text().splitlines():
+        if not line.strip():
+            continue
+        try:
+            t = json.loads(line)
+        except json.JSONDecodeError:
+            kept.append(line)
+            continue
+        # PARK beats PROMOTE — owned by another principal, keep out of executor.
+        park_match = match_rule(park_rules, t)
+        if park_match:
+            parked.append((t, park_match))
+            continue
+        match = match_rule(rules, t)
+        if match:
+            promoted.append((t, match))
+        else:
+            kept.append(line)
+
+    # Log parked items (kept OUT of both review re-queue and executor).
+    if parked:
+        log(f"parked {len(parked)} item(s) — owned elsewhere, not promoting")
+        if not DRY_RUN:
+            with PARKED.open("a") as pf:
+                for t, m in parked:
+                    pf.write(
+                        json.dumps(
+                            {
+                                "id": t.get("id"),
+                                "title": t.get("title", ""),
+                                "parked_at": now_iso(),
+                                "rule_id": m["id"],
+                                "reason": m.get("reason", ""),
+                            }
+                        )
+                        + "\n"
+                    )
+            # Also drop a resolved-audit row so the digest stops surfacing it.
+            with RESOLVED.open("a") as rf:
+                for t, m in parked:
+                    rf.write(
+                        json.dumps(
+                            {
+                                "id": t.get("id"),
+                                "resolved_at": now_iso(),
+                                "verdict": "parked",
+                                "resolver": "standing-auth-promoter",
+                                "rule_id": m["id"],
+                                "reason": m.get("reason", ""),
+                            }
+                        )
+                        + "\n"
+                    )
+
+    if not promoted:
+        # Even with no promotions, if we parked items we must rewrite review.jsonl
+        # to drop them (kept[] already excludes parked rows).
+        if parked and not DRY_RUN:
+            with REVIEW.open("w") as f:
+                for l in kept:
+                    f.write(l + "\n")
+            log(f"0 promoted; {len(parked)} parked + removed from review")
+        else:
+            log("0 promoted (no matches)")
+        return 0
+
+    log(f"promoting {len(promoted)} ASK→ACT under standing-auth rules")
+
+    if DRY_RUN:
+        for t, m in promoted:
+            log(
+                f"  (dry-run) PROMOTE id={t.get('id')} rule={m['id']} title={t.get('title', '')[:60]}"
+            )
+        return 0
+
+    # 1) Append promoted to tasks.jsonl (executor will spawn workers)
+    TASKS.parent.mkdir(parents=True, exist_ok=True)
+    with TASKS.open("a") as f:
+        for t, m in promoted:
+            t["verdict"] = "ACT"
+            t["promoted_by"] = "standing-auth-promoter"
+            t["promoted_rule"] = m["id"]
+            t["promoted_at"] = now_iso()
+            f.write(json.dumps(t) + "\n")
+            log(f"  → tasks.jsonl id={t.get('id')} rule={m['id']}")
+
+    # 2) Append audit to approval-resolved.jsonl
+    with RESOLVED.open("a") as f:
+        for t, m in promoted:
+            f.write(
+                json.dumps(
+                    {
+                        "id": t.get("id"),
+                        "resolved_at": now_iso(),
+                        "verdict": "auto-approve",
+                        "resolver": "standing-auth-promoter",
+                        "rule_id": m["id"],
+                        "reason": m.get("reason", ""),
+                    }
+                )
+                + "\n"
+            )
+
+    # 3) Rewrite review.jsonl without promoted rows
+    with REVIEW.open("w") as f:
+        for l in kept:
+            f.write(l + "\n")
+    log(f"review.jsonl now has {len(kept)} rows (was {len(kept) + len(promoted)})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude-ops/scripts/ops-pocket-standing-auth-promoter.py
+++ b/claude-ops/scripts/ops-pocket-standing-auth-promoter.py
@@ -211,7 +211,6 @@ def main() -> int:
     park_rules = load_park_rules()
     if not rules:
         log("no standing-auth rules configured")
-        return 0
 
     if DRY_RUN:
         promoted, parked, kept = partition_review(rules, park_rules, REVIEW.read_text())

--- a/claude-ops/scripts/ops-pocket-standing-auth-promoter.py
+++ b/claude-ops/scripts/ops-pocket-standing-auth-promoter.py
@@ -16,7 +16,7 @@ The original ASK row is preserved in approval-resolved.jsonl with verdict=
 Idempotent: tracks promoted task ids in seen.json (shared with watcher).
 
 Env:
-  POCKET_STATE_DIR     default /var/lib/pocket-pipeline
+  POCKET_STATE_DIR     default ~/.claude/state/pocket
   POCKET_DRY_RUN=1     log decisions, don't mutate files
 """
 
@@ -27,7 +27,8 @@ from pathlib import Path
 from datetime import datetime, timezone
 
 SCRIPT_DIR = Path(__file__).resolve().parent
-STATE_DIR = Path(os.environ.get("POCKET_STATE_DIR", "/var/lib/pocket-pipeline"))
+HOME = Path(os.path.expanduser("~"))
+STATE_DIR = Path(os.environ.get("POCKET_STATE_DIR", HOME / ".claude/state/pocket"))
 REVIEW = STATE_DIR / "review.jsonl"
 TASKS = STATE_DIR / "tasks.jsonl"
 RESOLVED = STATE_DIR / "approval-resolved.jsonl"
@@ -120,6 +121,32 @@ def _load_watcher():
     return mod
 
 
+def partition_review(
+    rules: list[dict], park_rules: list[dict], review_text: str
+) -> tuple[list[tuple[dict, dict]], list[tuple[dict, dict]], list[str]]:
+    promoted: list[tuple[dict, dict]] = []
+    parked: list[tuple[dict, dict]] = []
+    kept: list[str] = []
+    for line in review_text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            t = json.loads(line)
+        except json.JSONDecodeError:
+            kept.append(line)
+            continue
+        park_match = match_rule(park_rules, t)
+        if park_match:
+            parked.append((t, park_match))
+            continue
+        match = match_rule(rules, t)
+        if match:
+            promoted.append((t, match))
+        else:
+            kept.append(line)
+    return promoted, parked, kept
+
+
 def match_rule(rules: list[dict], task: dict) -> dict | None:
     hay = (
         task.get("title", "")
@@ -150,32 +177,11 @@ def main() -> int:
         log("no standing-auth rules configured")
         return 0
 
-    promoted = []
-    parked = []
-    kept = []
-
-    for line in REVIEW.read_text().splitlines():
-        if not line.strip():
-            continue
-        try:
-            t = json.loads(line)
-        except json.JSONDecodeError:
-            kept.append(line)
-            continue
-        # PARK beats PROMOTE — owned by another principal, keep out of executor.
-        park_match = match_rule(park_rules, t)
-        if park_match:
-            parked.append((t, park_match))
-            continue
-        match = match_rule(rules, t)
-        if match:
-            promoted.append((t, match))
-        else:
-            kept.append(line)
-
-    review_was = len(kept) + len(promoted) + len(parked)
-
     if DRY_RUN:
+        promoted, parked, kept = partition_review(
+            rules, park_rules, REVIEW.read_text()
+        )
+        review_was = len(kept) + len(promoted) + len(parked)
         if parked:
             log(f"parked {len(parked)} item(s) — owned elsewhere, not promoting")
         if promoted:
@@ -190,6 +196,10 @@ def main() -> int:
 
     w = _load_watcher()
     with w.pocket_state_lock():
+        promoted, parked, kept = partition_review(
+            rules, park_rules, REVIEW.read_text()
+        )
+        review_was = len(kept) + len(promoted) + len(parked)
         seen = w.load_seen()
         fresh_promoted: list[tuple[dict, dict]] = []
         already_promoted: list[tuple[dict, dict]] = []

--- a/claude-ops/scripts/ops-pocket-standing-auth-promoter.py
+++ b/claude-ops/scripts/ops-pocket-standing-auth-promoter.py
@@ -22,9 +22,18 @@ Env:
 
 from __future__ import annotations
 import importlib.util
-import json, os, re, sys
+import json, os, re, sys, tempfile
 from pathlib import Path
 from datetime import datetime, timezone
+
+# ── Mobile / SSH detection ────────────────────────────────────────────────────
+_IS_MOBILE: bool = bool(
+    os.environ.get("SSH_CONNECTION")
+    or os.environ.get("SSH_CLIENT")
+    or os.environ.get("SSH_TTY")
+    or os.environ.get("OPS_MOBILE") == "1"
+    or (os.environ.get("COLUMNS", "").isdigit() and int(os.environ["COLUMNS"]) < 80)
+)
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 HOME = Path(os.path.expanduser("~"))
@@ -41,7 +50,12 @@ DRY_RUN = os.environ.get("POCKET_DRY_RUN") == "1"
 
 
 def log(msg: str) -> None:
-    print(f"{LOG_PREFIX} {msg}", file=sys.stderr)
+    """Log to stderr, suppressing banners/colors in mobile/SSH mode."""
+    if _IS_MOBILE:
+        # Mobile mode: plain, prefix-free, one line
+        print(msg, file=sys.stderr)
+    else:
+        print(f"{LOG_PREFIX} {msg}", file=sys.stderr)
 
 
 def now_iso() -> str:
@@ -148,6 +162,8 @@ def partition_review(
 
 
 def match_rule(rules: list[dict], task: dict) -> dict | None:
+    """Return first matching rule or None. Case-insensitive via re.IGNORECASE
+    (never lowercase the pattern — that breaks word-boundary anchors like \\b)."""
     hay = (
         task.get("title", "")
         + "\n"
@@ -156,15 +172,35 @@ def match_rule(rules: list[dict], task: dict) -> dict | None:
         + task.get("summary", "")
         + "\n"
         + task.get("transcript", "")
-    ).lower()
+    )
     for r in rules:
         for pat in r.get("match_any", []):
             try:
-                if re.search(pat.lower(), hay):
+                if re.search(pat, hay, re.IGNORECASE):
                     return r
             except re.error:
                 continue
     return None
+
+
+def _atomic_write_review(lines: list[str]) -> None:
+    """Atomically rewrite review.jsonl using a temp file + rename to avoid
+    data loss if the process crashes mid-write (fixes Bugbot atomic-RMW issue)."""
+    REVIEW.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=REVIEW.parent, prefix=".review-tmp-", suffix=".jsonl"
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            for line in lines:
+                f.write(line + "\n")
+        os.replace(tmp_path, REVIEW)
+    except Exception:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 
 def main() -> int:
@@ -178,9 +214,7 @@ def main() -> int:
         return 0
 
     if DRY_RUN:
-        promoted, parked, kept = partition_review(
-            rules, park_rules, REVIEW.read_text()
-        )
+        promoted, parked, kept = partition_review(rules, park_rules, REVIEW.read_text())
         review_was = len(kept) + len(promoted) + len(parked)
         if parked:
             log(f"parked {len(parked)} item(s) — owned elsewhere, not promoting")
@@ -196,9 +230,7 @@ def main() -> int:
 
     w = _load_watcher()
     with w.pocket_state_lock():
-        promoted, parked, kept = partition_review(
-            rules, park_rules, REVIEW.read_text()
-        )
+        promoted, parked, kept = partition_review(rules, park_rules, REVIEW.read_text())
         review_was = len(kept) + len(promoted) + len(parked)
         seen = w.load_seen()
         fresh_promoted: list[tuple[dict, dict]] = []
@@ -250,9 +282,7 @@ def main() -> int:
 
         if not promoted:
             if parked:
-                with REVIEW.open("w") as f:
-                    for l in kept:
-                        f.write(l + "\n")
+                _atomic_write_review(kept)
                 log(f"0 promoted; {len(parked)} parked + removed from review")
             else:
                 log("0 promoted (no matches)")
@@ -290,9 +320,7 @@ def main() -> int:
                         + "\n"
                     )
 
-        with REVIEW.open("w") as f:
-            for l in kept:
-                f.write(l + "\n")
+        _atomic_write_review(kept)
         log(f"review.jsonl now has {len(kept)} rows (was {review_was})")
     return 0
 

--- a/claude-ops/scripts/ops-pocket-standing-auth-promoter.py
+++ b/claude-ops/scripts/ops-pocket-standing-auth-promoter.py
@@ -21,10 +21,12 @@ Env:
 """
 
 from __future__ import annotations
+import importlib.util
 import json, os, re, sys
 from pathlib import Path
 from datetime import datetime, timezone
 
+SCRIPT_DIR = Path(__file__).resolve().parent
 STATE_DIR = Path(os.environ.get("POCKET_STATE_DIR", "/var/lib/pocket-pipeline"))
 REVIEW = STATE_DIR / "review.jsonl"
 TASKS = STATE_DIR / "tasks.jsonl"
@@ -107,6 +109,17 @@ def load_park_rules() -> list[dict]:
         return []
 
 
+def _load_watcher():
+    """Reuse watcher's seen.json helpers and pocket_state_lock (shared state dir)."""
+    path = SCRIPT_DIR / "ops-cron-pocket-watcher.py"
+    spec = importlib.util.spec_from_file_location("ops_cron_pocket_watcher", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load watcher module at {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
 def match_rule(rules: list[dict], task: dict) -> dict | None:
     hay = (
         task.get("title", "")
@@ -137,7 +150,6 @@ def main() -> int:
         log("no standing-auth rules configured")
         return 0
 
-    review_rows = []
     promoted = []
     parked = []
     kept = []
@@ -161,10 +173,41 @@ def main() -> int:
         else:
             kept.append(line)
 
-    # Log parked items (kept OUT of both review re-queue and executor).
-    if parked:
-        log(f"parked {len(parked)} item(s) — owned elsewhere, not promoting")
-        if not DRY_RUN:
+    review_was = len(kept) + len(promoted) + len(parked)
+
+    if DRY_RUN:
+        if parked:
+            log(f"parked {len(parked)} item(s) — owned elsewhere, not promoting")
+        if promoted:
+            log(f"promoting {len(promoted)} ASK→ACT under standing-auth rules")
+            for t, m in promoted:
+                log(
+                    f"  (dry-run) PROMOTE id={t.get('id')} rule={m['id']} title={t.get('title', '')[:60]}"
+                )
+        elif not parked:
+            log("0 promoted (no matches)")
+        return 0
+
+    w = _load_watcher()
+    with w.pocket_state_lock():
+        seen = w.load_seen()
+        fresh_promoted: list[tuple[dict, dict]] = []
+        already_promoted: list[tuple[dict, dict]] = []
+        for t, m in promoted:
+            tid = t.get("id")
+            if isinstance(tid, str) and tid and tid in seen:
+                already_promoted.append((t, m))
+            else:
+                fresh_promoted.append((t, m))
+        if already_promoted:
+            log(
+                f"skip {len(already_promoted)} already-promoted id(s) in seen.json "
+                "(crash recovery)"
+            )
+
+        # Log parked items (kept OUT of both review re-queue and executor).
+        if parked:
+            log(f"parked {len(parked)} item(s) — owned elsewhere, not promoting")
             with PARKED.open("a") as pf:
                 for t, m in parked:
                     pf.write(
@@ -179,7 +222,6 @@ def main() -> int:
                         )
                         + "\n"
                     )
-            # Also drop a resolved-audit row so the digest stops surfacing it.
             with RESOLVED.open("a") as rf:
                 for t, m in parked:
                     rf.write(
@@ -196,60 +238,52 @@ def main() -> int:
                         + "\n"
                     )
 
-    if not promoted:
-        # Even with no promotions, if we parked items we must rewrite review.jsonl
-        # to drop them (kept[] already excludes parked rows).
-        if parked and not DRY_RUN:
-            with REVIEW.open("w") as f:
-                for l in kept:
-                    f.write(l + "\n")
-            log(f"0 promoted; {len(parked)} parked + removed from review")
-        else:
-            log("0 promoted (no matches)")
-        return 0
+        if not promoted:
+            if parked:
+                with REVIEW.open("w") as f:
+                    for l in kept:
+                        f.write(l + "\n")
+                log(f"0 promoted; {len(parked)} parked + removed from review")
+            else:
+                log("0 promoted (no matches)")
+            return 0
 
-    log(f"promoting {len(promoted)} ASK→ACT under standing-auth rules")
+        if fresh_promoted:
+            log(f"promoting {len(fresh_promoted)} ASK→ACT under standing-auth rules")
+            TASKS.parent.mkdir(parents=True, exist_ok=True)
+            with TASKS.open("a") as f:
+                for t, m in fresh_promoted:
+                    t["verdict"] = "ACT"
+                    t["promoted_by"] = "standing-auth-promoter"
+                    t["promoted_rule"] = m["id"]
+                    t["promoted_at"] = now_iso()
+                    f.write(json.dumps(t) + "\n")
+                    log(f"  → tasks.jsonl id={t.get('id')} rule={m['id']}")
+                    tid = t.get("id")
+                    if isinstance(tid, str) and tid:
+                        w._seen_add(seen, tid)
+                        w.save_seen(seen)
 
-    if DRY_RUN:
-        for t, m in promoted:
-            log(
-                f"  (dry-run) PROMOTE id={t.get('id')} rule={m['id']} title={t.get('title', '')[:60]}"
-            )
-        return 0
+            with RESOLVED.open("a") as f:
+                for t, m in fresh_promoted:
+                    f.write(
+                        json.dumps(
+                            {
+                                "id": t.get("id"),
+                                "resolved_at": now_iso(),
+                                "verdict": "auto-approve",
+                                "resolver": "standing-auth-promoter",
+                                "rule_id": m["id"],
+                                "reason": m.get("reason", ""),
+                            }
+                        )
+                        + "\n"
+                    )
 
-    # 1) Append promoted to tasks.jsonl (executor will spawn workers)
-    TASKS.parent.mkdir(parents=True, exist_ok=True)
-    with TASKS.open("a") as f:
-        for t, m in promoted:
-            t["verdict"] = "ACT"
-            t["promoted_by"] = "standing-auth-promoter"
-            t["promoted_rule"] = m["id"]
-            t["promoted_at"] = now_iso()
-            f.write(json.dumps(t) + "\n")
-            log(f"  → tasks.jsonl id={t.get('id')} rule={m['id']}")
-
-    # 2) Append audit to approval-resolved.jsonl
-    with RESOLVED.open("a") as f:
-        for t, m in promoted:
-            f.write(
-                json.dumps(
-                    {
-                        "id": t.get("id"),
-                        "resolved_at": now_iso(),
-                        "verdict": "auto-approve",
-                        "resolver": "standing-auth-promoter",
-                        "rule_id": m["id"],
-                        "reason": m.get("reason", ""),
-                    }
-                )
-                + "\n"
-            )
-
-    # 3) Rewrite review.jsonl without promoted rows
-    with REVIEW.open("w") as f:
-        for l in kept:
-            f.write(l + "\n")
-    log(f"review.jsonl now has {len(kept)} rows (was {len(kept) + len(promoted)})")
+        with REVIEW.open("w") as f:
+            for l in kept:
+                f.write(l + "\n")
+        log(f"review.jsonl now has {len(kept)} rows (was {review_was})")
     return 0
 
 

--- a/claude-ops/scripts/ops-pocket-standing-auth-promoter.py
+++ b/claude-ops/scripts/ops-pocket-standing-auth-promoter.py
@@ -165,13 +165,13 @@ def match_rule(rules: list[dict], task: dict) -> dict | None:
     """Return first matching rule or None. Case-insensitive via re.IGNORECASE
     (never lowercase the pattern — that breaks word-boundary anchors like \\b)."""
     hay = (
-        task.get("title", "")
+        (task.get("title") or "")
         + "\n"
-        + task.get("context", "")
+        + (task.get("context") or "")
         + "\n"
-        + task.get("summary", "")
+        + (task.get("summary") or "")
         + "\n"
-        + task.get("transcript", "")
+        + (task.get("transcript") or "")
     )
     for r in rules:
         for pat in r.get("match_any", []):
@@ -215,7 +215,6 @@ def main() -> int:
 
     if DRY_RUN:
         promoted, parked, kept = partition_review(rules, park_rules, REVIEW.read_text())
-        review_was = len(kept) + len(promoted) + len(parked)
         if parked:
             log(f"parked {len(parked)} item(s) — owned elsewhere, not promoting")
         if promoted:


### PR DESCRIPTION
## Summary

- Adds `scripts/ops-pocket-standing-auth-promoter.py` (257 lines, new file — zero git history until now).
- Reads `review.jsonl`, matches tasks against `standing-auth-rules.json` patterns, promotes matches directly to `tasks.jsonl` so pocket-executor spawns workers without manual approval.
- Park-rules (deny-list via `park-rules.json`) checked first — prevents duplicate workers on orchestrator-owned tasks (e.g. Healify prod fires). Park + promote audit both written to `approval-resolved.jsonl`.
- Idempotent: shares `seen.json` with the watcher. `POCKET_DRY_RUN=1` logs decisions without mutating files.
- Seeds default standing-auth rule for `agent-nudge-and-fleet-supervision` patterns on first run if `standing-auth-rules.json` absent.

Ref: `pocket_standing_auth_promoter` memory entry — runs every 3min via user systemd timer per Sam's 2026-05-25 directive.

## Test plan

- [ ] `python3 -m py_compile scripts/ops-pocket-standing-auth-promoter.py` — passes (verified pre-commit)
- [ ] `POCKET_DRY_RUN=1 python3 scripts/ops-pocket-standing-auth-promoter.py` with a seeded `review.jsonl` containing a nudge-pattern task — confirm log shows `(dry-run) PROMOTE`
- [ ] Run with a park-rule-matching task — confirm it appears in `parked.jsonl`, not `tasks.jsonl`
- [ ] Run with no `review.jsonl` — exits 0, logs "no review.jsonl"
- [ ] Confirm systemd timer fires every 3min: `systemctl --user status pocket-standing-auth-promoter.timer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Bypasses manual approval and appends to tasks.jsonl, which can spawn automated workers; incorrect or overly broad regex rules could promote the wrong work despite park rules and seen.json guards.
> 
> **Overview**
> Adds **`ops-pocket-standing-auth-promoter.py`**, a pocket-state daemon that scans **`review.jsonl`** and, for ASK items matching **`standing-auth-rules.json`** regexes, **auto-promotes** them to **`tasks.jsonl`** (verdict `ACT`) so **`pocket-executor`** can spawn workers without manual approval. **Park rules** in **`park-rules.json`** are evaluated first and matching items are removed from review, logged to **`parked.jsonl`**, and recorded in **`approval-resolved.jsonl`** as `parked` instead of being promoted.
> 
> The script **seeds default** standing-auth (agent nudge/fleet supervision) and park (Healify prod fires owned by orchestrator) rule files on first run, supports **`POCKET_DRY_RUN=1`**, uses **`pocket_state_lock`** and **`seen.json`** from **`ops-cron-pocket-watcher.py`** for idempotency/crash recovery, and **atomically rewrites** `review.jsonl` after promotions. Promotions are audited as **`auto-approve`** in **`approval-resolved.jsonl`** with rule id and reason.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd8445cabac34cdda4f04a59303e3702697c9166. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automated task promotion system that evaluates and escalates review items based on standing authorization rules.
  * Includes deny-list mechanism to exclude specific tasks from automatic promotion.
  * Supports dry-run mode for testing changes without modifying files.
  * Generates audit trails for all promotion and exclusion decisions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->