### PR TITLE
fix(ops-release): multi-line CHANGELOG notes via temp file; backfill v2.20.12 entry

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.20.12] - 2026-06-03
+
+### Changed
+ops-rotate-setup: delegate OAuth capture to rotate.mjs (Turnstile-capable browser-driver cascade) and write the consumed `Claude-Rotation-<key>`/`$USER` keychain schema; rewrite setup-account.mjs as a thin wrapper over `rotate.mjs --setup --only=<email> --auto --skip-valid`; update SKILL.md token-check, keychain references, and failure modes to match. The prior implementation launched a fresh Playwright Chromium (blocked by Cloudflare Turnstile, so the magic link was never sent) and wrote a sessionKey cookie under a keychain coordinate no consumer reads.
+
+### Fixed
+ops-release: CHANGELOG prepend now passes the multi-line section to awk via a temp file (`getline`), fixing the `awk: newline in string` error that silently skipped the changelog entry when `--notes` spanned multiple lines.
+
 ## [2.20.11] - 2026-06-03
 
 ### Changed

--- a/claude-ops/bin/ops-release
+++ b/claude-ops/bin/ops-release
@@ -134,12 +134,17 @@ if [ -n "$PACKAGE_REL" ] && [ -f "$WT/$PACKAGE_REL" ]; then
   jq empty "$WT/$PACKAGE_REL" || { echo "ops-release: produced invalid $PACKAGE_REL" >&2; exit 1; }
 fi
 
-# 4. prepend CHANGELOG section before the first existing "## [" entry
-awk -v sec="$changelog_section" '
-  !done && /^## [0-9[]/ { print sec; print ""; done=1 }
+# 4. prepend CHANGELOG section before the first existing "## [" entry.
+# The section is multi-line; pass it via a temp file (awk -v mangles embedded
+# newlines → "awk: newline in string"), reading it with getline at the insert.
+sec_file="$(mktemp)"; printf '%s\n' "$changelog_section" >"$sec_file"
+awk -v secfile="$sec_file" '
+  function emit_sec(  line) { while ((getline line < secfile) > 0) print line; print "" }
+  !done && /^## [0-9[]/ { emit_sec(); done=1 }
   { print }
-  END { if (!done) { print ""; print sec } }
+  END { if (!done) { print ""; emit_sec() } }
 ' "$wCL" >"$wCL.tmp" && mv "$wCL.tmp" "$wCL"
+rm -f "$sec_file"
 
 echo "ops-release: bumped plugin.json + marketplace.json$([ -n "$PACKAGE_REL" ] && echo " + $PACKAGE_REL") + CHANGELOG.md"
 


### PR DESCRIPTION
## Problem
`ops-release` prepends the CHANGELOG via `awk -v sec="$changelog_section"`. awk's `-v` cannot hold embedded newlines, so a multi-line `--notes` triggers `awk: newline in string` and the entry is silently dropped. This happened on the **v2.20.12** release — manifests + tag shipped, but no CHANGELOG section landed.

## Fix
- Write the multi-line section to a temp file and read it with `getline` at the insert point (handles any number of lines, no `-v` mangling). Verified in isolation.
- Backfill the missing **v2.20.12** CHANGELOG entry.

## Safety
`tests/test-no-secrets.sh`: 14/14. No PII (Rule 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-script and changelog-only changes; no runtime product paths or auth/data handling.
> 
> **Overview**
> **`ops-release`** no longer passes the full multi-line changelog block through `awk -v sec=…`, which broke when `--notes` contained newlines (`awk: newline in string` and the section was skipped). It now writes the section to a temp file and prepends it with `getline` at the first `## [` heading.
> 
> **`CHANGELOG.md`** adds the missing **v2.20.12** section: documents the prior `ops-rotate-setup` / `rotate.mjs` OAuth and keychain work, and records this release-tool fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 170141ded276f9234de70d03592828b81fb244cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->