### PR TITLE
fix: scope Claude Code-credentials keychain lookup to $USER account

### DIFF
--- a/claude-ops/scripts/account-rotation/force-rotate.sh
+++ b/claude-ops/scripts/account-rotation/force-rotate.sh
@@ -79,7 +79,9 @@ fi
 # the daemon also auto-corrects every 2min, but this surfaces it during manual
 # rotation). Don't block on failure; just log.
 {
-  LIVE_TOK=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null | python3 -c "import sys,json; print(json.loads(sys.stdin.read()).get('claudeAiOauth',{}).get('accessToken',''))" 2>/dev/null)
+  # Scope to $USER: the keychain can hold multiple "Claude Code-credentials"
+  # items and an unscoped lookup may return an mcpOAuth-only blob first.
+  LIVE_TOK=$( (security find-generic-password -s "Claude Code-credentials" -a "$USER" -w 2>/dev/null || security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null) | python3 -c "import sys,json; print(json.loads(sys.stdin.read()).get('claudeAiOauth',{}).get('accessToken',''))" 2>/dev/null)
   STATE_ACCT=$(python3 -c "import json; print(json.load(open('$DIR/state.json')).get('activeAccount',''))" 2>/dev/null)
   if [ -n "$LIVE_TOK" ] && [ -n "$STATE_ACCT" ]; then
     LIVE_ACCT=$(curl -s -m 4 -H "Authorization: Bearer $LIVE_TOK" -H "anthropic-beta: oauth-2025-04-20" https://api.anthropic.com/api/oauth/profile 2>/dev/null | python3 -c "import sys,json; print(json.loads(sys.stdin.read()).get('account',{}).get('email',''))" 2>/dev/null)

--- a/claude-ops/scripts/account-rotation/force-rotate.sh
+++ b/claude-ops/scripts/account-rotation/force-rotate.sh
@@ -81,7 +81,8 @@ fi
 {
   # Scope to $USER: the keychain can hold multiple "Claude Code-credentials"
   # items and an unscoped lookup may return an mcpOAuth-only blob first.
-  LIVE_TOK=$( (security find-generic-password -s "Claude Code-credentials" -a "$USER" -w 2>/dev/null || security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null) | python3 -c "import sys,json; print(json.loads(sys.stdin.read()).get('claudeAiOauth',{}).get('accessToken',''))" 2>/dev/null)
+  LIVE_TOK=$(security find-generic-password -s "Claude Code-credentials" -a "$USER" -w 2>/dev/null | python3 -c "import sys,json; print(json.loads(sys.stdin.read()).get('claudeAiOauth',{}).get('accessToken',''))" 2>/dev/null)
+  [ -z "$LIVE_TOK" ] && LIVE_TOK=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null | python3 -c "import sys,json; print(json.loads(sys.stdin.read()).get('claudeAiOauth',{}).get('accessToken',''))" 2>/dev/null)
   STATE_ACCT=$(python3 -c "import json; print(json.load(open('$DIR/state.json')).get('activeAccount',''))" 2>/dev/null)
   if [ -n "$LIVE_TOK" ] && [ -n "$STATE_ACCT" ]; then
     LIVE_ACCT=$(curl -s -m 4 -H "Authorization: Bearer $LIVE_TOK" -H "anthropic-beta: oauth-2025-04-20" https://api.anthropic.com/api/oauth/profile 2>/dev/null | python3 -c "import sys,json; print(json.loads(sys.stdin.read()).get('account',{}).get('email',''))" 2>/dev/null)

--- a/claude-ops/scripts/ops-memory-extractor.sh
+++ b/claude-ops/scripts/ops-memory-extractor.sh
@@ -108,14 +108,19 @@ except Exception:
   fi
 
   if command -v security &>/dev/null; then
-    local blob token
+    local blob token _kc_acct
     # Scope to the current user's account first: the keychain can hold multiple
     # "Claude Code-credentials" items (e.g. an mcpOAuth-only blob under another
     # account), and an unscoped lookup returns whichever matches first — which
     # may lack claudeAiOauth even when a valid token exists under $USER.
-    blob=$(security find-generic-password -s "Claude Code-credentials" -a "$USER" -w 2>/dev/null || true)
-    [[ -z "${blob}" ]] && blob=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null || true)
-    if [[ -n "${blob}" ]]; then
+    token=""
+    for _kc_acct in "$USER" ""; do
+      if [[ -n "${_kc_acct}" ]]; then
+        blob=$(security find-generic-password -s "Claude Code-credentials" -a "${_kc_acct}" -w 2>/dev/null || true)
+      else
+        blob=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null || true)
+      fi
+      [[ -z "${blob}" ]] && continue
       token=$(printf '%s' "${blob}" | python3 -c "
 import json, sys, time
 try:
@@ -129,13 +134,14 @@ try:
 except Exception:
     pass
 " 2>/dev/null || true)
-      if [[ -n "${token}" ]]; then
-        OPS_AUTH_HEADER="Authorization: Bearer ${token}"
-        OPS_AUTH_MODE="oauth"
-        OPS_AUTH_EXTRA_HEADERS=(-H "anthropic-beta: oauth-2025-04-20")
-        log "Auth: Claude Code OAuth (subscription — no per-token billing)"
-        return 0
-      fi
+      [[ -n "${token}" ]] && break
+    done
+    if [[ -n "${token}" ]]; then
+      OPS_AUTH_HEADER="Authorization: Bearer ${token}"
+      OPS_AUTH_MODE="oauth"
+      OPS_AUTH_EXTRA_HEADERS=(-H "anthropic-beta: oauth-2025-04-20")
+      log "Auth: Claude Code OAuth (subscription — no per-token billing)"
+      return 0
     fi
   fi
 

--- a/claude-ops/scripts/ops-memory-extractor.sh
+++ b/claude-ops/scripts/ops-memory-extractor.sh
@@ -109,7 +109,12 @@ except Exception:
 
   if command -v security &>/dev/null; then
     local blob token
-    blob=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null || true)
+    # Scope to the current user's account first: the keychain can hold multiple
+    # "Claude Code-credentials" items (e.g. an mcpOAuth-only blob under another
+    # account), and an unscoped lookup returns whichever matches first — which
+    # may lack claudeAiOauth even when a valid token exists under $USER.
+    blob=$(security find-generic-password -s "Claude Code-credentials" -a "$USER" -w 2>/dev/null || true)
+    [[ -z "${blob}" ]] && blob=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null || true)
     if [[ -n "${blob}" ]]; then
       token=$(printf '%s' "${blob}" | python3 -c "
 import json, sys, time


### PR DESCRIPTION
## Problem
The macOS keychain can hold multiple `Claude Code-credentials` generic-password items (e.g. an mcpOAuth-only blob under a different account name). An unscoped `security find-generic-password -s ... -w` returns whichever item matches first — which may lack `claudeAiOauth` even when a valid subscription token exists under the current user's account.

Symptoms:
- `ops-memory-extractor.sh` reports `No auth available` → daemon health `status=error` on every cron run, surfaced by `/ops:ops-doctor` as `daemon_health_status_memory-extractor`
- `force-rotate.sh` drift pre-flight silently no-ops (empty LIVE_TOK)

## Fix
Try `-a "$USER"` first; fall back to the unscoped lookup for single-item setups under a different account name. Applied to both call sites (repo-wide grep found no others).

## Verification
- `tests/test-no-secrets.sh`: 14 passed, 0 failed
- `bash -n` both scripts: OK
- Verified on a machine exhibiting the bug: scoped lookup returns a valid `claudeAiOauth` token (sub=max) where the unscoped lookup returned an mcpOAuth-only blob

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to macOS keychain lookup order in two shell scripts; no auth protocol or API behavior changes beyond picking the correct stored credential.
> 
> **Overview**
> Fixes **macOS Keychain** lookups for **`Claude Code-credentials`** when more than one generic-password item exists (e.g. an **mcpOAuth-only** entry under another account). Unscoped **`security find-generic-password`** can return the wrong blob, so **`claudeAiOauth`** is missing even when a valid subscription token exists under the current user.
> 
> **`ops-memory-extractor.sh`** now tries **`-a "$USER"`** first, then falls back to an unscoped search, and only accepts OAuth once a non-expired **`accessToken`** is parsed—restoring OAuth auth instead of **`No auth available`** / daemon health errors.
> 
> **`force-rotate.sh`** uses the same scoped-then-fallback pattern for drift pre-flight so **`LIVE_TOK`** is populated when the correct item is under **`$USER`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b67832faafedb603180c6957dba13198be917bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->