### PR TITLE
fix(email-cos): strip MCP from headless agents (context overflow)

### DIFF
--- a/claude-ops/email-cos/email-cos-approve-agent.py
+++ b/claude-ops/email-cos/email-cos-approve-agent.py
@@ -138,6 +138,11 @@ def interpret(reply_text, codemap):
         [
             "claude",
             "--print",
+            # NL interpretation is pure text reasoning — run with NO MCP servers
+            # so the full env's tool defs don't blow the model context.
+            "--strict-mcp-config",
+            "--mcp-config",
+            '{"mcpServers":{}}',
             "--model",
             NL_MODEL,
             "--dangerously-skip-permissions",

--- a/claude-ops/email-cos/email-cos-orch.sh
+++ b/claude-ops/email-cos/email-cos-orch.sh
@@ -42,8 +42,15 @@ print(tmpl)
 ")
 
 : > "$SD/orch.out"
+# Run headless with a MINIMAL MCP config (enrichment servers only, e.g. gbrain +
+# tavily) — loading the full env's MCP defs blows the model context. Point
+# EMAIL_COS_ORCH_MCP_CONFIG at a JSON file with just the servers the orchestrator
+# needs; unset/missing => no MCP (drafts from thread context only).
+_ORCH_MCP="${EMAIL_COS_ORCH_MCP_CONFIG:-}"
+if [ -z "$_ORCH_MCP" ] || [ ! -f "$_ORCH_MCP" ]; then _ORCH_MCP='{"mcpServers":{}}'; fi
 printf '%s' "$RENDERED_PROMPT" | \
-  claude --print --model "$EMAIL_COS_ORCH_MODEL" --dangerously-skip-permissions >> "$SD/orch.out" 2>&1
+  claude --print --model "$EMAIL_COS_ORCH_MODEL" --dangerously-skip-permissions \
+    --strict-mcp-config --mcp-config "$_ORCH_MCP" >> "$SD/orch.out" 2>&1
 rc=$?
 secs=$(( $(date +%s) - start ))
 echo "{\"ts\":\"$ts\",\"tier\":\"orch\",\"exit\":$rc,\"secs\":$secs}" >> "$SD/metrics.jsonl"

--- a/claude-ops/email-cos/email-cos-sweep.sh
+++ b/claude-ops/email-cos/email-cos-sweep.sh
@@ -71,8 +71,11 @@ print(tmpl)
 ")
 
 : > "$SD/sweep.out"
+# Run headless with NO MCP servers — otherwise the full env's MCP tool defs blow
+# the model context ("Prompt is too long"). Sweep only needs Bash (gog).
 printf '%s' "$RENDERED_PROMPT" | \
-  claude --print --model "$EMAIL_COS_SWEEP_MODEL" --dangerously-skip-permissions >> "$SD/sweep.out" 2>&1
+  claude --print --model "$EMAIL_COS_SWEEP_MODEL" --dangerously-skip-permissions \
+    --strict-mcp-config --mcp-config '{"mcpServers":{}}' --allowedTools Bash >> "$SD/sweep.out" 2>&1
 rc=$?
 secs=$(( $(date +%s) - start ))
 echo "{\"ts\":\"$ts\",\"tier\":\"sweep\",\"exit\":$rc,\"secs\":$secs,\"new\":$new}" >> "$SD/metrics.jsonl"

--- a/claude-ops/email-cos/email-cos.config.example.sh
+++ b/claude-ops/email-cos/email-cos.config.example.sh
@@ -29,6 +29,11 @@ EMAIL_COS_ORCH_MODEL="claude-opus-4-5"
 
 # Natural-language approval interpreter (haiku-class recommended).
 EMAIL_COS_NL_MODEL="claude-haiku-4-5-20251001"
+# Optional: path to a JSON file with ONLY the enrichment MCP servers the
+# orchestrator needs (e.g. gbrain + tavily). Headless agents must NOT load the
+# full MCP env or the model context overflows. Empty => orchestrator runs with
+# no MCP (drafts from thread context only).
+EMAIL_COS_ORCH_MCP_CONFIG=""
 
 # ── Caps ─────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Headless `claude --print` loaded the full MCP env and overflowed model context ("Prompt is too long") — sweep failed every cycle. Fix: sweep + NL-interpret run with no MCP (Bash-only); orchestrator uses a minimal `EMAIL_COS_ORCH_MCP_CONFIG` (gbrain+tavily). Verified live: sweep→orch end-to-end, no overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how enrichment and tools are available to sweep/orch/approval agents; misconfigured EMAIL_COS_ORCH_MCP_CONFIG could disable enrichment MCP until fixed, but avoids total pipeline failure from context overflow.
> 
> **Overview**
> Headless `claude --print` runs in the email-cos pipeline were inheriting the **full MCP environment**, inflating the prompt with tool definitions and triggering **"Prompt is too long"** (sweep was failing every cycle).
> 
> **Sweep** and the **NL approval interpreter** now use `--strict-mcp-config` with an empty `mcpServers` object; sweep also restricts tools to **`Bash`** only (gog via shell). The **orchestrator** uses the same strict mode but loads MCP from an optional **`EMAIL_COS_ORCH_MCP_CONFIG`** file path—if unset or missing, it runs with no MCP (thread-context drafts only). The example config documents the new variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff124d5c6c2c7fb8ddae879de72e53c4e68f24cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->