### PR TITLE
feat(pocket): port deploy-box patches — message-listener hardening + triage decision-log (2.15.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.14.1",
+      "version": "2.15.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -20,6 +20,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.15.0] — 2026-05-29
+
+### Added
+
+- **Triage decision-log hook** — `ops-pocket-triage.py` now records each triage decision (event type, confidence, reasoning) via `/opt/pocket-mcp/pipeline/ops-pocket-decisions.py` when present (try/except-guarded, no-op if absent), building an audit trail for downstream reporting.
+
+### Changed
+
+- **`ops-message-listener.sh` input hardening** — defense-in-depth on the dispatch path: env-var isolation for `QUEUE_FILE` (no shell interpolation), JSON load guarded by try/except + isinstance, per-message bounds (`MAX_LEN=4000`, sender ≤64), control-char stripping, and **NUL-delimited** dispatch output so newlines in message text can't smuggle extra dispatch lines. Merged on top of origin's existing stdin-piping fix; keeps the `|| true` call-site resilience.
+
+_(Ports two patches that had been applied directly on the deploy box into the repo, so the live checkout can track main cleanly.)_
+
+
 ## [2.14.1] — 2026-05-29
 
 ### Fixed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/claude-ops/scripts/ops-message-listener.sh
+++ b/claude-ops/scripts/ops-message-listener.sh
@@ -57,53 +57,76 @@ json.dump(data, open('$STATE_FILE', 'w'))
 }
 
 # ── Append messages to queue ──────────────────────────────────────────────
+# SECURITY: JSON payload piped via stdin (NEVER interpolated into source) to prevent
+# Python code injection from untrusted Telegram/WhatsApp message content.
 append_to_queue() {
   local new_msgs_json="$1"
-  # Pass JSON via stdin to avoid triple-quote shell injection (Bugbot issue #14328751/1).
-  printf '%s' "$new_msgs_json" | python3 -c "
-import json, sys
+  QUEUE_FILE="$QUEUE_FILE" printf '%s' "$new_msgs_json" | python3 -c "
+import json, os, sys
 from datetime import datetime, timezone
 
-queue_file = '$QUEUE_FILE'
+queue_file = os.environ['QUEUE_FILE']
 try:
-    queue = json.load(open(queue_file))
-except:
+    with open(queue_file) as f:
+        queue = json.load(f)
+except Exception:
     queue = {'messages': [], 'last_updated': None}
 
-new_msgs = json.load(sys.stdin)
-# Dedup by message id
+try:
+    new_msgs = json.load(sys.stdin)
+except Exception:
+    new_msgs = []
+
+if not isinstance(new_msgs, list):
+    new_msgs = []
+
 existing_ids = {m.get('id') for m in queue['messages']}
 added = 0
 for msg in new_msgs:
+    if not isinstance(msg, dict):
+        continue
     if msg.get('id') not in existing_ids:
         queue['messages'].append(msg)
         existing_ids.add(msg.get('id'))
         added += 1
 
-# Keep last 200 messages max
 queue['messages'] = queue['messages'][-200:]
 queue['last_updated'] = datetime.now(timezone.utc).isoformat()
 
-json.dump(queue, open(queue_file, 'w'), indent=2)
+with open(queue_file, 'w') as f:
+    json.dump(queue, f, indent=2)
 print(added)
 " 2>/dev/null || echo 0
 }
 
 # ── Dispatch Telegram messages to target session ───────────────────────────
+# SECURITY: JSON piped via stdin; output is NUL-delimited so newlines in message
+# text cannot smuggle additional dispatch lines or arguments.
 dispatch_telegram() {
   local new_msgs_json="$1"
   printf '%s' "$new_msgs_json" | python3 -c "
-import json, sys
-msgs = json.load(sys.stdin)
+import json, sys, re
+try:
+    msgs = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+if not isinstance(msgs, list):
+    sys.exit(0)
+MAX_LEN = 4000
+SAFE = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')
 for msg in msgs:
-    from_user = msg.get('from', 'unknown')
-    text = msg.get('text', '').replace('\n', '\\\\n')
-    print(f'telegram:{from_user}:{text}')
-" 2>/dev/null | while IFS= read -r dispatch_line; do
-    if [[ -n "$dispatch_line" ]]; then
-      ops-bg send "$TG_TARGET_SESSION" "$dispatch_line" 2>/dev/null || log "dispatch failed: $dispatch_line"
+    if not isinstance(msg, dict):
+        continue
+    from_user = str(msg.get('from', 'unknown'))[:64]
+    text = str(msg.get('text', ''))[:MAX_LEN]
+    from_user = SAFE.sub('', from_user).replace('\x00', '')
+    text = SAFE.sub('', text).replace('\x00', '')
+    sys.stdout.write(f'telegram:{from_user}:{text}\x00')
+" 2>/dev/null | while IFS= read -r -d '' dispatch_line; do
+    if [[ -n "$dispatch_line" && ${#dispatch_line} -lt 8192 ]]; then
+      ops-bg send "$TG_TARGET_SESSION" "$dispatch_line" 2>/dev/null || log "dispatch failed (len=${#dispatch_line})"
     fi
-  done || true
+  done
 }
 
 # ── Poll WhatsApp ─────────────────────────────────────────────────────────

--- a/claude-ops/scripts/ops-pocket-triage.py
+++ b/claude-ops/scripts/ops-pocket-triage.py
@@ -54,6 +54,17 @@ from urllib import error as urlerr
 from urllib import request as urlreq
 
 LOG_PREFIX = "[ops-pocket-triage]"
+
+# === Phase 2 hook: decision log =====================================
+try:
+    import importlib.util as _ilu
+    _dec_spec = _ilu.spec_from_file_location("_pkt_decisions", "/opt/pocket-mcp/pipeline/ops-pocket-decisions.py")
+    _dec_mod = _ilu.module_from_spec(_dec_spec)
+    _dec_spec.loader.exec_module(_dec_mod)
+except Exception as _e:
+    _dec_mod = None
+# ====================================================================
+
 HOME = Path(os.path.expanduser("~"))
 
 # ---------------------------------------------------------------------------
@@ -395,6 +406,21 @@ def main() -> int:
             "decision": decision,
             "routed_to": verdict,
         })
+        if _dec_mod:
+            try:
+                _dec_mod.write_decision(_dec_mod.make(
+                    event_type=task.get("source", "triage"),
+                    recording_id=task.get("recording_id", ""),
+                    title=task.get("title") or task.get("recording_title", ""),
+                    summary_excerpt=task.get("context", "") or "",
+                    classification=verdict,
+                    confidence=float(decision.get("confidence", 0) or 0),
+                    reasoning=str(decision.get("reasoning", ""))[:1500],
+                    action_taken=verdict,
+                    model=MODEL,
+                ))
+            except Exception as _e:
+                log(f"decision log skip: {_e}")
 
     # Drop only the snapshot we read; bytes appended during triage are kept.
     if not DRY_RUN:


### PR DESCRIPTION
## What

Ports two patches that were applied **directly on the deploy box** (uncommitted in the workspace checkout) back into the repo, so the live checkout can track `main` cleanly and all pocket services stay consistent.

### `ops-message-listener.sh` — input hardening (defense-in-depth)
Merged on top of origin's existing stdin-piping fix:
- env-var isolation for `QUEUE_FILE` (no shell interpolation)
- JSON load guarded by `try/except` + `isinstance`
- per-message bounds (`MAX_LEN=4000`, sender ≤64)
- control-char stripping (regex)
- **NUL-delimited** dispatch output → newlines in message text can't smuggle extra dispatch lines
- keeps origin's `|| true` call-site resilience

### `ops-pocket-triage.py` — decision-log hook
Records each triage decision (event type, confidence, reasoning) via `/opt/pocket-mcp/pipeline/ops-pocket-decisions.py` when present (`try/except`-guarded, no-op if absent) — audit trail for downstream reporting.

## Not ported (take-origin)
`rotate.mjs` (origin's refactor is newer), `package-lock.json` (stale), `ops-cron-pocket-executor.py` (identical to origin) — these were stale/superseded local diffs, not real local-ahead work.

## Tests
`bash -n` + `py_compile` clean; `test-no-secrets` 14/0; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sit on the live message-dispatch and triage paths; hardening reduces injection risk, but regressions could affect queueing or background session delivery if bounds/delimiters misbehave.
> 
> **Overview**
> Release **2.15.0** brings two operational patches from the deploy box into source control so production can track `main` without drift.
> 
> **`ops-message-listener.sh`** tightens the Telegram/WhatsApp dispatch path: `QUEUE_FILE` is passed via environment (no shell interpolation into Python), JSON parsing is guarded with type checks, sender/text are bounded and control characters stripped, and dispatch lines are **NUL-delimited** so embedded newlines cannot forge extra `ops-bg send` arguments.
> 
> **`ops-pocket-triage.py`** optionally records each triage verdict (classification, confidence, reasoning) through `/opt/pocket-mcp/pipeline/ops-pocket-decisions.py` when that module exists; failures are ignored so triage still runs without the pipeline installed.
> 
> Version fields in `plugin.json`, `marketplace.json`, `package.json`, and `CHANGELOG.md` are aligned to **2.15.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2628edbc926ae3a000a575d05ee87f786b1b55e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->