### PR TITLE
fix(pocket): optional least-privilege worker isolation via POCKET_WORKER_USER (2.11.9)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.11.8",
+      "version": "2.11.9",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.11.8",
+  "version": "2.11.9",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.11.9] — 2026-05-29
+
+### Security
+
+- **Pocket executor: optional least-privilege worker isolation (`POCKET_WORKER_USER`).** `ops-cron-pocket-executor.py` can now launch each `claude --bg` worker as a restricted unix user via `sudo -n -H -u <user>` instead of inheriting the executor user's full privileges, capping the blast radius of a prompt-injected or auto-promoted task. Opt-in: set `POCKET_WORKER_USER` (and optionally `POCKET_WORKER_CLAUDE_CONFIG_DIR` to point the worker at a readable Claude config). Default unset = unchanged behaviour. `--dangerously-skip-permissions` is retained (required for unattended `--bg` workers) but is now bounded by the worker user's FS/network grants rather than running with the executor's full access.
+
+
 ## [2.11.8] — 2026-05-29
 
 ### Security

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.11.8",
+  "version": "2.11.9",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/claude-ops/scripts/ops-cron-pocket-executor.py
+++ b/claude-ops/scripts/ops-cron-pocket-executor.py
@@ -66,6 +66,19 @@ WORKER_MODEL = os.environ.get("POCKET_WORKER_MODEL", "claude-sonnet-4-6")
 WORKER_TIMEOUT = int(os.environ.get("POCKET_WORKER_TIMEOUT", "1800"))
 DRY_RUN = os.environ.get("POCKET_EXEC_DRY_RUN") == "1"
 
+# Least-privilege worker isolation (security hardening). When POCKET_WORKER_USER
+# is set, each `claude --bg` worker is launched as that restricted unix user via
+# `sudo -n` instead of inheriting the executor user's full privileges. This caps
+# the blast radius of a prompt-injected/auto-promoted task: the worker can only
+# touch what that user is granted (e.g. ~/Projects), not the executor's secrets,
+# cloud creds, or SSH keys. Default empty = unchanged behaviour (runs as the
+# executor user). When set, the deployment must also provide a NOPASSWD sudoers
+# entry (<executor-user> -> POCKET_WORKER_USER; `sudo -n` fails loudly rather
+# than prompting if missing) and a Claude config dir the worker can read, pointed
+# to via POCKET_WORKER_CLAUDE_CONFIG_DIR (passed as CLAUDE_CONFIG_DIR).
+WORKER_USER = os.environ.get("POCKET_WORKER_USER", "").strip()
+WORKER_CLAUDE_CONFIG_DIR = os.environ.get("POCKET_WORKER_CLAUDE_CONFIG_DIR", "").strip()
+
 DURABLE_LOG = STATE_DIR / "tasks.jsonl"
 CURSOR_FILE = STATE_DIR / "supervisor-cursor.txt"
 SPAWN_LEDGER = STATE_DIR / "spawn-ledger.jsonl"
@@ -337,6 +350,9 @@ def spawn_worker(task: dict) -> dict | None:
     # ignored by --bg (would leave the session idle with "(send a prompt)").
     env = os.environ.copy()
     env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"] = "0"
+    if WORKER_USER and WORKER_CLAUDE_CONFIG_DIR:
+        # Point the restricted worker at a Claude config dir it can read.
+        env["CLAUDE_CONFIG_DIR"] = WORKER_CLAUDE_CONFIG_DIR
     # Display name shown in `claude agents` list — short, categorical, NOT the
     # full prompt. Sam corrected 2026-05-25: name field ≠ prompt field.
     display_name = f"pocket: {(task.get('title') or task_id)[:60]}"
@@ -346,6 +362,14 @@ def spawn_worker(task: dict) -> dict | None:
            "--model", WORKER_MODEL,
            "--add-dir", str(EXEC_CWD),
            "-p", prompt]
+    if WORKER_USER and WORKER_USER != (os.environ.get("USER") or ""):
+        # Drop privileges: run the worker as the restricted POCKET_WORKER_USER.
+        # `sudo -n` is non-interactive (fails loudly if NOPASSWD sudoers is missing
+        # rather than hanging); `-H` sets HOME to the worker user's home so Claude
+        # writes session state there; --preserve-env carries only the vars the
+        # worker needs, dropping the executor user's secrets from the environment.
+        _preserve = "PATH,CLAUDE_CONFIG_DIR,CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS,ANTHROPIC_API_KEY,POCKET_WORKER_MODEL"
+        cmd = ["sudo", "-n", "-H", "-u", WORKER_USER, f"--preserve-env={_preserve}", "--", *cmd]
 
     try:
         out_f = stdout_path.open("w")


### PR DESCRIPTION
## Security hardening (flagged by automated review)

`ops-cron-pocket-executor.py` launches autonomous `claude --bg` workers with `--dangerously-skip-permissions` — required for unattended `--bg` (a backgrounded worker can't answer interactive permission prompts). Combined with the pipeline's auto-promotion of action items sourced from ingested content, that gives a prompt-injected worker the executor user's **full** privileges.

### Change
- New opt-in `POCKET_WORKER_USER`: when set, each worker is launched as that **restricted unix user** via `sudo -n -H -u <user> --preserve-env=PATH,CLAUDE_CONFIG_DIR,...`. Drops the executor user's env/secrets; bounds the worker to that user's FS/network grants.
- Optional `POCKET_WORKER_CLAUDE_CONFIG_DIR` → exported as `CLAUDE_CONFIG_DIR` so the worker reads a shared/readable Claude config (keeps the account without a separate login).
- **Default unset = unchanged behaviour.** `sudo -n` fails loudly if the NOPASSWD sudoers entry is missing (no silent hang).
- `--dangerously-skip-permissions` is retained (necessary for `--bg`) but is now *contained* by the worker user's least-privilege scope rather than running with the executor's full access.

Deployment (dev box) provisions a `pocket-worker` user scoped to `~/Projects` + own workspace, with secret/cred dirs denied — out of band, not in this repo.

### Verification
- `python3 -m py_compile` passes; 24-line diff, no whole-file churn.
- `tests/test-no-secrets.sh` 14/0. No real paths/secrets in diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how privileged autonomous Claude workers are spawned (`sudo`, preserved secrets, `--dangerously-skip-permissions`); incorrect sudoers or env can break workers or weaken isolation.
> 
> **Overview**
> **Release 2.11.9** bumps plugin/marketplace/package versions and documents a Pocket executor security option in the changelog.
> 
> The functional change is in **`ops-cron-pocket-executor.py`**: when **`POCKET_WORKER_USER`** is set (and differs from the current user), each autonomous **`claude --bg`** worker is wrapped in **`sudo -n -H -u <user>`** with a tight **`--preserve-env`** list so workers no longer inherit the executor’s full environment. Optional **`POCKET_WORKER_CLAUDE_CONFIG_DIR`** sets **`CLAUDE_CONFIG_DIR`** for the worker when both isolation vars are configured. **`--dangerously-skip-permissions`** is unchanged (still required for unattended background workers); default behavior with env unset is identical to before.
> 
> Deployment expects out-of-repo **NOPASSWD sudoers** and filesystem grants for the worker account; misconfiguration causes spawn failure rather than interactive sudo prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3eb79f4d456fe0ee5a156b99967c0fae934c2bde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->