### PR TITLE
fix(whatsapp): canonicalize 180s restart-floor in wa-inbox-fresh + wa-bridge-keepalive (survive reinstall)

### DIFF
--- a/claude-ops/bin/wa-bridge-keepalive.sh
+++ b/claude-ops/bin/wa-bridge-keepalive.sh
@@ -31,5 +31,21 @@ if probe; then exit 0; fi
 state=$(systemctl --user show "$UNIT" -p ActiveState --value 2>/dev/null || echo unknown)
 if [ "$state" = "activating" ]; then exit 0; fi
 
+# Shared cross-caller restart floor — same stamp file claude_once uses for the key
+# "whatsapp-bridge-restart" (wa-inbox-fresh.sh writes it). Read/write the stamp
+# DIRECTLY here: a 2nd claude_once call would clobber the self-throttle's EXIT trap
+# (bash allows one EXIT trap) and orphan wa-bridge-keepalive.lock, self-disabling the
+# watchdog until the 60-min stale-reclaim. A stamp-only floor auto-expires at 180s and
+# can never self-block, which is what keepalive needs. One restart / 180s across this
+# script + wa-inbox-fresh.sh + whatsapp-bridge-up.sh.
+FLOOR_STAMP="$HOME/.claude/.once.whatsapp-bridge-restart.last"
+if [ -f "$FLOOR_STAMP" ]; then
+  last=$(cat "$FLOOR_STAMP" 2>/dev/null || echo 0)
+  if [ $(( $(date +%s) - ${last:-0} )) -lt 180 ]; then
+    logger -t wa-bridge-keepalive 'restart floor active (<180s) — skip'
+    exit 0
+  fi
+fi
 logger -t wa-bridge-keepalive "bridge unresponsive on $PROBE (state=$state) — restarting $UNIT"
 systemctl --user restart "$UNIT"
+date +%s > "$FLOOR_STAMP" 2>/dev/null

--- a/claude-ops/bin/wa-inbox-fresh.sh
+++ b/claude-ops/bin/wa-inbox-fresh.sh
@@ -32,15 +32,36 @@ log() { printf '%s\n' "$*"; }
 # (bridge still starting up) triggered a restart loop. The fix: fail-fast
 # probe × 2 with a 1s gap; only then restart; then wait up to 20s for it to
 # come back up before declaring dead.
-alive() { curl -s -o /dev/null -m 4 "$BRIDGE/" >/dev/null 2>&1; }
+alive() { curl -s -o /dev/null -m 10 "$BRIDGE/" >/dev/null 2>&1; }
 probe_dead() { ! alive && { sleep 1; ! alive; }; }   # two consecutive failures = truly dead
 
 if probe_dead; then
-  log "wa-fresh: bridge :8080 not responding (2 consecutive probes failed) — restarting…"
-  systemctl --user restart whatsapp-bridge.service 2>/dev/null
-  # Wait up to 20 s for the bridge to come back (it needs a few seconds to
-  # open the SQLite store and establish the WhatsApp websocket).
-  for i in $(seq 1 10); do sleep 2; alive && break; done
+  # Startup-grace gate: if the bridge (re)started <120s ago it is almost certainly
+  # mid-reconnect (opening the SQLite store + WhatsApp websocket), and a probe that
+  # fails here would re-trigger a restart → reconnect → probe-fail loop. Skip.
+  started=$(systemctl --user show whatsapp-bridge.service -p ActiveEnterTimestampMonotonic --value 2>/dev/null)
+  now=$(awk '{print int($1*1000000)}' /proc/uptime)
+  if [ -n "$started" ] && [ "$started" -gt 0 ] && [ $(( now - started )) -lt 120000000 ]; then
+    log "wa-fresh: bridge started <120s ago — skip restart (reconnect in progress)"
+  else
+    # Shared cross-caller restart floor: the SAME stamp every other restart caller
+    # uses (wa-bridge-keepalive.sh, whatsapp-bridge-up.sh). One restart / 180s max,
+    # no matter how many parallel agents invoke this script. claude_once is a one-shot
+    # guard (not a recurring loop), allowed under the cost rule.
+    do_restart=1
+    if [ -r "$HOME/.claude/scripts/lib/once.sh" ]; then
+      # shellcheck disable=SC1091
+      . "$HOME/.claude/scripts/lib/once.sh"
+      claude_once whatsapp-bridge-restart 180 || { log "wa-fresh: another caller restarted bridge <180s ago — skip"; do_restart=0; }
+    fi
+    if [ "$do_restart" = 1 ]; then
+      log "wa-fresh: bridge :8080 not responding (2 consecutive probes failed) — restarting…"
+      systemctl --user restart whatsapp-bridge.service 2>/dev/null
+      # Wait up to 20 s for the bridge to come back (it needs a few seconds to
+      # open the SQLite store and establish the WhatsApp websocket).
+      for i in $(seq 1 10); do sleep 2; alive && break; done
+    fi
+  fi
 fi
 if ! alive; then
   log "wa-fresh: ERROR bridge still down after restart — store is STALE, do not trust it"

--- a/claude-ops/bin/wa-inbox-fresh.sh
+++ b/claude-ops/bin/wa-inbox-fresh.sh
@@ -35,6 +35,7 @@ log() { printf '%s\n' "$*"; }
 alive() { curl -s -o /dev/null -m 10 "$BRIDGE/" >/dev/null 2>&1; }
 probe_dead() { ! alive && { sleep 1; ! alive; }; }   # two consecutive failures = truly dead
 
+bridge_restarted=0
 if probe_dead; then
   # Startup-grace gate: if the bridge (re)started <120s ago it is almost certainly
   # mid-reconnect (opening the SQLite store + WhatsApp websocket), and a probe that
@@ -55,16 +56,21 @@ if probe_dead; then
       claude_once whatsapp-bridge-restart 180 || { log "wa-fresh: another caller restarted bridge <180s ago — skip"; do_restart=0; }
     fi
     if [ "$do_restart" = 1 ]; then
+      bridge_restarted=1
       log "wa-fresh: bridge :8080 not responding (2 consecutive probes failed) — restarting…"
       systemctl --user restart whatsapp-bridge.service 2>/dev/null
-      # Wait up to 20 s for the bridge to come back (it needs a few seconds to
-      # open the SQLite store and establish the WhatsApp websocket).
-      for i in $(seq 1 10); do sleep 2; alive && break; done
     fi
   fi
+  # Wait up to 20 s for the bridge to come back (it needs a few seconds to
+  # open the SQLite store and establish the WhatsApp websocket).
+  for i in $(seq 1 10); do sleep 2; alive && break; done
 fi
 if ! alive; then
-  log "wa-fresh: ERROR bridge still down after restart — store is STALE, do not trust it"
+  if [ "$bridge_restarted" = 1 ]; then
+    log "wa-fresh: ERROR bridge still down after restart — store is STALE, do not trust it"
+  else
+    log "wa-fresh: ERROR bridge still down — store is STALE, do not trust it"
+  fi
   exit 2
 fi
 


### PR DESCRIPTION
## Problem
`#452` floored the plugin-side restart callers (`whatsapp-bridge-up.sh`, `ops-autofix`). But the two `~/bin` watchdog scripts — `wa-inbox-fresh.sh` and `wa-bridge-keepalive.sh` — only carried the 180s floor **live on the box**; the repo copies were the stale **pre-floor** versions.

`scripts/install-whatsapp-bridge-linux.sh` does `cp .../bin/wa-inbox-fresh.sh "$HOME/bin/..."` (verbatim copy). So any reinstall/migrate would **overwrite the live floored scripts with the stale ones**, reintroducing the uncoordinated-restart churn that silently drops phone-sent messages (whatsmeow cannot re-fetch own-sends on reconnect).

## Fix
Backport the proven live versions into the repo:
- **wa-inbox-fresh.sh:** 120s startup-grace (skip restart while the unit is <120s old = mid-reconnect) + `claude_once whatsapp-bridge-restart 180` shared floor + probe timeout `-m 4`→`-m 10`.
- **wa-bridge-keepalive.sh:** same 180s floor via direct read/write of the shared stamp `~/.claude/.once.whatsapp-bridge-restart.last` (a 2nd `claude_once` would clobber its self-throttle EXIT trap).

With #452 this completes the floor across **all** restart callers: ≤1 bridge restart / 180s regardless of how many parallel agents/health-checks fire.

## Test
`bash -n` clean on both. Files are byte-identical to the versions running live on dev-sandbox-fra (floor verified active there). No behavior change beyond adding the floor/grace.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Ops shell watchdog changes only; reduces uncoordinated bridge restarts with no auth or data-model impact.
> 
> **Overview**
> Backports the **live** WhatsApp bridge watchdog behavior into `claude-ops/bin` so `install-whatsapp-bridge-linux.sh` copies no longer replace floored scripts with stale versions that could restart the bridge too often and drop phone-sent messages on reconnect.
> 
> **`wa-bridge-keepalive.sh`** now enforces the same **180s** cross-caller restart floor by reading/writing `~/.claude/.once.whatsapp-bridge-restart.last` directly (avoiding a second `claude_once` that would break its own 50s self-throttle EXIT trap).
> 
> **`wa-inbox-fresh.sh`** adds a **120s** post-start grace before restarts, gates restarts with `claude_once whatsapp-bridge-restart 180`, lengthens liveness probes from **4s to 10s**, and only logs “after restart” when a restart actually ran this pass.
> 
> Together with other callers (#452), restarts are capped at **≤1 per 180s** across parallel health checks and agents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e96d2d5b64c8aa2e2557ca7ab3e593dfc1f236a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved WhatsApp bridge service stability by preventing excessive restarts within short time windows
  * Enhanced reconnection handling to avoid interrupting ongoing bridge recovery
  * Added intelligent gating to coordinate restarts and reduce service interruptions
  * Better error messaging for different failure scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->