### PR TITLE
release: v2.20.11

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.20.10",
+      "version": "2.20.11",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.20.10",
+  "version": "2.20.11",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.20.11] - 2026-06-03
+
+### Changed
+Stop ops-daemon falsely churning whatsapp-bridge. check_health/write_daemon_health now honor the configured `health_check` probe (e.g. `lsof -i :8080`) as authoritative liveness instead of tracking the ephemeral launcher-wrapper PID that exits as soon as the systemd-owned bridge is up — eliminating perpetual 'HEALTH: whatsapp-bridge is dead → RESTART' log spam, inflated restart counters and false max_restarts crash alerts for a healthy bridge. The probe-command lookup caches only on a clean parse so a transient config-read failure can't permanently disable it. Services without a `health_check` keep the legacy PID-liveness behavior.
+
+
 ## [2.20.9] - 2026-06-03
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.20.10",
+  "version": "2.20.11",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.20.11** (was 2.20.10).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

Stop ops-daemon falsely churning whatsapp-bridge. check_health/write_daemon_health now honor the configured `health_check` probe (e.g. `lsof -i :8080`) as authoritative liveness instead of tracking the ephemeral launcher-wrapper PID that exits as soon as the systemd-owned bridge is up — eliminating perpetual 'HEALTH: whatsapp-bridge is dead → RESTART' log spam, inflated restart counters and false max_restarts crash alerts for a healthy bridge. The probe-command lookup caches only on a clean parse so a transient config-read failure can't permanently disable it. Services without a `health_check` keep the legacy PID-liveness behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-metadata-only diff in the PR; the behavioral fix reduces false daemon restarts and is backward-compatible for services without a health_check probe.
> 
> **Overview**
> **Release v2.20.11** bumps the plugin and marketplace registry from **2.20.10 → 2.20.11** (`plugin.json`, root `marketplace.json`, `claude-ops/package.json`) and adds the matching **CHANGELOG** entry.
> 
> The substantive change in this release (documented in the changelog; not shown as code hunks in this diff) fixes **ops-daemon** falsely restarting **`whatsapp-bridge`**: `check_health` / `write_daemon_health` now treat a configured **`health_check`** command (e.g. `lsof -i :8080`) as the source of truth instead of the short-lived launcher wrapper PID, which stops restart spam and bogus **`max_restarts`** alerts when systemd already owns a healthy bridge. Probe lookup is cached only after a successful config parse; services without **`health_check`** keep PID-based liveness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbee936229e3d659e04ef7b75752d9f8d0e22837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->