### PR TITLE
release: v2.20.8

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.20.7",
+      "version": "2.20.8",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.20.7",
+  "version": "2.20.8",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.20.8] - 2026-06-02
+
+### Changed
+whatsapp-mcp: port apply-patches.py Fix A/B pairing + C/D/F/G/L to current upstream whatsmeow API (go build/vet clean); recover_app_state now resync-only (peer-recovery API removed upstream) (PR #479)
+
+
 ## [2.20.7] - 2026-06-02
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.20.7",
+  "version": "2.20.8",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.20.8** (was 2.20.7).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

whatsapp-mcp: port apply-patches.py Fix A/B pairing + C/D/F/G/L to current upstream whatsmeow API (go build/vet clean); recover_app_state now resync-only (peer-recovery API removed upstream) (PR #479)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low risk for the diff itself (metadata only), but the release documents WhatsApp bridge/MCP behavior changes (pairing patches, degraded recover_app_state) that affect a critical comms integration path.
> 
> **Overview**
> **Release v2.20.8** bumps the ops plugin and marketplace registry from **2.20.7 → 2.20.8** in `plugin.json`, `.claude-plugin/marketplace.json`, and `claude-ops/package.json`, and adds a **CHANGELOG** entry for this cut.
> 
> The release notes ship **whatsapp-mcp** maintenance from PR #479: `apply-patches.py` fixes **A/B** (pairing) and **C/D/F/G/L** are aligned with the current upstream **whatsmeow** API so fresh installs **build/vet** cleanly. **`recover_app_state`** is documented as **resync-only** because upstream removed the peer-recovery APIs—operators should treat fatal LTHash recovery as weaker than before unless they pin an older whatsmeow.
> 
> No application logic changes appear in this diff beyond versioning and changelog text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09b9116e25b019b9b501d5463a3882f875fb7eab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->