### PR TITLE
fix(ops-inbox): seed merged DM groups with lid twins (lid blind-spot)

### DIFF
--- a/claude-ops/bin/ops-inbox-scan
+++ b/claude-ops/bin/ops-inbox-scan
@@ -145,6 +145,15 @@ def scan_whatsapp():
         except sqlite3.Error as e:
             notes.append(f"whatsapp: lid_map unreadable ({e}); falling back to contacts.phone")
 
+    # Reverse map: phone_jid -> [lid_jids]. Used to seed merged groups with BOTH
+    # twins even when one twin's `chats` row is absent/stale at scan time (backfill
+    # timing). Without this a live @lid conversation can be missed while only the
+    # stale phone twin surfaces — the lid blind-spot. last_msgs() reads `messages`
+    # directly, so adding the twin as a member catches the live side regardless.
+    pn2lids = {}
+    for _l, _p in lid2pn.items():
+        pn2lids.setdefault(_p, []).append(_l)
+
     # contacts: jid -> name, and phone -> jids (fallback merge + name resolution)
     name_by_jid, phone_by_jid, jids_by_phone = {}, {}, {}
     try:
@@ -191,6 +200,10 @@ def scan_whatsapp():
         g = groups.setdefault(key, {"members": set(), "name": None, "latest": None})
         g["members"].add(jid)
         g["members"].add(key)
+        # Always include the phone key's lid twin(s), even if their chats row is
+        # missing/stale this scan — so the merged thread sees the live side.
+        for _lt in pn2lids.get(key, ()):
+            g["members"].add(_lt)
         nm = name_by_jid.get(jid) or (c["name"] if c["name"] and not c["name"][0].isdigit() else None)
         if nm and not g["name"]:
             g["name"] = nm


### PR DESCRIPTION
Fixes the WhatsApp lid↔phone blind-spot in `bin/ops-inbox-scan`: a live `@lid` conversation whose chats row was missing/stale at scan time surfaced as the stale phone twin or was double-counted. Now every merged group is seeded with the phone key's lid twin(s) from `whatsmeow_lid_map`, so the merged thread always sees the live side.

Verified on the live store: contact's lid+phone collapse to one conversation classified on the true last message (Nir: was stuck on May-12 phone twin → now correctly WAITING on the merged Jun-2 activity).

🚀 shipped by a human and an LLM who finally agree which chat is which

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only offline scan logic only; improves JID membership for classification with no auth or send-path changes.
> 
> **Overview**
> **WhatsApp inbox scan** now seeds each merged 1:1 thread with **both** phone and `@lid` JIDs from `whatsmeow_lid_map`, not only JIDs that appear in `chats` during this run.
> 
> A reverse map (`pn2lids`) is built from the existing lid→phone map. When grouping DMs by canonical phone JID, any linked `@lid` twin is added to `members` even if that twin’s `chats` row is missing or stale. **`last_msgs`** then queries `messages` across all members, so NEEDS_REPLY / WAITING reflects the real latest activity instead of an outdated phone-only snapshot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a66ea553b70159151884e18df42d404854331621. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->