### PR TITLE
release: v2.20.14

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.20.13",
+      "version": "2.20.14",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.20.13",
+  "version": "2.20.14",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.20.14] - 2026-06-04
+
+### Changed
+fix(ops-doctor): suppress non-actionable INFO for keys covered by global MCP; remove retired Kapture nag; widen stale-threshold to 2x interval to eliminate jitter false positives
+
+
 ## [2.20.13] - 2026-06-04
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.20.13",
+  "version": "2.20.14",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.20.14** (was 2.20.13).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

fix(ops-doctor): suppress non-actionable INFO for keys covered by global MCP; remove retired Kapture nag; widen stale-threshold to 2x interval to eliminate jitter false positives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only diff; ops-doctor behavior changes are diagnostic noise reduction with no production runtime impact.
> 
> **Overview**
> **Release v2.20.14** — bumps the ops plugin from **2.20.13** to **2.20.14** in `plugin.json`, root `marketplace.json`, and `claude-ops/package.json`, and prepends **CHANGELOG** for this release.
> 
> The changelog records **`ops-doctor` diagnostics tuning** (not shown in this diff): fewer noisy INFO lines for sensitive keys already satisfied by a **global MCP** server, no nag when **Kapture** is unconfigured (retired), and a **stale health threshold** of **2× the cron interval** so brief scheduler jitter does not look like a missed run.
> 
> Treat this PR as a **version/metadata publish** for those doctor fixes once they are on the release branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2c01ee394ea8fd4b7922e67866a9513f5d36734. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false positives in stale threshold detection
  * Removed outdated deprecation warnings
  * Improved logging by suppressing non-actionable informational messages for globally configured services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->