### PR TITLE
release: v2.18.19

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -3,6 +3,18 @@
 ## [2.18.19] - 2026-06-01
 
 ### Changed
+ops-inbox: offline scan engine replaces the ~330k-token agent fan-out.
+
+- New bin/ops-inbox-scan: deterministic, read-only, in-process classifier for the two heaviest channels — WhatsApp (direct whatsmeow sqlite read; merges each person's lid<->phone chats into one conversation; classifies needs_reply/waiting/groups/fyi from the true merged-thread last message; resolves names from contacts; ~0.9s) and Email (gog gmail search envelope first-pass + no-reply-sender heuristic). Opens the live DB mode=ro (not immutable=1) so WAL-buffered freshest messages aren't skipped; no hard recency cutoff (archived=0 is the filter).
+- ops-inbox SKILL.md: ops-inbox-scan is now the PRIMARY scan engine; the Workflow fan-out is demoted to a fallback for channels with real per-thread volume the script can't reach. Slack + Telegram become one light inline MCP call each (no subagent).
+- Fix the fan-out's 'args.map is not a function' crash via defensive JSON.parse (the harness can deliver args as a string).
+
+Net: the common WhatsApp + email + glance case drops from 5 agents / ~330k tokens / ~130s to a sub-second script + a couple of inline calls.
+
+
+## [2.18.19] - 2026-06-01
+
+### Changed
 Ship bin/ops-home snapshot producer (Homey Pro: power, alarms, presence, devices) so ops-go/ops-fires Home section resolves instead of 'home probe failed'. Project-aware ops-marketing-dash with owner-level channels.marketing Doppler-ref cred tier so the briefing Marketing section resolves Healify GA4/Meta/Klaviyo. (Code merged via #443 without a version bump; this cuts the actual release.)
 
 


### PR DESCRIPTION
Release **v2.18.19** (was 2.18.18).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

ops-inbox: offline scan engine replaces the ~330k-token agent fan-out.

- New bin/ops-inbox-scan: deterministic, read-only, in-process classifier for the two heaviest channels — WhatsApp (direct whatsmeow sqlite read; merges each person's lid<->phone chats into one conversation; classifies needs_reply/waiting/groups/fyi from the true merged-thread last message; resolves names from contacts; ~0.9s) and Email (gog gmail search envelope first-pass + no-reply-sender heuristic). Opens the live DB mode=ro (not immutable=1) so WAL-buffered freshest messages aren't skipped; no hard recency cutoff (archived=0 is the filter).
- ops-inbox SKILL.md: ops-inbox-scan is now the PRIMARY scan engine; the Workflow fan-out is demoted to a fallback for channels with real per-thread volume the script can't reach. Slack + Telegram become one light inline MCP call each (no subagent).
- Fix the fan-out's 'args.map is not a function' crash via defensive JSON.parse (the harness can deliver args as a string).

Net: the common WhatsApp + email + glance case drops from 5 agents / ~330k tokens / ~130s to a sub-second script + a couple of inline calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default inbox scan path and reads the live WhatsApp store (read-only); misclassification or DB/WAL edge cases could affect triage until fallback agents run.
> 
> **Overview**
> **Release v2.18.19** documents and ships the **ops-inbox** scan redesign: a new **`bin/ops-inbox-scan`** offline engine is now the **primary** path for WhatsApp and email instead of fanning out multiple Workflow subagents.
> 
> The script does a **read-only**, in-process classification: WhatsApp via direct **whatsmeow** SQLite (lid↔phone merge, contact names, `needs_reply` / `waiting` / groups / FYI from the merged thread’s last message) and email via **`gog gmail search`** plus a no-reply heuristic. **`ops-inbox` SKILL.md** demotes the old fan-out to a **fallback** for channels the script cannot cover; Slack and Telegram are **single inline MCP** calls. The Workflow path also gets a **`JSON.parse` guard** when `args` arrives as a string, fixing **`args.map is not a function`**.
> 
> Typical WhatsApp + email + glance work is intended to drop from **~5 agents / ~330k tokens / ~130s** to a **sub-second script** plus light follow-up calls. The changelog adds a second **2.18.19** block (duplicate heading date) alongside an earlier entry for home/marketing release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00182e65b38ca58ec25afb3b3c3d429bbc73c5c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->