### PR TITLE
release: v2.18.11

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## [2.18.11] - 2026-05-31
 
 ### Changed
+WhatsApp /api/recover_app_state (#427) — fatal LTHash app-state recovery via primary-device snapshot; unblocks archive after a fatal patch-chain desync
+
+
+## [2.18.11] - 2026-05-31
+
+### Changed
 WhatsApp /api/recover_app_state (#427) — fatal LTHash app-state recovery via primary-device snapshot; unblocks archive
 
 


### PR DESCRIPTION
Release **v2.18.11** (was 2.18.10).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

WhatsApp /api/recover_app_state (#427) — fatal LTHash app-state recovery via primary-device snapshot; unblocks archive after a fatal patch-chain desync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog-only change in the visible diff; no runtime code. Duplicate heading is a docs hygiene issue, not a deployment risk.
> 
> **Overview**
> **Release v2.18.11** — the PR is a version cut (from **2.18.10** per the description), with release notes centered on WhatsApp **`POST /api/recover_app_state`** (#427): fatal **LTHash** app-state recovery using a primary-device snapshot so archive works again after a fatal patch-chain desync.
> 
> The **git diff shown** only touches **`CHANGELOG.md`**: it prepends another **`## [2.18.11] - 2026-05-31`** block with the same #427 bullet, wording slightly expanded (“unblocks archive **after a fatal patch-chain desync**”). That duplicates the entry immediately below it and leaves a third **2.18.11** section for the keepalive watchdog (#424) — likely an accidental double entry from the release script rather than new product behavior in this diff.
> 
> If the full PR also bumps **`plugin.json`**, marketplace registry, and **`package.json`** (as described), those changes are not in the snippet provided here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 729e27cf8875041992f3512a8c258377f2340e58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WhatsApp app-state recovery mechanism to prevent archive blocking issues when synchronization conflicts occur.

* **Documentation**
  * Updated changelog with recovery improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->