### PR TITLE
feat(ops-inbox): offline scan script — replace ~330k-token agent fan-out

### DIFF
--- a/claude-ops/bin/ops-inbox-scan
+++ b/claude-ops/bin/ops-inbox-scan
@@ -69,7 +69,7 @@ export OIS_GMAIL_ACCOUNT="$GMAIL_ACCOUNT" OIS_PRETTY="$PRETTY"
 GMAIL_JSON_FILE=""
 GMAIL_ERR=""
 if [ "$DO_EMAIL" = 1 ]; then
-  GMAIL_JSON_FILE="$(mktemp "${TMPDIR:-/tmp}/ois-gmail.XXXXXX.json")"
+  GMAIL_JSON_FILE="$(mktemp "${TMPDIR:-/tmp}/ois-gmail.XXXXXX")"
   trap 'rm -f "$GMAIL_JSON_FILE"' EXIT
   ACCT_ARGS=()
   [ -n "$GMAIL_ACCOUNT" ] && ACCT_ARGS=(-a "$GMAIL_ACCOUNT")
@@ -288,6 +288,16 @@ def scan_whatsapp():
     return out
 
 # ------------------------------------------------------------------- Email ----
+def from_email_addr(header):
+    """Bare address from a From header (exact match; avoids substring false positives)."""
+    if not header:
+        return ""
+    m = re.search(r"<([^>]+)>", header)
+    if m:
+        return m.group(1).lower().strip()
+    m = re.search(r"[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}", header.lower())
+    return m.group(0) if m else header.lower().strip()
+
 def scan_email():
     res = {"account": ACCT or "(gog default account)",
            "needs_reply": [], "waiting": [], "fyi": [], "reachable": True}
@@ -317,7 +327,7 @@ def scan_email():
             "date": r.get("date"),
             "labels": labels,
         }
-        is_sent_last = ("SENT" in labels) or (self_addr and self_addr in frm)
+        is_sent_last = ("SENT" in labels) or (self_addr and self_addr == from_email_addr(frm))
         promo = any(l in labels for l in ("CATEGORY_PROMOTIONS", "CATEGORY_SOCIAL",
                                           "CATEGORY_UPDATES", "CATEGORY_FORUMS"))
         # Conservative no-reply / automated-sender heuristic: route obvious

--- a/claude-ops/bin/ops-inbox-scan
+++ b/claude-ops/bin/ops-inbox-scan
@@ -1,0 +1,366 @@
+#!/usr/bin/env bash
+# ops-inbox-scan — offline, (near) zero-token inbox scan + classify.
+#
+# WHY: the /ops:ops-inbox "all channels" path used to fan out one subagent per
+# channel through the Workflow tool. A single run burned ~330k subagent tokens to
+# do work that is, for the two heaviest channels, just a sqlite read (WhatsApp)
+# and a CLI call (Gmail). This script does that classification deterministically
+# in the main process and prints compact JSON, so the skill reads a tiny result
+# instead of paying for 5 agent contexts.
+#
+# COVERS (offline, no MCP, no subagents):
+#   - WhatsApp  : reads the whatsmeow bridge sqlite store directly; merges each
+#                 person's lid<->phone chats into one conversation; classifies
+#                 NEEDS_REPLY / WAITING / FYI from the true last message.
+#   - Email     : `gog gmail search` envelope first-pass classify (NEEDS_REPLY /
+#                 WAITING / FYI). Deep per-thread reads stay in the skill, run
+#                 only for the handful of NEEDS_REPLY candidates before drafting.
+#
+# DOES NOT COVER (left to the skill as single, light inline MCP calls — NOT
+# subagents): Slack (one conversations_unreads call) and Telegram (one
+# list_dialogs call). Those are one round-trip each; a subagent is overkill.
+#
+# OUTPUT: one JSON object on stdout. Always valid JSON, even on partial failure.
+# READ-ONLY: opens every sqlite db in immutable/read-only mode; never sends,
+# archives, or mutates anything. All sending stays in the skill under Rule 6.
+#
+# FLAGS:
+#   --whatsapp-only / --email-only   limit to one channel
+#   --days N                         recency window (default 7)
+#   --gmail-account ADDR             override Gmail account (default: gog default)
+#   --pretty                         pretty-print JSON
+set -euo pipefail
+
+DAYS=7
+DO_WA=1
+DO_EMAIL=1
+GMAIL_ACCOUNT="${GMAIL_ACCOUNT:-}"
+PRETTY=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --whatsapp-only) DO_EMAIL=0 ;;
+    --email-only)    DO_WA=0 ;;
+    --days)          DAYS="${2:-7}"; shift ;;
+    --gmail-account) GMAIL_ACCOUNT="${2:-}"; shift ;;
+    --pretty)        PRETTY=1 ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "ops-inbox-scan: unknown arg: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+WA_STORE="${WHATSAPP_BRIDGE_DIR:-$HOME/.local/share/whatsapp-mcp/whatsapp-bridge}/store"
+WA_MSGDB="${WHATSAPP_BRIDGE_DB:-$WA_STORE/messages.db}"
+WA_WADB="$WA_STORE/whatsapp.db"
+
+# Resolve a default Gmail account from gog if not supplied (best-effort).
+if [ "$DO_EMAIL" = 1 ] && [ -z "$GMAIL_ACCOUNT" ]; then
+  GMAIL_ACCOUNT="$(gog whoami 2>/dev/null | head -1 | grep -oE '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+' || true)"
+fi
+
+export OIS_DAYS="$DAYS" OIS_DO_WA="$DO_WA" OIS_DO_EMAIL="$DO_EMAIL"
+export OIS_WA_MSGDB="$WA_MSGDB" OIS_WA_WADB="$WA_WADB"
+export OIS_GMAIL_ACCOUNT="$GMAIL_ACCOUNT" OIS_PRETTY="$PRETTY"
+
+# Gmail is fetched in bash (gog is a CLI) and handed to python via a temp file so
+# python never shells out. Empty file => python emits an "unreachable" note.
+GMAIL_JSON_FILE=""
+GMAIL_ERR=""
+if [ "$DO_EMAIL" = 1 ]; then
+  GMAIL_JSON_FILE="$(mktemp "${TMPDIR:-/tmp}/ois-gmail.XXXXXX.json")"
+  trap 'rm -f "$GMAIL_JSON_FILE"' EXIT
+  ACCT_ARGS=()
+  [ -n "$GMAIL_ACCOUNT" ] && ACCT_ARGS=(-a "$GMAIL_ACCOUNT")
+  if ! gog gmail search "${ACCT_ARGS[@]}" -j --results-only --no-input \
+        --max 30 "in:inbox newer_than:${DAYS}d" >"$GMAIL_JSON_FILE" 2>"${GMAIL_JSON_FILE}.err"; then
+    GMAIL_ERR="$(head -c 400 "${GMAIL_JSON_FILE}.err" 2>/dev/null | tr '\n' ' ')"
+    : >"$GMAIL_JSON_FILE"   # blank => unreachable
+  fi
+  rm -f "${GMAIL_JSON_FILE}.err" 2>/dev/null || true
+fi
+export OIS_GMAIL_JSON_FILE="$GMAIL_JSON_FILE" OIS_GMAIL_ERR="$GMAIL_ERR"
+
+python3 <<'PY'
+import os, sys, json, sqlite3, re
+from datetime import datetime, timezone
+
+DAYS      = int(os.environ.get("OIS_DAYS", "7"))
+DO_WA     = os.environ.get("OIS_DO_WA") == "1"
+DO_EMAIL  = os.environ.get("OIS_DO_EMAIL") == "1"
+MSGDB     = os.environ.get("OIS_WA_MSGDB", "")
+WADB      = os.environ.get("OIS_WA_WADB", "")
+ACCT      = os.environ.get("OIS_GMAIL_ACCOUNT", "")
+PRETTY    = os.environ.get("OIS_PRETTY") == "1"
+GMAIL_F   = os.environ.get("OIS_GMAIL_JSON_FILE", "")
+GMAIL_ERR = os.environ.get("OIS_GMAIL_ERR", "")
+
+now = datetime.now(timezone.utc)
+notes = []
+
+def age_min(ts_str):
+    if not ts_str:
+        return None
+    s = ts_str.strip().replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        # try trimming fractional seconds / odd offsets
+        try:
+            dt = datetime.fromisoformat(re.sub(r"\.\d+", "", s))
+        except ValueError:
+            return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int((now - dt.astimezone(timezone.utc)).total_seconds() // 60)
+
+def trunc(s, n=160):
+    s = (s or "").replace("\n", " ").strip()
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+# ---------------------------------------------------------------- WhatsApp ----
+def ro(path):
+    # mode=ro (NOT immutable=1): the bridge writes this DB live in WAL mode;
+    # immutable=1 skips the -wal file and would hide the freshest, uncheckpointed
+    # messages. mode=ro respects WAL + locking and never mutates.
+    return sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+
+def scan_whatsapp():
+    out = {"needs_reply": [], "waiting": [], "groups": [], "fyi": []}
+    if not os.path.exists(MSGDB):
+        notes.append(f"whatsapp: store not found ({MSGDB}) — bridge not installed?")
+        return out
+    con = ro(MSGDB)
+    con.row_factory = sqlite3.Row
+
+    # lid<->phone map: lid_jid -> pn_jid  (authoritative, from whatsmeow store)
+    lid2pn = {}
+    if os.path.exists(WADB):
+        try:
+            w = ro(WADB)
+            for lid, pn in w.execute("SELECT lid, pn FROM whatsmeow_lid_map"):
+                lid2pn[f"{lid}@lid"] = f"{pn}@s.whatsapp.net"
+            w.close()
+        except sqlite3.Error as e:
+            notes.append(f"whatsapp: lid_map unreadable ({e}); falling back to contacts.phone")
+
+    # contacts: jid -> name, and phone -> jids (fallback merge + name resolution)
+    name_by_jid, phone_by_jid, jids_by_phone = {}, {}, {}
+    try:
+        for jid, name, phone in con.execute(
+            "SELECT jid, name, phone FROM contacts"
+        ):
+            if name:
+                name_by_jid[jid] = name
+            if phone:
+                phone_by_jid[jid] = phone
+                jids_by_phone.setdefault(phone, set()).add(jid)
+    except sqlite3.Error:
+        pass
+
+    def canonical(jid):
+        # Prefer the phone JID as the canonical key so a person's lid + phone
+        # chats collapse to one conversation.
+        if jid in lid2pn:
+            return lid2pn[jid]
+        ph = phone_by_jid.get(jid)
+        if ph:
+            for cand in jids_by_phone.get(ph, ()):
+                if cand.endswith("@s.whatsapp.net"):
+                    return cand
+        return jid
+
+    # Pull non-archived chats (groups/newsletters separated below).
+    chats = list(con.execute(
+        "SELECT jid, name, last_message_time FROM chats "
+        "WHERE archived=0 ORDER BY last_message_time DESC"
+    ))
+
+    # Build merged DM groups keyed by canonical jid.
+    groups = {}   # canonical_jid -> {member_jids:set, name, latest_ts}
+    g_chats = []  # @g.us
+    n_chats = []  # @newsletter
+    for c in chats:
+        jid = c["jid"]
+        if jid.endswith("@g.us"):
+            g_chats.append(c); continue
+        if jid.endswith("@newsletter") or jid.endswith("@broadcast"):
+            n_chats.append(c); continue
+        key = canonical(jid)
+        g = groups.setdefault(key, {"members": set(), "name": None, "latest": None})
+        g["members"].add(jid)
+        g["members"].add(key)
+        nm = name_by_jid.get(jid) or (c["name"] if c["name"] and not c["name"][0].isdigit() else None)
+        if nm and not g["name"]:
+            g["name"] = nm
+        if c["last_message_time"] and (g["latest"] is None or c["last_message_time"] > g["latest"]):
+            g["latest"] = c["last_message_time"]
+
+    def last_msgs(jids, limit=6):
+        qs = ",".join("?" * len(jids))
+        rows = con.execute(
+            f"SELECT is_from_me, content, media_type, timestamp, sender "
+            f"FROM messages WHERE chat_jid IN ({qs}) "
+            f"ORDER BY timestamp DESC LIMIT ?",
+            (*jids, limit),
+        ).fetchall()
+        return rows  # newest first
+
+    # DM classification
+    for key, g in groups.items():
+        members = sorted(g["members"])
+        rows = last_msgs(members, 6)
+        if not rows:
+            continue
+        last = rows[0]
+        am = age_min(last["timestamp"])
+        # NO hard recency cutoff: archived=0 IS the working-set filter. An
+        # unanswered ask from 10 days ago is still actionable (per SKILL.md).
+        # Recency only sorts (below).
+        name = (g["name"]
+                or name_by_jid.get(key)
+                or re.sub(r"@.*$", "", key))
+        preview = []
+        for r in reversed(rows):  # oldest->newest for readability
+            body = r["content"]
+            if not body and r["media_type"]:
+                body = f"[{r['media_type']}]"
+            preview.append({
+                "from_me": bool(r["is_from_me"]),
+                "text": trunc(body, 140),
+            })
+        item = {
+            "who": name,
+            "jid": key,
+            "alt_jids": [j for j in members if j != key],
+            "last_message_at": last["timestamp"],
+            "age_min": am,
+            "last_from_me": bool(last["is_from_me"]),
+            "preview": preview,
+        }
+        if last["is_from_me"]:
+            out["waiting"].append(item)
+        else:
+            out["needs_reply"].append(item)
+
+    # Group chats — surface recent ones for the skill to scan for @mentions /
+    # direct questions. Provisional status from last-message direction only.
+    for c in g_chats:
+        rows = last_msgs([c["jid"]], 6)
+        if not rows:
+            continue
+        last = rows[0]
+        am = age_min(last["timestamp"])
+        preview = []
+        for r in reversed(rows):
+            body = r["content"] or (f"[{r['media_type']}]" if r["media_type"] else "")
+            preview.append({
+                "from_me": bool(r["is_from_me"]),
+                "sender": re.sub(r"@.*$", "", r["sender"] or ""),
+                "text": trunc(body, 140),
+            })
+        out["groups"].append({
+            "who": c["name"] or re.sub(r"@.*$", "", c["jid"]),
+            "jid": c["jid"],
+            "last_message_at": last["timestamp"],
+            "age_min": am,
+            "last_from_me": bool(last["is_from_me"]),
+            "preview": preview,
+            "note": "group — scan preview for @mention/direct question before NEEDS_REPLY",
+        })
+
+    # Newsletters/broadcasts are always FYI.
+    for c in n_chats:
+        am = age_min(c["last_message_time"])
+        out["fyi"].append({
+            "who": c["name"] or re.sub(r"@.*$", "", c["jid"]),
+            "jid": c["jid"],
+            "last_message_at": c["last_message_time"],
+            "age_min": am,
+            "reason": "newsletter/broadcast",
+        })
+
+    con.close()
+    # Stable ordering: most recent first within each bucket.
+    for b in ("needs_reply", "waiting", "groups", "fyi"):
+        out[b].sort(key=lambda x: x.get("age_min") if x.get("age_min") is not None else 1 << 30)
+    return out
+
+# ------------------------------------------------------------------- Email ----
+def scan_email():
+    res = {"account": ACCT or "(gog default account)",
+           "needs_reply": [], "waiting": [], "fyi": [], "reachable": True}
+    if not GMAIL_F or not os.path.exists(GMAIL_F) or os.path.getsize(GMAIL_F) == 0:
+        res["reachable"] = False
+        res["note"] = "gmail unreachable: " + (GMAIL_ERR or "empty result from gog gmail search")
+        return res
+    try:
+        with open(GMAIL_F) as fh:
+            data = json.load(fh)
+    except (json.JSONDecodeError, OSError) as e:
+        res["reachable"] = False
+        res["note"] = f"gmail result unparseable: {e}"
+        return res
+    rows = data if isinstance(data, list) else data.get("results", data.get("threads", []))
+    self_addr = ACCT.lower()
+    for r in rows or []:
+        labels = r.get("labels") or r.get("labelIds") or []
+        labels = [str(l).upper() for l in labels]
+        frm = (r.get("from") or "").lower()
+        subj = r.get("subject") or "(no subject)"
+        tid = r.get("threadId") or r.get("id") or r.get("thread_id")
+        item = {
+            "who": r.get("from") or "(unknown)",
+            "subject": trunc(subj, 120),
+            "threadId": tid,
+            "date": r.get("date"),
+            "labels": labels,
+        }
+        is_sent_last = ("SENT" in labels) or (self_addr and self_addr in frm)
+        promo = any(l in labels for l in ("CATEGORY_PROMOTIONS", "CATEGORY_SOCIAL",
+                                          "CATEGORY_UPDATES", "CATEGORY_FORUMS"))
+        # Conservative no-reply / automated-sender heuristic: route obvious
+        # machine senders to FYI so they don't inflate needs_reply. Sender-address
+        # only — never subject keywords (those risk hiding real humans).
+        automated = bool(re.search(
+            r"(no[-_.]?reply|do[-_.]?not[-_.]?reply|notifications?@|alerts?@|"
+            r"mailer-daemon|postmaster@|@.*\.amazonses\.com|bounce)", frm))
+        if is_sent_last:
+            res["waiting"].append(item)
+        elif promo or automated:
+            res["fyi"].append(item)
+        else:
+            item["note"] = "first-pass (envelope) — deep-read thread before drafting"
+            res["needs_reply"].append(item)
+    return res
+
+# ------------------------------------------------------------------ assemble --
+result = {
+    "generated_at": now.isoformat(),
+    "window_days": DAYS,
+    "notes": notes,
+}
+if DO_WA:
+    result["whatsapp"] = scan_whatsapp()
+if DO_EMAIL:
+    result["email"] = scan_email()
+
+# Counts for a quick headline.
+def cnt(ch, bucket):
+    return len(result.get(ch, {}).get(bucket, []) or [])
+result["counts"] = {
+    "whatsapp": {b: cnt("whatsapp", b) for b in ("needs_reply", "waiting", "groups", "fyi")} if DO_WA else None,
+    "email":    {b: cnt("email", b) for b in ("needs_reply", "waiting", "fyi")} if DO_EMAIL else None,
+}
+result["notes"].append(
+    "Slack + Telegram NOT scanned here — the skill does one light inline MCP call each "
+    "(conversations_unreads / list_dialogs), no subagent."
+)
+result["notes"].append(
+    "WhatsApp store may lag phone-sent messages; confirm 'did I already reply?' with the human "
+    "for any NEEDS_REPLY before drafting (FULL-THREAD AWARENESS GATE)."
+)
+
+print(json.dumps(result, indent=2 if PRETTY else None, ensure_ascii=False))
+PY

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -256,13 +256,75 @@ sqlite3 "$DB" "SELECT jid, name, phone FROM contacts WHERE name LIKE '%<name>%' 
 ---
 
 
-## Scan engine — parallel Workflow fan-out (primary)
+## Scan engine — offline script first (primary), Workflow only for what it can't reach
 
-When scanning more than one channel (the "all channels" path, or any multi-channel
-selection), use the **`Workflow` tool** to fan out one **read-only** scanner agent per
-*available* channel, then synthesize. This replaces the old sequential / fire-and-forget
-scan: channels are scanned concurrently, each returns structured classified results, and
-wall-clock collapses to the slowest single channel instead of the sum of all of them.
+**Run `bin/ops-inbox-scan` FIRST. It is the primary scan engine.** It classifies the two
+heaviest channels — WhatsApp (direct read of the whatsmeow sqlite store) and Email (one
+`gog gmail search`) — deterministically, in-process, in well under a second, emitting compact
+JSON. No subagents, no MCP, near-zero tokens.
+
+```bash
+"$CLAUDE_PLUGIN_ROOT/bin/ops-inbox-scan" --pretty            # both channels
+"$CLAUDE_PLUGIN_ROOT/bin/ops-inbox-scan" --whatsapp-only     # WA only
+"$CLAUDE_PLUGIN_ROOT/bin/ops-inbox-scan" --days 14           # wider window
+```
+
+**Why this exists:** the multi-channel scan used to fan out one Workflow subagent per
+channel. A single real run burned **~330k subagent tokens / 5 agents / ~130s** to do work
+that, for WhatsApp, is a sqlite read, and for Email, a CLI call. The script does the same
+classification (and *better* — it merges each person's lid↔phone chats into one
+conversation and resolves real names from `contacts`) for free. Reserve agent fan-out for
+genuine reasoning, not for reading a database.
+
+`ops-inbox-scan` output (always valid JSON, even on partial failure):
+
+```jsonc
+{
+  "generated_at": "…", "window_days": 7,
+  "whatsapp": {
+    "needs_reply": [ { "who", "jid", "alt_jids", "last_message_at", "age_min",
+                       "last_from_me", "preview":[{from_me,text}] } ],
+    "waiting":  [ … ],   // you sent last — no action
+    "groups":   [ … ],   // group chats w/ recent activity + preview — YOU scan these
+                         // for @mentions / a direct question before any NEEDS_REPLY
+    "fyi":      [ … ]    // newsletters / broadcasts
+  },
+  "email": { "reachable": true, "needs_reply":[…], "waiting":[…], "fyi":[…] },
+  "counts": { … }, "notes": [ … ]
+}
+```
+
+**What the script does NOT do — and what you do next, in the MAIN session (no subagents):**
+
+1. **Slack** — one `mcp__slack__conversations_unreads {include_messages:true}` call. One
+   round-trip; a subagent is pure overhead. Skip entirely if prefs show 0 workspaces.
+2. **Telegram** — one `mcp__plugin_ops_telegram__list_dialogs` call (skip the
+   `@SamCloudDevBot` / Pocket ops bot dialog — that's automation). Skip if unconfigured.
+3. **FULL-THREAD AWARENESS GATE on the few NEEDS_REPLY candidates** — the script's WhatsApp
+   buckets are merged-thread, last-direction-correct *first passes*; its `groups` entries
+   are explicitly un-classified. Its email `needs_reply` is an envelope first pass. Before
+   you draft ANY reply, clear the gate per "Processing each channel": for the handful of
+   candidates, read the full thread both directions (incl. `[voice]`), write the 2-sentence
+   arc, reconcile the user's own phone-sent messages, and demote anything already answered.
+   You are now doing deep reads on ~3 threads, not scanning hundreds — that is the whole
+   point of the split: cheap script-side triage, expensive reasoning only where it pays.
+
+**When to fall back to the Workflow fan-out below (the exception, not the default):** only
+when the script genuinely can't cover a channel that has real volume needing per-thread
+*reasoning* — e.g. a Slack/Telegram backlog of dozens of human threads to classify, an
+iMessage host (macOS) the script doesn't read, or the WhatsApp store is down and you must
+classify via live MCP. For the common case (WA + email + a glance at Slack/Telegram), the
+script + a couple of inline MCP calls replaces the entire fan-out.
+
+---
+
+### Workflow fan-out (FALLBACK — only per the "when to fall back" note above)
+
+When the script can't reach a channel that has real per-thread volume, use the **`Workflow`
+tool** to fan out one **read-only** scanner agent per *such* channel, then synthesize.
+Channels are scanned concurrently and wall-clock collapses to the slowest single channel.
+**Do not run this for channels the script already covered** — that re-burns the tokens this
+engine exists to save.
 
 **Hard constraints (these override convenience — they are how this stays Rule-6-safe):**
 
@@ -330,7 +392,10 @@ const SCAN_SCHEMA = {
 }
 
 phase('Scan')
-const scans = (await parallel(args.map(c => () =>
+// args can arrive as a JSON string (harness serialization) — parse defensively
+// so the fan-out never dies with "args.map is not a function".
+const CHANNELS = (typeof args === 'string' ? JSON.parse(args) : args) || []
+const scans = (await parallel(CHANNELS.map(c => () =>
   agent(
     \`READ-ONLY inbox scanner for the "\${c.key}" channel. You MUST NOT send, archive, \` +
     \`mark-read, or mutate anything — read / search ONLY.\\n\` +
@@ -496,7 +561,7 @@ For each channel, detect availability at runtime:
 
 1. **Parse pre-gathered data** for initial counts (unread is just a starting signal).
 
-2. **For each channel, run a FULL scan** (not just unread). Drive this via the **Scan engine** above — a parallel `Workflow` fan-out of read-only scanners (Agent Teams / sequential as the documented fallback). The per-channel detail below defines what each scanner reads and how the main session presents results and replies:
+2. **For each channel, run a FULL scan** (not just unread). Drive this via the **Scan engine** above: run `bin/ops-inbox-scan` FIRST (offline WhatsApp + Email classify, near-zero tokens), then one inline `mcp__slack__conversations_unreads` and one `mcp__plugin_ops_telegram__list_dialogs` call for those channels — NO subagents. Fall back to the `Workflow` fan-out only for a channel with real per-thread volume the script can't reach (see "when to fall back"). The per-channel detail below defines what each reader covers and how the main session presents results and replies:
    - **Email**: Search `in:inbox` (not `is:unread`) via `gog gmail search -a $GMAIL_ACCOUNT -j --results-only --no-input --max 30 "in:inbox"`. For each thread, read the last message to determine who sent it last. Check for DRAFT or SENT labels. **Before suggesting to send a draft, verify no reply was already sent in the thread.**
    - **WhatsApp**: Call `mcp__whatsapp__list_chats {sort_by: "last_active"}` to get all chats. Filter to chats with `last_message_time` in the last 7 days (`last_message_time` is RFC3339+TZ — parse with timezone awareness, never strip the offset). Resolve display name from contacts.db first (`SELECT name FROM contacts WHERE jid=?`), fall back to the chat's `name` field, and only call giga memory when both are empty. Use `last_is_from_me` on the chat object (`1` = WAITING, `0` = NEEDS_REPLY) ONLY as a first pass — it does NOT finalise a classification. Before marking any chat NEEDS_REPLY you MUST clear the **FULL-THREAD AWARENESS GATE** above: fetch `mcp__whatsapp__list_messages {chat_jid, limit: 25}` reading BOTH directions (capture `is_from_me=1` rows AND `[voice]` transcripts), write the 2-sentence arc summary, and reconcile the user's own sends that may be missing from the store.
    - **iMessage**: Call `mcp__plugin_imessage_imessage__chat_messages {limit: 30}` (omit `chat_guid` to pull every allowlisted thread at once). Output is rendered text, not JSON: each thread is labelled `DM`/`Group` with its participant list, then timestamped messages oldest-first. Sent-by-you messages are marked (`Me:` / `→`); inbound messages carry the sender handle. Classify each thread by who sent the LAST message — same NEEDS_REPLY / WAITING / FYI logic as WhatsApp.


### PR DESCRIPTION
## Why
The `/ops:ops-inbox` multi-channel scan fanned out one `Workflow` subagent per channel. A single real run on dev-sandbox-fra burned **~330k subagent tokens / 5 agents / ~130s** to do work that — for the two heaviest channels — is a sqlite read (WhatsApp) and one CLI call (Email). Sam flagged it: "fix this so next run you're more token efficient … can be one sh script."

## What
**New `bin/ops-inbox-scan`** — deterministic, in-process, **read-only** classifier (Rule-6 safe; never sends/archives/mutates):
- **WhatsApp**: direct read of the whatsmeow sqlite store. Merges each person's `lid`↔`phone` chats into ONE conversation (`whatsmeow_lid_map`, `contacts.phone` fallback) so a contact isn't double-counted NEEDS_REPLY on `@lid` + WAITING on phone. Classifies `needs_reply / waiting / groups / fyi` from the **true merged-thread last message**; resolves real names from `contacts`. **~0.9s.**
  - Opens the live DB with `mode=ro` (**not** `immutable=1`) so WAL-buffered freshest messages aren't skipped (verified newest message surfaces).
  - **No hard recency cutoff** — `archived=0` is the working-set filter; recency only sorts (an unanswered ask from 10 days ago is still actionable, per the skill's own rule).
- **Email**: `gog gmail search` envelope first-pass (`needs_reply/waiting/fyi`) + conservative no-reply-sender → FYI heuristic. Deep per-thread reads stay in the skill, run only for the few NEEDS_REPLY candidates before drafting (the FULL-THREAD AWARENESS GATE).

**Rewired `skills/ops-inbox/SKILL.md`**: `ops-inbox-scan` is now the **primary** scan engine; the Workflow fan-out is demoted to a fallback for channels with real per-thread volume the script can't reach. Slack + Telegram become **one light inline MCP call each** (no subagent).

**Bug fix**: the fan-out's `args.map is not a function` crash — the harness can deliver `args` as a JSON string, which killed the whole dispatch on first run every time. Now defensively `JSON.parse`d.

## Net
The common WA + email + glance-at-Slack/Telegram case drops from **5 agents / ~330k tokens** to a **sub-second script + a couple of inline calls**.

## Test
- `bin/ops-inbox-scan --pretty` → valid JSON, 0.9s, on live store.
- `--whatsapp-only` / `--email-only` / `--days N` flags verified.
- `mode=ro` freshness verified: script's newest WA message == freshness-gate's newest.
- `tests/test-no-secrets.sh` → 14 passed, 0 failed (reads live data at runtime; no hardcoded PII).
- `bash -n` clean.

🚀 Shipped by a human and an LLM in a trench coat — prompt-driven, vibe-validated, and type-checked under protest. Any remaining bugs are an emergent property, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how inbox triage runs (local sqlite + Gmail CLI) and classification heuristics may mis-bucket threads until the FULL-THREAD gate runs; read-only by design with no send/archive from the script.
> 
> **Overview**
> Adds **`bin/ops-inbox-scan`**, a read-only bash + Python path that classifies **WhatsApp** (whatsmeow sqlite, lid↔phone merge, `mode=ro` WAL) and **Email** (`gog gmail search` envelope) into compact JSON—replacing the default multi-channel **Workflow** fan-out that cost ~330k subagent tokens per run.
> 
> **`skills/ops-inbox/SKILL.md`** makes the script the **primary** scan engine; Slack/Telegram become single inline MCP calls; Workflow is **fallback** only when the script cannot cover a channel. Also fixes Workflow **`args.map is not a function`** by parsing stringified `args` as JSON.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 736cade80e5025c16c4fd166a4fd74746ee815d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->