### PR TITLE
feat(pocket-approvals): A/B/C options + recommended + freeform redraft + untruncated Telegram ASKs

### DIFF
--- a/claude-ops/email-cos/pocket-responder.py
+++ b/claude-ops/email-cos/pocket-responder.py
@@ -206,7 +206,10 @@ _RE_EDIT_INTENT = re.compile(
 
 
 def _edit_intent(body):
-    return bool(_RE_EDIT_INTENT.search(body or ""))
+    # Strip negated phrases that contain edit tokens but mean approval, e.g.
+    # "no change needed, approve" or "we no longer need to wait".
+    t = re.sub(r"\bno (change|longer)\b", "", body or "", flags=re.I)
+    return bool(_RE_EDIT_INTENT.search(t))
 
 
 # Edit-then-send: a freeform reply with edit intent on an outbound email ASK
@@ -322,7 +325,7 @@ def cmd_send():
     if not items:
         log("send: no open items")
         print("no open items")
-        return
+        return set()
     resolved = _resolved_ids()
     cap = int(os.environ.get("COS_TG_SEND_CAP", "8"))
     callmap = json.loads(CALLMAP.read_text()) if CALLMAP.exists() else {}
@@ -348,6 +351,7 @@ def cmd_send():
         }
     CODEMAP.write_text(json.dumps(codemap, indent=2))
 
+    staged_set = set()
     staged = list(_revisions_staged)
     if staged:
         staged_set = set(staged)
@@ -357,10 +361,11 @@ def cmd_send():
         _revisions_staged.clear()
 
     sent = 0
+    revision_posted = set()
     for it in items:
-        if sent >= cap:
-            break
         iid = it["id"]
+        if sent >= cap and iid not in staged_set:
+            break
         if iid in resolved or iid in already:
             continue
         sid = _sid(iid)
@@ -411,11 +416,17 @@ def cmd_send():
         }
         if r.get("ok"):
             sent += 1
+            if iid in staged_set:
+                revision_posted.add(iid)
         else:
             log(f"send: sendMessage failed for {iid}: {r.get('error') or r}")
+    unsent_revisions = staged_set - revision_posted
+    for uid in unsent_revisions:
+        _revisions_staged.append(uid)
     CALLMAP.write_text(json.dumps(callmap, indent=0))
     log(f"send: sent {sent} button message(s); callmap={len(callmap)} codemap={len(codemap)}")
     print(f"sent {sent} button message(s); callmap={len(callmap)}")
+    return unsent_revisions
 
 
 # ---------------------------------------------------------------------------
@@ -962,11 +973,19 @@ def cmd_process():
     log(f"process: acted={acted}")
     # Post any re-drafted revision ASKs to Telegram now (not next send tick).
     if _revisions_staged:
-        log(f"process: staged {len(_revisions_staged)} revision(s) -> sending now")
+        want = list(_revisions_staged)
+        log(f"process: staged {len(want)} revision(s) -> sending now")
         try:
-            cmd_send()
+            unsent = cmd_send()
         except Exception as e:
             log(f"process: revision send failed: {e}")
+            _send(f"⚠️ Couldn't post the revised draft(s) to Telegram ({e}). "
+                  f"They're staged in review and will retry on the next send tick.")
+        else:
+            if unsent:
+                ids = ", ".join(sorted(unsent)[:5])
+                _send(f"⚠️ Some revised draft(s) didn't post to Telegram yet ({ids}). "
+                      f"They'll retry on the next send tick.")
     print(f"processed inbox; acted={acted}")
 
 

--- a/claude-ops/email-cos/pocket-responder.py
+++ b/claude-ops/email-cos/pocket-responder.py
@@ -122,8 +122,11 @@ def _norm(item):
     return (
         t.get("id") or item.get("id"),
         t.get("kind") or item.get("kind", "action_item"),
-        (t.get("title") or item.get("title") or "")[:120],
-        (t.get("context") or item.get("context") or "")[:600],
+        (t.get("title") or item.get("title") or "")[:140],
+        # Keep generous context here; cmd_send() does the final Telegram-fit
+        # truncation. The old 600-char cap silently amputated long ASKs
+        # (email drafts, voice-memo action items) before they were ever rendered.
+        (t.get("context") or item.get("context") or "")[:6000],
         t,
     )
 
@@ -174,6 +177,36 @@ def _resolve_code(codemap: dict, ref: str):
 
 def _sid(item_id):
     return "i" + hashlib.sha1(item_id.encode()).hexdigest()[:10]
+
+
+def _recommended_key(it, opts):
+    """Recommended option key for an ASK, if any: a per-option `recommended:true`
+    first, then a top-level recommended_option/recommended_key (also checked in raw
+    + raw.triage). '' if none. Backward-compatible — producers that don't set it
+    just get no star."""
+    for o in opts or []:
+        if isinstance(o, dict) and o.get("recommended"):
+            return str(o.get("key") or "")
+    raw = it.get("raw") if isinstance(it.get("raw"), dict) else {}
+    tri = raw.get("triage") if isinstance(raw.get("triage"), dict) else {}
+    for src in (it, raw, tri):
+        if isinstance(src, dict) and (src.get("recommended_option") or src.get("recommended_key")):
+            return str(src.get("recommended_option") or src.get("recommended_key"))
+    return ""
+
+
+# Words signalling "change this before it goes out" rather than a plain yes. Used
+# to block the footgun where a freeform reply like "send but say Friday" on an
+# outbound email ASK gets mis-mapped to a bare APPROVE and the UNEDITED draft is
+# sent to a third party. Edit-then-send re-drafting is not wired yet.
+_RE_EDIT_INTENT = re.compile(
+    r"\b(change|instead|edit|reword|rewrite|replace|revise|adjust|tweak|shorter|"
+    r"longer|add that|mention|leave out|take out|remove the|make it|don'?t say|"
+    r"say that|reslant|soften|reschedule to)\b", re.I)
+
+
+def _edit_intent(body):
+    return bool(_RE_EDIT_INTENT.search(body or ""))
 
 
 # ---------------------------------------------------------------------------
@@ -239,22 +272,36 @@ def cmd_send():
         sid = _sid(iid)
         opts = it.get("options") or []
         ap = it.get("action_preview") or ""
-        title = (it.get("title") or "")[:120]
-        ctx = _truncate_words(it.get("ctx") or "", 500)
+        dq = it.get("decision_question") or ""
+        kind = it.get("kind") or ""
+        title = (it.get("title") or "")[:140]
+        # Give the body the bulk of Telegram's 4096-char budget; the old 500-char
+        # cut amputated long ASKs (full email drafts, voice-memo action items).
+        ctx = _truncate_words(it.get("ctx") or "", 3200)
+        rk = _recommended_key(it, opts)
         text = f"*{title}*\n{ctx}"
+        if dq:
+            text += f"\n\n❓ *{dq}*"
         if ap:
             text += f"\n\n→ *Approve =* {ap}"
         if opts:
-            rows = [
-                [{"text": f"{o['key']}) {o['label'][:40]}", "callback_data": f"po:{sid}:{o['key']}"}]
-                for o in opts
-            ]
-            rows.append([{"text": "❌ Reject", "callback_data": f"pr:{sid}"}])
+            rows = []
+            for o in opts:
+                star = "⭐ " if rk and str(o.get("key", "")).lower() == rk.lower() else ""
+                rows.append([{"text": f"{star}{o['key']}) {o['label'][:38]}", "callback_data": f"po:{sid}:{o['key']}"}])
+            rows.append([{"text": "❌ None / reject", "callback_data": f"pr:{sid}"}])
+            if rk:
+                text += f"\n\n⭐ _= recommended ({rk})_"
         else:
             rows = [[
                 {"text": "✅ Approve", "callback_data": f"pa:{sid}"},
                 {"text": "❌ Reject", "callback_data": f"pr:{sid}"},
             ]]
+        # Advertise freeform reply — but NOT on outbound message kinds, where a
+        # freeform "send but change X" would mis-map to a bare APPROVE and silently
+        # send the unedited draft to a third party (also guarded in _handle_text).
+        if kind not in VALIDATE_KINDS:
+            text += "\n\n💬 _Or just reply in your own words — e.g. “do b”, “skip this one”, or your own instruction._"
         r = _api("sendMessage", {
             "chat_id": CHAT, "text": text[:3800], "parse_mode": "Markdown",
             "reply_markup": {"inline_keyboard": rows},
@@ -665,6 +712,11 @@ def _handle_text(ev, codemap, callmap, resolved, seen):
         if verb == "APPROVE" and (ent.get("options") or []):
             _send(f"`{ref}` is a choice item — reply e.g. `{ref} a`.")
             continue
+        if verb == "APPROVE" and _is_outbound(ent) and _edit_intent(body):
+            _send(f"`{ref}` looks like an *edit*, not a plain approve — I won't send the "
+                  f"original draft as-is. Tap ✅ Approve (or reply `approve {ref}`) to send "
+                  f"it unchanged, or `reject {ref}` to skip. _(Edit-then-send for emails isn't wired yet.)_")
+            continue
         toast = _apply_decision(ent, "APPROVE" if verb == "APPROVE" else "REJECT")
         resolved.add(tid); handled_ids.add(tid); acted += 1
         _, cment = _callmap_entry_for_id(callmap, tid)
@@ -706,6 +758,11 @@ def _handle_text(ev, codemap, callmap, resolved, seen):
                 continue
             toast = _apply_decision(ent, "CHOOSE", option=option)
         else:
+            if dec == "approve" and _is_outbound(ent) and _edit_intent(body):
+                _send(f"That looks like an *edit* of “{ent.get('title','')[:50]}”, not a plain "
+                      f"approve — I won't send the original draft as-is. Tap ✅ Approve to send it "
+                      f"unchanged, or reply `reject` to skip. _(Edit-then-send for emails isn't wired yet.)_")
+                continue
             toast = _apply_decision(ent, dec.upper())
         resolved.add(tid); handled_ids.add(tid); acted += 1
         _, cment = _callmap_entry_for_id(callmap, tid)

--- a/claude-ops/email-cos/pocket-responder.py
+++ b/claude-ops/email-cos/pocket-responder.py
@@ -209,6 +209,92 @@ def _edit_intent(body):
     return bool(_RE_EDIT_INTENT.search(body or ""))
 
 
+# Edit-then-send: a freeform reply with edit intent on an outbound email ASK
+# re-drafts the body via LLM and RE-STAGES it as a fresh approval ASK. The
+# revision is NEVER auto-sent — the owner approves the revised draft. Revisions
+# are capped to avoid loops; _revisions_staged tells cmd_process to post the new
+# ASK immediately instead of waiting for the next send tick.
+_REDRAFT_MAX_REVISIONS = 5
+_revisions_staged = []
+
+
+def _redraft_email(er, orig_body, instruction):
+    """Re-draft an email reply body per the owner's instruction. '' on failure."""
+    cb = _resolve_claude_bin()
+    if not cb:
+        return ""
+    model = os.environ.get("POCKET_REDRAFT_MODEL") or os.environ.get(
+        "POCKET_RESPONDER_MODEL", "claude-haiku-4-5"
+    )
+    prompt = (
+        "You revise a DRAFT email reply per the owner's instruction. Output ONLY JSON: "
+        '{"body":"<full revised reply>"}.\n'
+        "Rules: keep the owner's voice and the draft's language; apply ONLY what the "
+        "instruction asks and preserve everything else; keep it a complete, send-ready "
+        "reply (greeting + body + sign-off). NEVER invent commitments, numbers, dates, "
+        "prices, or facts not in the current draft or the instruction.\n\n"
+        f"RECIPIENT: {er.get('to','')}\nSUBJECT: {er.get('subject','')}\n\n"
+        f"CURRENT DRAFT:\n{orig_body}\n\nOWNER INSTRUCTION:\n{instruction}\n\nJSON:"
+    )
+    try:
+        r = subprocess.run([cb, "-p", prompt, "--model", model, *_CLAUDE_FLAGS],
+                           capture_output=True, text=True, timeout=120, env=os.environ)
+        out = (r.stdout or "").strip()
+    except Exception as e:
+        log(f"redraft: invocation failed: {e}")
+        return ""
+    mt = re.search(r"\{.*\}", out, re.S)
+    if not mt:
+        return ""
+    try:
+        d = json.loads(mt.group(0))
+    except Exception:
+        return ""
+    return (d.get("body") or "").strip()
+
+
+def _restage_revision(ent, instruction):
+    """Re-draft an outbound email ASK per `instruction`, append a fresh ASK to
+    review.jsonl, and resolve the original as REVISED so it is never sent. Returns
+    the new ASK id, or None to let the caller fall back (decline)."""
+    iid = ent["id"]
+    raw = ent.get("raw") if isinstance(ent.get("raw"), dict) else {}
+    er = dict(raw.get("email_reply") or {})
+    orig = er.get("body") or ""
+    if not orig:
+        return None
+    base = re.sub(r"-rev\d+$", "", iid)
+    existing = {r.get("id") for r in _load_jsonl(REVIEW)}
+    n = 1
+    while f"{base}-rev{n}" in existing:
+        n += 1
+    if n > _REDRAFT_MAX_REVISIONS:
+        return None
+    new_body = _redraft_email(er, orig, instruction)
+    if not new_body or new_body.strip() == orig.strip():
+        return None
+    new_id = f"{base}-rev{n}"
+    now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    er["body"] = new_body
+    new_rec = {
+        "id": new_id, "kind": "send_message",
+        "source": raw.get("source", "email-triage"),
+        "title": (raw.get("title") or ent.get("title") or "")[:120],
+        "action_preview": f"Sends this REVISED reply to {er.get('to','')} — exactly as written.",
+        "context": f"REVISED per your note: \u201c{instruction[:200]}\u201d\n\nPROPOSED REPLY (revised):\n{new_body}",
+        "confidence": 1.0, "captured_at": now,
+        "triage": {"verdict": "ASK", "confidence": 1.0,
+                   "reasoning": f"Revision of {iid} per owner note.", "decided_at": now},
+        "email_reply": er, "revised_from": iid,
+    }
+    open(REVIEW, "a").write(json.dumps(new_rec) + "\n")
+    open(RESOLVED, "a").write(json.dumps(
+        {"id": iid, "decision": "REVISED", "revised_to": new_id, "ts": time.time()}) + "\n")
+    _revisions_staged.append(new_id)
+    log(f"REVISED {iid} -> {new_id} (per: {instruction[:60]!r})")
+    return new_id
+
+
 # ---------------------------------------------------------------------------
 # Telegram API
 # ---------------------------------------------------------------------------
@@ -300,7 +386,9 @@ def cmd_send():
         # Advertise freeform reply — but NOT on outbound message kinds, where a
         # freeform "send but change X" would mis-map to a bare APPROVE and silently
         # send the unedited draft to a third party (also guarded in _handle_text).
-        if kind not in VALIDATE_KINDS:
+        if kind in VALIDATE_KINDS:
+            text += "\n\n💬 _Or reply with edits (e.g. “change the date to Friday”) — I'll re-draft and re-stage for approval; the original is never auto-sent._"
+        else:
             text += "\n\n💬 _Or just reply in your own words — e.g. “do b”, “skip this one”, or your own instruction._"
         r = _api("sendMessage", {
             "chat_id": CHAT, "text": text[:3800], "parse_mode": "Markdown",
@@ -325,6 +413,15 @@ def cmd_send():
 # ---------------------------------------------------------------------------
 # decision application (shared by taps + text)
 # ---------------------------------------------------------------------------
+# Flags that isolate every `claude -p` subprocess below from this box's heavy
+# session context (full MCP set + global CLAUDE.md). Without them each call dies
+# with "Prompt is too long" (same workaround email-cos-orch.sh uses); headless =>
+# skip permission prompts. Point POCKET_CLAUDE_FLAGS at a space-sep override if needed.
+_CLAUDE_FLAGS = (os.environ.get("POCKET_CLAUDE_FLAGS").split() if os.environ.get("POCKET_CLAUDE_FLAGS")
+                 else ["--strict-mcp-config", "--mcp-config", '{"mcpServers":{}}',
+                       "--dangerously-skip-permissions"])
+
+
 def _resolve_claude_bin():
     b = os.environ.get("POCKET_CLAUDE_BIN")
     if b and os.path.exists(b):
@@ -446,7 +543,7 @@ def _validate_action(ent):
         "If context is empty or unclear, default to proceed. JSON:"
     )
     try:
-        r = subprocess.run([cb, "-p", prompt, "--model", model],
+        r = subprocess.run([cb, "-p", prompt, "--model", model, *_CLAUDE_FLAGS],
                            capture_output=True, text=True, timeout=90, env=os.environ)
         out = (r.stdout or "").strip()
     except Exception as e:
@@ -594,16 +691,19 @@ def _llm_map(codemap, message):
     prompt = (
         "You map a person's freeform approval message to decisions on a fixed list "
         "of pending items. Output ONLY a JSON array, no prose.\n\n"
-        "Each element: {\"code\": \"A1\", \"decision\": \"approve\"|\"reject\"|\"choose\", "
+        "Each element: {\"code\": \"A1\", \"decision\": \"approve\"|\"reject\"|\"choose\"|\"revise\", "
         "\"option\": \"a\" (only for choose), \"confidence\": 0.0-1.0}.\n"
         "Rules: only reference codes from the list. If the message clearly targets "
         "several items (\"reject all the music ones\"), emit one element each. If you "
         "are not confident which item is meant, return [] (do NOT guess). For yes/no "
-        "items use approve|reject; for items with options use choose + the option key.\n\n"
+        "items use approve|reject; for items with options use choose + the option key. "
+        "If the message asks to CHANGE / edit / reword a draft before it goes out "
+        "(e.g. \"send but say Friday\", \"make it warmer\"), use decision \"revise\" "
+        "on that item — do NOT use approve.\n\n"
         f"PENDING ITEMS:\n{catalog}\n\nMESSAGE:\n{message}\n\nJSON:"
     )
     try:
-        r = subprocess.run([cb, "-p", prompt, "--model", model],
+        r = subprocess.run([cb, "-p", prompt, "--model", model, *_CLAUDE_FLAGS],
                            capture_output=True, text=True, timeout=90, env=os.environ)
         out = (r.stdout or "").strip()
     except Exception as e:
@@ -713,9 +813,16 @@ def _handle_text(ev, codemap, callmap, resolved, seen):
             _send(f"`{ref}` is a choice item — reply e.g. `{ref} a`.")
             continue
         if verb == "APPROVE" and _is_outbound(ent) and _edit_intent(body):
-            _send(f"`{ref}` looks like an *edit*, not a plain approve — I won't send the "
-                  f"original draft as-is. Tap ✅ Approve (or reply `approve {ref}`) to send "
-                  f"it unchanged, or `reject {ref}` to skip. _(Edit-then-send for emails isn't wired yet.)_")
+            new_id = _restage_revision(ent, body)
+            if new_id:
+                resolved.add(tid); handled_ids.add(tid); acted += 1
+                _, cment = _callmap_entry_for_id(callmap, tid)
+                _freeze(cment, "✍️ Revising per your note — new draft coming for approval.")
+                _send(f"✍️ Revising `{ref}` per your note — re-drafted and staged ({new_id}); "
+                      f"sending it to you for approval now. (Original NOT sent.)")
+            else:
+                _send(f"`{ref}` reads like an edit but I couldn't re-draft it (or nothing "
+                      f"changed). Tap ✅ Approve to send the original, or `reject {ref}` to skip.")
             continue
         toast = _apply_decision(ent, "APPROVE" if verb == "APPROVE" else "REJECT")
         resolved.add(tid); handled_ids.add(tid); acted += 1
@@ -740,7 +847,7 @@ def _handle_text(ev, codemap, callmap, resolved, seen):
         except (TypeError, ValueError):
             conf = 0.0
         ent = _resolve_code(codemap, code) if code else None
-        if ent and dec in ("approve", "reject", "choose") and conf >= thresh:
+        if ent and dec in ("approve", "reject", "choose", "revise") and conf >= thresh:
             confident.append((ent, dec, dd.get("option")))
     if not confident:
         _send(
@@ -752,6 +859,22 @@ def _handle_text(ev, codemap, callmap, resolved, seen):
         tid = ent["id"]
         if tid in resolved or tid in handled_ids:
             continue
+        if dec == "revise":
+            if not _is_outbound(ent):
+                _send(f"I can only re-draft email replies — \u201c{ent.get('title','')[:50]}\u201d "
+                      f"isn't one. Reply `approve`, `reject`, or an option instead.")
+                continue
+            new_id = _restage_revision(ent, body)
+            if new_id:
+                resolved.add(tid); handled_ids.add(tid); acted += 1
+                _, cment = _callmap_entry_for_id(callmap, tid)
+                _freeze(cment, "\u270d\ufe0f Revising per your note — new draft coming for approval.")
+                _send(f"\u270d\ufe0f Revised \u201c{ent.get('title','')[:50]}\u201d per your note — "
+                      f"staged {new_id}; sending it to you for approval now. (Original NOT sent.)")
+            else:
+                _send(f"I read that as an edit to \u201c{ent.get('title','')[:50]}\u201d but couldn't "
+                      f"re-draft it (or nothing changed). Tap \u2705 Approve to send the original, or `reject`.")
+            continue
         if dec == "choose":
             if not option:
                 _send(f"`{ent.get('title','')[:50]}` needs an option letter.")
@@ -759,9 +882,16 @@ def _handle_text(ev, codemap, callmap, resolved, seen):
             toast = _apply_decision(ent, "CHOOSE", option=option)
         else:
             if dec == "approve" and _is_outbound(ent) and _edit_intent(body):
-                _send(f"That looks like an *edit* of “{ent.get('title','')[:50]}”, not a plain "
-                      f"approve — I won't send the original draft as-is. Tap ✅ Approve to send it "
-                      f"unchanged, or reply `reject` to skip. _(Edit-then-send for emails isn't wired yet.)_")
+                new_id = _restage_revision(ent, body)
+                if new_id:
+                    resolved.add(tid); handled_ids.add(tid); acted += 1
+                    _, cment = _callmap_entry_for_id(callmap, tid)
+                    _freeze(cment, "✍️ Revising per your note — new draft coming for approval.")
+                    _send(f"✍️ Revised “{ent.get('title','')[:50]}” per your note — staged {new_id}; "
+                          f"sending it to you for approval now. (Original NOT sent.)")
+                else:
+                    _send(f"That reads like an edit but I couldn't re-draft it (or nothing "
+                          f"changed). Tap ✅ Approve to send the original, or reply `reject` to skip.")
                 continue
             toast = _apply_decision(ent, dec.upper())
         resolved.add(tid); handled_ids.add(tid); acted += 1
@@ -795,6 +925,13 @@ def cmd_process():
             acted += _handle_text(ev, codemap, callmap, resolved, seen)
     INBOX_SEEN.write_text("\n".join(sorted(seen)) + "\n")
     log(f"process: acted={acted}")
+    # Post any re-drafted revision ASKs to Telegram now (not next send tick).
+    if _revisions_staged:
+        log(f"process: staged {len(_revisions_staged)} revision(s) -> sending now")
+        try:
+            cmd_send()
+        except Exception as e:
+            log(f"process: revision send failed: {e}")
     print(f"processed inbox; acted={acted}")
 
 

--- a/claude-ops/email-cos/pocket-responder.py
+++ b/claude-ops/email-cos/pocket-responder.py
@@ -329,7 +329,8 @@ def cmd_send():
     resolved = _resolved_ids()
     cap = int(os.environ.get("COS_TG_SEND_CAP", "8"))
     callmap = json.loads(CALLMAP.read_text()) if CALLMAP.exists() else {}
-    already = {v.get("id") for v in callmap.values()}
+    # Only items with a real Telegram message were delivered; failed sends must retry.
+    already = {v.get("id") for v in callmap.values() if v.get("message_id")}
 
     # (Re)build the A/D codemap over the FULL open set (stable order) so freeform
     # "approve A3" / "A3 b" resolve even for items whose button was sent earlier.
@@ -407,6 +408,9 @@ def cmd_send():
             "chat_id": CHAT, "text": text[:3800], "parse_mode": "Markdown",
             "reply_markup": {"inline_keyboard": rows},
         })
+        if not r.get("ok"):
+            log(f"send: sendMessage failed for {iid}: {r.get('error') or r}")
+            continue
         mid = (r.get("result") or {}).get("message_id")
         raw = it.get("raw") if isinstance(it.get("raw"), dict) else {}
         callmap[sid] = {
@@ -414,12 +418,9 @@ def cmd_send():
             "raw": it.get("raw"), "options": opts, "message_id": mid, "title": title,
             "social_set": raw.get("social_set"), "typefully_draft_id": raw.get("typefully_draft_id"),
         }
-        if r.get("ok"):
-            sent += 1
-            if iid in staged_set:
-                revision_posted.add(iid)
-        else:
-            log(f"send: sendMessage failed for {iid}: {r.get('error') or r}")
+        sent += 1
+        if iid in staged_set:
+            revision_posted.add(iid)
     unsent_revisions = staged_set - revision_posted
     for uid in unsent_revisions:
         _revisions_staged.append(uid)

--- a/claude-ops/email-cos/pocket-responder.py
+++ b/claude-ops/email-cos/pocket-responder.py
@@ -348,6 +348,14 @@ def cmd_send():
         }
     CODEMAP.write_text(json.dumps(codemap, indent=2))
 
+    staged = list(_revisions_staged)
+    if staged:
+        staged_set = set(staged)
+        items = [it for it in items if it["id"] in staged_set] + [
+            it for it in items if it["id"] not in staged_set
+        ]
+        _revisions_staged.clear()
+
     sent = 0
     for it in items:
         if sent >= cap:
@@ -832,6 +840,33 @@ def _handle_text(ev, codemap, callmap, resolved, seen):
 
     if matched_any:
         return acted
+
+    # --- Fast-path: freeform edit on the sole open outbound ASK (no code / LLM). ---
+    if _edit_intent(body):
+        outbound = []
+        seen_ob: set[str] = set()
+        for ent in codemap.values():
+            tid = ent.get("id")
+            if not tid or tid in resolved or tid in handled_ids or tid in seen_ob:
+                continue
+            if not _is_outbound(ent):
+                continue
+            seen_ob.add(tid)
+            outbound.append(ent)
+        if len(outbound) == 1:
+            ent = outbound[0]
+            tid = ent["id"]
+            new_id = _restage_revision(ent, body)
+            if new_id:
+                resolved.add(tid); handled_ids.add(tid); acted += 1
+                _, cment = _callmap_entry_for_id(callmap, tid)
+                _freeze(cment, "✍️ Revising per your note — new draft coming for approval.")
+                _send(f"✍️ Revised “{ent.get('title','')[:50]}” per your note — staged {new_id}; "
+                      f"sending it to you for approval now. (Original NOT sent.)")
+            else:
+                _send(f"I read that as an edit to “{ent.get('title','')[:50]}” but couldn't "
+                      f"re-draft it (or nothing changed). Tap ✅ Approve to send the original, or `reject`.")
+            return acted
 
     # --- LLM fallback for natural language ("approve the Duetti one"). ---
     decisions = _llm_map(codemap, body)

--- a/claude-ops/email-cos/prompts/orchestrator.prompt
+++ b/claude-ops/email-cos/prompts/orchestrator.prompt
@@ -13,11 +13,13 @@ PER ITEM:
 2. ENRICH: recall the contact/thread via `mcp__gbrain__search` (+ get_page on a hit). If the counterparty/company is unfamiliar, do ONE Tavily web search to identify them.
 3. ACT by category:
    - Legal / Finance: do NOT draft a reply. Append a reminder-style ASK to the pocket review.jsonl (use the configured POCKET_STATE_DIR / {{EMAIL_COS_POCKET_STATE_DIR}} path the template already uses) with kind "action_item", source "email-triage", title "Review: <sender>: <subject ≤60>", context "WHO: <who>\nGIST: <what they need>\nACTION NEEDED: <what Sam must decide/do>", verdict ASK, and NO email_reply field (approving just acknowledges it — nothing is sent). This surfaces it as a Telegram button. Do NOT call icloud-reminder.sh or any other channel.
+     Also set "action_preview" to one concrete sentence on what approving does (usually "Marks this as acknowledged — nothing is sent."). When the item is a GENUINE fork the owner must decide (not a yes/no acknowledge), additionally set "decision_question" to the single question being decided and "options" to a 2–4 element array of {"key":"a","label":"<≤38 chars>","recommended":true|false} — keys a/b/c/d in order, exactly ONE option recommended:true (your best-guess answer). For a plain acknowledge with no real fork leave decision_question "" and options []. NEVER invent facts to manufacture options.
    - Other categories: COMPOSE a reply in the owner's voice (match the email's language; warm, concise, professional; end "Best,\n[Name]"). Then create a pocket APPROVAL ASK by appending ONE json line to {{EMAIL_COS_POCKET_STATE_DIR}}/review.jsonl using this exact python (fill the variables):
      ```
      python3 - <<PY
      import json,time
      rec={"id":"email-reply-<gmail_msg_id>","kind":"send_message","title":"Reply to <sender name>: <subject ≤60 chars>",
+       "action_preview":"Sends this reply to <sender name> (<sender email>) — exactly as written, nothing edited.",
        "context":"WHO: <1-line who they are>\nGIST: <1-line what they want>\n\nPROPOSED REPLY:\n<the full reply body>",
        "source":"email-triage","confidence":1.0,"captured_at":time.strftime('%Y-%m-%dT%H:%M:%SZ',time.gmtime()),
        "triage":{"verdict":"ASK","confidence":1.0,"reasoning":"Outbound email reply needs owner approval (Rule 6).","decided_at":time.strftime('%Y-%m-%dT%H:%M:%SZ',time.gmtime())},

--- a/claude-ops/scripts/ops-pocket-triage.py
+++ b/claude-ops/scripts/ops-pocket-triage.py
@@ -186,12 +186,12 @@ Return STRICT JSON, no markdown, no prose outside the JSON:
   "action_preview": "<ASK only — one concrete sentence: what will happen if the owner approves this item. E.g. 'Creates a GitHub issue in your-org/your-repo with the given title and assigns it to you.' Leave empty string for non-ASK verdicts.>",
   "decision_question": "<ASK only, and only when the item is a genuine multi-choice decision — the single question being decided. E.g. 'Which environment should this deploy target?' Leave empty string when it is a simple yes/no.>",
   "options": [
-    {{"key": "a", "label": "<concrete option text — what choosing this means>"}},
+    {{"key": "a", "label": "<concrete option text — what choosing this means>", "recommended": true}},
     {{"key": "b", "label": "<concrete option text>"}}
   ]
 }}
 
-For the options array: include 2–4 options only when decision_question is non-empty. Use keys a/b/c/d in order. When the item is a plain yes/no ASK, set options to an empty array []. Non-ASK verdicts must also set options to [].
+For the options array: include 2–4 options only when decision_question is non-empty. Use keys a/b/c/d in order. Mark exactly ONE option with "recommended": true — your best-guess answer (shown with a ⭐ in the approval UI); omit the key on the others. When the item is a plain yes/no ASK, set options to an empty array []. Non-ASK verdicts must also set options to [].
 
 Owner context (NEVER assume otherwise):
   • Owner name: {owner_name}
@@ -405,7 +405,12 @@ def route(task: dict, decision: dict) -> str:
             routed["decision_question"] = dq
         if opts and isinstance(opts, list):
             routed["options"] = [
-                {"key": str(o.get("key", "")).lower(), "label": str(o.get("label", ""))}
+                {
+                    "key": str(o.get("key", "")).lower(),
+                    "label": str(o.get("label", "")),
+                    # Carry the recommended flag through so the approval UI can ⭐ it.
+                    **({"recommended": True} if o.get("recommended") else {}),
+                }
                 for o in opts
                 if o.get("key") and o.get("label")
             ]


### PR DESCRIPTION
Salvaged from local-only branch during workspace audit (2026-06-05). Adds A/B/C options with recommended pick, freeform email edit→redraft→restage, untruncated Telegram ASKs, and fixes a silent LLM-call failure. Supersedes the redundant sam/pocket-email-redraft branch (same responder change). 2 commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes outbound-email approval behavior and LLM-driven re-drafts before third-party send; mistakes could still affect what gets staged or approved, though originals are not auto-sent on edit intent.
> 
> **Overview**
> Improves **Telegram pocket approvals** so owners see full ASK context, clearer multi-choice items, and can **revise outbound email drafts** without accidentally sending the original.
> 
> **`pocket-responder.py`** raises context/title limits and shows **decision questions**, **action previews**, and **⭐ recommended** options. Freeform replies that look like edits on outbound email ASKs trigger **LLM re-draft → new `-revN` ASK** (original marked `REVISED`, never auto-sent), with guards in regex, LLM `revise`, and `cmd_process` posting revisions immediately. **`_CLAUDE_FLAGS`** fixes headless `claude -p` calls failing with “Prompt is too long”; failed Telegram sends no longer block retries.
> 
> **`orchestrator.prompt`** and **`ops-pocket-triage.py`** now require producers to emit **`action_preview`**, optional **`decision_question` / `options`**, and exactly one **`recommended`** option so the UI stays in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d75fdd176f2356027dd6d3575c32f39d58d89e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now revise outbound email replies during the approval workflow with immediate re-staging for re-approval.

* **Improvements**
  * Enhanced Telegram notifications with improved message formatting, optimized text display, and clearer option highlighting.
  * Updated decision prompts with explicit action descriptions and better-structured multi-choice decision options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->