### PR TITLE
release: v2.18.13

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.18.12",
+      "version": "2.18.13",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.18.12",
+  "version": "2.18.13",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.18.13] - 2026-05-31
+
+### Fixed
+- **WhatsApp: stop destructive `regular_low` auto-resync on Connected (#431).** The bridge
+  ran `FetchAppState(regular_low, fullSync=true)` 3s after every connect, which on a fatally
+  desynced collection (whatsmeow #382/#858) deleted the local snapshot and re-fetched the
+  broken server patch chain — re-corrupting it on every restart and undoing `/api/recover_app_state`
+  recovery. Now leaves `regular_low` untouched on connect; recover on demand only.
+
 ## [2.18.12] - 2026-05-31
 
 ### Added

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.18.12",
+  "version": "2.18.13",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Ships #431 — stop destructive regular_low auto-resync on Connected. 4 surfaces bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff is version metadata and changelog only; the described bridge change reduces restart-induced app-state corruption risk rather than adding new attack surface.
> 
> **Overview**
> **v2.18.13** is a release cut that documents and ships **#431** (WhatsApp bridge behavior), with version aligned on all four release surfaces.
> 
> The **CHANGELOG** entry describes the functional change: on **Connected**, the bridge no longer runs a destructive **`FetchAppState(regular_low, fullSync=true)`** ~3s after connect. That auto-resync could wipe the local snapshot and re-pull a **broken server patch chain** when `regular_low` was fatally desynced (whatsmeow LTHash issues), **re-corrupting app state on every restart** and undoing **`POST /api/recover_app_state`** recovery. **`regular_low` is left alone on connect**; recovery stays **on demand** (e.g. recover endpoint / manual resync).
> 
> **`plugin.json`**, **`.claude-plugin/marketplace.json`**, and **`claude-ops/package.json`** are bumped **2.18.12 → 2.18.13** so marketplace, plugin metadata, and the `claude-ops-bin` package stay in lockstep.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3d4d2c0e51db228ce4234592ac08cf7cd0e62d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->