### PR TITLE
fix(mcp): resolve Doppler token via launcher so the MCP stops failing by default

### DIFF
--- a/claude-ops/.mcp.json
+++ b/claude-ops/.mcp.json
@@ -19,10 +19,10 @@
       }
     },
     "doppler": {
-      "command": "npx",
-      "args": ["-y", "-p", "@dopplerhq/mcp-server", "doppler-mcp"],
+      "command": "bash",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-servers/doppler-launcher.sh"],
       "env": {
-        "DOPPLER_TOKEN": "${user_config.doppler_token}"
+        "DOPPLER_TOKEN_CONFIG": "${user_config.doppler_token}"
       }
     },
     "desktop-act": {

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- **Doppler MCP no longer fails by default.** The server was wired with `DOPPLER_TOKEN: "${user_config.doppler_token}"`, and the `doppler_token` config defaults to `""` — so a blank value was passed to `npx doppler-mcp` as `DOPPLER_TOKEN=""`, clobbering any inherited token and forcing a "Not authenticated" exit (MCP showed "Failed to connect" on every box without a pasted token). The config description's promise — "leave blank — runtime resolves automatically" — was never actually implemented. Added `mcp-servers/doppler-launcher.sh`, which resolves the token from the pasted config value → inherited `DOPPLER_TOKEN` → `doppler configure get token` (a prior `doppler login`), and crucially never exports an empty `DOPPLER_TOKEN`. When no token resolves, the server starts with the var unset so it can use its own `doppler login` store instead of being force-failed.
+
 ## [2.18.9] - 2026-05-31
 
 ### Added

--- a/claude-ops/mcp-servers/doppler-launcher.sh
+++ b/claude-ops/mcp-servers/doppler-launcher.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# doppler-launcher.sh — resolve a Doppler token, then exec the Doppler MCP server.
+#
+# Why this exists:
+#   The plugin wires the Doppler MCP as
+#       env: { "DOPPLER_TOKEN": "${user_config.doppler_token}" }
+#   and the doppler_token userConfig field defaults to "". Its description tells
+#   users they may "leave blank — runtime resolves automatically". That promise
+#   was false: a blank value was passed straight to `npx doppler-mcp` as
+#   DOPPLER_TOKEN="", which (a) clobbered any inherited token and (b) made the
+#   server exit "Not authenticated", so the MCP showed as Failed to connect on
+#   every box that didn't paste a literal token.
+#
+# This launcher makes the documented behavior true. Resolution order:
+#   1. $DOPPLER_TOKEN_CONFIG — the pasted userConfig token (if non-empty).
+#   2. $DOPPLER_TOKEN already present in the spawn env (if non-empty).
+#   3. `doppler configure get token --plain` — the token from a prior
+#      `doppler login` / service-token setup (the common case).
+# If none yield a token we DO NOT export an empty DOPPLER_TOKEN — we exec the
+# server with the token unset so it can fall back to its own `doppler login`
+# store and report its real auth state, instead of being force-failed by "".
+#
+# Deliberately does not export a static token into anything but this server's
+# own process env (keeps `doppler login` token rotation in shells unmasked).
+set -euo pipefail
+
+token=""
+if [[ -n "${DOPPLER_TOKEN_CONFIG:-}" ]]; then
+  token="${DOPPLER_TOKEN_CONFIG}"
+elif [[ -n "${DOPPLER_TOKEN:-}" ]]; then
+  token="${DOPPLER_TOKEN}"
+elif command -v doppler >/dev/null 2>&1; then
+  token="$(doppler configure get token --plain 2>/dev/null || true)"
+fi
+
+if [[ -n "${token}" ]]; then
+  export DOPPLER_TOKEN="${token}"
+else
+  unset DOPPLER_TOKEN || true
+fi
+# DOPPLER_TOKEN_CONFIG is an internal hint — never leak it to the child.
+unset DOPPLER_TOKEN_CONFIG || true
+
+exec npx -y -p @dopplerhq/mcp-server doppler-mcp


### PR DESCRIPTION
## Problem
The `doppler` MCP server shows **Failed to connect** on every box that hasn't pasted a literal token.

`.mcp.json` wired it as:
```json
"doppler": { "command": "npx", "args": ["-y","-p","@dopplerhq/mcp-server","doppler-mcp"],
             "env": { "DOPPLER_TOKEN": "${user_config.doppler_token}" } }
```
…and `userConfig.doppler_token` defaults to `""`. So Claude Code spawns the server with `DOPPLER_TOKEN=""`, which (a) clobbers any token that would otherwise be inherited and (b) makes `doppler-mcp` exit `Not authenticated`. The field's description even claims *"leave blank — runtime resolves automatically"* — but nothing ever resolved it.

## Fix
Add `mcp-servers/doppler-launcher.sh` (matching the existing `desktop-act-launcher.py` pattern) and point the doppler entry at it, passing the config value as `DOPPLER_TOKEN_CONFIG`:
```json
"doppler": { "command": "bash", "args": ["${CLAUDE_PLUGIN_ROOT}/mcp-servers/doppler-launcher.sh"],
             "env": { "DOPPLER_TOKEN_CONFIG": "${user_config.doppler_token}" } }
```
Resolution order: pasted config token → inherited `DOPPLER_TOKEN` → `doppler configure get token --plain` (a prior `doppler login`). Crucially it **never exports an empty `DOPPLER_TOKEN`** — when nothing resolves, the server starts with the var unset and falls back to its own `doppler login` store instead of being force-failed. The token only ever enters this one server's process env, so shell-level `doppler login` rotation stays unmasked (respects the headless-CLI doctrine).

## Verification
- `bash -n` clean; `.mcp.json` valid JSON.
- With a token: launcher handshakes — `{"serverInfo":{"name":"doppler-api",...}}`.
- Blank path: no longer hard-fails on the empty clobber; surfaces the server's own auth state (and resolves via CLI fallback on `doppler login` boxes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local MCP startup and env wiring only; improves auth by avoiding empty-token clobber with no broad production surface.
> 
> **Overview**
> **Fixes the Doppler MCP failing to connect when `doppler_token` is left blank.** `.mcp.json` no longer spawns `npx doppler-mcp` with `DOPPLER_TOKEN=""` from the default empty plugin setting (which overwrote inherited tokens and forced "Not authenticated").
> 
> The **doppler** entry now runs **`mcp-servers/doppler-launcher.sh`** (same idea as `desktop-act-launcher.py`), passing the pasted value as **`DOPPLER_TOKEN_CONFIG`**. The script resolves a token in order: config → existing **`DOPPLER_TOKEN`** → **`doppler configure get token`**, exports **`DOPPLER_TOKEN`** only when non-empty, otherwise leaves it unset so the MCP can use CLI login state. **`CHANGELOG.md`** documents the fix under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bcfddaceb223e0b50436f0b3b3e15d1adfebb17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the Doppler MCP server would fail to initialize due to missing or empty authentication tokens during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->