### PR TITLE
feat(whatsapp): /api/recover_app_state — fatal LTHash recovery (Fix I)

### DIFF
--- a/claude-ops/scripts/whatsapp/ENDPOINTS.md
+++ b/claude-ops/scripts/whatsapp/ENDPOINTS.md
@@ -47,8 +47,9 @@ All POST, JSON body. Source: `whatsapp-bridge/main.go`.
 | `POST /api/send` | `{"recipient":"<JID>","message":"<text>"}` | `{success,message}` | Send a text. `recipient` is a full JID (`<phone>@s.whatsapp.net`, `<lid>@lid`, or `<id>@g.us`). |
 | `POST /api/download` | `{"message_id":"…","chat_jid":"…"}` | media bytes / path | Fetch media for a message. |
 | `POST /api/backfill` | (none) | `{success:"backfill requested"}` | Request history sync for the ~50 most-active chats. Also auto-runs 5s after each `Connected`. |
-| `POST /api/resync_app_state` | `{"name":"regular_low","full_sync":true}` | `{success,message}` | Force app-state (archive/mute/pin/contacts) resync. **Often fails LTHash — see blocker below.** |
-| `POST /api/archive` | `{"chat_jid":"<JID>","archive":true}` | `{success,message}` | Archive / unarchive (`archive:false`). Writes `chats.archived` AND pushes a `regular_low` app-state mutation. **Blocked when app-state is desynced — see blocker.** |
+| `POST /api/resync_app_state` | `{"name":"regular_low","full_sync":true}` | `{success,message}` | Force app-state resync from existing patches. **Cannot fix a fatally-corrupt patch chain — use `/api/recover_app_state`.** |
+| `POST /api/recover_app_state` | `{"name":"regular_low"}` | `{success,message}` | **Fatal recovery** for an unverifiable collection (`mismatching LTHash`). Asks the PRIMARY device for an unencrypted snapshot (`BuildAppStateRecoveryRequest`→`SendPeerMessage`); whatsmeow's `handleAppStateRecovery` rebuilds it, bypassing broken patches. **Phone must be online.** This is the ONLY thing that unblocks archive when LTHash is fatally desynced. |
+| `POST /api/archive` | `{"chat_jid":"<JID>","archive":true}` | `{success,message}` | Archive / unarchive (`archive:false`). Writes `chats.archived` AND pushes a `regular_low` app-state mutation. If it 409s LTHash, run `/api/recover_app_state` once (phone online), then it works. |
 
 There is **no** delete/mark-read/group-admin endpoint. There is no `/api/health` — probe `/` (404 = alive).
 
@@ -98,14 +99,18 @@ and the DB are still fully usable.
 
 ## Known blockers + heals
 
-- **App-state LTHash mismatch (archive / mute / pin / resync 409).** `POST /api/archive` returns
-  `409 conflict updating app state (regular_low)`, and `resync_app_state` returns
-  `failed to verify patch vNNN: mismatching LTHash`. The whatsmeow client can't verify the server's
-  `regular_low` patch chain. **Clearing the local snapshot does NOT fix it** (the server patches
-  themselves fail verification on re-fetch). The reliable heal is a **phone-side action: toggle archive
-  on ANY one chat from your phone** (archive then unarchive) — that emits a fresh app-state mutation the
-  bridge can resync from. Until then, archive is unavailable on every surface (REST and MCP). Setting
-  `chats.archived=1` locally is possible but does NOT propagate to the phone and diverges state — avoid.
+- **App-state LTHash mismatch (archive / mute / pin / resync 409) → FIXED via `/api/recover_app_state`.**
+  `POST /api/archive` returns `409 conflict updating app state (regular_low)` and `resync_app_state`
+  returns `failed to verify patch vNNN: mismatching LTHash` (whatsmeow [#382](https://github.com/tulir/whatsmeow/issues/382)/[#858](https://github.com/tulir/whatsmeow/issues/858)).
+  The whatsmeow client can't verify the server's `regular_low` patch chain. **Clearing the local
+  snapshot does NOT fix it, and a single phone archive-toggle does NOT fully heal it** — the server
+  patch chain itself fails verification on re-fetch. **The fix: `POST /api/recover_app_state` with the
+  phone online** — it requests a fresh unencrypted snapshot from the primary device and rebuilds the
+  collection from scratch (bypassing the broken patches), restoring `regular_low` to a clean version.
+  After it lands, archive works on every surface. (Do NOT hand-set `chats.archived=1` — it diverges
+  from the phone and can hide future inbound; archive through the bridge instead.) Note: archive is a
+  per-chat lid/phone-aware op — archive the actual `chat_jid` of the active chat, not a contacts-table
+  JID, which may differ from the live `@lid` chat.
 
 - **fts5 "no such module: fts5" → silent message loss.** If `messages.db` has `messages_fts` triggers
   but the bridge binary lacks fts5, every insert fails and messages (incl. your own phone-sends) are

--- a/claude-ops/scripts/whatsapp/apply-patches.py
+++ b/claude-ops/scripts/whatsapp/apply-patches.py
@@ -490,6 +490,61 @@ RESYNC_ENDPOINT_REPLACEMENT = """\t// claude-ops Fix D: POST /api/resync_app_sta
 
 RESYNC_ENDPOINT_SENTINEL = "claude-ops Fix D: POST /api/resync_app_state"
 
+# ─── main.go Fix I: POST /api/recover_app_state REST endpoint ─────────────────
+# Recovers a FATALLY corrupt app-state collection. When the server's patch chain
+# is unverifiable ("failed to verify patch vNNN: mismatching LTHash", whatsmeow
+# #382/#858) neither /api/archive nor /api/resync_app_state can apply or re-fetch
+# it — clearing the local snapshot doesn't help because the server snapshot itself
+# fails the LTHash check. whatsmeow's only real recovery is to ask the PRIMARY
+# device for an unencrypted copy: BuildAppStateRecoveryRequest -> SendPeerMessage.
+# The phone replies with a PEER_DATA_OPERATION_RESPONSE that whatsmeow's
+# handleAppStateRecovery (auto-wired in message.go) uses to rebuild the collection
+# from scratch, bypassing the broken patches. After it lands, archive works.
+# Applies AFTER Fix D (anchors on the goroutine block Fix D re-emits).
+RECOVER_ENDPOINT_NEEDLE = RESYNC_ENDPOINT_NEEDLE
+RECOVER_ENDPOINT_REPLACEMENT = """\t// claude-ops Fix I: POST /api/recover_app_state — recover a FATALLY corrupt
+\t// app-state collection whose server patch chain is unverifiable (LTHash
+\t// mismatch, whatsmeow #382/#858). Asks the user's PRIMARY device for an
+\t// unencrypted snapshot; whatsmeow's handleAppStateRecovery rebuilds from it.
+\t// The phone MUST be online to respond. Body: {"name":"regular_low"} (default).
+\thttp.HandleFunc(\"/api/recover_app_state\", func(w http.ResponseWriter, r *http.Request) {
+\t\tif r.Method != http.MethodPost {
+\t\t\thttp.Error(w, \"Method not allowed\", http.StatusMethodNotAllowed)
+\t\t\treturn
+\t\t}
+\t\tw.Header().Set(\"Content-Type\", \"application/json\")
+\t\tif !client.IsConnected() {
+\t\t\tw.WriteHeader(http.StatusServiceUnavailable)
+\t\t\tfmt.Fprintln(w, `{\"success\":false,\"message\":\"client not connected\"}`)
+\t\t\treturn
+\t\t}
+\t\tvar req struct {
+\t\t\tName string `json:\"name\"`
+\t\t}
+\t\treq.Name = \"regular_low\"
+\t\tif err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+\t\t\tif req.Name == \"\" {
+\t\t\t\treq.Name = \"regular_low\"
+\t\t\t}
+\t\t}
+\t\tmsg := whatsmeow.BuildAppStateRecoveryRequest(appstate.WAPatchName(req.Name))
+\t\tif _, err := client.SendPeerMessage(context.Background(), msg); err != nil {
+\t\t\tw.WriteHeader(http.StatusInternalServerError)
+\t\t\tfmt.Fprintf(w, `{\"success\":false,\"message\":%q}`, err.Error())
+\t\t\treturn
+\t\t}
+\t\tfmt.Fprintf(w, `{\"success\":true,\"message\":\"recovery request sent to primary device for %s — it returns a fresh snapshot in a few seconds (phone must be online), then archive works\"}`, req.Name)
+\t})
+
+\t// Run server in a goroutine so it doesn't block
+\tgo func() {
+\t\tif err := http.ListenAndServe(serverAddr, nil); err != nil {
+\t\t\tfmt.Printf(\"REST API server error: %v\\n\", err)
+\t\t}
+\t}()
+}"""
+RECOVER_ENDPOINT_SENTINEL = "claude-ops Fix I: POST /api/recover_app_state"
+
 # ─── main.go Fix D (Connected): auto-resync regular_low on startup ────────────
 CONNECTED_RESYNC_NEEDLE = """\t\tcase *events.Connected:
 \t\t\tlogger.Infof(\"Connected to WhatsApp\")
@@ -1119,6 +1174,14 @@ def main() -> int:
         RESYNC_ENDPOINT_REPLACEMENT,
         RESYNC_ENDPOINT_SENTINEL,
         "Fix D: POST /api/resync_app_state endpoint",
+    )
+    # Fix I must run AFTER Fix D — it anchors on the goroutine block Fix D re-emits.
+    changed_go |= replace_idempotent(
+        main_go,
+        RECOVER_ENDPOINT_NEEDLE,
+        RECOVER_ENDPOINT_REPLACEMENT,
+        RECOVER_ENDPOINT_SENTINEL,
+        "Fix I: POST /api/recover_app_state endpoint (LTHash fatal recovery)",
     )
     changed_go |= replace_idempotent(
         main_go,


### PR DESCRIPTION
## Problem
Archive (and mute/pin) push a `regular_low` app-state mutation. When the server's patch chain becomes unverifiable — `failed to verify patch vNNN: mismatching LTHash` (whatsmeow [#382](https://github.com/tulir/whatsmeow/issues/382)/[#858](https://github.com/tulir/whatsmeow/issues/858)) — **every** such op 409s. Neither `/api/resync_app_state`, nor clearing the local snapshot, nor a single phone archive-toggle heals it: the server patch chain itself fails verification on re-fetch.

## Fix
whatsmeow's only real recovery is `BuildAppStateRecoveryRequest` → `SendPeerMessage`: ask the **primary device** for an unencrypted snapshot, which `handleAppStateRecovery` (auto-wired to the peer-data-operation response in `message.go`) uses to rebuild the collection from scratch, bypassing the broken patches. The bridge had **no endpoint** for it.

**Fix I** adds **`POST /api/recover_app_state {"name":"regular_low"}`** via `apply-patches.py` (anchors after Fix D's goroutine block; idempotent sentinel; reuses the existing `whatsmeow`+`appstate` imports).

## Verified end-to-end (dev-sandbox-fra)
- Patcher: `py_compile` clean; sim confirms Fix D→Fix I produce both endpoints with a single goroutine block.
- Live: sent recovery request → phone returned snapshot → `regular_low` rebuilt **v621 (corrupt) → v622** → `/api/archive` returned `success`, **200+ chats archived**.
- Caveat documented: phone must be online to answer; archive the live `@lid` chat_jid (contacts-table JID may differ).

ENDPOINTS.md updated (#426 follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WhatsApp app-state recovery and archive workflows; mis-use or offline phone only delays healing, but successful recovery rebuilds `regular_low` from the primary device snapshot.
> 
> **Overview**
> Adds **`POST /api/recover_app_state`** to the WhatsApp bridge patcher so operators can recover a **fatally corrupt** `regular_low` app-state chain (LTHash mismatch) by asking the **primary phone** for a fresh snapshot via `BuildAppStateRecoveryRequest` → `SendPeerMessage`, instead of relying on resync or a one-off phone archive toggle.
> 
> `apply-patches.py` injects the handler **after Fix D** (idempotent sentinel, default `name: regular_low`, connected-client guard). **ENDPOINTS.md** documents the endpoint, clarifies that `/api/resync_app_state` cannot fix unverifiable server patches, and updates the archive 409 playbook to **run recover once with the phone online**, then retry archive (use live `chat_jid`, not contacts-table JIDs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d2e3cf62847af71c3579b51737add4d85c888ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->