### PR TITLE
fix(ops-merge): stop fixer agents from filing duplicate CI-failure issues

### DIFF
--- a/claude-ops/skills/ops-merge/SKILL.md
+++ b/claude-ops/skills/ops-merge/SKILL.md
@@ -288,6 +288,16 @@ After push (every classification):
 
 DO NOT call `gh pr merge` under any circumstances. Your job ends at "CI is green
 on the pushed SHA." The orchestrator will independently verify and merge.
+
+DO NOT file a tracking issue for a CI failure you could not fix — in ANY repo.
+No `gh issue create`, no `github.rest.issues.create`, no cross-repo issue. If you
+cannot get CI green, return the structured failure in your JSON result and STOP;
+the orchestrator decides what happens next. (Rationale: emergent issue-filing on
+unfixable CI produced 17+ duplicate `[TEAM] CI failure on PR #N` issues — one per
+failing check, zero dedup, cross-posted into the wrong repo. A fixer's only valid
+outputs are a pushed green SHA or a structured failure report — never an issue.)
+If a tracking issue is ever genuinely wanted, that is the orchestrator's call and
+it MUST first `gh issue list --search "PR #<n> in:title" --state open` to dedup.
 ```
 
 Use `model: "haiku"` for fixer agents (matches agent definition default).


### PR DESCRIPTION
## Problem
17+ duplicate GitHub issues titled `[HEA] CI failure on PR #N: <check>` flooded the Healify tracker (→ Linear HEA-4351..4372) — one issue **per failing check, per PR**, no dedup, cross-posted from `healify-api` PRs into the `healify` repo, authored by the `auroracapital` PAT.

## Root cause (investigation)
Ruled out every deterministic source: no such template exists in any local script, launchd job, `~/tools`, or claude-ops; and no `healify`/`healify-api` GitHub Actions workflow does cross-repo issue creation (the only issue-creating workflow, `smoke-tests.yml`, dedups and files in-repo as `github-actions[bot]` with a different title). Author = `auroracapital` (a real-user PAT, not `github-actions[bot]`) + cross-repo filing (requires elevated token) + 3 bursts aligning with the heartbeat→ops-merge fleet cadence ⇒ **emergent LLM behavior**: an `ops-merge` `pr-ci-fixer` agent ran `gh issue create` when it couldn't fix CI. The skill never instructed this.

## Fix
Add an explicit prohibition to the Phase 3 fixer brief: no `gh issue create` / `github.rest.issues.create` in any repo. If CI can't be made green, return the structured failure and stop — the orchestrator decides. If a tracking issue is ever genuinely wanted, that's the orchestrator's call and must `gh issue list --search "PR #<n> in:title"` to dedup first.

Sits alongside the existing "DO NOT call `gh pr merge`" fixer guardrail. Docs-only, one-file, +10 lines.

## Cleanup already done
The 17 stale mirrors were archived (all backing GitHub issues verified CLOSED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file skill documentation update with no code paths, auth, or merge behavior changes.
> 
> **Overview**
> Adds a **Phase 3 fixer guardrail** in `ops-merge/SKILL.md`, parallel to the existing “do not call `gh pr merge`” rule: **`pr-ci-fixer` agents must not open GitHub issues** (`gh issue create`, `github.rest.issues.create`, or cross-repo issues) when CI cannot be fixed.
> 
> If CI stays red, fixers must return the structured failure JSON and stop; only the orchestrator may decide on tracking issues, and only after **`gh issue list --search "PR #<n> in:title"`** to avoid duplicates. The brief documents why this was added (17+ duplicate `[TEAM] CI failure on PR #N` issues from emergent agent behavior).
> 
> Docs-only change to the fixer subagent brief; no runtime or merge/verification logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c44df7e7075940dc6d87e1b3fd6e859bde14cf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CI operations process documentation with explicit constraints on issue creation during CI failure remediation and failure reporting procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->