### PR TITLE
release: v2.18.11

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [2.18.11] - 2026-05-31
 
 ### Changed
+WhatsApp /api/recover_app_state (#427) — fatal LTHash app-state recovery via primary-device snapshot; unblocks archive
+
+
+## [2.18.11] - 2026-05-31
+
+### Changed
 WhatsApp bridge keepalive watchdog (#424) — hang-detection so phone-originated own-sends always sync
 
 


### PR DESCRIPTION
Release **v2.18.11** (was 2.18.10).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

WhatsApp /api/recover_app_state (#427) — fatal LTHash app-state recovery via primary-device snapshot; unblocks archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata and changelog only in the shown diff; functional risk is limited to operators invoking the new WhatsApp recovery endpoint on linked bridges.
> 
> **Overview**
> **Release v2.18.11** bumps `plugin.json`, marketplace registry, and `claude-ops/package.json` from 2.18.10 and adds a **CHANGELOG** entry for this cut.
> 
> The highlighted change is **WhatsApp bridge `POST /api/recover_app_state`** (#427): when `regular_low` app-state hits a fatal **LTHash** mismatch, the bridge requests a fresh snapshot from the **primary device** and rebuilds state so **`/api/archive`** and other app-state writes work again (distinct from `/api/resync_app_state`, which cannot repair an unverifiable patch chain).
> 
> **Note:** `CHANGELOG.md` now has **two** `## [2.18.11]` sections (recover vs keepalive #424); consider merging or re-versioning one entry for clarity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f58057298483d17447d23e1f6c1e557c3f7eb169. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->