### PR TITLE
chore(release): ops plugin v2.18.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.18.1",
+      "version": "2.18.2",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.18.1",
+  "version": "2.18.2",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",


### PR DESCRIPTION
Cuts a clean release containing today's merged fixes (#403 ops-inbox-autosync + cross-thread scan rule, #404 whatsapp-mcp outbound persist + resync_app_state + dict serialisation). v2.18.1 was tagged before #404 merged, so 2.18.2 re-releases main HEAD with the WhatsApp bridge fix included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bumps with no runtime or security logic changes in this diff.
> 
> **Overview**
> **Bumps the ops plugin release to `2.18.2`** in `.claude-plugin/marketplace.json` and `claude-ops/.claude-plugin/plugin.json` so the marketplace and plugin metadata match **main** after fixes that landed in **2.18.1**’s window.
> 
> This is a **version-only** PR in the diff; it re-tags the release so consumers get **#403** (ops-inbox autosync + cross-thread scan rule) and **#404** (WhatsApp MCP outbound persist, `resync_app_state`, dict serialisation), which **2.18.1** shipped without **#404**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31962827345e88c6ab21026ed7c05c67ada318e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->