### PR TITLE
fix(setup): accept registry from plugin data dir, not just cache

### DIFF
--- a/claude-ops/scripts/setup.sh
+++ b/claude-ops/scripts/setup.sh
@@ -54,9 +54,12 @@ for tool in "${MISSING[@]}"; do
   echo "  ✗ ops: $tool not found — run /ops:setup to configure"
 done
 
-# Check registry
-REGISTRY="$SCRIPT_DIR/registry.json"
-if [ ! -f "$REGISTRY" ]; then
+# Check registry. The canonical registry lives in the plugin DATA dir
+# (CLAUDE_PLUGIN_DATA_DIR), which survives plugin upgrades; the cached copy
+# under $SCRIPT_DIR is wiped on every upgrade. Accept either location so a
+# valid data-dir registry doesn't trigger a false "no registry" warning.
+REGISTRY_DATA_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+if [ ! -f "$SCRIPT_DIR/registry.json" ] && [ ! -f "$REGISTRY_DATA_DIR/registry.json" ]; then
   echo "  ✗ ops: no project registry — run /ops:setup to create one"
 fi
 


### PR DESCRIPTION
## Problem
SessionStart `scripts/setup.sh` checked only `$SCRIPT_DIR/registry.json` — the plugin **cache** dir (`~/.claude/plugins/cache/ops-marketplace/ops/<version>/scripts/`), which is **wiped on every plugin upgrade**. The canonical registry lives in the **data** dir (`CLAUDE_PLUGIN_DATA_DIR`, default `~/.claude/plugins/data/ops-ops-marketplace/`), which persists and is where `/ops:setup` writes it.

Result: a valid registry in the data dir was ignored, and every session start printed a false:
```
✗ ops: no project registry — run /ops:setup to create one
```

## Fix
Check both locations; warn only when **neither** has `registry.json`.

## Verification
- `bash -n` syntax: OK
- Data-dir registry present → no warning
- Both absent → warning still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only path check in session bootstrap; no changes to registry writes, secrets, or runtime behavior beyond suppressing a false warning.
> 
> **Overview**
> SessionStart **`scripts/setup.sh`** no longer treats a missing cache-side **`registry.json`** as “no registry” when the canonical file exists under **`CLAUDE_PLUGIN_DATA_DIR`** (default `~/.claude/plugins/data/ops-ops-marketplace/`).
> 
> The check now requires **both** `$SCRIPT_DIR/registry.json` and the data-dir copy to be absent before printing the setup warning, matching where **`/ops:setup`** persists the registry across plugin upgrades.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b939cf7171774cdb8f4ad062c6783668495cc499. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed erroneous "no project registry" warnings that incorrectly appeared following plugin upgrades. The registry validation now properly checks multiple registry locations to ensure accurate detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->