### PR TITLE
release: v2.25.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 38 skills, 20 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.24.0",
+      "version": "2.25.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "description": "Business operations command center for Claude Code — 38 skills, 20 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, and /ops:ops-home smart home control via Homey Pro.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.25.0] - 2026-06-06
+
+### Changed
+WhatsApp ops-inbox: project the HistorySync per-conversation archive flag onto chats.archived so the inbox view mirrors the phone independent of the chronically-corrupt regular_low app-state (Fix O); request maximum history on (re-)pair via RequireFullSync + maxed history-sync limits (Fix P).
+
+
 ## [2.24.0] - 2026-06-06
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.25.0** (was 2.24.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

WhatsApp ops-inbox: project the HistorySync per-conversation archive flag onto chats.archived so the inbox view mirrors the phone independent of the chronically-corrupt regular_low app-state (Fix O); request maximum history on (re-)pair via RequireFullSync + maxed history-sync limits (Fix P).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff is version metadata and changelog only; no runtime code changes in this PR.
> 
> **Overview**
> **Release v2.25.0** — bumps the plugin from **2.24.0** to **2.25.0** in `plugin.json`, `.claude-plugin/marketplace.json`, and `claude-ops/package.json`, and adds a **CHANGELOG** entry for this release.
> 
> The changelog documents **WhatsApp ops-inbox** improvements shipped under this tag: **Fix O** projects HistorySync’s per-chat archive flag onto `chats.archived` so the inbox matches the phone without relying on corrupt `regular_low` app-state; **Fix P** requests maximum history on (re-)pair via `RequireFullSync` and raised history-sync limits. This PR’s diff is version alignment and release notes only (no bridge/patcher code changes in the diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3037e466192609a33d07dbaee97ef4b034047781. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->