### PR TITLE
fix(account-rotation): single forwarding inbox + magic-link-only + mcpOAuth preservation

### DIFF
--- a/claude-ops/scripts/account-rotation/config.example.json
+++ b/claude-ops/scripts/account-rotation/config.example.json
@@ -20,6 +20,8 @@
     "extraUsageSafetyMargin": 0.75,
     "note": "Max 20x defaults: ~220K tokens / ~900 messages per 5h window. extraUsageSafetyMargin: accounts with paid overage enabled rotate at 75% of their threshold to avoid incurring charges."
   },
+  "magicLinkGmailAccount": "shared-inbox@example.com",
+  "_magicLinkGmailAccount_note": "Single Gmail inbox that ALL accounts' Claude magic-link login emails forward to. The rotator polls only this inbox (via gog --account) for every account's link, then disambiguates by target email. Leave unset to poll each account's own mailbox. Real value belongs in the gitignored override config or CLAUDE_ROT_GMAIL_ACCOUNT / GOG_ACCOUNT env, never here.",
   "toolUseThreshold": 800,
   "maxHoursPerAccount": 4,
   "autoRotate": true,

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -176,6 +176,21 @@ function notify(title, msg) {
 function readConfig() {
   return JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
 }
+
+// All accounts' Claude login emails forward to ONE Gmail inbox, so every
+// magic-link poll queries that single account rather than each account's own
+// mailbox. Resolve it from env or the gitignored override config — never
+// hardcode a real address in the public repo (Rule 0). Returns '' if
+// unconfigured, in which case callers fall back to the per-account mailbox.
+function magicLinkInbox() {
+  if ((process.env.CLAUDE_ROT_GMAIL_ACCOUNT || '').trim()) return process.env.CLAUDE_ROT_GMAIL_ACCOUNT.trim();
+  if ((process.env.GOG_ACCOUNT || '').trim()) return process.env.GOG_ACCOUNT.trim();
+  try {
+    return (readConfig().magicLinkGmailAccount || '').trim();
+  } catch {
+    return '';
+  }
+}
 function readState() {
   try {
     return JSON.parse(readFileSync(STATE_PATH, 'utf8'));
@@ -680,16 +695,34 @@ async function swapToken(account) {
     const current = readKeychain();
     const currentParsed = JSON.parse(current);
     const newParsed = JSON.parse(token);
-    if (currentParsed.mcpOAuth && Object.keys(currentParsed.mcpOAuth).length > 0) {
-      // Merge: keep current mcpOAuth, only swap claudeAiOauth
+    // Unconditional merge: vault tokens ship mcpOAuth:{} by design (stripped at
+    // save time). The previous `Object.keys > 0` guard was self-reinforcing —
+    // once a wipe wrote mcpOAuth:{}, the next rotation read empty, skipped the
+    // merge, and wiped again forever, forcing every OAuth MCP server
+    // (giga/Amplitude/higgsfield) to browser-reauth on the next CC launch.
+    if (currentParsed.mcpOAuth) {
       newParsed.mcpOAuth = { ...newParsed.mcpOAuth, ...currentParsed.mcpOAuth };
       writeKeychain(JSON.stringify(newParsed));
-      log('[primary] Preserved mcpOAuth from previous session');
+      log('[primary] Wrote token (mcpOAuth merged from current session)');
       return true;
     }
   } catch {}
 
-  writeKeychain(token);
+  // Defensive fallback: catch path or falsy currentParsed.mcpOAuth lands here.
+  // Re-attempt the merge once before writing so a transient read/parse error
+  // doesn't wipe mcpOAuth and force every MCP OAuth server to reauth.
+  let outToken = token;
+  try {
+    const cur = readKeychain();
+    const cp = JSON.parse(cur);
+    if (cp.mcpOAuth && Object.keys(cp.mcpOAuth).length > 0) {
+      const np = JSON.parse(token);
+      np.mcpOAuth = { ...np.mcpOAuth, ...cp.mcpOAuth };
+      outToken = JSON.stringify(np);
+      log('[primary] mcpOAuth preserved via fallback merge');
+    }
+  } catch {}
+  writeKeychain(outToken);
   return true;
 }
 
@@ -1513,6 +1546,15 @@ async function pollGmailForMagicLink(accountEmail, maxWaitMs = 120_000) {
   // Track skipped (stale/wrong-target) thread IDs so we don't re-evaluate them every poll
   const seenSkip = new Set();
 
+  // All accounts forward their Claude login emails to one inbox; query that
+  // single account. Falls back to the per-account mailbox if unconfigured.
+  // The per-link target-email check below still disambiguates which link
+  // belongs to the account being rotated, so a shared inbox is safe.
+  const inbox = magicLinkInbox() || accountEmail;
+  if (inbox !== accountEmail) {
+    log(`[magic-link] Using shared forwarding inbox for ${accountEmail}'s link`);
+  }
+
   while (Date.now() - startTime < maxWaitMs) {
     try {
       // Pull up to 10 recent matches so a stale top-result doesn't block us.
@@ -1522,7 +1564,7 @@ async function pollGmailForMagicLink(accountEmail, maxWaitMs = 120_000) {
         'gog',
         [
           '--account',
-          accountEmail,
+          inbox,
           'gmail',
           'search',
           'subject:"Secure link to log in to Claude" newer_than:5m',
@@ -1548,7 +1590,7 @@ async function pollGmailForMagicLink(accountEmail, maxWaitMs = 120_000) {
 
         const threadJson = execFileSync(
           'gog',
-          ['--account', accountEmail, 'gmail', 'thread', 'get', threadIdRaw, '-j', '--no-input'],
+          ['--account', inbox, 'gmail', 'thread', 'get', threadIdRaw, '-j', '--no-input'],
           {
             timeout: 15_000,
             stdio: ['ignore', 'pipe', 'pipe'],
@@ -2195,18 +2237,11 @@ async function runAuthFlow(driver, account) {
             }
             continue;
           }
-          if (IS_LINUX) {
-            // Headless Linux has no device trust; Google OAuth stalls on push-2FA.
-            log(
-              `[magic-link] No magic link found in Gmail — failing account (Google OAuth unavailable on headless Linux).`,
-            );
-            throw new Error(`magic-link timeout for ${account.email} (Google OAuth disabled on Linux)`);
-          }
-          log(`[magic-link] No magic link found in Gmail — falling through to Google OAuth`);
-          try {
-            await driver.goto(driver._authUrl || 'https://claude.ai/login');
-          } catch {}
-          await sleep(3000);
+          // Magic-link is the ONLY auth method on every platform — never fall
+          // through to Google OAuth (it stalls on push-2FA and the user wants
+          // magic-link only). Fail the account so the missing link surfaces.
+          log(`[magic-link] No magic link found in Gmail — failing account (magic-link-only, no Google fallback).`);
+          throw new Error(`magic-link timeout for ${account.email} (magic-link-only)`);
         }
       }
     }
@@ -2879,8 +2914,21 @@ async function rotate(targetEmail, opts = {}) {
             if (prevAccount) {
               const prevToken = readStoredToken(prevAccount);
               if (prevToken) {
-                writeKeychain(prevToken);
-                log(`Reverted keychain to previous account ${prevKey}`);
+                // prevToken came from the vault (mcpOAuth:{} stripped by design).
+                // Merge the current active keychain's mcpOAuth before rollback,
+                // otherwise this revert wipes giga/Amplitude/higgsfield OAuth.
+                let outToken = prevToken;
+                try {
+                  const cur = readKeychain();
+                  const cp = JSON.parse(cur);
+                  if (cp.mcpOAuth && Object.keys(cp.mcpOAuth).length > 0) {
+                    const np = JSON.parse(prevToken);
+                    np.mcpOAuth = { ...np.mcpOAuth, ...cp.mcpOAuth };
+                    outToken = JSON.stringify(np);
+                  }
+                } catch {}
+                writeKeychain(outToken);
+                log(`Reverted keychain to previous account ${prevKey} (mcpOAuth preserved)`);
               }
             }
             return false;


### PR DESCRIPTION
## Summary
- Rotation now polls a **single shared forwarding inbox** for every account's Claude magic-link (resolver: `CLAUDE_ROT_GMAIL_ACCOUNT` > `GOG_ACCOUNT` > `config.magicLinkGmailAccount`), then disambiguates the correct link by target email. Falls back to per-account mailbox when unset — non-regressive.
- **Magic-link is the only auth method on every platform.** Removed the macOS Google-OAuth fallthrough (stalled on push-2FA) and the Linux-only throw; both now fail the account with a clear `magic-link timeout` error.
- `swapToken` merges `mcpOAuth` from the current keychain **unconditionally** (+ defensive fallback merge), fixing the self-reinforcing guard that re-wiped OAuth MCP tokens once an empty `{}` was written. Rollback path preserves `mcpOAuth` on revert too.
- Documented Rule-0-safe `magicLinkGmailAccount` placeholder in `config.example.json`.

Rebased fresh off current `main` (supersedes closed #371, which was stale against main's newer rotation rework).

## Test plan
- [x] `node --check rotate.mjs` passes
- [x] `config.example.json` valid JSON
- [x] `tests/test-no-secrets.sh` 14/14 pass
- [ ] Live rotation pulls magic link from shared inbox for a non-primary account
- [ ] OAuth MCP servers (giga/Amplitude) survive a rotation without re-auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live rotation auth and keychain token composition; misconfigured shared inbox or stricter magic-link-only behavior can fail rotations, but scope is limited to the rotator script and example config.
> 
> **Overview**
> Account rotation now supports a **single shared Gmail inbox** for all accounts’ Claude magic-link emails (`magicLinkInbox()` via `CLAUDE_ROT_GMAIL_ACCOUNT`, `GOG_ACCOUNT`, or `magicLinkGmailAccount` in override config), with per-link disambiguation by target email and fallback to each account’s own mailbox when unset.
> 
> **Magic-link is the only re-auth path** on every platform: Google OAuth fallthrough after a missing link was removed so failures surface as `magic-link timeout` instead of stalling on push-2FA.
> 
> **`mcpOAuth` is preserved across swaps and billing rollbacks**: `swapToken` always merges session MCP OAuth from the active keychain (vault entries intentionally store `mcpOAuth:{}`), with a defensive second merge on write; extra-usage revert merges `mcpOAuth` before restoring the previous vault token.
> 
> `config.example.json` documents the shared-inbox placeholder under Rule 0 (no real addresses in-repo).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c76681c5ecefeffd1a702aaca3e2b587a26101e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->