### PR TITLE
release: v2.26.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 38 skills, 20 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.26.1",
+      "version": "2.26.2",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.26.1",
+  "version": "2.26.2",
   "description": "Business operations command center for Claude Code — 39 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.26.2] - 2026-06-07
+
+### Changed
+fix(daemon): Linux/systemd status detection in ops-daemon-manager (installed/running/pid now correct on systemd --user hosts, not just macOS launchd); real whatsapp-bridge PID reporting via optional registry pid_probe field (reporting-only, never fed into liveness/restart path).
+
+
 ## [2.26.1] - 2026-06-07
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.26.1",
+  "version": "2.26.2",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.26.2** (was 2.26.1).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

fix(daemon): Linux/systemd status detection in ops-daemon-manager (installed/running/pid now correct on systemd --user hosts, not just macOS launchd); real whatsapp-bridge PID reporting via optional registry pid_probe field (reporting-only, never fed into liveness/restart path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-metadata and changelog-only diff in this PR; documented daemon changes are status/reporting fixes with pid_probe explicitly excluded from restart logic.
> 
> **Overview**
> **Release v2.26.2** — bumps the ops plugin from **2.26.1** to **2.26.2** in `plugin.json`, `.claude-plugin/marketplace.json`, and `claude-ops/package.json`, and prepends a **2.26.2** section to `CHANGELOG.md`.
> 
> The changelog records the shipped behavior for this tag: **`ops-daemon-manager`** now reports **installed / running / PID** correctly on **Linux `systemd --user`** hosts (not only macOS launchd), and **whatsapp-bridge** can show a **real process PID** via an optional registry **`pid_probe`** field that is **reporting-only** and does not drive liveness or restarts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f9fb41ed96f647d970b8f3ab2d37f173ee6b087. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->