### PR TITLE
fix(registry-resolve): redact embedded token from derived repo slugs

### DIFF
--- a/claude-ops/lib/registry-resolve.sh
+++ b/claude-ops/lib/registry-resolve.sh
@@ -24,7 +24,7 @@ ops_registry_repos() {
         elif (.remote_url // "") != "" then
           ( .remote_url
             | sub("^git@github.com:"; "")
-            | sub("^https?://github.com/"; "")
+            | sub("^https?://([^@/]+@)?github.com/"; "")
             | sub("\\.git$"; "") )
         else empty end
     ]


### PR DESCRIPTION
ops_registry_repos() only stripped clean https://github.com/ URLs, so authenticated remote_urls (https://x-access-token:TOKEN@github.com/...) leaked the live PAT into /ops:merge pre-gathered data (and thus transcripts). Regex now strips the optional userinfo@. Verified: 0 token occurrences in output, clean slugs preserved. Opened by /ops:merge security hardening. (Do NOT paste any token in this PR.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line jq hardening that removes secrets from derived output; no auth or merge logic changes beyond safer URL normalization.
> 
> **Overview**
> **Fixes credential leakage** when `ops_registry_repos` derives `owner/repo` slugs from `.remote_url` values that include HTTP basic auth (e.g. `https://x-access-token:TOKEN@github.com/...`).
> 
> The jq `sub` for HTTPS remotes now strips an optional `userinfo@` segment before `github.com/`, so tokens are not left embedded in slugs consumed by **ops:merge** pre-gather and related tooling. Plain `https://github.com/...` and `git@github.com:` URLs behave as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2de8772d8184f3ebd9292ca25fdcacfcfb1c88fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced repository URL normalization to properly handle GitHub URLs that include embedded credentials, ensuring consistent identification and registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->