### PR TITLE
fix(daemon): Linux/systemd status detection + real bridge PID reporting

### DIFF
--- a/claude-ops/scripts/daemon-services.default.json
+++ b/claude-ops/scripts/daemon-services.default.json
@@ -17,6 +17,7 @@
       "enabled": true,
       "command": "${CLAUDE_PLUGIN_ROOT}/scripts/lib/whatsapp-bridge-up.sh",
       "health_check": "lsof -i :8080 | grep LISTEN",
+      "pid_probe": "lsof -ti :8080 -sTCP:LISTEN 2>/dev/null | head -1",
       "restart_delay": 60,
       "max_restarts": 10,
       "_note": "Cross-platform bridge starter. Looks at uname: macOS → launchctl kickstart gui/$UID/com.${USER}.whatsapp-bridge ; Linux → systemctl --user restart whatsapp-bridge.service. Install via `bash scripts/install-whatsapp-bridge-linux.sh --wa-phone <E.164>` on Linux hosts; on macOS the legacy launchctl plist still applies. Bridge source: github.com/lharries/whatsapp-mcp (with claude-ops patches applied by install script — see scripts/whatsapp/apply-patches.py)."

--- a/claude-ops/scripts/ops-daemon-manager.sh
+++ b/claude-ops/scripts/ops-daemon-manager.sh
@@ -368,6 +368,35 @@ cmd_status() {
         fi
       fi
       ;;
+    linux|wsl)
+      # The daemon runs as a systemd --user unit here, not a launchd plist, so
+      # the plist-based detection above never fires. Probe the unit instead:
+      #   installed  = unit file exists (loaded by systemd)
+      #   running    = unit is active + MainPID is alive
+      #   script_path= ExecStart's ops-daemon.sh path (the live source path)
+      #   version_match = that script path still exists on disk (Linux's analog
+      #                   of "plist points at current version"; systemd tracks
+      #                   whatever ExecStart points at, so staleness = missing file)
+      local unit="claude-ops-daemon.service"
+      if systemctl --user cat "$unit" >/dev/null 2>&1; then
+        installed=true
+        local exec_path
+        exec_path="$(systemctl --user show -p ExecStart --value "$unit" 2>/dev/null \
+          | grep -oE '/[^ ]*ops-daemon\.sh' | head -1)"
+        if [[ -n "$exec_path" ]]; then
+          script_path="$exec_path"
+          [[ -f "$exec_path" ]] && plist_version_match=true
+        fi
+        if systemctl --user is-active "$unit" >/dev/null 2>&1; then
+          local p
+          p="$(systemctl --user show -p MainPID --value "$unit" 2>/dev/null || echo 0)"
+          if [[ -n "$p" ]] && [[ "$p" != "0" ]] && kill -0 "$p" 2>/dev/null; then
+            pid="$p"
+            running=true
+          fi
+        fi
+      fi
+      ;;
   esac
 
   if [[ -f "$HEALTH_FILE" ]]; then

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -455,9 +455,25 @@ print(json.dumps(sys.argv[1]))
       if [[ -n "$hc_cmd" ]]; then
         # Command-supervised service: liveness was already determined by
         # check_health via the configured probe. The tracked PID is an
-        # ephemeral launcher and not meaningful — report status as-is with a
-        # null pid; do NOT downgrade running→dead on a dead wrapper PID.
+        # ephemeral launcher and not meaningful — never use it for liveness or
+        # downgrade running→dead on a dead wrapper PID.
+        #
+        # For OBSERVABILITY only, if the service registry defines a `pid_probe`
+        # command, resolve the REAL externally-supervised PID (e.g. the process
+        # LISTENing on the bridge port, owned by whatsapp-bridge.service) and
+        # report it. This is strictly reporting — it is never fed back into the
+        # restart/liveness path, so it cannot reintroduce the false-dead churn.
         pid_val="null"
+        if [[ "$status" == "running" ]]; then
+          local pid_probe_cmd real_pid
+          pid_probe_cmd=$(get_service_field "$name" "pid_probe")
+          if [[ -n "$pid_probe_cmd" ]]; then
+            real_pid=$(eval "$pid_probe_cmd" 2>/dev/null | head -1 | tr -dc '0-9' | head -c 12)
+            if [[ -n "$real_pid" ]] && kill -0 "$real_pid" 2>/dev/null; then
+              pid_val="$real_pid"
+            fi
+          fi
+        fi
       elif [[ "$pid" == "null" ]] || [[ -z "$pid" ]]; then
         pid_val="null"
         # No PID tracked — status cannot be "running"

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -468,9 +468,10 @@ print(json.dumps(sys.argv[1]))
           local pid_probe_cmd real_pid
           pid_probe_cmd=$(get_service_field "$name" "pid_probe")
           if [[ -n "$pid_probe_cmd" ]]; then
-            real_pid=$(eval "$pid_probe_cmd" 2>/dev/null | head -1 | tr -dc '0-9' | head -c 12)
-            if [[ -n "$real_pid" ]] && kill -0 "$real_pid" 2>/dev/null; then
-              pid_val="$real_pid"
+            if real_pid=$(eval "$pid_probe_cmd" 2>/dev/null | head -1 | tr -dc '0-9' | head -c 12); then
+              if [[ -n "$real_pid" ]] && kill -0 "$real_pid" 2>/dev/null; then
+                pid_val="$real_pid"
+              fi
             fi
           fi
         fi


### PR DESCRIPTION
## Two persistent daemon fixes

### 1. `ops-daemon-manager.sh status` reported `installed=false`/`running=false` on Linux
`cmd_status` only had a macOS launchd branch. On Linux the daemon runs as a `systemd --user` unit (`claude-ops-daemon.service`), so the plist probe never matched and a perfectly healthy daemon looked uninstalled/stopped to every consumer (`ops-status`, `ops-go`). Added a `linux|wsl` branch:
- `installed` = `systemctl --user cat` succeeds
- `running` = `is-active` + live `MainPID`
- `script_path` = ExecStart's `ops-daemon.sh` path; `version_match` = that file exists

### 2. `whatsapp-bridge` reported `pid: null` despite a live listener
The ephemeral launcher PID is intentionally cleared (tracking it caused false-dead → restart churn, since the real process is owned by `whatsapp-bridge.service`). Added an optional registry field `pid_probe` that resolves the REAL externally-supervised PID **for reporting only** — it is never fed back into the liveness/restart path, so it cannot reintroduce churn. Wired to whatsapp-bridge via `lsof -ti :8080 -sTCP:LISTEN`.

## Verification (live, this EC2 box)
```
installed: True   running: True   pid: 1482627
pid_probe → 57918  (real :8080 listener)
bash -n clean · JSON valid
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, read-path changes to status/health reporting; liveness and restart logic stay on health_check/PID tracking as before.
> 
> **Overview**
> Fixes **daemon visibility on Linux** and **WhatsApp bridge PID reporting** without changing restart/liveness behavior.
> 
> `ops-daemon-manager.sh status` now treats **Linux/WSL** hosts as using the user `systemd` unit `claude-ops-daemon.service` (installed/running/`MainPID`, `ExecStart` script path, and a file-exists check analogous to plist version match). That stops healthy daemons from showing as uninstalled/stopped to tools that read this JSON.
> 
> For services supervised by `health_check` (e.g. `whatsapp-bridge`), health JSON can still show `pid: null` because the tracked launcher PID is intentionally cleared. The registry gains an optional **`pid_probe`**; `write_daemon_health` runs it only when status is `running` and emits the real listener PID in `daemon-health.json`. **`whatsapp-bridge`** is wired with `lsof` on `:8080`; probes are **observability-only** and are not used for restarts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14247d282ee29e15b6e9c7c785dc55b63288e853. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->