### PR TITLE
release: v2.18.20

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.18.19",
+      "version": "2.18.20",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.18.19",
+  "version": "2.18.20",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2.18.20] - 2026-06-01
+
+### Changed
+ops-inbox: offline scan engine replaces the ~330k-token agent fan-out.
+
+(The ops-inbox-scan feature landed on main after the sibling v2.18.19 release tag was cut, so it ships here as 2.18.20.)
+
+- bin/ops-inbox-scan: deterministic read-only classifier — WhatsApp (whatsmeow sqlite, lid<->phone merge into one conversation, names from contacts, mode=ro WAL-safe, archived=0 filter / no recency cutoff) + Email (gog gmail search envelope first-pass + no-reply-sender heuristic). ~0.9s, near-zero tokens.
+- ops-inbox SKILL.md: bin/ops-inbox-scan is now the PRIMARY scan engine; the Workflow fan-out is demoted to a fallback for channels with real per-thread volume the script can't reach. Slack + Telegram become one light inline MCP call each (no subagent).
+- Fix the fan-out's 'args.map is not a function' crash via defensive JSON.parse.
+
+Net: the common WhatsApp + email + glance case drops from 5 agents / ~330k tokens / ~130s to a sub-second script + a couple of inline calls.
+
+
 ## [2.18.19] - 2026-06-01
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.18.19",
+  "version": "2.18.20",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.18.20** (was 2.18.19).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

ops-inbox: offline scan engine replaces the ~330k-token agent fan-out.

(The ops-inbox-scan feature landed on main after the sibling v2.18.19 release tag was cut, so it ships here as 2.18.20.)

- bin/ops-inbox-scan: deterministic read-only classifier — WhatsApp (whatsmeow sqlite, lid<->phone merge into one conversation, names from contacts, mode=ro WAL-safe, archived=0 filter / no recency cutoff) + Email (gog gmail search envelope first-pass + no-reply-sender heuristic). ~0.9s, near-zero tokens.
- ops-inbox SKILL.md: bin/ops-inbox-scan is now the PRIMARY scan engine; the Workflow fan-out is demoted to a fallback for channels with real per-thread volume the script can't reach. Slack + Telegram become one light inline MCP call each (no subagent).
- Fix the fan-out's 'args.map is not a function' crash via defensive JSON.parse.

Net: the common WhatsApp + email + glance case drops from 5 agents / ~330k tokens / ~130s to a sub-second script + a couple of inline calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-metadata-only diff; behavioral changes are documented inbox scan optimizations with read-only local access, not auth or payment paths.
> 
> **Overview**
> **Release v2.18.20** bumps the plugin and marketplace registry from **2.18.19 → 2.18.20** (`plugin.json`, `marketplace.json`, `claude-ops/package.json`) and adds a **CHANGELOG** entry for what this tag ships.
> 
> The documented product change is **ops-inbox**: **`bin/ops-inbox-scan`** becomes the primary offline classifier (read-only WhatsApp sqlite + Gmail envelope pass); Workflow fan-out is fallback only; Slack/Telegram are light inline MCP; fan-out **`args.map`** crash fixed with defensive **`JSON.parse`**. Typical WhatsApp + email scans go from multi-agent / ~330k tokens to a sub-second script plus minimal inline calls.
> 
> The PR diff itself is **version + changelog only** (feature already on main; v2.18.19 tag predated `ops-inbox-scan`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0458558dcb08969fecb3b7c65d78e8e708feee83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->