### PR TITLE
fix(rotation): untrack config.json; readers prefer gitignored override (2.11.8)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.11.7",
+      "version": "2.11.8",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.11.7",
+  "version": "2.11.8",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.11.8] — 2026-05-29
+
+### Security
+
+- **Account-rotation config: stop tracking `config.json`; readers prefer the gitignored override.** `rotate.mjs` and `kapture-claim-credits.mjs` now resolve the rotation config from `$CLAUDE_PLUGIN_DATA_DIR/account-rotation-config.json` (where `setup-account.mjs` already writes real accounts), falling back to a local gitignored `config.json` and then the shipped empty `config.example.json`. `config.json` is `git rm --cached`'d so real emails can never land in a tracked file (it was already in `.gitignore` but remained tracked). No data was ever leaked to the remote — the committed `config.json` was always the empty default; this closes the accidental-commit footgun.
+
+
 ## [2.11.7] — 2026-05-29
 
 ### Added

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.11.7",
+  "version": "2.11.8",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/claude-ops/scripts/account-rotation/config.json
+++ b/claude-ops/scripts/account-rotation/config.json
@@ -1,5 +1,0 @@
-{
-  "version": "1.0",
-  "comment": "Default empty config. User overrides land at ~/.claude/plugins/data/ops-ops-marketplace/account-rotation-config.json (gitignored). Never commit real emails — Rule 0.",
-  "accounts": []
-}

--- a/claude-ops/scripts/account-rotation/kapture-claim-credits.mjs
+++ b/claude-ops/scripts/account-rotation/kapture-claim-credits.mjs
@@ -74,8 +74,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // dir (where setup-account.mjs writes real accounts), fall back to the local
 // gitignored config.json, then the shipped empty config.example.json.
 const ROTATION_DATA_DIR =
-  process.env.CLAUDE_PLUGIN_DATA_DIR ||
-  join(homedir(), '.claude', 'plugins', 'data', 'ops-ops-marketplace');
+  process.env.CLAUDE_PLUGIN_DATA_DIR || join(homedir(), '.claude', 'plugins', 'data', 'ops-ops-marketplace');
 const CONFIG_OVERRIDE = join(ROTATION_DATA_DIR, 'account-rotation-config.json');
 const CONFIG_LOCAL = join(__dirname, 'config.json');
 const CONFIG_EXAMPLE = join(__dirname, 'config.example.json');

--- a/claude-ops/scripts/account-rotation/kapture-claim-credits.mjs
+++ b/claude-ops/scripts/account-rotation/kapture-claim-credits.mjs
@@ -70,7 +70,20 @@ import {
 } from './ledger.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const CONFIG_PATH = join(__dirname, 'config.json');
+// Config resolution (Rule 0): prefer the gitignored override in the plugin data
+// dir (where setup-account.mjs writes real accounts), fall back to the local
+// gitignored config.json, then the shipped empty config.example.json.
+const ROTATION_DATA_DIR =
+  process.env.CLAUDE_PLUGIN_DATA_DIR ||
+  join(homedir(), '.claude', 'plugins', 'data', 'ops-ops-marketplace');
+const CONFIG_OVERRIDE = join(ROTATION_DATA_DIR, 'account-rotation-config.json');
+const CONFIG_LOCAL = join(__dirname, 'config.json');
+const CONFIG_EXAMPLE = join(__dirname, 'config.example.json');
+const CONFIG_PATH = existsSync(CONFIG_OVERRIDE)
+  ? CONFIG_OVERRIDE
+  : existsSync(CONFIG_LOCAL)
+    ? CONFIG_LOCAL
+    : CONFIG_EXAMPLE;
 const LEDGER_PATH = join(homedir(), '.claude', 'credits-ledger.json');
 const RECEIPTS_DIR = join(homedir(), '.claude', 'credits-ledger-receipts');
 

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -57,8 +57,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // is the shipped empty template. Preferring the override keeps the read path in
 // sync with the write path and prevents real emails landing in a tracked file.
 const ROTATION_DATA_DIR =
-  process.env.CLAUDE_PLUGIN_DATA_DIR ||
-  join(homedir(), '.claude', 'plugins', 'data', 'ops-ops-marketplace');
+  process.env.CLAUDE_PLUGIN_DATA_DIR || join(homedir(), '.claude', 'plugins', 'data', 'ops-ops-marketplace');
 const CONFIG_OVERRIDE = join(ROTATION_DATA_DIR, 'account-rotation-config.json');
 const CONFIG_LOCAL = join(__dirname, 'config.json');
 const CONFIG_EXAMPLE = join(__dirname, 'config.example.json');

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -40,7 +40,7 @@ import {
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync, execFileSync, spawnSync, spawn } from 'child_process';
-import { tmpdir } from 'os';
+import { tmpdir, homedir } from 'os';
 import { createHmac } from 'node:crypto';
 import { askAIBrain, executeAIAction, AI_BRAIN_MAX_DECISIONS } from './ai-brain.mjs';
 
@@ -51,7 +51,22 @@ const IS_LINUX = process.platform === 'linux';
 let _linuxVault = IS_LINUX ? await import('./vault-linux.mjs') : null;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const CONFIG_PATH = join(__dirname, 'config.json');
+// Config resolution (Rule 0): real accounts live in the gitignored plugin data
+// dir (where setup-account.mjs writes them); the in-repo config.json is
+// gitignored + untracked and used only as a local fallback; config.example.json
+// is the shipped empty template. Preferring the override keeps the read path in
+// sync with the write path and prevents real emails landing in a tracked file.
+const ROTATION_DATA_DIR =
+  process.env.CLAUDE_PLUGIN_DATA_DIR ||
+  join(homedir(), '.claude', 'plugins', 'data', 'ops-ops-marketplace');
+const CONFIG_OVERRIDE = join(ROTATION_DATA_DIR, 'account-rotation-config.json');
+const CONFIG_LOCAL = join(__dirname, 'config.json');
+const CONFIG_EXAMPLE = join(__dirname, 'config.example.json');
+const CONFIG_PATH = existsSync(CONFIG_OVERRIDE)
+  ? CONFIG_OVERRIDE
+  : existsSync(CONFIG_LOCAL)
+    ? CONFIG_LOCAL
+    : CONFIG_EXAMPLE;
 const STATE_PATH = join(__dirname, 'state.json');
 const LOCK_PATH = join(__dirname, '.rotating');
 const LOG_PATH = join(__dirname, 'rotation.log');


### PR DESCRIPTION
## Security hygiene (Rule 0)

Surfaced by automated security review: real account emails were present in the **local** `scripts/account-rotation/config.json`. 

**No remote leak** — verified the committed `config.json` on `main` is the empty default and `git grep` across `origin/main` finds zero real emails. This PR closes the *accidental-commit footgun*: the file was in `.gitignore` but still **tracked**, and the daemon read paths wrote/grew real data into it.

### Root cause
- Writer (`setup-account.mjs`) already targets the gitignored override `$CLAUDE_PLUGIN_DATA_DIR/account-rotation-config.json`.
- Readers (`rotate.mjs:54`, `kapture-claim-credits.mjs:73`) hardcoded `__dirname/config.json`. Mismatch → real accounts lived in a tracked file.

### Fix
- Both readers now resolve: **override (data dir) → local `config.json` → `config.example.json`**. Backward compatible.
- `git rm --cached config.json` (stays gitignored). `config.example.json` remains the shipped empty template.
- Bump to 2.11.8 + CHANGELOG (Security).

### Verification
- `node --check` on both files; rotation `__tests__` pass; resolver smoke confirms the override is selected when present.
- `tests/test-no-secrets.sh` 14/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes where rotation and credit-claim load account emails; misconfigured paths could break local rotation, but layered fallbacks limit blast radius and the fix reduces accidental secret commits.
> 
> **Overview**
> **Release 2.11.8** aligns account-rotation **read** paths with where **`setup-account.mjs` already writes** real account lists.
> 
> `rotate.mjs` and `kapture-claim-credits.mjs` no longer hardcode in-repo `config.json`. They pick config in order: `$CLAUDE_PLUGIN_DATA_DIR/account-rotation-config.json` (default under `~/.claude/plugins/data/ops-ops-marketplace/`), then a local gitignored `config.json`, then shipped `config.example.json`.
> 
> The in-repo **`scripts/account-rotation/config.json` is removed from git tracking** (empty template was still tracked despite `.gitignore`). That closes the footgun where local rotation could grow real emails into a committed file. Version bumps and a **Security** changelog entry document the change; behavior stays backward compatible when only the override or example file exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f955fbb72bd6de37aeffd9afc7555dd51731461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->