### PR TITLE
feat(skills): add people, ledger, tonight skills + auth-stall-guard hook

### DIFF
--- a/claude-ops/hooks/auth-stall-guard.sh
+++ b/claude-ops/hooks/auth-stall-guard.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # PreToolUse advisory — fires when an agent is about to ASK THE USER for a
 # credential (auth stall). Injects the credential-source search order so the
-# agent exhausts local vaults BEFORE bothering Sam.
+# agent exhausts local vaults BEFORE bothering the owner.
 #
 # Trigger: AskUserQuestion whose text mentions a credential keyword
 #          (password, token, api key, secret, credential, ssh, login,
@@ -37,15 +37,15 @@ if printf '%s' "$BLOB" | grep -qE '(password|passphrase|credential|api[ _-]?key|
   python3 - <<'PY'
 import json
 msg = (
-  "AUTH-STALL CHECK — you are about to ask Sam for a credential. "
-  "Sam's rule: exhaust local credential sources FIRST, in this order, before prompting:\n"
+  "AUTH-STALL CHECK — you are about to ask the owner for a credential. "
+  "Owner rule: exhaust local credential sources FIRST, in this order, before prompting:\n"
   "  1. dcli (Dashlane — the master vault, has ALL accounts incl. device/SSH/router pw):\n"
   "       dcli password --output json <query>   |   dcli password --output json ''   |   dcli note --output json   |   dcli otp <query>\n"
   "  2. Doppler:   doppler secrets   /   doppler secrets get <NAME> --plain\n"
   "  3. macOS keychain:   security find-generic-password -s <svc> -w   /   security find-internet-password -s <host> -w\n"
   "  4. Env vars:   env | grep -i <name>\n"
   "  5. Filesystem scan:   ~/.secrets, ~/.config, repo .env*, ~/.aws, ~/.ssh\n"
-  "Only ask Sam if ALL of the above miss. (2026-05-26: ~1h lost on UniFi SSH before checking dcli.)"
+  "Only ask the owner if ALL of the above miss. (2026-05-26: ~1h lost on UniFi SSH before checking dcli.)"
 )
 print(json.dumps({
   "hookSpecificOutput": {

--- a/claude-ops/hooks/auth-stall-guard.sh
+++ b/claude-ops/hooks/auth-stall-guard.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# PreToolUse advisory — fires when an agent is about to ASK THE USER for a
+# credential (auth stall). Injects the credential-source search order so the
+# agent exhausts local vaults BEFORE bothering Sam.
+#
+# Trigger: AskUserQuestion whose text mentions a credential keyword
+#          (password, token, api key, secret, credential, ssh, login,
+#           passphrase, 2fa/otp, key).
+#
+# Why: 2026-05-26 an agent burned ~1h "stuck" on UniFi gateway SSH before
+#      checking dcli (Dashlane CLI), which had the creds all along. dcli holds
+#      device/router/SSH passwords that are NOT in Doppler or keychain.
+#
+# Contract: advisory only — never blocks. Emits hookSpecificOutput.additionalContext
+#           (the reminder) on stdout, exit 0. If keyword not matched, exit 0 silent.
+#
+# Source of truth: ~/Projects/claude-ops/claude-ops/hooks/auth-stall-guard.sh
+# Symlinked to ~/.claude/scripts/hooks/auth-stall-guard.sh.
+
+raw="${TOOL_INPUT:-}"
+[ -z "$raw" ] && raw=$(cat) || true
+
+TOOL=$(printf '%s' "$raw" | jq -r '(.tool_name // empty)' 2>/dev/null || true)
+[ "$TOOL" = "AskUserQuestion" ] || { exit 0; }
+
+# Flatten all question + option text to one lowercase blob.
+BLOB=$(printf '%s' "$raw" | jq -r '
+  [ (.tool_input.questions // [])[]
+    | (.question // ""), (.header // ""),
+      ((.options // [])[] | (.label // ""), (.description // "")) ]
+  | join(" ")' 2>/dev/null | tr '[:upper:]' '[:lower:]')
+[ -z "$BLOB" ] && exit 0
+
+# Credential keywords that signal an auth stall. Word-ish boundaries to cut
+# false positives (e.g. "tokenize", "keyboard" excluded by the patterns).
+if printf '%s' "$BLOB" | grep -qE '(password|passphrase|credential|api[ _-]?key|secret[ _-]?key|access[ _-]?key|\bsecret\b|\btoken\b|\bssh\b|\blogin\b|\bauth\b|\b2fa\b|\botp\b|\bapi key\b|client[ _-]?secret|private[ _-]?key|\bpat\b)'; then
+  python3 - <<'PY'
+import json
+msg = (
+  "AUTH-STALL CHECK — you are about to ask Sam for a credential. "
+  "Sam's rule: exhaust local credential sources FIRST, in this order, before prompting:\n"
+  "  1. dcli (Dashlane — the master vault, has ALL accounts incl. device/SSH/router pw):\n"
+  "       dcli password --output json <query>   |   dcli password --output json ''   |   dcli note --output json   |   dcli otp <query>\n"
+  "  2. Doppler:   doppler secrets   /   doppler secrets get <NAME> --plain\n"
+  "  3. macOS keychain:   security find-generic-password -s <svc> -w   /   security find-internet-password -s <host> -w\n"
+  "  4. Env vars:   env | grep -i <name>\n"
+  "  5. Filesystem scan:   ~/.secrets, ~/.config, repo .env*, ~/.aws, ~/.ssh\n"
+  "Only ask Sam if ALL of the above miss. (2026-05-26: ~1h lost on UniFi SSH before checking dcli.)"
+)
+print(json.dumps({
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "additionalContext": msg
+  }
+}))
+PY
+fi
+exit 0

--- a/claude-ops/skills/ledger/SKILL.md
+++ b/claude-ops/skills/ledger/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: ledger
+description: Inspect the shared Ops Ledger — what's awaiting Sam, what was handled autonomously, what claude-ops or Perplexity did in the last 24h. Always the single source of truth between the two systems.
+allowed-tools:
+  - Bash
+---
+
+# /ops:ledger
+
+Single source of truth shared between claude-ops (Mac) and Perplexity (off-Mac).
+Stored at `~/.claude-ops/ledger.jsonl` and mirrored to Notion DB "Ops Ledger".
+
+## Usage
+
+```bash
+# Default: human digest of last 24h
+/ops:ledger
+
+# What needs Sam's attention right now?
+/ops:ledger awaiting
+
+# What did Perplexity do while I was at the gym?
+/ops:ledger query --source perplexity --since -PT4H
+
+# What's been touched on this Gmail thread?
+/ops:ledger query --claim-key gmail:thread:19e690a55d213f52
+```
+
+## Behavior
+
+Wraps `~/.claude-ops/bin/ledger` (the CLI from this skill). Always reports:
+1. Awaiting Sam (top of digest, sorted newest first)
+2. Drafted by either system (needs send / merge / approve)
+3. Done autonomously in last 24h, grouped by source (claude-ops, Perplexity)
+4. Skipped or expired claims
+
+## Conventions every command in this plugin follows
+
+Before doing real work, run:
+```bash
+~/.claude-ops/bin/ledger query --claim-key "$CLAIM_KEY" --since -PT24H
+```
+If result has any entry with `status in (in_progress, done, drafted, awaiting_sam)`,
+SKIP — the other system already handled it. Don't duplicate.
+
+After doing work:
+```bash
+~/.claude-ops/bin/ledger claim --claim-key "$CLAIM_KEY" --kind <kind> --brand <brand> \
+  --title "<title>" --source claude-ops
+# ... do work ...
+~/.claude-ops/bin/ledger resolve <id> --status done|drafted|awaiting_sam
+```

--- a/claude-ops/skills/ledger/SKILL.md
+++ b/claude-ops/skills/ledger/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ledger
-description: Inspect the shared Ops Ledger — what's awaiting Sam, what was handled autonomously, what claude-ops or Perplexity did in the last 24h. Always the single source of truth between the two systems.
+description: Inspect the shared Ops Ledger — what's awaiting owner, what was handled autonomously, what claude-ops or Perplexity did in the last 24h. Always the single source of truth between the two systems.
 allowed-tools:
   - Bash
 ---
@@ -16,7 +16,7 @@ Stored at `~/.claude-ops/ledger.jsonl` and mirrored to Notion DB "Ops Ledger".
 # Default: human digest of last 24h
 /ops:ledger
 
-# What needs Sam's attention right now?
+# What needs owner's attention right now?
 /ops:ledger awaiting
 
 # What did Perplexity do while I was at the gym?
@@ -29,7 +29,7 @@ Stored at `~/.claude-ops/ledger.jsonl` and mirrored to Notion DB "Ops Ledger".
 ## Behavior
 
 Wraps `~/.claude-ops/bin/ledger` (the CLI from this skill). Always reports:
-1. Awaiting Sam (top of digest, sorted newest first)
+1. Awaiting owner (top of digest, sorted newest first)
 2. Drafted by either system (needs send / merge / approve)
 3. Done autonomously in last 24h, grouped by source (claude-ops, Perplexity)
 4. Skipped or expired claims

--- a/claude-ops/skills/people/SKILL.md
+++ b/claude-ops/skills/people/SKILL.md
@@ -53,9 +53,9 @@ Apple Contacts is source of truth. Notion "People" database is the working layer
 
 ## Behavior
 
-- First run will ask Sam to confirm `relationship_strength` for top ~30 contacts
+- First run will ask owner to confirm `relationship_strength` for top ~30 contacts
 - Subsequent runs are silent unless something new is inferred
-- Birthdays without years get treated as recurring annual; first detection asks Sam to confirm before storing
+- Birthdays without years get treated as recurring annual; first detection asks owner to confirm before storing
 
 ## Ledger writes
 

--- a/claude-ops/skills/people/SKILL.md
+++ b/claude-ops/skills/people/SKILL.md
@@ -4,6 +4,7 @@ description: Sync Apple Contacts to Notion 'People' database. Track last_contact
 allowed-tools:
   - Bash
   - Read
+  - AskUserQuestion
 ---
 
 # /ops:people

--- a/claude-ops/skills/people/SKILL.md
+++ b/claude-ops/skills/people/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: people
+description: Sync Apple Contacts to Notion 'People' database. Track last_contacted, relationship_strength, recent_topics, next_nudge_due. Foundation for relationship intelligence — birthdays, anniversaries, overdue-outreach, news-mention nudges.
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# /ops:people
+
+Apple Contacts is source of truth. Notion "People" database is the working layer.
+
+## Subcommands
+
+| Subcommand | What it does |
+|---|---|
+| `sync` (default) | Pull Apple Contacts via `pc contacts fetch`, upsert to Notion People DB |
+| `birthdays [--window 7]` | Who has a birthday/anniversary in the next N days |
+| `overdue` | Who's past their relationship-strength cadence and needs reach-out |
+| `whois <name>` | Pull single person's full profile + last interaction across all channels |
+| `bump <name>` | Manually mark "I just talked to X" — resets last_contacted |
+
+## Notion People schema (auto-created on first run)
+
+| Property | Type | Source |
+|---|---|---|
+| name | title | Apple Contacts |
+| emails | multi-select | Apple Contacts |
+| phones | multi-select | Apple Contacts |
+| birthday | date | Apple Contacts (year may be missing) |
+| relationship_strength | select: close, active, dormant, professional, family | Heuristic + manual |
+| last_contacted | date | Computed from Gmail/Slack/iMessage/WhatsApp |
+| last_topic | rich_text | Last 1-line subject from any channel |
+| next_nudge_due | date | Computed: last_contacted + cadence_for(strength) |
+| brand_context | multi-select: your brand/project codes | Inferred from email domains/threads |
+| notes | rich_text | Manual |
+
+## Cadences (configurable)
+
+- `close` — 14 days (partner, parents, closest friends)
+- `active` — 30 days (team, frequent collaborators)
+- `professional` — 60 days (clients, partners)
+- `dormant` — 180 days (warm but distant)
+- `family` — birthday + anniversary + monthly check-in
+
+## Sync logic
+
+1. `pc contacts fetch --format json` — pull all Apple Contacts
+2. For each contact: upsert into Notion People DB matched by email (primary) or phone
+3. Walk last 30 days of Gmail/Slack/iMessage/WhatsApp threads to compute `last_contacted`
+4. Compute `next_nudge_due = last_contacted + cadence_for(relationship_strength)`
+5. Write a ledger entry: `kind=nudge`, `brand=OPS`, status=done
+
+## Behavior
+
+- First run will ask Sam to confirm `relationship_strength` for top ~30 contacts
+- Subsequent runs are silent unless something new is inferred
+- Birthdays without years get treated as recurring annual; first detection asks Sam to confirm before storing
+
+## Ledger writes
+
+```bash
+~/.claude-ops/bin/ledger claim --claim-key "people:sync:$(date +%F)" --kind nudge \
+  --brand OPS --title "Apple Contacts → Notion sync" --source claude-ops
+# ... sync ...
+~/.claude-ops/bin/ledger resolve <id> --status done
+```

--- a/claude-ops/skills/tonight/SKILL.md
+++ b/claude-ops/skills/tonight/SKILL.md
@@ -23,8 +23,8 @@ The "before-bed brief." Counterpart to `/ops:go` (morning).
 
 ## Behavior
 
-- Runs in claude-ops when Sam is at the Mac
-- Runs in Perplexity when Sam isn't (Perplexity reads the same Notion ledger)
+- Runs in claude-ops when owner is at the Mac
+- Runs in Perplexity when owner isn't (Perplexity reads the same Notion ledger)
 - Both systems write a ledger entry `kind=nudge`, `brand=OPS`, `claim_key=tonight:YYYY-MM-DD`
   so they don't both fire
 - Push notification only if section 5 has unresolved items OR section 3 has anyone

--- a/claude-ops/skills/tonight/SKILL.md
+++ b/claude-ops/skills/tonight/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: tonight
+description: Evening tomorrow-brief. Reads the Ops Ledger, calendar, and People DB. Surfaces tomorrow's meetings with prep status, birthdays hitting tomorrow, overdue outreach, top 3 priorities, and any unresolved decisions from today. Push notification if anything is genuinely time-sensitive.
+allowed-tools:
+  - Bash
+  - Read
+---
+
+# /ops:tonight
+
+The "before-bed brief." Counterpart to `/ops:go` (morning).
+
+## Output sections
+
+1. **Tomorrow's calendar** — every meeting >=15min with: attendees, prep status (brief
+   exists Y/N), and the suggested 1-line prep ask if no brief exists.
+2. **Birthdays / anniversaries tomorrow** — from Notion People DB. Pre-drafted
+   message ready to send.
+3. **Overdue outreach** — anyone whose `next_nudge_due <= tomorrow`. Top 3 only.
+4. **Top 3 priorities for tomorrow** — pulled from Linear (assignee=me, priority<=High,
+   updated last 7d, not Done).
+5. **Unresolved from today** — ledger entries with `status=awaiting_sam` still open.
+
+## Behavior
+
+- Runs in claude-ops when Sam is at the Mac
+- Runs in Perplexity when Sam isn't (Perplexity reads the same Notion ledger)
+- Both systems write a ledger entry `kind=nudge`, `brand=OPS`, `claim_key=tonight:YYYY-MM-DD`
+  so they don't both fire
+- Push notification only if section 5 has unresolved items OR section 3 has anyone
+  past cadence
+
+## Schedule
+
+Suggested cron: `30 21 * * 1-5` Europe/Amsterdam (9:30pm weekdays)
+Or run manually with `/ops:tonight`
+
+## Ledger writes
+
+Each section that surfaces an item writes a sub-entry so morning `/ops:go` can pick
+up where this left off without re-deriving.


### PR DESCRIPTION
## What
The clean, additive subset of untracked work — cut **fresh off `main`** (not the diverged `feat/ops-inbox-imessage-parity` branch).

| File | Status |
|------|--------|
| `skills/people/SKILL.md` | ✅ Apple Contacts → Notion People DB sync; relationship cadence nudges |
| `skills/ledger/SKILL.md` | ✅ shared Ops Ledger interface (claude-ops ↔ Perplexity) |
| `skills/tonight/SKILL.md` | ✅ evening tomorrow-brief |
| `hooks/auth-stall-guard.sh` | ⚠️ staged, **not wired** into `hooks.json` (see below) |

## Rule 0 (public repo) — verified clean
- `tests/test-no-secrets.sh` **passes**.
- Scrubbed real first names from the `people` cadence example and replaced internal brand codes with a generic placeholder.
- No PIDs / phone numbers / emails / API keys / absolute home paths in the diff.

## Why the hook isn't registered
`auth-stall-guard.sh` is an advisory PreToolUse guard (never blocks — always `{"continue": true}`). It's included as a file but **intentionally not added to `hooks.json`** yet, pending review of the matcher (`AskUserQuestion` vs broad). Harmless inert until wired.

## Scope notes
- Skills auto-discover via the manifest `skills` directory entry — no manifest edit needed.
- **No version bump** — repo convention lands features first, then a separate `chore(release)`.
- ℹ️ Heads-up unrelated to this PR: `main` ships `2.16.0` in `plugin.json` but the `v2.16.0` git tag was never pushed (latest tag `v2.15.0`).
- Excluded local machine artifacts that were also untracked: `.gbrain-source`, `.metadata_never_index`, `.wiki-work/`, `.gstack/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive documentation and an optional, non-blocking hook script with no hooks.json wiring in this PR; no runtime behavior change until the hook is registered.
> 
> **Overview**
> Adds **four new agent-facing artifacts** to claude-ops: three skill specs and one optional PreToolUse hook script.
> 
> **`auth-stall-guard.sh`** intercepts **`AskUserQuestion`** when question text matches credential-related keywords. It **never blocks**—it injects **`hookSpecificOutput.additionalContext`** reminding agents to try **dcli → Doppler → keychain → env → filesystem** before asking the owner. The PR notes this file is **not yet registered** in **`hooks.json`**, so it is inert until wired.
> 
> **`/ops:ledger`** documents the shared **Ops Ledger** CLI (`~/.claude-ops/bin/ledger`): digests, **`awaiting`**, **`query`**, and the **claim-before-work / resolve-after** convention so **claude-ops** and **Perplexity** do not duplicate work.
> 
> **`/ops:people`** defines **Apple Contacts → Notion People** sync, relationship cadences, subcommands (`birthdays`, `overdue`, `whois`, `bump`), and ledger writes on sync.
> 
> **`/ops:tonight`** defines the evening **tomorrow-brief** (calendar prep, birthdays, overdue outreach, Linear top 3, open **`awaiting_sam`** items), dual-runner dedup via ledger **`claim_key`**, and optional push rules.
> 
> All three skills are **markdown-only** in this diff—behavior depends on existing **`bin/ledger`** and other tooling already on the machine.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72a78e8645038782a5b55b149c65b68b5e0a73d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->