### PR TITLE
fix(whatsapp): guard fts5 triggers behind bridge-binary capability probe

### DIFF
--- a/claude-ops/scripts/whatsapp-bridge-migrate.sh
+++ b/claude-ops/scripts/whatsapp-bridge-migrate.sh
@@ -16,6 +16,8 @@ set -euo pipefail
 
 # ── Config ────────────────────────────────────────────────────────────────────
 BRIDGE_DB="${WHATSAPP_BRIDGE_DB:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/store/messages.db}"
+# The Go bridge binary whose embedded sqlite must ALSO support fts5 — see Step 1 guard.
+BRIDGE_BIN="${WHATSAPP_BRIDGE_BIN:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge/whatsapp-bridge}"
 DRY_RUN=0
 VERBOSE=0
 
@@ -64,38 +66,78 @@ query_sql() {
 # ── Step 1: FTS5 virtual table ────────────────────────────────────────────────
 log "Step 1: Checking FTS5 index..."
 
-FTS_EXISTS=$(query_sql "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='messages_fts';" 2>/dev/null || echo "0")
-if [[ "$FTS_EXISTS" == "1" ]]; then
-  log "  messages_fts already exists — skipping table creation."
-else
-  log "  Creating messages_fts FTS5 virtual table..."
-  run_sql "CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
-    content,
-    content='messages',
-    content_rowid='rowid'
-  );"
-  log "  Backfilling FTS index from existing messages..."
-  run_sql "INSERT INTO messages_fts(rowid, content)
-    SELECT rowid, content FROM messages WHERE content IS NOT NULL AND content != '';"
+# ── fts5 CAPABILITY GUARD (storage-integrity invariant) ───────────────────────
+# The fts triggers below are created via the SYSTEM sqlite3 CLI, which almost
+# always has fts5 — so creation SUCCEEDS regardless. But the triggers fire on the
+# GO BRIDGE's OWN inserts, using the bridge binary's EMBEDDED sqlite. If that
+# binary was built WITHOUT fts5 (e.g. an old binary, a `--skip-build` install, or
+# a CGO build that dropped `-tags sqlite_fts5`), every bridge insert fires the
+# AFTER INSERT trigger → `no such module: fts5` → the whole INSERT fails →
+# messages are SILENTLY DROPPED (live AND backfilled). This guard makes the two
+# halves agree: only install fts triggers when the bridge binary can satisfy
+# them; otherwise DROP any leftover fts schema so storage is never bricked.
+# (mattn/go-sqlite3 built with -DSQLITE_ENABLE_FTS5 links the fts5 C source, so
+# `strings` on the binary is a reliable capability probe.)
+BRIDGE_HAS_FTS5="unknown"
+if command -v strings &>/dev/null && [[ -f "$BRIDGE_BIN" ]]; then
+  # NB: use `grep -c` (reads ALL input), NOT `grep -q`. Under `set -o pipefail`,
+  # `grep -q` closes the pipe on first match → `strings` dies with SIGPIPE → the
+  # pipeline reports failure → false "no fts5". `grep -c` drains strings fully.
+  fts5_hits=$(strings "$BRIDGE_BIN" 2>/dev/null | grep -ci 'fts5' || true)
+  if [[ "${fts5_hits:-0}" -gt 0 ]]; then
+    BRIDGE_HAS_FTS5="yes"
+  else
+    BRIDGE_HAS_FTS5="no"
+  fi
 fi
 
-# Always ensure triggers exist (idempotent — handles partial failure recovery)
-log "  Ensuring FTS triggers exist..."
-run_sql "CREATE TRIGGER IF NOT EXISTS messages_fts_insert
-  AFTER INSERT ON messages BEGIN
-    INSERT INTO messages_fts(rowid, content) VALUES (new.rowid, new.content);
-  END;"
-  run_sql "CREATE TRIGGER IF NOT EXISTS messages_fts_update
-  AFTER UPDATE ON messages BEGIN
-    INSERT INTO messages_fts(messages_fts, rowid, content) VALUES ('delete', old.rowid, old.content);
-    INSERT INTO messages_fts(rowid, content) VALUES (new.rowid, new.content);
-  END;"
-  run_sql "CREATE TRIGGER IF NOT EXISTS messages_fts_delete
-  AFTER DELETE ON messages BEGIN
-    INSERT INTO messages_fts(messages_fts, rowid, content) VALUES ('delete', old.rowid, old.content);
-  END;"
+if [[ "$BRIDGE_HAS_FTS5" == "no" ]]; then
+  log "  ⚠ Bridge binary at $BRIDGE_BIN was built WITHOUT fts5."
+  log "  ⚠ Installing fts triggers would brick ALL message storage (no such module: fts5)."
+  log "  → Protecting storage: dropping any existing messages_fts triggers + virtual table."
+  log "  → Search will use the LIKE fallback until the bridge is rebuilt with -tags sqlite_fts5"
+  log "    (CGO_ENABLED=1 go build -tags sqlite_fts5 -o whatsapp-bridge .)."
+  run_sql "DROP TRIGGER IF EXISTS messages_fts_insert;
+           DROP TRIGGER IF EXISTS messages_fts_update;
+           DROP TRIGGER IF EXISTS messages_fts_delete;
+           DROP TABLE   IF EXISTS messages_fts;"
+  log "  Step 1 complete (fts disabled — storage protected)."
+else
+  [[ "$BRIDGE_HAS_FTS5" == "unknown" ]] && log "  (bridge binary not found / strings unavailable — cannot probe fts5; proceeding)"
 
-log "  FTS5 index and triggers verified."
+  FTS_EXISTS=$(query_sql "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='messages_fts';" 2>/dev/null || echo "0")
+  if [[ "$FTS_EXISTS" == "1" ]]; then
+    log "  messages_fts already exists — skipping table creation."
+  else
+    log "  Creating messages_fts FTS5 virtual table..."
+    run_sql "CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+      content,
+      content='messages',
+      content_rowid='rowid'
+    );"
+    log "  Backfilling FTS index from existing messages..."
+    run_sql "INSERT INTO messages_fts(rowid, content)
+      SELECT rowid, content FROM messages WHERE content IS NOT NULL AND content != '';"
+  fi
+
+  # Always ensure triggers exist (idempotent — handles partial failure recovery)
+  log "  Ensuring FTS triggers exist..."
+  run_sql "CREATE TRIGGER IF NOT EXISTS messages_fts_insert
+    AFTER INSERT ON messages BEGIN
+      INSERT INTO messages_fts(rowid, content) VALUES (new.rowid, new.content);
+    END;"
+  run_sql "CREATE TRIGGER IF NOT EXISTS messages_fts_update
+    AFTER UPDATE ON messages BEGIN
+      INSERT INTO messages_fts(messages_fts, rowid, content) VALUES ('delete', old.rowid, old.content);
+      INSERT INTO messages_fts(rowid, content) VALUES (new.rowid, new.content);
+    END;"
+  run_sql "CREATE TRIGGER IF NOT EXISTS messages_fts_delete
+    AFTER DELETE ON messages BEGIN
+      INSERT INTO messages_fts(messages_fts, rowid, content) VALUES ('delete', old.rowid, old.content);
+    END;"
+
+  log "  FTS5 index and triggers verified."
+fi
 
 # ── Step 2: contacts table ────────────────────────────────────────────────────
 log "Step 2: Checking contacts table..."


### PR DESCRIPTION
## Drift
`whatsapp-bridge-migrate.sh` creates `messages_fts` fts5 triggers via the **system sqlite3 CLI** (which has fts5) — so creation always succeeds. But those triggers fire on the **Go bridge's own inserts**, using the **bridge binary's embedded sqlite**. When that binary lacks fts5 (an old binary, `--skip-build`, or a CGO build missing `-tags sqlite_fts5`), **every insert fails** `no such module: fts5` → the whole INSERT rolls back → **messages silently dropped**, live and backfilled.

Observed **2026-05-31**: a pre-rebuild bridge process dropped an entire midday conversation window; only surfaced because the human noticed missing messages. The two halves (CLI-created triggers vs bridge-binary capability) had no agreement gate.

## Fix
Probe `BRIDGE_BIN` for fts5 (`strings … | grep -c` — drains fully; `grep -q` would SIGPIPE `strings` under `set -o pipefail` and false-negative). Then:
- **binary HAS fts5** → create vtable + triggers as before (search works).
- **binary LACKS fts5** → DROP any leftover `messages_fts` triggers+vtable, warn loudly (search → LIKE fallback, **storage protected**).
- **binary not found** → proceed as before (no regression), with a note.

`WHATSAPP_BRIDGE_BIN` env override added.

## Test
Both paths run against a throwaway copy of the live store:
- real fts5 binary → `FTS5 index and triggers verified` (8 fts objects kept)
- fake no-fts5 binary → `built WITHOUT fts5 … storage protected` (0 fts objects)

Complements the immediate fix already applied to the live box (dropped+restored triggers; bridge rebuilt 18:41 already carries fts5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes message-store migration and FTS trigger lifecycle; incorrect probing could disable search or leave triggers mismatched, but the change directly mitigates silent message loss.
> 
> **Overview**
> **`whatsapp-bridge-migrate.sh`** now gates FTS5 setup on whether the **Go `whatsapp-bridge` binary** (not just the system `sqlite3` CLI) actually supports fts5.
> 
> It adds **`WHATSAPP_BRIDGE_BIN`** (default under the MCP bridge install path) and probes the binary with **`strings … | grep -c`** (avoiding **`grep -q`** under **`pipefail`**, which could false-negative). If the bridge **lacks** fts5, the script **drops** any existing **`messages_fts`** table and insert/update/delete triggers and logs that search falls back to **LIKE**, so bridge inserts are not rolled back by **`no such module: fts5`**. If fts5 is present (or the binary cannot be probed), behavior stays the same: create/backfill the virtual table and ensure triggers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b13d3e091c070475cbb6ad0c39a8a2c84b3f0d5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->