### PR TITLE
release: v2.18.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.18.5",
+      "version": "2.18.6",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.18.5",
+  "version": "2.18.6",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -143,6 +143,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.18.6] - 2026-05-31
+
+### Changed
+fix(whatsapp-bridge): build with -tags sqlite_fts5 so the bridge's SQLite has the fts5 module — fixes silent message-storage failure where every INSERT hit the messages_fts triggers and failed with "no such module: fts5". ops-autofix now verifies binary fts5 capability before running the migration (PR #412).
+
+
 ## [2.18.5] - 2026-05-31
 
 ### Added


### PR DESCRIPTION
Release **v2.18.6** (was 2.18.5).

- plugin.json + marketplace.json (registry) bumped
- CHANGELOG updated

fix(whatsapp-bridge): build with -tags sqlite_fts5 so the bridge's SQLite has the fts5 module — fixes silent message-storage failure where every INSERT hit the messages_fts triggers and failed with "no such module: fts5". ops-autofix now verifies binary fts5 capability before running the migration (PR #412).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff is version pins and changelog only; no runtime code changes in this PR. Underlying fts5 fix affects WhatsApp persistence but is already shipped via #412.
> 
> **Overview**
> **Release v2.18.6** bumps the ops plugin version from **2.18.5** to **2.18.6** in `.claude-plugin/marketplace.json` and `claude-ops/.claude-plugin/plugin.json`, and adds a **2.18.6** section to `CHANGELOG.md`.
> 
> The release documents the WhatsApp bridge fix from **PR #412** (not re-diffed here): the bridge must be built with **`-tags sqlite_fts5`** so SQLite exposes **fts5**. Without it, **`messages_fts` triggers** cause every message **INSERT** to fail with *no such module: fts5*, so storage can fail silently. **`ops-autofix`** is described as verifying fts5 in the binary before running the FTS migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bb9d779aae0607db670cea3eee995cbc8ebbd71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->