### PR TITLE
fix(ops-ar): restore agent-teams compliance after #513

### DIFF
--- a/claude-ops/skills/ops-ar/SKILL.md
+++ b/claude-ops/skills/ops-ar/SKILL.md
@@ -20,7 +20,7 @@ effort: high
 
 ## Agent Teams support
 
-If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** when A&R'ing a batch or a full inbox sweep — one ar-producer teammate per track, coordinating in real time. This enables:
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** when A&R'ing a batch or a full inbox sweep — one ar-producer teammate per track, in waves of ≤2 (stem separation is CPU-heavy; check `nproc`/`uptime` first), coordinating in real time. This enables:
 - Teammates share cross-track context (a recurring mix flaw or reference act spotted on track 1 informs the verdict on track 3)
 - You can steer mid-sweep: "rank the dance-pop demos first, hold the ballads"
 - Each verdict card streams back as its track finishes, so you assemble the ranked summary as results land
@@ -32,7 +32,7 @@ Agent(team_name="ar-panel", name="ar-[track-slug]", ...)
 ```
 Steer with `SendMessage` / `broadcast`.
 
-If the flag is NOT set, fall back to standard fire-and-forget subagents (one ar-producer Agent per track, dispatched in parallel).
+If the flag is NOT set, fall back to standard fire-and-forget subagents (one ar-producer Agent per track, in waves of ≤2).
 
 A&R the given record(s) like a pop/dance-hit label owner + master producer. The deliverable is always the full A&R card per track:
 

--- a/claude-ops/skills/ops-ar/SKILL.md
+++ b/claude-ops/skills/ops-ar/SKILL.md
@@ -9,12 +9,30 @@ allowed-tools:
   - Grep
   - Glob
   - Agent
+  - TeamCreate
+  - SendMessage
   - AskUserQuestion
   - WebSearch
 effort: high
 ---
 
 # /ops:ops-ar — A&R Command
+
+## Agent Teams support
+
+If `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set, use **Agent Teams** when A&R'ing a batch or a full inbox sweep — one ar-producer teammate per track, coordinating in real time. This enables:
+- Teammates share cross-track context (a recurring mix flaw or reference act spotted on track 1 informs the verdict on track 3)
+- You can steer mid-sweep: "rank the dance-pop demos first, hold the ballads"
+- Each verdict card streams back as its track finishes, so you assemble the ranked summary as results land
+
+**Team setup** (only when flag is enabled, batch/inbox mode):
+```
+TeamCreate("ar-panel")
+Agent(team_name="ar-panel", name="ar-[track-slug]", ...)
+```
+Steer with `SendMessage` / `broadcast`.
+
+If the flag is NOT set, fall back to standard fire-and-forget subagents (one ar-producer Agent per track, dispatched in parallel).
 
 A&R the given record(s) like a pop/dance-hit label owner + master producer. The deliverable is always the full A&R card per track:
 


### PR DESCRIPTION
## Why

PR #513 (ops-ar A&R command) merged to main without the Agent Teams scaffolding that `tests/test-agent-teams.sh` requires for any skill that spawns Agents. As a result `test-suite` is red on main:

```
FAIL: ops-ar: missing 'TeamCreate' in allowed-tools
FAIL: ops-ar: missing 'SendMessage' in allowed-tools
FAIL: ops-ar: missing '## Agent Teams support' section
FAIL: ops-ar: missing CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS flag check
FAIL: ops-ar: missing TeamCreate() usage example in body
```

## What

Adds `TeamCreate`/`SendMessage` to the ops-ar `allowed-tools` and an `## Agent Teams support` section (team setup + fallback) matching the `skills/ops-fires` template.

Local: `bash tests/test-agent-teams.sh` → **120 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and allowed-tools only for the ops-ar skill; no runtime code or auth/data paths change.
> 
> **Overview**
> Restores **Agent Teams** compliance for the `ops-ar` skill after #513 landed without the required scaffolding, which was failing `tests/test-agent-teams.sh` on main.
> 
> The skill now allows **`TeamCreate`** and **`SendMessage`**, and adds an **`## Agent Teams support`** section: when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`, batch/inbox A&R uses an `ar-panel` team (≤2 tracks per wave, `SendMessage`/broadcast steering, streaming verdict cards); otherwise it keeps the existing per-track **Agent** waves of ≤2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4584747f7fa7c3cb68f2082124f06ce07783a4ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->