### PR TITLE
release: v2.18.14

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.18.13",
+      "version": "2.18.14",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.18.13",
+  "version": "2.18.14",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.18.14] - 2026-06-01
+
+### Changed
+Fix /ops:ops-go briefing empty Git/PRs/Infra/GSD sections — registry.json schema collision (GSD project schema vs old partner-template schema). New lib/registry-resolve.sh (null-guarded readers: repos from .remote_url, paths from .path, alias fallback) adopted by ops-git/ops-prs/ops-ci/ops-merge-scan/ops-dash; ops-merge-salvage-scan uses object-level derivation; ops-gsd-states matches the GSD-only registry (fixes empty GSD State); ops-infra reads ECS clusters from durable $OPS_DATA_DIR/infra.json (survives the twice-daily GSD sync + upgrades) with optional region. Audited all 20 registry consumers; 15 already tolerant/unrelated, no behavior change.
+
+
 ## [2.18.13] - 2026-05-31
 
 ### Fixed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.18.13",
+  "version": "2.18.14",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.18.14** (was 2.18.13).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

Fix /ops:ops-go briefing empty Git/PRs/Infra/GSD sections — registry.json schema collision (GSD project schema vs old partner-template schema). New lib/registry-resolve.sh (null-guarded readers: repos from .remote_url, paths from .path, alias fallback) adopted by ops-git/ops-prs/ops-ci/ops-merge-scan/ops-dash; ops-merge-salvage-scan uses object-level derivation; ops-gsd-states matches the GSD-only registry (fixes empty GSD State); ops-infra reads ECS clusters from durable $OPS_DATA_DIR/infra.json (survives the twice-daily GSD sync + upgrades) with optional region. Audited all 20 registry consumers; 15 already tolerant/unrelated, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only diff in the shown patch; operational risk depends on the registry-resolve changes referenced in the changelog, which are localized to ops briefing/gather scripts.
> 
> **Overview**
> **Release v2.18.14** bumps the plugin and npm package version from **2.18.13 → 2.18.14** in `plugin.json`, root `marketplace.json`, and `claude-ops/package.json`, and adds the **2.18.14** changelog entry.
> 
> The release notes describe a fix for **empty Git / PRs / Infra / GSD sections** in `/ops:ops-go` briefings caused by a **`registry.json` schema collision** (GSD project entries vs the older partner-template shape). That work is documented as: shared **`lib/registry-resolve.sh`** (null-safe alias, path, and repo resolution from `.path` / `.remote_url`), adoption by gather/dash scripts (`ops-git`, `ops-prs`, `ops-ci`, merge scans, `ops-dash`), GSD-state alignment, and **`ops-infra`** reading ECS config from durable **`$OPS_DATA_DIR/infra.json`** so infra survives GSD syncs. *(This PR diff only shows version + changelog files; implementation may live in other commits on the same release branch.)*
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff392f60ecb3f1cce395cbc50bb95d5f405f6719. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->