### PR TITLE
release: v2.20.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,9 +9,9 @@
   "plugins": [
     {
       "name": "ops",
-      "description": "Business operations command center for Claude Code \u2014 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
+      "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.19.3",
+      "version": "2.20.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ops",
-  "version": "2.19.3",
-  "description": "Business operations command center for Claude Code \u2014 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
+  "version": "2.20.0",
+  "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",
     "url": "https://github.com/Lifecycle-Innovations-Limited"
@@ -66,7 +66,7 @@
     "no_rm_rf_anchor": {
       "type": "boolean",
       "title": "Block rm -rf against root anchors",
-      "description": "PreToolUse hook denies `rm -rf` targeting /, ~, $HOME, .., or . \u2014 protecting against catastrophic filesystem wipes. Specific subpaths (./node_modules, /tmp/foo) are allowed.",
+      "description": "PreToolUse hook denies `rm -rf` targeting /, ~, $HOME, .., or . — protecting against catastrophic filesystem wipes. Specific subpaths (./node_modules, /tmp/foo) are allowed.",
       "default": true
     },
     "warn_mainpush": {
@@ -83,7 +83,7 @@
     },
     "monitor_post_merge": {
       "type": "boolean",
-      "title": "Monitor PR merges \u2192 deploys",
+      "title": "Monitor PR merges → deploys",
       "description": "After `gh pr merge` to dev/main, watch the deploy workflow + audit service health.",
       "default": true
     },
@@ -96,7 +96,7 @@
     "auto_dispatch_fixer": {
       "type": "boolean",
       "title": "Auto-dispatch headless Claude fixer",
-      "description": "When off, failures are logged + notified only \u2014 no agent runs.",
+      "description": "When off, failures are logged + notified only — no agent runs.",
       "default": true
     },
     "allow_dangerous": {
@@ -148,7 +148,7 @@
     "registry_path": {
       "type": "file",
       "title": "Service registry JSON",
-      "description": "Maps owner/repo:base \u2192 health/version URLs. Project .claude/post-merge-services.json overrides.",
+      "description": "Maps owner/repo:base → health/version URLs. Project .claude/post-merge-services.json overrides.",
       "default": "~/.claude/config/post-merge-services.json"
     },
     "repo_search_roots": {
@@ -210,33 +210,33 @@
     "suggest_specialized_agents": {
       "type": "boolean",
       "title": "Suggest specialized subagents",
-      "description": "PreToolUse hook on Agent \u2014 when subagent_type=general-purpose, asks if a domain-specific agent fits better.",
+      "description": "PreToolUse hook on Agent — when subagent_type=general-purpose, asks if a domain-specific agent fits better.",
       "default": true
     },
     "telegram_api_id": {
       "title": "Telegram API ID",
-      "description": "Numeric API ID from https://my.telegram.org/apps. Optional \u2014 run /ops:setup telegram to auto-configure.",
+      "description": "Numeric API ID from https://my.telegram.org/apps. Optional — run /ops:setup telegram to auto-configure.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "telegram_api_hash": {
       "title": "Telegram API Hash",
-      "description": "API hash from https://my.telegram.org/apps. Optional \u2014 run /ops:setup telegram to auto-configure. If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "API hash from https://my.telegram.org/apps. Optional — run /ops:setup telegram to auto-configure. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "telegram_phone": {
       "title": "Telegram Phone Number",
-      "description": "Your phone number in E.164 format. Optional \u2014 run /ops:setup telegram to auto-configure.",
+      "description": "Your phone number in E.164 format. Optional — run /ops:setup telegram to auto-configure.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "telegram_session": {
       "title": "Telegram Session String",
-      "description": "gram.js StringSession. Optional \u2014 run /ops:setup telegram to auto-configure. If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "gram.js StringSession. Optional — run /ops:setup telegram to auto-configure. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -264,14 +264,14 @@
     },
     "klaviyo_private_key": {
       "title": "Klaviyo Private API Key",
-      "description": "Private API key from Klaviyo Settings > API Keys (starts with pk_ or ck_) If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Private API key from Klaviyo Settings > API Keys (starts with pk_ or ck_) If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "meta_ads_token": {
       "title": "Meta Ads Access Token",
-      "description": "Meta Marketing API access token from Facebook Business If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Meta Marketing API access token from Facebook Business If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -307,49 +307,49 @@
     },
     "shopify_admin_token": {
       "title": "Shopify Admin API Token",
-      "description": "Admin API access token from Shopify Partners or custom app If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Admin API access token from Shopify Partners or custom app If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "shipbob_access_token": {
       "title": "ShipBob Access Token",
-      "description": "ShipBob Personal Access Token for fulfillment tracking (optional) If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "ShipBob Personal Access Token for fulfillment tracking (optional) If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "bland_ai_api_key": {
       "title": "Bland AI API Key",
-      "description": "API key from https://app.bland.ai \u2014 used for /ops:ops-voice call If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "API key from https://app.bland.ai — used for /ops:ops-voice call If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "elevenlabs_api_key": {
       "title": "ElevenLabs API Key",
-      "description": "API key from https://elevenlabs.io \u2014 used for /ops:ops-voice tts If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "API key from https://elevenlabs.io — used for /ops:ops-voice tts If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "groq_api_key": {
       "title": "Groq API Key",
-      "description": "API key from https://console.groq.com \u2014 used for /ops:ops-voice transcribe (Whisper) If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "API key from https://console.groq.com — used for /ops:ops-voice transcribe (Whisper) If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "stripe_secret_key": {
       "title": "Stripe Secret Key",
-      "description": "Stripe secret key (sk_live_... or sk_test_...) for revenue tracking. Prefer Doppler reference. If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Stripe secret key (sk_live_... or sk_test_...) for revenue tracking. Prefer Doppler reference. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "revenuecat_api_key": {
       "title": "RevenueCat API Key",
-      "description": "RevenueCat API key for mobile subscription revenue tracking (V2 API). If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "RevenueCat API key for mobile subscription revenue tracking (V2 API). If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -363,21 +363,21 @@
     },
     "datadog_api_key": {
       "title": "Datadog API Key",
-      "description": "From Datadog Organization Settings > API Keys \u2014 used for /ops:monitor If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "From Datadog Organization Settings > API Keys — used for /ops:monitor If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "datadog_app_key": {
       "title": "Datadog Application Key",
-      "description": "From Datadog Organization Settings > Application Keys If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "From Datadog Organization Settings > Application Keys If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "newrelic_api_key": {
       "title": "New Relic API Key",
-      "description": "User API Key from one.newrelic.com/api-keys \u2014 used for /ops:monitor If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "User API Key from one.newrelic.com/api-keys — used for /ops:monitor If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -413,42 +413,42 @@
     },
     "pushover_user_key": {
       "title": "Pushover User Key",
-      "description": "From https://pushover.net/ \u2014 paired with pushover_app_token. If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "From https://pushover.net/ — paired with pushover_app_token. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "pushover_app_token": {
       "title": "Pushover App Token",
-      "description": "App-specific token from https://pushover.net/apps/build If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "App-specific token from https://pushover.net/apps/build If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "discord_bot_token": {
       "title": "Discord Bot Token",
-      "description": "Bot token from Discord Developer Portal \u2014 used for channel reads and DMs. Prefer Doppler reference. If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Bot token from Discord Developer Portal — used for channel reads and DMs. Prefer Doppler reference. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "discord_guild_id": {
       "title": "Discord Guild ID",
-      "description": "Server/guild ID (right-click server in Discord \u2192 Copy ID with Developer Mode enabled)",
+      "description": "Server/guild ID (right-click server in Discord → Copy ID with Developer Mode enabled)",
       "type": "string",
       "sensitive": false,
       "default": ""
     },
     "discord_default_webhook_url": {
       "title": "Discord Default Webhook URL",
-      "description": "Optional default webhook URL (https://discord.com/api/webhooks/\u2026) for /ops:comms discord send. Shared with the ops-fires notification sink (which also reads discord_webhook_url). If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Optional default webhook URL (https://discord.com/api/webhooks/…) for /ops:comms discord send. Shared with the ops-fires notification sink (which also reads discord_webhook_url). If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "doppler_token": {
       "title": "Doppler Token",
-      "description": "Doppler service or personal token for the @dopplerhq/mcp-server MCP integration. Generated by /ops:setup or paste manually. If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Doppler service or personal token for the @dopplerhq/mcp-server MCP integration. Generated by /ops:setup or paste manually. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -469,35 +469,35 @@
     },
     "myparcel_api_key": {
       "title": "MyParcel.nl API Key",
-      "description": "Plain API key from backoffice.myparcel.nl \u2192 Settings \u2192 API. Used by /ops:ops-package. Script base64-encodes it at runtime \u2014 do NOT pre-encode.",
+      "description": "Plain API key from backoffice.myparcel.nl → Settings → API. Used by /ops:ops-package. Script base64-encodes it at runtime — do NOT pre-encode.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "sendcloud_public_key": {
       "title": "Sendcloud Public Key",
-      "description": "Public key from Sendcloud Panel \u2192 Settings \u2192 Integrations \u2192 Sendcloud API. Paired with sendcloud_private_key.",
+      "description": "Public key from Sendcloud Panel → Settings → Integrations → Sendcloud API. Paired with sendcloud_private_key.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "sendcloud_private_key": {
       "title": "Sendcloud Private Key",
-      "description": "Private key from Sendcloud Panel \u2192 Settings \u2192 Integrations \u2192 Sendcloud API. Paired with sendcloud_public_key.",
+      "description": "Private key from Sendcloud Panel → Settings → Integrations → Sendcloud API. Paired with sendcloud_public_key.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "dhl_parcel_user_id": {
       "title": "DHL Parcel NL User ID",
-      "description": "User ID issued in My DHL Parcel \u2192 User settings \u2192 API settings. Paired with dhl_parcel_key.",
+      "description": "User ID issued in My DHL Parcel → User settings → API settings. Paired with dhl_parcel_key.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "dhl_parcel_key": {
       "title": "DHL Parcel NL API Key",
-      "description": "API key from My DHL Parcel \u2192 User settings \u2192 API settings. Paired with dhl_parcel_user_id.",
+      "description": "API key from My DHL Parcel → User settings → API settings. Paired with dhl_parcel_user_id.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -532,7 +532,7 @@
     },
     "dpd_password": {
       "title": "DPD Password",
-      "description": "Password for the DelisID. Exchanged at login for a short-lived token. If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Password for the DelisID. Exchanged at login for a short-lived token. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -546,7 +546,7 @@
     },
     "ups_client_secret": {
       "title": "UPS OAuth Client Secret",
-      "description": "Client secret for the UPS app. Used for OAuth2 client_credentials. If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Client secret for the UPS app. Used for OAuth2 client_credentials. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -567,7 +567,7 @@
     },
     "fedex_client_secret": {
       "title": "FedEx OAuth Client Secret",
-      "description": "Secret Key for the FedEx project. Used for OAuth2 client_credentials. If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Secret Key for the FedEx project. Used for OAuth2 client_credentials. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -582,7 +582,7 @@
     "telegram_enabled": {
       "type": "boolean",
       "title": "Enable Telegram integration",
-      "description": "Use Telegram for inbox + notifications. Requires telegram_api_id/hash/phone/session \u2014 run /ops:setup telegram.",
+      "description": "Use Telegram for inbox + notifications. Requires telegram_api_id/hash/phone/session — run /ops:setup telegram.",
       "default": false
     },
     "discord_enabled": {
@@ -782,7 +782,7 @@
     },
     "ip_whitelist_desc_prefix": {
       "title": "IP-whitelist rule description prefix",
-      "description": "Description prefix for managed rules \u2014 e.g. 'mylaptop'. Defaults to <hostname>-laptop. Rules with this prefix are reaped when older than ip_whitelist_keep_recent.",
+      "description": "Description prefix for managed rules — e.g. 'mylaptop'. Defaults to <hostname>-laptop. Rules with this prefix are reaped when older than ip_whitelist_keep_recent.",
       "type": "string",
       "sensitive": false,
       "default": ""

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.20.0] - 2026-06-02
+
+### Changed
+### Added
+- Pocket/email-cos Telegram approvals now render A/B/C options with a ⭐ recommended pick, a decision-question header, and untruncated message bodies (full email drafts + voice-memo context) (#459).
+- Freeform email **edit → re-draft → re-stage**: replying to an email approval with edits (e.g. "change the date to Friday") re-drafts the body via LLM and re-stages a fresh approval ASK; the original draft is never auto-sent (#462).
+
+### Fixed
+- Every `claude -p` subprocess in pocket-responder (`_redraft_email`, `_llm_map`, `_validate_action`) was silently dying with "Prompt is too long" on context-heavy boxes — added MCP-isolation flags (`--strict-mcp-config --mcp-config '{}'`) so freeform natural-language approval mapping and the pre-send validation guard actually work, not just the regex fast-path (#462).
+
+
 ## [2.19.3] - 2026-06-01
 
 ### Added

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.19.3",
+  "version": "2.20.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.20.0** (was 2.19.1).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

### Added
- Pocket/email-cos Telegram approvals now render A/B/C options with a ⭐ recommended pick, a decision-question header, and untruncated message bodies (full email drafts + voice-memo context) (#459).
- Freeform email **edit → re-draft → re-stage**: replying to an email approval with edits (e.g. "change the date to Friday") re-drafts the body via LLM and re-stages a fresh approval ASK; the original draft is never auto-sent (#462).

### Fixed
- Every `claude -p` subprocess in pocket-responder (`_redraft_email`, `_llm_map`, `_validate_action`) was silently dying with "Prompt is too long" on context-heavy boxes — added MCP-isolation flags (`--strict-mcp-config --mcp-config '{}'`) so freeform natural-language approval mapping and the pre-send validation guard actually work, not just the regex fast-path (#462).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff is version metadata, changelog text, and non-functional JSON description encoding—no executable logic changes in this PR.
> 
> **Overview**
> **Release v2.20.0** — bumps `version` to **2.20.0** in `marketplace.json`, `claude-ops/.claude-plugin/plugin.json`, and `claude-ops/package.json`, and adds a **CHANGELOG** entry for 2026-06-02.
> 
> The changelog documents shipped behavior (not new code in this diff): richer **Pocket/email-cos Telegram approvals** (A/B/C + recommended option, full bodies), **freeform email edit → LLM re-draft → new approval** without auto-sending the original, and a fix for **`claude -p` in pocket-responder** failing with “Prompt is too long” via **MCP-isolation** flags.
> 
> **Plugin/marketplace JSON** also normalizes description punctuation (Unicode em dashes and arrows instead of escaped `\u2014` / `\u2192` sequences).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e41a85fadf72291d94a0d5ca32915d81ded1ac0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->