### PR TITLE
release: v2.19.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.18.20",
+      "version": "2.19.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.18.20",
+  "version": "2.19.0",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.19.0] - 2026-06-01
+
+### Changed
+- feat(ops-update): one-command local plugin upgrade with prune + version-rewrite (#450)
+- fix(ops-dash): align box right-borders via display-width-aware padding (#449)
+
+
 ## [2.18.20] - 2026-06-01
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.18.20",
+  "version": "2.19.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.19.0** (was 2.18.20).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

- feat(ops-update): one-command local plugin upgrade with prune + version-rewrite (#450)
- fix(ops-dash): align box right-borders via display-width-aware padding (#449)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version/metadata-only PR with no runtime code changes in the diff; low risk aside from normal release tagging and install expectations for 2.19.0.
> 
> **Overview**
> This PR **cuts release v2.19.0** by bumping the published version from **2.18.20 → 2.19.0** in `claude-ops/.claude-plugin/plugin.json`, root `.claude-plugin/marketplace.json`, and `claude-ops/package.json`, and adding a **CHANGELOG** entry for that release.
> 
> The changelog documents what already landed on main: **`ops-update`** (#450) as a one-command local plugin upgrade (marketplace refresh, install/update with stale-cache fallback, cache prune, version-pinned path rewrite, migrations), and an **`ops-dash`** fix (#449) so boxed UI rows pad using **display-width** (wide chars/emojis) so right borders line up.
> 
> There is **no new application logic in this diff**—only version alignment and release notes for reviewers installing or tagging **2.19.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f435cd07df4a74e30a4151b660dc573930a914b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->