### PR TITLE
chore(release): ops v2.17.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.16.0",
+      "version": "2.17.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.17.0 — 2026-05-30
+
+### Added
+- **`/ops:people`** — Apple Contacts → Notion People DB sync; relationship cadence
+  tracking (birthdays, anniversaries, overdue-outreach nudges). No PII stored in-repo.
+- **`/ops:ledger`** — shared Ops Ledger interface (claude-ops ↔ Perplexity source of truth).
+- **`/ops:tonight`** — evening tomorrow-brief: calendar prep status, birthdays,
+  overdue outreach, top-3 priorities, unresolved decisions.
+- **`hooks/auth-stall-guard.sh`** — advisory PreToolUse guard that injects the
+  credential-source search order when an agent is about to ask the user for a
+  credential. Advisory only (never blocks); staged but not yet wired into `hooks.json`.
+- **ops-socials** — auto-consume post-performance learnings before composing
+  personal/founder Typefully drafts (biases tone/format toward what the data shows works).
+
 ## 2.16.0 — 2026-05-29
 
 ### Added


### PR DESCRIPTION
Bumps plugin.json + marketplace.json 2.16.0 -> 2.17.0; adds CHANGELOG section.

### Included since v2.16.0 (already merged to main via #396, #394)
- skills/people — Apple Contacts -> Notion People DB sync + cadence nudges (#396)
- skills/ledger — shared Ops Ledger interface (#396)
- skills/tonight — evening tomorrow-brief (#396)
- hooks/auth-stall-guard.sh — advisory credential-source injector; staged, not wired (#396)
- ops-socials — auto-consume post-performance learnings before composing (#394)

### Gates
- test-no-secrets.sh -> pass
- both JSON files validate
- Rule 0: version-only diff, no PII

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes; no behavioral code in the diff.
> 
> **Overview**
> This PR **releases ops v2.17.0** by bumping **`version`** from `2.16.0` to `2.17.0` in **`.claude-plugin/marketplace.json`** and **`claude-ops/.claude-plugin/plugin.json`**, and adding a **`CHANGELOG.md`** section dated 2026-05-30.
> 
> The changelog documents capabilities already on main (not introduced in this diff): **`/ops:people`**, **`/ops:ledger`**, **`/ops:tonight`**, staged **`hooks/auth-stall-guard.sh`**, and **ops-socials** post-performance learnings. No skill, hook wiring, or runtime code changes appear in the diff itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 653a869b9c82cc094cdbb451b8385bc4e0a1c1d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->