### PR TITLE
feat(whatsapp): auto-backfill chat display names in link_contacts.py

### DIFF
--- a/claude-ops/scripts/whatsapp/link_contacts.py
+++ b/claude-ops/scripts/whatsapp/link_contacts.py
@@ -79,43 +79,51 @@ def main():
     msg.commit()
     # Backfill chats.name from contacts (direct jid + via lid_map both directions)
     # so chat rows never display raw numbers when a name is known. Idempotent.
-    cur.execute(f"ATTACH '{WA_DB}' AS wa")
     chat_names_fixed = 0
-    for sql in (
-        # direct: contact row for this exact jid
-        """UPDATE chats SET name = (
-             SELECT c.name FROM contacts c
-             WHERE c.jid = chats.jid AND c.name <> '' AND c.name NOT GLOB '[0-9]*')
-           WHERE (name IS NULL OR name='' OR name GLOB '[0-9]*')
-             AND jid NOT LIKE '%@g.us' AND jid NOT LIKE '%@newsletter'
-             AND EXISTS (SELECT 1 FROM contacts c WHERE c.jid = chats.jid
-                         AND c.name <> '' AND c.name NOT GLOB '[0-9]*')""",
-        # lid chat -> phone contact name
-        """UPDATE chats SET name = (
-             SELECT c.name FROM wa.whatsmeow_lid_map m
-             JOIN contacts c ON c.jid = m.pn||'@s.whatsapp.net'
-             WHERE m.lid||'@lid' = chats.jid AND c.name <> '' AND c.name NOT GLOB '[0-9]*')
-           WHERE (name IS NULL OR name='' OR name GLOB '[0-9]*') AND jid LIKE '%@lid'
-             AND EXISTS (SELECT 1 FROM wa.whatsmeow_lid_map m
-                         JOIN contacts c ON c.jid = m.pn||'@s.whatsapp.net'
-                         WHERE m.lid||'@lid' = chats.jid
-                           AND c.name <> '' AND c.name NOT GLOB '[0-9]*')""",
-        # phone chat -> lid contact name
-        """UPDATE chats SET name = (
-             SELECT c.name FROM wa.whatsmeow_lid_map m
-             JOIN contacts c ON c.jid = m.lid||'@lid'
-             WHERE m.pn||'@s.whatsapp.net' = chats.jid AND c.name <> '' AND c.name NOT GLOB '[0-9]*')
-           WHERE (name IS NULL OR name='' OR name GLOB '[0-9]*') AND jid LIKE '%@s.whatsapp.net'
-             AND EXISTS (SELECT 1 FROM wa.whatsmeow_lid_map m
-                         JOIN contacts c ON c.jid = m.lid||'@lid'
-                         WHERE m.pn||'@s.whatsapp.net' = chats.jid
-                           AND c.name <> '' AND c.name NOT GLOB '[0-9]*')""",
-    ):
-        try:
-            cur.execute(sql)
-            chat_names_fixed += cur.rowcount if cur.rowcount > 0 else 0
-        except sqlite3.OperationalError:
-            pass
+    try:
+        cur.execute(
+            """UPDATE chats SET name = (
+                 SELECT c.name FROM contacts c
+                 WHERE c.jid = chats.jid AND c.name <> '' AND c.name NOT GLOB '[0-9]*')
+               WHERE (name IS NULL OR name='' OR name GLOB '[0-9]*')
+                 AND jid NOT LIKE '%@g.us' AND jid NOT LIKE '%@newsletter'
+                 AND EXISTS (SELECT 1 FROM contacts c WHERE c.jid = chats.jid
+                             AND c.name <> '' AND c.name NOT GLOB '[0-9]*')"""
+        )
+        chat_names_fixed += cur.rowcount if cur.rowcount > 0 else 0
+    except sqlite3.OperationalError:
+        pass
+    try:
+        cur.execute(f"ATTACH '{WA_DB}' AS wa")
+        for sql in (
+            # lid chat -> phone contact name
+            """UPDATE chats SET name = (
+                 SELECT c.name FROM wa.whatsmeow_lid_map m
+                 JOIN contacts c ON c.jid = m.pn||'@s.whatsapp.net'
+                 WHERE m.lid||'@lid' = chats.jid AND c.name <> '' AND c.name NOT GLOB '[0-9]*')
+               WHERE (name IS NULL OR name='' OR name GLOB '[0-9]*') AND jid LIKE '%@lid'
+                 AND EXISTS (SELECT 1 FROM wa.whatsmeow_lid_map m
+                             JOIN contacts c ON c.jid = m.pn||'@s.whatsapp.net'
+                             WHERE m.lid||'@lid' = chats.jid
+                               AND c.name <> '' AND c.name NOT GLOB '[0-9]*')""",
+            # phone chat -> lid contact name
+            """UPDATE chats SET name = (
+                 SELECT c.name FROM wa.whatsmeow_lid_map m
+                 JOIN contacts c ON c.jid = m.lid||'@lid'
+                 WHERE m.pn||'@s.whatsapp.net' = chats.jid AND c.name <> '' AND c.name NOT GLOB '[0-9]*')
+               WHERE (name IS NULL OR name='' OR name GLOB '[0-9]*') AND jid LIKE '%@s.whatsapp.net'
+                 AND EXISTS (SELECT 1 FROM wa.whatsmeow_lid_map m
+                             JOIN contacts c ON c.jid = m.lid||'@lid'
+                             WHERE m.pn||'@s.whatsapp.net' = chats.jid
+                               AND c.name <> '' AND c.name NOT GLOB '[0-9]*')""",
+        ):
+            try:
+                cur.execute(sql)
+                chat_names_fixed += cur.rowcount if cur.rowcount > 0 else 0
+            except sqlite3.OperationalError:
+                pass
+    except sqlite3.OperationalError:
+        pass
     msg.commit()
     total = cur.execute(
         "SELECT count(*) FROM contacts WHERE name IS NOT NULL AND name<>''"

--- a/claude-ops/scripts/whatsapp/link_contacts.py
+++ b/claude-ops/scripts/whatsapp/link_contacts.py
@@ -77,6 +77,46 @@ def main():
             )
             lid_upserts += 1
     msg.commit()
+    # Backfill chats.name from contacts (direct jid + via lid_map both directions)
+    # so chat rows never display raw numbers when a name is known. Idempotent.
+    cur.execute(f"ATTACH '{WA_DB}' AS wa")
+    chat_names_fixed = 0
+    for sql in (
+        # direct: contact row for this exact jid
+        """UPDATE chats SET name = (
+             SELECT c.name FROM contacts c
+             WHERE c.jid = chats.jid AND c.name <> '' AND c.name NOT GLOB '[0-9]*')
+           WHERE (name IS NULL OR name='' OR name GLOB '[0-9]*')
+             AND jid NOT LIKE '%@g.us' AND jid NOT LIKE '%@newsletter'
+             AND EXISTS (SELECT 1 FROM contacts c WHERE c.jid = chats.jid
+                         AND c.name <> '' AND c.name NOT GLOB '[0-9]*')""",
+        # lid chat -> phone contact name
+        """UPDATE chats SET name = (
+             SELECT c.name FROM wa.whatsmeow_lid_map m
+             JOIN contacts c ON c.jid = m.pn||'@s.whatsapp.net'
+             WHERE m.lid||'@lid' = chats.jid AND c.name <> '' AND c.name NOT GLOB '[0-9]*')
+           WHERE (name IS NULL OR name='' OR name GLOB '[0-9]*') AND jid LIKE '%@lid'
+             AND EXISTS (SELECT 1 FROM wa.whatsmeow_lid_map m
+                         JOIN contacts c ON c.jid = m.pn||'@s.whatsapp.net'
+                         WHERE m.lid||'@lid' = chats.jid
+                           AND c.name <> '' AND c.name NOT GLOB '[0-9]*')""",
+        # phone chat -> lid contact name
+        """UPDATE chats SET name = (
+             SELECT c.name FROM wa.whatsmeow_lid_map m
+             JOIN contacts c ON c.jid = m.lid||'@lid'
+             WHERE m.pn||'@s.whatsapp.net' = chats.jid AND c.name <> '' AND c.name NOT GLOB '[0-9]*')
+           WHERE (name IS NULL OR name='' OR name GLOB '[0-9]*') AND jid LIKE '%@s.whatsapp.net'
+             AND EXISTS (SELECT 1 FROM wa.whatsmeow_lid_map m
+                         JOIN contacts c ON c.jid = m.lid||'@lid'
+                         WHERE m.pn||'@s.whatsapp.net' = chats.jid
+                           AND c.name <> '' AND c.name NOT GLOB '[0-9]*')""",
+    ):
+        try:
+            cur.execute(sql)
+            chat_names_fixed += cur.rowcount if cur.rowcount > 0 else 0
+        except sqlite3.OperationalError:
+            pass
+    msg.commit()
     total = cur.execute(
         "SELECT count(*) FROM contacts WHERE name IS NOT NULL AND name<>''"
     ).fetchone()[0]
@@ -87,6 +127,7 @@ def main():
                 "ok": True,
                 "phone_contacts": upserts,
                 "lid_aliases": lid_upserts,
+                "chat_names_fixed": chat_names_fixed,
                 "named_total": total,
             }
         )


### PR DESCRIPTION
## Summary
- chat rows displayed raw phone/LID numbers (181 on the live store) even when `contacts` had real names — nothing propagated names into `chats.name`
- adds an idempotent backfill pass to `link_contacts.py` (direct jid match + `whatsmeow_lid_map` both directions), running on every ops-inbox invocation
- schema-guarded (`try/except OperationalError`) so whatsmeow schema drift degrades gracefully
- adds `chat_names_fixed` to the JSON summary

## Test plan
- live store: 181 unnamed chats → 5 (remainders are genuinely unknown numbers)
- idempotent re-run: `{"ok": true, "chat_names_fixed": 0}`
- dual-JID spot check: Michelle resolves on both `@lid` and `@s.whatsapp.net`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local SQLite display-name updates only; guarded SQL and no auth or messaging path changes.
> 
> **Overview**
> Extends **`link_contacts.py`** so that after contacts are synced from whatsmeow, **`chats.name`** is backfilled from **`contacts`** when the chat still shows a blank or numeric-only label (1:1 chats only; groups/newsletters skipped).
> 
> The pass is **idempotent** and runs on every existing **`link_contacts.py`** invocation (e.g. ops-inbox autosync). It matches by **direct JID**, then via **`whatsmeow_lid_map`** in both directions (LID chat → phone contact name and phone chat → LID contact name). **`OperationalError`** handlers keep partial schema drift from failing the run. The JSON summary now includes **`chat_names_fixed`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0894bd8340d8aa13d7fb4f02fc0ad2e96c788416. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat name resolution during WhatsApp data import via a post-import backfill. Chats that previously showed numbers or blank names are now populated from matched contacts across different identifier formats.
  * The import now reports how many chat names were fixed in the final JSON output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->