### PR TITLE
release: v2.20.13

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.20.12",
+      "version": "2.20.13",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.20.12",
+  "version": "2.20.13",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.20.13] - 2026-06-04
+
+### Changed
+- salvage-scan: single-instance lock, hard timeout, bounded gh calls, nice priority (#494)
+- desktop-act-launcher: document macOS as a first-class native backend (#493)
+- scope Claude Code-credentials keychain lookup to $USER account (#492)
+- add Claude Code GitHub Action workflow (#491)
+
+
 ## [2.20.12] - 2026-06-03
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.20.12",
+  "version": "2.20.13",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.20.13** (was 2.20.12).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

- salvage-scan: single-instance lock, hard timeout, bounded gh calls, nice priority (#494)
- desktop-act-launcher: document macOS as a first-class native backend (#493)
- scope Claude Code-credentials keychain lookup to $USER account (#492)
- add Claude Code GitHub Action workflow (#491)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version and changelog updates; bundled behavior changes are operational hardening and CI/docs, not breaking API surface in this diff.
> 
> **Overview**
> **Release v2.20.13** bumps the plugin from **2.20.12 → 2.20.13** in `plugin.json`, root `marketplace.json`, and `claude-ops/package.json`, and prepends **CHANGELOG** for 2026-06-04.
> 
> The release bundles four changes already landed on main (not in this diff): **`ops-merge-salvage-scan`** gets a single-instance lock, hard timeout, bounded `gh` usage, and lower CPU priority to stop stacked scans from spiking load; **`desktop-act-launcher`** docs treat **macOS** as a first-class native backend; **keychain** reads for **`Claude Code-credentials`** are scoped to the **`$USER`** account; and a **Claude Code GitHub Action** workflow was added (#491–#494).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e2361f76f5cef870e36ba448129e5a8d5ce4d63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->