### PR TITLE
release: v2.20.12

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.20.11",
+      "version": "2.20.12",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.20.11",
+  "version": "2.20.12",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.20.11",
+  "version": "2.20.12",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.20.12** (was 2.20.11).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

ops-rotate-setup: delegate OAuth capture to rotate.mjs (Turnstile-capable browser-driver cascade) and write the consumed Claude-Rotation-<key>/$USER keychain schema; rewrite setup-account.mjs as a thin wrapper; update SKILL.md token-check, keychain refs, and failure modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version alignment with no runtime or security-sensitive code changes in the diff.
> 
> **Overview**
> **Release v2.20.12** — bumps the published plugin version from `2.20.11` to `2.20.12` in the marketplace registry (`.claude-plugin/marketplace.json`), the ops plugin manifest (`claude-ops/.claude-plugin/plugin.json`), and the internal bin package (`claude-ops/package.json`). No functional code changes appear in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60ea5ef5cd4a34a45bead531f987c3c6cfd5ec31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->