### PR TITLE
release: v2.19.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.19.1",
+      "version": "2.19.2",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.19.1",
+  "version": "2.19.2",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.19.2] - 2026-06-01
+
+### Changed
+feat(ops-release): register /ops:ops-release slash command (#455); fix(whatsapp): canonicalize 180s restart-floor in wa-inbox-fresh + wa-bridge-keepalive so it survives reinstall (#454)
+
+
 ## [2.19.1] - 2026-06-01
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.19.1",
+  "version": "2.19.2",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.19.2** (was 2.19.1).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

feat(ops-release): register /ops:ops-release slash command (#455); fix(whatsapp): canonicalize 180s restart-floor in wa-inbox-fresh + wa-bridge-keepalive so it survives reinstall (#454)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release; functional changes were reviewed in #454 and #455. Risk is limited to incorrect version pins or release notes, not runtime behavior in this diff.
> 
> **Overview**
> **Release v2.19.2** — bumps the plugin version from **2.19.1 → 2.19.2** in `plugin.json`, root `marketplace.json`, and `claude-ops/package.json`, and adds a **CHANGELOG** entry for 2026-06-01.
> 
> This PR is a **version/metadata cut** (no application logic in the diff). It documents work already merged on main:
> 
> - **`/ops:ops-release`** — registers the release slash command so operators can run the existing `bin/ops-release` flow from Claude Code (#455).
> - **WhatsApp** — canonical **180s restart-floor** in `wa-inbox-fresh` and `wa-bridge-keepalive` so the shared throttle survives reinstall, building on v2.19.1’s bridge-up/autofix restart-floor fix (#454).
> 
> After merge/tag, consumers upgrade via the normal plugin update path (e.g. `/ops:ops-update`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed8a8b9e04793ca5b965e90668201f85984b5315. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->