### PR TITLE
feat(whatsapp): keepalive watchdog so phone-sends always sync

### DIFF
--- a/claude-ops/bin/wa-bridge-keepalive.sh
+++ b/claude-ops/bin/wa-bridge-keepalive.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# wa-bridge-keepalive.sh — keep the whatsmeow whatsapp-bridge ONLINE so phone-originated
+# own-sends always sync. systemd Restart=always catches CRASHES; this catches HANGS
+# (process alive, websocket dead) which would silently drop every incoming message —
+# including your own phone sends, which whatsmeow CANNOT re-fetch once missed.
+#
+# Liveness = a real HTTP probe of the bridge REST port. NOT `ss | grep :8080` — ss renders
+# port 8080 as the service name "webcache", so that grep never matches and would false-restart
+# a perfectly healthy bridge (documented ops-inbox footgun). curl treats HTTP 404 as success
+# (connection worked); only connection-refused / timeout counts as down.
+set -uo pipefail
+
+# single-instance + 50s throttle (timer fires every 60s; never stack)
+if [ -r "$HOME/.claude/scripts/lib/once.sh" ]; then
+  # shellcheck disable=SC1091
+  source "$HOME/.claude/scripts/lib/once.sh"
+  claude_once wa-bridge-keepalive 50 || exit 0
+fi
+
+PROBE="${WA_BRIDGE_PROBE:-http://127.0.0.1:8080/}"
+UNIT="whatsapp-bridge.service"
+
+probe() { curl -s -o /dev/null -m 4 "$PROBE" 2>/dev/null; }
+
+# two probes 3s apart — tolerate a single transient blip
+if probe; then exit 0; fi
+sleep 3
+if probe; then exit 0; fi
+
+# Don't fight systemd if it's already mid-(re)start (crash path owned by Restart=always)
+state=$(systemctl --user show "$UNIT" -p ActiveState --value 2>/dev/null || echo unknown)
+if [ "$state" = "activating" ]; then exit 0; fi
+
+logger -t wa-bridge-keepalive "bridge unresponsive on $PROBE (state=$state) — restarting $UNIT"
+systemctl --user restart "$UNIT"

--- a/claude-ops/scripts/install-whatsapp-bridge-linux.sh
+++ b/claude-ops/scripts/install-whatsapp-bridge-linux.sh
@@ -113,6 +113,11 @@ mkdir -p "$HOME/bin"
 cp "$SCRIPT_DIR/../bin/wa-inbox-fresh.sh" "$HOME/bin/wa-inbox-fresh.sh"
 chmod +x "$HOME/bin/wa-inbox-fresh.sh"
 
+# ─── Ship wa-bridge-keepalive.sh (hang-detection so phone-sends always sync) ──
+echo "▶ Installing wa-bridge-keepalive.sh → ~/bin (uptime watchdog)"
+cp "$SCRIPT_DIR/../bin/wa-bridge-keepalive.sh" "$HOME/bin/wa-bridge-keepalive.sh"
+chmod +x "$HOME/bin/wa-bridge-keepalive.sh"
+
 # ─── Bump Go deps + build ────────────────────────────────────────────────────
 if [ "$SKIP_BUILD" -ne 1 ]; then
   echo "▶ Bumping Go deps + building bridge"
@@ -154,6 +159,12 @@ if [ "$WITH_BACKFILL_TIMER" -eq 1 ]; then
   cp "$WA_ASSETS/systemd/whatsapp-backfill.timer"   "$SYSTEMD_DIR/"
 fi
 
+# Keepalive watchdog: Restart=always catches crashes; this catches HANGS (socket
+# dead, process alive) which would silently drop phone-originated own-sends that
+# whatsmeow can never re-fetch. Always installed.
+cp "$WA_ASSETS/systemd/whatsapp-bridge-keepalive.service" "$SYSTEMD_DIR/"
+cp "$WA_ASSETS/systemd/whatsapp-bridge-keepalive.timer"   "$SYSTEMD_DIR/"
+
 if [ "$WITH_TRANSCRIBE_TIMER" -eq 1 ]; then
   sed "s|__INSTALL_DIR__|$INSTALL_DIR|g" \
       "$WA_ASSETS/systemd/whatsapp-transcribe.service" \
@@ -184,6 +195,7 @@ echo "▶ Reloading systemd + starting services"
 loginctl enable-linger "$USER" 2>/dev/null || true   # survive logout
 systemctl --user daemon-reload
 systemctl --user enable --now whatsapp-bridge.service
+systemctl --user enable --now whatsapp-bridge-keepalive.timer
 if [ "$WITH_BACKFILL_TIMER" -eq 1 ]; then
   systemctl --user enable --now whatsapp-backfill.timer
 fi

--- a/claude-ops/scripts/whatsapp/systemd/whatsapp-bridge-keepalive.service
+++ b/claude-ops/scripts/whatsapp/systemd/whatsapp-bridge-keepalive.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=WhatsApp bridge keepalive (hang-detection so phone-sends always sync)
+After=whatsapp-bridge.service
+
+[Service]
+Type=oneshot
+ExecStart=%h/bin/wa-bridge-keepalive.sh

--- a/claude-ops/scripts/whatsapp/systemd/whatsapp-bridge-keepalive.timer
+++ b/claude-ops/scripts/whatsapp/systemd/whatsapp-bridge-keepalive.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run whatsapp-bridge keepalive every 60s
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=60
+AccuracySec=10s
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Why
Phone-originated own-sends only land in the whatsmeow store while the bridge is **online** — whatsmeow can't re-fetch your own sends missed during downtime. `Restart=always` catches crashes but **not hangs** (process alive, socket dead), during which every inbound message — including your phone sends — is silently dropped. That's a root cause of ops-inbox mislabeling threads 'awaiting you' when you already replied.

## Fix
- `~/bin/wa-bridge-keepalive.sh` — curl liveness probe (2 tries, 3s apart) that restarts the bridge **only** on genuine unresponsiveness. Deliberately **not** `ss | grep :8080` (ss renders 8080 as service name `webcache` → never matches → false-restarts a healthy bridge). Skips while unit is `activating`; `claude_once` lock + 50s throttle.
- `whatsapp-bridge-keepalive.{service,timer}` (systemd-user, every 60s), always installed + enabled by `install-whatsapp-bridge-linux.sh`.

## Test
- `bash -n` clean on installer + script.
- Verified live on dev-sandbox-fra: timer active, and the script does **not** restart a healthy bridge (start-time unchanged after a manual run).

Pairs with the fts5 storage guard (#419/v2.18.8) — together: storage never fails + uptime maximized = phone-sends reliably captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Ops-only watchdog around an existing user service; bounded probes and skips restart while activating, with low blast radius beyond occasional bridge restarts.
> 
> **Overview**
> Adds a **background hang watchdog** for the WhatsApp bridge so phone-originated own-sends keep syncing when the process is alive but the websocket/HTTP stack is dead—something `Restart=always` alone does not fix.
> 
> **`~/bin/wa-bridge-keepalive.sh`** runs on a 60s user timer: **curl** liveness against `WA_BRIDGE_PROBE` (default `http://127.0.0.1:8080/`), two failures 3s apart, then `systemctl --user restart whatsapp-bridge.service` unless the unit is already `activating`. Uses `claude_once` throttling; deliberately avoids `ss | grep :8080` (known false-positive with port 8080 labeled `webcache`).
> 
> **`install-whatsapp-bridge-linux.sh`** now ships the script, installs **`whatsapp-bridge-keepalive.{service,timer}`** (always, not optional), and **`enable --now`** the timer alongside the main bridge service.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 305856dabe895dab83e07b583448699e30829e96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->