### PR TITLE
fix(pocket): ops-pocket-notify wrapper resolves symlinks (2.14.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.14.0",
+      "version": "2.14.1",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.14.0",
+  "version": "2.14.1",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -20,6 +20,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.14.1] — 2026-05-29
+
+### Fixed
+
+- **`ops-pocket-notify` wrapper resolves symlinks.** The `bin/ops-pocket-notify` bash wrapper computed the Python script path from `dirname "$0"`, which resolves relative to a PATH symlink's directory rather than the real file — so invoking it via a `~/.local/bin` symlink failed to find `../scripts/ops-pocket-notify.py`. Now `readlink -f`s itself first. Also syncs `package.json` (had drifted to 2.13.0) to the plugin version.
+
+
 ## [2.13.0] — 2026-05-29
 
 ### Added

--- a/claude-ops/bin/ops-pocket-notify
+++ b/claude-ops/bin/ops-pocket-notify
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 # Thin wrapper so `ops-pocket-notify` is on PATH; the implementation is Python.
-exec python3 "$(dirname "$0")/../scripts/ops-pocket-notify.py" "$@"
+# Resolve symlinks (readlink -f) so PATH-symlinked invocations still locate the
+# script — `dirname "$0"` alone resolves relative to the symlink's dir, not the
+# real file, which breaks `../scripts/...`.
+SELF="$(readlink -f "$0")"
+exec python3 "$(dirname "$SELF")/../scripts/ops-pocket-notify.py" "$@"

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.13.0",
+  "version": "2.14.1",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
## Fix

`bin/ops-pocket-notify` (the bash wrapper for the Python dispatcher) computed its script path with `dirname "$0"`, which resolves relative to a **PATH symlink's** directory, not the real file. Invoked via a `~/.local/bin/ops-pocket-notify` symlink, `../scripts/ops-pocket-notify.py` pointed at the wrong place and notification dispatch silently failed (found live during 2.13.0 provisioning).

Now the wrapper `readlink -f`s itself first. Proven by invoking through a symlink in a different dir → resolves correctly.

Also syncs `package.json` (had drifted to 2.13.0) and `marketplace.json` to the plugin version → **2.14.1**.

## Tests
`test-bin-scripts` 186/0, `test-no-secrets` 14/0; symlink-invocation verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small bash wrapper and version-bump change only; restores pocket notify when called via symlink with no auth or data-model impact.
> 
> **Overview**
> **Release 2.14.1** fixes pocket notification dispatch when `ops-pocket-notify` is invoked through a PATH symlink (e.g. `~/.local/bin`). The bash wrapper now resolves its real path with `readlink -f` before locating `scripts/ops-pocket-notify.py`, instead of using `dirname "$0"` against the symlink directory.
> 
> Version metadata is aligned across `plugin.json`, `marketplace.json`, `package.json` (was **2.13.0**), and **CHANGELOG** for the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d6eb9d60f84f81f8039d462eee8b14e2092100a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->