### PR TITLE
release: v2.18.10

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.18.9",
+      "version": "2.18.10",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.18.9",
+  "version": "2.18.10",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.18.10] - 2026-05-31
+
+### Changed
+### Fixed
+- Doppler MCP no longer fails to connect by default. Added `mcp-servers/doppler-launcher.sh`, which resolves `DOPPLER_TOKEN` (pasted config → inherited env → `doppler configure get token`) and never exports an empty token, so the server stops being force-failed when `doppler_token` is left blank (#422).
+
+
 ## [Unreleased]
 
 ### Fixed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.18.9",
+  "version": "2.18.10",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.18.10** (was 2.18.9).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

### Fixed
- Doppler MCP no longer fails to connect by default. Added `mcp-servers/doppler-launcher.sh`, which resolves `DOPPLER_TOKEN` (pasted config → inherited env → `doppler configure get token`) and never exports an empty token, so the server stops being force-failed when `doppler_token` is left blank (#422).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The diff is version metadata and release notes only; the documented Doppler change is a local MCP launcher/credential-resolution fix with no production deploy surface in this patch.
> 
> **Overview**
> **Release v2.18.10** bumps the plugin and marketplace registry from `2.18.9` to **`2.18.10`**, and aligns **`claude-ops/package.json`** (`claude-ops-bin`) to the same version.
> 
> **CHANGELOG** records the user-facing fix for **#422**: Doppler MCP should stop failing on connect when `doppler_token` is left blank—via **`mcp-servers/doppler-launcher.sh`**, which resolves `DOPPLER_TOKEN` (plugin config → inherited env → `doppler configure get token`) and avoids exporting an empty token that forced authentication failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47498165d0c7cadf78eea59837a822407b70a4e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->