### PR TITLE
feat(ops-inbox): WhatsApp voice-note transcription + freshness gate + bridge persistence (2.18.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.18.2",
+      "version": "2.18.3",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.18.2",
+  "version": "2.18.3",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 2.18.3 — 2026-05-31
+
+### Added
+- **WhatsApp voice-note auto-transcription.** New `scripts/whatsapp/transcribe_voice_notes.py`
+  finds incoming voice notes (`media_type='audio'`, empty `content`), downloads them via the
+  bridge `/api/download`, transcribes with OpenAI `whisper-1`, and writes `[voice] <text>`
+  back into `messages.content` — **only** where content is still empty, so it never clobbers
+  real text and is fully idempotent. Run by a new `whatsapp-transcribe.{service,timer}`
+  (systemd-user, every 10 min + 2 min after boot), so voice notes appear in `ops-inbox`
+  scans exactly like text. Cost-safe: `mkdir`-based single-instance lock, `--max` per-run
+  cap on the metered Whisper API, and idempotent updates (never re-bills a row).
+- **Pre-scan freshness gate** `bin/wa-inbox-fresh.sh`, installed to `~/bin`. `ops-inbox` runs
+  it FIRST in every WhatsApp scan: it connection-probes the bridge with **curl** (not
+  `ss | grep :8080`, which mis-resolves 8080 to the service name `webcache` and would bounce
+  a healthy bridge), forces a backfill, triggers transcription, waits (bounded ~32s) for the
+  store to settle, and prints a freshness report — only restarting the bridge if the curl
+  probe genuinely fails twice. Exit 2 signals an unrecoverable bridge so callers never
+  classify against a stale store.
+
+### Changed
+- `scripts/install-whatsapp-bridge-linux.sh` now also ships the voice-note transcriber and
+  the freshness gate, drops + enables the `whatsapp-transcribe.{service,timer}` units (reading
+  `OPENAI_API_KEY` from `~/.config/systemd/env/mcp-secrets.env`), and adds a
+  `--no-transcribe-timer` opt-out.
+- `skills/ops-inbox/SKILL.md` step-0 documents the freshness gate (run first) and that voice
+  notes are first-class (`[voice] …` bodies), alongside the existing backfill + contacts-link
+  auto-sync.
+
+> Folds in the bridge-side fixes already on `main` as of 2.18.x — outbound `/api/send`
+> persistence, the `resync_app_state` endpoint, MCP dict serialisation (#404), and the
+> WhatsApp autosync + LID contacts-link (#403) — and layers voice transcription + the
+> freshness gate on top.
+
 ## 2.18.1 — 2026-05-31
 
 ### Added

--- a/claude-ops/bin/wa-inbox-fresh.sh
+++ b/claude-ops/bin/wa-inbox-fresh.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# wa-inbox-fresh.sh — guarantee the WhatsApp bridge store is current BEFORE any
+# ops-inbox triage. Run this FIRST in every WhatsApp scan.
+#
+#   1. ensure the whatsmeow bridge is up + connected (restart if :8080 is dead)
+#   2. force a history backfill (POST /api/backfill)
+#   3. fill any new voice notes with transcripts (whatsapp-transcribe.service)
+#   4. wait (bounded) for the store's newest message to settle
+#   5. print a FRESHNESS report so the caller never classifies blind
+#
+# Exit 0 = store is as-fresh-as-this-bridge-can-be (report printed).
+# Exit 2 = bridge unreachable and could not be recovered (do NOT trust the store).
+#
+# HARD LIMIT (state it, don't hide it): messages YOU send from your PHONE may not
+# replicate to a companion bridge — WhatsApp's multi-device protocol does not
+# guarantee it (WhatsApp Web has the same gap). So for "did I already reply?",
+# the human's word is authoritative over this store.
+set -u
+DB="${WHATSAPP_BRIDGE_DB:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db}"
+BRIDGE="http://127.0.0.1:8080"
+WAIT_TICKS="${WA_FRESH_WAIT_TICKS:-8}"   # ×4s ≈ 32s max wait
+
+log() { printf '%s\n' "$*"; }
+
+# 1. bridge up?  Liveness = a real TCP/HTTP connection to :8080 (curl exit 7 =
+# connection refused). Do NOT use `ss | grep :8080` — ss resolves 8080 to the
+# service name "webcache", so the grep never matches and we'd bounce a healthy
+# bridge. Only restart when the connection probe genuinely fails twice.
+alive() { curl -s -o /dev/null -m 4 "$BRIDGE/" >/dev/null 2>&1; }   # exit 0 even on 404; nonzero only if not listening
+if ! { alive || { sleep 2; alive; }; }; then
+  log "wa-fresh: bridge :8080 not responding — restarting…"
+  systemctl --user restart whatsapp-bridge.service 2>/dev/null
+  for i in $(seq 1 10); do sleep 2; alive && break; done
+fi
+if ! alive; then
+  log "wa-fresh: ERROR bridge still down after restart — store is STALE, do not trust it"
+  exit 2
+fi
+
+# connection sanity from the journal (best-effort)
+if journalctl --user -u whatsapp-bridge.service -n 40 --no-pager 2>/dev/null \
+     | grep -q "Connected to WhatsApp"; then
+  log "wa-fresh: bridge connected ✓"
+fi
+
+before=$(sqlite3 "$DB" "SELECT COALESCE(datetime(MAX(timestamp)),'1970-01-01') FROM messages;" 2>/dev/null)
+
+# 2. force backfill
+code=$(curl -fsS -m 20 -X POST -o /dev/null -w "%{http_code}" "$BRIDGE/api/backfill" 2>/dev/null || echo "ERR")
+log "wa-fresh: backfill → HTTP ${code}"
+
+# 3. transcribe any freshly-synced voice notes (idempotent, lock-guarded)
+systemctl --user start whatsapp-transcribe.service 2>/dev/null && log "wa-fresh: voice transcription triggered"
+
+# 4. bounded wait for the store to settle
+new=0
+for i in $(seq 1 "$WAIT_TICKS"); do
+  sleep 4
+  cnt=$(sqlite3 "$DB" "SELECT COUNT(*) FROM messages WHERE datetime(timestamp) > datetime('$before');" 2>/dev/null || echo 0)
+  [ "${cnt:-0}" -gt 0 ] && { new=$cnt; break; }
+done
+
+# 5. freshness report
+after=$(sqlite3 "$DB" "SELECT COALESCE(datetime(MAX(timestamp)),'?') FROM messages;" 2>/dev/null)
+age_min=$(sqlite3 "$DB" "SELECT CAST((julianday('now')-julianday(MAX(timestamp)))*1440 AS INT) FROM messages;" 2>/dev/null)
+log "wa-fresh: newest message = ${after} (${age_min:-?} min old) | new rows this cycle = ${new}"
+if [ "${age_min:-9999}" -gt 120 ]; then
+  log "wa-fresh: WARNING newest message is >2h old — store may be lagging; treat 'last-sender' classification with caution"
+fi
+log "wa-fresh: NOTE phone-sent messages may be absent — confirm 'did I reply?' with the human, not this store"
+exit 0

--- a/claude-ops/bin/wa-inbox-fresh.sh
+++ b/claude-ops/bin/wa-inbox-fresh.sh
@@ -4,12 +4,12 @@
 #
 #   1. ensure the whatsmeow bridge is up + connected (restart if :8080 is dead)
 #   2. force a history backfill (POST /api/backfill)
-#   3. fill any new voice notes with transcripts (whatsapp-transcribe.service)
-#   4. wait (bounded) for the store's newest message to settle
+#   3. wait (bounded) for the store's newest message to settle
+#   4. queue voice transcription (async; does not block on Whisper)
 #   5. print a FRESHNESS report so the caller never classifies blind
 #
 # Exit 0 = store is as-fresh-as-this-bridge-can-be (report printed).
-# Exit 2 = bridge unreachable and could not be recovered (do NOT trust the store).
+# Exit 2 = bridge unreachable or messages store unreadable (do NOT trust the store).
 #
 # HARD LIMIT (state it, don't hide it): messages YOU send from your PHONE may not
 # replicate to a companion bridge — WhatsApp's multi-device protocol does not
@@ -43,16 +43,21 @@ if journalctl --user -u whatsapp-bridge.service -n 40 --no-pager 2>/dev/null \
   log "wa-fresh: bridge connected ✓"
 fi
 
-before=$(sqlite3 "$DB" "SELECT COALESCE(datetime(MAX(timestamp)),'1970-01-01') FROM messages;" 2>/dev/null)
+if [ ! -r "$DB" ]; then
+  log "wa-fresh: ERROR messages store missing or unreadable at $DB — do not trust it"
+  exit 2
+fi
+
+before=$(sqlite3 "$DB" "SELECT COALESCE(datetime(MAX(timestamp)),'1970-01-01') FROM messages;") || {
+  log "wa-fresh: ERROR cannot read messages store at $DB — do not trust it"
+  exit 2
+}
 
 # 2. force backfill
 code=$(curl -fsS -m 20 -X POST -o /dev/null -w "%{http_code}" "$BRIDGE/api/backfill" 2>/dev/null || echo "ERR")
 log "wa-fresh: backfill → HTTP ${code}"
 
-# 3. transcribe any freshly-synced voice notes (idempotent, lock-guarded)
-systemctl --user start whatsapp-transcribe.service 2>/dev/null && log "wa-fresh: voice transcription triggered"
-
-# 4. bounded wait for the store to settle
+# 3. bounded wait for the store to settle (after backfill, before transcription)
 new=0
 for i in $(seq 1 "$WAIT_TICKS"); do
   sleep 4
@@ -60,9 +65,19 @@ for i in $(seq 1 "$WAIT_TICKS"); do
   [ "${cnt:-0}" -gt 0 ] && { new=$cnt; break; }
 done
 
+# 4. transcribe voice notes synced during backfill (async — gate stays bounded)
+if systemctl --user start --no-block whatsapp-transcribe.service 2>/dev/null; then
+  log "wa-fresh: voice transcription queued"
+else
+  log "wa-fresh: voice transcription not started"
+fi
+
 # 5. freshness report
-after=$(sqlite3 "$DB" "SELECT COALESCE(datetime(MAX(timestamp)),'?') FROM messages;" 2>/dev/null)
-age_min=$(sqlite3 "$DB" "SELECT CAST((julianday('now')-julianday(MAX(timestamp)))*1440 AS INT) FROM messages;" 2>/dev/null)
+after=$(sqlite3 "$DB" "SELECT COALESCE(datetime(MAX(timestamp)),'?') FROM messages;") || {
+  log "wa-fresh: ERROR cannot read messages store at $DB — do not trust it"
+  exit 2
+}
+age_min=$(sqlite3 "$DB" "SELECT CAST((julianday('now')-julianday(MAX(timestamp)))*1440 AS INT) FROM messages;") || age_min=""
 log "wa-fresh: newest message = ${after} (${age_min:-?} min old) | new rows this cycle = ${new}"
 if [ "${age_min:-9999}" -gt 120 ]; then
   log "wa-fresh: WARNING newest message is >2h old — store may be lagging; treat 'last-sender' classification with caution"

--- a/claude-ops/scripts/install-whatsapp-bridge-linux.sh
+++ b/claude-ops/scripts/install-whatsapp-bridge-linux.sh
@@ -20,6 +20,8 @@
 #   --reset-session        Delete whatsapp.db so a fresh pair code is
 #                          generated (you'll need to scan with the phone)
 #   --no-backfill-timer    Drop only the bridge unit, skip the 2h timer
+#   --no-transcribe-timer  Skip the 10-min voice-note transcription timer
+#                          (voice notes won't be auto-transcribed into content)
 
 set -euo pipefail
 
@@ -32,6 +34,7 @@ INSTALL_DIR="$INSTALL_DIR_DEFAULT"
 SKIP_BUILD=0
 RESET_SESSION=0
 WITH_BACKFILL_TIMER=1
+WITH_TRANSCRIBE_TIMER=1
 
 # Source-tree dir (where this script lives in claude-ops checkout)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -49,6 +52,7 @@ while (("$#")); do
     --skip-build)          SKIP_BUILD=1; shift ;;
     --reset-session)       RESET_SESSION=1; shift ;;
     --no-backfill-timer)   WITH_BACKFILL_TIMER=0; shift ;;
+    --no-transcribe-timer) WITH_TRANSCRIBE_TIMER=0; shift ;;
     -h|--help)             usage 0 ;;
     *) echo "unknown flag: $1" >&2; usage 1 ;;
   esac
@@ -76,6 +80,7 @@ echo "▶ claude-ops WhatsApp bridge install"
 echo "  install dir: $INSTALL_DIR"
 echo "  wa-phone:    $WA_PHONE"
 echo "  backfill timer: $([ "$WITH_BACKFILL_TIMER" -eq 1 ] && echo on || echo off)"
+echo "  transcribe timer: $([ "$WITH_TRANSCRIBE_TIMER" -eq 1 ] && echo on || echo off)"
 
 # ─── Clone / refresh upstream ────────────────────────────────────────────────
 mkdir -p "$(dirname "$INSTALL_DIR")"
@@ -95,6 +100,18 @@ python3 "$WA_ASSETS/apply-patches.py" --install-dir "$INSTALL_DIR"
 echo "▶ Installing link_contacts.py (contacts link: phone + LID aliases)"
 cp "$WA_ASSETS/link_contacts.py" "$INSTALL_DIR/whatsapp-bridge/link_contacts.py"
 chmod +x "$INSTALL_DIR/whatsapp-bridge/link_contacts.py"
+
+# ─── Ship voice-note transcriber (whatsapp-transcribe.timer runs it) ──────────
+echo "▶ Installing transcribe_voice_notes.py (Whisper voice-note → content)"
+mkdir -p "$INSTALL_DIR/transcriber"
+cp "$WA_ASSETS/transcribe_voice_notes.py" "$INSTALL_DIR/transcriber/transcribe_voice_notes.py"
+chmod +x "$INSTALL_DIR/transcriber/transcribe_voice_notes.py"
+
+# ─── Ship wa-inbox-fresh.sh (pre-scan freshness gate, run FIRST by ops-inbox) ─
+echo "▶ Installing wa-inbox-fresh.sh → ~/bin (pre-scan freshness gate)"
+mkdir -p "$HOME/bin"
+cp "$SCRIPT_DIR/../bin/wa-inbox-fresh.sh" "$HOME/bin/wa-inbox-fresh.sh"
+chmod +x "$HOME/bin/wa-inbox-fresh.sh"
 
 # ─── Bump Go deps + build ────────────────────────────────────────────────────
 if [ "$SKIP_BUILD" -ne 1 ]; then
@@ -133,6 +150,16 @@ if [ "$WITH_BACKFILL_TIMER" -eq 1 ]; then
   cp "$WA_ASSETS/systemd/whatsapp-backfill.timer"   "$SYSTEMD_DIR/"
 fi
 
+if [ "$WITH_TRANSCRIBE_TIMER" -eq 1 ]; then
+  cp "$WA_ASSETS/systemd/whatsapp-transcribe.service" "$SYSTEMD_DIR/"
+  cp "$WA_ASSETS/systemd/whatsapp-transcribe.timer"   "$SYSTEMD_DIR/"
+  # The transcribe service reads OPENAI_API_KEY from this EnvironmentFile.
+  if [ ! -f "$HOME/.config/systemd/env/mcp-secrets.env" ]; then
+    echo "  NOTE: ~/.config/systemd/env/mcp-secrets.env not found — the transcribe"
+    echo "        service needs OPENAI_API_KEY there (KEY=value lines) to run."
+  fi
+fi
+
 # ─── Disable deprecated wacli daemon if present ──────────────────────────────
 if systemctl --user list-unit-files claude-ops-wacli-keepalive.service 2>/dev/null | grep -q wacli-keepalive; then
   echo "▶ Disabling deprecated claude-ops-wacli-keepalive.service (replaced by systemd-managed bridge)"
@@ -153,6 +180,9 @@ systemctl --user daemon-reload
 systemctl --user enable --now whatsapp-bridge.service
 if [ "$WITH_BACKFILL_TIMER" -eq 1 ]; then
   systemctl --user enable --now whatsapp-backfill.timer
+fi
+if [ "$WITH_TRANSCRIBE_TIMER" -eq 1 ]; then
+  systemctl --user enable --now whatsapp-transcribe.timer
 fi
 
 # ─── Surface the pairing code if present ─────────────────────────────────────
@@ -182,5 +212,7 @@ fi
 echo ""
 echo "▶ Status reference:"
 echo "    systemctl --user status whatsapp-bridge.service"
-echo "    systemctl --user list-timers whatsapp-backfill.timer"
-echo "    curl -fsS -X POST http://127.0.0.1:8080/api/backfill   # on-demand"
+echo "    systemctl --user list-timers whatsapp-backfill.timer whatsapp-transcribe.timer"
+echo "    curl -fsS -X POST http://127.0.0.1:8080/api/backfill   # on-demand backfill"
+echo "    systemctl --user start whatsapp-transcribe.service     # on-demand transcribe"
+echo "    ~/bin/wa-inbox-fresh.sh                                 # pre-scan freshness gate"

--- a/claude-ops/scripts/whatsapp/apply-patches.py
+++ b/claude-ops/scripts/whatsapp/apply-patches.py
@@ -16,6 +16,19 @@ Patches included:
   Python whatsapp.py — LID-to-phone resolver via whatsmeow_lid_map, and
           contact-name lookup via whatsmeow_contacts (replaces the macOS-only
           `contacts` table populated by the Contacts.app mapper).
+  Fix C — Outbound send persistence: /api/send handler persists sent messages
+          as is_from_me=1 rows in messages.db immediately after SendMessage
+          succeeds. Without this, agent-sent messages were absent from the MCP
+          read path (bridge only stored phone-originated echoes, not API sends).
+  Fix D — POST /api/resync_app_state REST endpoint: makes the MCP server's
+          resync_app_state tool actually reachable (previously returned 404).
+          Triggers client.FetchAppState for the requested patch name.
+  Fix E — Python MCP shape fix: all tool functions now return JSON-serialisable
+          dicts (not dataclass objects). Adds _open_db() with WAL mode so reads
+          never block the bridge writer and always see the latest committed state
+          (single source of truth). Fixes the 30+ pydantic validation errors on
+          list_chats, list_messages, search_contacts, get_chat, get_contact_chats,
+          get_direct_chat_by_contact, get_last_interaction, get_message_context.
 
 Every patch is gated on a sentinel string so re-running is a no-op.
 
@@ -332,6 +345,220 @@ def _name_from_whatsmeow_contacts(jid: str):
 
 PY_PATH_SENTINEL = "_name_from_whatsmeow_contacts"
 
+# ─── main.go Fix C: persist outbound sends to messages.db (is_from_me=1) ─────
+# The /api/send handler called client.SendMessage but discarded the response and
+# never wrote a row to messages.db. Phone-originated self-sends were stored via
+# the inbound event path, but agent sends via POST /api/send were invisible to
+# the MCP read path. This patch persists each successful send immediately.
+OUTBOUND_PERSIST_NEEDLE = """\t// Send message
+\t_, err = client.SendMessage(context.Background(), recipientJID, msg)
+
+\tif err != nil {
+\t\treturn false, fmt.Sprintf("Error sending message: %v", err)
+\t}
+
+\treturn true, fmt.Sprintf("Message sent to %s", recipient)
+}"""
+
+OUTBOUND_PERSIST_REPLACEMENT = """\t// Send message
+\tsendResp, err := client.SendMessage(context.Background(), recipientJID, msg)
+
+\tif err != nil {
+\t\treturn false, fmt.Sprintf("Error sending message: %v", err)
+\t}
+
+\t// claude-ops Fix C: persist the sent message to messages.db so the MCP server
+\t// sees it as is_from_me=1 (single source of truth). The bridge's inbound event
+\t// handler stores phone-originated sends; POST /api/send sends were previously
+\t// never written. INSERT OR REPLACE is idempotent if whatsmeow also echoes it.
+\tif messageStore != nil {
+\t\tchatJID := recipientJID.String()
+\t\tsenderJID := client.Store.ID.User
+\t\tts := sendResp.Timestamp
+\t\tif ts.IsZero() {
+\t\t\tts = time.Now()
+\t\t}
+\t\tmsgID := string(sendResp.ID)
+\t\tif msgID == "" {
+\t\t\tmsgID = client.GenerateMessageID()
+\t\t}
+\t\t_ = messageStore.StoreChat(chatJID, "", ts)
+\t\t_ = messageStore.StoreMessage(
+\t\t\tmsgID, chatJID, senderJID, message, ts, true,
+\t\t\t"", "", "", nil, nil, nil, 0,
+\t\t)
+\t}
+
+\treturn true, fmt.Sprintf("Message sent to %s", recipient)
+}"""
+
+OUTBOUND_PERSIST_SENTINEL = "claude-ops Fix C: persist the sent message"
+
+# The function signature must also accept *MessageStore (needle matches original)
+OUTBOUND_SIG_NEEDLE = "func sendWhatsAppMessage(client *whatsmeow.Client, recipient string, message string, mediaPath string) (bool, string) {"
+OUTBOUND_SIG_REPLACEMENT = "func sendWhatsAppMessage(client *whatsmeow.Client, messageStore *MessageStore, recipient string, message string, mediaPath string) (bool, string) {"
+OUTBOUND_SIG_SENTINEL = "messageStore *MessageStore, recipient string"
+
+# The /api/send call site must pass messageStore
+OUTBOUND_CALLSITE_NEEDLE = "success, message := sendWhatsAppMessage(client, req.Recipient, req.Message, req.MediaPath)"
+OUTBOUND_CALLSITE_REPLACEMENT = "// messageStore passed so outbound is persisted immediately (claude-ops Fix C)\n\t\tsuccess, message := sendWhatsAppMessage(client, messageStore, req.Recipient, req.Message, req.MediaPath)"
+OUTBOUND_CALLSITE_SENTINEL = "messageStore passed so outbound is persisted immediately"
+
+# The appstate import is needed for Fix D
+APPSTATE_IMPORT_NEEDLE = (
+    '\t"go.mau.fi/whatsmeow"\n\twaProto "go.mau.fi/whatsmeow/binary/proto"'
+)
+APPSTATE_IMPORT_REPLACEMENT = '\t"go.mau.fi/whatsmeow"\n\t"go.mau.fi/whatsmeow/appstate"\n\twaProto "go.mau.fi/whatsmeow/binary/proto"'
+APPSTATE_IMPORT_SENTINEL = '"go.mau.fi/whatsmeow/appstate"'
+
+# ─── main.go Fix D: POST /api/resync_app_state REST endpoint ──────────────────
+RESYNC_ENDPOINT_NEEDLE = """\t// Run server in a goroutine so it doesn't block
+\tgo func() {
+\t\tif err := http.ListenAndServe(serverAddr, nil); err != nil {
+\t\t\tfmt.Printf(\"REST API server error: %v\\n\", err)
+\t\t}
+\t}()
+}"""
+
+RESYNC_ENDPOINT_REPLACEMENT = """\t// claude-ops Fix D: POST /api/resync_app_state — force a full whatsmeow
+\t// app-state resync. Used by the MCP server's resync_app_state tool.
+\t// Body: {"name":"regular_low","full_sync":true}
+\thttp.HandleFunc(\"/api/resync_app_state\", func(w http.ResponseWriter, r *http.Request) {
+\t\tif r.Method != http.MethodPost {
+\t\t\thttp.Error(w, \"Method not allowed\", http.StatusMethodNotAllowed)
+\t\t\treturn
+\t\t}
+\t\tw.Header().Set(\"Content-Type\", \"application/json\")
+\t\tif !client.IsConnected() {
+\t\t\tw.WriteHeader(http.StatusServiceUnavailable)
+\t\t\tfmt.Fprintln(w, `{\"success\":false,\"message\":\"client not connected\"}`)
+\t\t\treturn
+\t\t}
+\t\tvar req struct {
+\t\t\tName     string `json:\"name\"`
+\t\t\tFullSync bool   `json:\"full_sync\"`
+\t\t}
+\t\treq.Name = \"regular_low\"
+\t\treq.FullSync = true
+\t\tif err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+\t\t\tif req.Name == \"\" {
+\t\t\t\treq.Name = \"regular_low\"
+\t\t\t}
+\t\t}
+\t\tif err := client.FetchAppState(context.Background(), appstate.WAPatchName(req.Name), req.FullSync, false); err != nil {
+\t\t\tw.WriteHeader(http.StatusInternalServerError)
+\t\t\tfmt.Fprintf(w, `{\"success\":false,\"message\":%q}`, err.Error())
+\t\t\treturn
+\t\t}
+\t\tfmt.Fprintf(w, `{\"success\":true,\"message\":\"app-state %s resynced\"}`, req.Name)
+\t})
+
+\t// Run server in a goroutine so it doesn't block
+\tgo func() {
+\t\tif err := http.ListenAndServe(serverAddr, nil); err != nil {
+\t\t\tfmt.Printf(\"REST API server error: %v\\n\", err)
+\t\t}
+\t}()
+}"""
+
+RESYNC_ENDPOINT_SENTINEL = "claude-ops Fix D: POST /api/resync_app_state"
+
+# ─── main.go Fix D (Connected): auto-resync regular_low on startup ────────────
+CONNECTED_RESYNC_NEEDLE = """\t\tcase *events.Connected:
+\t\t\tlogger.Infof(\"Connected to WhatsApp\")
+\t\t\t// claude-ops: auto-trigger a deep history backfill on every Connected event."""
+
+CONNECTED_RESYNC_REPLACEMENT = """\t\tcase *events.Connected:
+\t\t\tlogger.Infof(\"Connected to WhatsApp\")
+\t\t\t// claude-ops Fix D: force a full resync of the regular_low app-state patch
+\t\t\t// on every connect. Clears LTHash mismatch errors that fire when the local
+\t\t\t// snapshot is stale. Non-fatal if it fails (message delivery unaffected).
+\t\t\tgo func(c *whatsmeow.Client) {
+\t\t\t\ttime.Sleep(3 * time.Second)
+\t\t\t\tlogger.Infof(\"Auto-resync: fetching fresh regular_low app-state snapshot\")
+\t\t\t\tif err := c.FetchAppState(context.Background(), \"regular_low\", true, false); err != nil {
+\t\t\t\t\tlogger.Debugf(\"regular_low app-state resync: %v (non-fatal)\", err)
+\t\t\t\t} else {
+\t\t\t\t\tlogger.Infof(\"regular_low app-state resync complete\")
+\t\t\t\t}
+\t\t\t}(client)
+\t\t\t// claude-ops: auto-trigger a deep history backfill on every Connected event."""
+
+CONNECTED_RESYNC_SENTINEL = "claude-ops Fix D: force a full resync of the regular_low"
+
+# ─── whatsapp.py Fix E: WAL-mode _open_db + dict serialisation helpers ────────
+# The MCP server returned raw dataclass objects where FastMCP expected dicts,
+# causing 30+ pydantic validation errors on every list_chats / list_messages
+# call. This patch adds _open_db (WAL mode, read-only) and _*_to_dict helpers,
+# then all public functions return dicts/list-of-dicts.
+PY_SHAPE_NEEDLE = """@dataclass
+class MessageContext:
+    message: Message
+    before: List[Message]
+    after: List[Message]
+
+
+def get_sender_name(sender_jid: str) -> str:"""
+
+PY_SHAPE_REPLACEMENT = """@dataclass
+class MessageContext:
+    message: Message
+    before: List[Message]
+    after: List[Message]
+
+
+# claude-ops Fix E: serialization helpers + WAL-mode DB open.
+# All public tool functions return plain dicts so FastMCP can validate them.
+def _open_db(path: str, read_only: bool = True):
+    \"\"\"Open SQLite in WAL mode: reads see bridge's latest committed state without
+    ever blocking or being blocked by the bridge writer (single source of truth).\"\"\"
+    import sqlite3 as _sq
+    if read_only:
+        conn = _sq.connect(f"file:{path}?mode=ro", uri=True, check_same_thread=False)
+    else:
+        conn = _sq.connect(path, check_same_thread=False)
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+    except _sq.Error:
+        pass
+    return conn
+
+
+def _message_to_dict(msg) -> dict:
+    ts = msg.timestamp
+    return {
+        "id": msg.id,
+        "chat_jid": msg.chat_jid,
+        "chat_name": msg.chat_name,
+        "sender": msg.sender,
+        "content": msg.content,
+        "timestamp": ts.isoformat() if hasattr(ts, "isoformat") else str(ts),
+        "is_from_me": bool(msg.is_from_me),
+        "media_type": msg.media_type,
+    }
+
+
+def _chat_to_dict(chat) -> dict:
+    lmt = chat.last_message_time
+    return {
+        "jid": chat.jid,
+        "name": chat.name,
+        "last_message_time": lmt.isoformat() if hasattr(lmt, "isoformat") else (str(lmt) if lmt else None),
+        "last_message": chat.last_message,
+        "last_sender": chat.last_sender,
+        "last_is_from_me": bool(chat.last_is_from_me) if chat.last_is_from_me is not None else None,
+        "is_group": chat.is_group,
+    }
+
+
+def _contact_to_dict(contact) -> dict:
+    return {"phone_number": contact.phone_number, "name": contact.name, "jid": contact.jid}
+
+
+def get_sender_name(sender_jid: str) -> str:"""
+
+PY_SHAPE_SENTINEL = "claude-ops Fix E: serialization helpers + WAL-mode DB open"
+
 
 def replace_idempotent(
     p: pathlib.Path, needle: str, replacement: str, sentinel: str, label: str
@@ -405,6 +632,48 @@ def main() -> int:
         SAFE_RHS_SENTINEL,
         "crash-safe requestHistorySync (per-chat anchor)",
     )
+    changed_go |= replace_idempotent(
+        main_go,
+        APPSTATE_IMPORT_NEEDLE,
+        APPSTATE_IMPORT_REPLACEMENT,
+        APPSTATE_IMPORT_SENTINEL,
+        "Fix D: add go.mau.fi/whatsmeow/appstate import",
+    )
+    changed_go |= replace_idempotent(
+        main_go,
+        OUTBOUND_SIG_NEEDLE,
+        OUTBOUND_SIG_REPLACEMENT,
+        OUTBOUND_SIG_SENTINEL,
+        "Fix C: sendWhatsAppMessage signature (+messageStore)",
+    )
+    changed_go |= replace_idempotent(
+        main_go,
+        OUTBOUND_CALLSITE_NEEDLE,
+        OUTBOUND_CALLSITE_REPLACEMENT,
+        OUTBOUND_CALLSITE_SENTINEL,
+        "Fix C: /api/send call site passes messageStore",
+    )
+    changed_go |= replace_idempotent(
+        main_go,
+        OUTBOUND_PERSIST_NEEDLE,
+        OUTBOUND_PERSIST_REPLACEMENT,
+        OUTBOUND_PERSIST_SENTINEL,
+        "Fix C: persist outbound send as is_from_me=1 row",
+    )
+    changed_go |= replace_idempotent(
+        main_go,
+        CONNECTED_RESYNC_NEEDLE,
+        CONNECTED_RESYNC_REPLACEMENT,
+        CONNECTED_RESYNC_SENTINEL,
+        "Fix D: auto-resync regular_low on Connected event",
+    )
+    changed_go |= replace_idempotent(
+        main_go,
+        RESYNC_ENDPOINT_NEEDLE,
+        RESYNC_ENDPOINT_REPLACEMENT,
+        RESYNC_ENDPOINT_SENTINEL,
+        "Fix D: POST /api/resync_app_state endpoint",
+    )
 
     print("  whatsapp.py:")
     changed_py = replace_idempotent(
@@ -413,6 +682,13 @@ def main() -> int:
         PY_PATH_REPLACEMENT,
         PY_PATH_SENTINEL,
         "LID resolver + whatsmeow_contacts lookup",
+    )
+    changed_py |= replace_idempotent(
+        whatsapp_py,
+        PY_SHAPE_NEEDLE,
+        PY_SHAPE_REPLACEMENT,
+        PY_SHAPE_SENTINEL,
+        "Fix E: WAL _open_db + dict serialisation helpers",
     )
 
     if changed_go:

--- a/claude-ops/scripts/whatsapp/systemd/whatsapp-transcribe.service
+++ b/claude-ops/scripts/whatsapp/systemd/whatsapp-transcribe.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=WhatsApp voice-note transcriber — fills empty audio rows with Whisper transcripts (oneshot)
+Documentation=https://github.com/lharries/whatsapp-mcp
+After=whatsapp-bridge.service
+Requires=whatsapp-bridge.service
+PartOf=whatsapp-bridge.service
+
+[Service]
+Type=oneshot
+# OPENAI_API_KEY (and other secrets) for the metered Whisper API.
+EnvironmentFile=%h/.config/systemd/env/mcp-secrets.env
+# Wait up to 10s for the bridge :8080 before downloading media.
+ExecStartPre=/bin/sh -c 'for i in 1 2 3 4 5; do ss -ltn 2>/dev/null | grep -q ":8080" && exit 0; sleep 2; done; exit 0'
+ExecStart=/usr/bin/python3 %h/.local/share/whatsapp-mcp/transcriber/transcribe_voice_notes.py --days 2 --max 80
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=whatsapp-transcribe

--- a/claude-ops/scripts/whatsapp/systemd/whatsapp-transcribe.service
+++ b/claude-ops/scripts/whatsapp/systemd/whatsapp-transcribe.service
@@ -7,6 +7,8 @@ PartOf=whatsapp-bridge.service
 
 [Service]
 Type=oneshot
+# Batch may run many Whisper calls; disable the default ~90s start timeout.
+TimeoutStartSec=0
 # OPENAI_API_KEY (and other secrets) for the metered Whisper API.
 EnvironmentFile=%h/.config/systemd/env/mcp-secrets.env
 # Wait up to 10s for the bridge :8080 before downloading media.

--- a/claude-ops/scripts/whatsapp/systemd/whatsapp-transcribe.timer
+++ b/claude-ops/scripts/whatsapp/systemd/whatsapp-transcribe.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Transcribe new WhatsApp voice notes every 10 min + on boot (ops-inbox integration)
+Documentation=https://github.com/lharries/whatsapp-mcp
+
+[Timer]
+# First fire 2 min after boot/session start (after the bridge connects), then every 10 min.
+OnBootSec=2min
+OnUnitActiveSec=10min
+AccuracySec=30s
+Persistent=true
+Unit=whatsapp-transcribe.service
+
+[Install]
+WantedBy=timers.target

--- a/claude-ops/scripts/whatsapp/transcribe_voice_notes.py
+++ b/claude-ops/scripts/whatsapp/transcribe_voice_notes.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""WhatsApp voice-note transcriber — makes voice notes first-class in ops-inbox.
+
+Finds WhatsApp messages with media_type='audio' and empty content, downloads
+them via the bridge /api/download endpoint, transcribes with OpenAI whisper-1,
+and writes '[voice] <text>' back into messages.content — but ONLY where content
+is still empty, so it never clobbers real text and is fully idempotent.
+
+Run by the whatsapp-transcribe.timer (systemd --user) every few minutes so new
+voice notes are transcribed automatically before any inbox scan reads them.
+
+Guards (per global cost-leak + no-stacking rules):
+  * mkdir-based single-instance lock (defense-in-depth on top of systemd oneshot)
+  * --max cap per run (rate-floor on the metered Whisper API)
+  * idempotent: only ever touches empty-content audio rows
+
+Env: OPENAI_API_KEY (from ~/.config/systemd/env/mcp-secrets.env).
+Args: --days N (lookback window, default 2)  --max N (cap per run, default 80)
+"""
+
+import argparse, json, os, shutil, sqlite3, subprocess, sys, time, urllib.request
+
+DB = os.path.expanduser("~/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db")
+BRIDGE = "http://127.0.0.1:8080/api/download"
+LOCKDIR = "/tmp/.wa-transcribe.lock"
+
+
+def acquire_lock():
+    try:
+        os.mkdir(LOCKDIR)  # atomic; fails if another run holds it
+        return True
+    except FileExistsError:
+        # stale lock older than 30 min → reclaim
+        try:
+            if time.time() - os.path.getmtime(LOCKDIR) > 1800:
+                shutil.rmtree(LOCKDIR, ignore_errors=True)
+                os.mkdir(LOCKDIR)
+                return True
+        except FileNotFoundError:
+            pass
+        return False
+
+
+def download(msg_id, chat_jid):
+    body = json.dumps({"message_id": msg_id, "chat_jid": chat_jid}).encode()
+    req = urllib.request.Request(
+        BRIDGE, data=body, headers={"Content-Type": "application/json"}
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        d = json.load(r)
+    return d.get("path") if d.get("success") else None
+
+
+def transcribe(path, key):
+    out = subprocess.run(
+        [
+            "curl",
+            "-s",
+            "-m",
+            "180",
+            "https://api.openai.com/v1/audio/transcriptions",
+            "-H",
+            f"Authorization: Bearer {key}",
+            "-F",
+            f"file=@{path}",
+            "-F",
+            "model=whisper-1",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=200,
+    )
+    try:
+        return json.loads(out.stdout).get("text", "").strip()
+    except Exception:
+        return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--days", type=int, default=2)
+    ap.add_argument("--max", type=int, default=80)
+    args = ap.parse_args()
+
+    key = os.environ.get("OPENAI_API_KEY")
+    if not key:
+        print("transcriber: OPENAI_API_KEY not set — abort", flush=True)
+        sys.exit(1)
+    if not os.path.exists(DB):
+        print(f"transcriber: db not found {DB} — abort", flush=True)
+        sys.exit(0)
+    if not acquire_lock():
+        print("transcriber: another run holds the lock — exit", flush=True)
+        sys.exit(0)
+
+    try:
+        con = sqlite3.connect(DB, timeout=15)
+        con.execute("PRAGMA busy_timeout=8000;")
+        rows = con.execute(
+            "SELECT id, chat_jid, is_from_me FROM messages "
+            "WHERE media_type='audio' AND (content='' OR content IS NULL) "
+            "AND timestamp >= datetime('now', ?) "
+            "ORDER BY timestamp DESC LIMIT ?",
+            (f"-{args.days} days", args.max),
+        ).fetchall()
+        if not rows:
+            print(f"transcriber: nothing to do (last {args.days}d)", flush=True)
+            return
+        print(
+            f"transcriber: {len(rows)} voice note(s) to transcribe (last {args.days}d, cap {args.max})",
+            flush=True,
+        )
+        ok = fail = 0
+        for i, (mid, jid, mine) in enumerate(rows, 1):
+            try:
+                path = download(mid, jid)
+                if not path or not os.path.exists(path):
+                    fail += 1
+                    print(f"  [{i}] {mid[:8]} download-fail", flush=True)
+                    continue
+                text = transcribe(path, key)
+                if not text:
+                    fail += 1
+                    print(f"  [{i}] {mid[:8]} transcribe-fail", flush=True)
+                    continue
+                con.execute(
+                    "UPDATE messages SET content=? WHERE id=? AND chat_jid=? "
+                    "AND (content='' OR content IS NULL)",
+                    (f"[voice] {text}", mid, jid),
+                )
+                con.commit()
+                ok += 1
+                print(f"  [{i}] {mid[:8]} ({'me' if mine else 'them'}) ok", flush=True)
+            except Exception as e:
+                fail += 1
+                print(f"  [{i}] {mid[:8]} err {e}", flush=True)
+            time.sleep(0.2)
+        con.close()
+        print(f"transcriber: done — {ok} transcribed, {fail} failed", flush=True)
+    finally:
+        shutil.rmtree(LOCKDIR, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/claude-ops/scripts/whatsapp/transcribe_voice_notes.py
+++ b/claude-ops/scripts/whatsapp/transcribe_voice_notes.py
@@ -15,30 +15,75 @@ Guards (per global cost-leak + no-stacking rules):
   * idempotent: only ever touches empty-content audio rows
 
 Env: OPENAI_API_KEY (from ~/.config/systemd/env/mcp-secrets.env).
+     WHATSAPP_BRIDGE_DB (same default as wa-inbox-fresh / ops tooling).
 Args: --days N (lookback window, default 2)  --max N (cap per run, default 80)
 """
 
-import argparse, json, os, shutil, sqlite3, subprocess, sys, time, urllib.request
+import argparse
+import json
+import os
+import shutil
+import signal
+import sqlite3
+import subprocess
+import sys
+import time
+import urllib.request
 
-DB = os.path.expanduser("~/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db")
+DB = os.path.expanduser(
+    os.environ.get(
+        "WHATSAPP_BRIDGE_DB",
+        "~/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db",
+    )
+)
 BRIDGE = "http://127.0.0.1:8080/api/download"
 LOCKDIR = "/tmp/.wa-transcribe.lock"
+PIDFILE = os.path.join(LOCKDIR, "pid")
+FAIL_MARKER = "[voice] (transcription unavailable)"
+
+
+def _pid_alive(pid):
+    try:
+        os.kill(pid, 0)
+        return True
+    except OSError:
+        return False
+
+
+def release_lock(signum=None, frame=None):
+    shutil.rmtree(LOCKDIR, ignore_errors=True)
+    if signum is not None:
+        sys.exit(128 + signum)
 
 
 def acquire_lock():
     try:
-        os.mkdir(LOCKDIR)  # atomic; fails if another run holds it
-        return True
+        os.mkdir(LOCKDIR)
     except FileExistsError:
-        # stale lock older than 30 min → reclaim
         try:
-            if time.time() - os.path.getmtime(LOCKDIR) > 1800:
-                shutil.rmtree(LOCKDIR, ignore_errors=True)
-                os.mkdir(LOCKDIR)
-                return True
-        except FileNotFoundError:
+            with open(PIDFILE) as f:
+                old = int(f.read().strip())
+            if _pid_alive(old):
+                return False
+        except (FileNotFoundError, ValueError, OSError):
             pass
-        return False
+        shutil.rmtree(LOCKDIR, ignore_errors=True)
+        try:
+            os.mkdir(LOCKDIR)
+        except FileExistsError:
+            return False
+    with open(PIDFILE, "w") as f:
+        f.write(str(os.getpid()))
+    return True
+
+
+def mark_unavailable(con, mid, jid):
+    con.execute(
+        "UPDATE messages SET content=? WHERE id=? AND chat_jid=? "
+        "AND (content='' OR content IS NULL)",
+        (FAIL_MARKER, mid, jid),
+    )
+    con.commit()
 
 
 def download(msg_id, chat_jid):
@@ -86,12 +131,15 @@ def main():
     if not key:
         print("transcriber: OPENAI_API_KEY not set — abort", flush=True)
         sys.exit(1)
-    if not os.path.exists(DB):
+    if not os.path.isfile(DB):
         print(f"transcriber: db not found {DB} — abort", flush=True)
-        sys.exit(0)
+        sys.exit(2)
     if not acquire_lock():
         print("transcriber: another run holds the lock — exit", flush=True)
         sys.exit(0)
+
+    signal.signal(signal.SIGTERM, release_lock)
+    signal.signal(signal.SIGINT, release_lock)
 
     try:
         con = sqlite3.connect(DB, timeout=15)
@@ -116,11 +164,13 @@ def main():
                 path = download(mid, jid)
                 if not path or not os.path.exists(path):
                     fail += 1
+                    mark_unavailable(con, mid, jid)
                     print(f"  [{i}] {mid[:8]} download-fail", flush=True)
                     continue
                 text = transcribe(path, key)
                 if not text:
                     fail += 1
+                    mark_unavailable(con, mid, jid)
                     print(f"  [{i}] {mid[:8]} transcribe-fail", flush=True)
                     continue
                 con.execute(
@@ -133,12 +183,13 @@ def main():
                 print(f"  [{i}] {mid[:8]} ({'me' if mine else 'them'}) ok", flush=True)
             except Exception as e:
                 fail += 1
+                mark_unavailable(con, mid, jid)
                 print(f"  [{i}] {mid[:8]} err {e}", flush=True)
             time.sleep(0.2)
         con.close()
         print(f"transcriber: done — {ok} transcribed, {fail} failed", flush=True)
     finally:
-        shutil.rmtree(LOCKDIR, ignore_errors=True)
+        release_lock()
 
 
 if __name__ == "__main__":

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -79,15 +79,21 @@ If you find yourself reaching for any `wacli ...` shell command, stop and use th
 
 Before executing, load available context:
 
-0. **Auto-sync WhatsApp in the background (DEFAULT — every invocation)** — the FIRST thing this skill does, before any scan or menu, is fire a recent-conversation history backfill **and** a contacts-link in the background, non-blocking. The backfill pulls recent messages for the 50 most-active chats; the link populates `messages.db.contacts` from the whatsmeow session store so both `<pn>@s.whatsapp.net` and `<lid>@lid` chat JIDs resolve to names (without it the `contacts` table is empty and LID-format chats show raw phone numbers). Both are idempotent and safe to run every time:
+0. **Auto-sync WhatsApp in the background (DEFAULT — every invocation)** — the FIRST thing this skill does, before any scan or menu, is guarantee the store is fresh, then fire a recent-conversation history backfill **and** a contacts-link in the background, non-blocking.
+
+   **0a. Freshness gate (run FIRST, blocking, bounded).** Before classifying anything, run `~/bin/wa-inbox-fresh.sh` (shipped by `scripts/install-whatsapp-bridge-linux.sh`). It probes the bridge with a real **curl connection probe** (`curl -s -m4 http://127.0.0.1:8080/`), forces a backfill, triggers voice-note transcription, and waits (bounded ~32s) for the newest message to settle, then prints a FRESHNESS report (`newest message = … (N min old)`). It **only restarts the bridge if the curl probe genuinely fails twice** — do NOT gate liveness on `ss | grep :8080`, because `ss` renders port 8080 as the service name `webcache`, so the grep never matches and you'd needlessly bounce a healthy bridge. Exit 2 means the bridge is down and unrecoverable → the store is STALE, do not trust last-sender classification.
+
+   **0b. Background backfill + contacts-link** (idempotent, safe every time). The backfill pulls recent messages for the 50 most-active chats; the link populates `messages.db.contacts` from the whatsmeow session store so both `<pn>@s.whatsapp.net` and `<lid>@lid` chat JIDs resolve to names (without it the `contacts` table is empty and LID-format chats show raw phone numbers):
    ```bash
    BR="${WHATSAPP_BRIDGE_DIR:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge}"
-   if lsof -i :8080 2>/dev/null | grep -q LISTEN; then
+   if curl -s -o /dev/null -m 4 http://127.0.0.1:8080/ 2>/dev/null; then
      curl -fsS -m 10 -X POST http://127.0.0.1:8080/api/backfill >/dev/null 2>&1 &   # recent-conversation backfill
      [ -f "$BR/link_contacts.py" ] && python3 "$BR/link_contacts.py" >/dev/null 2>&1 &  # contacts link (phone + LID aliases)
    fi
    ```
    Kick this off, then continue with the steps below while it runs — give the link ~2s before name-resolving chats. `link_contacts.py` resolves names via `whatsmeow_contacts` + `whatsmeow_lid_map` (name preference: full_name → first_name → push_name → business_name). It ships via `scripts/install-whatsapp-bridge-linux.sh` into the bridge dir; recreate it from `whatsmeow_contacts`/`whatsmeow_lid_map` if absent.
+
+   **0c. Voice notes are first-class.** Incoming voice notes (`media_type='audio'`, empty `content`) are auto-transcribed into `content` as `[voice] <text>` by the `whatsapp-transcribe.timer` (systemd-user, every 10 min, OpenAI `whisper-1`) — and `wa-inbox-fresh.sh` triggers a transcribe pass on every scan. So a voice note shows up in NEEDS_REPLY / thread scans exactly like a text message; treat a `[voice] …` body as the sender's words. Transcription is idempotent (only ever fills empty audio rows, never clobbers real text) and capped per run, so it never re-bills or stacks.
 
 1. **Self-heal plugin version pin** — if any `${CLAUDE_PLUGIN_DATA_DIR}` file or `~/.claude/plugins/installed_plugins.json` references a `cache/ops-marketplace/ops/X.Y.Z/` path that no longer exists on disk, downstream hooks (`stop-all.sh`, `ops-post-session-cleanup`) emit `Plugin directory does not exist`. Resolve before scanning:
    ```bash
@@ -181,7 +187,7 @@ lsof -i :8080 | grep -q LISTEN && echo "bridge up" || journalctl --user -u whats
 ```bash
 bash "$CLAUDE_PLUGIN_ROOT/scripts/install-whatsapp-bridge-linux.sh" --wa-phone <E.164>
 ```
-This clones lharries/whatsapp-mcp into `~/.local/share/whatsapp-mcp`, applies the in-repo claude-ops patches (Fix A/B pair-phone hardening, auto-backfill on Connected, `POST /api/backfill` REST endpoint, crash-safe `requestHistorySync`, Python LID↔phone↔contact resolver), drops three systemd-user units (`whatsapp-bridge.service`, `whatsapp-backfill.service`, `whatsapp-backfill.timer`), enables linger, and emits the pairing code via `journalctl --user -u whatsapp-bridge -f`. Idempotent: re-running is safe and updates patches in place.
+This clones lharries/whatsapp-mcp into `~/.local/share/whatsapp-mcp`, applies the in-repo claude-ops patches (Fix A/B pair-phone hardening, auto-backfill on Connected, `POST /api/backfill` REST endpoint, crash-safe `requestHistorySync`, Python LID↔phone↔contact resolver), drops the systemd-user units (`whatsapp-bridge.service`, `whatsapp-backfill.{service,timer}`, `whatsapp-transcribe.{service,timer}`), installs the voice-note transcriber (`transcriber/transcribe_voice_notes.py`) and the pre-scan freshness gate (`~/bin/wa-inbox-fresh.sh`), enables linger, and emits the pairing code via `journalctl --user -u whatsapp-bridge -f`. Idempotent: re-running is safe and updates patches in place. Pass `--no-transcribe-timer` to skip voice-note transcription. The transcribe service reads `OPENAI_API_KEY` from `~/.config/systemd/env/mcp-secrets.env`.
 
 **MCP tools** (use these instead of any wacli CLI command):
 


### PR DESCRIPTION
## Summary

Consolidates the WhatsApp inbox-freshness work into one release (2.18.3) and ships the two pieces that were **not yet on `main`**: voice-note auto-transcription and the pre-scan freshness gate. Bridge-side fixes and the autosync/contacts-link already landed on `main` (#404, #403) — this layers on top and bumps the version.

## What's new (genuinely missing from `main`)

- **WhatsApp voice-note auto-transcription** — `scripts/whatsapp/transcribe_voice_notes.py` finds incoming voice notes (`media_type='audio'`, empty `content`), downloads via the bridge, transcribes with OpenAI `whisper-1`, and writes `[voice] <text>` into `messages.content` **only where content is empty** (idempotent, never clobbers text). Driven by new `whatsapp-transcribe.{service,timer}` (systemd-user, every 10 min). Cost-safe: mkdir single-instance lock, `--max` per-run cap, idempotent updates.
- **Pre-scan freshness gate** — `bin/wa-inbox-fresh.sh` (installed to `~/bin`), run FIRST by `ops-inbox`. Connection-probes the bridge with **curl** (NOT `ss | grep :8080`, which mis-resolves 8080 to the service name `webcache` and would bounce a healthy bridge), forces a backfill, triggers transcription, waits bounded for the store to settle, prints a freshness report, and restarts the bridge only if the curl probe fails twice. Exit 2 = unrecoverable bridge → store is stale.
- **Installer wiring** — `install-whatsapp-bridge-linux.sh` ships both artifacts, drops + enables the transcribe units (reads `OPENAI_API_KEY` from `~/.config/systemd/env/mcp-secrets.env`), and adds `--no-transcribe-timer`.
- **SKILL.md** — step-0 now documents the freshness gate (run first) and first-class voice notes, alongside the existing backfill + contacts-link autosync.
- **Version** bumped 2.18.2 → **2.18.3** in `.claude-plugin/marketplace.json` + `claude-ops/.claude-plugin/plugin.json`; CHANGELOG entry added.

## Three folded sources

1. **`fix/whatsapp-mcp-shapes`** (bridge: outbound `/api/send` persistence, `resync_app_state`, MCP dict serialisation) — merged here for provenance (`da7e1ac`). **Note:** this code already shipped to `main` as #404; the merge adds no functional delta beyond the history link.
2. **Uncommitted main-checkout work** (ops-inbox autosync step-0, `link_contacts.py`, installer +5, hooks.json, `ops-inbox-autosync`) — verified already on `main` via #403; the working-tree copies are byte-identical to `main`, so nothing to re-add. (The working-tree `SKILL.md` was actually *behind* `main`, so `main` was kept as the base.)
3. **New local artifacts** — voice transcriber, freshness gate, transcribe units — ported and wired (the genuinely new content of this PR).

## Safety / scope

- Built entirely in an isolated worktree; the sibling session's uncommitted work in the main checkout was only **read**, never mutated.
- This does **not** auto-publish to the marketplace — publish happens on merge.
- Do **not** merge yet (per request).

## Verification

- `python3 -m py_compile` on both `.py` files — OK
- `bash -n` on installer + `wa-inbox-fresh.sh` — OK
- JSON load of both manifests — OK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches inbox triage behavior, local SQLite updates, optional metered OpenAI API usage, and can restart the WhatsApp bridge when probes fail—wrong freshness logic could misclassify replies.
> 
> **Overview**
> Release **2.18.3** adds two WhatsApp **ops-inbox** capabilities on top of existing bridge autosync: **voice-note transcription** and a **pre-scan freshness gate**.
> 
> Incoming audio messages with empty `content` are filled via `transcribe_voice_notes.py` (bridge download + OpenAI `whisper-1` → `[voice] …`), only on still-empty rows, with per-run caps and a lock. A **systemd-user** `whatsapp-transcribe` timer (10 min) runs it; `install-whatsapp-bridge-linux.sh` ships the script and units (optional `--no-transcribe-timer`), reading `OPENAI_API_KEY` from `mcp-secrets.env`.
> 
> Before triage, **`~/bin/wa-inbox-fresh.sh`** probes the bridge with **curl** (avoiding `ss | grep :8080` false negatives), triggers backfill, queues transcription, waits briefly, and prints a freshness report; exit **2** means do not trust the store. **`ops-inbox` SKILL.md** documents running this gate first and treating `[voice]` bodies like text; background sync now uses curl for liveness too.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78ccc246894d1eb6f3de29e5ae1a469aeb597385. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice-note auto-transcription: WhatsApp voice messages are now automatically transcribed and included in message content as `[voice] ...` for easier triage.
  * Freshness gate: New pre-processing check verifies WhatsApp bridge connectivity and waits for message store to settle, ensuring reliable message sync.

* **Chores**
  * Updated ops plugin version to 2.18.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->