### PR TITLE
fix(overnight-merge): base-health gate — never compound a red base

### DIFF
--- a/claude-ops/scripts/healify/overnight-merge-cron.sh
+++ b/claude-ops/scripts/healify/overnight-merge-cron.sh
@@ -25,6 +25,22 @@ fi
 
 merge_ready_prs() {
   local owner=$1 repo=$2 base=$3
+  # BASE-HEALTH GATE (2026-06-03): never pile PRs onto a base whose own CI is red.
+  # Individually-green PRs can combine into a broken base; once red, --admin-merging
+  # more PRs onto it only compounds the breakage. Gate on the base HEAD rollup.
+  local base_state
+  base_state=$(gh api graphql -f query='
+    query($o:String!,$r:String!,$b:String!){
+      repository(owner:$o,name:$r){
+        ref(qualifiedName:$b){target{... on Commit{statusCheckRollup{state}}}}}}' \
+    -f o="$owner" -f r="$repo" -f b="refs/heads/$base" \
+    --jq '.data.repository.ref.target.statusCheckRollup.state // "NONE"' 2>/dev/null || echo NONE)
+  if [[ "$base_state" == "FAILURE" || "$base_state" == "ERROR" ]]; then
+    echo "  ⛔ BASE $owner/$repo:$base CI rollup=$base_state — HALTING merges to this base this cycle (would compound a broken base)"
+    mkdir -p ~/.claude/logs 2>/dev/null || true
+    touch ~/.claude/logs/healify-overnight-BASE-RED-"$repo"-"$base".flag 2>/dev/null || true
+    return
+  fi
   # GraphQL: list open PRs with author + branch info. Allowlist applied below.
   # Only auto-merge:
   #   (a) PRs whose head ref starts with `sync(dev` or `sync/dev` (dev→main sync PRs WE opened), OR


### PR DESCRIPTION
On 2026-06-03 the overnight merge daemon admin-merged a cascade of individually-green inboxassist PRs that combined into a broken main (duplicate code blocks + malformed HANDOFF.json), then kept merging onto the red main, compounding it. This adds a base-health gate to merge_ready_prs(): before merging to a base, check the base HEAD statusCheckRollup; if FAILURE/ERROR, halt merges to that base for the cycle and raise a BASE-RED flag. Opened by /ops:merge root-cause fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes autonomous merge behavior for production repos; mis-read rollup state could pause merges, but the gate only blocks when base CI is FAILURE/ERROR.
> 
> **Overview**
> Adds a **base-health gate** at the start of `merge_ready_prs()` in `overnight-merge-cron.sh`: before any auto-merge to a given base (`dev` or `main`), the cron queries GitHub for that base ref’s **HEAD `statusCheckRollup`**. If the rollup is **FAILURE** or **ERROR**, it **skips all merges to that base for the tick**, logs a halt message, and writes `~/.claude/logs/healify-overnight-BASE-RED-<repo>-<base>.flag`.
> 
> This closes a gap where only **per-PR** CI was checked—green PRs could still land on a **already-red base** and worsen breakage when using **`--admin` merges**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb94f7d65d15d9b5a6268fcc6e2b91ed0a5edddb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->