### PR TITLE
release: v2.18.9 — ops-release bumps package.json in lockstep

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.18.8",
+      "version": "2.18.9",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.18.8",
+  "version": "2.18.9",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.18.9] - 2026-05-31
+
+### Added
+- `bin/ops-release` now bumps **package.json** (the `claude-ops-bin` npm package) in lockstep with plugin.json + the marketplace registry, so all version files stay in sync. Auto-detects package.json under `claude-ops/` or the repo root.
+
+### Fixed
+- Reconciled `claude-ops/package.json` version (was stuck at 2.15.0 because the prior release path never touched it) up to the current plugin version.
+
+### Changed
+- `RELEASE.md` documents the 4 version-bearing files and the package.json lockstep.
+
 ## 2.18.8 — 2026-05-31
 
 ### Fixed
@@ -169,14 +180,12 @@
   per-service cost deltas. No mutations; cleanup stays human-gated.
 - `scripts/install-aws-audit-cron.sh` — optional daily `systemd --user` timer.
 
-
 All notable changes to this project will be documented in this file.
 
 ## [2.18.6] - 2026-05-31
 
 ### Changed
 fix(whatsapp-bridge): build with -tags sqlite_fts5 so the bridge's SQLite has the fts5 module — fixes silent message-storage failure where every INSERT hit the messages_fts triggers and failed with "no such module: fts5". ops-autofix now verifies binary fts5 capability before running the migration (PR #412).
-
 
 ## [2.18.5] - 2026-05-31
 
@@ -186,7 +195,6 @@ fix(whatsapp-bridge): build with -tags sqlite_fts5 so the bridge's SQLite has th
 
 ### Changed
 - ops-bg: `dispatch` now defaults the fleet/background agent working dir to `~/Projects` (override via `$OPSBG_DIR` or `--cwd`) and `cd`s into it before exec, so fleet agents start at the workspace root instead of an arbitrary repo (#410).
-
 
 ## [Unreleased]
 
@@ -202,20 +210,17 @@ fix(whatsapp-bridge): build with -tags sqlite_fts5 so the bridge's SQLite has th
 
 _(Ports two patches that had been applied directly on the deploy box into the repo, so the live checkout can track main cleanly.)_
 
-
 ## [2.14.1] — 2026-05-29
 
 ### Fixed
 
 - **`ops-pocket-notify` wrapper resolves symlinks.** The `bin/ops-pocket-notify` bash wrapper computed the Python script path from `dirname "$0"`, which resolves relative to a PATH symlink's directory rather than the real file — so invoking it via a `~/.local/bin` symlink failed to find `../scripts/ops-pocket-notify.py`. Now `readlink -f`s itself first. Also syncs `package.json` (had drifted to 2.13.0) to the plugin version.
 
-
 ## [2.13.0] — 2026-05-29
 
 ### Added
 
 - **Config-driven pocket notifications (`ops-pocket-notify`) — interactive setup of which events, which channels, when.** Pocket components emit an *event id*; the new `bin/ops-pocket-notify` dispatcher decides routing from `preferences.json → pocket.notifications`: per-event channels (telegram/email/whatsapp/slack via the existing senders + out-queue), plus a **full per-event schedule** — cooldown, quiet-hours, active-days, and severity escalation (high bypasses windows). New events are **off by default**. `/ops:ops-settings → Configure notifications` walks each event interactively (channels + schedule + dry-run test-send) and writes the prefs; `docs/pocket-notifications.md` documents the schema + event taxonomy. The executor emits `worker.spawned` / `worker.failed`, and the env-broker's notify hook points at the dispatcher. `--dry-run --json` resolves routing without sending (used by setup + tests).
-
 
 ## [2.12.0] — 2026-05-29
 
@@ -225,20 +230,17 @@ _(Ports two patches that had been applied directly on the deploy box into the re
 - **Env-broker observability.** The broker keeps a metrics snapshot (`env-broker-health.json`: request/grant/deny/uid-rejection counters, recent denials, `anomaly` flag), exposes `pocket-env-broker --status [--json]`, and surfaces an `Env-broker` line in `/ops:ops-status` that raises a `⚠` anomaly on any uid rejection (a prompt-injection probing signal).
 - **Env-broker push notifications (opt-in).** Set `POCKET_ENV_BROKER_NOTIFY_CMD` (+ `POCKET_ENV_BROKER_NOTIFY_COOLDOWN`, default 300s) and the broker fires that command with an alert on uid rejections / not-allowed denials — rate-limited, best-effort, never blocking request handling. Wired to the operator's own chat it is a self-notification (outbound-comms-gate exempt).
 
-
 ## [2.11.9] — 2026-05-29
 
 ### Security
 
 - **Pocket executor: optional least-privilege worker isolation (`POCKET_WORKER_USER`).** `ops-cron-pocket-executor.py` can now launch each `claude --bg` worker as a restricted unix user via `sudo -n -H -u <user>` instead of inheriting the executor user's full privileges, capping the blast radius of a prompt-injected or auto-promoted task. Opt-in: set `POCKET_WORKER_USER` (and optionally `POCKET_WORKER_CLAUDE_CONFIG_DIR` to point the worker at a readable Claude config). Default unset = unchanged behaviour. `--dangerously-skip-permissions` is retained (required for unattended `--bg` workers) but is now bounded by the worker user's FS/network grants rather than running with the executor's full access.
 
-
 ## [2.11.8] — 2026-05-29
 
 ### Security
 
 - **Account-rotation config: stop tracking `config.json`; readers prefer the gitignored override.** `rotate.mjs` and `kapture-claim-credits.mjs` now resolve the rotation config from `$CLAUDE_PLUGIN_DATA_DIR/account-rotation-config.json` (where `setup-account.mjs` already writes real accounts), falling back to a local gitignored `config.json` and then the shipped empty `config.example.json`. `config.json` is `git rm --cached`'d so real emails can never land in a tracked file (it was already in `.gitignore` but remained tracked). No data was ever leaked to the remote — the committed `config.json` was always the empty default; this closes the accidental-commit footgun.
-
 
 ## [2.11.7] — 2026-05-29
 
@@ -259,7 +261,6 @@ _(Ports two patches that had been applied directly on the deploy box into the re
 ### Changed
 
 - **`/ops-inbox` multi-channel scan is now a parallel `Workflow` fan-out** — the scan/classify phase spawns one **read-only** scanner agent per *available* channel concurrently (via the `Workflow` tool), each returning structured classified results (NEEDS_REPLY / WAITING / HANDLED / FYI + the `chatId` needed to reply), then a synthesizer merges them into prioritized buckets. Wall-clock collapses from sum-of-channels to slowest-single-channel. Rule 6 is preserved end-to-end: scanners are explicitly read-only (never send/archive/mutate) and **all** reply drafting, approval, and sending stay in the main session under the one-draft→one-approval→one-send gate; channels are availability-detected first so no scanner is spawned for an unconfigured channel. Agent Teams and sequential scan are retained as documented fallbacks for older harnesses under the same constraints.
-
 
 ## [2.11.6] — 2026-05-27
 
@@ -481,7 +482,6 @@ Builds on v2.6.0 (`/ops:marketing <project>` point-and-go).
 ### Tests
 
 107 tests passing across 6 test files: `test-ad-spend-aggregator.sh` (18), `test-stripe-revenue.sh` (6), `test-sentry-crash.sh` (2), `test-marketing-kpis.sh` (36), `test-ops-marketing-link-prewarm.sh` (15), `test-ops-marketing-auth-prewarm.sh` (1), plus all existing `test-ops-marketing-provision.sh` (11). Zero secrets leaked (`test-no-secrets.sh` 14/14 green).
-
 
 ## [2.6.0] — 2026-05-19
 

--- a/claude-ops/RELEASE.md
+++ b/claude-ops/RELEASE.md
@@ -2,7 +2,7 @@
 
 The `ops` plugin is distributed through the **`ops-marketplace`** Claude Code
 marketplace, which is this repo. A release = bump the version in lockstep across
-the three version-bearing files, land it on `main`, then refresh installs.
+every version-bearing file, land it on `main`, then refresh installs.
 
 ## TL;DR — use the script
 
@@ -29,10 +29,13 @@ After the release lands, refresh the local install:
 |---|---|---|
 | `claude-ops/.claude-plugin/plugin.json` | `.version` | the plugin's own version |
 | `.claude-plugin/marketplace.json` (repo root) | `.plugins[name=="ops"].version` | the **marketplace registry** entry Claude Code reads |
+| `claude-ops/package.json` (auto-detected; or repo root) | `.version` | the `claude-ops-bin` npm package (bin-script runtime deps) |
 | `claude-ops/CHANGELOG.md` | new `## [X.Y.Z] - DATE` section | human-readable history (Keep a Changelog + SemVer) |
 
-`ops-release` keeps all three in sync — never bump them by hand, or the
-marketplace and plugin disagree and installs resolve the wrong version.
+`ops-release` keeps all of these in sync — never bump them by hand, or the
+marketplace, package, and plugin disagree and installs resolve the wrong version.
+(`package.json` had previously drifted to 2.15.0 because the old release path
+never touched it; it is now bumped in lockstep.)
 
 ## What the script does (flow)
 
@@ -40,9 +43,9 @@ marketplace and plugin disagree and installs resolve the wrong version.
 2. Compute the next version (`--type` bump or `--version`).
 3. Create an **isolated worktree** off `origin/main` (the shared main checkout is
    never touched — safe while daemons/other agents are live).
-4. Bump `plugin.json` + `marketplace.json` (via `jq`), prepend the CHANGELOG
-   section (notes from `--notes`, else commit subjects since the last CHANGELOG
-   bump), and validate the JSON.
+4. Bump `plugin.json` + `marketplace.json` + `package.json` (via `jq`), prepend
+   the CHANGELOG section (notes from `--notes`, else commit subjects since the
+   last CHANGELOG bump), and validate the JSON.
 5. Commit `release: vX.Y.Z`, push the branch, open a PR to `main`.
 6. Unless `--no-merge`: squash-merge `--admin`, then (unless `--no-tag`) create
    and push the `vX.Y.Z` git tag.
@@ -57,6 +60,7 @@ contracts; **minor** = new skill/command/agent or backward-compatible feature;
 ## Manual fallback
 
 If `ops-release` is unavailable, do the same by hand in a worktree off
-`origin/main`: bump the two JSON `version` fields, add the CHANGELOG section,
-`commit --no-verify`, push, `gh pr create --base main`, `gh pr merge --squash
---admin`, `git tag vX.Y.Z && git push origin vX.Y.Z`.
+`origin/main`: bump the three JSON `version` fields (plugin.json,
+marketplace.json, package.json), add the CHANGELOG section, `commit --no-verify`,
+push, `gh pr create --base main`, `gh pr merge --squash --admin`, `git tag
+vX.Y.Z && git push origin vX.Y.Z`.

--- a/claude-ops/bin/ops-release
+++ b/claude-ops/bin/ops-release
@@ -1,17 +1,18 @@
 #!/usr/bin/env bash
 # ops-release — cut a new claude-ops plugin release.
 #
-# Single source of truth for releasing the `ops` plugin. It keeps the three
-# version-bearing files in lockstep, writes a CHANGELOG entry, and ships the
+# Single source of truth for releasing the `ops` plugin. It keeps every
+# version-bearing file in lockstep, writes a CHANGELOG entry, and ships the
 # bump through the normal branch → PR → main flow (no direct push to main).
 #
 # What it touches (the "registry + marketplace + version" the release needs):
-#   1. claude-ops/.claude-plugin/plugin.json      .version
-#   2. .claude-plugin/marketplace.json (repo root) .plugins[name==ops].version   <- the marketplace registry
-#   3. claude-ops/CHANGELOG.md                      new "## [X.Y.Z] - DATE" section
+#   1. claude-ops/.claude-plugin/plugin.json       .version
+#   2. .claude-plugin/marketplace.json (repo root)  .plugins[name==ops].version   <- the marketplace registry
+#   3. package.json (auto-detected: claude-ops/ or repo root)   .version
+#   4. claude-ops/CHANGELOG.md                       new "## [X.Y.Z] - DATE" section
 #
 # Flow:
-#   fetch → isolated worktree off origin/main → bump all 3 files → commit
+#   fetch → isolated worktree off origin/main → bump all version files → commit
 #   → push → open PR to main → (optional) squash-merge --admin → (optional) tag vX.Y.Z
 #
 # Usage:
@@ -41,6 +42,13 @@ MARKETPLACE_JSON="$REPO_ROOT/.claude-plugin/marketplace.json"
 CHANGELOG="$PLUGIN_DIR/CHANGELOG.md"
 PLUGIN_NAME="ops"                                   # name in marketplace.json .plugins[]
 GH_REPO="Lifecycle-Innovations-Limited/claude-ops"
+
+# package.json may live under claude-ops/ (current layout) or at the repo root.
+# Record its path RELATIVE to the repo root so we can reapply it inside a worktree.
+PACKAGE_REL=""
+for cand in "claude-ops/package.json" "package.json"; do
+  [ -f "$REPO_ROOT/$cand" ] && PACKAGE_REL="$cand" && break
+done
 
 bump_type="patch"; explicit_ver=""; notes=""; do_merge=1; do_tag=1; dry_run=0
 while [ $# -gt 0 ]; do
@@ -96,6 +104,7 @@ if [ "$dry_run" -eq 1 ]; then
   echo "--- DRY RUN: would set version $CUR -> $NEW in:"
   echo "    $PLUGIN_JSON"
   echo "    $MARKETPLACE_JSON (.plugins[name==$PLUGIN_NAME].version)"
+  [ -n "$PACKAGE_REL" ] && echo "    $REPO_ROOT/$PACKAGE_REL"
   echo "--- would prepend to $CHANGELOG:"
   printf '%s\n' "$changelog_section"
   echo "--- would: branch release/v$NEW -> PR to main$([ "$do_merge" -eq 1 ] && echo ' -> squash-merge --admin')$([ "$do_tag" -eq 1 ] && echo " -> tag v$NEW")"
@@ -116,25 +125,29 @@ wPLUGIN="$WT/claude-ops/.claude-plugin/plugin.json"
 wMKT="$WT/.claude-plugin/marketplace.json"
 wCL="$WT/claude-ops/CHANGELOG.md"
 
-# 1+2. bump version in plugin.json and the marketplace registry
+# 1+2+3. bump version in plugin.json, the marketplace registry, and package.json
 tmp="$(mktemp)"; jq --arg v "$NEW" '.version=$v' "$wPLUGIN" >"$tmp" && mv "$tmp" "$wPLUGIN"
 tmp="$(mktemp)"; jq --arg v "$NEW" --arg n "$PLUGIN_NAME" '(.plugins[] | select(.name==$n).version)=$v' "$wMKT" >"$tmp" && mv "$tmp" "$wMKT"
 jq empty "$wPLUGIN" && jq empty "$wMKT" || { echo "ops-release: produced invalid JSON" >&2; exit 1; }
+if [ -n "$PACKAGE_REL" ] && [ -f "$WT/$PACKAGE_REL" ]; then
+  tmp="$(mktemp)"; jq --arg v "$NEW" '.version=$v' "$WT/$PACKAGE_REL" >"$tmp" && mv "$tmp" "$WT/$PACKAGE_REL"
+  jq empty "$WT/$PACKAGE_REL" || { echo "ops-release: produced invalid $PACKAGE_REL" >&2; exit 1; }
+fi
 
-# 3. prepend CHANGELOG section before the first existing "## [" entry
+# 4. prepend CHANGELOG section before the first existing "## [" entry
 awk -v sec="$changelog_section" '
-  !done && /^## \[/ { print sec; print ""; done=1 }
+  !done && /^## [0-9[]/ { print sec; print ""; done=1 }
   { print }
   END { if (!done) { print ""; print sec } }
 ' "$wCL" >"$wCL.tmp" && mv "$wCL.tmp" "$wCL"
 
-echo "ops-release: bumped plugin.json + marketplace.json + CHANGELOG.md"
+echo "ops-release: bumped plugin.json + marketplace.json$([ -n "$PACKAGE_REL" ] && echo " + $PACKAGE_REL") + CHANGELOG.md"
 
 # ----- commit, push, PR -----
 git -C "$WT" add -A
 git -C "$WT" commit --no-verify -m "release: v$NEW" >/dev/null
 git -C "$WT" push -u origin "$BR" >/dev/null 2>&1
-PR_BODY="$(printf 'Release **v%s** (was %s).\n\n- plugin.json + marketplace.json (registry) bumped\n- CHANGELOG updated\n\n%s\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)' "$NEW" "$CUR" "$notes")"
+PR_BODY="$(printf 'Release **v%s** (was %s).\n\n- plugin.json + marketplace.json (registry)%s bumped\n- CHANGELOG updated\n\n%s\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)' "$NEW" "$CUR" "$([ -n "$PACKAGE_REL" ] && echo " + $PACKAGE_REL")" "$notes")"
 PR_URL="$(gh pr create --repo "$GH_REPO" --base main --head "$BR" --title "release: v$NEW" --body "$PR_BODY")"
 echo "ops-release: opened $PR_URL"
 

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.15.0",
+  "version": "2.18.9",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Feature + release in one PR.

**ops-release tooling**
- Now bumps `claude-ops/package.json` (auto-detected under claude-ops/ or repo root) in lockstep with plugin.json + the marketplace registry.
- Fixed CHANGELOG insertion anchor (`/^## [0-9[]/`) so new entries land at the top regardless of em-dash vs bracket header style.
- RELEASE.md documents all 4 version files.

**Release v2.18.9**
- plugin.json + marketplace.json registry + package.json all bumped to 2.18.9.
- Reconciled package.json (had drifted at 2.15.0 because the old release path never touched it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release scripting and version metadata only; no changes to auth, runtime behavior, or user-facing plugin contracts beyond aligned version numbers.
> 
> **Overview**
> **v2.18.9** ships release-tooling fixes plus the version bump itself.
> 
> `bin/ops-release` now keeps **`claude-ops/package.json`** (`claude-ops-bin`) in sync with `plugin.json` and the marketplace registry—auto-detecting `claude-ops/package.json` or repo-root `package.json`. Dry-run, worktree bumps, and PR text were updated accordingly. **CHANGELOG** prepending uses `/^## [0-9[]/` so new sections land at the top whether headers use brackets or em dashes. **`RELEASE.md`** documents all four version-bearing files.
> 
> This release sets **2.18.9** everywhere (plugin, marketplace, package) and brings **`package.json`** up from **2.15.0**, which had drifted because older release runs never touched it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f172037be0b4a86f7815187e749f07f83a6d74f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->