### PR TITLE
fix(ops-go): briefing surfaces Home + Marketing; correct FinOps note (v2.18.17)

### DIFF
--- a/claude-ops/bin/ops-home
+++ b/claude-ops/bin/ops-home
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# ops-home — smart-home (Homey Pro) probe for the morning briefing.
+#
+# The morning briefing (skills/ops-go/SKILL.md) and incident dashboard
+# (skills/ops-fires/SKILL.md) call:
+#     ${CLAUDE_PLUGIN_ROOT}/bin/ops-home snapshot
+# This binary previously DID NOT EXIST — only skills/ops-home/SKILL.md was
+# present — so every briefing hit file-not-found and rendered the fallback
+# {"configured":true,"error":"home probe failed"}. This script provides the
+# missing `snapshot` producer.
+#
+# Output (snapshot): a single JSON object the briefing renders into the HOME line:
+#   {"configured":bool, "power_w":num|null, "kwh_today":num|null,
+#    "alarms":{"active":int,"types":[...]}, "presence":null,
+#    "devices":{"total":int,"online":int}, "last_flow":obj|null,
+#    "homey_version":str}
+#
+# Cred resolution: env HOMEY_PRO_API_KEY, else Doppler
+# (project/config read from prefs channels.home, falling back to home_automation).
+# API base + Homey id are read from prefs channels.home; constructed from id if
+# only the id is present. All probes are non-fatal: a failed/absent endpoint maps
+# to null/0 so the briefing always receives parseable JSON.
+#
+# Verified live (fw 13.2.1, cloud proxy connect.athom.com):
+#   /manager/system        200
+#   /manager/energy/live   200  (power = .totalConsumed.W, NOT .totalPower)
+#   /manager/alarms/alarm  200  (OBJECT keyed by id, not an array)
+#   /manager/devices/device 200 (OBJECT keyed by id)
+#   /manager/flow/flow     200  (OBJECT keyed by id; .lastExecuted often null)
+#   /manager/energy/report 404  -> kwh_today null
+#   /manager/presence      404  -> presence null
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck disable=SC1091
+OPS_PLUGIN_ROOT_FALLBACK="${SCRIPT_DIR}/.." . "${SCRIPT_DIR}/../lib/registry-path.sh"
+PREFS="${OPS_DATA_DIR}/preferences.json"
+
+CMD="${1:-snapshot}"
+
+emit() { printf '%s\n' "$1"; }
+
+# ---- resolve config from prefs (channels.home, then home_automation) ----
+H_DPROJ=""; H_DCFG=""; H_ID=""; H_BASE=""
+if [ -f "$PREFS" ]; then
+  H_DPROJ="$(jq -r '.channels.home.doppler_project // .home_automation.doppler_project // empty' "$PREFS" 2>/dev/null)"
+  H_DCFG="$(jq -r '.channels.home.config // .home_automation.config // empty' "$PREFS" 2>/dev/null)"
+  H_ID="$(jq -r '.channels.home.homey_pro_id // empty' "$PREFS" 2>/dev/null)"
+  H_BASE="$(jq -r '.channels.home.api_base // empty' "$PREFS" 2>/dev/null)"
+fi
+[ -z "$H_BASE" ] && [ -n "$H_ID" ] && H_BASE="https://${H_ID}.connect.athom.com/api"
+
+# ---- resolve API key: env first, then Doppler ----
+KEY="${HOMEY_PRO_API_KEY:-}"
+if [ -z "$KEY" ] && command -v doppler >/dev/null 2>&1 && [ -n "$H_DPROJ" ]; then
+  KEY="$(doppler secrets get HOMEY_PRO_API_KEY --project "$H_DPROJ" --config "${H_DCFG:-dev}" --plain 2>/dev/null || true)"
+fi
+
+if [ "$CMD" != "snapshot" ]; then
+  echo "usage: ops-home snapshot" >&2
+  exit 64
+fi
+
+# Not configured -> briefing omits the HOME section.
+if [ -z "$KEY" ] || [ -z "$H_BASE" ]; then
+  emit '{"configured":false}'
+  exit 0
+fi
+
+# homey_get <path> -> response body on HTTP 2xx, else empty string.
+homey_get() {
+  local path="$1" body code
+  body="$(curl -s --max-time 20 -o - -w '\n%{http_code}' \
+    -H "Authorization: Bearer ${KEY}" "${H_BASE}${path}" 2>/dev/null)" || { printf ''; return 0; }
+  code="${body##*$'\n'}"
+  body="${body%$'\n'*}"
+  if [ "$code" -ge 200 ] 2>/dev/null && [ "$code" -lt 300 ] 2>/dev/null; then
+    printf '%s' "$body"
+  else
+    printf ''
+  fi
+}
+
+# Reachability gate: /manager/system must answer 200.
+SYS="$(homey_get /manager/system)"
+SYS_VER="$(printf '%s' "$SYS" | jq -r '.homeyVersion // .softwareVersion // empty' 2>/dev/null || echo "")"
+if [ -z "$SYS" ]; then
+  emit '{"configured":true,"error":"home probe failed: system unreachable"}'
+  exit 0
+fi
+
+# Live power: .totalConsumed.W (NOT .totalPower).
+ENERGY="$(homey_get /manager/energy/live)"
+POWER_W="$(printf '%s' "$ENERGY" | jq -r '(.totalConsumed.W // .totalPower // empty)' 2>/dev/null || echo "")"
+if [ -n "$POWER_W" ]; then
+  POWER_W="$(awk "BEGIN{printf \"%.1f\", ${POWER_W}+0}" 2>/dev/null || echo "")"
+fi
+
+# Alarms: OBJECT keyed by id. Active = those with .active==true (handles object
+# or array form). Also collect active alarm names/types for severity.
+ALARMS="$(homey_get /manager/alarms/alarm)"
+ALARM_ACTIVE="$(printf '%s' "$ALARMS" | jq -r '[ (if type=="object" then .[] else .[]? end) | select(.active==true) ] | length' 2>/dev/null || echo 0)"
+ALARM_TYPES="$(printf '%s' "$ALARMS" | jq -c '[ (if type=="object" then .[] else .[]? end) | select(.active==true) | (.name // .type // "alarm") ]' 2>/dev/null || echo '[]')"
+[ -z "$ALARM_ACTIVE" ] && ALARM_ACTIVE=0
+[ -z "$ALARM_TYPES" ] && ALARM_TYPES='[]'
+
+# Devices: OBJECT keyed by id.
+DEVICES="$(homey_get /manager/devices/device)"
+DEV_TOTAL="$(printf '%s' "$DEVICES" | jq -r '[ (if type=="object" then .[] else .[]? end) ] | length' 2>/dev/null || echo 0)"
+DEV_ONLINE="$(printf '%s' "$DEVICES" | jq -r '[ (if type=="object" then .[] else .[]? end) | select(.available==true) ] | length' 2>/dev/null || echo 0)"
+[ -z "$DEV_TOTAL" ] && DEV_TOTAL=0
+[ -z "$DEV_ONLINE" ] && DEV_ONLINE=0
+
+# Flows: OBJECT keyed by id; pick most-recently-executed (null when none have run).
+FLOWS="$(homey_get /manager/flow/flow)"
+LAST_FLOW="$(printf '%s' "$FLOWS" | jq -c '[ (if type=="object" then .[] else .[]? end) | select(.lastExecuted != null) ] | sort_by(.lastExecuted) | reverse | (.[0] // null) | (if . == null then null else {name: (.name // "flow"), lastExecuted: .lastExecuted} end)' 2>/dev/null || echo 'null')"
+[ -z "$LAST_FLOW" ] && LAST_FLOW='null'
+
+# kwh_today + presence not available on this firmware (404) -> null.
+jq -n \
+  --argjson power "${POWER_W:-null}" \
+  --argjson alarms_active "${ALARM_ACTIVE:-0}" \
+  --argjson alarm_types "${ALARM_TYPES:-[]}" \
+  --argjson dev_total "${DEV_TOTAL:-0}" \
+  --argjson dev_online "${DEV_ONLINE:-0}" \
+  --argjson last_flow "${LAST_FLOW:-null}" \
+  --arg version "${SYS_VER}" \
+  '{
+    configured: true,
+    power_w: $power,
+    kwh_today: null,
+    alarms: {active: $alarms_active, types: $alarm_types},
+    presence: null,
+    devices: {total: $dev_total, online: $dev_online},
+    last_flow: $last_flow,
+    homey_version: (if $version == "" then null else $version end)
+  }'

--- a/claude-ops/bin/ops-marketing-dash
+++ b/claude-ops/bin/ops-marketing-dash
@@ -39,15 +39,45 @@ if [ -z "$PROJECT" ] && [ -f "$PREFS" ]; then
   PROJECT="$(jq -r '.marketing.default_project // empty' "$PREFS" 2>/dev/null || true)"
 fi
 
-# Credential resolution — three-tier:
-#   1. Project config in preferences.json (NEW, primary)
+# Read a Doppler-ref from preferences.json channels.marketing.<channel>.<key_field>.
+# This is the OWNER-LEVEL marketing schema (channels.marketing.*) — distinct from
+# the project-scoped marketing.projects.<project>.* schema that prefs_get reads.
+# The channel block names a Doppler SECRET via a *_key field plus doppler_project
+# + config, e.g.:
+#   channels.marketing.klaviyo = {doppler_project, config, key: "BRIGHT_KLAVIYO_TOKEN"}
+#   channels.marketing.meta    = {doppler_project, config, system_user_token_key: "..."}
+# Key names may carry a @project suffix (e.g. "VITE_GA4_MEASUREMENT_ID@healify-web")
+# which overrides doppler_project for that single secret.
+# $1=channel  $2=key_field  -> resolved secret value (empty if unresolvable).
+prefs_marketing_cred() {
+  [ -f "$PREFS" ] || return 0
+  local channel="$1" key_field="$2" keyname dproj dcfg realkey suffixproj
+  keyname="$(jq -r --arg c "$channel" --arg f "$key_field" \
+    '.channels.marketing[$c][$f] // empty' "$PREFS" 2>/dev/null)"
+  [ -z "$keyname" ] && return 0
+  dproj="$(jq -r --arg c "$channel" '.channels.marketing[$c].doppler_project // empty' "$PREFS" 2>/dev/null)"
+  dcfg="$(jq -r --arg c "$channel" '.channels.marketing[$c].config // empty' "$PREFS" 2>/dev/null)"
+  realkey="${keyname%@*}"
+  suffixproj="${keyname#*@}"
+  [ "$suffixproj" != "$keyname" ] && dproj="$suffixproj"
+  [ -z "$dproj" ] || [ -z "$realkey" ] && return 0
+  doppler secrets get "$realkey" --project "$dproj" --config "${dcfg:-prd}" --plain 2>/dev/null || true
+}
+
+# Credential resolution — four-tier:
+#   1. Project config in preferences.json marketing.projects.<p>.<c>.<f> (project mode)
 #   2. Flat env / `claude plugin config get` (legacy)
 #   3. Doppler with bare key name (legacy)
+#   4. channels.marketing.<channel>.<key_field> owner-level Doppler-ref (NEW) —
+#      this tier is what lets the morning briefing resolve creds that live in
+#      Doppler under the owner-level schema. Pass it via the 5th/6th args.
 get_cred() {
   local proj_channel="$1"  # e.g. "klaviyo.private_key"
   local env_var="$2"
   local plugin_key="$3"
   local doppler_key="${4:-}"
+  local cm_channel="${5:-}"   # channels.marketing.<channel>
+  local cm_keyfield="${6:-}"  # .<key_field> naming the Doppler secret
 
   local val=""
   if [ -n "$PROJECT" ]; then
@@ -60,22 +90,71 @@ get_cred() {
   if [ -z "$val" ] && [ -n "$doppler_key" ]; then
     val="$(doppler secrets get "$doppler_key" --plain 2>/dev/null || echo "")"
   fi
+  if [ -z "$val" ] && [ -n "$cm_channel" ] && [ -n "$cm_keyfield" ]; then
+    val="$(prefs_marketing_cred "$cm_channel" "$cm_keyfield")"
+  fi
   printf '%s' "$val"
 }
 
-KLAVIYO_KEY="$(get_cred 'klaviyo.private_key' KLAVIYO_PRIVATE_KEY klaviyo_private_key KLAVIYO_PRIVATE_KEY)"
-META_TOKEN="$(get_cred 'meta.access_token' META_ADS_TOKEN meta_ads_token META_ADS_TOKEN)"
-META_ACCOUNT="$(get_cred 'meta.ad_account_id' META_AD_ACCOUNT_ID meta_ad_account_id META_AD_ACCOUNT_ID)"
+# The 5th/6th args add the owner-level channels.marketing.<channel>.<key_field>
+# Doppler-ref fallback (see get_cred). This is the tier the morning briefing
+# relies on — Healify's marketing creds live in Doppler under channels.marketing.
+KLAVIYO_KEY="$(get_cred 'klaviyo.private_key' KLAVIYO_PRIVATE_KEY klaviyo_private_key KLAVIYO_PRIVATE_KEY klaviyo key)"
+META_TOKEN="$(get_cred 'meta.access_token' META_ADS_TOKEN meta_ads_token META_ADS_TOKEN meta system_user_token_key)"
+# meta fallback_env names an env-resident token (META_HEALIFY_ACCESS_TOKEN) — try it last.
+if [ -z "$META_TOKEN" ]; then
+  _meta_fb="$(jq -r '.channels.marketing.meta.fallback_env // empty' "$PREFS" 2>/dev/null)"
+  [ -n "$_meta_fb" ] && META_TOKEN="${!_meta_fb:-}"
+fi
+META_ACCOUNT="$(get_cred 'meta.ad_account_id' META_AD_ACCOUNT_ID meta_ad_account_id META_AD_ACCOUNT_ID meta ad_account_id_key)"
+# GA4 property id: prefer the project-scoped tier, then the owner-level
+# channels.marketing.ga4.property_id (a literal id, not a Doppler ref).
 GA4_PROPERTY="$(get_cred 'ga4.property_id' GA4_PROPERTY_ID ga4_property_id)"
+if [ -z "$GA4_PROPERTY" ] && [ -f "$PREFS" ]; then
+  GA4_PROPERTY="$(jq -r '.channels.marketing.ga4.property_id // empty' "$PREFS" 2>/dev/null)"
+fi
+# GA4 read auth uses an SA key file (analytics.readonly). prefs names it under
+# channels.marketing.ga4.sa_json; export it so ga4_auth_token (ga4-data-api.sh)
+# picks it up. Expand a leading ~ to $HOME.
+if [ -z "${GA4_SERVICE_ACCOUNT_KEY_FILE:-}" ] && [ -f "$PREFS" ]; then
+  _ga4_sa="$(jq -r '.channels.marketing.ga4.sa_json // empty' "$PREFS" 2>/dev/null)"
+  [ -n "$_ga4_sa" ] && GA4_SERVICE_ACCOUNT_KEY_FILE="${_ga4_sa/#\~/$HOME}"
+  export GA4_SERVICE_ACCOUNT_KEY_FILE
+fi
 GSC_SITE="$(get_cred 'gsc.site_url' GOOGLE_SEARCH_CONSOLE_SITE google_search_console_site)"
-GADS_DEV_TOKEN="$(get_cred 'google_ads.developer_token' GOOGLE_ADS_DEVELOPER_TOKEN google_ads_developer_token)"
+GADS_DEV_TOKEN="$(get_cred 'google_ads.developer_token' GOOGLE_ADS_DEVELOPER_TOKEN google_ads_developer_token GOOGLE_ADS_DEVELOPER_TOKEN google_ads dev_token_key)"
 GADS_CLIENT_ID="${GOOGLE_ADS_CLIENT_ID:-$(claude plugin config get google_ads_client_id 2>/dev/null || echo "")}"
 GADS_CLIENT_SECRET="${GOOGLE_ADS_CLIENT_SECRET:-$(claude plugin config get google_ads_client_secret 2>/dev/null || echo "")}"
-GADS_REFRESH_TOKEN="$(get_cred 'google_ads.refresh_token' GOOGLE_ADS_REFRESH_TOKEN google_ads_refresh_token GOOGLE_ADS_REFRESH_TOKEN)"
+GADS_REFRESH_TOKEN="$(get_cred 'google_ads.refresh_token' GOOGLE_ADS_REFRESH_TOKEN google_ads_refresh_token GOOGLE_ADS_REFRESH_TOKEN google_ads refresh_token_key)"
 GADS_CUSTOMER_ID="$(get_cred 'google_ads.customer_id' GOOGLE_ADS_CUSTOMER_ID google_ads_customer_id)"
 GADS_LOGIN_CUSTOMER_ID="${GOOGLE_ADS_LOGIN_CUSTOMER_ID:-$(claude plugin config get google_ads_login_customer_id 2>/dev/null || echo "")}"
 INSTAGRAM_ACCOUNT_ID="$(get_cred 'instagram.account_id' INSTAGRAM_ACCOUNT_ID instagram_account_id)"
-META_APP_SECRET="$(get_cred 'meta.app_secret' META_APP_SECRET meta_app_secret META_APP_SECRET)"
+# Meta app secret enables appsecret_proof (required for system-user tokens).
+# prefs stores it under channels.marketing.meta.app_secret_key (Doppler ref);
+# also accept a bare META_HEALIFY_APP_SECRET @ claude-ops/prd as a known location.
+META_APP_SECRET="$(get_cred 'meta.app_secret' META_APP_SECRET meta_app_secret META_APP_SECRET meta app_secret_key)"
+if [ -z "$META_APP_SECRET" ]; then
+  META_APP_SECRET="$(doppler secrets get META_HEALIFY_APP_SECRET --project claude-ops --config prd --plain 2>/dev/null || echo "")"
+fi
+
+# Meta ad-account id: prefs carries only the Business Manager id (bm_id_key), not
+# an act_ id. If we have a token+secret but no ad account, resolve the first owned
+# ad account via the BM. Leaves META_ACCOUNT empty (meta insights null) on failure
+# — never fabricated.
+if [ -z "$META_ACCOUNT" ] && [ -n "$META_TOKEN" ] && [ -n "$META_APP_SECRET" ] && [ -f "$PREFS" ]; then
+  _bm_keyname="$(jq -r '.channels.marketing.meta.bm_id_key // empty' "$PREFS" 2>/dev/null)"
+  _bm_id=""
+  if [ -n "$_bm_keyname" ]; then
+    _bm_dproj="$(jq -r '.channels.marketing.meta.doppler_project // empty' "$PREFS" 2>/dev/null)"
+    _bm_dcfg="$(jq -r '.channels.marketing.meta.config // "prd"' "$PREFS" 2>/dev/null)"
+    _bm_id="$(doppler secrets get "$_bm_keyname" --project "${_bm_dproj:-healify-marketing}" --config "${_bm_dcfg:-prd}" --plain 2>/dev/null || echo "")"
+  fi
+  if [ -n "$_bm_id" ]; then
+    _bm_proof="$(printf '%s' "$META_TOKEN" | openssl dgst -sha256 -hmac "$META_APP_SECRET" -hex 2>/dev/null | awk '{print $NF}')"
+    META_ACCOUNT="$(curl -gsS --max-time 8 "https://graph.facebook.com/v21.0/${_bm_id}/owned_ad_accounts?fields=id&limit=1&appsecret_proof=${_bm_proof}" \
+      -H "Authorization: Bearer ${META_TOKEN}" 2>/dev/null | jq -r '.data[0].id // empty' 2>/dev/null || echo "")"
+  fi
+fi
 
 # Compute appsecret_proof for projects that require it (Meta system-user tokens
 # and any project with app_secret configured). Empty string when no secret.
@@ -90,6 +169,12 @@ META_PROOF_QS=""
 
 # Strip dashes from customer ID (API requires no dashes)
 GADS_CUSTOMER_ID="${GADS_CUSTOMER_ID//-/}"
+
+# NOTE on remaining gaps (intentional, not bugs):
+#   GSC — needs a one-time SA grant on the Search Console property
+#         (gap gsc_api: AUTH_READY_GRANT_PENDING). Stays null until granted.
+#   Google Ads — resolves dev+refresh tokens but also needs client_id/secret +
+#         customer_id; if any are absent the channel returns null (expected).
 
 TODAY=$(date +%Y-%m-%d)
 
@@ -353,7 +438,7 @@ GADS_SPEND_RAW=$(echo "$GADS_DATA" | jq '[.[].results[]?.metrics.costMicros // "
 GADS_REV_RAW=$(echo "$GADS_DATA" | jq '[.[].results[]?.metrics.conversionsValue // "0" | tonumber] | add // 0' 2>/dev/null || echo "0")
 TOTAL_SPEND=$(awk "BEGIN { printf \"%.2f\", ${META_SPEND:-0} + ${GADS_SPEND_RAW:-0} }")
 TOTAL_REV=$(awk "BEGIN { printf \"%.2f\", ${META_REV:-0} + ${GADS_REV_RAW:-0} }")
-BLENDED_ROAS=$(awk "BEGIN { if (${TOTAL_SPEND:-0} > 0) printf \"%.2f\", ${TOTAL_REV:-0} / ${TOTAL_SPEND:-1}; else print \"0\" }")
+BLENDED_ROAS=$(awk -v s="${TOTAL_SPEND:-0}" -v v="${TOTAL_REV:-0}" 'BEGIN { s=s+0; v=v+0; if (s > 0) printf "%.2f", v/s; else print "0" }')
 
 # Compute marketing health score (0-100)
 # ROAS score (0-30)

--- a/claude-ops/skills/ops-go/SKILL.md
+++ b/claude-ops/skills/ops-go/SKILL.md
@@ -101,10 +101,20 @@ that case the briefing falls back to the per-source data below.
 ${CLAUDE_PLUGIN_ROOT}/scripts/finops-bridge.sh snapshot 2>/dev/null || echo "{}"
 ```
 
-When this snapshot is non-empty, prefer it for the burn/runway/anomaly
-lines in the briefing. The per-source `Infrastructure` and AWS Cost
-Explorer sections below are kept as a fallback when the dashboard is
-unreachable.
+**Interpreting the snapshot — two different empty states, do NOT conflate:**
+
+1. **`{}` or unreachable** → `FINOPS_DASHBOARD_URL` / `FINOPS_OPS_API_TOKEN`
+   genuinely unset (or the dashboard is down). Report "FinOps creds unset" and
+   fall back to per-source AWS Cost Explorer / `Infrastructure` below.
+2. **Snapshot present (non-null `generated_at`) but `services_tracked: 0` and
+   all-zero `current_month_spend`/`revenue_snapshot`** → dashboard reachable +
+   authenticated, but its **ingest pipeline is unpopulated**. This is NOT a
+   creds problem — do NOT report "token unset". Say "FinOps dashboard reachable
+   but ingest empty" and fall back to per-source data for burn/revenue.
+
+When the snapshot has non-zero `services_tracked`, prefer it for the
+burn/runway/anomaly lines. The per-source `Infrastructure` and AWS Cost
+Explorer sections below are the fallback for both empty states above.
 
 ### Infrastructure
 


### PR DESCRIPTION
## What

The morning briefing (`/ops:ops-go`) showed **Home**, **Marketing**, and **FinOps** as empty/'not configured' even though all creds exist in Doppler + the registry. Three root causes:

### 1. Home — `bin/ops-home` binary never existed
`skills/ops-go/SKILL.md` and `skills/ops-fires/SKILL.md` call `${CLAUDE_PLUGIN_ROOT}/bin/ops-home snapshot`, but only `skills/ops-home/SKILL.md` existed → file-not-found → fallback `{"error":"home probe failed"}` every run. **NEW** `bin/ops-home` snapshot producer: resolves `HOMEY_PRO_API_KEY` from `doppler homey-optimization/dev` (reads project/config/id from prefs `channels.home`), probes the `connect.athom.com` cloud proxy. Live-verified: `{"configured":true,"power_w":7.6,"alarms":{"active":0},"devices":{"total":40,"online":40}}`. Handles fw 13.2.1 quirks (energy/report + presence 404 → null; alarms is an object not array; flows object-keyed).

### 2. Marketing — schema mismatch
`bin/ops-marketing-dash` `get_cred` resolved only from `marketing.projects.<key>.<channel>`, but prefs uses `channels.marketing.<channel>.<*_key>` Doppler-refs. Added a fallback tier that reads the `*_key` + `doppler_project`/`config` from `channels.marketing` and does `doppler secrets get`. Klaviyo / Meta (with `appsecret_proof` via META_HEALIFY_APP_SECRET) / Google Ads / Ahrefs now resolve. GA4 + GSC stay null pending the one-time property grant (documented gap `gsc_api: AUTH_READY_GRANT_PENDING`).

### 3. FinOps — doc-only correction
The briefing implied empty = 'token unset'. Verified false: token IS set, dashboard returns 200, but `services_tracked:0` / all-zero = unpopulated ingest (dashboard-side). Corrected `ops-go/SKILL.md` to distinguish (a) `{}`/unreachable = creds unset → fall back to Cost Explorer, from (b) `generated_at` present + `services_tracked:0` = reachable-but-unpopulated.

## Test
- `bash -n` clean on both bins.
- `bin/ops-home snapshot` → live 200, real watts + device counts.
- `bin/ops-marketing-dash` → configured channels resolve (no longer empty {}).

v2.18.16 → **2.18.17** (plugin.json + marketplace.json + package.json + CHANGELOG).

🚀 Shipped by a human and an LLM in a trench coat — prompt-driven, vibe-validated, and type-checked under protest. Any remaining bugs are an emergent property, not a regression.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New external API calls and Doppler/Meta credential paths affect live briefing data; changes are read-only probes with fail-open JSON but broaden secret resolution and Graph API usage.
> 
> **Overview**
> The morning briefing was showing empty **Home**, **Marketing**, and misleading **FinOps** states despite configured credentials. This PR wires up the missing probes and fixes how marketing secrets and FinOps emptiness are interpreted.
> 
> **Home:** Adds **`bin/ops-home`** with a `snapshot` command the briefing already invoked but that did not exist. It resolves Homey Pro config from prefs/Doppler, calls the cloud API with fail-open probes, and emits JSON for power, alarms, devices, and last flow.
> 
> **Marketing:** Extends **`bin/ops-marketing-dash`** so `get_cred` can read owner-level **`channels.marketing.*`** Doppler refs (not only `marketing.projects.*`), including Meta `appsecret_proof`, optional BM → first ad account resolution, GA4 SA key export, and a safer blended ROAS awk calculation.
> 
> **FinOps (docs):** Updates **`skills/ops-go/SKILL.md`** to separate “creds unset / unreachable `{}`” from “dashboard reachable but ingest empty (`services_tracked: 0`)” so the briefing does not mislabel an unpopulated pipeline as missing tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22d99dbf7257395520de6219901493171227ef00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->