### PR TITLE
release: v2.18.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.18.6",
+      "version": "2.18.7",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.18.6",
+  "version": "2.18.7",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.18.7 — 2026-05-31
+
+### Fixed
+- **ops-inbox: WhatsApp lid↔phone identity merge (#415).** whatsmeow stores the same
+  person as two chats — `<lid>@lid` and `<pn>@s.whatsapp.net` — and the classifier scanned
+  per-JID with no merge, so every run double-counted contacts (routinely **NEEDS_REPLY on
+  one JID and WAITING on the other at once**), inflated counts, mis-prioritised, and read
+  only half the person's history → drafts off a fragmented arc. Added a **blocking
+  identity-merge step** to the FULL-THREAD AWARENESS GATE: map each JID via
+  `whatsmeow_lid_map` (`store/whatsapp.db`; `contacts.phone` fallback), union both JIDs,
+  sort by timestamp, classify on the merged thread's true last message, and read merged
+  history for the arc + reply context. Also wired into the headless DB-fallback path and the
+  parallel scan-engine WhatsApp steps. Recipe validated against the live store.
+
 ## 2.18.3 — 2026-05-31
 
 ### Added


### PR DESCRIPTION
Bumps ops plugin to **v2.18.7**.

Ships #415 — ops-inbox WhatsApp **lid↔phone identity merge**: collapse a person's `<lid>@lid` and `<pn>@s.whatsapp.net` chats into one conversation before classify, fixing the every-run double-count (NEEDS_REPLY + WAITING on the same person) and fragmented-history drift.

- `.claude-plugin/marketplace.json` → 2.18.7
- `claude-ops/.claude-plugin/plugin.json` → 2.18.7
- CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release; no runtime code changes in the diff.
> 
> **Overview**
> **Release v2.18.7** — bumps the ops plugin version in `.claude-plugin/marketplace.json` and `claude-ops/.claude-plugin/plugin.json` from **2.18.6 → 2.18.7**, with a matching **CHANGELOG** entry.
> 
> The release notes **#415**: **ops-inbox** WhatsApp **lid↔phone identity merge** — before classify, collapse a contact’s `<lid>@lid` and `<pn>@s.whatsapp.net` chats using `whatsmeow_lid_map` (and `contacts.phone` fallback), merge message history, and classify on the true last message so the same person is not double-counted (e.g. NEEDS_REPLY on one JID and WAITING on the other) or drafted from fragmented context. Documented as wired through the full-thread gate, headless DB fallback, and parallel scan workflow.
> 
> No implementation files appear in this diff; it is a **version + changelog** cut for work already merged under #415.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98a8f1e6f0635a0fd46a67ebc2d00a8dd39e8389. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->