### PR TITLE
release: v2.18.19

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.18.18",
+      "version": "2.18.19",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.18.18",
+  "version": "2.18.19",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.18.19] - 2026-06-01
+
+### Changed
+Ship bin/ops-home snapshot producer (Homey Pro: power, alarms, presence, devices) so ops-go/ops-fires Home section resolves instead of 'home probe failed'. Project-aware ops-marketing-dash with owner-level channels.marketing Doppler-ref cred tier so the briefing Marketing section resolves Healify GA4/Meta/Klaviyo. (Code merged via #443 without a version bump; this cuts the actual release.)
+
+
 ## [2.18.18] - 2026-06-01
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.18.18",
+  "version": "2.18.19",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.18.19** (was 2.18.18).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

Ship bin/ops-home snapshot producer (Homey Pro: power, alarms, presence, devices) so ops-go/ops-fires Home section resolves instead of 'home probe failed'. Project-aware ops-marketing-dash with owner-level channels.marketing Doppler-ref cred tier so the briefing Marketing section resolves Healify GA4/Meta/Klaviyo. (Code merged via #443 without a version bump; this cuts the actual release.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff is version strings and changelog only; no runtime code changes in this PR. Operational impact comes from prior #443 merge already on the branch being released.
> 
> **Overview**
> Cuts **v2.18.19** by bumping the plugin version from **2.18.18** in `claude-ops/.claude-plugin/plugin.json`, root `.claude-plugin/marketplace.json`, and `claude-ops/package.json`, and adding a **CHANGELOG** entry for that release.
> 
> The changelog documents behavior already merged in **#443** (not in this diff): **`bin/ops-home`** as a Homey Pro snapshot producer so **`/ops:go`** / fires **Home** sections stop failing with “home probe failed”, and **project-aware `ops-marketing-dash`** using owner-level **`channels.marketing`** Doppler-ref creds so briefing **Marketing** (e.g. Healify GA4/Meta/Klaviyo) can resolve.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5e12cf5eeddebd22cecb5fe8133026e82fa5a2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->