### PR TITLE
fix(whatsapp): stop destructive regular_low auto-resync on Connected

### DIFF
--- a/claude-ops/scripts/whatsapp/apply-patches.py
+++ b/claude-ops/scripts/whatsapp/apply-patches.py
@@ -552,21 +552,21 @@ CONNECTED_RESYNC_NEEDLE = """\t\tcase *events.Connected:
 
 CONNECTED_RESYNC_REPLACEMENT = """\t\tcase *events.Connected:
 \t\t\tlogger.Infof(\"Connected to WhatsApp\")
-\t\t\t// claude-ops Fix D: force a full resync of the regular_low app-state patch
-\t\t\t// on every connect. Clears LTHash mismatch errors that fire when the local
-\t\t\t// snapshot is stale. Non-fatal if it fails (message delivery unaffected).
-\t\t\tgo func(c *whatsmeow.Client) {
-\t\t\t\ttime.Sleep(3 * time.Second)
-\t\t\t\tlogger.Infof(\"Auto-resync: fetching fresh regular_low app-state snapshot\")
-\t\t\t\tif err := c.FetchAppState(context.Background(), \"regular_low\", true, false); err != nil {
-\t\t\t\t\tlogger.Debugf(\"regular_low app-state resync: %v (non-fatal)\", err)
-\t\t\t\t} else {
-\t\t\t\t\tlogger.Infof(\"regular_low app-state resync complete\")
-\t\t\t\t}
-\t\t\t}(client)
+\t\t\t// claude-ops Fix I: do NOT auto-touch regular_low app-state on connect.
+\t\t\t// The previous handler ran FetchAppState(regular_low, fullSync=true), which
+\t\t\t// DELETED the local snapshot and re-fetched the server's broken patch chain
+\t\t\t// (\"failed to verify patch vNNN: mismatching LTHash\", whatsmeow #382/#858),
+\t\t\t// re-corrupting it on EVERY connect and undoing any recovery. Auto-requesting
+\t\t\t// recovery on connect is also wrong — it overwrites a good in-sync snapshot
+\t\t\t// with the phone's low-version recovery baseline, so the next archive mutation
+\t\t\t// conflicts with the server head (409). Correct behaviour: leave regular_low
+\t\t\t// untouched and recover ON DEMAND via POST /api/recover_app_state only when an
+\t\t\t// archive/mute/pin op actually fails with LTHash.
 \t\t\t// claude-ops: auto-trigger a deep history backfill on every Connected event."""
 
-CONNECTED_RESYNC_SENTINEL = "claude-ops Fix D: force a full resync of the regular_low"
+CONNECTED_RESYNC_SENTINEL = (
+    "claude-ops Fix I: do NOT auto-touch regular_low app-state on connect"
+)
 
 # ─── whatsapp.py Fix E: WAL-mode _open_db + dict serialisation helpers ────────
 # The MCP server returned raw dataclass objects where FastMCP expected dicts,
@@ -1166,7 +1166,7 @@ def main() -> int:
         CONNECTED_RESYNC_NEEDLE,
         CONNECTED_RESYNC_REPLACEMENT,
         CONNECTED_RESYNC_SENTINEL,
-        "Fix D: auto-resync regular_low on Connected event",
+        "Fix I: no destructive auto-resync on Connected (recover on demand)",
     )
     changed_go |= replace_idempotent(
         main_go,


### PR DESCRIPTION
## Problem
The bridge's `*events.Connected` handler ran `FetchAppState(regular_low, fullSync=true)` 3s after every connect. On a fatally-desynced collection (`mismatching LTHash`, whatsmeow [#382](https://github.com/tulir/whatsmeow/issues/382)/[#858](https://github.com/tulir/whatsmeow/issues/858)) `fullSync=true` **deletes the local snapshot** and re-fetches the broken server patch chain — re-corrupting `regular_low` on **every connect/restart** and undoing any `/api/recover_app_state` recovery. (Auto-requesting recovery on connect is also wrong: it overwrites a good in-sync snapshot with the phone's low-version recovery baseline, so the next archive mutation 409s against the server head.)

## Fix
Leave `regular_low` untouched on connect. Recover **on demand** via `POST /api/recover_app_state` only when an archive/mute/pin op actually fails with LTHash. (Updates Fix D's `CONNECTED_RESYNC` replacement + sentinel; idempotent against the live hand-patched box.)

## Verified live (dev-sandbox-fra)
Connect no longer logs `Auto-resync`; the 211 archived chats stay archived across restarts; `/api/recover_app_state` still heals on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WhatsApp bridge connect-time app-state behavior; wrong recovery timing could break archive/sync, but scope is limited to patch definitions for `regular_low` on connect.
> 
> **Overview**
> Updates **`apply-patches.py`** so the bridge’s `*events.Connected` patch no longer schedules a delayed **`FetchAppState(regular_low, fullSync=true)`** on every connect.
> 
> The new replacement is comments-only at that hook: **`regular_low`** stays untouched at connect time; healing stays **on demand** via **`POST /api/recover_app_state`** when archive/mute/pin ops hit LTHash errors. The idempotent **sentinel** and apply log label are aligned with that behavior (replacing the old “Fix D auto-resync” wording).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 299c92621403d0ecf267120a5a8fadba178c0c23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->