### PR TITLE
release: v2.18.15

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.18.14",
+      "version": "2.18.15",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.18.14",
+  "version": "2.18.15",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.18.15] - 2026-06-01
+
+### Changed
+CI: fix two pre-existing red suites blocking the merge gate. test-hooks.sh — add UserPromptSubmit + PreCompact to the valid hook-event allowlist (UserPromptSubmit is a real Claude Code event declared in hooks.json). test-agent-teams.sh — add Agent Teams boilerplate to the `flow` skill (TeamCreate + SendMessage in allowed-tools, '## Agent Teams support' section with flag check + example + fallback), matching every other agent-spawning skill. Full CI green for the first time.
+
+
 ## [2.18.14] - 2026-06-01
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.18.14",
+  "version": "2.18.15",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.18.15** (was 2.18.14).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

CI: fix two pre-existing red suites blocking the merge gate. test-hooks.sh — add UserPromptSubmit + PreCompact to the valid hook-event allowlist (UserPromptSubmit is a real Claude Code event declared in hooks.json). test-agent-teams.sh — add Agent Teams boilerplate to the `flow` skill (TeamCreate + SendMessage in allowed-tools, '## Agent Teams support' section with flag check + example + fallback), matching every other agent-spawning skill. Full CI green for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes in the shown diff; CI/test alignment is low risk and does not alter runtime plugin behavior for end users.
> 
> **Overview**
> **Release v2.18.15** bumps the ops plugin version in sync across **marketplace.json**, **plugin.json**, **package.json**, and **CHANGELOG.md** (2.18.14 → 2.18.15).
> 
> Per the changelog, this release also documents **CI fixes** that were blocking the merge gate: **`test-hooks.sh`** now treats **`UserPromptSubmit`** and **`PreCompact`** as valid hook events (aligned with **`hooks.json`**), and the **`flow`** skill was brought in line with other agent-spawning skills for **Agent Teams** (`TeamCreate` / `SendMessage`, allowed-tools, and an Agent Teams section) so **`test-agent-teams.sh`** passes. The visible diff in this PR is primarily the version/metadata sync; those test/skill changes are described as part of the release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f04181cc708cf64351f81eceb168dda7a0abd72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->