### PR TITLE
release: v2.26.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 38 skills, 20 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.26.0",
+      "version": "2.26.1",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "description": "Business operations command center for Claude Code — 39 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.26.1] - 2026-06-07
+
+### Changed
+fix(whatsapp): durable post-re-pair app-state LTHash prevention — readiness gate on /api/archive (HTTP 425 until regular_low synced), new /api/app_state_status, discard_local resync to heal corruption without a phone tap, and wa-inbox-fresh freshness wait (#521). feat(whatsapp): auto-backfill chat display names in link_contacts.py so LID/phone chats never show raw numbers (#520).
+
+
 ## [2.26.0] - 2026-06-06
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.26.0",
+  "version": "2.26.1",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.26.1** (was 2.26.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

fix(whatsapp): durable post-re-pair app-state LTHash prevention — readiness gate on /api/archive (HTTP 425 until regular_low synced), new /api/app_state_status, discard_local resync to heal corruption without a phone tap, and wa-inbox-fresh freshness wait (#521). feat(whatsapp): auto-backfill chat display names in link_contacts.py so LID/phone chats never show raw numbers (#520).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release PR; functional WhatsApp changes are documented in the changelog but not modified in this diff.
> 
> **Overview**
> **Release v2.26.1** bumps the plugin from **2.26.0 → 2.26.1** across the marketplace registry (`.claude-plugin/marketplace.json`), plugin manifest (`claude-ops/.claude-plugin/plugin.json`), and `claude-ops/package.json`.
> 
> `CHANGELOG.md` documents what ships in this tag (already merged via #520–#521): **WhatsApp** hardening after re-pair—`/api/archive` returns **HTTP 425** until `regular_low` app state is synced, new **`GET /api/app_state_status`**, **`discard_local` resync** to heal LTHash corruption without a phone tap, and **`wa-inbox-fresh`** waiting for app-state readiness; plus **`link_contacts.py`** auto-backfill of chat display names so LID/phone chats don’t show raw numbers.
> 
> There is **no application code** in this diff—version metadata and release notes only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fc535135b603b0f5a8684184f346089cdd35d1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->