### PR TITLE
release: v2.18.12

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.18.11",
+      "version": "2.18.12",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.18.11",
+  "version": "2.18.12",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2.18.12] - 2026-05-31
+
+### Added
+- **WhatsApp `POST /api/recover_app_state` — fatal LTHash app-state recovery (#427, Fix I).**
+  When the server's `regular_low` patch chain is unverifiable (`failed to verify patch vNNN:
+  mismatching LTHash`, whatsmeow #382/#858), archive/mute/pin 409 and neither resync, clearing
+  the local snapshot, nor a single phone toggle heals it. The new endpoint requests a fresh
+  unencrypted snapshot from the primary device (`BuildAppStateRecoveryRequest`→`SendPeerMessage`);
+  whatsmeow's `handleAppStateRecovery` rebuilds the collection from scratch, bypassing the broken
+  patches. Phone must be online. Verified end-to-end: `regular_low` rebuilt v621→v622, archive
+  then succeeded.
+
 ## [2.18.11] - 2026-05-31
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.18.11",
+  "version": "2.18.12",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Bumps ops plugin to **v2.18.12**. Ships #427 — WhatsApp `/api/recover_app_state` fatal LTHash recovery. All 4 surfaces (marketplace.json, plugin.json, package.json, CHANGELOG) bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release; no runtime code changes in the diff.
> 
> **Overview**
> **Release v2.18.12** bumps the ops plugin on all four version surfaces (`marketplace.json`, `plugin.json`, `package.json`, and **CHANGELOG**) from **2.18.11** to **2.18.12**.
> 
> The release documents **#427**: WhatsApp **`POST /api/recover_app_state`** for fatal **`regular_low`** LTHash / patch-chain desync (when archive/mute/pin and resync cannot recover). Recovery pulls an unencrypted app-state snapshot from the primary device via whatsmeow so the collection can be rebuilt; the phone must be online.
> 
> This PR contains **no implementation changes** in the diff—only versioning and changelog text for what was already merged as #427.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fdf0805f1dbfe04552ce15dc171e04ce90378d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->