### PR TITLE
fix(whatsapp): honor shared restart-floor in bridge-up + ops-autofix (stop restart churn dropping phone-sends)

### DIFF
--- a/claude-ops/bin/ops-autofix
+++ b/claude-ops/bin/ops-autofix
@@ -96,7 +96,14 @@ fix_bridge_fts() {
   if [ -f "$BRIDGE_BIN" ] && ! grep -qa "fts5" "$BRIDGE_BIN" 2>/dev/null; then
     if command -v go >/dev/null 2>&1; then
       if ( cd "$(dirname "$BRIDGE_BIN")" && CGO_ENABLED=1 go build -tags "sqlite_fts5" -o whatsapp-bridge . ) 2>/dev/null; then
+        # This restart is mandatory (the freshly-built binary must be loaded) and rare
+        # (only when the binary lacks fts5), so we don't floor-SKIP it — but we DO stamp
+        # the shared cross-caller restart floor afterwards so other callers
+        # (wa-bridge-keepalive.sh, wa-inbox-fresh.sh, whatsapp-bridge-up.sh) back off for
+        # 180s and don't pile on. whatsmeow can't re-fetch phone-sent messages on
+        # reconnect, so coordinated restarts prevent dropping the user's own sends.
         systemctl --user restart whatsapp-bridge.service 2>/dev/null || true
+        date +%s > "$HOME/.claude/.once.whatsapp-bridge-restart.last" 2>/dev/null || true
         log_fix "bridge-fts: rebuilt bridge binary with -tags sqlite_fts5 (was missing fts5 module)"
       else
         log_fail "bridge-fts: binary lacks fts5 and rebuild failed — skipping migration (triggers would break message storage)"

--- a/claude-ops/scripts/lib/whatsapp-bridge-up.sh
+++ b/claude-ops/scripts/lib/whatsapp-bridge-up.sh
@@ -25,7 +25,24 @@ case "$OS" in
     ;;
   Linux)
     if command -v systemctl >/dev/null && systemctl --user cat whatsapp-bridge.service >/dev/null 2>&1; then
-      systemctl --user restart whatsapp-bridge.service
+      # Shared cross-caller restart floor — the SAME stamp wa-bridge-keepalive.sh and
+      # wa-inbox-fresh.sh use ($HOME/.claude/.once.whatsapp-bridge-restart.last). One
+      # bridge restart / 180s max across ALL callers. whatsmeow CANNOT re-fetch your own
+      # phone-sent messages on reconnect, so each uncoordinated restart is a window where
+      # outbound you typed on your phone is dropped permanently. Without this floor,
+      # parallel ops health-checks calling this wrapper churn the bridge (observed: 4
+      # restarts in 1 second) and silently lose sends. If a restart happened <180s ago the
+      # bridge is already coming up — skip and let the wait loop below confirm :8080.
+      _wa_floor="$HOME/.claude/.once.whatsapp-bridge-restart.last"
+      _wa_skip=0
+      if [ -f "$_wa_floor" ]; then
+        _wa_last="$(cat "$_wa_floor" 2>/dev/null || echo 0)"
+        if [ "$(( $(date +%s) - ${_wa_last:-0} ))" -lt 180 ]; then _wa_skip=1; fi
+      fi
+      if [ "$_wa_skip" = 0 ]; then
+        systemctl --user restart whatsapp-bridge.service
+        date +%s > "$_wa_floor" 2>/dev/null || true
+      fi
     else
       echo "claude-ops/whatsapp-bridge-up: no whatsapp-bridge.service installed on this Linux host." >&2
       echo "Run: bash \$CLAUDE_PLUGIN_ROOT/scripts/install-whatsapp-bridge-linux.sh --wa-phone <E.164>" >&2


### PR DESCRIPTION
## Problem

The whatsmeow `whatsapp-bridge` only captures the user's **own phone-sent messages** as a *live echo while connected* — whatsmeow **cannot re-fetch them on reconnect** (history sync backfills *incoming* messages only). So every uncoordinated bridge restart is a window where outbound the user typed on their phone is **dropped permanently**.

Observed live on dev-sandbox-fra: the last outbound that persisted to a given contact was 3 days stale, while the journal showed the bridge restarting in bursts — **4 restarts within a single second** (23:22:32), then ~90s-spaced restarts — and the shared floor stamp `~/.claude/.once.whatsapp-bridge-restart.last` **did not exist**, proving the restarts came from callers that bypass the floor.

## Root cause

`wa-bridge-keepalive.sh` and `wa-inbox-fresh.sh` already coordinate via a shared **180s restart floor**. But two callers bypassed it:

- **`scripts/lib/whatsapp-bridge-up.sh`** — bare `systemctl --user restart`, no floor check, no stamp. Invoked by parallel ops health-checks (`daemon-services`), this is the churn source.
- **`bin/ops-autofix`** — its rebuild-and-restart path wrote no floor stamp.

## Fix

- **`whatsapp-bridge-up.sh` (Linux branch):** skip the restart if another caller restarted <180s ago (the bridge is already coming up; the existing 5s wait loop confirms `:8080`), and stamp the floor after any restart it performs.
- **`ops-autofix`:** the post-rebuild restart is mandatory (the freshly-built binary must load) and rare, so it is **not** floor-skipped — but it now **stamps** the floor afterwards so the other callers back off for 180s instead of piling on.

Net: **≤1 bridge restart / 180s across all callers**, closing the windows that silently dropped the user's phone-sent messages.

## Test
- `bash -n` clean on both files.
- Patched files propagated to the live cache + marketplace copies on the affected host; floor logic verified present.
- No behavioral change to the macOS path or the "already healthy → exit 0" fast path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when the bridge restarts on Linux health paths; mis-timed skips could delay recovery, but the change targets message-loss from restart storms.
> 
> **Overview**
> Coordinates **WhatsApp bridge** restarts so parallel ops callers cannot churn `systemctl` restarts and drop **phone-sent** messages that whatsmeow cannot backfill after reconnect.
> 
> On **Linux**, `whatsapp-bridge-up.sh` now reads the same **180s** stamp as `wa-bridge-keepalive.sh` / `wa-inbox-fresh.sh`: skip restart if one happened recently, otherwise restart and stamp the floor. **`ops-autofix`** still restarts after a rare FTS5 rebuild (required to load the new binary) but **writes the stamp** afterward so other scripts back off.
> 
> macOS behavior and the “already listening on :8080” fast path are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b9b53a53ff5321b34509d602164dcd332725b4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WhatsApp bridge restart coordination with intelligent backoff logic to prevent excessive service restarts when multiple concurrent operations are triggered.

* **Chores**
  * Enhanced synchronization of bridge service restart requests across concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->