### PR TITLE
chore(release): ops v2.16.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.15.0",
+      "version": "2.16.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.15.0",
+  "version": "2.16.0",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,4 +1,22 @@
 # Changelog
+
+## 2.16.0 — 2026-05-29
+
+### Added
+- **Pocket decision-log module** (`scripts/ops-pocket-decisions.py`) — append-only,
+  UTC-bucketed audit trail of triage ACT/ASK decisions, consumed by `ops-pocket-triage.py`
+  via a portable `POCKET_SCRIPTS_DIR` loader (symlink-safe; no hardcoded `/opt` path).
+- **Pocket webhook receiver** (`scripts/webhook-receiver/`) — `app.py` (signed-webhook
+  ingest → handler handoff), `on-memory.sh` (journal + per-event dispatch), README.
+
+### Security / Hardening (PR #369 review fixes)
+- Webhook receiver claims dedup **after** successful handoff and **releases the claim +
+  returns 500** on dispatch failure — prevents permanent loss of a recording on transient errors.
+- Auth fails **closed** (503) when no signing secret is configured (was fail-open).
+- Replay check accepts second- or millisecond-epoch timestamps (prevents total-ingestion 401 outage).
+- `on-memory.sh` sanitizes the event name before any file path (post-auth path-traversal fix).
+- `seen` dedup table + webhook journal pruned/rotated (bounded disk); decision-log load failure now logged, not swallowed.
+
 ## 2.14.0 — 2026-05-29
 
 ### Added


### PR DESCRIPTION
Releases #369 — pocket decision-log module, webhook-receiver, and the PR-369 security hardening (dedup-release-on-failure, fail-closed auth, timestamp normalization, path-traversal sanitize, bounded disk). Version bump 2.15.0→2.16.0 across plugin.json + marketplace.json + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff only changes version pins and changelog text; runtime risk depends on #369’s webhook and Pocket code already on the branch, not on edits in this PR itself.
> 
> **Overview**
> Release **ops v2.16.0** (2.15.0 → 2.16.0) in `plugin.json` and `marketplace.json`, with a new **CHANGELOG** section documenting what ships in this release from **#369**.
> 
> The release notes cover a **Pocket decision-log** (`ops-pocket-decisions.py`) wired into triage via `POCKET_SCRIPTS_DIR`, plus a **signed webhook receiver** (`scripts/webhook-receiver/`). **Security hardening** called out there includes fail-closed auth without a signing secret, dedup only after successful handoff (with claim release on dispatch failure), replay-timestamp normalization, event-name sanitization for paths, and bounded on-disk dedup/journal state.
> 
> *This PR’s diff is metadata-only; the implementation is described in the changelog as already merged via #369.*
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54662d7be52842af7c12119121744d5b697f1c03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->