### PR TITLE
release: v2.19.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.19.0",
+      "version": "2.19.1",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.19.1] - 2026-06-01
+
+### Changed
+fix(whatsapp): honor shared restart-floor in bridge-up + ops-autofix to stop restart churn that dropped phone-sent messages (#452)
+
+
 ## [2.19.0] - 2026-06-01
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.19.1** (was 2.19.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

fix(whatsapp): honor shared restart-floor in bridge-up + ops-autofix to stop restart churn that dropped phone-sent messages (#452)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release; behavioral change is scoped to WhatsApp bridge restart logic documented in #452, not shown here.
> 
> **Overview**
> **Release v2.19.1** bumps the published plugin version from **2.19.0** to **2.19.1** in `.claude-plugin/marketplace.json`, `claude-ops/.claude-plugin/plugin.json`, and `claude-ops/package.json`, and adds a **CHANGELOG** entry for **2026-06-01**.
> 
> The release note documents **fix(whatsapp) (#452)**: `bridge-up` and `ops-autofix` now honor a **shared restart-floor** so the WhatsApp bridge is not restarted in a tight loop—churn that could cause **phone-sent messages** to be dropped. This PR does not include the implementation diff; it is the version and changelog cut for that fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af3ebd5868f9cef8ff167f89c1050f985008d824. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->