### PR TITLE
feat(telegram-channel): leader-exclusive poll + reply gate

### DIFF
--- a/claude-ops/scripts/email/README.md
+++ b/claude-ops/scripts/email/README.md
@@ -8,8 +8,8 @@ sending to the wrong account or burning the outbound-comms approval token**.
 ### The bug it prevents
 
 Replying with `gog gmail send --reply-to-message-id <ID>` **404s** when the
-message-ID was scanned from one Gmail account (e.g. `sam.renders@gmail.com`) but
-the send defaults to a **different** account (e.g. `sam@samfeldt.com`) — the same
+message-ID was scanned from one Gmail account (e.g. account A) but
+the send defaults to a **different** account (e.g. account B) — the same
 thread has different message/thread IDs per account.
 
 Worse: **every** `gog gmail send` attempt — even one that errors on a 404 or a bad
@@ -43,7 +43,7 @@ gog-reply.sh --to <email> --body <text> \
 | `--subject <subj>` | Subject. If omitted, derived as `Re: <original subject>`. |
 | `--match-from <email>` | From-address used to find the thread. Defaults to `--to`. |
 | `--match-subject <text>` | Substring to disambiguate the thread. Optional. |
-| `--account <acct>` | Pin a gog account. If omitted, **auto-discovers** (enumerates oauth gmail accounts via `gog auth list`, always also probing `sam@samfeldt.com` and `sam.renders@gmail.com`). |
+| `--account <acct>` | Pin a gog account. If omitted, **auto-discovers** (enumerates oauth gmail accounts via `gog auth list`, always also probing any accounts in `$GOG_EXTRA_ACCOUNTS`). |
 | `--dry-run` | Resolve and print the account / threadId / message-id / to / subject / body, then exit 0 without sending. |
 
 ### Exit codes
@@ -75,6 +75,6 @@ gog-reply.sh --to ash@unified-songs.com --body "On it, thanks." --dry-run
 # Pin an account + disambiguate by subject, then actually reply.
 gog-reply.sh --to client@example.com \
   --match-subject "invoice" \
-  --account sam@samfeldt.com \
+  --account <your-account> \
   --body "Attached, let me know if anything's off."
 ```

--- a/claude-ops/scripts/email/gog-reply.sh
+++ b/claude-ops/scripts/email/gog-reply.sh
@@ -5,8 +5,8 @@
 # THE BUG THIS PREVENTS
 # ---------------------
 # A Gmail reply via `gog gmail send --reply-to-message-id <ID>` 404s when the
-# message-ID was scanned from one account (e.g. sam.renders@gmail.com) but the
-# send defaults to a DIFFERENT account (e.g. sam@samfeldt.com): the same thread
+# message-ID was scanned from one account (e.g. your scanning mailbox) but the
+# send defaults to a DIFFERENT account (e.g. your sending mailbox): the same thread
 # carries different message/thread IDs per account.
 #
 # Worse: EVERY `gog gmail send` attempt — even one that 404s or trips a bad flag
@@ -98,7 +98,7 @@ discover_accounts() {
     return 0
   fi
   gog auth list -j 2>/dev/null | python3 -c '
-import sys, json
+import os, sys, json
 seen, out = set(), []
 try:
     d = json.load(sys.stdin)
@@ -113,9 +113,10 @@ try:
                 seen.add(email); out.append(email)
 except Exception:
     pass
-# Always try the two known mailboxes on this box.
-for e in ("sam@samfeldt.com", "sam.renders@gmail.com"):
-    if e not in seen:
+# Always also probe any extra mailboxes named in $GOG_EXTRA_ACCOUNTS
+# (comma/space separated) — keeps personal addresses out of source.
+for e in os.environ.get("GOG_EXTRA_ACCOUNTS", "").replace(",", " ").split():
+    if e and e not in seen:
         seen.add(e); out.append(e)
 print("\n".join(out))
 ' 2>/dev/null

--- a/claude-ops/telegram-server/channel-mcp.mjs
+++ b/claude-ops/telegram-server/channel-mcp.mjs
@@ -82,31 +82,36 @@ function loadSecretsEnv() {
 const secretsEnv = loadSecretsEnv();
 
 function thisSessionIsLeader() {
+  // FAIL OPEN by default: the leader-gate is an opt-in fleet feature. A plain
+  // claude-ops install (no fleet supervisor) or a non-Linux host (no /proc) must
+  // poll normally — the gate only LOCKS OUT a session when it can positively prove
+  // a *different* live session leads. Anything it can't prove → poll.
+  let marker;
   try {
-    const marker = readFileSync(join(homedir(), '.claude', 'state', 'fleet-supervisor.leader'), 'utf8');
-    const m = marker.match(/pid:(\d+)/);
-    if (!m) return false;
-    const leaderPid = m[1];
-    let pid = String(process.pid);
-    for (let i = 0; i < 8; i++) {
-      if (pid === leaderPid) return true;
-      let stat;
-      try {
-        stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
-      } catch {
-        return false;
-      }
-      const after = stat
-        .slice(stat.lastIndexOf(')') + 2)
-        .trim()
-        .split(/\s+/);
-      pid = after[1];
-      if (!pid || pid === '0' || pid === '1') return false;
-    }
-    return false;
+    marker = readFileSync(join(homedir(), '.claude', 'state', 'fleet-supervisor.leader'), 'utf8');
   } catch {
-    return false;
+    return true; // no fleet marker → not a managed fleet → poll normally
   }
+  const m = marker.match(/pid:(\d+)/);
+  if (!m) return true; // marker without a pid → can't enforce → poll
+  const leaderPid = m[1];
+  let pid = String(process.pid);
+  for (let i = 0; i < 64; i++) {
+    if (pid === leaderPid) return true; // this process is in the leader's tree
+    let stat;
+    try {
+      stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+    } catch {
+      return true; // /proc unreadable (non-Linux / process gone) → can't prove → poll
+    }
+    const after = stat
+      .slice(stat.lastIndexOf(')') + 2)
+      .trim()
+      .split(/\s+/);
+    pid = after[1];
+    if (!pid || pid === '0' || pid === '1') return false; // reached init: NOT the leader's tree
+  }
+  return false; // ran out of hops without matching → treat as non-leader
 }
 
 const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN || prefs.bot_token || secretsEnv.TELEGRAM_BOT_TOKEN || '';

--- a/claude-ops/telegram-server/channel-mcp.mjs
+++ b/claude-ops/telegram-server/channel-mcp.mjs
@@ -91,8 +91,15 @@ function thisSessionIsLeader() {
     for (let i = 0; i < 8; i++) {
       if (pid === leaderPid) return true;
       let stat;
-      try { stat = readFileSync(`/proc/${pid}/stat`, 'utf8'); } catch { return false; }
-      const after = stat.slice(stat.lastIndexOf(')') + 2).trim().split(/\s+/);
+      try {
+        stat = readFileSync(`/proc/${pid}/stat`, 'utf8');
+      } catch {
+        return false;
+      }
+      const after = stat
+        .slice(stat.lastIndexOf(')') + 2)
+        .trim()
+        .split(/\s+/);
       pid = after[1];
       if (!pid || pid === '0' || pid === '1') return false;
     }
@@ -215,7 +222,9 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
   }
   if (!thisSessionIsLeader()) {
     return {
-      content: [{ type: 'text', text: 'not the fleet-orchestrator leader — refusing to send (Telegram is leader-exclusive)' }],
+      content: [
+        { type: 'text', text: 'not the fleet-orchestrator leader — refusing to send (Telegram is leader-exclusive)' },
+      ],
       isError: true,
     };
   }
@@ -386,7 +395,9 @@ async function poll() {
   }
 
   try {
-    try { writeFileSync(join(STATE_DIR, 'channel.alive'), String(Date.now())); } catch {}
+    try {
+      writeFileSync(join(STATE_DIR, 'channel.alive'), String(Date.now()));
+    } catch {}
     // offset = lastUpdateId + 1 tells Telegram to skip everything ≤ lastUpdateId.
     // This is the key correctness property: offset NEVER freezes at 0 after
     // the first batch, because we update lastUpdateId = MAX(update_id) seen

--- a/claude-ops/telegram-server/channel-mcp.mjs
+++ b/claude-ops/telegram-server/channel-mcp.mjs
@@ -66,8 +66,45 @@ function loadPreferences() {
 
 const prefs = loadPreferences();
 
-const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN || prefs.bot_token || '';
-const OWNER_ID_STR = process.env.TELEGRAM_OWNER_ID || String(prefs.owner_id ?? '');
+function loadSecretsEnv() {
+  try {
+    const raw = readFileSync(join(homedir(), '.mcp-secrets.env'), 'utf8');
+    const out = {};
+    for (const line of raw.split('\n')) {
+      const m = line.match(/^\s*(?:export\s+)?(TELEGRAM_BOT_TOKEN|TELEGRAM_OWNER_ID)\s*=\s*(.+?)\s*$/);
+      if (m) out[m[1]] = m[2].replace(/^["']|["']$/g, '');
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+const secretsEnv = loadSecretsEnv();
+
+function thisSessionIsLeader() {
+  try {
+    const marker = readFileSync(join(homedir(), '.claude', 'state', 'fleet-supervisor.leader'), 'utf8');
+    const m = marker.match(/pid:(\d+)/);
+    if (!m) return false;
+    const leaderPid = m[1];
+    let pid = String(process.pid);
+    for (let i = 0; i < 8; i++) {
+      if (pid === leaderPid) return true;
+      let stat;
+      try { stat = readFileSync(`/proc/${pid}/stat`, 'utf8'); } catch { return false; }
+      const after = stat.slice(stat.lastIndexOf(')') + 2).trim().split(/\s+/);
+      pid = after[1];
+      if (!pid || pid === '0' || pid === '1') return false;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+const BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN || prefs.bot_token || secretsEnv.TELEGRAM_BOT_TOKEN || '';
+const OWNER_ID_STR =
+  process.env.TELEGRAM_OWNER_ID || (prefs.owner_id ? String(prefs.owner_id) : '') || secretsEnv.TELEGRAM_OWNER_ID || '';
 const OWNER_ID = OWNER_ID_STR ? parseInt(OWNER_ID_STR, 10) : 0;
 const POLL_TIMEOUT = parseInt(process.env.TELEGRAM_POLL_TIMEOUT || '25', 10);
 
@@ -175,6 +212,12 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
   }
   if (!BOT_TOKEN) {
     return { content: [{ type: 'text', text: 'TELEGRAM_BOT_TOKEN not configured' }], isError: true };
+  }
+  if (!thisSessionIsLeader()) {
+    return {
+      content: [{ type: 'text', text: 'not the fleet-orchestrator leader — refusing to send (Telegram is leader-exclusive)' }],
+      isError: true,
+    };
   }
   try {
     const result = await sendMessage(chatId, text);
@@ -337,8 +380,13 @@ async function poll() {
     setTimeout(poll, 30_000).unref();
     return;
   }
+  if (!thisSessionIsLeader()) {
+    setTimeout(poll, 15_000).unref();
+    return;
+  }
 
   try {
+    try { writeFileSync(join(STATE_DIR, 'channel.alive'), String(Date.now())); } catch {}
     // offset = lastUpdateId + 1 tells Telegram to skip everything ≤ lastUpdateId.
     // This is the key correctness property: offset NEVER freezes at 0 after
     // the first batch, because we update lastUpdateId = MAX(update_id) seen


### PR DESCRIPTION
## Problem
`telegram-server/channel-mcp.mjs` is spawned per Claude session. If more than one session's channel-mcp has a bot token, they all long-poll the same bot — and Telegram delivers each update to exactly **one** long-poller, so they steal each other's updates (and 409-contend). In practice inbound DMs reached whichever consumer won the race, so the orchestrator session often never saw them in real time.

## Fix — leader-exclusive gate
Only the **fleet-orchestrator leader** session may poll + reply. Leadership = the `pid:<N>` in `~/.claude/state/fleet-supervisor.leader` is an ancestor of this process. Re-checked on every poll, so a leadership handoff is honored within ~15s without a restart.

- `thisSessionIsLeader()` — walks the process's parent chain via `/proc/<pid>/stat`, matches the marker pid.
- Token/owner fallback from `~/.mcp-secrets.env` so the leader can poll **without** a global `user_config` token (a global token would make *every* session poll and contend — the exact failure we're fixing).
- Heartbeat file (`channel.alive`) so an external supervisor/cron can detect a live leader-poller and skip its own `getUpdates` backstop (no double-consumer).
- `reply` tool is also leader-gated (non-leader sessions refuse to send).

## Safety / public-repo hygiene
All environment-specific values are read **at runtime** from `$HOME`-relative state files — **no hardcoded pid / session-id / owner chat-id / bot token / absolute path** in the committed source. `pid:(\d+)` is a regex, not a literal.

## Verification
- `node --check` ✅
- built-in `--selftest` (owner-allowlist + offset round-trip) **ALL PASS** on a deps-present copy.
- Leader-gate logic unit-checked: from the leader session it resolves `LEADER`; from a non-leader chain it returns false.

Shipped locally as a cache-patch (`scripts/cache-patches/10-telegram-channel-leader-gate.sh`) pending this merge; once merged the cache-patch can be removed.

🚀 the bot now answers to exactly one boss; the rest just watch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes who may poll/send Telegram (fleet leadership) and where credentials are read; misconfiguration could drop inbound DMs or block replies until leadership is correct.
> 
> **Overview**
> **Telegram channel** now ensures only one Claude session owns the bot: `thisSessionIsLeader()` reads `~/.claude/state/fleet-supervisor.leader` and walks `/proc` parent PIDs so non-leader sessions skip long-polling and refuse the `reply` tool; leaders write `channel.alive` while polling. Bot token and owner ID can also load from `~/.mcp-secrets.env` (after env and `preferences.json`), so the leader can poll without a shared global config that would make every session contend on `getUpdates`.
> 
> **Email helper** removes hardcoded mailbox addresses from docs and `gog-reply.sh`; auto-discovery still uses `gog auth list` and now always probes accounts listed in **`$GOG_EXTRA_ACCOUNTS`** (comma/space separated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ad8463cb940a1f2d5a465fe6f436debb40d0724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Load Telegram credentials from a local configuration file as an alternative to environment variables.
  * Enforce a session leader check so only the active instance processes and sends Telegram messages; non-leaders skip polling and cannot send replies.
  * Write periodic heartbeat state during polling to indicate session health.

* **Bug Fixes**
  * Email reply script now probes additional configured accounts to avoid cross-account reply mismatches.

* **Documentation**
  * Clarified README examples and account auto-discovery behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lifecycle-Innovations-Limited/claude-ops/pull/481?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->