### PR TITLE
chore(release): 2.12.0 — Linux WhatsApp bridge install + patches

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.11.6",
+      "version": "2.12.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.11.6",
+  "version": "2.12.0",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.12.0] — 2026-05-29
+
 ### Added
 - **WhatsApp bridge: Linux (systemd-user) install path.** `scripts/install-whatsapp-bridge-linux.sh` clones lharries/whatsapp-mcp, applies the in-repo claude-ops patches (`scripts/whatsapp/apply-patches.py`), drops three systemd-user units (`whatsapp-bridge.service`, `whatsapp-backfill.service`, `whatsapp-backfill.timer`), and pairs via the bridge's pairing-code flow. Idempotent — re-running is safe and only applies missing patches.
 - **`POST /api/backfill` REST endpoint** on the bridge (patch). Lets the claude-ops daemon, a 2h systemd timer, or `curl` trigger a fresh history backfill without restarting the bridge. Returns `{"success":true,"message":"backfill requested"}` when connected; 503 otherwise.


### PR DESCRIPTION
Release 2.12.0. Bumps `plugin.json` + `marketplace.json` to `2.12.0` and stamps the `[2.12.0] — 2026-05-29` header onto the CHANGELOG `[Unreleased]` section that landed in #366.

## Highlights

`/ops:ops-inbox whatsapp` now works on Linux. Installs the systemd-user bridge, applies 5 sentinel-gated patches that fix the upstream pair-phone hang + crash-prone history-sync request, wires an auto-backfill on `events.Connected` + `POST /api/backfill` endpoint, and resolves group senders from `@lid` form to real contact names via whatsmeow's own contacts + lid_map tables (replacing the macOS-only Contacts.app mapper).

## What's in 2.12.0

See [CHANGELOG.md `[2.12.0]`](https://github.com/Lifecycle-Innovations-Limited/claude-ops/blob/release/v2.12.0/claude-ops/CHANGELOG.md) — full feat/fix list shipped with PR #366.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only PR; no runtime code changes in the diff.
> 
> **Overview**
> **Release 2.12.0** — bumps the ops plugin from **2.11.6** to **2.12.0** in `.claude-plugin/marketplace.json` and `claude-ops/.claude-plugin/plugin.json`, and adds a dated **`[2.12.0] — 2026-05-29`** section to `claude-ops/CHANGELOG.md` (content previously under `[Unreleased]` from #366).
> 
> The changelog documents the **Linux WhatsApp bridge** work: systemd-user install script, sentinel-gated patches (pair-phone hang, history-sync crash), `POST /api/backfill`, reconnect auto-backfill, cross-platform daemon wiring (`launchctl` / `systemctl --user`), and MCP contact resolution from whatsmeow tables instead of macOS Contacts.app.
> 
> No application logic changes in this diff — metadata and release notes only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d26db16de9e2d7a431b4e769fe5c704ada39e14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->