### PR TITLE
fix(ops-rotate-setup): delegate OAuth to rotate.mjs; write consumed keychain schema

### DIFF
--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -3219,6 +3219,11 @@ async function setup() {
     }
   }
   console.log(`\nSetup done. Run \`node rotate.mjs --audit-billing\` anytime to re-check.\n`);
+
+  if (filter && accounts.length === 0) return false;
+  if (results.some((r) => !r.ok)) return false;
+  if (filter && results.length === 0) return false;
+  return true;
 }
 
 // ── Status ────────────────────────────────────────────────────────────────────
@@ -3339,7 +3344,7 @@ function captureCmd(targetEmail = null) {
 const args = process.argv.slice(2);
 
 if (args.includes('--setup')) {
-  await setup();
+  process.exit((await setup()) ? 0 : 1);
 } else if (args.includes('--utilization')) {
   // Live utilization query for all accounts
   const config = readConfig();

--- a/claude-ops/scripts/account-rotation/setup-account.mjs
+++ b/claude-ops/scripts/account-rotation/setup-account.mjs
@@ -34,14 +34,9 @@ import { homedir } from 'node:os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROTATE_SCRIPT = resolve(__dirname, 'rotate.mjs');
-const CONFIG_USER = join(
-  homedir(),
-  '.claude',
-  'plugins',
-  'data',
-  'ops-ops-marketplace',
-  'account-rotation-config.json',
-);
+const ROTATION_DATA_DIR =
+  process.env.CLAUDE_PLUGIN_DATA_DIR || join(homedir(), '.claude', 'plugins', 'data', 'ops-ops-marketplace');
+const CONFIG_USER = join(ROTATION_DATA_DIR, 'account-rotation-config.json');
 const CONFIG_REPO = resolve(__dirname, 'config.json');
 const LOG_DIR = join(homedir(), '.claude', 'logs', 'account-rotation');
 

--- a/claude-ops/scripts/account-rotation/setup-account.mjs
+++ b/claude-ops/scripts/account-rotation/setup-account.mjs
@@ -132,7 +132,8 @@ function runRotateSetup(email) {
   return new Promise((resolveExit) => {
     log(`delegating OAuth to rotate.mjs --setup --only=${email} --auto --skip-valid`);
     const child = spawn(process.execPath, [ROTATE_SCRIPT, '--setup', `--only=${email}`, '--auto', '--skip-valid'], {
-      stdio: ['ignore', 'inherit', 'inherit'],
+      // Child progress must not land on stdout — callers parse a single JSON line there.
+      stdio: ['ignore', process.stderr, 'inherit'],
     });
     child.on('exit', (code) => resolveExit(code ?? 1));
     child.on('error', (e) => {

--- a/claude-ops/scripts/account-rotation/setup-account.mjs
+++ b/claude-ops/scripts/account-rotation/setup-account.mjs
@@ -131,11 +131,9 @@ function upsertAccount(args) {
 function runRotateSetup(email) {
   return new Promise((resolveExit) => {
     log(`delegating OAuth to rotate.mjs --setup --only=${email} --auto --skip-valid`);
-    const child = spawn(
-      process.execPath,
-      [ROTATE_SCRIPT, '--setup', `--only=${email}`, '--auto', '--skip-valid'],
-      { stdio: ['ignore', 'inherit', 'inherit'] },
-    );
+    const child = spawn(process.execPath, [ROTATE_SCRIPT, '--setup', `--only=${email}`, '--auto', '--skip-valid'], {
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
     child.on('exit', (code) => resolveExit(code ?? 1));
     child.on('error', (e) => {
       log(`failed to spawn rotate.mjs: ${e.message}`);
@@ -154,9 +152,7 @@ async function main() {
 
   const code = await runRotateSetup(args.email);
   if (code !== 0) {
-    console.log(
-      JSON.stringify({ ok: false, accountId: args.accountId, email: args.email, error: 'oauth_failed' }),
-    );
+    console.log(JSON.stringify({ ok: false, accountId: args.accountId, email: args.email, error: 'oauth_failed' }));
     process.exit(1);
   }
 

--- a/claude-ops/scripts/account-rotation/setup-account.mjs
+++ b/claude-ops/scripts/account-rotation/setup-account.mjs
@@ -1,29 +1,39 @@
 #!/usr/bin/env node
-// setup-account.mjs — Standalone OAuth init for a single Claude account.
+// setup-account.mjs — OAuth init for a single Claude account in the rotator.
 //
-// Walks a magic-link login flow against claude.ai using Playwright, extracts
-// the session token from cookies, verifies the token against api.anthropic.com,
-// and writes it to the OS keychain via lib/credential-store.sh as
-// `Claude-Rotation-<account_id>`. Does NOT touch the active rotation state.
+// Thin wrapper around the proven rotate.mjs setup flow. It:
+//   1. Upserts the account into the user config (gitignored override).
+//   2. Delegates the OAuth capture to `rotate.mjs --setup --only=<email>
+//      --auto --skip-valid`, which drives the browser-driver cascade
+//      (CDP-attach to a real Chrome → spawn Chrome with a real profile →
+//      bundled Chromium), polls Gmail for the magic link via `gog`, verifies
+//      the token, and writes it to the keychain under the SAME schema the
+//      daemon/rotator consume: service `Claude-Rotation-<key>`, account
+//      `$USER` (or $CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT), value
+//      `{ "claudeAiOauth": { "accessToken": ... } }`.
+//
+// Why delegate instead of re-implementing the browser flow here: a freshly
+// launched Playwright Chromium is blocked by claude.ai's Cloudflare Turnstile
+// (the magic link is never sent), and a hand-rolled web-cookie capture writes a
+// credential shape (sessionKey cookie) that NO consumer in this repo reads.
+// rotate.mjs already solves both correctly — this wrapper just feeds it one
+// account and reports a machine-readable result.
 //
 // Usage:
 //   node setup-account.mjs --email user@example.com [--display "Personal"] \
 //                          [--plan max] [--account-id <slug>] [--no-headless]
 //
-// Note: when the parallel account-rotation source lands, this file should be
-// folded into rotate.mjs as a `--setup-account <email>` mode, calling shared
-// keychain/verification helpers from there. Until then this file is callable
-// standalone.
+// --gmail-poll / --no-headless are accepted for backward compatibility but are
+// no-ops: rotate.mjs --auto always polls Gmail and manages its own browser.
 
-import { spawn, spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { homedir } from 'node:os';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = resolve(__dirname, '..', '..');
-const CRED_STORE = resolve(REPO_ROOT, 'lib', 'credential-store.sh');
+const ROTATE_SCRIPT = resolve(__dirname, 'rotate.mjs');
 const CONFIG_USER = join(
   homedir(),
   '.claude',
@@ -36,18 +46,19 @@ const CONFIG_REPO = resolve(__dirname, 'config.json');
 const LOG_DIR = join(homedir(), '.claude', 'logs', 'account-rotation');
 
 function parseArgs(argv) {
-  const out = { headless: true, plan: 'max' };
+  const out = { plan: 'max' };
   for (let i = 2; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--email') out.email = argv[++i];
     else if (a === '--display') out.display = argv[++i];
     else if (a === '--plan') out.plan = argv[++i];
     else if (a === '--account-id') out.accountId = argv[++i];
-    else if (a === '--no-headless') out.headless = false;
-    else if (a === '--gmail-poll') out.gmailPoll = true;
-    else if (a === '--help' || a === '-h') {
+    else if (a === '--label') out.label = argv[++i];
+    else if (a === '--no-headless' || a === '--gmail-poll') {
+      /* accepted for backward compat — no-op (rotate.mjs --auto handles both) */
+    } else if (a === '--help' || a === '-h') {
       console.log(
-        'usage: setup-account.mjs --email <addr> [--display <name>] [--plan pro|max] [--account-id <slug>] [--no-headless] [--gmail-poll]',
+        'usage: setup-account.mjs --email <addr> [--display <name>] [--plan pro|max] [--account-id <slug>] [--label <key>]',
       );
       process.exit(0);
     }
@@ -88,221 +99,54 @@ function loadConfig() {
 }
 
 function saveConfig(cfg) {
-  const path = CONFIG_USER;
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, JSON.stringify(cfg, null, 2));
+  mkdirSync(dirname(CONFIG_USER), { recursive: true });
+  writeFileSync(CONFIG_USER, JSON.stringify(cfg, null, 2));
 }
 
+// Write the account into the user-override config (never the committed repo
+// default — Rule 0). rotate.mjs reads this same file via its USER_CONFIG_PATH
+// preference, so the --only=<email> filter below will find it.
 function upsertAccount(args) {
   const cfg = loadConfig();
   cfg.accounts = cfg.accounts || [];
-  const existing = cfg.accounts.find((a) => a.id === args.accountId);
+  const existing = cfg.accounts.find((a) => a.id === args.accountId || a.email === args.email);
   if (existing) {
     existing.email = args.email;
     existing.display = args.display;
     existing.plan = args.plan;
+    if (args.label) existing.label = args.label;
   } else {
-    cfg.accounts.push({
+    const acct = {
       id: args.accountId,
       email: args.email,
       display: args.display,
       plan: args.plan,
       added: new Date().toISOString(),
-    });
+    };
+    if (args.label) acct.label = args.label;
+    cfg.accounts.push(acct);
   }
   saveConfig(cfg);
-  log(`config upserted: ${args.accountId} -> ${CONFIG_USER}`);
+  log(`config upserted: ${args.accountId} (${args.email}) -> ${CONFIG_USER}`);
 }
 
-function credSet(service, account, secret) {
-  const r = spawnSync('bash', [CRED_STORE, 'set-stdin', service, account], {
-    input: secret,
-    encoding: 'utf8',
-  });
-  if (r.status !== 0) {
-    log(`credential-store set failed: ${r.stderr}`);
-    return false;
-  }
-  return true;
-}
-
-function credGet(service, account) {
-  const r = spawnSync('bash', [CRED_STORE, 'get', service, account], {
-    encoding: 'utf8',
-  });
-  if (r.status !== 0) return null;
-  return r.stdout.trim() || null;
-}
-
-async function ensurePlaywright() {
-  try {
-    await import('playwright');
-    return true;
-  } catch {
-    log('installing playwright (one-time)...');
-    const r = spawnSync('npm', ['install', '--no-save', 'playwright@^1.52.0'], {
-      cwd: REPO_ROOT,
-      stdio: 'inherit',
-    });
-    if (r.status !== 0) {
-      log('playwright install failed');
-      return false;
-    }
-    spawnSync('npx', ['playwright', 'install', 'chromium'], {
-      cwd: REPO_ROOT,
-      stdio: 'inherit',
-    });
-    return true;
-  }
-}
-
-async function pollGmailForMagicLink(toEmail, sinceTs) {
-  // Best-effort: use `gog` if available. Returns the link URL or null.
-  const probe = spawnSync('which', ['gog'], { encoding: 'utf8' });
-  if (probe.status !== 0) {
-    log('gog CLI not installed — falling back to manual confirmation');
-    return null;
-  }
-  const deadline = Date.now() + 5 * 60 * 1000; // 5 min
-  while (Date.now() < deadline) {
-    const r = spawnSync(
-      'gog',
-      [
-        'gmail',
-        'search',
-        `to:${toEmail} from:noreply@anthropic.com after:${Math.floor(sinceTs / 1000)} subject:"sign in"`,
-        '--max',
-        '3',
-        '-j',
-        '--results-only',
-        '--no-input',
-      ],
-      { encoding: 'utf8', timeout: 15000 },
+// Delegate the actual OAuth capture to rotate.mjs's proven setup flow.
+// --skip-valid: no-op if a valid token already exists for this account.
+// --auto: fully automated (browser cascade + Gmail magic-link polling).
+function runRotateSetup(email) {
+  return new Promise((resolveExit) => {
+    log(`delegating OAuth to rotate.mjs --setup --only=${email} --auto --skip-valid`);
+    const child = spawn(
+      process.execPath,
+      [ROTATE_SCRIPT, '--setup', `--only=${email}`, '--auto', '--skip-valid'],
+      { stdio: ['ignore', 'inherit', 'inherit'] },
     );
-    if (r.status === 0 && r.stdout.trim()) {
-      try {
-        const threads = JSON.parse(r.stdout);
-        const first = Array.isArray(threads) ? threads[0] : null;
-        if (first?.id) {
-          const t = spawnSync('gog', ['gmail', 'thread', 'get', first.id, '-j'], { encoding: 'utf8', timeout: 15000 });
-          if (t.status === 0) {
-            const m = t.stdout.match(/https:\/\/claude\.ai\/(?:magic-link|verify|login)[^\s"'<>]+/);
-            if (m) return m[0];
-          }
-        }
-      } catch {}
-    }
-    await new Promise((r) => setTimeout(r, 5000));
-  }
-  return null;
-}
-
-async function runOAuth(args) {
-  const ok = await ensurePlaywright();
-  if (!ok) return null;
-  const { chromium } = await import('playwright');
-  const browser = await chromium.launch({ headless: args.headless });
-  const ctx = await browser.newContext();
-  const page = await ctx.newPage();
-
-  log('navigating to claude.ai/login');
-  await page.goto('https://claude.ai/login', { waitUntil: 'domcontentloaded' });
-
-  log(`filling email: ${args.email}`);
-  // Selector is best-effort — Anthropic's login form may change.
-  let emailSubmitted = true;
-  try {
-    await page.fill('input[type="email"], input[name="email"]', args.email, {
-      timeout: 15000,
+    child.on('exit', (code) => resolveExit(code ?? 1));
+    child.on('error', (e) => {
+      log(`failed to spawn rotate.mjs: ${e.message}`);
+      resolveExit(1);
     });
-    await page.click('button[type="submit"], button:has-text("Continue")', {
-      timeout: 5000,
-    });
-  } catch (e) {
-    log(`email entry failed: ${e.message}`);
-    emailSubmitted = false;
-  }
-
-  if (!emailSubmitted && args.headless) {
-    log('aborting: email step failed in headless mode (no manual recovery)');
-    await browser.close();
-    return null;
-  }
-
-  const sinceTs = Date.now();
-  log('magic-link sent — waiting for completion...');
-  if (args.gmailPoll) {
-    const link = await pollGmailForMagicLink(args.email, sinceTs);
-    if (link) {
-      log(`got magic link from gmail — navigating`);
-      await page.goto(link, { waitUntil: 'domcontentloaded' });
-    } else {
-      log('gmail poll timed out — waiting for manual click');
-    }
-  }
-
-  // Poll for 2FA indicators while waiting for the post-login app shell.
-  // This emits a log line the SKILL.md contract expects so the operator
-  // can relay a TOTP code via AskUserQuestion.
-  let twoFaLogged = false;
-  const twoFaPoll = setInterval(async () => {
-    if (twoFaLogged) return;
-    try {
-      const has2FA = await page.evaluate(() => {
-        const text = (document.body?.innerText || '').toLowerCase();
-        return (
-          text.includes('two-factor') ||
-          text.includes('2fa') ||
-          text.includes('verification code') ||
-          text.includes('authenticator') ||
-          text.includes('one-time') ||
-          !!document.querySelector('input[autocomplete="one-time-code"]')
-        );
-      });
-      if (has2FA) {
-        twoFaLogged = true;
-        log('2FA prompt detected');
-      }
-    } catch {
-      /* page may have navigated — ignore */
-    }
-  }, 3000);
-  // Wait for the post-login app shell. 10 min ceiling for 2FA / manual click.
-  try {
-    await page.waitForURL(/claude\.ai\/(?:chats?|new|projects)/, {
-      timeout: 10 * 60 * 1000,
-    });
-  } catch (e) {
-    clearInterval(twoFaPoll);
-    log(`login did not complete in time: ${e.message}`);
-    await browser.close();
-    return null;
-  }
-  clearInterval(twoFaPoll);
-
-  const cookies = await ctx.cookies('https://claude.ai');
-  const session = cookies.find((c) => c.name === 'sessionKey' || c.name === '__Secure-next-auth.session-token');
-  await browser.close();
-  if (!session) {
-    log('no session cookie found after login');
-    return null;
-  }
-  return { name: session.name, value: session.value };
-}
-
-async function verifyToken(session) {
-  // Minimal probe — the rotation system uses this token to mint API requests
-  // via the Claude Code OAuth bridge. We just check that claude.ai accepts it.
-  const { name, value } = session;
-  try {
-    const res = await fetch('https://claude.ai/api/organizations', {
-      headers: { Cookie: `${name}=${value}` },
-    });
-    return res.ok;
-  } catch (e) {
-    log(`verify error: ${e.message}`);
-    return false;
-  }
+  });
 }
 
 async function main() {
@@ -310,38 +154,18 @@ async function main() {
   ensureLogDir();
   log(`starting setup for ${args.email} (id=${args.accountId}, plan=${args.plan})`);
 
-  const existingToken = credGet('Claude-Rotation', args.accountId);
-  if (existingToken) {
-    log(`keychain entry already present for ${args.accountId} — skipping OAuth`);
-    upsertAccount(args);
-    console.log(JSON.stringify({ ok: true, accountId: args.accountId, skipped: true }));
-    return;
-  }
-
-  const session = await runOAuth(args);
-  if (!session) {
-    console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: 'oauth_failed' }));
-    process.exit(1);
-  }
-
-  const verified = await verifyToken(session);
-  if (!verified) {
-    console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: 'verify_failed' }));
-    process.exit(1);
-  }
-
-  const stored = credSet(
-    'Claude-Rotation',
-    args.accountId,
-    JSON.stringify({ cookieName: session.name, token: session.value }),
-  );
-  if (!stored) {
-    console.log(JSON.stringify({ ok: false, accountId: args.accountId, error: 'keychain_write_failed' }));
-    process.exit(1);
-  }
-
+  // Persist the account first so rotate.mjs's config read picks it up.
   upsertAccount(args);
-  log(`✓ ${args.accountId} initialized`);
+
+  const code = await runRotateSetup(args.email);
+  if (code !== 0) {
+    console.log(
+      JSON.stringify({ ok: false, accountId: args.accountId, email: args.email, error: 'oauth_failed' }),
+    );
+    process.exit(1);
+  }
+
+  log(`✓ ${args.accountId} initialized (token written to Claude-Rotation-<key> by rotate.mjs)`);
   console.log(JSON.stringify({ ok: true, accountId: args.accountId, email: args.email }));
 }
 

--- a/claude-ops/skills/ops-rotate-setup/SKILL.md
+++ b/claude-ops/skills/ops-rotate-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ops-rotate-setup
-description: Interactive OAuth init wizard for the multi-account Claude rotator. Walks through every account in the rotation config, runs the Playwright magic-link flow for any account missing a keychain token, and writes verified tokens to `Claude-Rotation-<account_id>`. Re-runnable any time. Standalone alias of the same step inside `/ops:setup`.
+description: Interactive OAuth init wizard for the multi-account Claude rotator. Walks through every account in the rotation config and, for any account missing a valid keychain token, delegates to the proven `rotate.mjs` magic-link flow (browser-driver cascade + Gmail polling), which writes the verified OAuth token to `Claude-Rotation-<key>` (key = account label or email, keychain account `$USER`). Re-runnable any time. Standalone alias of the same step inside `/ops:setup`.
 argument-hint: "[--all|--account <email>|--add]"
 allowed-tools:
   - Bash
@@ -14,9 +14,20 @@ maxTurns: 25
 
 Initialize OAuth tokens for the multi-account Claude rotator system (the
 `account-rotation` daemon). For each configured account that does not already
-have a keychain entry `Claude-Rotation-<account_id>`, run the Playwright magic-
-link login flow against `claude.ai`, capture the session cookie, verify it,
-and write it to the OS keychain via `lib/credential-store.sh`.
+have a valid keychain token, delegate to `rotate.mjs --setup --only=<email>
+--auto --skip-valid`, which drives the browser-driver cascade (CDP-attach to a
+real Chrome → spawn Chrome with a real profile → bundled Chromium), polls Gmail
+for the magic link via `gog`, verifies the token, and writes it to the OS
+keychain under the schema the daemon/rotator consume: service
+`Claude-Rotation-<key>` (key = account `label` or `email`), keychain account
+`$USER` (override with `$CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT`), value
+`{ "claudeAiOauth": { "accessToken": ... } }`.
+
+> Why delegate: a freshly launched Playwright Chromium is blocked by
+> claude.ai's Cloudflare Turnstile (the magic link is never sent), and a
+> hand-rolled web-cookie capture writes a credential shape no consumer reads.
+> `rotate.mjs` solves both correctly, so `setup-account.mjs` is a thin wrapper
+> around it.
 
 Use this skill when:
 - You ran `/ops:setup` and skipped the account-rotation step
@@ -30,8 +41,9 @@ Use this skill when:
   display name come from runtime user input only.
 - **Rule 1**: Max 4 options per `AskUserQuestion`. Paginate at 4 with
   `[More...]` bridges when listing accounts.
-- **Rule 4**: Background by default. The Playwright OAuth flow is long-running;
-  always launch it with `run_in_background: true` and tail the log.
+- **Rule 4**: Background by default. The OAuth flow (rotate.mjs browser cascade
+  + Gmail polling) is long-running; always launch it with
+  `run_in_background: true` and tail the log.
 - Never auto-enable `account_rotation_enabled` after init. The user flips that
   switch from `/plugins` settings.
 
@@ -60,7 +72,7 @@ No Claude accounts are configured for the rotator yet. Add some now?
 ```
 
 - `[Help]`: print one-paragraph explainer (rotator purpose, where keychain entries live, how `/plugins` toggles `account_rotation_enabled`) and exit.
-- `[Use existing keychain]`: print "Looking for `Claude-Rotation-*` entries..." and run `bash $CRED_STORE backends 2>/dev/null && for id in $(jq -r '.accounts[].id' "$CFG" 2>/dev/null); do bash $CRED_STORE get "Claude-Rotation" "$id" >/dev/null 2>&1 && echo "✓ $id" || echo "✗ $id"; done || echo "(no backends available — re-run with [Add now])"`. Exit.
+- `[Use existing keychain]`: print "Looking for `Claude-Rotation-*` entries..." and run `CRED="${CLAUDE_PLUGIN_ROOT}/lib/credential-store.sh"; ACCT="${CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT:-$USER}"; bash "$CRED" backends 2>/dev/null && jq -r '.accounts[] | (.label // .email)' "$CFG" 2>/dev/null | while read -r key; do bash "$CRED" get "Claude-Rotation-$key" "$ACCT" >/dev/null 2>&1 && echo "✓ $key" || echo "✗ $key"; done || echo "(no backends available — re-run with [Add now])"`. Exit.
 - `[Skip]`: exit.
 - `[Add now]`: enter the **add loop** below.
 
@@ -97,20 +109,24 @@ jq --argjson new "$NEW_ACCOUNTS_JSON" \
 
 ## Step 3 — Token check
 
-For each account in the merged config, check the keychain:
+For each account in the merged config, check the keychain under the consumed
+schema (service `Claude-Rotation-<key>`, account `$USER`):
 
 ```bash
 CRED="${CLAUDE_PLUGIN_ROOT}/lib/credential-store.sh"
-for id in $(jq -r '.accounts[].id' "$USER_CFG"); do
-  if bash "$CRED" get "Claude-Rotation" "$id" >/dev/null 2>&1; then
-    echo "✓ $id"
+ACCT="${CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT:-$USER}"
+jq -r '.accounts[] | (.label // .email)' "$USER_CFG" | while read -r key; do
+  if bash "$CRED" get "Claude-Rotation-$key" "$ACCT" >/dev/null 2>&1; then
+    echo "✓ $key"
   else
-    echo "✗ $id (needs OAuth)"
+    echo "✗ $key (needs OAuth)"
   fi
 done
 ```
 
 If every account is `✓`, print a success line and jump to **Step 5 — Summary**.
+(`rotate.mjs --setup ... --skip-valid` also re-checks token validity itself, so
+a stale-but-present entry is re-captured during Step 4.)
 
 ## Step 4 — OAuth init loop
 
@@ -132,18 +148,23 @@ echo "PID=$! LOG=$LOG"
 
 - Launch with `run_in_background: true`.
 - Use `Monitor` (or `Read` of the log file) to surface progress lines.
-- The script:
-  1. Opens Playwright Chromium
-  2. Navigates to `claude.ai/login`, fills email, submits magic-link
-  3. Polls Gmail via `gog` (best-effort) OR waits up to 10 minutes for the user to click the link manually
-  4. Captures `sessionKey` or `__Secure-next-auth.session-token` cookie
-  5. Verifies via `GET claude.ai/api/organizations`
-  6. Writes to keychain as `Claude-Rotation-<account_id>` via `credential-store.sh`
-- **2FA / TOTP**: the script polls the page for two-factor prompts every 3 seconds.
-  If it detects one it logs `2FA prompt detected` to stderr. When you see that
-  line in the log, ask the user via `AskUserQuestion` to provide the TOTP code.
-  In **headless** mode the code cannot be typed into the browser — re-run the
-  account with `--no-headless` so the user can complete 2FA interactively.
+- `setup-account.mjs` upserts the account into `$USER_CFG`, then delegates to
+  `rotate.mjs --setup --only=<email> --auto --skip-valid`, which:
+  1. Skips immediately if a valid token already exists (`--skip-valid`).
+  2. Runs the browser-driver cascade: attach to a real Chrome on CDP `:9222`
+     (passes Cloudflare Turnstile) → else spawn Chrome with a real profile →
+     else bundled Chromium.
+  3. Submits the email and polls Gmail via `gog` for the magic link, then
+     completes login (handling the org chooser).
+  4. Verifies the token against `api.anthropic.com/api/oauth/usage`.
+  5. Writes it to the keychain as `Claude-Rotation-<key>` (account `$USER`),
+     value `{ "claudeAiOauth": { "accessToken": ... } }`.
+- It emits a single-line JSON result: `{"ok":true,"accountId":...,"email":...}`
+  on success, or `{"ok":false,...,"error":"oauth_failed"}` on failure.
+- **2FA / Google SSO**: some accounts (Google Workspace domains) require an
+  interactive Google verification that automation cannot complete unattended.
+  If `rotate.mjs` logs a 2FA / verification prompt or times out, surface the log
+  to the user and let them complete the login in the cascade's visible Chrome.
   Do NOT attempt to auto-solve 2FA.
 
 After each account completes (success or failure):
@@ -169,7 +190,7 @@ If success and no more accounts remain, jump to **Step 5**.
    ✗ <id> (failed — re-run /ops:rotate-setup --account <email>)
 
  Config: ~/.claude/plugins/data/ops-ops-marketplace/account-rotation-config.json
- Keychain: Claude-Rotation-<id>
+ Keychain: Claude-Rotation-<key> (account: $USER)  ·  key = label or email
 
  To enable automatic rotation, open /plugins → claude-ops → settings and
  toggle "Multi-account Claude rotator" (account_rotation_enabled).
@@ -189,9 +210,8 @@ to the user, made explicitly through the plugin settings UI.
 
 | Symptom | Cause | Action |
 |---|---|---|
-| `playwright install failed` | npm offline / sandbox | Run `npx playwright install chromium` via Bash tool, then retry |
-| `oauth_failed` | login form selector changed | Open log, surface the page URL at failure, suggest `--no-headless` retry |
-| `verify_failed` | session cookie captured but rejected | Re-run; likely transient |
-| `keychain_write_failed` | no backend available | Run `bash $CRED backends` and surface options |
-| `no session cookie` | login flow blocked by 2FA | Re-run with `--no-headless` so user can complete in-browser |
-| `2FA prompt detected` + timeout | 2FA required in headless mode | Re-run with `--no-headless`; prompt user for TOTP via `AskUserQuestion` |
+| `oauth_failed` (rotate.mjs exit ≠ 0) | login did not complete — Turnstile, Google SSO/2FA, or timeout | Open `$LOG` + `rotation.log`; if the cascade is waiting on a visible Chrome, let the user finish login there, then re-run |
+| `playwright install failed` | npm offline / sandbox | Run `npx playwright install chromium` in `${CLAUDE_PLUGIN_ROOT}/scripts/account-rotation`, then retry |
+| token still `✗` after success | account `label`/`email` mismatch vs config | Confirm the config `key` (`label // email`) matches the `Claude-Rotation-<key>` service name |
+| no CDP browser available | no Chrome on `:9222` and none installed | rotate.mjs falls back to bundled Chromium, which Turnstile may block — install/launch Chrome so the cascade can attach |
+| Google SSO / 2FA prompt | Workspace-domain account needs interactive Google login | Let the user complete login in the cascade's visible Chrome; do NOT auto-solve 2FA |


### PR DESCRIPTION
## Problem

`/ops:ops-rotate-setup` → `setup-account.mjs` was doubly broken:

1. **Blocked at login.** It launched a fresh Playwright Chromium, which claude.ai's **Cloudflare Turnstile** flags as a bot → the magic-link email is never sent. (Confirmed via DOM probe: post-email-submit redirects to `challenge_redirect` / `cf-turnstile-response`.)
2. **Wrong credential schema.** Even on success it wrote a claude.ai `sessionKey` cookie under keychain `service="Claude-Rotation"`, `account="<id>"` — a coordinate **no consumer reads**. The daemon and `rotate.mjs` read `service="Claude-Rotation-<key>"`, `account="$USER"`, value `{claudeAiOauth:{accessToken}}`. So the bootstrap produced dead entries.

## Fix

- **Rewrite `setup-account.mjs`** as a thin wrapper: upsert the account into the gitignored user config, then delegate OAuth to the proven `rotate.mjs --setup --only=<email> --auto --skip-valid`. That flow drives the Turnstile-capable browser-driver cascade (CDP-attach to a real Chrome → spawn Chrome w/ real profile → bundled Chromium), polls Gmail for the magic link via `gog`, verifies the token, and writes it under the schema the rotator actually consumes. Removes the dead Playwright web-cookie capture (−273 lines).
- **Update `SKILL.md`**: token-check, OAuth-loop description, keychain refs, and failure modes now match the consumed schema (`Claude-Rotation-<key>`/`$USER`) and the delegation model.

> Note: this branch is based on `main`, which already resolves the config-override path correctly (`CLAUDE_PLUGIN_DATA_DIR` → user data dir → `config.json` → `config.example.json`). No `rotate.mjs` change needed.

## Public-repo safety (Rule 0)

No real emails or hardcoded paths — runtime input + `$USER`/`$CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT` only. `tests/test-no-secrets.sh` passes 14/14.

## Verification

- `node -c` syntax OK on `setup-account.mjs`.
- `tests/test-no-secrets.sh`: 14 passed, 0 failed.
- End-to-end smoke run: `setup-account.mjs` upserted config → delegated to `rotate.mjs` → `--skip-valid` detected the live valid token in the consumed schema → `1/1 captured`, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how OAuth tokens are captured and stored for the multi-account rotator; misconfiguration could still block login, but the new path matches existing daemon/rotate consumers rather than the previous dead credential format.
> 
> **Overview**
> **Rotator OAuth bootstrap** no longer uses a standalone Playwright magic-link flow that Cloudflare blocks and that wrote **session cookies** under the wrong keychain shape. **`setup-account.mjs`** is now a thin wrapper: upsert into the gitignored user config (optional **`--label`**), then run **`rotate.mjs --setup --only=<email> --auto --skip-valid`** so tokens land as **`Claude-Rotation-<label|email>`** / **`$USER`** with **`claudeAiOauth.accessToken`**—the same vault schema **`daemon.mjs`** already reads.
> 
> **`rotate.mjs --setup`** now returns success/failure (including **`--only`** with no matches or all failures), and the CLI **`process.exit`** reflects that so **`setup-account.mjs`** can emit one JSON line on stdout.
> 
> **`ops-rotate-setup` SKILL.md** is updated: token checks, OAuth steps, keychain references, and failure modes match the delegated cascade (CDP Chrome, Gmail/`gog`, interactive Google SSO) instead of the removed Playwright/cookie path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45d3b431ab037264ef3976c1700fdfc1ce9f05db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined OAuth account setup flow with improved delegation.
  * Account credentials now keyed using label or email for consistency.
  * Added support for `--label` parameter.

* **Documentation**
  * Updated setup workflow guidance including 2FA and Google SSO handling.
  * Revised failure mode documentation to reflect current operation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->