### PR TITLE
release: v2.20.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.20.2",
+      "version": "2.20.3",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.20.2",
+  "version": "2.20.3",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.20.3] - 2026-06-02
+
+### Changed
+add telegram_bot_token/owner_id to plugin userConfig schema (telegram-channel MCP); bump yolo maxTurns 20→35
+
+
 ## [2.20.2] - 2026-06-02
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.20.2",
+  "version": "2.20.3",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.20.3** (was 2.20.2).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

add telegram_bot_token/owner_id to plugin userConfig schema (telegram-channel MCP); bump yolo maxTurns 20→35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version alignment plus additive plugin settings and a higher agent turn cap; no auth or deploy-path changes in the diff itself.
> 
> **Overview**
> **Release v2.20.3** bumps the plugin version from **2.20.2** across the marketplace manifest, `plugin.json`, and `claude-ops/package.json`, and adds a matching **CHANGELOG** entry.
> 
> The release packages two behavior/config updates called out in the changelog (not shown in this diff’s line edits): **`telegram_bot_token`** and **`telegram_owner_id`** exposed in plugin **userConfig** so the **`telegram-channel`** MCP can be configured from `/plugins` settings, and **YOLO** C-suite agents **`maxTurns`** raised from **20 → 35** for longer autonomous analysis runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82d2a913da6937e069481f6b56a17936177da01b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->