### PR TITLE
chore(ops-bg): default fleet/bg agent cwd to ~/Projects

### DIFF
--- a/claude-ops/bin/ops-bg
+++ b/claude-ops/bin/ops-bg
@@ -63,7 +63,7 @@ SUB="$1"; shift
 cmd_dispatch() {
   local model="opus"
   local effort="high"
-  local add_dir="$PWD"
+  local add_dir="${OPSBG_DIR:-$HOME/Projects}"
   local agent=""
   local extra=()
   while [ $# -gt 0 ]; do
@@ -88,6 +88,7 @@ cmd_dispatch() {
   fi
   args+=("$prompt")
   args+=("${extra[@]}")
+  cd "$add_dir" 2>/dev/null || true   # start fleet agents in default workdir
   exec "$CLAUDE_BIN" "${args[@]}"
 }
 

--- a/claude-ops/bin/ops-bg
+++ b/claude-ops/bin/ops-bg
@@ -82,13 +82,18 @@ cmd_dispatch() {
     exit 2
   fi
   local prompt="$*"
+  if [ ! -d "$add_dir" ]; then
+    echo "ops-bg dispatch: workdir does not exist: $add_dir" >&2
+    exit 2
+  fi
+  add_dir="$(cd "$add_dir" && pwd)"
   local -a args=(--bg --model "$model" --effort "$effort" --add-dir "$add_dir")
   if [ -n "$agent" ]; then
     args+=(--agent "$agent")
   fi
   args+=("$prompt")
   args+=("${extra[@]}")
-  cd "$add_dir" 2>/dev/null || true   # start fleet agents in default workdir
+  cd "$add_dir"   # start fleet agents in default workdir
   exec "$CLAUDE_BIN" "${args[@]}"
 }
 


### PR DESCRIPTION
## What
`ops-bg dispatch` (the `claude --bg` fleet wrapper) hardcoded `--add-dir "$PWD"` and never `cd`'d, so background/fleet agents started in whatever directory the dispatching shell sat in — typically a deep single-repo checkout — not the workspace root.

## Change
- `cmd_dispatch`: `add_dir` now defaults to `${OPSBG_DIR:-$HOME/Projects}` (was `$PWD`).
- `cd "$add_dir"` before `exec` so the agent and any fleet it forks start at the workspace root.
- Still overridable per-dispatch with `--cwd`/`--add-dir`, or globally via `$OPSBG_DIR`.

## Why
Fleet agents inherit the launcher's cwd; there is no config key for a default. This makes the default sane (workspace root) instead of an arbitrary repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change to an ops wrapper script; no auth, data, or production runtime paths.
> 
> **Overview**
> **`ops-bg dispatch`** no longer ties background/fleet agents to the shell’s current directory. The default **`--add-dir`** is now **`${OPSBG_DIR:-$HOME/Projects}`** instead of **`$PWD`**, with the same override via **`--cwd` / `--add-dir`** or **`$OPSBG_DIR`**.
> 
> Before **`exec`**, dispatch **validates** the workdir, **resolves** it to an absolute path, and **`cd`**s there so spawned agents inherit a stable workspace root rather than a random deep repo checkout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c20623e2daf63e0c2801f65989a146181d6927d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory validation and error handling to gracefully exit when specified directories don't exist or are inaccessible
  * Updated default directory configuration to reference a dedicated projects location instead of using the current working directory
  * Enhanced path normalization to resolve all directory paths to absolute references before initializing background sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->