### PR TITLE
fix(ops-inbox): seed merged DM groups with lid twins from whatsmeow_lid_map

### DIFF
--- a/claude-ops/bin/ops-inbox-scan
+++ b/claude-ops/bin/ops-inbox-scan
@@ -145,6 +145,15 @@ def scan_whatsapp():
         except sqlite3.Error as e:
             notes.append(f"whatsapp: lid_map unreadable ({e}); falling back to contacts.phone")
 
+    # Reverse map: phone_jid -> [lid_jids]. Used to seed merged groups with BOTH
+    # twins even when one twin's `chats` row is absent/stale at scan time (backfill
+    # timing). Without this a live @lid conversation can be missed while only the
+    # stale phone twin surfaces — the lid blind-spot. last_msgs() reads `messages`
+    # directly, so adding the twin as a member catches the live side regardless.
+    pn2lids = {}
+    for _l, _p in lid2pn.items():
+        pn2lids.setdefault(_p, []).append(_l)
+
     # contacts: jid -> name, and phone -> jids (fallback merge + name resolution)
     name_by_jid, phone_by_jid, jids_by_phone = {}, {}, {}
     try:
@@ -191,6 +200,10 @@ def scan_whatsapp():
         g = groups.setdefault(key, {"members": set(), "name": None, "latest": None})
         g["members"].add(jid)
         g["members"].add(key)
+        # Always include the phone key's lid twin(s), even if their chats row is
+        # missing/stale this scan — so the merged thread sees the live side.
+        for _lt in pn2lids.get(key, ()):
+            g["members"].add(_lt)
         nm = name_by_jid.get(jid) or (c["name"] if c["name"] and not c["name"][0].isdigit() else None)
         if nm and not g["name"]:
             g["name"] = nm


### PR DESCRIPTION
Salvaged from local-only branch during workspace audit (2026-06-05). Seeds merged DM groups with LID twins from whatsmeow_lid_map in ops-inbox-scan (1 file, +13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only offline classification tweak in one script; improves merge completeness without changing send/mutate behavior or auth.
> 
> **Overview**
> Fixes a **WhatsApp LID blind spot** in `ops-inbox-scan` when merging a contact’s phone and `@lid` chats into one DM thread.
> 
> The scan already maps LID → phone via `whatsmeow_lid_map` and merges on the canonical phone JID, but merged groups only collected JIDs from **`chats` rows** present at scan time. If the live conversation lives on the `@lid` twin while the phone twin’s `chats` row is missing or stale (e.g. backfill timing), **`last_msgs`** could read only the stale side and mis-classify **needs_reply** vs **waiting**.
> 
> This change builds a **phone → LID(s)** reverse map and **always adds those LID JIDs** to each merged DM’s `members` set, so message lookup includes the live twin even when its `chats` row didn’t surface in this pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a66ea553b70159151884e18df42d404854331621. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->