### PR TITLE
release: v2.23.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 37 skills, 19 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.22.0",
+      "version": "2.23.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.22.0",
+  "version": "2.23.0",
   "description": "Business operations command center for Claude Code — 37 skills, 19 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.23.0] - 2026-06-05
+
+### Changed
+First-class WhatsApp media enrichment (video/image/document via vision+whisper) + bridge media-retry self-heal for 403/404/410 (Fix M), whatsmeow API-drift sync (Fix N + A/B/D/F/G/I ctx), and pinned whatsmeow in the installer to fix the @latest broken-build.
+
+
 ## [2.22.0] - 2026-06-05
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.22.0",
+  "version": "2.23.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.23.0** (was 2.22.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

First-class WhatsApp media enrichment (video/image/document via vision+whisper) + bridge media-retry self-heal for 403/404/410 (Fix M), whatsmeow API-drift sync (Fix N + A/B/D/F/G/I ctx), and pinned whatsmeow in the installer to fix the @latest broken-build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This PR only updates version metadata and changelog; no runtime code changes in the diff.
> 
> **Overview**
> **Release v2.23.0** bumps the published plugin version from **2.22.0** in `plugin.json`, root `marketplace.json`, and `claude-ops/package.json`, and prepends **CHANGELOG** for 2026-06-05.
> 
> The release notes document **WhatsApp-focused** changes shipped under this tag (not shown in this diff): **first-class media enrichment** (video/image/document via vision + Whisper), **bridge media-retry self-heal** on HTTP 403/404/410, **whatsmeow API-drift** patch sync (Fix N and related context fixes), and **pinning whatsmeow** in the installer instead of `@latest` to avoid broken builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fcc44f0ce2b02eff44b029470285a5d79a34659. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->