### PR TITLE
release: v2.20.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.20.4",
+      "version": "2.20.5",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.20.4",
+  "version": "2.20.5",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.20.5] - 2026-06-02
+
+### Changed
+ops-inbox: act on finance/legal/personal threads instead of surface-only (PR #472)
+
+
 ## [2.20.4] - 2026-06-02
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.20.4",
+  "version": "2.20.5",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.20.5** (was 2.20.4).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

ops-inbox: act on finance/legal/personal threads instead of surface-only (PR #472)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release PR with no code changes in the diff; low risk for installs beyond picking up the documented ops-inbox behavior from the prior merge.
> 
> **Overview**
> Release **v2.20.5** by aligning the published plugin version everywhere it is stamped: **2.20.4 → 2.20.5** in `.claude-plugin/marketplace.json`, `claude-ops/.claude-plugin/plugin.json`, and `claude-ops/package.json`.
> 
> `CHANGELOG.md` adds a **[2.20.5]** entry noting the shipped product change from **PR #472**: **`ops-inbox`** should **act on finance / legal / personal threads** instead of treating them as **surface-only** (listing without full handling). That behavior is **not** in this diff—only the version + release notes.
> 
> **Risk:** Low — metadata and documentation only in this PR; no runtime code paths changed here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeaa68697f69fcd8ce83426de9f83c3d3e1a7927. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->