### PR TITLE
fix(whatsapp-bridge): build with -tags sqlite_fts5 so message storage works

### DIFF
--- a/claude-ops/bin/ops-autofix
+++ b/claude-ops/bin/ops-autofix
@@ -88,7 +88,28 @@ fix_bridge_fts() {
     return
   fi
 
-  # Run bridge schema migration to add FTS5 index (sqlite built-in, no rebuild needed)
+  # The bridge binary (mattn/go-sqlite3) MUST be compiled with the `sqlite_fts5`
+  # build tag. Without it, the FTS triggers added by the migration make EVERY
+  # message INSERT fail with "no such module: fts5" and the bridge silently
+  # stores nothing. So guarantee the binary is fts5-capable BEFORE adding triggers.
+  BRIDGE_BIN="$(dirname "$(dirname "$BRIDGE_DB")")/whatsapp-bridge"
+  if [ -f "$BRIDGE_BIN" ] && ! grep -qa "fts5" "$BRIDGE_BIN" 2>/dev/null; then
+    if command -v go >/dev/null 2>&1; then
+      if ( cd "$(dirname "$BRIDGE_BIN")" && CGO_ENABLED=1 go build -tags "sqlite_fts5" -o whatsapp-bridge . ) 2>/dev/null; then
+        systemctl --user restart whatsapp-bridge.service 2>/dev/null || true
+        log_fix "bridge-fts: rebuilt bridge binary with -tags sqlite_fts5 (was missing fts5 module)"
+      else
+        log_fail "bridge-fts: binary lacks fts5 and rebuild failed — skipping migration (triggers would break message storage)"
+        return
+      fi
+    else
+      log_fail "bridge-fts: binary lacks fts5 and go toolchain not found — skipping migration (triggers would break message storage)"
+      return
+    fi
+  fi
+
+  # Run bridge schema migration to add the FTS5 index + triggers (the binary is
+  # now guaranteed fts5-capable above, so the triggers won't break inserts).
   MIGRATE="${CLAUDE_PLUGIN_ROOT:-$(dirname "$0")/..}/scripts/whatsapp-bridge-migrate.sh"
   if bash "$MIGRATE" 2>/dev/null; then
     FTS_AFTER=$(sqlite3 "$BRIDGE_DB" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='messages_fts';" 2>/dev/null || echo "0")

--- a/claude-ops/bin/ops-setup-install
+++ b/claude-ops/bin/ops-setup-install
@@ -150,7 +150,7 @@ install_special() {
       return 2 ;;
     whatsapp-bridge)
       # whatsapp-bridge is installed as part of whatsapp-mcp
-      echo "○ whatsapp-bridge install: git clone https://github.com/Lifecycle-Innovations-Limited/whatsapp-mcp ~/.local/share/whatsapp-mcp && cd ~/.local/share/whatsapp-mcp/whatsapp-bridge && go build -o whatsapp-bridge ." >&2
+      echo "○ whatsapp-bridge install: git clone https://github.com/Lifecycle-Innovations-Limited/whatsapp-mcp ~/.local/share/whatsapp-mcp && cd ~/.local/share/whatsapp-mcp/whatsapp-bridge && go build -tags \"sqlite_fts5\" -o whatsapp-bridge ." >&2
       return 2 ;;
     brew)
       # Homebrew has its own bootstrap installer.

--- a/claude-ops/scripts/install-whatsapp-bridge-linux.sh
+++ b/claude-ops/scripts/install-whatsapp-bridge-linux.sh
@@ -120,7 +120,11 @@ if [ "$SKIP_BUILD" -ne 1 ]; then
   go get -u go.mau.fi/whatsmeow@latest
   go get -u ./...
   go mod tidy
-  go build -o whatsapp-bridge .
+  # -tags sqlite_fts5 is REQUIRED: ops-inbox search + whatsapp-bridge-migrate.sh
+  # add an fts5 virtual table & triggers on messages.db. The bridge's own
+  # mattn/go-sqlite3 must therefore have the fts5 module, or every message
+  # INSERT fails with "no such module: fts5" and the bridge stores nothing.
+  go build -tags "sqlite_fts5" -o whatsapp-bridge .
   popd >/dev/null
 fi
 

--- a/claude-ops/skills/setup/channels/whatsapp.md
+++ b/claude-ops/skills/setup/channels/whatsapp.md
@@ -17,7 +17,7 @@ If binary missing: ask `AskUserQuestion`: `[Show install docs]`, `[Skip WhatsApp
 ```
 whatsapp-bridge (whatsmeow) is not installed. Install:
   git clone https://github.com/lharries/whatsapp-mcp ~/.local/share/whatsapp-mcp
-  cd ~/.local/share/whatsapp-mcp/whatsapp-bridge && go build -o whatsapp-bridge .
+  cd ~/.local/share/whatsapp-mcp/whatsapp-bridge && go build -tags "sqlite_fts5" -o whatsapp-bridge .
   mkdir -p ~/.local/share/whatsapp-mcp/whatsapp-bridge/logs
 ```
 


### PR DESCRIPTION
## Problem

The WhatsApp bridge was **silently storing zero new messages**. journalctl showed a flood of:

```
[Client WARN] Failed to store message: no such module: fts5
```

### Root cause

Two claude-ops pieces are at odds:

1. `scripts/whatsapp-bridge-migrate.sh` adds an fts5 `messages_fts` virtual table + `messages_fts_insert/update/delete` triggers on `messages.db` (so `ops-inbox` can search via `messages_fts MATCH`).
2. The bridge binary was built with a plain `go build -o whatsapp-bridge .`. `mattn/go-sqlite3` **omits the fts5 module unless built with `-tags sqlite_fts5`**.

So the bridge's `INSERT OR REPLACE INTO messages …` fires the trigger → trigger touches the fts5 virtual table → `no such module: fts5` → the entire insert transaction fails → nothing is stored.

`ops-autofix`'s `fix_bridge_fts()` actively manufactured the broken state: it ran the migration (creating the triggers) with the comment *"sqlite built-in, no rebuild needed"* — true for the `sqlite3` CLI, false for the Go bridge binary.

## Fix

- Add `-tags "sqlite_fts5"` to all three build invocations:
  - `scripts/install-whatsapp-bridge-linux.sh`
  - `bin/ops-setup-install`
  - `skills/setup/channels/whatsapp.md`
- `bin/ops-autofix` `fix_bridge_fts()`: verify the bridge **binary** has the fts5 module *before* running the migration; rebuild it with the tag if missing, or skip the migration with a clear failure rather than break storage.

## Verification (dev-sandbox-fra)

- Rebuilt bridge with `-tags sqlite_fts5`: `strings whatsapp-bridge | grep -c fts5` went **0 → 337**.
- Re-ran `whatsapp-bridge-migrate.sh` → `messages_fts` + triggers restored, FTS backfilled (`messages=14646  messages_fts=14646`).
- Bridge now stores incoming messages with **0** `fts5`/`Failed to store` errors; `messages_fts MATCH 'invite'` returns results; `NRestarts=0`, stable.

## Related (out of scope — flagged separately)

`scripts/whatsapp/apply-patches.py` guards its "Fix D" `/api/resync_app_state` handler with a **comment-text sentinel** (`RESYNC_ENDPOINT_SENTINEL = "claude-ops Fix D: POST /api/resync_app_state"`). If the route is already registered without that exact comment, the sentinel misses it and appends a duplicate `http.HandleFunc("/api/resync_app_state", …)` → Go 1.22+ `ServeMux` **panics on startup** (`pattern … conflicts with pattern …`) → crash-loop. Observed live; deduped in the local main.go to unblock. Worth a follow-up to make the sentinel match the route registration, not the comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect the WhatsApp message persistence path and autofix can rebuild/restart the bridge, but scope is limited to build flags and a guarded migration order with fail-safe skips.
> 
> **Overview**
> Ensures the WhatsApp **bridge** is built with Go **`-tags sqlite_fts5`** everywhere install docs and scripts tell users to compile it, so `mattn/go-sqlite3` includes the FTS5 module. That matches **`whatsapp-bridge-migrate.sh`**, which adds FTS5 tables and triggers on `messages.db` for inbox search—without the tag, inserts fail with *no such module: fts5* and new messages are not stored.
> 
> **`fix_bridge_fts` in `ops-autofix`** no longer runs the migration on a binary that lacks FTS5. It detects a non-fts5 binary (via `grep` on the binary), rebuilds with `sqlite_fts5` when `go` is available, restarts the user systemd unit on Linux, or **skips** the migration with a clear failure if rebuild is impossible—avoiding the previous path that enabled FTS while the bridge could not satisfy the triggers.
> 
> Install/setup surfaces updated: Linux install script, `ops-setup-install` manual instructions, and the WhatsApp setup channel doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 567c6d9379bde938e67f00845594f12932ff0afc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->