### PR TITLE
chore(pocket): bump webhook deps — fastapi 0.136.3, uvicorn 0.48.0

### DIFF
--- a/claude-ops/skills/ops-pocket/webhook-server/requirements.txt
+++ b/claude-ops/skills/ops-pocket/webhook-server/requirements.txt
@@ -1,2 +1,2 @@
-fastapi==0.115.5
-uvicorn[standard]==0.32.1
+fastapi==0.136.3
+uvicorn[standard]==0.48.0


### PR DESCRIPTION
Bumps the Pocket Layer-1 webhook server from `fastapi==0.115.5` / `uvicorn[standard]==0.32.1` (months stale) to latest `0.136.3` / `0.48.0`.

**Safe for the deploy target:** the webhook ships as Docker `python:3.12-slim` on Render (`Dockerfile` + `render.yaml`), where both versions are compatible (fastapi 0.136 needs ≥3.10; this box's 3.9 is irrelevant to the deploy).

**Verified by building the real image:** `docker build` on `python:3.12-slim` installs both clean, and `import main` loads the FastAPI app OK (only needs `POCKET_HMAC_SECRET` at runtime, as expected).

🚀 Shipped by a human and an LLM in a trench coat — prompt-driven, vibe-validated, and type-checked under protest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no logic changes; main risk is minor framework/runtime behavior differences between FastAPI/uvicorn minor versions.
> 
> **Overview**
> Updates pinned dependencies for the Pocket Layer-1 webhook server in `requirements.txt`: **FastAPI** `0.115.5` → `0.136.3` and **uvicorn[standard]** `0.32.1` → `0.48.0`. No changes to `main.py`, the Dockerfile, or webhook/HMAC behavior—only the dependency lockfile moves forward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79268106b90df358478b6eddc96be263d9ee57b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->