### PR TITLE
release: v2.26.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 38 skills, 20 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.25.0",
+      "version": "2.26.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.25.0",
+  "version": "2.26.0",
   "description": "Business operations command center for Claude Code — 39 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.26.0] - 2026-06-06
+
+### Changed
+Add /ops:ops-unifi UniFi network command center + ops:unifi-agent probe agent. Curl-native control across all three official UniFi APIs — Site Manager (cloud api.ui.com: hosts, sites, devices, ISP/WAN metrics, SD-WAN), Network Integration (local proxy/network/integration/v1: devices, clients, restart, block/unblock, vouchers, live stats), and Protect Integration (local proxy/protect/integration/v1: cameras, NVR, snapshot, settings). Includes a predict mode that cross-correlates ISP metrics + device stats + camera state to flag WAN degradation, AP stress, weak-RF clients, and surveillance gaps. Adds a /ops:setup network wizard section; all state-changing actions Rule-5 gated, outbound alerts Rule-6 gated.
+
+
 ## [2.25.0] - 2026-06-06
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.25.0",
+  "version": "2.26.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.26.0** (was 2.25.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

Add /ops:ops-unifi UniFi network command center + ops:unifi-agent probe agent. Curl-native control across all three official UniFi APIs — Site Manager (cloud api.ui.com: hosts, sites, devices, ISP/WAN metrics, SD-WAN), Network Integration (local proxy/network/integration/v1: devices, clients, restart, block/unblock, vouchers, live stats), and Protect Integration (local proxy/protect/integration/v1: cameras, NVR, snapshot, settings). Includes a predict mode that cross-correlates ISP metrics + device stats + camera state to flag WAN degradation, AP stress, weak-RF clients, and surveillance gaps. Adds a /ops:setup network wizard section; all state-changing actions Rule-5 gated, outbound alerts Rule-6 gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff is version strings and documentation only; functional UniFi/network control risk lives in the feature code tagged by this release, not in these metadata edits.
> 
> **Overview**
> Release **v2.26.0** bumps the plugin from **2.25.0** across `plugin.json`, marketplace registry, and `claude-ops/package.json`, and prepends the **2.26.0** section to `CHANGELOG.md`.
> 
> The release notes document the headline change for this version: **`/ops:ops-unifi`** (UniFi network command center) and **`ops:unifi-agent`**, with curl-based access to Site Manager, Network Integration, and Protect APIs, a **predict** mode for cross-signal health flags, **`/ops:setup`** network wizard coverage, and **Rule 5 / Rule 6** gates on mutating actions and outbound alerts. `plugin.json`’s description is updated to mention UniFi alongside existing surfaces (e.g. `/ops:ops-home`).
> 
> This diff does not include the skill/agent implementation files—only version metadata, changelog, and registry copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1845963bfd58371aa74949862c73bcc32b4bcc74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->