### PR TITLE
chore(release): ops v2.14.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.13.0",
+      "version": "2.14.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,4 +1,20 @@
 # Changelog
+## 2.14.0 — 2026-05-29
+
+### Added
+- **`/ops:ops-aws-audit`** — read-only, account-agnostic AWS audit skill. A single
+  self-contained `scripts/ops-aws-audit.sh` that uses the caller's credential
+  chain and **auto-discovers all enabled regions** for a full-account sweep.
+  Severity-ranked findings (CRITICAL→LOW) in `report.md` + machine-readable
+  `findings.json`, and a pixel-art terminal summary on completion. Covers IAM
+  (root key/MFA, stale keys, Access Analyzer), EC2/EBS (unattached/gp2/unencrypted
+  volumes, idle EIPs, world-open security groups incl. all-traffic), RDS
+  (unencrypted/public, orphaned snapshots — Aurora-aware), S3 (account BPA,
+  encryption, lifecycle), CloudWatch retention, Lambda EOL runtimes,
+  GuardDuty/Security Hub/Cost Anomaly/Compute Optimizer enrollment, and
+  per-service cost deltas. No mutations; cleanup stays human-gated.
+- `scripts/install-aws-audit-cron.sh` — optional daily `systemd --user` timer.
+
 
 All notable changes to this project will be documented in this file.
 


### PR DESCRIPTION
Release **v2.14.0**. Bumps plugin.json + marketplace.json and adds the CHANGELOG entry.

Includes #377 — `/ops:ops-aws-audit` (read-only, full-account, all-region AWS audit; pixel-art report; human-gated cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only changes; no runtime code in the shown diff.
> 
> **Overview**
> Release **v2.14.0** bumps the ops plugin version in `plugin.json` and marketplace `marketplace.json` from **2.13.0 → 2.14.0** and adds the **2.14.0** changelog entry for work merged via **#377**.
> 
> The release note documents **`/ops:ops-aws-audit`**: a read-only, credential-chain-driven, multi-region AWS sweep (`scripts/ops-aws-audit.sh`) that emits severity-ranked `report.md` + `findings.json` and a terminal summary, with optional daily scheduling via `scripts/install-aws-audit-cron.sh` (systemd user timer). No AWS mutations in this release packaging PR itself—only version metadata and changelog text change in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc6d66287e855a92d7aa5805e2f2208bb2e578ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->