### PR TITLE
release: v2.18.17

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.18.16",
+      "version": "2.18.17",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.18.16",
+  "version": "2.18.17",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.18.17] - 2026-06-01
+
+### Changed
+Fix L: WhatsApp bridge phone-online prerequisite gate (recover/archive 503 when offline) + archive auto-retry on 409 conflict + recovery-with-backfill-on-alive
+
+
 ## [2.18.16] - 2026-06-01
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.18.16",
+  "version": "2.18.17",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.18.17** (was 2.18.16).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

Fix L: WhatsApp bridge phone-online prerequisite gate (recover/archive 503 when offline) + archive auto-retry on 409 conflict + recovery-with-backfill-on-alive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff is version and changelog only; Fix L tightens WhatsApp bridge failure modes (503 when offline, auto-recovery on archive conflicts), which is operational hardening rather than auth or data-model changes.
> 
> **Overview**
> **Release v2.18.17** bumps the plugin and package version from **2.18.16 → 2.18.17** in `plugin.json`, marketplace registry, and `claude-ops/package.json`, and adds a **CHANGELOG** entry for this cut.
> 
> The functional headline is **Fix L (WhatsApp bridge)**: **`/api/recover_app_state`** and **`/api/archive`** now require the phone to be online (`IsConnected` + `IsLoggedIn`) and return **503** when the link is down instead of implying success. **`/api/archive`** on app-state **409 conflict** triggers automatic recovery and a bounded retry, and recovery while connected can pair with **history backfill** so ops callers need fewer manual recover→retry steps.
> 
> This diff is **release metadata only** (no bridge source edits in the patch hunk); the bridge behavior is what the version documents as shipped in **2.18.17**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f7f30b45e63e3a25f2490f84d0904a32467f6d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->