### PR TITLE
fix(ops-go): schema-tolerant git/prs/infra gatherers + durable cluster source

### DIFF
--- a/claude-ops/bin/ops-ci
+++ b/claude-ops/bin/ops-ci
@@ -20,6 +20,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 OPS_PLUGIN_ROOT_FALLBACK="${SCRIPT_DIR}/.." . "${SCRIPT_DIR}/../lib/registry-path.sh"
+. "${SCRIPT_DIR}/../lib/registry-resolve.sh"
 
 if [ ! -f "$REGISTRY" ]; then
   echo '{"error":"registry.json not found"}' && exit 1
@@ -29,7 +30,8 @@ if ! command -v gh &>/dev/null; then
   echo '{"error":"gh CLI not found","failures":[]}' && exit 0
 fi
 
-REPOS=$(jq -r '[.projects[].repos[]] | unique | .[]' "$REGISTRY")
+# schema-tolerant: GSD registry has no .repos[]; resolver derives slugs from .remote_url (dedup)
+REPOS=$(ops_registry_repos "$REGISTRY")
 MODE="${OPS_CI_MODE:-current}"
 TRACKED_BRANCHES=("main" "dev" "master")
 

--- a/claude-ops/bin/ops-dash
+++ b/claude-ops/bin/ops-dash
@@ -7,6 +7,8 @@ set -euo pipefail
 
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 . "${PLUGIN_ROOT}/lib/registry-path.sh"
+# Schema-tolerant registry readers (GSD schema has no .repos[]/.paths[]/.gsd).
+. "${PLUGIN_ROOT}/lib/registry-resolve.sh"
 PREFS="${OPS_DATA_DIR}/preferences.json"
 
 # ── Mobile / SSH detection (Rule 7) ─────────────────────────────────────────
@@ -220,7 +222,9 @@ TOTAL_PROBES=13
   # CI fails: iterate registry repos with gh run list --repo (works outside git cwd)
   FAIL_COUNT=0
   if [ -f "$REGISTRY" ] && command -v gh &>/dev/null; then
-    REPOS=$(jq -r '[.projects[].repos[]?] | unique | .[]' "$REGISTRY" 2>/dev/null || true)
+    # Schema-tolerant: GSD registry has no .repos[]; derive slugs from .remote_url.
+    # `|| true` preserves set -e guard so the probe still touches done_ci on jq error.
+    REPOS=$(ops_registry_repos "$REGISTRY" || true)
     for repo in $REPOS; do
       C=$(gh run list --repo "$repo" --limit 10 --json conclusion 2>/dev/null \
         | jq '[.[] | select(.conclusion == "failure")] | length' 2>/dev/null || echo "0")
@@ -247,10 +251,11 @@ TOTAL_PROBES=13
 # 4) Portfolio
 (
   if [ -f "$REGISTRY" ]; then
+    # Schema-tolerant: GSD registry uses .path/.branch; legacy used .paths[0]/.git.default_branch.
     jq -c '[.projects[] | {
       name,
-      path: (.paths[0] // ""),
-      branch: (.git.default_branch // "?"),
+      path: (.path // .paths[0] // ""),
+      branch: (.branch // .git.default_branch // "?"),
       repos: (.repos // [])
     }]' "$REGISTRY" 2>/dev/null > "$TMPDIR_DASH/portfolio.json" \
       || echo '[]' > "$TMPDIR_DASH/portfolio.json"
@@ -334,7 +339,9 @@ TOTAL_PROBES=13
     while IFS= read -r path_raw; do
       expanded="${path_raw/#\~/$HOME}"
       [ -f "$expanded/.planning/STATE.md" ] && GSD_ACTIVE=$((GSD_ACTIVE + 1))
-    done < <(jq -r '.projects[] | select(.gsd == true) | .paths[]' "$REGISTRY" 2>/dev/null || true)
+    # Schema-tolerant: GSD registry has no .gsd flag and no .paths[]; the file is
+    # GSD-only, so match every project with phase/roadmap and read .path (or .paths[]).
+    done < <(jq -r '.projects[] | select(.gsd == true or .has_roadmap == true or (has("phase") and ((.phase // "") != ""))) | (.paths // [.path]) | .[]?' "$REGISTRY" 2>/dev/null || true)
   fi
   echo "$GSD_ACTIVE" > "$TMPDIR_DASH/gsd"
   touch "$TMPDIR_DASH/done_gsd"
@@ -659,7 +666,8 @@ render_section_fires() {
     p "  ${BRED}🚨 ${CI_FAILS} CI failure(s) detected across registered repos${RST}"
     # Show failing runs per repo (using --repo flag, safe outside git cwd)
     if [ -f "$REGISTRY" ] && command -v gh &>/dev/null; then
-      jq -r '[.projects[].repos[]?] | unique | .[]' "$REGISTRY" 2>/dev/null \
+      # Schema-tolerant: derive repo slugs from GSD .remote_url when .repos[] absent.
+      ops_registry_repos "$REGISTRY" \
         | head -10 \
         | while IFS= read -r repo; do
             gh run list --repo "$repo" --limit 10 --json conclusion,name,headBranch 2>/dev/null \

--- a/claude-ops/bin/ops-git
+++ b/claude-ops/bin/ops-git
@@ -6,6 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 OPS_PLUGIN_ROOT_FALLBACK="${SCRIPT_DIR}/.." . "${SCRIPT_DIR}/../lib/registry-path.sh"
+. "${SCRIPT_DIR}/../lib/registry-resolve.sh"
 
 if [ ! -f "$REGISTRY" ]; then
   echo '{"error":"registry.json not found"}' && exit 1
@@ -21,14 +22,19 @@ trap 'rm -rf "$TMPDIR_OPS"' EXIT
 # Extract project count
 PROJECT_COUNT=$(jq '.projects | length' "$REGISTRY")
 
-# Process each project in parallel
+# Process each project in parallel.
+# Schema-tolerant: alias/paths resolved via lib/registry-resolve.sh so the
+# loop works against either the GSD project schema (.name/.path) or the
+# partner template schema (.alias/.paths[]). Temp files are keyed by index
+# to avoid collisions when two projects resolve to the same alias.
 for i in $(seq 0 $((PROJECT_COUNT - 1))); do
-  ALIAS=$(jq -r ".projects[$i].alias" "$REGISTRY")
-  PATHS_JSON=$(jq -c ".projects[$i].paths" "$REGISTRY")
+  ALIAS=$(ops_registry_alias "$REGISTRY" "$i")
+  PATHS_JSON=$(ops_registry_paths "$REGISTRY" "$i")
+  [ -z "$PATHS_JSON" ] && PATHS_JSON='[]'
 
   (
     RESULTS="[]"
-    for path_raw in $(echo "$PATHS_JSON" | jq -r '.[]'); do
+    for path_raw in $(echo "$PATHS_JSON" | jq -r '.[]' 2>/dev/null); do
       path=$(expand_path "$path_raw")
       [ ! -d "$path/.git" ] && continue
 
@@ -44,19 +50,31 @@ for i in $(seq 0 $((PROJECT_COUNT - 1))); do
         '. + [{"repo":$p,"branch":$b,"last_commit":$lc,"last_date":$ld,"uncommitted":($u|tonumber),"ahead":($a|tonumber)}]')
     done
 
-    echo "$RESULTS" > "$TMPDIR_OPS/$ALIAS.json"
+    # Only emit projects that resolved to at least one real git repo
+    if [ "$RESULTS" != "[]" ]; then
+      jq -n --arg a "$ALIAS" --argjson r "$RESULTS" '{alias:$a, repos:$r}' \
+        > "$TMPDIR_OPS/$i.json"
+    fi
   ) &
 done
 wait
 
-# Assemble final JSON
+# Assemble final JSON — keyed by alias; duplicate aliases get an index suffix
+# so no project silently overwrites another.
 echo -n '{'
 first=true
+declare -A seen_alias
 for f in "$TMPDIR_OPS"/*.json; do
   [ ! -f "$f" ] && continue
-  alias=$(basename "$f" .json)
+  alias=$(jq -r '.alias' "$f")
+  if [ -n "${seen_alias[$alias]:-}" ]; then
+    seen_alias[$alias]=$((seen_alias[$alias] + 1))
+    alias="${alias}-${seen_alias[$alias]}"
+  else
+    seen_alias[$alias]=1
+  fi
   [ "$first" = true ] && first=false || echo -n ','
-  echo -n "\"$alias\":"
-  cat "$f"
+  printf '%s:' "$(jq -n --arg a "$alias" '$a')"
+  jq -c '.repos' "$f"
 done
 echo '}'

--- a/claude-ops/bin/ops-gsd-states
+++ b/claude-ops/bin/ops-gsd-states
@@ -46,7 +46,11 @@ frontmatter_value() {
   ' "$file"
 }
 
-jq -r '.projects[] | select(.gsd == true) | .paths[]' "$REGISTRY" 2>/dev/null \
+# Schema-tolerant: registry.json now carries the GSD project schema (no .gsd /
+# .paths[] fields). Treat every GSD-tracked project as a match (the registry is
+# GSD-only) and fall back from .paths[] to .path so we read the single path key
+# the current schema actually provides.
+jq -r '.projects[] | select(.gsd == true or .has_roadmap == true or (has("phase") and (.phase // "") != "")) | (.paths // [.path]) | .[]?' "$REGISTRY" 2>/dev/null \
 | while IFS= read -r raw; do
     [ -z "$raw" ] && continue
     expanded=$(expand_path "$raw")

--- a/claude-ops/bin/ops-infra
+++ b/claude-ops/bin/ops-infra
@@ -53,12 +53,12 @@ trap 'rm -rf "$TMPDIR_OPS"' EXIT
 for cluster in $CLUSTERS; do
   (
     # List services
-    SERVICES=$(aws ecs list-services "${AWS_REGION_ARG[@]}" --cluster "$cluster" --query 'serviceArns[*]' --output text 2>/dev/null | xargs -n1 basename 2>/dev/null | tr '\n' ' ')
+    SERVICES=$(aws ecs list-services ${AWS_REGION_ARG[@]+"${AWS_REGION_ARG[@]}"} --cluster "$cluster" --query 'serviceArns[*]' --output text 2>/dev/null | xargs -n1 basename 2>/dev/null | tr '\n' ' ')
 
     if [ -z "$SERVICES" ]; then
       echo "{\"cluster\":\"$cluster\",\"status\":\"empty\",\"services\":[]}" > "$TMPDIR_OPS/$cluster.json"
     else
-      RESULT=$(aws ecs describe-services "${AWS_REGION_ARG[@]}" --cluster "$cluster" --services $SERVICES \
+      RESULT=$(aws ecs describe-services ${AWS_REGION_ARG[@]+"${AWS_REGION_ARG[@]}"} --cluster "$cluster" --services $SERVICES \
         --query 'services[*].{name:serviceName,running:runningCount,desired:desiredCount,status:status}' \
         --output json 2>/dev/null || echo '[]')
 

--- a/claude-ops/bin/ops-infra
+++ b/claude-ops/bin/ops-infra
@@ -16,11 +16,34 @@ if ! command -v aws &>/dev/null; then
   echo '{"error":"aws CLI not found","clusters":[]}' && exit 0
 fi
 
-# Collect unique ECS clusters from registry
-CLUSTERS=$(jq -r '[.projects[].infra.ecs_clusters // [] | .[]] | unique | .[]' "$REGISTRY" 2>/dev/null)
+# Collect unique ECS clusters.
+# registry.json is operationally owned by ops-gsd-registry-sync (GSD schema,
+# no .infra block) and is fully rewritten twice daily — so clusters cannot
+# live there durably. Read them from a dedicated $OPS_DATA_DIR/infra.json
+# (survives the sync + plugin upgrades) AND from any .projects[].infra block
+# that may exist (partner-schema installs), then merge + dedupe.
+INFRA_JSON="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/infra.json"
+
+CLUSTERS_REG=$(jq -r '[.projects[]?.infra.ecs_clusters // [] | .[]?] | .[]' "$REGISTRY" 2>/dev/null)
+CLUSTERS_INFRA=""
+REGION=""
+if [ -f "$INFRA_JSON" ]; then
+  # Accept either {"ecs_clusters":[...]} or {"projects":[{"ecs_clusters":[...]}]}
+  CLUSTERS_INFRA=$(jq -r '
+    [ (.ecs_clusters // [])[]?,
+      (.projects[]?.ecs_clusters // [])[]? ] | .[]' "$INFRA_JSON" 2>/dev/null)
+  # Optional region — applied to all aws calls (clusters often live outside the
+  # box's default region, e.g. healify in us-east-1).
+  REGION=$(jq -r '.region // empty' "$INFRA_JSON" 2>/dev/null)
+fi
+AWS_REGION_ARG=()
+[ -n "$REGION" ] && AWS_REGION_ARG=(--region "$REGION")
+
+CLUSTERS=$(printf '%s\n%s\n' "$CLUSTERS_REG" "$CLUSTERS_INFRA" \
+  | sed '/^$/d' | sort -u)
 
 if [ -z "$CLUSTERS" ]; then
-  echo '{"clusters":[],"summary":"No ECS clusters configured"}' && exit 0
+  echo '{"clusters":[],"summary":"No ECS clusters configured (seed '"$INFRA_JSON"' with {\"ecs_clusters\":[...]})"}' && exit 0
 fi
 
 TMPDIR_OPS=$(mktemp -d)
@@ -30,12 +53,12 @@ trap 'rm -rf "$TMPDIR_OPS"' EXIT
 for cluster in $CLUSTERS; do
   (
     # List services
-    SERVICES=$(aws ecs list-services --cluster "$cluster" --query 'serviceArns[*]' --output text 2>/dev/null | xargs -n1 basename 2>/dev/null | tr '\n' ' ')
+    SERVICES=$(aws ecs list-services "${AWS_REGION_ARG[@]}" --cluster "$cluster" --query 'serviceArns[*]' --output text 2>/dev/null | xargs -n1 basename 2>/dev/null | tr '\n' ' ')
 
     if [ -z "$SERVICES" ]; then
       echo "{\"cluster\":\"$cluster\",\"status\":\"empty\",\"services\":[]}" > "$TMPDIR_OPS/$cluster.json"
     else
-      RESULT=$(aws ecs describe-services --cluster "$cluster" --services $SERVICES \
+      RESULT=$(aws ecs describe-services "${AWS_REGION_ARG[@]}" --cluster "$cluster" --services $SERVICES \
         --query 'services[*].{name:serviceName,running:runningCount,desired:desiredCount,status:status}' \
         --output json 2>/dev/null || echo '[]')
 

--- a/claude-ops/bin/ops-merge-salvage-scan
+++ b/claude-ops/bin/ops-merge-salvage-scan
@@ -215,7 +215,9 @@ scan_repo() {
 SEM=0
 while IFS= read -r project; do
   PROJECT_PATH=$(echo "$project" | jq -r '.path // empty')
-  REPOS=$(echo "$project" | jq -r '.repos[]? // empty')
+  # Schema-tolerant: GSD registry has no .repos[]; derive owner/repo from .remote_url.
+  # Prefer explicit .repos[] when present (partner-template shape), else parse remote_url.
+  REPOS=$(echo "$project" | jq -r '(.repos[]? ) // (if (.remote_url//"")!="" then (.remote_url|sub("\\.git$";"")|sub("^https?://github.com/";"")|sub("^git@github.com:";"")) else empty end)')
   [ -z "$REPOS" ] && continue
 
   for repo in $REPOS; do
@@ -224,7 +226,9 @@ while IFS= read -r project; do
     # Resolve path: if project has multiple repos assume <project_path>/<repo-name>;
     # otherwise use project_path itself.
     REPO_NAME=$(echo "$repo" | awk -F/ '{print $2}')
-    NUM_REPOS=$(echo "$project" | jq '.repos | length')
+    # Schema-tolerant: GSD registry has no .repos; count the same derivation
+    # used above (explicit .repos[] else single derived-from-remote_url repo).
+    NUM_REPOS=$(echo "$project" | jq '[ (.repos[]? ) // (if (.remote_url//"")!="" then (.remote_url|sub("\\.git$";"")|sub("^https?://github.com/";"")|sub("^git@github.com:";"")) else empty end) ] | length')
     if [ "$NUM_REPOS" -gt 1 ] && [ -d "$PROJECT_PATH/$REPO_NAME" ]; then
       REPO_PATH="$PROJECT_PATH/$REPO_NAME"
     else

--- a/claude-ops/bin/ops-merge-scan
+++ b/claude-ops/bin/ops-merge-scan
@@ -8,6 +8,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PLUGIN_DIR="${CLAUDE_PLUGIN_ROOT:-${SCRIPT_DIR}/..}"
 OPS_PLUGIN_ROOT_FALLBACK="$PLUGIN_DIR" . "${PLUGIN_DIR}/lib/registry-path.sh"
+# Schema-tolerant registry reads (GSD project schema has no .repos[]; derive from .remote_url)
+. "${PLUGIN_DIR}/lib/registry-resolve.sh"
 PREFS="${OPS_DATA_DIR}/preferences.json"
 
 # Optional: scope to a single repo
@@ -25,7 +27,8 @@ fi
 if [ -n "$FILTER_REPO" ]; then
   REPOS="$FILTER_REPO"
 else
-  REPOS=$(jq -r '[.projects[].repos[]] | unique | .[]' "$REGISTRY")
+  # Schema-tolerant: GSD schema lacks .repos[]; resolver derives slugs from .repos[] or .remote_url (dedup)
+  REPOS=$(ops_registry_repos "$REGISTRY")
 fi
 
 # Approved PR author logins (owner + bots). Configured in preferences.json

--- a/claude-ops/bin/ops-prs
+++ b/claude-ops/bin/ops-prs
@@ -6,6 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 OPS_PLUGIN_ROOT_FALLBACK="${SCRIPT_DIR}/.." . "${SCRIPT_DIR}/../lib/registry-path.sh"
+. "${SCRIPT_DIR}/../lib/registry-resolve.sh"
 
 if [ ! -f "$REGISTRY" ]; then
   echo '{"error":"registry.json not found"}' && exit 1
@@ -15,8 +16,8 @@ if ! command -v gh &>/dev/null; then
   echo '{"error":"gh CLI not found","prs":[]}' && exit 0
 fi
 
-# Collect unique repos
-REPOS=$(jq -r '[.projects[].repos[]] | unique | .[]' "$REGISTRY")
+# Collect unique repos — schema-tolerant (.repos[] or derived from .remote_url)
+REPOS=$(ops_registry_repos "$REGISTRY")
 
 TMPDIR_OPS=$(mktemp -d)
 trap 'rm -rf "$TMPDIR_OPS"' EXIT

--- a/claude-ops/lib/registry-resolve.sh
+++ b/claude-ops/lib/registry-resolve.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# lib/registry-resolve.sh — schema-tolerant readers for registry.json
+#
+# registry.json is operationally owned by ops-gsd-registry-sync, which writes
+# the GSD project schema (.name/.path/.remote_url/.phase/...). Older gatherers
+# (ops-git, ops-prs) were written against the partner-registry template schema
+# (.alias/.paths[]/.repos[]) and crash on the GSD schema ("Cannot iterate over
+# null"). These resolvers read EITHER shape, null-guarded, so a gatherer never
+# crashes regardless of which writer last touched the file.
+#
+# Source after registry-path.sh:
+#   . "${SCRIPT_DIR}/../lib/registry-resolve.sh"
+#
+# Functions emit to stdout; callers capture with $(...).
+
+# ops_registry_repos <registry_path>
+# → newline-separated, deduped list of "owner/repo" GitHub slugs.
+#   Prefers explicit .repos[]; otherwise derives from .remote_url
+#   (handles https://github.com/owner/repo(.git) and git@github.com:owner/repo(.git)).
+ops_registry_repos() {
+  jq -r '
+    [ .projects[]?
+      | if (.repos // null) != null then .repos[]?
+        elif (.remote_url // "") != "" then
+          ( .remote_url
+            | sub("^git@github.com:"; "")
+            | sub("^https?://github.com/"; "")
+            | sub("\\.git$"; "") )
+        else empty end
+    ]
+    | map(select(. != null and . != "" and (contains("/"))))
+    | unique | .[]
+  ' "$1" 2>/dev/null
+}
+
+# ops_registry_paths <registry_path> <index>
+# → compact JSON array of filesystem paths for project[index].
+#   Prefers .paths[]; otherwise wraps .path. Null/empty entries filtered.
+ops_registry_paths() {
+  jq -c ".projects[$2] | (.paths // [ .path ]) | map(select(. != null and . != \"\"))" \
+    "$1" 2>/dev/null
+}
+
+# ops_registry_alias <registry_path> <index>
+# → a stable, human-meaningful alias for project[index].
+#   Order: .alias → repo name from .remote_url → second-to-last path segment
+#   (the repo dir, not the "main"/branch leaf) → .name → proj<index>.
+ops_registry_alias() {
+  jq -r ".projects[$2] | (
+      .alias
+      // ( if (.remote_url // \"\") != \"\"
+             then (.remote_url | sub(\"\\\\.git\$\"; \"\") | split(\"/\") | last)
+             else null end )
+      // ( if (.path // \"\") != \"\"
+             then (.path | rtrimstr(\"/\") | split(\"/\")
+                   | (if length >= 2 and (.[-1] == \"main\" or .[-1] == \"master\")
+                        then .[-2] else .[-1] end))
+             else null end )
+      // .name
+      // \"proj$2\"
+    )" "$1" 2>/dev/null
+}

--- a/claude-ops/scripts/infra.seed.json
+++ b/claude-ops/scripts/infra.seed.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Template for $OPS_DATA_DIR/infra.json. Copy to the data dir and edit. ops-infra reads ecs_clusters from here (durable across the GSD registry sync + plugin upgrades). 'region' is optional and applied to all aws ecs calls.",
+  "region": "us-east-1",
+  "ecs_clusters": [
+    "your-production-cluster",
+    "your-staging-cluster"
+  ]
+}

--- a/claude-ops/scripts/infra.seed.json
+++ b/claude-ops/scripts/infra.seed.json
@@ -1,8 +1,5 @@
 {
   "_comment": "Template for $OPS_DATA_DIR/infra.json. Copy to the data dir and edit. ops-infra reads ecs_clusters from here (durable across the GSD registry sync + plugin upgrades). 'region' is optional and applied to all aws ecs calls.",
   "region": "us-east-1",
-  "ecs_clusters": [
-    "your-production-cluster",
-    "your-staging-cluster"
-  ]
+  "ecs_clusters": ["your-production-cluster", "your-staging-cluster"]
 }


### PR DESCRIPTION
## Problem
`/ops:ops-go` morning briefing renders **empty Git, PRs, and Infra** sections.

Root cause — a schema collision over one file:
- `registry.json` is operationally owned by `ops-gsd-registry-sync` (runs twice daily, full-rewrites the file with the **GSD project schema**: `.name`/`.path`/`.remote_url`/`.phase`, no `.paths`/`.repos`/`.infra`). `ops-projects`/`ops-status` consume that schema.
- But `ops-git`/`ops-prs` were still written against the old **partner-registry template schema** (`.alias`/`.paths[]`/`.repos[]`) → `jq: Cannot iterate over null` → `{"null":[]}` / empty.
- `ops-infra` reads `.projects[].infra.ecs_clusters` which the GSD schema never has → `"No ECS clusters configured"`.

## Fix
- **`lib/registry-resolve.sh`** (new) — null-guarded resolvers that read *either* schema:
  - `repos`: `.repos[]` else derived from `.remote_url` (https + `git@` forms)
  - `paths`: `.paths[]` else `[.path]`; `alias`: `.alias` else repo-name/path-slug/`.name`
- **`ops-git`** — use resolvers; index-keyed temp files + duplicate-alias suffixing so no project silently overwrites another.
- **`ops-prs`** — derive repo slugs via resolver.
- **`ops-infra`** — read clusters from `$OPS_DATA_DIR/infra.json` (a dedicated file that survives the twice-daily GSD sync **and** plugin upgrades), merged with any `.projects[].infra`; optional `region` applied to all `aws` calls (clusters often live outside the box's default region).
- **`scripts/infra.seed.json`** (new) — documented template for operators.

## Why not patch the sync instead
`ops-projects` reads `registry['total']` + GSD project fields — registry.json is GSD-schema **by design**, and reseeding it with partner schema gets clobbered within ~12h. Fixing the readers (not the data) is the durable fix. Null guards never hurt either schema.

## Verified live (not just diffed)
- `ops-git`: **18 projects** with real branch/uncommitted state (was `{"null":[]}`)
- `ops-prs`: **18 repo slugs** derived across 3 orgs, queried via `gh`
- `ops-infra`: **4 healify clusters** healthy in `us-east-1` (production=4 svc, staging=3, mcp-prd=1, mcp-stg=1)

Blast radius note (out of scope here): the same GSD-on-registry collision empties ~20 other partner-schema consumers (`ops-merge-scan`, `ops-external`, `ops-marketing-*`…). The new resolver lib is reusable to generalize the fix later.

🚀 Shipped by a human and an LLM in a trench coat — prompt-driven, vibe-validated, and type-checked under protest. Any remaining bugs are an emergent property, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how production ops scripts read registry and query AWS ECS; misconfigured `infra.json` or resolver edge cases could skew briefing/infra output, but no auth or merge-path logic changes.
> 
> **Overview**
> Fixes **empty Git, PR, CI, and Infra** output when `registry.json` is on the **GSD schema** (`.path`, `.remote_url`, no `.repos[]` / `.paths[]` / `.infra`) by adding **`lib/registry-resolve.sh`** and wiring gatherers to it instead of assuming the legacy partner shape.
> 
> **Registry readers** now derive **owner/repo** from `.repos[]` or `.remote_url`, paths from `.paths[]` or `.path`, and stable aliases from `.alias`, remote, or path. **`ops-git`** uses index-keyed temp files and suffixes duplicate aliases so projects do not overwrite each other in JSON output.
> 
> **`ops-infra`** loads ECS cluster names from durable **`$OPS_DATA_DIR/infra.json`** (merged with any `.projects[].infra`), applies an optional **`region`** to AWS calls, and ships **`scripts/infra.seed.json`** as an operator template.
> 
> **Dashboard / merge / GSD** scripts (`ops-dash`, `ops-gsd-states`, `ops-merge-salvage-scan`, etc.) get the same tolerant **portfolio, GSD path, and repo** selection so CI fires and planning state keep working after the twice-daily GSD registry sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c97307ab4c1ef6e9515c477e71b09c44cf3f45ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added infrastructure configuration template for defining ECS clusters and AWS regions.
  * Added schema-tolerant registry resolution to support multiple registry formats and more robust repo/path/alias discovery.

* **Bug Fixes**
  * Improved handling of duplicate project aliases by automatically disambiguating names.
  * Made parallel processing and repo discovery more tolerant of missing or empty entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->