### PR TITLE
feat(ops): add telegram_bot_token/owner_id to plugin schema + bump yolo agent turns

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -425,6 +425,20 @@
       "sensitive": true,
       "default": ""
     },
+    "telegram_bot_token": {
+      "title": "Telegram Bot Token",
+      "description": "Bot token for outbound notifications + channel-mcp DM polling. From @BotFather. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
+      "type": "string",
+      "sensitive": true,
+      "default": ""
+    },
+    "telegram_owner_id": {
+      "title": "Telegram Owner Chat ID",
+      "description": "Your personal Telegram chat ID (numeric). DMs and fire alerts are sent to this ID. Run /ops:setup telegram to auto-detect.",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
+    },
     "discord_bot_token": {
       "title": "Discord Bot Token",
       "description": "Bot token from Discord Developer Portal — used for channel reads and DMs. Prefer Doppler reference. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",

--- a/claude-ops/agents/yolo-ceo.md
+++ b/claude-ops/agents/yolo-ceo.md
@@ -3,7 +3,7 @@ name: yolo-ceo
 description: Strategic priority agent. Analyzes the business from a CEO perspective — growth blockers, resource allocation, build vs. buy decisions, investor-readiness. No sugar-coating. Runs in parallel with CTO/CFO/COO.
 model: claude-opus-4-6
 effort: high
-maxTurns: 20
+maxTurns: 35
 tools:
   - Bash
   - Read
@@ -19,6 +19,8 @@ memory: project
 ---
 
 # YOLO CEO AGENT
+
+> **TURN BUDGET (READ FIRST).** You run under a hard `maxTurns` cap and WILL be cut off mid-run if you over-investigate. Your FIRST or SECOND action MUST be to write your analysis file (`/tmp/yolo-[session]/ceo-analysis.md`) using the pre-gathered data already supplied in your prompt — a written file is the ONLY deliverable that counts. ONLY AFTER the file exists may you spend remaining turns on targeted verification (1–3 commands max) and update the file in place. An agent that researches for 20 turns and never writes its file has FAILED its single job. When in doubt, write now, refine later.
 
 You are the CEO of this business. You have access to all data — technical, financial, operational. You are brutal and honest. You do not sugarcoat. You are optimizing for growth and survival.
 

--- a/claude-ops/agents/yolo-cfo.md
+++ b/claude-ops/agents/yolo-cfo.md
@@ -3,7 +3,7 @@ name: yolo-cfo
 description: Financial analysis agent. Follows the money — AWS burn rate, runway, ROI on current work, credits expiry, cost anomalies. No optimism without data.
 model: claude-opus-4-6
 effort: high
-maxTurns: 20
+maxTurns: 35
 tools:
   - Bash
   - Read
@@ -15,6 +15,8 @@ memory: project
 ---
 
 # YOLO CFO AGENT
+
+> **TURN BUDGET (READ FIRST).** You run under a hard `maxTurns` cap and WILL be cut off mid-run if you over-investigate. Your FIRST or SECOND action MUST be to write your analysis file (`/tmp/yolo-[session]/cfo-analysis.md`) using the pre-gathered data already supplied in your prompt — a written file is the ONLY deliverable that counts. ONLY AFTER the file exists may you spend remaining turns on targeted verification (1–3 commands max) and update the file in place. An agent that researches for 20 turns and never writes its file has FAILED its single job. When in doubt, write now, refine later.
 
 You are the CFO. You follow the money. You have no patience for engineering work that doesn't have a financial return. You are not pessimistic — you are accurate.
 

--- a/claude-ops/agents/yolo-coo.md
+++ b/claude-ops/agents/yolo-coo.md
@@ -3,7 +3,7 @@ name: yolo-coo
 description: Operations execution agent. Finds what's falling through the cracks — stale work, broken processes, missing automation, communication failures. What the CEO doesn't see.
 model: claude-opus-4-6
 effort: high
-maxTurns: 25
+maxTurns: 40
 tools:
   - Bash
   - Read
@@ -18,6 +18,8 @@ memory: project
 ---
 
 # YOLO COO AGENT
+
+> **TURN BUDGET (READ FIRST).** You run under a hard `maxTurns` cap and WILL be cut off mid-run if you over-investigate. Your FIRST or SECOND action MUST be to write your analysis file (`/tmp/yolo-[session]/coo-analysis.md`) using the pre-gathered data already supplied in your prompt — a written file is the ONLY deliverable that counts. ONLY AFTER the file exists may you spend remaining turns on targeted verification (1–3 commands max) and update the file in place. An agent that researches for 20 turns and never writes its file has FAILED its single job. When in doubt, write now, refine later.
 
 You are the COO. You see what everyone else misses — the things that don't get done, the processes that are broken, the work that keeps getting pushed. You have no interest in what we're building, only in whether it's getting built efficiently.
 

--- a/claude-ops/agents/yolo-cto.md
+++ b/claude-ops/agents/yolo-cto.md
@@ -3,7 +3,7 @@ name: yolo-cto
 description: Technical health agent. Analyzes architecture, tech debt, production risks, scalability limits, and cut corners. Brutally honest about what will break.
 model: claude-opus-4-6
 effort: high
-maxTurns: 25
+maxTurns: 40
 tools:
   - Bash
   - Read
@@ -17,6 +17,8 @@ memory: project
 ---
 
 # YOLO CTO AGENT
+
+> **TURN BUDGET (READ FIRST).** You run under a hard `maxTurns` cap and WILL be cut off mid-run if you over-investigate. Your FIRST or SECOND action MUST be to write your analysis file (`/tmp/yolo-[session]/cto-analysis.md`) using the pre-gathered data already supplied in your prompt — a written file is the ONLY deliverable that counts. ONLY AFTER the file exists may you spend remaining turns on targeted verification (1–3 commands max) and update the file in place. An agent that researches for 20 turns and never writes its file has FAILED its single job. When in doubt, write now, refine later.
 
 You are the CTO. You know what shortcuts were taken, what will break at scale, what the architecture can't support. You do not protect the engineers. You call it like it is.
 


### PR DESCRIPTION
Salvaged from local-only branch during workspace audit (2026-06-05). Adds telegram_bot_token/owner_id to plugin schema; bumps yolo agent max turns. Branch was ~35 commits behind main; PR diff is merge-base scoped (5 files, +26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and agent-prompt-only changes; the bot token field is marked sensitive like other notification secrets.
> 
> **Overview**
> Adds **`telegram_bot_token`** and **`telegram_owner_id`** to the ops plugin `userConfig` so Bot API notifications and `telegram-channel` MCP env (`TELEGRAM_BOT_TOKEN` / `TELEGRAM_OWNER_ID`) can be set in the marketplace UI, alongside existing gram.js Telegram fields.
> 
> Raises **`maxTurns`** on the four YOLO C-suite agents (CEO/CFO to 35, COO/CTO to 40) and adds a **turn-budget** callout at the top of each agent prompt: write `/tmp/yolo-[session]/*-analysis.md` on the first or second turn from pre-gathered context, then allow at most a few verification passes—reducing empty runs when agents hit the cap while researching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97d69b410e03643d6e3b3bd627420f9e33828fb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Telegram bot integration support for outbound notifications and alert routing configuration.

* **Chores**
  * Improved agent execution efficiency by optimizing turn budgets and streamlining analysis workflows for CEO, CFO, COO, and CTO agents to prioritize output delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->