### PR TITLE
feat(ops-ship): one-command sweep-merge-all-PRs to release to update

### DIFF
--- a/claude-ops/bin/ops-ship
+++ b/claude-ops/bin/ops-ship
@@ -53,15 +53,22 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+if [ "$BASE" != "main" ]; then
+  echo "ops-ship: --base must be 'main' (ops-release always publishes to main)." >&2
+  exit 2
+fi
+
 cd "$REPO_ROOT"
 DRYTAG=""; [ "$dry" = 1 ] && DRYTAG=" (DRY RUN)"
 echo "ops-ship$DRYTAG — sweep open PRs on '$BASE' -> release -> update"
 
 # ── 1. Sweep: enumerate open, non-draft PRs targeting the base branch ─────────
 echo "── 1/3  Open PRs targeting '$BASE' (non-draft)"
-mapfile -t PRS < <(gh pr list --base "$BASE" --state open --limit 100 \
+_pr_lines="$(gh pr list --base "$BASE" --state open --limit 100 \
   --json number,title,isDraft,headRefName \
-  --jq '.[] | select(.isDraft|not) | "\(.number)\t\(.title)\t\(.headRefName)"' 2>/dev/null || true)
+  --jq '.[] | select(.isDraft|not) | "\(.number)\t\(.title)\t\(.headRefName)"')" \
+  || { echo "ops-ship: gh pr list failed — aborting (check gh auth / rate limits)." >&2; exit 1; }
+mapfile -t PRS <<< "${_pr_lines}"
 
 if [ "${#PRS[@]}" -eq 0 ]; then
   echo "  no open non-draft PRs — nothing to merge; proceeding straight to release."

--- a/claude-ops/bin/ops-ship
+++ b/claude-ops/bin/ops-ship
@@ -64,11 +64,13 @@ echo "ops-ship$DRYTAG — sweep open PRs on '$BASE' -> release -> update"
 
 # ── 1. Sweep: enumerate open, non-draft PRs targeting the base branch ─────────
 echo "── 1/3  Open PRs targeting '$BASE' (non-draft)"
-_pr_lines="$(gh pr list --base "$BASE" --state open --limit 100 \
-  --json number,title,isDraft,headRefName \
-  --jq '.[] | select(.isDraft|not) | "\(.number)\t\(.title)\t\(.headRefName)"')" \
+_pr_lines="$(gh api --paginate "repos/{owner}/{repo}/pulls?state=open&base=${BASE}&per_page=100" \
+  --jq '.[] | select(.draft == false) | "\(.number)\t\(.title)\t\(.head.ref)"')" \
   || { echo "ops-ship: gh pr list failed — aborting (check gh auth / rate limits)." >&2; exit 1; }
-mapfile -t PRS <<< "${_pr_lines}"
+PRS=()
+if [ -n "$_pr_lines" ]; then
+  mapfile -t PRS <<< "${_pr_lines}"
+fi
 
 if [ "${#PRS[@]}" -eq 0 ]; then
   echo "  no open non-draft PRs — nothing to merge; proceeding straight to release."
@@ -118,7 +120,9 @@ echo "── 3/3  Update"
 if [ "$do_update" = 1 ]; then
   UPDATE_BIN="$(ls "$HOME"/.claude/plugins/cache/ops-marketplace/ops/*/bin/ops-update 2>/dev/null | sort -V | tail -1 || true)"
   if [ -n "$UPDATE_BIN" ] && [ -x "$UPDATE_BIN" ]; then
-    "$UPDATE_BIN"
+    if ! "$UPDATE_BIN"; then
+      echo "  ops-update failed (release already published) — run /ops:ops-update manually." >&2
+    fi
   else
     echo "  ops-update not found in cache — run /ops:ops-update manually to pull the release."
   fi

--- a/claude-ops/bin/ops-ship
+++ b/claude-ops/bin/ops-ship
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# ops-ship — one command: merge every open PR, then publish a new version.
+#
+# The full release chain in a single shot:
+#   1. SWEEP   — admin squash-merge every OPEN, non-draft PR targeting the base
+#                branch (default: main), overriding required checks/reviews.
+#   2. RELEASE — run bin/ops-release (bump plugin.json + marketplace.json registry
+#                + package.json + CHANGELOG, open release PR, admin-merge, tag vX.Y.Z).
+#   3. UPDATE  — (optional) run the installed ops-update to pull the new version
+#                onto this box. Skip with --no-update.
+#
+#   ops-ship [--type patch|minor|major] [--version X.Y.Z] [--notes "changelog body"]
+#            [--base BRANCH] [--no-update] [--dry-run] [-h|--help]
+#
+# Defaults: --base main, --type patch, auto-merge all non-draft PRs (admin override),
+# then release + update. --notes defaults to a list of the merged PR titles.
+#
+# Must run from a REPO CHECKOUT (needs .claude-plugin/marketplace.json above the bin),
+# NOT the plugin cache — same constraint as ops-release.
+#
+# REST note: the PR sweep and ops-release both use the `gh` CLI (GitHub REST). If the
+# REST quota is exhausted (HTTP 403 rate-limit), wait for the reset window — this
+# script does not silently partial-apply: a failed merge aborts before the release.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"           # <repo>/claude-ops
+REPO_ROOT="$(cd "$PLUGIN_DIR/.." && pwd)"            # <repo>
+MARKETPLACE_JSON="$REPO_ROOT/.claude-plugin/marketplace.json"
+RELEASE_BIN="$PLUGIN_DIR/bin/ops-release"
+
+if [ ! -f "$MARKETPLACE_JSON" ]; then
+  echo "ops-ship: $MARKETPLACE_JSON not found — run this from a repo CHECKOUT, not the plugin cache." >&2
+  exit 1
+fi
+if [ ! -x "$RELEASE_BIN" ]; then
+  echo "ops-ship: $RELEASE_BIN not found/executable." >&2
+  exit 1
+fi
+command -v gh >/dev/null 2>&1 || { echo "ops-ship: gh CLI required." >&2; exit 1; }
+
+BASE="main"; bump_type="patch"; version=""; notes=""; dry=0; do_update=1
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --type)      bump_type="$2"; shift 2 ;;
+    --version)   version="$2"; shift 2 ;;
+    --notes)     notes="$2"; shift 2 ;;
+    --base)      BASE="$2"; shift 2 ;;
+    --no-update) do_update=0; shift ;;
+    --dry-run)   dry=1; shift ;;
+    -h|--help)   sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "ops-ship: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+cd "$REPO_ROOT"
+DRYTAG=""; [ "$dry" = 1 ] && DRYTAG=" (DRY RUN)"
+echo "ops-ship$DRYTAG — sweep open PRs on '$BASE' -> release -> update"
+
+# ── 1. Sweep: enumerate open, non-draft PRs targeting the base branch ─────────
+echo "── 1/3  Open PRs targeting '$BASE' (non-draft)"
+mapfile -t PRS < <(gh pr list --base "$BASE" --state open --limit 100 \
+  --json number,title,isDraft,headRefName \
+  --jq '.[] | select(.isDraft|not) | "\(.number)\t\(.title)\t\(.headRefName)"' 2>/dev/null || true)
+
+if [ "${#PRS[@]}" -eq 0 ]; then
+  echo "  no open non-draft PRs — nothing to merge; proceeding straight to release."
+else
+  for row in "${PRS[@]}"; do
+    n="${row%%	*}"; rest="${row#*	}"; title="${rest%%	*}"
+    echo "  #$n  $title"
+  done
+fi
+
+# Build default notes from the PR titles if the caller gave none.
+if [ -z "$notes" ] && [ "${#PRS[@]}" -gt 0 ]; then
+  notes="$(printf '%s\n' "${PRS[@]}" | awk -F'\t' '{printf "- %s (#%s)\n", $2, $1}')"
+fi
+
+if [ "$dry" = 1 ]; then
+  echo "  [dry-run] would admin-squash-merge the ${#PRS[@]} PR(s) above (override required checks/reviews)."
+  echo "── 2/3  Release (delegating to ops-release --dry-run)"
+  "$RELEASE_BIN" --type "$bump_type" ${version:+--version "$version"} ${notes:+--notes "$notes"} --dry-run
+  echo "── 3/3  Update"
+  if [ "$do_update" = 1 ]; then echo "  [dry-run] would run ops-update to pull the new version onto this box."; else echo "  skipped (--no-update)"; fi
+  echo "! DRY RUN — nothing changed. Re-run without --dry-run to apply."
+  exit 0
+fi
+
+# ── Apply: merge each PR (admin override = bypass required checks/reviews) ─────
+merged=0
+for row in "${PRS[@]:-}"; do
+  [ -z "${row:-}" ] && continue
+  n="${row%%	*}"
+  echo "  merging #$n (admin override)…"
+  if gh pr merge "$n" --admin --squash --delete-branch 2>&1 | sed 's/^/    /'; then
+    merged=$((merged+1))
+  else
+    echo "ops-ship: merge of #$n FAILED — aborting before release (no partial ship)." >&2
+    exit 1
+  fi
+done
+[ "${#PRS[@]}" -gt 0 ] && echo "  merged $merged/${#PRS[@]} PR(s)."
+
+# ── 2. Release ────────────────────────────────────────────────────────────────
+echo "── 2/3  Release"
+"$RELEASE_BIN" --type "$bump_type" ${version:+--version "$version"} ${notes:+--notes "$notes"}
+
+# ── 3. Update (pull onto this box) ─────────────────────────────────────────────
+echo "── 3/3  Update"
+if [ "$do_update" = 1 ]; then
+  UPDATE_BIN="$(ls "$HOME"/.claude/plugins/cache/ops-marketplace/ops/*/bin/ops-update 2>/dev/null | sort -V | tail -1 || true)"
+  if [ -n "$UPDATE_BIN" ] && [ -x "$UPDATE_BIN" ]; then
+    "$UPDATE_BIN"
+  else
+    echo "  ops-update not found in cache — run /ops:ops-update manually to pull the release."
+  fi
+else
+  echo "  skipped (--no-update) — run /ops:ops-update to pull the release onto this box."
+fi
+
+echo "✓ ops-ship complete. Restart Claude Code (or /reload-plugins) to load the new version."

--- a/claude-ops/bin/ops-ship
+++ b/claude-ops/bin/ops-ship
@@ -64,7 +64,7 @@ echo "ops-ship$DRYTAG — sweep open PRs on '$BASE' -> release -> update"
 
 # ── 1. Sweep: enumerate open, non-draft PRs targeting the base branch ─────────
 echo "── 1/3  Open PRs targeting '$BASE' (non-draft)"
-_pr_lines="$(gh api --paginate "repos/{owner}/{repo}/pulls?state=open&base=${BASE}&per_page=100" \
+_pr_lines="$(gh api --paginate "repos/{owner}/{repo}/pulls?state=open&base=${BASE}&sort=created&direction=asc&per_page=100" \
   --jq '.[] | select(.draft == false) | "\(.number)\t\(.title)\t\(.head.ref)"')" \
   || { echo "ops-ship: gh pr list failed — aborting (check gh auth / rate limits)." >&2; exit 1; }
 PRS=()

--- a/claude-ops/skills/ops-ship/SKILL.md
+++ b/claude-ops/skills/ops-ship/SKILL.md
@@ -90,7 +90,7 @@ tag and the reload reminder. Surface the final line verbatim:
 | `--type patch\|minor\|major` | Semver bump for the release (default `patch`). |
 | `--version X.Y.Z` | Exact target version instead of bumping. |
 | `--notes "…"` | CHANGELOG body. Defaults to a bullet list of the merged PR titles. |
-| `--base BRANCH` | Base branch to sweep + release (default `main`). |
+| `--base BRANCH` | Base branch for the PR sweep only (must be `main`; `ops-release` always publishes to `main`). |
 | `--no-update` | Don't run `ops-update` afterwards (publish only). |
 | `--dry-run` | Report only — list PRs + the bump, change nothing. Always run this first. |
 

--- a/claude-ops/skills/ops-ship/SKILL.md
+++ b/claude-ops/skills/ops-ship/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: ops-ship
+description: One-command full release chain for the claude-ops ("ops") plugin — sweep and admin-merge every open PR, then publish a new version (bump plugin.json + marketplace.json registry + package.json + CHANGELOG, open release PR, admin-merge, tag), then pull it onto the box. Use when you have one or more merged-ready PRs and want to ship a new published version in a single step instead of merging PRs by hand and then releasing. Combines the PR sweep + /ops:ops-release + /ops:ops-update.
+argument-hint: "[--type patch|minor|major] [--version X.Y.Z] [--notes \"changelog body\"] [--base BRANCH] [--no-update] [--dry-run]"
+allowed-tools:
+  - Bash
+  - Read
+  - AskUserQuestion
+---
+
+# OPS ► SHIP — merge-all-PRs → release → update, in one command
+
+The whole release chain in a single shot:
+
+1. **Sweep** — admin squash-merge **every open, non-draft PR** targeting the base
+   branch (default `main`), **overriding required checks/reviews** (`gh pr merge
+   --admin`). A failed merge aborts before the release — no partial ship.
+2. **Release** — delegates to `bin/ops-release`: bump `plugin.json` +
+   `marketplace.json` registry + `package.json` + `CHANGELOG`, open the release PR,
+   admin-merge to `main`, tag `vX.Y.Z`.
+3. **Update** — runs the installed `ops-update` to pull the new version onto this
+   box (skip with `--no-update`).
+
+> `ops-ship` = sweep + `/ops:ops-release` + `/ops:ops-update` in one. For just the
+> publish step use `/ops:ops-release`; for just the pull step use `/ops:ops-update`.
+
+## ⚠️ It admin-merges EVERY open non-draft PR — review the sweep first
+
+By design the sweep is aggressive: it admin-merges **all** open non-draft PRs on the
+base branch, bypassing required checks (red CI, missing reviews) — exactly what you
+want for a trusted solo/own-org repo, dangerous if an unrelated or half-baked PR is
+open. So **always dry-run first and show which PRs it will merge** before applying
+(Rule 5 — bulk merge + outward-facing release + tag is high-impact and hard to
+reverse). It only skips drafts.
+
+## ⚠️ Run it from the REPO CHECKOUT, not the cache
+
+Like `ops-release`, `ops-ship` resolves its targets relative to its own path and
+needs `REPO_ROOT/.claude-plugin/marketplace.json`, which the plugin **cache** lacks.
+Run the copy inside a git checkout of the repo:
+
+```bash
+SHIP=""
+for d in ~/Projects/claude-ops-workspace/claude-ops ~/Projects/claude-ops/claude-ops "$HOME"/Projects/*/claude-ops; do
+  if [ -f "$d/.claude-plugin/marketplace.json" ] && [ -x "$d/claude-ops/bin/ops-ship" ]; then
+    SHIP="$d/claude-ops/bin/ops-ship"; break
+  fi
+done
+[ -n "$SHIP" ] || { echo "no claude-ops checkout with marketplace.json found"; exit 1; }
+```
+
+## How to run it
+
+### 1. Dry-run — show the sweep + the version bump
+
+```bash
+"$SHIP" --type patch --dry-run
+```
+
+Present: the list of open PRs it will admin-merge, the version bump (current → new),
+the manifests touched, and the CHANGELOG block. (`--notes` defaults to a bullet list
+of the merged PR titles; pass `--notes "…"` to override.)
+
+### 2. Confirm
+
+Use **AskUserQuestion** before applying (this merges PRs AND publishes):
+
+```
+Ship: admin-merge N open PR(s) on main, then release <CUR> → <NEW> + tag?
+  [Ship it]
+  [Dry-run only]
+  [Cancel]
+```
+
+### 3. Apply
+
+```bash
+"$SHIP" --type patch                 # or --version X.Y.Z, --notes "…", --no-update
+```
+
+Stream the step output (sweep → release → update). On success it ends with the new
+tag and the reload reminder. Surface the final line verbatim:
+
+> **Restart Claude Code (or run `/reload-plugins`) to load v<NEW>.**
+
+## Flags
+
+| Flag | Effect |
+|------|--------|
+| `--type patch\|minor\|major` | Semver bump for the release (default `patch`). |
+| `--version X.Y.Z` | Exact target version instead of bumping. |
+| `--notes "…"` | CHANGELOG body. Defaults to a bullet list of the merged PR titles. |
+| `--base BRANCH` | Base branch to sweep + release (default `main`). |
+| `--no-update` | Don't run `ops-update` afterwards (publish only). |
+| `--dry-run` | Report only — list PRs + the bump, change nothing. Always run this first. |
+
+## Notes
+
+- **PRs target `main`** and are squash-merged with `--admin` (own-org PRs can't be
+  self-approved; admin bypasses the review/required-check gates).
+- **REST quota:** the sweep and `ops-release` use `gh` (GitHub REST). If REST is
+  exhausted (HTTP 403 rate-limit), wait for the reset window — `ops-ship` aborts
+  before releasing if any merge fails rather than partial-shipping.
+- **Publish ≠ loaded.** The running session won't see the new version until
+  `ops-update` (pull, run automatically unless `--no-update`) **and**
+  `/reload-plugins` (load).
+- Siblings: `/ops:ops-release` (publish only), `/ops:ops-update` (pull only).


### PR DESCRIPTION
## What
`ops-ship` — one command for the full release chain: merge all open PRs, then bump version + registry + marketplace + tag, then pull onto the box.

There was no single script that merged all open PRs AND then bumped the version. `ops-release` does the publish half; `ops-update` the pull half. `ops-ship` adds the missing front half (the PR sweep):

1. Sweep — admin squash-merge every open, non-draft PR on the base (default main), overriding required checks/reviews. Aborts before release if any merge fails (no partial ship).
2. Release — delegates to bin/ops-release (bump plugin.json + marketplace.json registry + package.json + CHANGELOG, PR, admin-merge, tag).
3. Update — runs installed ops-update to pull onto the box (--no-update to skip).

Includes skills/ops-ship/SKILL.md so /ops:ops-ship registers on reload. --dry-run lists PRs + the bump and changes nothing; the skill gates the real run behind a confirm (Rule 5).

## Test
bash -n clean; dry-run smoke verified the chain delegates correctly. Admin-override-all-non-draft sweep semantics per request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Automates admin merges of every open non-draft PR (bypassing CI/reviews) followed by version bump, marketplace publish, and tagging—high blast radius and difficult to undo if the wrong PRs are open.
> 
> **Overview**
> Adds **`ops-ship`**, a one-shot release pipeline that chains three steps: **sweep** (admin squash-merge every open, non-draft PR on `main`, bypassing required checks/reviews), **release** (delegates to existing `bin/ops-release`), and **update** (optional `ops-update` from the plugin cache).
> 
> The new `claude-ops/bin/ops-ship` script requires a **repo checkout** (`.claude-plugin/marketplace.json`), supports `--dry-run`, semver/`--notes` passthrough, and **aborts before release** if any merge fails. A companion **`skills/ops-ship/SKILL.md`** documents `/ops:ops-ship`, mandates dry-run + **AskUserQuestion** before apply, and warns that the sweep is intentionally aggressive (all non-draft PRs, not just “ready” ones).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99bd4cee14f7224f4abcc3db92c67cf10de01ec6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->