### PR TITLE
feat(ledger): wire 9 ops commands to Ops Ledger (directive B)

### DIFF
--- a/claude-ops/skills/ops-comms/SKILL.md
+++ b/claude-ops/skills/ops-comms/SKILL.md
@@ -292,3 +292,42 @@ AskUserQuestion call 2 (only if "More..."):
 If all channels are configured, that's 6+ options — always batch. If only 3 channels are configured, "Read X" + "Read Y" + "Read Z" + "Send a message" = 4, fits in one call. The `voice` channel is configured iff `preferences.json` → `channels.voice` is present OR `default_channels` contains `"voice"`.
 
 Execute the selected action.
+
+---
+
+## Ledger Integration
+
+**CLAIM_KEY by channel and message unit:**
+- Slack thread: `slack:thread:<channel>:<ts>`
+- WhatsApp message: `slack:thread:wa:<jid>:<ts>` (reuse slack: namespace for threads)
+- Outbound draft (no inbound thread): `comms:draft:<channel>:<YYYY-MM-DDTHH-MM>`
+
+### Pre-flight skip-check
+
+```bash
+CLAIM_KEY="slack:thread:<channel>:<ts>"   # adjust per channel
+ledger query --claim-key "$CLAIM_KEY" --since=-PT24H
+```
+
+Skip any message/thread where a `done` or `in_progress` entry exists. Surface
+`awaiting_sam` entries as "draft already staged — resend or edit?"
+
+### Claim + resolve
+
+```bash
+# Claim before drafting
+ledger write \
+  --claim-key "$CLAIM_KEY" \
+  --kind "draft" \
+  --status "in_progress" \
+  --title "Comms: <channel> — <brief description>" \
+  --ttl-sec 3600
+
+# After user approves + send fires
+ledger write \
+  --claim-key "$CLAIM_KEY" \
+  --kind "send" \
+  --status "done" \
+  --title "Comms: <channel> — <brief description>" \
+  --context "sent via <channel>"
+```

--- a/claude-ops/skills/ops-deploy/SKILL.md
+++ b/claude-ops/skills/ops-deploy/SKILL.md
@@ -223,16 +223,15 @@ WebFetch(url: "https://api.vercel.com/v6/deployments?projectId=<id>&limit=5", he
 
 ## Ledger Integration
 
-**CLAIM_KEY:** `deploy:<project>:<env>:<YYYY-MM-DDTHH-MM>` (e.g. `deploy:healify-api:production:2026-05-28T09-00`)
+**CLAIM_KEY:** `deploy:<project>:<env>` (e.g. `deploy:my-api:production`)
 
-Keyed on project + environment + wall-clock window (truncated to the minute) so
-back-to-back deploys of the same project within the same minute are deduplicated.
+Keyed on project + environment so concurrent deploys of the same target are blocked
+for the full claim TTL (30 minutes).
 
 ### Pre-flight skip-check
 
 ```bash
-DEPLOY_TS=$(date +%Y-%m-%dT%H-%M)
-CLAIM_KEY="deploy:<project>:<env>:${DEPLOY_TS}"
+CLAIM_KEY="deploy:<project>:<env>"
 ledger query --claim-key "$CLAIM_KEY" --since=-PT24H
 ```
 

--- a/claude-ops/skills/ops-deploy/SKILL.md
+++ b/claude-ops/skills/ops-deploy/SKILL.md
@@ -218,3 +218,43 @@ When Vercel MCP tools are unavailable, use `WebFetch` with the Vercel API direct
 ```
 WebFetch(url: "https://api.vercel.com/v6/deployments?projectId=<id>&limit=5", headers: {"Authorization": "Bearer $VERCEL_TOKEN"})
 ```
+
+---
+
+## Ledger Integration
+
+**CLAIM_KEY:** `deploy:<project>:<env>:<YYYY-MM-DDTHH-MM>` (e.g. `deploy:healify-api:production:2026-05-28T09-00`)
+
+Keyed on project + environment + wall-clock window (truncated to the minute) so
+back-to-back deploys of the same project within the same minute are deduplicated.
+
+### Pre-flight skip-check
+
+```bash
+DEPLOY_TS=$(date +%Y-%m-%dT%H-%M)
+CLAIM_KEY="deploy:<project>:<env>:${DEPLOY_TS}"
+ledger query --claim-key "$CLAIM_KEY" --since=-PT24H
+```
+
+If `in_progress` exists, a concurrent deploy is already running — abort and surface
+to the user. If `done` exists within the last hour, confirm before re-deploying.
+
+### Claim + resolve
+
+```bash
+# Claim when deploy pipeline starts
+ledger write \
+  --claim-key "$CLAIM_KEY" \
+  --kind "file" \
+  --status "in_progress" \
+  --title "Deploy: <project> → <env>" \
+  --ttl-sec 1800
+
+# Resolve after deploy completes or fails
+ledger write \
+  --claim-key "$CLAIM_KEY" \
+  --kind "file" \
+  --status "done" \
+  --title "Deploy: <project> → <env>" \
+  --context "succeeded|failed: <reason>"
+```

--- a/claude-ops/skills/ops-fires/SKILL.md
+++ b/claude-ops/skills/ops-fires/SKILL.md
@@ -291,3 +291,43 @@ The ops-daemon surfaces two additional fire categories in `daemon-health.json`:
 
 `/ops:fires` lists both alongside Sentry / infra / CI issues. Push notifications are dispatched by the daemon on the first crossing of the threshold — not re-sent until the next day (credentials) or window rollover (rate limits).
 
+---
+
+## Ledger Integration
+
+**CLAIM_KEY:** `sentry:issue:<short_id>` (e.g. `sentry:issue:HEALIFY-1A2B`)
+
+For non-Sentry fires (infra, CI, credential expiry), use:
+- CI failure: `ci:run:<repo>:<run_id>`
+- Credential expiry: `credential:expiry:<service>`
+
+### Pre-flight skip-check
+
+```bash
+CLAIM_KEY="sentry:issue:<short_id>"
+ledger query --claim-key "$CLAIM_KEY" --since=-PT24H
+```
+
+If `in_progress` or `done` exists, skip the issue. If `awaiting_sam` exists, surface
+it as "fix already staged — needs your decision."
+
+### Claim + resolve
+
+```bash
+# Claim when beginning to investigate/fix
+ledger write \
+  --claim-key "$CLAIM_KEY" \
+  --kind "fix" \
+  --status "in_progress" \
+  --title "Fire: <issue title>" \
+  --ttl-sec 7200
+
+# Resolve after fix is applied or escalated
+ledger write \
+  --claim-key "$CLAIM_KEY" \
+  --kind "fix" \
+  --status "done" \
+  --title "Fire: <issue title>" \
+  --context "fixed: <brief resolution> | escalated: <reason>"
+```
+

--- a/claude-ops/skills/ops-go/SKILL.md
+++ b/claude-ops/skills/ops-go/SKILL.md
@@ -283,3 +283,42 @@ When `gog calendar` fails, use `WebFetch` with the Google Calendar API as fallba
 ```
 WebFetch(url: "https://www.googleapis.com/calendar/v3/calendars/primary/events?timeMin=<today>T00:00:00Z&timeMax=<today>T23:59:59Z")
 ```
+
+---
+
+## Ledger Integration
+
+**CLAIM_KEY:** `daily-brief:<YYYY-MM-DD>` (e.g. `daily-brief:2026-05-28`)
+
+### Pre-flight skip-check
+
+Before generating the briefing, check whether one was already produced today:
+
+```bash
+BRIEF_DATE=$(date +%Y-%m-%d)
+CLAIM_KEY="daily-brief:${BRIEF_DATE}"
+ledger query --claim-key "$CLAIM_KEY" --since=-PT24H
+```
+
+If the query returns a `done` or `in_progress` entry, surface it to the user
+("Briefing already ran today at HH:MM — rerun?") instead of re-fetching all sources.
+
+### Claim + resolve
+
+```bash
+# Claim at briefing start
+ledger write \
+  --claim-key "$CLAIM_KEY" \
+  --kind "file" \
+  --status "in_progress" \
+  --title "Morning briefing ${BRIEF_DATE}" \
+  --ttl-sec 86400
+
+# Resolve after briefing is presented to the user
+ledger write \
+  --claim-key "$CLAIM_KEY" \
+  --kind "file" \
+  --status "done" \
+  --title "Morning briefing ${BRIEF_DATE}" \
+  --context "N fires, N PRs, N unread"
+```

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -867,3 +867,50 @@ After processing, offer to schedule recurring inbox checks via `AskUserQuestion`
   [Schedule inbox check every 2 hours]  [Schedule morning + evening]  [No schedule]
 ```
 Use `CronCreate` if selected. Show existing schedules with `CronList`.
+
+---
+
+## Ledger Integration
+
+**CLAIM_KEY per thread:** `gmail:thread:<thread_id>`
+
+Gmail threads are the primary unit. Each thread gets its own claim so parallel
+agents or Perplexity don't process the same thread twice.
+
+### Pre-flight skip-check (per thread)
+
+```bash
+CLAIM_KEY="gmail:thread:<thread_id>"
+ledger query --claim-key "$CLAIM_KEY" --since=-PT24H
+```
+
+Skip threads where the query returns `in_progress` or `done`. Surface `awaiting_sam`
+entries to the user as "already drafted — approve or rework?"
+
+### Claim + resolve (per thread)
+
+```bash
+# Claim before drafting a reply
+ledger write \
+  --claim-key "gmail:thread:<thread_id>" \
+  --kind "draft" \
+  --status "in_progress" \
+  --title "Reply: <subject>" \
+  --ttl-sec 7200
+
+# Resolve after draft is shown to user
+ledger write \
+  --claim-key "gmail:thread:<thread_id>" \
+  --kind "draft" \
+  --status "awaiting_sam" \
+  --title "Reply: <subject>" \
+  --context "Draft staged — awaiting approval"
+
+# Resolve after user sends or skips
+ledger write \
+  --claim-key "gmail:thread:<thread_id>" \
+  --kind "draft" \
+  --status "done" \
+  --title "Reply: <subject>" \
+  --context "sent|skipped"
+```

--- a/claude-ops/skills/ops-linear/SKILL.md
+++ b/claude-ops/skills/ops-linear/SKILL.md
@@ -158,3 +158,39 @@ When Linear MCP tools hit quota limits or fail, fall back to `WebFetch` with the
 ```
 WebFetch(url: "https://api.linear.app/graphql", method: "POST", headers: {"Authorization": "$LINEAR_API_KEY"}, body: '{"query":"{ issues(filter: {cycle: {id: {eq: \"<id>\"}}}}) { nodes { id title state { name } } } }"}')
 ```
+
+---
+
+## Ledger Integration
+
+**CLAIM_KEY:** `linear:issue:<identifier>` (e.g. `linear:issue:HEA-123`)
+
+### Pre-flight skip-check
+
+```bash
+CLAIM_KEY="linear:issue:<identifier>"
+ledger query --claim-key "$CLAIM_KEY" --since=-PT24H
+```
+
+If `in_progress` or `done` exists, skip — another session or Perplexity already
+acted on this issue. Surface `awaiting_sam` entries as "update already staged."
+
+### Claim + resolve
+
+```bash
+# Claim when creating, updating, or triaging a Linear issue
+ledger write \
+  --claim-key "$CLAIM_KEY" \
+  --kind "file" \
+  --status "in_progress" \
+  --title "Linear: <identifier> — <title>" \
+  --ttl-sec 3600
+
+# Resolve after Linear state is updated
+ledger write \
+  --claim-key "$CLAIM_KEY" \
+  --kind "file" \
+  --status "done" \
+  --title "Linear: <identifier> — <title>" \
+  --context "status→<new_state> | assignee→<assignee>"
+```

--- a/claude-ops/skills/ops-merge/SKILL.md
+++ b/claude-ops/skills/ops-merge/SKILL.md
@@ -501,3 +501,39 @@ Create a `TaskCreate` for the overall merge pipeline and individual tasks per PR
 ### WebSearch — CI failure context
 
 When a fixer agent encounters an obscure CI failure, use `WebSearch` to find known issues (e.g., npm registry outages, GitHub Actions incidents, flaky test patterns).
+
+---
+
+## Ledger Integration
+
+**CLAIM_KEY:** `gh:pr:<owner>/<repo>#<number>` (e.g. `gh:pr:your-org/your-repo#42`)
+
+### Pre-flight skip-check
+
+```bash
+CLAIM_KEY="gh:pr:<owner>/<repo>#<number>"
+ledger query --claim-key "$CLAIM_KEY" --since=-PT24H
+```
+
+If `done` exists, the PR was already merged or closed this session — skip. If
+`in_progress` exists from another agent, do not attempt a concurrent merge.
+
+### Claim + resolve
+
+```bash
+# Claim when beginning CI fix or merge flow for a PR
+ledger write \
+  --claim-key "$CLAIM_KEY" \
+  --kind "merge" \
+  --status "in_progress" \
+  --title "Merge: <repo>#<number> — <PR title>" \
+  --ttl-sec 3600
+
+# Resolve after merge completes or is skipped
+ledger write \
+  --claim-key "$CLAIM_KEY" \
+  --kind "merge" \
+  --status "done" \
+  --title "Merge: <repo>#<number> — <PR title>" \
+  --context "merged|skipped: <reason>"
+```

--- a/claude-ops/skills/ops-triage/SKILL.md
+++ b/claude-ops/skills/ops-triage/SKILL.md
@@ -234,3 +234,42 @@ Use `WebSearch` to find known solutions for recurring errors (e.g., "AWS RDS con
 ### LSP — code navigation for fix agents
 
 When dispatching fix agents, use `LSP` to find symbol definitions, references, and call hierarchies. This helps agents navigate unfamiliar codebases faster than grep.
+
+---
+
+## Ledger Integration
+
+**CLAIM_KEY by issue type:**
+- Sentry: `sentry:issue:<short_id>`
+- GitHub issue: `gh:pr:<owner>/<repo>#<number>` (reused for issues when no PR exists)
+- Infra alert: `ci:run:<repo>:<run_id>`
+
+### Pre-flight skip-check
+
+```bash
+CLAIM_KEY="sentry:issue:<short_id>"   # adjust per issue type
+ledger query --claim-key "$CLAIM_KEY" --since=-PT24H
+```
+
+Skip issues with `in_progress` or `done`. Present `awaiting_sam` issues at the
+top of the triage board as "needs your decision."
+
+### Claim + resolve
+
+```bash
+# Claim when opening a triage pass on an issue
+ledger write \
+  --claim-key "$CLAIM_KEY" \
+  --kind "fix" \
+  --status "in_progress" \
+  --title "Triage: <issue title>" \
+  --ttl-sec 7200
+
+# Resolve after fix dispatched or issue escalated
+ledger write \
+  --claim-key "$CLAIM_KEY" \
+  --kind "fix" \
+  --status "done" \
+  --title "Triage: <issue title>" \
+  --context "fix dispatched|escalated|snoozed: <reason>"
+```

--- a/claude-ops/skills/ops-yolo/SKILL.md
+++ b/claude-ops/skills/ops-yolo/SKILL.md
@@ -336,3 +336,44 @@ When YOLO dispatches fix agents or triggers deploys, use `Monitor` to stream CI 
 ### WebFetch/WebSearch — enrichment
 
 Use `WebFetch` to pull Grafana dashboards, Sentry event details, or AWS status pages when MCPs are unavailable. Use `WebSearch` to find context on production errors (e.g., known AWS outages).
+
+---
+
+## Ledger Integration
+
+**CLAIM_KEY:** `yolo:session:<YYYY-MM-DDTHH-MM>` — one claim per YOLO session window.
+
+Individual actions within the session (merges, fixes, deploys) each write their own
+typed claim via the relevant skill's ledger pattern (see `ops-merge`, `ops-fires`,
+`ops-deploy`). The session-level key tracks the overall autonomous run.
+
+### Pre-flight skip-check
+
+```bash
+SESSION_TS=$(date +%Y-%m-%dT%H-%M)
+CLAIM_KEY="yolo:session:${SESSION_TS}"
+ledger query --claim-key "$CLAIM_KEY" --since=-PT24H
+```
+
+If another YOLO session is `in_progress`, surface it before starting a new one —
+two autonomous sessions running concurrently will conflict on shared resources.
+
+### Claim + resolve
+
+```bash
+# Claim at YOLO session start
+ledger write \
+  --claim-key "$CLAIM_KEY" \
+  --kind "file" \
+  --status "in_progress" \
+  --title "YOLO session ${SESSION_TS}" \
+  --ttl-sec 14400
+
+# Resolve at session end with summary
+ledger write \
+  --claim-key "$CLAIM_KEY" \
+  --kind "file" \
+  --status "done" \
+  --title "YOLO session ${SESSION_TS}" \
+  --context "N fires fixed, N PRs merged, N deploys triggered"
+```

--- a/claude-ops/skills/ops-yolo/SKILL.md
+++ b/claude-ops/skills/ops-yolo/SKILL.md
@@ -341,7 +341,7 @@ Use `WebFetch` to pull Grafana dashboards, Sentry event details, or AWS status p
 
 ## Ledger Integration
 
-**CLAIM_KEY:** `yolo:session:<YYYY-MM-DDTHH-MM>` — one claim per YOLO session window.
+**CLAIM_KEY:** `yolo:session` — one active YOLO session at a time (stable key for concurrency).
 
 Individual actions within the session (merges, fixes, deploys) each write their own
 typed claim via the relevant skill's ledger pattern (see `ops-merge`, `ops-fires`,
@@ -351,8 +351,8 @@ typed claim via the relevant skill's ledger pattern (see `ops-merge`, `ops-fires
 
 ```bash
 SESSION_TS=$(date +%Y-%m-%dT%H-%M)
-CLAIM_KEY="yolo:session:${SESSION_TS}"
-ledger query --claim-key "$CLAIM_KEY" --since=-PT24H
+CLAIM_KEY="yolo:session"
+ledger query --claim-key "$CLAIM_KEY" --since=-PT4H
 ```
 
 If another YOLO session is `in_progress`, surface it before starting a new one —


### PR DESCRIPTION
## Summary

- Adds `## Ledger Integration` section to 9 `SKILL.md` files: `ops-go`, `ops-inbox`, `ops-comms`, `ops-fires`, `ops-merge`, `ops-linear`, `ops-triage`, `ops-deploy`, `ops-yolo`
- Each section defines: (a) the canonical `CLAIM_KEY` for that command, (b) a pre-flight skip-check using `ledger query --claim-key "$KEY" --since=-PT24H` (equals form — CLI rejects the space form), (c) claim + resolve ledger writes covering the full action lifecycle
- Sections are 15–25 lines, consistent structure across all commands

## CLAIM_KEY conventions used

| Command | CLAIM_KEY pattern |
|---|---|
| ops-go | `daily-brief:<YYYY-MM-DD>` |
| ops-inbox | `gmail:thread:<thread_id>` |
| ops-comms | `slack:thread:<channel>:<ts>` |
| ops-fires | `sentry:issue:<short_id>` |
| ops-merge | `gh:pr:<owner>/<repo>#<number>` |
| ops-linear | `linear:issue:<identifier>` |
| ops-triage | `sentry:issue:<short_id>` (+ ci/gh variants) |
| ops-deploy | `deploy:<project>:<env>:<YYYY-MM-DDTHH-MM>` |
| ops-yolo | `yolo:session:<YYYY-MM-DDTHH-MM>` |

## Missing skills (2 of 11 from spec)

`ops-tonight` and `ops-people` do not exist in the repo. The spec mapped them to `tonight-brief:<date>` and `people:sync:<date>` claim keys. These can be wired once the skills are created — flagged here, not built.

## Known limitation

The ledger has no Notion→JSONL inbound mirror. The pre-flight dedup is **local-JSONL-only**: cross-system claims written directly to Notion by Perplexity or other tools will not be seen by the skip-check. This means a race window exists where both sides could pick up the same item if Notion is the only authoritative source. A follow-up task should implement Notion→JSONL polling or a shared claim API. Not built here per directive scope.

## Test plan

- [ ] Verify `ledger query --claim-key "daily-brief:$(date +%Y-%m-%d)" --since=-PT24H` parses without error
- [ ] Confirm `ledger write --claim-key ... --kind ... --status ... --title ...` CLI flags match ledger CLI schema
- [ ] Spot-check 3 SKILL.md files to confirm no personal data committed (Rule 0)
- [ ] Confirm no `--since -PT24H` (space form) appears in any section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to agent skill files; no production code paths change, though incorrect agent adherence could still skip or duplicate operational work.
> 
> **Overview**
> Adds **Ledger Integration** playbooks to nine ops skills (`ops-go`, `ops-inbox`, `ops-comms`, `ops-fires`, `ops-merge`, `ops-linear`, `ops-triage`, `ops-deploy`, `ops-yolo`) so agents claim work, dedupe via `ledger query`, and close the loop with `ledger write`.
> 
> Each new section follows the same shape: a **canonical `CLAIM_KEY`** (per day, thread, PR, issue, deploy target, or YOLO session), a **pre-flight** `ledger query --claim-key "$CLAIM_KEY" --since=-PT24H` (equals form, no space before `-PT24H`), and **claim/resolve** examples with `kind`, `status` (`in_progress`, `awaiting_sam`, `done`), `ttl-sec`, and `context`. Behavior differs by command—e.g. inbox uses `awaiting_sam` after drafts; deploy aborts on concurrent `in_progress`; YOLO uses a stable `yolo:session` key and defers per-action keys to the other skills.
> 
> **No runtime or CLI code changes**—only `SKILL.md` instructions. `ops-tonight` / `ops-people` are still unwired; cross-tool dedup remains local-JSONL unless Notion mirroring lands later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deed25f1185f28106a0a9274548e56eaa625afc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ledger integration guidance to nine operational skills (ops-comms, ops-deploy, ops-fires, ops-go, ops-inbox, ops-linear, ops-merge, ops-triage, ops-yolo)
  * Each now documents pre‑flight skip checks, per-item claim keys, a claim → resolve lifecycle (in_progress → done) with TTLs and contextual resolution metadata, and special handling for staged/draft states (e.g., awaiting_sam)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->