### PR TITLE
release: v2.22.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.21.0",
+      "version": "2.22.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.22.0] - 2026-06-05
+
+### Changed
+- ops-inbox: seed merged DM groups with lid twins from whatsmeow_lid_map (#504)
+- ops: add telegram_bot_token/owner_id to plugin schema; bump yolo agent turns (#503)
+- deps: bump hono (#499)
+- dispatch: strip ANTHROPIC_API_KEY from all claude agent spawns (#497)
+
+
 ## [2.21.0] - 2026-06-05
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.21.0",
+  "version": "2.22.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.22.0** (was 2.21.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

- ops-inbox: seed merged DM groups with lid twins from whatsmeow_lid_map (#504)
- ops: add telegram_bot_token/owner_id to plugin schema; bump yolo agent turns (#503)
- deps: bump hono (#499)
- dispatch: strip ANTHROPIC_API_KEY from all claude agent spawns (#497)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The release bundles auth-env changes for all Claude agent spawns and WhatsApp inbox classification logic; misconfiguration could break headless agents or alter NEEDS_REPLY behavior, though the PR diff itself is only version metadata.
> 
> **Overview**
> **Release v2.22.0** bumps the plugin and marketplace manifests plus `claude-ops/package.json` from **2.21.0 → 2.22.0** and prepends **CHANGELOG** for the shipped work (no application logic in this diff).
> 
> Documented changes in this release:
> 
> - **ops-inbox:** merged DM groups are seeded with **lid twins** from `whatsmeow_lid_map` so live `@lid` threads are not missed when only the phone JID row is stale.
> - **Plugin config:** `telegram_bot_token` / `telegram_owner_id` in userConfig; **YOLO** agent **maxTurns** increased.
> - **Security / billing:** **`ANTHROPIC_API_KEY` is stripped** from spawned Claude agents so background dispatch uses OAuth/subscription auth instead of inheriting an API key from the environment.
> - **deps:** Hono version bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 260c2c2d41f4914df4d32f085d94f87765b98a12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded plugin schema to support telegram bot token and owner ID configuration.
  * Enhanced inbox seeding with improved handling of merged direct message groups.

* **Chores**
  * Updated hono dependency.
  * Version incremented to 2.22.0.
  * Security improvements to agent configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->