### PR TITLE
release: v2.20.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.20.3",
+      "version": "2.20.4",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.20.3",
+  "version": "2.20.4",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.20.4] - 2026-06-02
+
+### Changed
+ops-inbox: INBOX ZERO is now the mandate — archive everything not actionable (incl. WAITING, auto-resurfaces), auto-archive immediately after replying, include_context:true hard default on every read, verify bridge fully up first, and the verified phone archive-toggle heal for the /api/archive LTHash hang.
+
+
 ## [2.20.3] - 2026-06-02
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.20.3",
+  "version": "2.20.4",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.20.4** (was 2.20.3).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

ops-inbox: INBOX ZERO is now the mandate — archive everything not actionable (incl. WAITING, auto-resurfaces), auto-archive immediately after replying, include_context:true hard default on every read, verify bridge fully up first, and the verified phone archive-toggle heal for the /api/archive LTHash hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff is metadata and release notes only; inbox behavior changes are procedural/skill-level and affect WhatsApp archiving ergonomics, not auth or payment paths.
> 
> **Overview**
> **Release v2.20.4** bumps the plugin and registry versions from **2.20.3 → 2.20.4** in `plugin.json`, root `marketplace.json`, and `claude-ops/package.json`, and adds a **CHANGELOG** entry for that release.
> 
> The release notes document a stricter **`/ops:ops-inbox`** operating model (not new code in this diff): treat **inbox zero** as the goal—archive non-actionable threads (including **WAITING**), **auto-archive right after replies**, default **`include_context: true`** on WhatsApp reads, **verify the bridge is up** before classifying, and use the documented **phone archive-toggle** workaround when **`/api/archive`** hits **LTHash** desync hangs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b7131ec65a0ebc53f57a892c8ab9c9febf60e6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->