### PR TITLE
feat(deploy-fix): fleet coexistence — global cap, fleet-claim dedup, census sidecar, tighter blast radius

### DIFF
--- a/claude-ops/CLAUDE.md
+++ b/claude-ops/CLAUDE.md
@@ -20,6 +20,12 @@ These rules apply to ALL skills in this plugin. They are non-negotiable and over
 
 Run `tests/test-no-secrets.sh` before every commit to verify.
 
+## Deploy-fix fleet contract
+
+- Fixer is **fully autonomous up to opening a DRAFT PR** (`gh pr create --draft`); it never merges, triggers builds, or promotes to prod.
+- Global concurrency is capped by `max_concurrent_fixers` (default 3); if a fleet agent is already active on the same repo the dispatch is skipped (rc=7 via `respect_fleet_claims`).
+- Running fixers register in `~/.claude/state/deploy-fix-active.jsonl` (source=deploy-fix) for fleet-census visibility.
+
 ## Credit-pool gate — `CLAUDE_OPS_USE_CREDIT_POOL`
 
 Daemon scripts that invoke Claude (recap digest, deploy-fix fixer, agent-drafter hook) route through `scripts/lib/claude-invoke.sh`, which provides a `claude_invoke` shell function. When `CLAUDE_OPS_USE_CREDIT_POOL=1` is exported in the environment, `claude_invoke` delegates to `scripts/account-rotation/claude-p-as.mjs`, which selects the highest-credit Max-OAuth account from the shared ledger. When the variable is unset or any other value, `claude_invoke` calls `claude` directly (standard keychain account), preserving existing behaviour. Set `CLAUDE_OPS_USE_CREDIT_POOL=1` only after the credit ledger is activated (target: 2026-06-15); before that date the wrapper exits 2 when the ledger is empty and daemons would fail silently. The gate can be exported in your shell profile or per-launch environment and takes effect immediately without restarting daemons.

--- a/claude-ops/agents/deploy-fixer.md
+++ b/claude-ops/agents/deploy-fixer.md
@@ -15,7 +15,7 @@ You are **Deploy Fixer** — focused infrastructure SRE persona. You execute one
 3. **Locate the repo** on disk. Worktree off the deploy branch: `git worktree add .worktrees/fix-deploy-<short-sha> <base>`.
 4. **Apply minimal fix.** Surgical only.
 5. **Run quality gate** appropriate to the project (type-check + lint + tests).
-6. **Commit `--no-verify`**, push, open PR with title `fix(deploy): <one-line>`. Body links to failed run.
+6. **Commit `--no-verify`**, push, open a **DRAFT** PR with title `fix(deploy): <one-line>`. Body links to failed run. Use `gh pr create --draft`.
 
 # Hard guardrails — non-negotiable
 
@@ -26,6 +26,8 @@ You are **Deploy Fixer** — focused infrastructure SRE persona. You execute one
 - MAX 10 files changed (else STOP, scope mismatch)
 - NEVER spawn more than 2 sub-subagents
 - NEVER send outbound comms
+- NEVER trigger builds or workflows — no `gh workflow run`, no `eas build`, no deploy/release commands
+- NEVER promote to prod/main. You open a DRAFT PR and stop; merge & promotion are owned by the human / fleet supervisor
 
 # Output
 

--- a/claude-ops/bin/ops-deploy-fix-build-trigger
+++ b/claude-ops/bin/ops-deploy-fix-build-trigger
@@ -70,6 +70,10 @@ if [ "$(config auto_dispatch_fixer true)" != "true" ]; then
   exit 0
 fi
 
+if [ -n "$repo_org" ]; then
+  export DEPLOY_FIX_REPO="${repo_org}/${repo_slug}"
+fi
+
 set +e
 fix_log=$(dispatch_fix_agent "build-fixer" "$repo_slug-build" \
   "COMMAND=$cmd" "REPO_PATH=$repo_path" "BRANCH=$branch" "LOGS=$last_lines")
@@ -88,5 +92,7 @@ case $dispatch_status in
 JSON
     ;;
   2|3) notify "Auto-fix skipped" "$repo_slug — already in flight or budget exhausted" ;;
+  6) notify "Auto-fix skipped" "$repo_slug — global concurrency cap reached" ;;
+  7) notify "Auto-fix skipped" "$repo_slug — fleet agent already active on this repo" ;;
 esac
 exit 0

--- a/claude-ops/bin/ops-deploy-fix-build-trigger
+++ b/claude-ops/bin/ops-deploy-fix-build-trigger
@@ -72,11 +72,13 @@ fi
 
 if [ -n "$repo_org" ]; then
   export DEPLOY_FIX_REPO="${repo_org}/${repo_slug}"
+else
+  export DEPLOY_FIX_REPO="$repo_slug"
 fi
 
 set +e
 fix_log=$(dispatch_fix_agent "build-fixer" "$repo_slug-build" \
-  "COMMAND=$cmd" "REPO_PATH=$repo_path" "BRANCH=$branch" "LOGS=$last_lines")
+  "REPO=$DEPLOY_FIX_REPO" "COMMAND=$cmd" "REPO_PATH=$repo_path" "BRANCH=$branch" "LOGS=$last_lines")
 dispatch_status=$?
 set -e
 case $dispatch_status in
@@ -91,6 +93,7 @@ case $dispatch_status in
 }
 JSON
     ;;
+  1) notify "Auto-fix failed" "$repo_slug — fixer process failed to start" ;;
   2|3) notify "Auto-fix skipped" "$repo_slug — already in flight or budget exhausted" ;;
   6) notify "Auto-fix skipped" "$repo_slug — global concurrency cap reached" ;;
   7) notify "Auto-fix skipped" "$repo_slug — fleet agent already active on this repo" ;;

--- a/claude-ops/docs/deploy-fix.md
+++ b/claude-ops/docs/deploy-fix.md
@@ -256,6 +256,46 @@ No. The fixer creates a new branch (`fix/auto-deploy-<sha>`) and opens a PR. You
 
 ---
 
+## Fleet coexistence
+
+The deploy-fix subsystem runs cleanly alongside the `claude --bg` agent fleet. Four config keys govern the integration:
+
+| Key | Type | Default | Purpose |
+|-----|------|---------|---------|
+| `max_concurrent_fixers` | number | `3` | Global cap on simultaneously-running fixer processes. Dispatch returns rc=6 when the cap is reached. |
+| `respect_fleet_claims` | boolean | `true` | Skip dispatch (rc=7) when `~/.claude/state/fleet-tui.json` shows an active fleet agent (`running`/`in_progress`/`working`/`active`) already working on the same repo. Missing/unparseable file = no claim = proceed. |
+| `register_in_fleet_census` | boolean | `true` | Append launch + completion entries to the sidecar (see below). |
+| `max_fixes_per_hour` | number | `3` | Per-repo hourly budget (existing; listed here for completeness). |
+
+**Dispatch return-code map:**
+
+| rc | Meaning |
+|----|---------|
+| 0 | Dispatched successfully |
+| 2 | Single-flight lock held (same repo+kind already running) |
+| 3 | Hourly budget exhausted |
+| 4 | Agent definition file missing |
+| 5 | `claude` binary not on PATH |
+| 6 | Global concurrency cap (`max_concurrent_fixers`) reached |
+| 7 | Fleet agent already active on this repo |
+
+**Census sidecar** — `~/.claude/state/deploy-fix-active.jsonl`
+
+One JSON line appended per event (APPEND-only, never clobbered):
+
+```json
+{"id":"<lock-epoch>","name":"deploy-fix:<owner/repo>","status":"running","repo":"<owner/repo>","branch":"deploy-fix","source":"deploy-fix","pid":<n>,"started":"<iso8601>"}
+{"id":"<lock-epoch>","name":"deploy-fix:<owner/repo>","status":"done",  "repo":"<owner/repo>","branch":"deploy-fix","source":"deploy-fix","ended":"<iso8601>"}
+```
+
+Consumers take the latest entry per `id` (running → done). The `source` field is always `"deploy-fix"` so the fleet TUI can distinguish these from `claude --bg` sessions.
+
+> **NOTE:** To surface these in the fleet TUI, have `~/bin/fleet-tui-census.sh` merge `deploy-fix-active.jsonl` (source=deploy-fix) — separate local change.
+
+**Autonomy boundary:** the fixer is fully autonomous up to opening a **draft PR**. It never merges, never triggers builds (`gh workflow run`, `eas build`), never promotes to prod/main. Merge and promotion remain owned by the human / fleet supervisor.
+
+---
+
 ## See also
 
 - [`docs/agents.md`](agents.md) — pre-installed specialist agents (deploy-fixer + build-fixer live here).

--- a/claude-ops/prompts/deploy-fix.md
+++ b/claude-ops/prompts/deploy-fix.md
@@ -54,7 +54,7 @@ You are running headless inside a Claude Code session with full claude-ops tooli
 
 6. **Commit with `--no-verify`** (project hooks are bugged per Sam's CLAUDE.md). Co-author trailer: `Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>`.
 
-7. **Push + open PR** targeting `{{BASE}}`:
+7. **Push + open a DRAFT PR** targeting `{{BASE}}` using `gh pr create --draft`:
    - Title: `fix(deploy): <one-line root cause>`
    - Body: link to the failed run, the diagnosed root cause, the change rationale, the gate results.
 
@@ -70,6 +70,8 @@ You are running headless inside a Claude Code session with full claude-ops tooli
 - **NEVER call `/ops:ops-yolo`, `/ops:ops-orchestrate`, or anything that fans out parallel work.** You have one job.
 - **NEVER send outbound comms** (email, Slack, WhatsApp) — read-only on those surfaces.
 - **NEVER ship unrelated dependency upgrades.** If a transitive bump is needed, pin to the exact required version only.
+- **NEVER trigger builds or workflows** — no `gh workflow run`, no `eas build`, no deploy/release commands.
+- **NEVER promote to prod/main.** You open a DRAFT PR and stop; merge & promotion are owned by the human / fleet supervisor.
 
 # Scope
 

--- a/claude-ops/scripts/lib/deploy-fix-common.sh
+++ b/claude-ops/scripts/lib/deploy-fix-common.sh
@@ -187,6 +187,7 @@ dispatch_fix_agent() {
   #
   # Return codes:
   #   0  dispatched successfully
+  #   1  background fixer failed to start (budget rolled back)
   #   2  single-flight lock already held (same repo+kind already in flight)
   #   3  hourly budget exhausted for this repo
   #   4  agent definition file not found (misconfiguration)
@@ -222,21 +223,32 @@ dispatch_fix_agent() {
     lock_release "$lock_id"
     return 6
   fi
-  local _lock_safe _pidfile
+  local _lock_safe
   _lock_safe=$(printf '%s' "$lock_id" | tr '/: ' '---')
-  _pidfile="$_active_dir/${_lock_safe}-$$.pid"
-  echo $$ > "$_pidfile"
+  local _pidfile="$_active_dir/${_lock_safe}.pid"
+
+  # Build brief and resolve repo from KEY=VAL pairs before fleet dedup.
+  local brief="Context for this fix:"
+  local kv k v
+  local _census_branch="deploy-fix"
+  local _census_repo_kv=""
+  for kv in "$@"; do
+    k="${kv%%=*}"
+    v="${kv#*=}"
+    case "$k" in
+      BRANCH) _census_branch="$v" ;;
+      BASE) _census_branch="$v" ;;
+      REPO) _census_repo_kv="$v" ;;
+    esac
+    brief="$brief"$'\n'"$k: $v"
+  done
+  local _fix_repo="${DEPLOY_FIX_REPO:-}"
+  [ -z "$_fix_repo" ] && _fix_repo="${_census_repo_kv:-}"
+  [ -z "$_fix_repo" ] && _fix_repo="$slug"
 
   # --- Fleet-claim dedup (rc=7) ---
   local _fleet_file="$HOME/.claude/state/fleet-tui.json"
-  if [ "$(config respect_fleet_claims true)" = "true" ] && [ -f "$_fleet_file" ]; then
-    if ! command -v jq >/dev/null 2>&1; then
-      notify "Fleet dedup blocked" "fleet-tui.json present but jq missing — skipping dispatch for $slug"
-      rm -f "$_pidfile"
-      lock_release "$lock_id"
-      return 7
-    fi
-    local _fix_repo="${DEPLOY_FIX_REPO:-}"
+  if [ "$(config respect_fleet_claims true)" = "true" ] && [ -f "$_fleet_file" ] && command -v jq >/dev/null 2>&1; then
     local _repo_bare="${_fix_repo#*/}"
     local _fleet_active
     _fleet_active=$(jq -r --arg full "$_fix_repo" --arg bare "$_repo_bare" '
@@ -248,7 +260,6 @@ dispatch_fix_agent() {
     ' "$_fleet_file" 2>/dev/null || echo "0")
     if [ "${_fleet_active:-0}" -gt 0 ] 2>/dev/null; then
       notify "Fleet agent active" "fleet agent already working on $_fix_repo — deploy-fixer skipped"
-      rm -f "$_pidfile"
       lock_release "$lock_id"
       return 7
     fi
@@ -264,37 +275,18 @@ dispatch_fix_agent() {
   # If the agent file is absent, treat as misconfiguration: release the lock
   # and surface rc=4 so callers can fall back to manual notification.
   if [ ! -f "$PLUGIN_ROOT/agents/$agent_name.md" ]; then
-    rm -f "$_pidfile"
     lock_release "$lock_id"
     return 4
   fi
-
-  # Build the brief from KEY=VAL pairs. One pair per line so downstream parsers
-  # (and the test mock) can match on `REPO: owner/repo` etc.
-  local brief="Context for this fix:"
-  local kv k v
-  local _census_branch="deploy-fix"
-  local _census_repo_kv=""
-  for kv in "$@"; do
-    k="${kv%%=*}"
-    v="${kv#*=}"
-    case "$k" in
-      BRANCH) _census_branch="$v" ;;
-      BASE) _census_branch="$v" ;;
-      REPO) _census_repo_kv="$v" ;;
-    esac
-    brief="$brief"$'\n'"$k: $v"
-  done
 
   local fix_log="$LOGS_DIR/fix-${lock_id}-$(date +%s).log"
   local danger_flag="--permission-mode acceptEdits"
   [ "$(config allow_dangerous false)" = "true" ] && danger_flag="--dangerously-skip-permissions"
 
-  command -v claude >/dev/null || { rm -f "$_pidfile"; lock_release "$lock_id"; return 5; }
+  command -v claude >/dev/null || { lock_release "$lock_id"; return 5; }
 
   if ! budget_check_increment "$slug"; then
     notify "Auto-fix budget exhausted" "$slug hit hourly cap — manual intervention needed"
-    rm -f "$_pidfile"
     lock_release "$lock_id"
     return 3
   fi
@@ -303,8 +295,7 @@ dispatch_fix_agent() {
   # on $PLUGIN_ROOT being exported (it may not be in all caller environments).
   local _invoker="$PLUGIN_ROOT/scripts/lib/claude-invoke.sh"
 
-  local _fix_repo_for_sidecar="${DEPLOY_FIX_REPO:-}"
-  [ -z "$_fix_repo_for_sidecar" ] && _fix_repo_for_sidecar="${_census_repo_kv:-unknown}"
+  local _fix_repo_for_sidecar="$_fix_repo"
   local _epoch
   _epoch=$(date +%s)
   local _sidecar_dir="$HOME/.claude/state"
@@ -345,7 +336,6 @@ dispatch_fix_agent() {
     if [ "$_bn" -gt 0 ] 2>/dev/null; then
       echo $((_bn - 1)) > "$_budget_f"
     fi
-    rm -f "$_pidfile"
     lock_release "$lock_id"
     return 1
   fi

--- a/claude-ops/scripts/lib/deploy-fix-common.sh
+++ b/claude-ops/scripts/lib/deploy-fix-common.sh
@@ -200,11 +200,6 @@ dispatch_fix_agent() {
     return 2  # already in flight
   fi
   local slug="${lock_id%%:*}"
-  if ! budget_check_increment "$slug"; then
-    notify "Auto-fix budget exhausted" "$slug hit hourly cap — manual intervention needed"
-    lock_release "$lock_id"
-    return 3
-  fi
 
   # --- Global concurrency cap (rc=6) ---
   local _active_dir="$STATE_DIR/active"
@@ -227,6 +222,10 @@ dispatch_fix_agent() {
     lock_release "$lock_id"
     return 6
   fi
+  local _lock_safe _pidfile
+  _lock_safe=$(printf '%s' "$lock_id" | tr '/: ' '---')
+  _pidfile="$_active_dir/${_lock_safe}-$$.pid"
+  echo $$ > "$_pidfile"
 
   # --- Fleet-claim dedup (rc=7) ---
   local _fleet_file="$HOME/.claude/state/fleet-tui.json"
@@ -237,12 +236,13 @@ dispatch_fix_agent() {
     _fleet_active=$(jq -r --arg full "$_fix_repo" --arg bare "$_repo_bare" '
       .agents // [] |
       map(select(
-        (.status | ascii_downcase | test("running|in_progress|working|active")) and
+        (.status | ascii_downcase | test("^(running|in_progress|working|active)$")) and
         (.repo == $full or .repo == $bare)
       )) | length
     ' "$_fleet_file" 2>/dev/null || echo "0")
     if [ "${_fleet_active:-0}" -gt 0 ] 2>/dev/null; then
       notify "Fleet agent active" "fleet agent already working on $_fix_repo — deploy-fixer skipped"
+      rm -f "$_pidfile"
       lock_release "$lock_id"
       return 7
     fi
@@ -258,6 +258,7 @@ dispatch_fix_agent() {
   # If the agent file is absent, treat as misconfiguration: release the lock
   # and surface rc=4 so callers can fall back to manual notification.
   if [ ! -f "$PLUGIN_ROOT/agents/$agent_name.md" ]; then
+    rm -f "$_pidfile"
     lock_release "$lock_id"
     return 4
   fi
@@ -276,16 +277,19 @@ dispatch_fix_agent() {
   local danger_flag="--permission-mode acceptEdits"
   [ "$(config allow_dangerous false)" = "true" ] && danger_flag="--dangerously-skip-permissions"
 
-  command -v claude >/dev/null || { lock_release "$lock_id"; return 5; }
+  command -v claude >/dev/null || { rm -f "$_pidfile"; lock_release "$lock_id"; return 5; }
+
+  if ! budget_check_increment "$slug"; then
+    notify "Auto-fix budget exhausted" "$slug hit hourly cap — manual intervention needed"
+    rm -f "$_pidfile"
+    lock_release "$lock_id"
+    return 3
+  fi
 
   # Capture invoker path so the nohup subshell can source it without relying
   # on $PLUGIN_ROOT being exported (it may not be in all caller environments).
   local _invoker="$PLUGIN_ROOT/scripts/lib/claude-invoke.sh"
 
-  # Register active pidfile BEFORE the nohup so the count is accurate.
-  # Sanitize lock_id for use as a filename (replace / and : with -).
-  local _lock_safe
-  _lock_safe=$(printf '%s' "$lock_id" | tr '/: ' '---')
   local _fix_repo_for_sidecar="${DEPLOY_FIX_REPO:-unknown}"
   local _epoch
   _epoch=$(date +%s)
@@ -293,40 +297,46 @@ dispatch_fix_agent() {
   _started_iso=$(date -u +%FT%TZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
   local _sidecar_dir="$HOME/.claude/state"
   local _sidecar_file="$_sidecar_dir/deploy-fix-active.jsonl"
+  local _census_id="${_lock_safe}-${_epoch}"
+  local _register_census
+  _register_census=$(config register_in_fleet_census true)
+
+  # Fleet census sidecar — "running" before background work so it always precedes "done".
+  if [ "$_register_census" = "true" ]; then
+    mkdir -p "$_sidecar_dir"
+    touch "$_sidecar_file"
+    jq -nc \
+      --arg id "$_census_id" \
+      --arg repo "$_fix_repo_for_sidecar" \
+      --arg started "$_started_iso" \
+      '{id:$id,name:("deploy-fix:"+$repo),status:"running",repo:$repo,branch:"deploy-fix",source:"deploy-fix",started:$started}' \
+      >> "$_sidecar_file" 2>/dev/null || true
+  fi
 
   nohup bash -c "
+    _census_done=0
+    _on_exit() {
+      rm -f '$_pidfile'
+      rm -f '$STATE_DIR/lock-$lock_id'
+      if [ '$_register_census' = 'true' ] && [ \"\$_census_done\" = 0 ]; then
+        _census_done=1
+        _ended_iso=\$(date -u +%FT%TZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
+        printf '%s\n' \"\$(jq -nc \
+          --arg id '$_census_id' \
+          --arg repo '$_fix_repo_for_sidecar' \
+          --arg ended \"\$_ended_iso\" \
+          '{id:\$id,name:\"deploy-fix:\"+\$repo,status:\"done\",repo:\$repo,branch:\"deploy-fix\",source:\"deploy-fix\",ended:\$ended}' \
+          2>/dev/null || true)\" >> '$_sidecar_file' 2>/dev/null || true
+      fi
+    }
+    trap _on_exit EXIT
     . '$_invoker'
     printf '%s' \"\$1\" | claude_invoke -p --agent $agent_name $danger_flag --no-session-persistence > '$fix_log' 2>&1
-    _ended_iso=\$(date -u +%FT%TZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
-    rm -f '$STATE_DIR/lock-$lock_id'
-    rm -f '$_active_dir/${_lock_safe}-\$\$.pid'
-    if [ '$(config register_in_fleet_census true)' = 'true' ]; then
-      printf '%s\n' \"\$(jq -nc \
-        --arg id '${_lock_safe}-${_epoch}' \
-        --arg repo '$_fix_repo_for_sidecar' \
-        --arg ended \"\$_ended_iso\" \
-        '{id:\$id,name:\"deploy-fix:\"+\$repo,status:\"done\",repo:\$repo,branch:\"deploy-fix\",source:\"deploy-fix\",ended:\$ended}' \
-        2>/dev/null || true)\" >> '$_sidecar_file' 2>/dev/null || true
-    fi
   " _ "$brief" </dev/null >/dev/null 2>&1 &
   local _bg_pid=$!
   disown 2>/dev/null || true
 
-  # Write pidfile now that we have the background PID.
-  echo "$_bg_pid" > "$_active_dir/${_lock_safe}-${_bg_pid}.pid"
-
-  # Fleet census sidecar — "running" entry on launch.
-  if [ "$(config register_in_fleet_census true)" = "true" ]; then
-    mkdir -p "$_sidecar_dir"
-    touch "$_sidecar_file"
-    jq -nc \
-      --arg id "${_lock_safe}-${_epoch}" \
-      --arg repo "$_fix_repo_for_sidecar" \
-      --arg started "$_started_iso" \
-      --argjson pid "$_bg_pid" \
-      '{id:$id,name:("deploy-fix:"+$repo),status:"running",repo:$repo,branch:"deploy-fix",source:"deploy-fix",pid:$pid,started:$started}' \
-      >> "$_sidecar_file" 2>/dev/null || true
-  fi
+  echo "$_bg_pid" > "$_pidfile"
 
   echo "$fix_log"
   return 0

--- a/claude-ops/scripts/lib/deploy-fix-common.sh
+++ b/claude-ops/scripts/lib/deploy-fix-common.sh
@@ -204,12 +204,12 @@ dispatch_fix_agent() {
   # --- Global concurrency cap (rc=6) ---
   local _active_dir="$STATE_DIR/active"
   mkdir -p "$_active_dir"
-  # Prune stale pidfiles whose process is no longer alive.
+  # Prune stale pidfiles whose process is no longer alive (or invalid/empty).
   for _pf in "$_active_dir"/*.pid; do
     [ -f "$_pf" ] || continue
     local _ppid
-    _ppid=$(cat "$_pf" 2>/dev/null || true)
-    if [ -n "$_ppid" ] && ! kill -0 "$_ppid" 2>/dev/null; then
+    _ppid=$(tr -d '[:space:]' < "$_pf" 2>/dev/null || true)
+    if [ -z "$_ppid" ] || ! kill -0 "$_ppid" 2>/dev/null; then
       rm -f "$_pf"
     fi
   done
@@ -229,7 +229,13 @@ dispatch_fix_agent() {
 
   # --- Fleet-claim dedup (rc=7) ---
   local _fleet_file="$HOME/.claude/state/fleet-tui.json"
-  if [ "$(config respect_fleet_claims true)" = "true" ] && [ -f "$_fleet_file" ] && command -v jq >/dev/null 2>&1; then
+  if [ "$(config respect_fleet_claims true)" = "true" ] && [ -f "$_fleet_file" ]; then
+    if ! command -v jq >/dev/null 2>&1; then
+      notify "Fleet dedup blocked" "fleet-tui.json present but jq missing — skipping dispatch for $slug"
+      rm -f "$_pidfile"
+      lock_release "$lock_id"
+      return 7
+    fi
     local _fix_repo="${DEPLOY_FIX_REPO:-}"
     local _repo_bare="${_fix_repo#*/}"
     local _fleet_active
@@ -267,9 +273,16 @@ dispatch_fix_agent() {
   # (and the test mock) can match on `REPO: owner/repo` etc.
   local brief="Context for this fix:"
   local kv k v
+  local _census_branch="deploy-fix"
+  local _census_repo_kv=""
   for kv in "$@"; do
     k="${kv%%=*}"
     v="${kv#*=}"
+    case "$k" in
+      BRANCH) _census_branch="$v" ;;
+      BASE) _census_branch="$v" ;;
+      REPO) _census_repo_kv="$v" ;;
+    esac
     brief="$brief"$'\n'"$k: $v"
   done
 
@@ -290,28 +303,15 @@ dispatch_fix_agent() {
   # on $PLUGIN_ROOT being exported (it may not be in all caller environments).
   local _invoker="$PLUGIN_ROOT/scripts/lib/claude-invoke.sh"
 
-  local _fix_repo_for_sidecar="${DEPLOY_FIX_REPO:-unknown}"
+  local _fix_repo_for_sidecar="${DEPLOY_FIX_REPO:-}"
+  [ -z "$_fix_repo_for_sidecar" ] && _fix_repo_for_sidecar="${_census_repo_kv:-unknown}"
   local _epoch
   _epoch=$(date +%s)
-  local _started_iso
-  _started_iso=$(date -u +%FT%TZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
   local _sidecar_dir="$HOME/.claude/state"
   local _sidecar_file="$_sidecar_dir/deploy-fix-active.jsonl"
   local _census_id="${_lock_safe}-${_epoch}"
   local _register_census
   _register_census=$(config register_in_fleet_census true)
-
-  # Fleet census sidecar — "running" before background work so it always precedes "done".
-  if [ "$_register_census" = "true" ]; then
-    mkdir -p "$_sidecar_dir"
-    touch "$_sidecar_file"
-    jq -nc \
-      --arg id "$_census_id" \
-      --arg repo "$_fix_repo_for_sidecar" \
-      --arg started "$_started_iso" \
-      '{id:$id,name:("deploy-fix:"+$repo),status:"running",repo:$repo,branch:"deploy-fix",source:"deploy-fix",started:$started}' \
-      >> "$_sidecar_file" 2>/dev/null || true
-  fi
 
   nohup bash -c "
     _census_done=0
@@ -324,8 +324,9 @@ dispatch_fix_agent() {
         printf '%s\n' \"\$(jq -nc \
           --arg id '$_census_id' \
           --arg repo '$_fix_repo_for_sidecar' \
+          --arg branch '$_census_branch' \
           --arg ended \"\$_ended_iso\" \
-          '{id:\$id,name:\"deploy-fix:\"+\$repo,status:\"done\",repo:\$repo,branch:\"deploy-fix\",source:\"deploy-fix\",ended:\$ended}' \
+          '{id:\$id,name:\"deploy-fix:\"+\$repo,status:\"done\",repo:\$repo,branch:\$branch,source:\"deploy-fix\",ended:\$ended}' \
           2>/dev/null || true)\" >> '$_sidecar_file' 2>/dev/null || true
       fi
     }
@@ -336,7 +337,35 @@ dispatch_fix_agent() {
   local _bg_pid=$!
   disown 2>/dev/null || true
 
+  if [ -z "$_bg_pid" ] || ! kill -0 "$_bg_pid" 2>/dev/null; then
+    local _hour _budget_f _bn
+    _hour=$(date +%Y%m%d-%H)
+    _budget_f="$STATE_DIR/budget-$slug-$_hour"
+    _bn=$(cat "$_budget_f" 2>/dev/null || echo 0)
+    if [ "$_bn" -gt 0 ] 2>/dev/null; then
+      echo $((_bn - 1)) > "$_budget_f"
+    fi
+    rm -f "$_pidfile"
+    lock_release "$lock_id"
+    return 1
+  fi
+
   echo "$_bg_pid" > "$_pidfile"
+
+  if [ "$_register_census" = "true" ] && command -v jq >/dev/null 2>&1; then
+    local _started_iso
+    _started_iso=$(date -u +%FT%TZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
+    mkdir -p "$_sidecar_dir"
+    touch "$_sidecar_file"
+    jq -nc \
+      --arg id "$_census_id" \
+      --arg repo "$_fix_repo_for_sidecar" \
+      --arg branch "$_census_branch" \
+      --argjson pid "$_bg_pid" \
+      --arg started "$_started_iso" \
+      '{id:$id,name:("deploy-fix:"+$repo),status:"running",repo:$repo,branch:$branch,source:"deploy-fix",pid:$pid,started:$started}' \
+      >> "$_sidecar_file" 2>/dev/null || true
+  fi
 
   echo "$fix_log"
   return 0

--- a/claude-ops/scripts/lib/deploy-fix-common.sh
+++ b/claude-ops/scripts/lib/deploy-fix-common.sh
@@ -184,6 +184,15 @@ dispatch_fix_agent() {
   # $2 = lock_id, $3.. = context KEY=VAL pairs that become "KEY: VAL" lines in the brief.
   # Legacy callers passed prompt template paths like "build-fix.md" / "deploy-fix.md";
   # those are remapped to the new agent names so the contract change is transparent.
+  #
+  # Return codes:
+  #   0  dispatched successfully
+  #   2  single-flight lock already held (same repo+kind already in flight)
+  #   3  hourly budget exhausted for this repo
+  #   4  agent definition file not found (misconfiguration)
+  #   5  `claude` binary not on PATH
+  #   6  global concurrency cap reached (max_concurrent_fixers)
+  #   7  fleet agent already active on this repo (respect_fleet_claims)
   local agent_name="$1"
   local lock_id="$2"
   shift 2
@@ -195,6 +204,48 @@ dispatch_fix_agent() {
     notify "Auto-fix budget exhausted" "$slug hit hourly cap — manual intervention needed"
     lock_release "$lock_id"
     return 3
+  fi
+
+  # --- Global concurrency cap (rc=6) ---
+  local _active_dir="$STATE_DIR/active"
+  mkdir -p "$_active_dir"
+  # Prune stale pidfiles whose process is no longer alive.
+  for _pf in "$_active_dir"/*.pid; do
+    [ -f "$_pf" ] || continue
+    local _ppid
+    _ppid=$(cat "$_pf" 2>/dev/null || true)
+    if [ -n "$_ppid" ] && ! kill -0 "$_ppid" 2>/dev/null; then
+      rm -f "$_pf"
+    fi
+  done
+  local _live_count
+  _live_count=$(find "$_active_dir" -maxdepth 1 -name '*.pid' 2>/dev/null | wc -l | tr -d ' ')
+  local _max_concurrent
+  _max_concurrent=$(config max_concurrent_fixers 3)
+  if [ "$_live_count" -ge "$_max_concurrent" ]; then
+    notify "Fixer concurrency cap" "global cap of $_max_concurrent reached — skipping dispatch for $slug"
+    lock_release "$lock_id"
+    return 6
+  fi
+
+  # --- Fleet-claim dedup (rc=7) ---
+  local _fleet_file="$HOME/.claude/state/fleet-tui.json"
+  if [ "$(config respect_fleet_claims true)" = "true" ] && [ -f "$_fleet_file" ] && command -v jq >/dev/null 2>&1; then
+    local _fix_repo="${DEPLOY_FIX_REPO:-}"
+    local _repo_bare="${_fix_repo#*/}"
+    local _fleet_active
+    _fleet_active=$(jq -r --arg full "$_fix_repo" --arg bare "$_repo_bare" '
+      .agents // [] |
+      map(select(
+        (.status | ascii_downcase | test("running|in_progress|working|active")) and
+        (.repo == $full or .repo == $bare)
+      )) | length
+    ' "$_fleet_file" 2>/dev/null || echo "0")
+    if [ "${_fleet_active:-0}" -gt 0 ] 2>/dev/null; then
+      notify "Fleet agent active" "fleet agent already working on $_fix_repo — deploy-fixer skipped"
+      lock_release "$lock_id"
+      return 7
+    fi
   fi
 
   # Legacy → new contract mapping.
@@ -231,12 +282,52 @@ dispatch_fix_agent() {
   # on $PLUGIN_ROOT being exported (it may not be in all caller environments).
   local _invoker="$PLUGIN_ROOT/scripts/lib/claude-invoke.sh"
 
+  # Register active pidfile BEFORE the nohup so the count is accurate.
+  # Sanitize lock_id for use as a filename (replace / and : with -).
+  local _lock_safe
+  _lock_safe=$(printf '%s' "$lock_id" | tr '/: ' '---')
+  local _fix_repo_for_sidecar="${DEPLOY_FIX_REPO:-unknown}"
+  local _epoch
+  _epoch=$(date +%s)
+  local _started_iso
+  _started_iso=$(date -u +%FT%TZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
+  local _sidecar_dir="$HOME/.claude/state"
+  local _sidecar_file="$_sidecar_dir/deploy-fix-active.jsonl"
+
   nohup bash -c "
     . '$_invoker'
     printf '%s' \"\$1\" | claude_invoke -p --agent $agent_name $danger_flag --no-session-persistence > '$fix_log' 2>&1
+    _ended_iso=\$(date -u +%FT%TZ 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)
     rm -f '$STATE_DIR/lock-$lock_id'
+    rm -f '$_active_dir/${_lock_safe}-\$\$.pid'
+    if [ '$(config register_in_fleet_census true)' = 'true' ]; then
+      printf '%s\n' \"\$(jq -nc \
+        --arg id '${_lock_safe}-${_epoch}' \
+        --arg repo '$_fix_repo_for_sidecar' \
+        --arg ended \"\$_ended_iso\" \
+        '{id:\$id,name:\"deploy-fix:\"+\$repo,status:\"done\",repo:\$repo,branch:\"deploy-fix\",source:\"deploy-fix\",ended:\$ended}' \
+        2>/dev/null || true)\" >> '$_sidecar_file' 2>/dev/null || true
+    fi
   " _ "$brief" </dev/null >/dev/null 2>&1 &
+  local _bg_pid=$!
   disown 2>/dev/null || true
+
+  # Write pidfile now that we have the background PID.
+  echo "$_bg_pid" > "$_active_dir/${_lock_safe}-${_bg_pid}.pid"
+
+  # Fleet census sidecar — "running" entry on launch.
+  if [ "$(config register_in_fleet_census true)" = "true" ]; then
+    mkdir -p "$_sidecar_dir"
+    touch "$_sidecar_file"
+    jq -nc \
+      --arg id "${_lock_safe}-${_epoch}" \
+      --arg repo "$_fix_repo_for_sidecar" \
+      --arg started "$_started_iso" \
+      --argjson pid "$_bg_pid" \
+      '{id:$id,name:("deploy-fix:"+$repo),status:"running",repo:$repo,branch:"deploy-fix",source:"deploy-fix",pid:$pid,started:$started}' \
+      >> "$_sidecar_file" 2>/dev/null || true
+  fi
+
   echo "$fix_log"
   return 0
 }

--- a/claude-ops/scripts/ops-deploy-monitor.sh
+++ b/claude-ops/scripts/ops-deploy-monitor.sh
@@ -83,15 +83,19 @@ if [ "$CONCLUSION" != "success" ]; then
   notify "Deploy failed" "$REPO #$PR → $BASE: $CONCLUSION"
 
   if [ "$(config auto_dispatch_fixer true)" = "true" ]; then
+    export DEPLOY_FIX_REPO="$REPO"
     fix_log=$(dispatch_fix_agent "deploy-fixer" "$SLUG-deploy" \
       "REPO=$REPO" "PR=$PR" "BASE=$BASE" "SHA=$SHA" "RUN_ID=$RUN_ID" \
       "SUMMARY=deploy workflow #$RUN_ID concluded $CONCLUSION" \
       "LOGS=$failed_log")
-    case $? in
+    _dfa_rc=$?
+    case $_dfa_rc in
       0) log "fixer dispatched → $fix_log" ;;
       2) log "fixer skipped — already in flight for $SLUG-deploy" ;;
       3) log "fixer skipped — hourly budget exhausted" ;;
-      *) log "fixer dispatch failed — exit code $?" ;;
+      6) log "fixer skipped — global concurrency cap ($(config max_concurrent_fixers 3) active)"; notify "Fixer cap" "$REPO #$PR — concurrency cap reached, skipping" ;;
+      7) log "fixer skipped — fleet agent already active on $REPO"; notify "Fleet dedup" "$REPO #$PR — fleet agent already active, deploy-fixer skipped" ;;
+      *) log "fixer dispatch failed — exit code $_dfa_rc" ;;
     esac
   else
     log "auto_dispatch_fixer=false — notification only"
@@ -110,10 +114,18 @@ if [ "$HTTP" != "200" ]; then
   fire "service $URL → HTTP $HTTP after deploy"
   notify "Service unhealthy" "$REPO $BASE: $URL → HTTP $HTTP"
   if [ "$(config auto_dispatch_fixer true)" = "true" ]; then
+    export DEPLOY_FIX_REPO="$REPO"
     dispatch_fix_agent "deploy-fixer" "$SLUG-health" \
       "REPO=$REPO" "PR=$PR" "BASE=$BASE" "SHA=$SHA" "RUN_ID=$RUN_ID" \
       "SUMMARY=service health URL $URL returned HTTP $HTTP" \
       "LOGS=(no workflow logs — health check failure)" >/dev/null
+    _dfa_rc=$?
+    case $_dfa_rc in
+      0) : ;;
+      6) log "health fixer skipped — global concurrency cap ($(config max_concurrent_fixers 3) active)" ;;
+      7) log "health fixer skipped — fleet agent already active on $REPO" ;;
+      *) : ;;
+    esac
   fi
   exit 1
 fi

--- a/claude-ops/scripts/ops-deploy-monitor.sh
+++ b/claude-ops/scripts/ops-deploy-monitor.sh
@@ -93,6 +93,7 @@ if [ "$CONCLUSION" != "success" ]; then
       0) log "fixer dispatched → $fix_log" ;;
       2) log "fixer skipped — already in flight for $SLUG-deploy" ;;
       3) log "fixer skipped — hourly budget exhausted" ;;
+      1) log "fixer failed — background process did not start" ;;
       6) log "fixer skipped — global concurrency cap ($(config max_concurrent_fixers 3) active)" ;;
       7) log "fixer skipped — fleet agent already active on $REPO" ;;
       *) log "fixer dispatch failed — exit code $_dfa_rc" ;;
@@ -122,9 +123,10 @@ if [ "$HTTP" != "200" ]; then
     _dfa_rc=$?
     case $_dfa_rc in
       0) : ;;
+      1) log "health fixer failed — background process did not start" ;;
       6) log "health fixer skipped — global concurrency cap ($(config max_concurrent_fixers 3) active)" ;;
       7) log "health fixer skipped — fleet agent already active on $REPO" ;;
-      *) : ;;
+      *) log "health fixer dispatch failed — exit code $_dfa_rc" ;;
     esac
   fi
   exit 1

--- a/claude-ops/scripts/ops-deploy-monitor.sh
+++ b/claude-ops/scripts/ops-deploy-monitor.sh
@@ -93,8 +93,8 @@ if [ "$CONCLUSION" != "success" ]; then
       0) log "fixer dispatched → $fix_log" ;;
       2) log "fixer skipped — already in flight for $SLUG-deploy" ;;
       3) log "fixer skipped — hourly budget exhausted" ;;
-      6) log "fixer skipped — global concurrency cap ($(config max_concurrent_fixers 3) active)"; notify "Fixer cap" "$REPO #$PR — concurrency cap reached, skipping" ;;
-      7) log "fixer skipped — fleet agent already active on $REPO"; notify "Fleet dedup" "$REPO #$PR — fleet agent already active, deploy-fixer skipped" ;;
+      6) log "fixer skipped — global concurrency cap ($(config max_concurrent_fixers 3) active)" ;;
+      7) log "fixer skipped — fleet agent already active on $REPO" ;;
       *) log "fixer dispatch failed — exit code $_dfa_rc" ;;
     esac
   else

--- a/claude-ops/tests/test-deploy-fix-fleet.sh
+++ b/claude-ops/tests/test-deploy-fix-fleet.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# test-deploy-fix-fleet.sh — Hermetic tests for fleet coexistence additions.
+#
+# Asserts:
+#   (a) 4th concurrent dispatch returns rc=6 when 3 live pidfiles exist
+#   (b) sidecar line appended with source=deploy-fix on launch
+#   (c) returns rc=7 when fleet-tui.json shows an active agent on the repo
+#   (d) proceeds (rc=0) when fleet-tui.json is missing
+#
+# Hermetic: temp HOME + STATE_DIR, stub `claude` + real `jq`, NO network.
+
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
+MOCKS="$TESTS_DIR/mocks"
+
+chmod +x "$MOCKS"/* 2>/dev/null || true
+
+SUITE_TMP="$(mktemp -d -t ops-deploy-fix-fleet-tests.XXXXXX)"
+trap 'rm -rf "$SUITE_TMP"' EXIT
+
+PASS=0
+FAIL=0
+FAILED_CASES=()
+
+pass() { printf '  PASS: %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf '  FAIL: %s -- %s\n' "$1" "$2"; FAIL=$((FAIL+1)); FAILED_CASES+=("$1"); }
+
+assert_eq() {
+  if [ "$2" = "$3" ]; then pass "$1"; else fail "$1" "expected='$2' actual='$3'"; fi
+}
+assert_file_exists() {
+  if [ -f "$2" ]; then pass "$1"; else fail "$1" "missing file: $2"; fi
+}
+assert_contains() {
+  case "$3" in *"$2"*) pass "$1" ;; *) fail "$1" "needle='$2' not in haystack" ;; esac
+}
+
+# ---------------------------------------------------------------------------
+# Isolated env setup (exports OPS_DEPLOY_FIX_STATE/LOGS + fake HOME)
+# ---------------------------------------------------------------------------
+new_isolated_env() {
+  local id="$1"
+  TEST_STATE="$SUITE_TMP/$id/state"
+  TEST_LOGS="$SUITE_TMP/$id/logs"
+  TEST_BIN="$SUITE_TMP/$id/bin"
+  TEST_HOME="$SUITE_TMP/$id/home"
+  TEST_FLEET_STATE="$TEST_HOME/.claude/state"
+  mkdir -p "$TEST_STATE" "$TEST_LOGS" "$TEST_BIN" "$TEST_FLEET_STATE"
+  mkdir -p "$TEST_STATE/active"
+
+  # Symlink mocks
+  for m in gh curl terminal-notifier; do
+    ln -sf "$MOCKS/$m" "$TEST_BIN/$m"
+  done
+  # Stub claude: write argv to log, write prompt to prompt-out, exit 0
+  cat > "$TEST_BIN/claude" <<'STUB'
+#!/usr/bin/env bash
+LOG="${MOCK_CLAUDE_LOG:-/dev/null}"
+PROMPT_OUT="${MOCK_CLAUDE_PROMPT_OUT:-/dev/null}"
+prompt="$(cat)"
+printf '%s' "$prompt" > "$PROMPT_OUT"
+printf 'argv=%s\n' "$*" >> "$LOG"
+exit "${MOCK_CLAUDE_RC:-0}"
+STUB
+  chmod +x "$TEST_BIN/claude"
+
+  export OPS_DEPLOY_FIX_STATE="$TEST_STATE"
+  export OPS_DEPLOY_FIX_LOGS="$TEST_LOGS"
+  export CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT"
+  export HOME="$TEST_HOME"
+  export MOCK_CLAUDE_LOG="$TEST_LOGS/claude.log"
+  export MOCK_CLAUDE_PROMPT_OUT="$TEST_LOGS/claude-prompt.txt"
+  export MOCK_CURL_LOG="$TEST_LOGS/curl.log"
+  export MOCK_NOTIFIER_LOG="$TEST_LOGS/notifier.log"
+  : > "$TEST_LOGS/claude.log"
+  : > "$TEST_LOGS/curl.log"
+  : > "$TEST_LOGS/notifier.log"
+
+  ORIGINAL_PATH="${ORIGINAL_PATH:-$PATH}"
+  export PATH="$TEST_BIN:$ORIGINAL_PATH"
+}
+
+load_lib() {
+  # shellcheck disable=SC1091
+  . "$PLUGIN_ROOT/scripts/lib/deploy-fix-common.sh"
+}
+
+# ---------------------------------------------------------------------------
+# CASE A — global concurrency cap: 4th dispatch returns rc=6
+# ---------------------------------------------------------------------------
+echo ""
+echo "── Case A: global concurrency cap (rc=6) ─────────────────────────"
+
+(
+  new_isolated_env "caseA"
+  load_lib
+  # Create 3 live pidfiles with the current shell's PID (it is alive)
+  echo $$ > "$TEST_STATE/active/fix-aaa-$$.pid"
+  echo $$ > "$TEST_STATE/active/fix-bbb-$$.pid"
+  echo $$ > "$TEST_STATE/active/fix-ccc-$$.pid"
+  export CLAUDE_PLUGIN_OPTION_MAX_CONCURRENT_FIXERS=3
+  export DEPLOY_FIX_REPO="owner/repo-a"
+  rc=0
+  dispatch_fix_agent "build-fixer" "owner-repo-a-deploy" "REPO=owner/repo-a" "SHA=aaa" >/dev/null 2>&1 || rc=$?
+  assert_eq "A.rc-is-6" "6" "$rc"
+) && PASS=$((PASS+1)) || { fail "caseA.concurrency-cap" "see above"; }
+
+
+# ---------------------------------------------------------------------------
+# CASE B — sidecar appended with source=deploy-fix on successful launch
+# ---------------------------------------------------------------------------
+echo ""
+echo "── Case B: census sidecar written on launch ──────────────────────"
+
+(
+  new_isolated_env "caseB"
+  load_lib
+  export CLAUDE_PLUGIN_OPTION_REGISTER_IN_FLEET_CENSUS=true
+  export DEPLOY_FIX_REPO="owner/repo-b"
+  dispatch_fix_agent "build-fixer" "owner-repo-b-deploy" "REPO=owner/repo-b" "SHA=bbb" >/dev/null 2>&1
+  rc=$?
+  assert_eq "B.rc-is-0" "0" "$rc"
+  # Wait for the nohup'd background to start (sidecar written synchronously before nohup)
+  _sidecar="$TEST_HOME/.claude/state/deploy-fix-active.jsonl"
+  assert_file_exists "B.sidecar-created" "$_sidecar"
+  if [ -f "$_sidecar" ]; then
+    content=$(cat "$_sidecar")
+    assert_contains "B.source-field" '"source":"deploy-fix"' "$content"
+    assert_contains "B.repo-field" '"repo":"owner/repo-b"' "$content"
+    assert_contains "B.status-running" '"status":"running"' "$content"
+  fi
+) && true || { fail "caseB.sidecar" "see above"; }
+
+
+# ---------------------------------------------------------------------------
+# CASE C — fleet-claim dedup: rc=7 when fleet-tui.json has active agent on repo
+# ---------------------------------------------------------------------------
+echo ""
+echo "── Case C: fleet-claim dedup (rc=7) ──────────────────────────────"
+
+(
+  new_isolated_env "caseC"
+  load_lib
+  export CLAUDE_PLUGIN_OPTION_RESPECT_FLEET_CLAIMS=true
+  export DEPLOY_FIX_REPO="owner/repo-c"
+  # Write a fleet-tui.json with an active agent on the same repo
+  cat > "$TEST_HOME/.claude/state/fleet-tui.json" <<'JSON'
+{
+  "ts": "2026-01-01T00:00:00Z",
+  "agents": [
+    {"id": "abc", "name": "feature-agent", "status": "running", "repo": "owner/repo-c", "branch": "feat/x"}
+  ]
+}
+JSON
+  rc=0
+  dispatch_fix_agent "build-fixer" "owner-repo-c-deploy" "REPO=owner/repo-c" "SHA=ccc" >/dev/null 2>&1 || rc=$?
+  assert_eq "C.rc-is-7" "7" "$rc"
+) && PASS=$((PASS+1)) || { fail "caseC.fleet-dedup" "see above"; }
+
+
+# ---------------------------------------------------------------------------
+# CASE D — proceeds (rc=0) when fleet-tui.json is missing
+# ---------------------------------------------------------------------------
+echo ""
+echo "── Case D: no fleet-tui.json → proceeds normally ─────────────────"
+
+(
+  new_isolated_env "caseD"
+  load_lib
+  export CLAUDE_PLUGIN_OPTION_RESPECT_FLEET_CLAIMS=true
+  export DEPLOY_FIX_REPO="owner/repo-d"
+  # Ensure no fleet-tui.json exists
+  rm -f "$TEST_HOME/.claude/state/fleet-tui.json"
+  rc=0
+  dispatch_fix_agent "build-fixer" "owner-repo-d-deploy" "REPO=owner/repo-d" "SHA=ddd" >/dev/null 2>&1 || rc=$?
+  assert_eq "D.rc-is-0" "0" "$rc"
+) && PASS=$((PASS+1)) || { fail "caseD.missing-fleet-tui" "see above"; }
+
+
+# ---------------------------------------------------------------------------
+# CASE E — stale pidfiles are pruned before counting
+# ---------------------------------------------------------------------------
+echo ""
+echo "── Case E: stale pidfiles pruned (dead PIDs don't count) ─────────"
+
+(
+  new_isolated_env "caseE"
+  load_lib
+  export CLAUDE_PLUGIN_OPTION_MAX_CONCURRENT_FIXERS=3
+  export DEPLOY_FIX_REPO="owner/repo-e"
+  # 3 pidfiles with a dead PID (99999 is almost certainly not alive)
+  echo 99999 > "$TEST_STATE/active/fix-stale1-99999.pid"
+  echo 99999 > "$TEST_STATE/active/fix-stale2-99999.pid"
+  echo 99999 > "$TEST_STATE/active/fix-stale3-99999.pid"
+  rc=0
+  dispatch_fix_agent "build-fixer" "owner-repo-e-deploy" "REPO=owner/repo-e" "SHA=eee" >/dev/null 2>&1 || rc=$?
+  # Stale pids should be pruned → 0 live → under cap → rc=0
+  assert_eq "E.rc-is-0-after-prune" "0" "$rc"
+) && PASS=$((PASS+1)) || { fail "caseE.stale-prune" "see above"; }
+
+
+# ---------------------------------------------------------------------------
+# CASE F — fleet-tui.json with INACTIVE status → proceeds (rc=0)
+# ---------------------------------------------------------------------------
+echo ""
+echo "── Case F: fleet agent done/idle → not blocked ───────────────────"
+
+(
+  new_isolated_env "caseF"
+  load_lib
+  export CLAUDE_PLUGIN_OPTION_RESPECT_FLEET_CLAIMS=true
+  export DEPLOY_FIX_REPO="owner/repo-f"
+  cat > "$TEST_HOME/.claude/state/fleet-tui.json" <<'JSON'
+{
+  "ts": "2026-01-01T00:00:00Z",
+  "agents": [
+    {"id": "xyz", "name": "old-agent", "status": "completed", "repo": "owner/repo-f", "branch": "feat/y"}
+  ]
+}
+JSON
+  rc=0
+  dispatch_fix_agent "build-fixer" "owner-repo-f-deploy" "REPO=owner/repo-f" "SHA=fff" >/dev/null 2>&1 || rc=$?
+  assert_eq "F.rc-is-0-on-inactive" "0" "$rc"
+) && PASS=$((PASS+1)) || { fail "caseF.inactive-fleet" "see above"; }
+
+
+# ---------------------------------------------------------------------------
+# SUMMARY
+# ---------------------------------------------------------------------------
+echo ""
+echo "═══════════════════════════════════════════════════════════════════"
+echo "deploy-fix-fleet test summary"
+echo "═══════════════════════════════════════════════════════════════════"
+echo "  PASS: $PASS"
+echo "  FAIL: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "Failed cases:"
+  for c in "${FAILED_CASES[@]}"; do echo "  - $c"; done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## What this closes

Four gaps that caused `ops-deploy-fix` to conflict with the `claude --bg` agent fleet:
- No global concurrency cap → unbounded parallel fixers
- No awareness of fleet agents already working on the same repo → duplicate effort
- No fleet visibility → fixer runs were invisible to the fleet TUI
- Fixer opened a normal (ready-to-merge) PR and had no guardrail against triggering builds/workflows

## Changes

### `scripts/lib/deploy-fix-common.sh` — `dispatch_fix_agent()`
- **Global concurrency cap (rc=6):** before launch, prunes stale pidfiles (`kill -0` check), counts live `.pid` files in `$STATE_DIR/active/`. If count ≥ `max_concurrent_fixers` (default 3) → `lock_release` + return 6.
- **Fleet-claim dedup (rc=7):** reads `~/.claude/state/fleet-tui.json` (tolerant: missing/unparseable = proceed). If any agent has an active status (`running|in_progress|working|active`, case-insensitive) AND its `.repo` matches `DEPLOY_FIX_REPO` (full `owner/repo` or bare name) → `lock_release` + return 7. Gated by `respect_fleet_claims` (default true).
- **Pidfile registration:** after `nohup … &`, writes `$STATE_DIR/active/<lock_safe>-<pid>.pid`. The nohup subshell removes it on exit (guaranteed cleanup alongside lock removal).
- **Census sidecar:** on launch appends a `"status":"running"` JSON line to `~/.claude/state/deploy-fix-active.jsonl`; nohup subshell appends `"status":"done"` on exit. Gated by `register_in_fleet_census` (default true). `source` field is always `"deploy-fix"` for census consumers.

### `scripts/ops-deploy-monitor.sh`
- `export DEPLOY_FIX_REPO="$REPO"` before each `dispatch_fix_agent` call (both deploy-failure and health-failure paths).
- Handles rc=6 and rc=7 with log + notify; existing 0/2/3 handling unchanged.

### `agents/deploy-fixer.md` + `prompts/deploy-fix.md`
- Added hard guardrails: never `gh workflow run`, never `eas build`, never deploy/release commands, never promote to prod/main.
- PR open step changed to `gh pr create --draft`; both files updated consistently.

### `docs/deploy-fix.md`
- New **Fleet coexistence** section: 4 config keys+defaults, full rc map (0/2/3/4/5/6/7), sidecar path + schema, autonomy boundary statement, NOTE about local census follow-up.

### `CLAUDE.md`
- 3-bullet summary of the fleet contract under a new `## Deploy-fix fleet contract` section.

## New config keys + defaults

| Key | Default | Purpose |
|-----|---------|---------|
| `max_concurrent_fixers` | `3` | Global cap on simultaneous fixer processes |
| `respect_fleet_claims` | `true` | Skip if fleet agent active on same repo (rc=7) |
| `register_in_fleet_census` | `true` | Append to `~/.claude/state/deploy-fix-active.jsonl` |

Existing: `max_fixes_per_hour=3`, `allow_dangerous=false`, `auto_dispatch_fixer=true`.

## Autonomy boundary

Fixer remains **fully autonomous up to opening a DRAFT PR**. No new human gates. Merge, build triggers, and promotion continue to be owned by human / fleet supervisor — now enforced as explicit guardrails in both agent definition files.

## Pidfile + sidecar cleanup guarantee

Both removals happen inside the same `nohup` subshell that already removes the lock file:
```bash
rm -f '$STATE_DIR/lock-$lock_id'
rm -f '$_active_dir/${_lock_safe}-$$.pid'
# append "done" line to sidecar
```
If the subshell is killed, the pidfile becomes stale — the next dispatch's pruning pass (`kill -0` check) reclaims it before counting.

## Census sidecar contract

`~/.claude/state/deploy-fix-active.jsonl` — append-only, one JSON line per event, consumers take latest per `id`:
```json
{"id":"<lock-epoch>","name":"deploy-fix:<repo>","status":"running","repo":"<repo>","branch":"deploy-fix","source":"deploy-fix","pid":<n>,"started":"<iso8601>"}
{"id":"<lock-epoch>","name":"deploy-fix:<repo>","status":"done",  "repo":"<repo>","branch":"deploy-fix","source":"deploy-fix","ended":"<iso8601>"}
```
To surface in the fleet TUI: have `~/bin/fleet-tui-census.sh` merge this file (source=deploy-fix) — separate local change, not in this repo.

## Test results

**New `tests/test-deploy-fix-fleet.sh`** — 10 assertions, 6 cases, all pass:
- A: 4th dispatch returns rc=6 with 3 live pidfiles ✓
- B: sidecar created with `source=deploy-fix`, `status=running` ✓
- C: rc=7 when fleet-tui.json has active agent on same repo ✓
- D: rc=0 (proceeds) when fleet-tui.json missing ✓
- E: stale pidfiles (dead PIDs) pruned before counting ✓
- F: completed/idle fleet agent does not block dispatch ✓

**Existing `tests/test-deploy-fix-hooks.sh`** — 36 pass, 3 fail. All 3 failures are pre-existing environment issues on the Amazon Linux test host (`shasum` absent → `already_seen` hash broken; two nohup timing tests flaky). Verified by running the same test against `origin/main` baseline — those cases were already failing before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes autonomous fixer dispatch and CI-adjacent behavior (concurrency, fleet skipping, draft PRs); mistakes could suppress needed fixes or leave failures unaddressed, but scope is bounded to the deploy-fix subsystem with tests.
> 
> **Overview**
> This PR makes **deploy-fix** coexist with the `claude --bg` fleet and narrows fixer blast radius.
> 
> **`dispatch_fix_agent()`** now enforces a global cap via live pidfiles under `$STATE_DIR/active` (stale PIDs pruned), returns **rc=6** when `max_concurrent_fixers` (default 3) is hit, and **rc=7** when `respect_fleet_claims` sees an active agent on the same repo in `fleet-tui.json`. Successful launches write pidfiles, append **running/done** lines to `~/.claude/state/deploy-fix-active.jsonl` (`source=deploy-fix`), and roll back the hourly budget on failed background start (**rc=1**). Callers set `DEPLOY_FIX_REPO`, pass `REPO=` in build dispatch, and handle the new return codes in the monitor and build hook.
> 
> **Fixer policy** is tightened everywhere it is defined: PRs must be opened with **`gh pr create --draft`**, and agents must not merge, trigger workflows/builds, or promote to prod/main. Docs and `CLAUDE.md` document the fleet contract, config keys, and full rc map.
> 
> **`tests/test-deploy-fix-fleet.sh`** adds hermetic coverage for concurrency cap, census sidecar, fleet dedup, missing fleet file, stale pid pruning, and inactive fleet agents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 144c6e452b98bc1f51e026e668ae7c1081f644c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->