### PR TITLE
ops-socials: add owner-autopilot status sub-route

### DIFF
--- a/claude-ops/skills/ops-socials/SKILL.md
+++ b/claude-ops/skills/ops-socials/SKILL.md
@@ -102,6 +102,7 @@ In every recipe below, treat the literal string `$SOCIAL_SET_ID` as a placeholde
 | **Schedule** | Typefully with `schedule_date: "next-free-slot"` or ISO | `mcp__typefully__typefully_get_queue` to inspect |
 | **Analytics** (own posts) | `mcp__typefully__typefully_list_social_set_analytics_posts` (or `mcp__x-mcp__get_metrics` per tweet) | replies excluded by default |
 | **LinkedIn org mention** | `mcp__typefully__typefully_linkedin_resolve_linkedin_organization_from_url` → `@[Name](urn:li:organization:ID)` | paste into draft body |
+| **Owner autopilot status** | shell out to `$OPS_SOCIAL_AUTOPILOT_CMD` (user-configured path to an owner-specific status script that returns per-channel state) | example: `OPS_SOCIAL_AUTOPILOT_CMD=~/tools/<owner>-social-autopilot/status.py` |
 
 ## Hard rules
 
@@ -224,6 +225,13 @@ Per-tweet drill-down on impressions/engagement: `mcp__x-mcp__get_metrics({ id })
 ### "Publish a markdown article to X" — not the safe path
 
 `x-article-publisher-skill` automates X's web UI via Playwright. Hard rule 3 forbids that from this router. Instead: stage a Typefully draft that's a hook + summary + a link to the full piece (your blog, Substack, static page). If you genuinely need a native X Article, publish it manually in the X client.
+
+### "Show me the autopilot status" / "/ops-socials healify" / owner-autopilot read-out
+```bash
+[ -n "$OPS_SOCIAL_AUTOPILOT_CMD" ] && bash -c "$OPS_SOCIAL_AUTOPILOT_CMD" || echo "no autopilot wired — set OPS_SOCIAL_AUTOPILOT_CMD in your env or $PREFS_PATH/preferences.json"
+```
+Returns per-channel state: connected, queue depth, recent fires, next action. Read-only.
+
 
 ## Pre-flight check (run when troubleshooting)
 

--- a/claude-ops/skills/ops-socials/SKILL.md
+++ b/claude-ops/skills/ops-socials/SKILL.md
@@ -102,7 +102,7 @@ In every recipe below, treat the literal string `$SOCIAL_SET_ID` as a placeholde
 | **Schedule** | Typefully with `schedule_date: "next-free-slot"` or ISO | `mcp__typefully__typefully_get_queue` to inspect |
 | **Analytics** (own posts) | `mcp__typefully__typefully_list_social_set_analytics_posts` (or `mcp__x-mcp__get_metrics` per tweet) | replies excluded by default |
 | **LinkedIn org mention** | `mcp__typefully__typefully_linkedin_resolve_linkedin_organization_from_url` → `@[Name](urn:li:organization:ID)` | paste into draft body |
-| **Owner autopilot status** | shell out to `$OPS_SOCIAL_AUTOPILOT_CMD` (user-configured path to an owner-specific status script that returns per-channel state) | example: `OPS_SOCIAL_AUTOPILOT_CMD=~/tools/<owner>-social-autopilot/status.py` |
+| **Owner autopilot status** | shell out via `bash -c` to resolved `$OPS_SOCIAL_AUTOPILOT_CMD` (full shell command to an owner-specific status script) | env: `OPS_SOCIAL_AUTOPILOT_CMD='python3 $HOME/tools/<owner>-social-autopilot/status.py'`; prefs: `ops_social.autopilot_cmd` in `$PREFS_PATH/preferences.json` |
 
 ## Hard rules
 
@@ -227,8 +227,13 @@ Per-tweet drill-down on impressions/engagement: `mcp__x-mcp__get_metrics({ id })
 `x-article-publisher-skill` automates X's web UI via Playwright. Hard rule 3 forbids that from this router. Instead: stage a Typefully draft that's a hook + summary + a link to the full piece (your blog, Substack, static page). If you genuinely need a native X Article, publish it manually in the X client.
 
 ### "Show me the autopilot status" / "/ops-socials healify" / owner-autopilot read-out
+Resolve the command in this order: (1) `$OPS_SOCIAL_AUTOPILOT_CMD` if set; (2) `$PREFS_PATH/preferences.json` → `ops_social.autopilot_cmd`. The value must be a **full shell command** (e.g. `python3 $HOME/tools/<owner>-social-autopilot/status.py`), not a bare `.py` path — the recipe runs it via `bash -c`.
 ```bash
-if [ -n "$OPS_SOCIAL_AUTOPILOT_CMD" ]; then bash -c "$OPS_SOCIAL_AUTOPILOT_CMD"; else echo "no autopilot wired — set OPS_SOCIAL_AUTOPILOT_CMD in your env or $PREFS_PATH/preferences.json"; fi
+CMD="${OPS_SOCIAL_AUTOPILOT_CMD:-}"
+if [ -z "$CMD" ] && [ -f "$PREFS_PATH/preferences.json" ] && command -v jq >/dev/null 2>&1; then
+  CMD="$(jq -r '.ops_social.autopilot_cmd // empty' "$PREFS_PATH/preferences.json" 2>/dev/null)"
+fi
+if [ -n "$CMD" ]; then bash -c "$CMD"; else echo "no autopilot wired — set OPS_SOCIAL_AUTOPILOT_CMD or ops_social.autopilot_cmd in $PREFS_PATH/preferences.json"; fi
 ```
 Returns per-channel state: connected, queue depth, recent fires, next action. Read-only.
 

--- a/claude-ops/skills/ops-socials/SKILL.md
+++ b/claude-ops/skills/ops-socials/SKILL.md
@@ -228,7 +228,7 @@ Per-tweet drill-down on impressions/engagement: `mcp__x-mcp__get_metrics({ id })
 
 ### "Show me the autopilot status" / "/ops-socials healify" / owner-autopilot read-out
 ```bash
-[ -n "$OPS_SOCIAL_AUTOPILOT_CMD" ] && bash -c "$OPS_SOCIAL_AUTOPILOT_CMD" || echo "no autopilot wired — set OPS_SOCIAL_AUTOPILOT_CMD in your env or $PREFS_PATH/preferences.json"
+if [ -n "$OPS_SOCIAL_AUTOPILOT_CMD" ]; then bash -c "$OPS_SOCIAL_AUTOPILOT_CMD"; else echo "no autopilot wired — set OPS_SOCIAL_AUTOPILOT_CMD in your env or $PREFS_PATH/preferences.json"; fi
 ```
 Returns per-channel state: connected, queue depth, recent fires, next action. Read-only.
 

--- a/claude-ops/skills/ops-socials/SKILL.md
+++ b/claude-ops/skills/ops-socials/SKILL.md
@@ -61,6 +61,9 @@ This router serves two **strictly separated** classes of identity. Posting to th
 **Resolution algorithm — run at the start of every flow:**
 
 ```
+intent is owner autopilot status (`healify`, "show me the autopilot status", `/ops-socials healify`, owner-autopilot read-out)?
+├─ YES → skip project/personal identity resolution; run the Owner autopilot status recipe below (read-only). `healify` here is NOT a project name.
+└─ NO  → continue
 intent mentions / implies a named project (project arg, product name, "post for <project>")?
 ├─ YES → read marketing.projects.<project>.social.engine from $PREFS_PATH/preferences.json
 │        ├─ engine.primary == "upload-post" → publish via mcp__upload-post__* with engine.upload_post.user.


### PR DESCRIPTION
## Summary
- New routing-table row `Owner autopilot status` → shells out to `$OPS_SOCIAL_AUTOPILOT_CMD` (owner-configured status script returning per-channel state).
- New recipe under `## Routing recipes` so `/ops-socials healify` / "show me the autopilot status" / owner-autopilot read-out calls all route to the same one-liner; falls back to a clear "not wired" message when the env var is unset.
- Public-repo safe: uses `<owner>` placeholder + `~/` + env vars; no real names/paths/handles. `tests/test-no-secrets.sh` = 14 passed / 0 failed.

## Test plan
- [x] `bash claude-ops/tests/test-no-secrets.sh` exits 0
- [ ] Confirm the recipe runs as expected once the owner sets `OPS_SOCIAL_AUTOPILOT_CMD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to skill routing; read-only status via owner-configured commands, no posting or auth changes.
> 
> **Overview**
> Adds a **read-only owner autopilot status** path to the `/ops-socials` skill so intents like "show me the autopilot status" or `/ops-socials healify` no longer go through project vs personal identity resolution (and **`healify` is documented as not a project name** for this flow).
> 
> The identity algorithm now **short-circuits** on owner-autopilot read-outs, the routing table gains an **Owner autopilot status** row, and a new recipe runs a **full shell command** from `$OPS_SOCIAL_AUTOPILOT_CMD` or `ops_social.autopilot_cmd` in preferences via `bash -c`, with a clear message when nothing is wired.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8554e97c1ace5eae1fc551861911be403b610ff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ops-socials skill documentation to include Owner autopilot status capability.
  * Added configuration guidance for user-defined autopilot status commands.
  * Documented per-channel status snapshot functionality with error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->