### PR TITLE
release: v2.20.9

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.20.8",
+      "version": "2.20.9",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.20.8",
+  "version": "2.20.9",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.20.9] - 2026-06-03
+
+### Changed
+Telegram channel-mcp leader-exclusive poll+reply gate (#481): only the fleet-orchestrator leader session consumes the bot, preventing multi-session getUpdates contention; fails open for non-fleet / non-Linux installs so default single-session behavior is preserved.
+
+
 ## [2.20.8] - 2026-06-02
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.20.8",
+  "version": "2.20.9",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.20.9** (was 2.20.8).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

Telegram channel-mcp leader-exclusive poll+reply gate (#481): only the fleet-orchestrator leader session consumes the bot, preventing multi-session getUpdates contention; fails open for non-fleet / non-Linux installs so default single-session behavior is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only in the diff; the documented Telegram gate reduces bot API contention and fails open for non-fleet installs.
> 
> **Overview**
> **Release v2.20.9** bumps the plugin from **2.20.8 → 2.20.9** in `plugin.json`, root `marketplace.json`, and `claude-ops/package.json`, and adds a **CHANGELOG** entry for the shipped behavior in **#481**.
> 
> The functional change (not in this diff’s file list beyond the changelog line) is **Telegram `channel-mcp` leader exclusivity**: on fleet-managed Linux hosts, only the **fleet-orchestrator leader** session runs bot **`getUpdates`** and may **`reply`**; other sessions back off so one token isn’t contended across parallel Claude sessions. The gate **fails open** when there is no fleet leader marker or the host isn’t fleet/Linux, so typical single-session installs keep polling as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1ca6f4e776f8180ba2aa6165e292de2e2b2b2e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->