### PR TITLE
fix(hooks): block gh polling loops with sleep <25s (deploy-watch evasion)

### DIFF
--- a/claude-ops/hooks/gh-watch-guard.sh
+++ b/claude-ops/hooks/gh-watch-guard.sh
@@ -60,19 +60,38 @@ EOF
     exit 0
 fi
 
-# --- Pattern 2: tight gh loops (single-digit sleep = under 10s) ---
-# Catches: `while true; do gh ...; sleep 5; done` style polls (not sleep 10+).
-if echo "$CMD_ONELINE" | grep -qE '(^|[^[:alnum:]_])(while|until|for)([^[:alnum:]_]|$).*gh[[:space:]]+(api|pr|run|issue)' && \
-   echo "$CMD_ONELINE" | grep -qE 'sleep[[:space:]]+[0-9]([[:space:];]|$)'; then
-    emit_pre_tool_deny <<'EOF'
-BLOCKED: tight gh polling loop (sleep < 10s) detected.
+# --- Pattern 2: gh polling loops with sleep < 25s ---
+# Catches ANY while/until/for loop calling `gh api|pr|run|issue|search` whose smallest
+# sleep interval is under 25s — including deploy-watch loops:
+#   until [ -n "$(gh run list --workflow=… )" ]; do sleep 15; done
+# `gh run list|view` is the same REST drain as `gh pr …`; "waiting for my deploy" is NOT
+# an exemption. The minimum sleep is parsed numerically so two-digit evasions (sleep 15,
+# sleep 20, sleep 24) are caught — the old single-digit-only regex let these through.
+# (2026-05-30: a sleep-15 `gh run list` deploy-watch loop drove REST to 0/5000.)
+if echo "$CMD_ONELINE" | grep -qE '(^|[^[:alnum:]_])(while|until|for)([^[:alnum:]_]|$).*gh[[:space:]]+(api|pr|run|issue|search)'; then
+    # Extract every `sleep N` interval and take the minimum; a loop with sleep 30 AND
+    # sleep 15 is judged by its tightest phase (15).
+    MIN_SLEEP=$(echo "$CMD_ONELINE" | grep -oE 'sleep[[:space:]]+[0-9]+' | grep -oE '[0-9]+' | sort -n | head -1)
+    # No explicit sleep in a gh loop = unbounded hammer → treat as 0.
+    [ -z "$MIN_SLEEP" ] && MIN_SLEEP=0
+    if [ "$MIN_SLEEP" -lt 25 ]; then
+        emit_pre_tool_deny <<EOF
+BLOCKED: gh polling loop with sleep ${MIN_SLEEP}s (< 25s) detected.
 
 The 5000/hr REST quota is shared across this session, background daemons, the overnight
-sync cron, and any other gh process. A loop at sleep 5 burns 720 calls/hr — easy to OOM-cache.
+sync cron, and every other gh process. A loop at sleep 15 burns ~240 calls/hr and stacks
+with siblings — one such loop drove REST to 0/5000 on 2026-05-30, blocking prod tooling.
 
-Bump to `sleep 30` (or use Monitor tool — handles ≥25s naturally).
+This covers deploy-watch loops too: \`until gh run list/view … ; do sleep <25; done\` is
+forbidden. Waiting on an Actions deploy is NOT an exemption.
+
+Fix: bump to \`sleep 30\`+ (run_in_background) or use the Monitor tool (handles ≥25s natively).
+For multi-PR/run state, prefer ONE GraphQL query (separate 5000/hr bucket).
+
+Source: ~/Projects/claude-ops/claude-ops/hooks/gh-watch-guard.sh
 EOF
-    exit 0
+        exit 0
+    fi
 fi
 
 exit 0

--- a/claude-ops/scripts/account-rotation/.gitignore
+++ b/claude-ops/scripts/account-rotation/.gitignore
@@ -1,3 +1,10 @@
 config.json
 .chromium-linux-profile/
 .chrome-beta-automation/
+
+# runtime artifacts — never commit (live PIDs / session state / rotation backups)
+.daemon.pid
+.rotating
+state.json
+*.bak.*
+*.bak-*


### PR DESCRIPTION
## Problem
`gh-watch-guard.sh` Pattern 2 matched only **single-digit** sleeps (`sleep[[:space:]]+[0-9]`), so a deploy-watch loop `until [ -n "$(gh run list --workflow=… )" ]; do sleep 15; done` slipped through and drove REST to **0/5000** on 2026-05-30, blocking an org-invite and prod tooling. `gh run list|view` was never the gap — the sleep threshold was.

## Fix
- Parse the **minimum** `sleep N` numerically; deny any `gh api|pr|run|issue|search` loop with min sleep **<25s** (matches documented ≥25s doctrine).
- No-sleep gh loop → treated as 0 → denied.
- Explicitly covers `gh run list|view` deploy-watch loops; deny message states that waiting on a deploy is not an exemption.
- Harden `account-rotation/.gitignore`: never commit `.daemon.pid` / `.rotating` / `state.json` / `rotate.mjs.bak.*` (live PIDs + session state).

## Tests (run against patched hook)
| case | expect | got |
|---|---|---|
| real sleep-15 `gh run list` deploy-watch | deny | PASS |
| sleep-20 `gh run view` loop | deny | PASS |
| no-sleep gh loop | deny | PASS |
| sleep-30 gh loop | allow | PASS |
| plain `gh run list` (no loop) | allow | PASS |
| Pattern 1 watch-flag | deny | PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bash PreToolUse guard and .gitignore only; no auth, data, or production app logic—may block previously allowed tight gh loops until sleep is ≥25s.
> 
> **Overview**
> **Pattern 2** in `gh-watch-guard.sh` no longer blocks only single-digit `sleep` values. It now matches `while`/`until`/`for` loops that call `gh api|pr|run|issue|search`, computes the **minimum** `sleep N` in the command, and denies when that minimum is **&lt; 25s** (including loops with no `sleep`, treated as 0). The deny text calls out deploy-watch `gh run list|view` loops and documents the 2026-05-30 quota incident.
> 
> `account-rotation/.gitignore` gains ignores for runtime files (`.daemon.pid`, `.rotating`, `state.json`, backup globs) so live PIDs and session state are not committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0c80c6e5295472c197e32db3e30ef30d3ef7ccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced detection of polling loops that violate rate limits; now blocks operations with sleep intervals under 25 seconds to protect shared API quota.

* **Chores**
  * Updated ignore patterns for account rotation runtime artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->