### PR TITLE
release: v2.24.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 38 skills, 20 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.23.1",
+      "version": "2.24.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.23.1",
+  "version": "2.24.0",
   "description": "Business operations command center for Claude Code — 38 skills, 20 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.24.0] - 2026-06-06
+
+### Changed
+Add /ops:ops-ar A&R command + ar-producer agent (Opus): runs the audio-ar stack (BPM/key/loudness/structure, stems, CLAP mood/genre/hit-lean, Whisper lyrics, Cyanite/Music.ai pro layer) and delivers verdict cards. Modes: single track, batch, full Gmail-inbox demo sweep; emails the full verdict with direct listen links (Rule 6 gated).
+
+
 ## [2.23.1] - 2026-06-06
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.23.1",
+  "version": "2.24.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.24.0** (was 2.23.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

Add /ops:ops-ar A&R command + ar-producer agent (Opus): runs the audio-ar stack (BPM/key/loudness/structure, stems, CLAP mood/genre/hit-lean, Whisper lyrics, Cyanite/Music.ai pro layer) and delivers verdict cards. Modes: single track, batch, full Gmail-inbox demo sweep; emails the full verdict with direct listen links (Rule 6 gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release (versions + changelog); no runtime code changes in the diff.
> 
> **Overview**
> **Release v2.24.0** bumps the plugin from **2.23.1 → 2.24.0** in `marketplace.json`, `claude-ops/.claude-plugin/plugin.json`, and `claude-ops/package.json`, and prepends a **CHANGELOG** entry for 2026-06-06.
> 
> What ships in this version (per changelog): **`/ops:ops-ar`** and the **`ar-producer`** agent (Opus) — audio A&R via the **audio-ar** stack (technical analysis, stems, CLAP mood/genre, Whisper lyrics, optional Cyanite/Music.ai), **verdict cards**, and modes for **single track**, **batch**, or **Gmail inbox demo sweep**, with optional **email of full verdicts** and listen links (**Rule 6** gated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d70cb24d913f64ea4fc0135832203a91ef3f60e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->