### PR TITLE
release: v2.21.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.20.14",
+      "version": "2.21.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.20.14",
+  "version": "2.21.0",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.21.0] - 2026-06-05
+
+### Changed
+ops-inbox: autonomous WhatsApp refresh + send-log reconciliation on every scan. ops-inbox-scan now blocks (bounded) on a backfill+settle so classification reads a converged store, and reconciles the bridge outbound-send journal to auto-demote NEEDS_REPLY threads already answered via /api/send or a phone send not yet in the store. Closes the race where the background autosync hook left the scan reading stale data.
+
+
 ## [2.20.14] - 2026-06-04
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.20.14",
+  "version": "2.21.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.21.0** (was 2.20.14).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

ops-inbox: autonomous WhatsApp refresh + send-log reconciliation on every scan. ops-inbox-scan now blocks (bounded) on a backfill+settle so classification reads a converged store, and reconciles the bridge outbound-send journal to auto-demote NEEDS_REPLY threads already answered via /api/send or a phone send not yet in the store. Closes the race where the background autosync hook left the scan reading stale data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The PR only changes version fields and CHANGELOG; no runtime code in the diff. Inbox classification changes described in the release notes affect WhatsApp triage accuracy but are packaging/documentation here.
> 
> **Overview**
> **Release v2.21.0** bumps the plugin and marketplace registry from **2.20.14** to **2.21.0** (`plugin.json`, `.claude-plugin/marketplace.json`, `claude-ops/package.json`) and prepends **CHANGELOG** for 2026-06-05.
> 
> The release note documents **ops-inbox** behavior (not new files in this diff): **`ops-inbox-scan`** now waits on a bounded WhatsApp **backfill + settle** before classifying so scans don’t read a stale store while background autosync is still catching up, and it **reconciles the bridge outbound-send journal** so threads already answered via `/api/send` or phone sends not yet in the DB are **auto-demoted** from **NEEDS_REPLY**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9647018846035729ee2fa3fd0bb3bd774b20734a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->