### PR TITLE
fix(ops-doctor): stop pocket + gog auth false-positive warnings

### DIFF
--- a/claude-ops/bin/ops-doctor
+++ b/claude-ops/bin/ops-doctor
@@ -341,19 +341,25 @@ fi
 # --- 5e. Pocket health probe ---
 POCKET_STATE_DIR="$HOME/.claude/state/pocket"
 POCKET_CONFIGURED=false
+POCKET_DISABLED=false
 if [ -f "$PREFS" ] && command -v jq >/dev/null 2>&1; then
-  jq -e '.pocket.enabled == true' "$PREFS" >/dev/null 2>&1 && POCKET_CONFIGURED=true
+  jq -e '.pocket.enabled == true'  "$PREFS" >/dev/null 2>&1 && POCKET_CONFIGURED=true
+  # Explicit opt-out wins: if pocket.enabled is set to false, never warn about it.
+  jq -e '.pocket.enabled == false' "$PREFS" >/dev/null 2>&1 && POCKET_DISABLED=true
 fi
-# Also probe if any health/config file already exists (partial install)
+# Also treat pocket as active if a service has actually registered a health file.
+# NOTE: config JSONs (whatsapp-config.json / email-config.json) are written by
+# setup and may linger after pocket is turned off — they do NOT imply the daemon
+# should be running, so they must NOT flip POCKET_CONFIGURED (false-positive source).
 for _pf in \
   "$POCKET_STATE_DIR/.activity-notifier-health" \
   "$POCKET_STATE_DIR/.out-queue-health" \
   "$POCKET_STATE_DIR/.email-bridge-health" \
-  "$POCKET_STATE_DIR/.whatsapp-bridge-health" \
-  "$POCKET_STATE_DIR/whatsapp-config.json" \
-  "$POCKET_STATE_DIR/email-config.json"; do
+  "$POCKET_STATE_DIR/.whatsapp-bridge-health"; do
   [ -f "$_pf" ] && POCKET_CONFIGURED=true && break
 done
+# Explicit disable overrides any inferred-active signal.
+[ "$POCKET_DISABLED" = true ] && POCKET_CONFIGURED=false
 
 if [ "$POCKET_CONFIGURED" = true ]; then
   NOW=$(date +%s)
@@ -429,7 +435,12 @@ if [ "$POCKET_CONFIGURED" = true ]; then
   if [ -f "$POCKET_STATE_DIR/email-config.json" ]; then
     EM_EN=$(jq -r '.enabled // "true"' "$POCKET_STATE_DIR/email-config.json" 2>/dev/null || echo "true")
     if [ "$EM_EN" != "false" ] && command -v gog >/dev/null 2>&1; then
-      if ! gog auth status 2>&1 | grep -qi "authenticated\|logged in\|active"; then
+      # `gog auth status` does not print the word "authenticated"; it emits
+      # key<TAB>value lines. The authoritative signal is `credentials_exists true`
+      # alongside a non-empty `account`. (Old grep for "authenticated|logged in|
+      # active" never matched and always false-warned.)
+      GOG_STATUS=$(gog auth status 2>&1 || true)
+      if ! printf '%s\n' "$GOG_STATUS" | grep -qE '^credentials_exists[[:space:]]+true'; then
         WARNINGS+=("pocket_email_auth: gog gmail not authenticated — email notifications will fail. Run: gog auth add <email> --services gmail")
       fi
     fi


### PR DESCRIPTION
## Problem
`/ops:ops-doctor` surfaced two warnings on a healthy box:
- `pocket_health_missing_*` (activity-notifier, out-queue, email-bridge) — even though the Pocket pipeline isn't in use here.
- `pocket_email_auth: gog gmail not authenticated` — even though gog has valid oauth creds (`<PERSONAL_EMAIL>`, verified live).

## Root causes
1. **Pocket gating too loose.** `POCKET_CONFIGURED` flipped `true` merely because a leftover `email-config.json`/`whatsapp-config.json` existed. Those config JSONs are written by setup and linger after pocket is turned off — they don't mean the daemon should be running. So a disabled pocket raised missing-service warnings.
2. **gog probe grepped the wrong thing.** It ran `gog auth status | grep -i 'authenticated|logged in|active'`, but that command emits `key<TAB>value` lines containing none of those words — so it **always** false-warned, even with valid creds.

## Fix
- Pocket is now considered active only when explicitly enabled (`.pocket.enabled == true`) **or** a real `*-health` file exists (a service actually registered). Config JSONs no longer flip the flag. `.pocket.enabled == false` hard-disables (explicit opt-out wins).
- gog check now keys off the authoritative `credentials_exists true` field.

## Verification
`./bin/ops-doctor` → `{errors: [], warnings: [], info: []}` on a box with valid gog oauth and pocket not in use. `bash -n` clean; `tests/test-no-secrets.sh` 14/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostic-only changes in ops-doctor with no runtime or security behavior changes beyond when warnings fire.
> 
> **Overview**
> **`ops-doctor`** pocket and gog checks are tightened so healthy, non-Pocket setups stop getting bogus warnings.
> 
> Pocket probes now run only when Pocket is actually in use: **`POCKET_CONFIGURED`** turns on from **`.pocket.enabled == true`** or a real **`*-health`** file, not leftover **`email-config.json` / `whatsapp-config.json`**. **`.pocket.enabled == false`** forces Pocket off and skips health warnings.
> 
> The gog Gmail probe no longer greps for “authenticated”; it treats **`credentials_exists true`** from **`gog auth status`** as the auth signal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c28989d6206f0385c36c01c5ad7a71b5390783f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->