### PR TITLE
Bug audit fixes

### DIFF
--- a/claude-ops/email-cos/email-cos-orch.sh
+++ b/claude-ops/email-cos/email-cos-orch.sh
@@ -48,10 +48,13 @@ print(tmpl)
 # needs; unset/missing => no MCP (drafts from thread context only).
 _ORCH_MCP="${EMAIL_COS_ORCH_MCP_CONFIG:-}"
 if [ -z "$_ORCH_MCP" ] || [ ! -f "$_ORCH_MCP" ]; then _ORCH_MCP='{"mcpServers":{}}'; fi
+rc=0
+# `|| rc=$?` keeps `set -e`/`pipefail` from aborting the script on a non-zero
+# claude exit, so the metrics + failure-notify error-handling below still runs.
+# Under pipefail the pipeline status is claude's (rightmost non-zero) exit code.
 printf '%s' "$RENDERED_PROMPT" | \
   claude --print --model "$EMAIL_COS_ORCH_MODEL" --dangerously-skip-permissions \
-    --strict-mcp-config --mcp-config "$_ORCH_MCP" >> "$SD/orch.out" 2>&1
-rc=$?
+    --strict-mcp-config --mcp-config "$_ORCH_MCP" >> "$SD/orch.out" 2>&1 || rc=$?
 secs=$(( $(date +%s) - start ))
 echo "{\"ts\":\"$ts\",\"tier\":\"orch\",\"exit\":$rc,\"secs\":$secs}" >> "$SD/metrics.jsonl"
 

--- a/claude-ops/email-cos/email-cos-sweep.sh
+++ b/claude-ops/email-cos/email-cos-sweep.sh
@@ -73,10 +73,12 @@ print(tmpl)
 : > "$SD/sweep.out"
 # Run headless with NO MCP servers — otherwise the full env's MCP tool defs blow
 # the model context ("Prompt is too long"). Sweep only needs Bash (gog).
+rc=0
+# `|| rc=$?` keeps `set -e`/`pipefail` from aborting before the metrics line
+# below runs. Under pipefail the pipeline status is claude's exit code.
 printf '%s' "$RENDERED_PROMPT" | \
   claude --print --model "$EMAIL_COS_SWEEP_MODEL" --dangerously-skip-permissions \
-    --strict-mcp-config --mcp-config '{"mcpServers":{}}' --allowedTools Bash >> "$SD/sweep.out" 2>&1
-rc=$?
+    --strict-mcp-config --mcp-config '{"mcpServers":{}}' --allowedTools Bash >> "$SD/sweep.out" 2>&1 || rc=$?
 secs=$(( $(date +%s) - start ))
 echo "{\"ts\":\"$ts\",\"tier\":\"sweep\",\"exit\":$rc,\"secs\":$secs,\"new\":$new}" >> "$SD/metrics.jsonl"
 

--- a/claude-ops/scripts/ops-message-listener.sh
+++ b/claude-ops/scripts/ops-message-listener.sh
@@ -61,7 +61,7 @@ json.dump(data, open('$STATE_FILE', 'w'))
 # Python code injection from untrusted Telegram/WhatsApp message content.
 append_to_queue() {
   local new_msgs_json="$1"
-  QUEUE_FILE="$QUEUE_FILE" printf '%s' "$new_msgs_json" | python3 -c "
+  printf '%s' "$new_msgs_json" | QUEUE_FILE="$QUEUE_FILE" python3 -c "
 import json, os, sys
 from datetime import datetime, timezone
 


### PR DESCRIPTION
Conservative bug audit. Three genuine, high-confidence fixes:

- **`claude-ops/email-cos/email-cos-orch.sh`** (and **`email-cos-sweep.sh`**): Under `set -euo pipefail`, the `claude … | …` pipeline followed by a separate `rc=$?` line never captured the failure path — `set -e` + `pipefail` aborted the script the instant the pipeline returned non-zero, so the metrics-emit line, the failure-notify call, and (in orch) the digest-chaining step were all skipped on any claude error. Changed to `… || rc=$?` so the exit code is captured and the downstream error-handling/metrics logic runs.
- **`claude-ops/scripts/ops-message-listener.sh`** (`append_to_queue`): `QUEUE_FILE="$QUEUE_FILE" printf … | python3 …` set the env var on `printf`, not on `python3`, so `os.environ['QUEUE_FILE']` raised `KeyError`. The exception was swallowed by `2>/dev/null || echo 0`, silently dropping every incoming WhatsApp/Telegram message. Moved the assignment onto the `python3` process. (Also keeps the JSON-via-stdin injection-safety property intact.)

All Python (`py_compile`) and shell (`bash -n`) files in the repo pass syntax checks; no other clear bugs found.

https://claude.ai/code/session_01FJBEsohg4rmvSi3XrSkL7J

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJBEsohg4rmvSi3XrSkL7J)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production email automation and the WhatsApp/Telegram inbox path; fixes are small and align behavior with intended error handling and queuing.
> 
> **Overview**
> Fixes three reliability bugs in ops shell scripts so failures are recorded and inbound messages are actually queued.
> 
> **Email COS (`email-cos-orch.sh`, `email-cos-sweep.sh`):** The `claude` pipelines now end with `|| rc=$?` instead of a separate `rc=$?` after the pipeline. With `set -euo pipefail`, a non-zero `claude` exit used to terminate the script before metrics, orch failure notifications, sweep→orch chaining, or digest chaining could run.
> 
> **Message listener (`ops-message-listener.sh`):** `QUEUE_FILE` is exported on the `python3` process (`printf … | QUEUE_FILE=… python3`) so `append_to_queue` can read the path from the environment. Previously it was only set for `printf`, which caused `KeyError` and silently dropped WhatsApp/Telegram messages (masked by `2>/dev/null`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fd4fa6f3a634c2b550df92a0ba20bad41a94c74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->