### PR TITLE
feat(pocket-approvals): A/B/C options + ⭐recommended + freeform + untruncated Telegram ASKs

### DIFF
--- a/claude-ops/email-cos/pocket-responder.py
+++ b/claude-ops/email-cos/pocket-responder.py
@@ -210,6 +210,20 @@ def _edit_intent(body):
     return bool(_RE_EDIT_INTENT.search(body or ""))
 
 
+def _classic_approve_clause(body, ent, codemap):
+    """Matched `approve <ref>` token for ent, if any — not the full Telegram reply."""
+    tid = ent.get("id")
+    if not tid:
+        return ""
+    for mt in _RE_CLASSIC.finditer(body or ""):
+        if mt.group(1).upper() != "APPROVE":
+            continue
+        e = _resolve_code(codemap, mt.group(2))
+        if e and e.get("id") == tid:
+            return mt.group(0)
+    return ""
+
+
 # ---------------------------------------------------------------------------
 # Telegram API
 # ---------------------------------------------------------------------------
@@ -713,7 +727,7 @@ def _handle_text(ev, codemap, callmap, resolved, seen):
         if verb == "APPROVE" and (ent.get("options") or []):
             _send(f"`{ref}` is a choice item — reply e.g. `{ref} a`.")
             continue
-        if verb == "APPROVE" and _is_outbound(ent) and _edit_intent(body):
+        if verb == "APPROVE" and _is_outbound(ent) and _edit_intent(mt.group(0)):
             _send(f"`{ref}` looks like an *edit*, not a plain approve — I won't send the "
                   f"original draft as-is. Tap ✅ Approve (or reply `approve {ref}`) to send "
                   f"it unchanged, or `reject {ref}` to skip. _(Edit-then-send for emails isn't wired yet.)_")
@@ -759,7 +773,8 @@ def _handle_text(ev, codemap, callmap, resolved, seen):
                 continue
             toast = _apply_decision(ent, "CHOOSE", option=option)
         else:
-            if dec == "approve" and _is_outbound(ent) and _edit_intent(body):
+            clause = _classic_approve_clause(body, ent, codemap) or body
+            if dec == "approve" and _is_outbound(ent) and _edit_intent(clause):
                 _send(f"That looks like an *edit* of “{ent.get('title','')[:50]}”, not a plain "
                       f"approve — I won't send the original draft as-is. Tap ✅ Approve to send it "
                       f"unchanged, or reply `reject` to skip. _(Edit-then-send for emails isn't wired yet.)_")

--- a/claude-ops/email-cos/pocket-responder.py
+++ b/claude-ops/email-cos/pocket-responder.py
@@ -122,8 +122,11 @@ def _norm(item):
     return (
         t.get("id") or item.get("id"),
         t.get("kind") or item.get("kind", "action_item"),
-        (t.get("title") or item.get("title") or "")[:120],
-        (t.get("context") or item.get("context") or "")[:600],
+        (t.get("title") or item.get("title") or "")[:140],
+        # Keep generous context here; cmd_send() does the final Telegram-fit
+        # truncation. The old 600-char cap silently amputated long ASKs
+        # (email drafts, voice-memo action items) before they were ever rendered.
+        (t.get("context") or item.get("context") or "")[:6000],
         t,
     )
 
@@ -174,6 +177,36 @@ def _resolve_code(codemap: dict, ref: str):
 
 def _sid(item_id):
     return "i" + hashlib.sha1(item_id.encode()).hexdigest()[:10]
+
+
+def _recommended_key(it, opts):
+    """Recommended option key for an ASK, if any: a per-option `recommended:true`
+    first, then a top-level recommended_option/recommended_key (also checked in raw
+    + raw.triage). '' if none. Backward-compatible — producers that don't set it
+    just get no star."""
+    for o in opts or []:
+        if isinstance(o, dict) and o.get("recommended"):
+            return str(o.get("key") or "")
+    raw = it.get("raw") if isinstance(it.get("raw"), dict) else {}
+    tri = raw.get("triage") if isinstance(raw.get("triage"), dict) else {}
+    for src in (it, raw, tri):
+        if isinstance(src, dict) and (src.get("recommended_option") or src.get("recommended_key")):
+            return str(src.get("recommended_option") or src.get("recommended_key"))
+    return ""
+
+
+# Words signalling "change this before it goes out" rather than a plain yes. Used
+# to block the footgun where a freeform reply like "send but say Friday" on an
+# outbound email ASK gets mis-mapped to a bare APPROVE and the UNEDITED draft is
+# sent to a third party. Edit-then-send re-drafting is not wired yet.
+_RE_EDIT_INTENT = re.compile(
+    r"\b(change|instead|edit|reword|rewrite|replace|revise|adjust|tweak|shorter|"
+    r"longer|add that|mention|leave out|take out|remove the|make it|don'?t say|"
+    r"say that|reslant|soften|reschedule to)\b", re.I)
+
+
+def _edit_intent(body):
+    return bool(_RE_EDIT_INTENT.search(body or ""))
 
 
 # ---------------------------------------------------------------------------
@@ -239,22 +272,36 @@ def cmd_send():
         sid = _sid(iid)
         opts = it.get("options") or []
         ap = it.get("action_preview") or ""
-        title = (it.get("title") or "")[:120]
-        ctx = _truncate_words(it.get("ctx") or "", 500)
+        dq = it.get("decision_question") or ""
+        kind = it.get("kind") or ""
+        title = (it.get("title") or "")[:140]
+        # Give the body the bulk of Telegram's 4096-char budget; the old 500-char
+        # cut amputated long ASKs (full email drafts, voice-memo action items).
+        ctx = _truncate_words(it.get("ctx") or "", 3200)
+        rk = _recommended_key(it, opts)
         text = f"*{title}*\n{ctx}"
+        if dq:
+            text += f"\n\n❓ *{dq}*"
         if ap:
             text += f"\n\n→ *Approve =* {ap}"
         if opts:
-            rows = [
-                [{"text": f"{o['key']}) {o['label'][:40]}", "callback_data": f"po:{sid}:{o['key']}"}]
-                for o in opts
-            ]
-            rows.append([{"text": "❌ Reject", "callback_data": f"pr:{sid}"}])
+            rows = []
+            for o in opts:
+                star = "⭐ " if rk and str(o.get("key", "")).lower() == rk.lower() else ""
+                rows.append([{"text": f"{star}{o['key']}) {o['label'][:38]}", "callback_data": f"po:{sid}:{o['key']}"}])
+            rows.append([{"text": "❌ None / reject", "callback_data": f"pr:{sid}"}])
+            if rk:
+                text += f"\n\n⭐ _= recommended ({rk})_"
         else:
             rows = [[
                 {"text": "✅ Approve", "callback_data": f"pa:{sid}"},
                 {"text": "❌ Reject", "callback_data": f"pr:{sid}"},
             ]]
+        # Advertise freeform reply — but NOT on outbound message kinds, where a
+        # freeform "send but change X" would mis-map to a bare APPROVE and silently
+        # send the unedited draft to a third party (also guarded in _handle_text).
+        if kind not in VALIDATE_KINDS:
+            text += "\n\n💬 _Or just reply in your own words — e.g. “do b”, “skip this one”, or your own instruction._"
         r = _api("sendMessage", {
             "chat_id": CHAT, "text": text[:3800], "parse_mode": "Markdown",
             "reply_markup": {"inline_keyboard": rows},
@@ -665,6 +712,11 @@ def _handle_text(ev, codemap, callmap, resolved, seen):
         if verb == "APPROVE" and (ent.get("options") or []):
             _send(f"`{ref}` is a choice item — reply e.g. `{ref} a`.")
             continue
+        if verb == "APPROVE" and _is_outbound(ent) and _edit_intent(body):
+            _send(f"`{ref}` looks like an *edit*, not a plain approve — I won't send the "
+                  f"original draft as-is. Tap ✅ Approve (or reply `approve {ref}`) to send "
+                  f"it unchanged, or `reject {ref}` to skip. _(Edit-then-send for emails isn't wired yet.)_")
+            continue
         toast = _apply_decision(ent, "APPROVE" if verb == "APPROVE" else "REJECT")
         resolved.add(tid); handled_ids.add(tid); acted += 1
         _, cment = _callmap_entry_for_id(callmap, tid)
@@ -706,6 +758,11 @@ def _handle_text(ev, codemap, callmap, resolved, seen):
                 continue
             toast = _apply_decision(ent, "CHOOSE", option=option)
         else:
+            if dec == "approve" and _is_outbound(ent) and _edit_intent(body):
+                _send(f"That looks like an *edit* of “{ent.get('title','')[:50]}”, not a plain "
+                      f"approve — I won't send the original draft as-is. Tap ✅ Approve to send it "
+                      f"unchanged, or reply `reject` to skip. _(Edit-then-send for emails isn't wired yet.)_")
+                continue
             toast = _apply_decision(ent, dec.upper())
         resolved.add(tid); handled_ids.add(tid); acted += 1
         _, cment = _callmap_entry_for_id(callmap, tid)

--- a/claude-ops/email-cos/pocket-responder.py
+++ b/claude-ops/email-cos/pocket-responder.py
@@ -203,7 +203,7 @@ _RE_EDIT_INTENT = re.compile(
     r"\b(change|instead of|edit|reword|rewrite|replace|revise|adjust|tweak|shorter|"
     r"longer|add that|mention|leave out|take out|remove the|"
     r"make it (?:shorter|longer|clearer|more|less|sound|polite|formal|casual|better)|"
-    r"don'?t say|say that|reslant|soften|reschedule to)\b", re.I)
+    r"don'?t say|say(?:\s+that)?|send but|reslant|soften|reschedule to)\b", re.I)
 
 
 def _edit_intent(body):

--- a/claude-ops/email-cos/pocket-responder.py
+++ b/claude-ops/email-cos/pocket-responder.py
@@ -200,9 +200,10 @@ def _recommended_key(it, opts):
 # outbound email ASK gets mis-mapped to a bare APPROVE and the UNEDITED draft is
 # sent to a third party. Edit-then-send re-drafting is not wired yet.
 _RE_EDIT_INTENT = re.compile(
-    r"\b(change|instead|edit|reword|rewrite|replace|revise|adjust|tweak|shorter|"
-    r"longer|add that|mention|leave out|take out|remove the|make it|don'?t say|"
-    r"say that|reslant|soften|reschedule to)\b", re.I)
+    r"\b(change|instead of|edit|reword|rewrite|replace|revise|adjust|tweak|shorter|"
+    r"longer|add that|mention|leave out|take out|remove the|"
+    r"make it (?:shorter|longer|clearer|more|less|sound|polite|formal|casual|better)|"
+    r"don'?t say|say that|reslant|soften|reschedule to)\b", re.I)
 
 
 def _edit_intent(body):
@@ -300,7 +301,7 @@ def cmd_send():
         # Advertise freeform reply — but NOT on outbound message kinds, where a
         # freeform "send but change X" would mis-map to a bare APPROVE and silently
         # send the unedited draft to a third party (also guarded in _handle_text).
-        if kind not in VALIDATE_KINDS:
+        if not _is_outbound(it):
             text += "\n\n💬 _Or just reply in your own words — e.g. “do b”, “skip this one”, or your own instruction._"
         r = _api("sendMessage", {
             "chat_id": CHAT, "text": text[:3800], "parse_mode": "Markdown",

--- a/claude-ops/email-cos/prompts/orchestrator.prompt
+++ b/claude-ops/email-cos/prompts/orchestrator.prompt
@@ -13,11 +13,13 @@ PER ITEM:
 2. ENRICH: recall the contact/thread via `mcp__gbrain__search` (+ get_page on a hit). If the counterparty/company is unfamiliar, do ONE Tavily web search to identify them.
 3. ACT by category:
    - Legal / Finance: do NOT draft a reply. Append a reminder-style ASK to the pocket review.jsonl (use the configured POCKET_STATE_DIR / {{EMAIL_COS_POCKET_STATE_DIR}} path the template already uses) with kind "action_item", source "email-triage", title "Review: <sender>: <subject ≤60>", context "WHO: <who>\nGIST: <what they need>\nACTION NEEDED: <what Sam must decide/do>", verdict ASK, and NO email_reply field (approving just acknowledges it — nothing is sent). This surfaces it as a Telegram button. Do NOT call icloud-reminder.sh or any other channel.
+     Also set "action_preview" to one concrete sentence on what approving does (usually "Marks this as acknowledged — nothing is sent."). When the item is a GENUINE fork the owner must decide (not a yes/no acknowledge), additionally set "decision_question" to the single question being decided and "options" to a 2–4 element array of {"key":"a","label":"<≤38 chars>","recommended":true|false} — keys a/b/c/d in order, exactly ONE option recommended:true (your best-guess answer). For a plain acknowledge with no real fork leave decision_question "" and options []. NEVER invent facts to manufacture options.
    - Other categories: COMPOSE a reply in the owner's voice (match the email's language; warm, concise, professional; end "Best,\n[Name]"). Then create a pocket APPROVAL ASK by appending ONE json line to {{EMAIL_COS_POCKET_STATE_DIR}}/review.jsonl using this exact python (fill the variables):
      ```
      python3 - <<PY
      import json,time
      rec={"id":"email-reply-<gmail_msg_id>","kind":"send_message","title":"Reply to <sender name>: <subject ≤60 chars>",
+       "action_preview":"Sends this reply to <sender name> (<sender email>) — exactly as written, nothing edited.",
        "context":"WHO: <1-line who they are>\nGIST: <1-line what they want>\n\nPROPOSED REPLY:\n<the full reply body>",
        "source":"email-triage","confidence":1.0,"captured_at":time.strftime('%Y-%m-%dT%H:%M:%SZ',time.gmtime()),
        "triage":{"verdict":"ASK","confidence":1.0,"reasoning":"Outbound email reply needs owner approval (Rule 6).","decided_at":time.strftime('%Y-%m-%dT%H:%M:%SZ',time.gmtime())},

--- a/claude-ops/scripts/ops-pocket-triage.py
+++ b/claude-ops/scripts/ops-pocket-triage.py
@@ -186,12 +186,12 @@ Return STRICT JSON, no markdown, no prose outside the JSON:
   "action_preview": "<ASK only — one concrete sentence: what will happen if the owner approves this item. E.g. 'Creates a GitHub issue in your-org/your-repo with the given title and assigns it to you.' Leave empty string for non-ASK verdicts.>",
   "decision_question": "<ASK only, and only when the item is a genuine multi-choice decision — the single question being decided. E.g. 'Which environment should this deploy target?' Leave empty string when it is a simple yes/no.>",
   "options": [
-    {{"key": "a", "label": "<concrete option text — what choosing this means>"}},
+    {{"key": "a", "label": "<concrete option text — what choosing this means>", "recommended": true}},
     {{"key": "b", "label": "<concrete option text>"}}
   ]
 }}
 
-For the options array: include 2–4 options only when decision_question is non-empty. Use keys a/b/c/d in order. When the item is a plain yes/no ASK, set options to an empty array []. Non-ASK verdicts must also set options to [].
+For the options array: include 2–4 options only when decision_question is non-empty. Use keys a/b/c/d in order. Mark exactly ONE option with "recommended": true — your best-guess answer (shown with a ⭐ in the approval UI); omit the key on the others. When the item is a plain yes/no ASK, set options to an empty array []. Non-ASK verdicts must also set options to [].
 
 Owner context (NEVER assume otherwise):
   • Owner name: {owner_name}
@@ -405,7 +405,12 @@ def route(task: dict, decision: dict) -> str:
             routed["decision_question"] = dq
         if opts and isinstance(opts, list):
             routed["options"] = [
-                {"key": str(o.get("key", "")).lower(), "label": str(o.get("label", ""))}
+                {
+                    "key": str(o.get("key", "")).lower(),
+                    "label": str(o.get("label", "")),
+                    # Carry the recommended flag through so the approval UI can ⭐ it.
+                    **({"recommended": True} if o.get("recommended") else {}),
+                }
                 for o in opts
                 if o.get("key") and o.get("label")
             ]


### PR DESCRIPTION
## What Sam hit
The Pocket/email-cos approval messages in Telegram **only offered ✅Approve / ❌Reject** and were **truncated** mid-body. Sam asked for: A/B/C options, a recommendation, and a freeform-text option.

## Root cause (two layers)
1. **Producers never emitted options.** The responder already supports a/b/c choice buttons + freeform reply mapping — but `orchestrator.prompt` (the dominant producer, 13/17 live ASKs) and the `ops-pocket-triage.py` path didn't populate `options`/`action_preview`/`decision_question`, so everything fell back to binary.
2. **Two truncation caps** amputated the body before send: `_norm` capped context at 600 chars, `cmd_send` at 500 — long email drafts + voice-memo context (some 90k+ chars) were cut to a stub.

## Changes
**`email-cos/pocket-responder.py`**
- Untruncate: `_norm` 600→6000, `cmd_send` 500→3200 (Telegram limit 4096; text still hard-capped 3800).
- Render `decision_question` (❓ header); mark the recommended option with **⭐** (reads per-option `recommended:true`, or top-level `recommended_option`/`recommended_key`, incl. inside `raw`/`raw.triage`).
- Advertise freeform reply (💬 footer) on **non-outbound** kinds only.
- **Footgun guard:** a freeform "send but change X" on a `send_message`/`email_reply` ASK no longer mis-maps to a bare APPROVE that ships the **unedited** draft to a third party — it's declined with an explanation. (Edit-then-send re-drafting is intentionally **out of scope**.)

**`email-cos/prompts/orchestrator.prompt`** — email replies carry `action_preview`; Legal/Finance "Review:" items carry `action_preview` + (when a genuine fork) `decision_question` + `options` with exactly one `recommended`.

**`scripts/ops-pocket-triage.py`** — options schema marks one `recommended`; `route()` carries the flag through to `review.jsonl`.

## Verification
End-to-end against the **real Telegram API** (synthetic multi-choice + email-reply ASKs → owner self-chat → asserted full text, a/b/c, ⭐ on recommended, footer present/suppressed by kind, untruncated 3468/3340-char bodies → test messages deleted). Existing pocket tests green (`test-pocket-approvals-digest` 6/6). Idempotent on the live 17-item queue (`sent 0`, no re-spam).

## Deploy note (already applied on the box)
The running pipeline uses deployed copies: `~/.local/share/email-cos/pocket-responder.py` (synced byte-identical to this PR) and the **runtime override** `~/.local/state/email-cos/orchestrator.prompt` (orch.sh prefers it over the repo template) — both updated live so the fix is active now. The repo template here is the durable source for the next `install.sh`. Existing already-sent ASKs keep their old rendering; new ASKs get the rich one.
🚀 Shipped by a human and an LLM in a trench coat; the trench coat tested it against real Telegram.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches outbound email approval paths and freeform/LLM mapping; misconfiguration could still affect what gets sent, though the change adds explicit edit-intent blocking.
> 
> **Overview**
> Telegram Pocket approvals get **fuller ASK bodies** and **richer decision UI**: context limits rise (`_norm` 600→6000, `cmd_send` 500→3200), messages show **`decision_question`**, **`action_preview`**, multi-choice buttons with a **⭐ recommended** option, and a **freeform-reply** hint on non-outbound items only.
> 
> **Producers** now emit those fields: `orchestrator.prompt` adds `action_preview` (and optional `decision_question` / `options` with one `recommended`) for Legal/Finance reviews and email replies; `ops-pocket-triage.py` documents and passes through `recommended` on ASK options.
> 
> **Safety:** freeform or classic approve text that looks like an **edit** (e.g. “send but…”) on outbound `send_message` / `email_reply` ASKs is **blocked** so an unedited draft is not sent; edit-then-send remains out of scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9050766f0cb5f47a7601302b531746e9cc9993ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recommended approval options now visually marked in decision messages with a star indicator.

* **Bug Fixes**
  * Fixed unintended email sends when users request edits during the approval workflow.
  * Improved freeform-text handling to properly distinguish between approval and edit requests.

* **Improvements**
  * Enhanced context preservation in approval requests for better decision-making.
  * Refined button message formatting and decision option presentation for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->