### PR TITLE
fix(ops-doctor): suppress non-actionable noise + fix stale-threshold false positives

### DIFF
--- a/claude-ops/bin/ops-doctor
+++ b/claude-ops/bin/ops-doctor
@@ -245,7 +245,7 @@ if [ -f "$PLUGIN_JSON" ] && command -v jq >/dev/null 2>&1; then
       done
 
       if [ "$ALL_COVERED_BY_GLOBAL" = true ]; then
-        INFO+=("unconfigured_sensitive_keys: Sensitive user config values not set in plugin: $(IFS=,; echo "${MCP_REFERENCED_SENSITIVE[*]}"), but a separate working MCP server provides equivalent functionality.")
+        : # Covered by a working global MCP server — intentionally unconfigured, non-actionable. Suppress.
       else
         WARNINGS+=("unconfigured_sensitive_keys: Sensitive user config values not set: $(IFS=,; echo "${MCP_REFERENCED_SENSITIVE[*]}"). MCP servers depending on these will fail. Run /ops:setup to configure.")
       fi
@@ -297,7 +297,7 @@ if command -v jq >/dev/null 2>&1; then
       WARNINGS+=("kapture_transport_proxy: Kapture is routed through mcp-proxy (found in ~/.claude/mcp-proxy/servers.json) but not present as a direct stdio entry in ~/.claude.json. The proxy SSE layer causes mcp__kapture__* tools to silently drop. Move kapture to a direct stdio entry in ~/.claude.json. See: https://github.com/Lifecycle-Innovations-Limited/claude-ops/issues/206")
       ;;
     unconfigured)
-      INFO+=("kapture_not_configured: Kapture MCP is not configured. To enable browser automation (Kapture), add a stdio entry in ~/.claude.json. See: https://github.com/Lifecycle-Innovations-Limited/claude-ops/issues/206")
+      : # Kapture is RETIRED (2026-05-24 doctrine) — browser automation is gstack /browse only. Do not nag to add it.
       ;;
   esac
 fi
@@ -654,10 +654,12 @@ else
       DOW_FIELD=$(echo "$CRON_EXPR" | awk '{if (NF>=5) print $5; else print "*"}')
       if echo "$MINUTE_FIELD" | grep -qE '^\*/([0-9]+)$'; then
         CRON_INTERVAL=$(echo "$MINUTE_FIELD" | grep -oE '[0-9]+')
+        # Alert only after a full cycle is genuinely missed (2x interval) so scheduler
+        # jitter or a brief daemon restart delaying one run isn't a false positive.
         if [ "$CRON_INTERVAL" -le 10 ]; then
-          STALE_THRESHOLD=5
+          STALE_THRESHOLD=10
         else
-          STALE_THRESHOLD="$CRON_INTERVAL"
+          STALE_THRESHOLD=$(( CRON_INTERVAL * 2 ))
         fi
       elif echo "$HOUR_FIELD" | grep -qE '^\*/([0-9]+)$'; then
         CRON_HOURS=$(echo "$HOUR_FIELD" | grep -oE '[0-9]+')


### PR DESCRIPTION
## What

Three diagnostics-quality fixes in `bin/ops-doctor` so a healthy install reports **0 errors / 0 warnings / 0 info** instead of two perpetual non-actionable items plus jitter false-alarms.

| # | Item | Before | After |
|---|------|--------|-------|
| 1 | `unconfigured_sensitive_keys` | INFO emitted even when a working global MCP server fully covers the keys | suppressed when fully covered (WARNING path for the genuinely-broken case unchanged) |
| 2 | `kapture_not_configured` | INFO nagging to add Kapture via stdio | removed — Kapture is a **retired** surface; `gstack /browse` is the sole supported browser path |
| 3 | `*/N` daemon stale threshold | exactly one cycle (`N`) → scheduler jitter or a brief daemon restart delaying one run trips a false "stale" | **2× interval** (10m floor for `N≤10`) → alerts only when a full cycle is genuinely missed |

## Why

Running `/ops:ops-doctor` on a healthy box surfaced two permanent non-actionable items (telegram keys covered by MCP; Kapture, which is retired) and intermittently false-flagged daemons (e.g. a `*/30` service read at 46m after a daemon restart). All three are signal-quality bugs, not real health issues.

## Verification

- `bash -n bin/ops-doctor` → OK
- `./bin/ops-doctor` → `{errors:[], warnings:[], info:[]}`
- `tests/test-no-secrets.sh` → 14 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostic-only changes to INFO suppression and stale thresholds; real misconfigurations still surface via existing WARNING paths.
> 
> **Overview**
> Tightens **`ops-doctor`** so healthy installs aren’t flooded with noise: when sensitive plugin keys are missing but a **working global MCP server** already covers them, the former informational `unconfigured_sensitive_keys` line is **suppressed** (the warning path when coverage is incomplete is unchanged).
> 
> **Kapture** is treated as retired when absent—`kapture_not_configured` INFO is removed so users aren’t prompted to add stdio Kapture; misconfigured **sse/proxy** Kapture checks still warn.
> 
> For **`*/N` minute cron** daemons, stale detection now uses **2× the interval** (10-minute floor for `N ≤ 10`) instead of alerting after a single missed cycle, reducing false “stale” warnings from jitter or brief restarts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 251196f20e16a7392747adb957bc12e1589f2e63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed informational messages when sensitive configurations are properly covered by working global MCP servers
  * Updated daemon health check thresholds to detect staleness only after missing a full monitoring cycle
  * Modified health check status reporting for unconfigured MCP components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->