### PR TITLE
release: v2.18.8

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.18.7",
+      "version": "2.18.8",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.18.7",
+  "version": "2.18.8",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2.18.8 — 2026-05-31
+
+### Fixed
+- **WhatsApp: guard fts5 triggers behind a bridge-binary capability probe (#419).**
+  `whatsapp-bridge-migrate.sh` created `messages_fts` fts5 triggers via the system
+  sqlite3 CLI (which has fts5), so creation always succeeded — but the triggers fire
+  on the **Go bridge's own inserts** using the bridge binary's embedded sqlite. A
+  binary built without fts5 (old binary, `--skip-build`, or a CGO build missing
+  `-tags sqlite_fts5`) then failed **every** insert with `no such module: fts5`,
+  silently dropping messages (live + backfilled). Observed 2026-05-31: a pre-rebuild
+  bridge dropped an entire midday conversation window. The migrate now probes
+  `BRIDGE_BIN` for fts5 and only installs triggers when the binary can satisfy them;
+  otherwise it drops any leftover fts schema (search → LIKE fallback, storage
+  protected). `WHATSAPP_BRIDGE_BIN` env override added.
+
 ## 2.18.7 — 2026-05-31
 
 ### Fixed


### PR DESCRIPTION
Bumps ops plugin to **v2.18.8**.

Ships #419 — WhatsApp **fts5 trigger capability guard**: only install `messages_fts` triggers when the bridge binary actually supports fts5; otherwise drop them so a no-fts5 binary can't silently brick message storage.

- `.claude-plugin/marketplace.json` → 2.18.8
- `claude-ops/.claude-plugin/plugin.json` → 2.18.8
- CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata and changelog only in the diff; the underlying WhatsApp change reduces risk of silent message loss rather than introducing new behavior in this PR.
> 
> **Overview**
> **Release v2.18.8** bumps the ops plugin version in **`.claude-plugin/marketplace.json`** and **`claude-ops/.claude-plugin/plugin.json`** from **2.18.7** → **2.18.8**, and adds a **CHANGELOG** entry for the shipped fix from **#419**.
> 
> That fix (already in the tree; this PR publishes it) changes **`whatsapp-bridge-migrate.sh`** so **`messages_fts` FTS5 triggers are only created when the Go bridge binary actually supports fts5** (probed via `BRIDGE_BIN` / optional **`WHATSAPP_BRIDGE_BIN`**). Otherwise leftover FTS schema is removed so inserts from a no-fts5 bridge cannot fail with `no such module: fts5` and silently drop messages—search falls back to **LIKE** while storage stays intact.
> 
> No other source files appear in the diff; this is a version + release-notes alignment PR for the WhatsApp storage guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64ab870fc098a93279d3081e4793108de78d93e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->