### PR TITLE
release: v2.18.16

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.18.15",
+      "version": "2.18.16",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.18.15",
+  "version": "2.18.16",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.18.16] - 2026-06-01
+
+### Changed
+Ship Fix K: recover_app_state MCP tool canonicalized in apply-patches (15th mcp__whatsapp__* tool); ENDPOINTS.md updated
+
+
 ## [2.18.15] - 2026-06-01
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.18.15",
+  "version": "2.18.16",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.18.16** (was 2.18.15).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

Ship Fix K: recover_app_state MCP tool canonicalized in apply-patches (15th mcp__whatsapp__* tool); ENDPOINTS.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff only updates version fields and changelog; no runtime logic in the shown patch. Low risk unless unreleased apply-patches changes ship separately without review.
> 
> **Overview**
> **Release v2.18.16** bumps the plugin version in lockstep across **`.claude-plugin/marketplace.json`**, **`claude-ops/.claude-plugin/plugin.json`**, and **`claude-ops/package.json`** (2.18.15 → 2.18.16).
> 
> **`CHANGELOG.md`** adds the 2.18.16 entry documenting **Ship Fix K**: canonicalizing the **`recover_app_state`** WhatsApp MCP tool in **`apply-patches`** (15th `mcp__whatsapp__*` tool) and updating **`ENDPOINTS.md`**. The attached diff is metadata-only; functional patch/docs changes are described in the changelog and may land in the same release branch outside this diff hunk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beb7c300a96f3fb4c3c2cbd300a3e7b7437e9092. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->