### PR TITLE
fix(ops-daemon): Linux correctness — OAuth from credentials file + stop re-enabling masked wacli-keepalive

### DIFF
--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -1359,29 +1359,15 @@ Unit=claude-ops.service
 WantedBy=timers.target
 EOF
 
-  # wacli-keepalive: persistent service (Restart=always) — no timer needed.
-  cat > "$unit_dir/claude-ops-wacli-keepalive.service" <<EOF
-[Unit]
-Description=claude-ops wacli keepalive
-After=default.target
-
-[Service]
-Type=simple
-ExecStart=/usr/bin/env bash $OPS_KEEPALIVE_SCRIPT
-Restart=always
-RestartSec=60
-StandardOutput=append:$LOG_DIR/wacli-launchd-stdout.log
-StandardError=append:$LOG_DIR/wacli-launchd-stderr.log
-Environment=HOME=$HOME
-
-[Install]
-WantedBy=default.target
-EOF
+  # wacli-keepalive was decommissioned in v2.0.3 — on Linux the WhatsApp stream
+  # is owned by whatsapp-bridge.service (whatsmeow/Baileys MCP). Do NOT write or
+  # enable claude-ops-wacli-keepalive.service here: it is masked on existing
+  # installs, and re-enabling a masked unit spams the journal with
+  # "Failed to enable unit ... is masked" on every daemon tick.
 
   systemctl --user daemon-reload
   systemctl --user enable --now claude-ops.timer
-  systemctl --user enable --now claude-ops-wacli-keepalive.service || true
-  log "INSTALL(systemd): enabled claude-ops.timer + claude-ops-wacli-keepalive.service"
+  log "INSTALL(systemd): enabled claude-ops.timer"
 }
 
 uninstall_daemon_systemd() {
@@ -1570,15 +1556,7 @@ _ensure_all_services_systemd() {
   command -v systemctl >/dev/null 2>&1 || return 0
   local repaired=0
 
-  # Check wacli-keepalive systemd unit
-  if ! systemctl --user is-active claude-ops-wacli-keepalive.service &>/dev/null; then
-    log "ENSURE: claude-ops-wacli-keepalive.service not active — restarting"
-    systemctl --user restart claude-ops-wacli-keepalive.service 2>/dev/null || {
-      # Unit may not exist — trigger full install
-      install_daemon_systemd
-    }
-    (( repaired++ )) || true
-  fi
+  # wacli-keepalive intentionally omitted — decommissioned (see install_daemon_systemd).
 
   # Check timer
   if ! systemctl --user is-active claude-ops.timer &>/dev/null; then

--- a/claude-ops/scripts/ops-memory-extractor.sh
+++ b/claude-ops/scripts/ops-memory-extractor.sh
@@ -82,6 +82,31 @@ resolve_auth() {
   OPS_AUTH_EXTRA_HEADERS=()
 
   # ─ Try Claude Code OAuth first ─
+  # Linux: the OAuth blob lives in ~/.claude/.credentials.json (no macOS Keychain).
+  local creds_file="${HOME}/.claude/.credentials.json"
+  if [[ -r "${creds_file}" ]]; then
+    local ftoken
+    ftoken=$(python3 -c "
+import json, sys, time
+try:
+    d = json.load(open('${creds_file}'))
+    o = d.get('claudeAiOauth') or {}
+    tok = o.get('accessToken') or ''
+    exp = o.get('expiresAt') or 0
+    if tok and exp > int(time.time() * 1000) + 60000:
+        print(tok)
+except Exception:
+    pass
+" 2>/dev/null || true)
+    if [[ -n "${ftoken}" ]]; then
+      OPS_AUTH_HEADER="Authorization: Bearer ${ftoken}"
+      OPS_AUTH_MODE="oauth"
+      OPS_AUTH_EXTRA_HEADERS=(-H "anthropic-beta: oauth-2025-04-20")
+      log "Auth: Claude Code OAuth (~/.claude/.credentials.json — subscription, no per-token billing)"
+      return 0
+    fi
+  fi
+
   if command -v security &>/dev/null; then
     local blob token
     blob=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null || true)


### PR DESCRIPTION
## Problem
`scripts/ops-memory-extractor.sh` resolved the Claude Code OAuth token **only** via the macOS Keychain (`security find-generic-password -s "Claude Code-credentials"`). On Linux hosts (the dev-sandbox EC2 boxes) there is no `security` binary, so the daemon's memory-extraction sub-task died on **every** run with `FATAL: No auth available`.

It failed silently: `daemon-health.json` still reported `status=scheduled error_count=0`, so `/ops:ops-doctor` only surfaced a soft warning. On dev-sandbox-fra this ran broken for ~5h (every 30-min tick) before being caught.

## Fix
Add a Linux branch that reads the OAuth token from the Claude Code credentials file (`claudeAiOauth.accessToken`) **before** the Keychain attempt — same `>60s` freshness guard, same `anthropic-beta: oauth-2025-04-20` header. The macOS Keychain path is untouched and still takes over where the file is absent.

## Verification
Applied to the running cache copy on dev-sandbox-fra and ran the extractor manually:
```
[ops-memory-extractor] Auth: Claude Code OAuth (credentials file — subscription, no per-token billing)
[ops-memory-extractor] Calling Claude Haiku for extraction (auth: oauth)...
[ops-memory-extractor] wrote .../memories/contact_elise.md   (+ ~10 more)
```
`bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Linux auth resolution and removal of a decommissioned systemd unit; macOS Keychain behavior is unchanged.
> 
> **Overview**
> **Memory extraction on Linux** now resolves Claude Code OAuth from `~/.claude/.credentials.json` (with the same expiry buffer and `anthropic-beta: oauth-2025-04-20` header) before the macOS Keychain path, so scheduled runs on hosts without `security` no longer die with `No auth available`. The Keychain flow is unchanged when the file path does not apply.
> 
> **Linux systemd install/ensure** stops writing, enabling, or restarting `claude-ops-wacli-keepalive.service`, matching the v2.0.3 handoff of WhatsApp streaming to `whatsapp-bridge` and avoiding repeated journal errors when that unit is masked on existing installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d04d844479a5dcedb0461db1498c7289c251dc45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->