### PR TITLE
fix(ci): resolve pre-existing test-hooks + test-agent-teams failures

### DIFF
--- a/claude-ops/skills/flow/SKILL.md
+++ b/claude-ops/skills/flow/SKILL.md
@@ -9,9 +9,32 @@ allowed-tools:
   - Glob
   - Skill
   - Agent
+  - TeamCreate
+  - SendMessage
 effort: medium
 maxTurns: 20
 ---
+
+## Agent Teams support
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** when a
+lifecycle stage fans out into parallel, coordinated work (e.g. build + test +
+review running together, or a multi-repo ship). This enables:
+- Stage agents share context mid-flight (the test agent surfaces a regression →
+  the build agent pivots before review starts)
+- You can steer priorities in real time ("land the API change first, then docs")
+- Agents report progress as each stage completes, so you sequence the merge
+
+**Team setup** (only when the flag is enabled, and only for genuinely parallel stages):
+```
+TeamCreate("flow-lifecycle")
+Agent(team_name="flow-lifecycle", name="stage-build", ...)
+Agent(team_name="flow-lifecycle", name="stage-test", ...)
+```
+Steer with `SendMessage` / `broadcast`; share work via `TaskCreate`/`TaskUpdate`.
+
+If the flag is NOT set, fall back to standard fire-and-forget subagents (the
+default), or just route the stage to its single canonical command inline.
 
 ## Runtime Context
 

--- a/claude-ops/tests/test-hooks.sh
+++ b/claude-ops/tests/test-hooks.sh
@@ -101,7 +101,7 @@ fi
 echo ""
 echo "Checking hook event names..."
 
-valid_events=("SessionStart" "SessionEnd" "PreToolUse" "PostToolUse" "Stop" "SubagentStop" "Notification")
+valid_events=("SessionStart" "SessionEnd" "PreToolUse" "PostToolUse" "Stop" "SubagentStop" "Notification" "UserPromptSubmit" "PreCompact")
 
 if command -v jq &>/dev/null; then
   events=$(jq -r '.hooks | keys[]' "$HOOKS_FILE" 2>/dev/null || true)


### PR DESCRIPTION
Resolves the two pre-existing red CI suites on `main` (surfaced while shipping the ops-go registry fix in #433/#434 — unrelated to that work).

## Fixes
- **test-hooks.sh** — `valid_events` allowlist was missing `UserPromptSubmit` (which `hooks/hooks.json` legitimately declares; it's a real Claude Code hook event used by `approve-outbound-comms.py`) and `PreCompact`. Added both. → 19 passed, 0 failed.
- **test-agent-teams.sh** — the `flow` skill declares `Agent` in allowed-tools (it spawns agents) but lacked the Agent Teams boilerplate the suite enforces on every agent-spawning skill. Added `TeamCreate` + `SendMessage` to allowed-tools and an `## Agent Teams support` section (flag check + `TeamCreate()` example + fallback), modeled on `ops-fires`. → 114 passed, 0 failed.

## Verification
Both suites green locally. Full `run-all.sh` locally leaves only `test-safety-hooks.sh` + `test-deploy-fix-hooks.sh` red — those are **environment-specific** (hook output / `claude`-mock harness on this box) and **pass in CI's clean runner**: the prior CI run failed *exactly* test-hooks + test-agent-teams and no others. CI on this PR is the ground truth.

🚀 Shipped by a human and an LLM in a trench coat — prompt-driven, vibe-validated, and type-checked under protest. Any remaining bugs are an emergent property, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test allowlist and skill documentation/frontmatter only; no runtime hook or routing behavior changes beyond what was already configured.
> 
> **Overview**
> Aligns CI test suites with **already-valid** hook config and the **`flow`** skill’s agent usage.
> 
> **`test-hooks.sh`** now treats **`UserPromptSubmit`** and **`PreCompact`** as allowed top-level hook events, matching keys in `hooks/hooks.json` (e.g. inbox autosync on prompt submit) so the event-name check stops failing on `main`.
> 
> **`skills/flow/SKILL.md`** adds **`TeamCreate`** / **`SendMessage`** to `allowed-tools` and an **Agent Teams support** section (flag-gated teams for parallel lifecycle stages, fallback to fire-and-forget subagents), satisfying **`test-agent-teams.sh`** for a skill that already declares **`Agent`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d547875e7c4524e70cc8fc9f7fe7e70acd17d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->