### PR TITLE
release: v2.18.11

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.18.10",
+      "version": "2.18.11",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.18.10",
+  "version": "2.18.11",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.18.11] - 2026-05-31
+
+### Changed
+WhatsApp bridge keepalive watchdog (#424) — hang-detection so phone-originated own-sends always sync
+
+
 ## [2.18.10] - 2026-05-31
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.18.10",
+  "version": "2.18.11",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.18.11** (was 2.18.10).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

WhatsApp bridge keepalive watchdog (#424) — hang-detection so phone-originated own-sends always sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version metadata and changelog only; no runtime code changes in this diff.
> 
> **Overview**
> **Release v2.18.11** bumps the plugin from **2.18.10** to **2.18.11** everywhere versions are published: `.claude-plugin/marketplace.json`, `claude-ops/.claude-plugin/plugin.json`, and `claude-ops/package.json`.
> 
> `CHANGELOG.md` adds a **2.18.11** entry (2026-05-31) noting the shipped change: **WhatsApp bridge keepalive watchdog** ([#424](https://github.com/...)) — hang detection so messages you send from your phone still sync reliably. No other files change in this diff; it is a version + changelog release PR for work already merged under #424.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0a6c0dd19b5c32647d8781bcf093834c56391af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->