### PR TITLE
fix(account-rotation): re-auth live sessions via /login + resume-path; daemon runs both strategies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 node_modules/
 *.log
 .worktrees/
+.gstack/

--- a/claude-ops/bin/ops-speedup
+++ b/claude-ops/bin/ops-speedup
@@ -326,7 +326,7 @@ run_parallel_scan() {
 # Protected processes — never kill, never demote
 # Spotlight stack (mds/mdworker) + iCloud/App Store sync (bird/cloudd/akd/itunescloudd/appstoreagent/storeagent/storeaccountd/commerce/storedownloadd/identityservicesd/apsd) must stay at normal priority.
 # Demoting them via taskpolicy -b starves CloudKit/StoreKit traffic and surfaces as "Cannot Connect" in App Store / iCloud / iCloud Drive sync stalls.
-PROTECTED_RE="kernel_task|launchd|WindowServer|loginwindow|Finder|SystemUIServer|Dock|systemd|init|sshd|ssh|mosh|bash|zsh|fish|tmux|screen|cursor|Cursor|comet|Comet|Shortwave|shortwave|claude|Claude|node|npm|python|Xcode|xcodebuild|mds|mds_stores|mdworker|mdworker_shared|mdbulkimport|Spotlight|bird|cloudd|akd|itunescloudd|appstoreagent|storeagent|storeaccountd|storedownloadd|commerce|identityservicesd|apsd|nsurlsessiond|fmfd|callservicesd|imagent|softwareupdated|nsurlstoraged|trustd|networkd|symptomsd|locationd|dasd|powerd"
+PROTECTED_RE="kernel_task|launchd|WindowServer|loginwindow|Finder|SystemUIServer|Dock|systemd|init|sshd|ssh|mosh|bash|zsh|fish|tmux|screen|cursor|Cursor|comet|Comet|Shortwave|shortwave|claude|Claude|node|npm|python|Xcode|xcodebuild|mds|mds_stores|mdworker|mdworker_shared|mdbulkimport|Spotlight|bird|cloudd|akd|itunescloudd|appstoreagent|storeagent|storeaccountd|storedownloadd|commerce|identityservicesd|apsd|nsurlsessiond|fmfd|callservicesd|imagent|softwareupdated|nsurlstoraged|trustd|networkd|symptomsd|locationd|dasd|powerd|Supercharge|supercharge"
 
 # Safe to demote to background priority (not kill).
 # Excludes: bird/cloudd (iCloud/CloudKit), identityservicesd (iMessage/FaceTime/iCloud auth) — demoting these breaks App Store + iCloud sync.

--- a/claude-ops/scripts/account-rotation/daemon.mjs
+++ b/claude-ops/scripts/account-rotation/daemon.mjs
@@ -534,20 +534,23 @@ async function doRotation(reason) {
   try {
     // --no-browser: no Chrome, no API calls (works when rate limited)
     // --to: daemon controls which account to rotate to (pre-validated token)
-    // --reload-agents: after the keychain swap, sequentially respawn running bg
-    //   agents so they pick up the new token. Sequential + 15s stagger; max 4
-    //   agents per invocation (anti-stampede). Adds up to ~60s of wall time on
-    //   top of the keychain swap — timeout raised to 200s to accommodate.
-    // NO --session: keychain swap only. Background rotation must not inject /login
-    // into running sessions — that interrupts active work. When sessions hit the wall
-    // they show "not logged in" — user runs /login → instant success because the fresh
-    // token is already in the keychain.
+    // Two re-auth strategies, targeting DISJOINT session classes (best practice:
+    // detached headless sessions cannot be steered via `--resume --print`, so they
+    // must be respawned; live TTY sessions can take a direct /login injection):
+    //   --reload-agents → sequentially respawn running *detached* bg agents (no TTY,
+    //     no human mid-keystroke) onto the fresh token. Sequential + 15s stagger;
+    //     max 4/invocation (anti-stampede).
+    //   --session → inject /login into live TTY-reachable sessions (tmux panes +
+    //     iTerm2) plus a best-effort resume-path for non-tmux interactive sessions,
+    //     so they re-auth immediately instead of failing at the auth wall.
+    // refreshRunningSession explicitly skips bg sessions (they auto-reauth via the
+    // 30s keychain poll), so the two flags never double-act on the same session.
     const result = execFileSync(
       process.execPath,
-      [ROTATE_SCRIPT, '--no-browser', '--to', targetKey, '--reload-agents'],
+      [ROTATE_SCRIPT, '--no-browser', '--to', targetKey, '--reload-agents', '--session'],
       {
         cwd: __dirname,
-        timeout: 200_000, // 120s swap + up to 4×15s stagger = ~180s; 200s gives headroom
+        timeout: 240_000, // 120s swap + up to 4×15s reload stagger + session inject; headroom
         env: { ...process.env, NODE_NO_WARNINGS: '1' },
       },
     ).toString();

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -2480,6 +2480,18 @@ function findClaudeSessions() {
       }
     } catch {}
 
+    // Load session state files to detect bg sessions (kind: 'bg')
+    const sessionStateDir = join(homedir(), '.claude', 'sessions');
+    const bgPids = new Set();
+    try {
+      for (const f of readdirSync(sessionStateDir).filter((f) => f.endsWith('.json'))) {
+        try {
+          const s = JSON.parse(readFileSync(join(sessionStateDir, f), 'utf8'));
+          if (s.kind === 'bg' && s.pid) bgPids.add(s.pid);
+        } catch {}
+      }
+    } catch {}
+
     for (const line of psOut.split('\n')) {
       const match = line.trim().match(/^(\d+)\s+(ttys?\d+)\s+(.+)$/);
       if (!match) continue;
@@ -2488,7 +2500,8 @@ function findClaudeSessions() {
       const resumeMatch = args.match(/--resume\s+(\S+)/);
       const resumeId = resumeMatch ? resumeMatch[1] : null;
       const pane = ttyMap[tty] || null;
-      sessions.push({ pid: parseInt(pid), tty, pane, resumeId, args });
+      const isBg = bgPids.has(parseInt(pid));
+      sessions.push({ pid: parseInt(pid), tty, pane, resumeId, args, isBg });
     }
   } catch (e) {
     log(`[session] Failed to enumerate sessions: ${e.message.substring(0, 80)}`);
@@ -2571,13 +2584,14 @@ async function refreshRunningSession(rotatedAccount = null, noBrowser = false) {
 
   if (sessions.length === 0) {
     log('[session] No running Claude Code sessions found');
-    return;
   }
 
-  // Tag each session with its owning terminal app. We only have a reliable
-  // AppleScript injection path for tmux + iTerm2. For Ghostty/Terminal/others,
-  // writing to the raw TTY shows as OUTPUT (garbles the live display) and
-  // `tell application "iTerm2"` would spuriously *launch* iTerm2 — so we skip.
+  // Tag each session with its owning terminal app.
+  // Injection paths (in priority order):
+  //   1. tmux pane — most reliable, works from any terminal including Ghostty
+  //   2. iTerm2 AppleScript — for non-tmux iTerm2 sessions
+  //   3. claude --resume --print /login — for bg sessions (no TTY) or any
+  //      session that has a resumeId but no reachable TTY
   for (const s of sessions) {
     if (!s.pane && s.pid) s.terminal = detectTerminalForPid(s.pid);
   }
@@ -2585,42 +2599,80 @@ async function refreshRunningSession(rotatedAccount = null, noBrowser = false) {
   const sendKeys = (s, txt) => {
     if (s.pane) return sendKeysToPane(s.pane, txt);
     if (s.terminal === 'iTerm2' && s.tty) return sendKeysToITerm(s.tty, txt);
-    // Ghostty, Terminal.app, Alacritty, WezTerm, kitty, unknown: skip.
-    // Raw TTY write would render "/login" as on-screen output text, not
-    // stdin — corrupting the session without triggering the re-auth.
+    // Ghostty, Terminal.app, Alacritty, WezTerm, kitty, unknown: fall through
+    // to resume-path below; raw TTY write garbles the display.
     return false;
   };
 
-  // Reachable = tmux pane OR known-good terminal (iTerm2). Everyone else
-  // is logged + skipped so we never pop a visual window or garble Ghostty.
-  const reachable = sessions.filter((s) => s.pane || (s.terminal === 'iTerm2' && s.tty));
-  const skipped = sessions.filter((s) => !s.pane && s.terminal && s.terminal !== 'iTerm2');
-  for (const s of skipped) {
-    log(
-      `[session] Skipping PID ${s.pid} (${s.terminal}) — no safe inject path; token-refresh daemon keeps keys fresh so restart isn't required`,
-    );
+  // Resume path: sessions that have a --resume UUID can receive /login via
+  // `claude --resume <uuid> --print /login`. Works for claude --bg sessions
+  // (no TTY, detached) and Ghostty / non-tmux sessions where AppleScript is unavailable.
+  async function sendViaResume(s) {
+    if (!s.resumeId) return false;
+    try {
+      spawnSync('claude', ['--resume', s.resumeId, '--print', '/login'],
+        { timeout: 15_000, stdio: 'ignore' }
+      );
+      return true;
+    } catch {
+      return false;
+    }
   }
-  if (reachable.length === 0) {
-    log(`[session] Found ${sessions.length} sessions but none have a reachable TTY`);
+
+  const reachable = sessions.filter((s) => s.pane || (s.terminal === 'iTerm2' && s.tty));
+  const resumable = sessions.filter((s) => !s.pane && !(s.terminal === 'iTerm2' && s.tty) && s.resumeId);
+  const unreachable = sessions.filter((s) => !s.pane && !(s.terminal === 'iTerm2' && s.tty) && !s.resumeId);
+
+  for (const s of unreachable) {
+    log(`[session] Skipping PID ${s.pid} (${s.terminal || 'unknown'}) — no tmux pane, no iTerm2, no resumeId`);
+  }
+
+  const totalActionable = reachable.length + resumable.length;
+  if (totalActionable === 0 && sessions.length > 0) {
+    log(`[session] Found ${sessions.length} session(s) but none have a reachable inject path`);
+  } else if (sessions.length === 0) {
     return;
   }
 
-  log(`[session] Injecting /login into ${reachable.length} session(s):`);
-  for (const s of reachable) {
-    log(`  PID ${s.pid} ${s.pane ? 'pane=' + s.pane : 'tty=' + s.tty}`);
+  if (reachable.length > 0) {
+    log(`[session] Injecting /login into ${reachable.length} TTY-reachable session(s):`);
+    for (const s of reachable) {
+      log(`  PID ${s.pid} ${s.pane ? 'pane=' + s.pane : 'tty=' + s.tty}`);
+    }
   }
 
   // Keychain was already swapped to the fresh account's valid token.
   // /login re-reads the keychain → picks up the new token → "Login successful" instantly.
-  // No /exit, no process restart, no OAuth browser flow needed (token is already valid).
-  // Stagger slightly to avoid all sessions hitting the API at the exact same millisecond.
   for (const s of reachable) {
     if (sendKeys(s, '/login')) {
       log(`[session] Sent /login to PID ${s.pid} (${s.pane || s.tty})`);
     } else {
-      log(`[session] Failed to inject /login to PID ${s.pid} (${s.pane || s.tty})`);
+      log(`[session] Failed TTY inject for PID ${s.pid} — trying resume path`);
+      if (s.resumeId) {
+        const ok = await sendViaResume(s);
+        log(`[session] Resume fallback for PID ${s.pid}: ${ok ? 'ok' : 'failed'}`);
+      }
     }
-    await sleep(500); // 500ms stagger between sessions
+    await sleep(500);
+  }
+
+  // Non-tmux sessions with a resumeId (non-bg interactive sessions in Ghostty etc):
+  // use claude --resume --print /login.
+  // NOTE: claude --bg daemon sessions auto-reauth within 30s via Claude Code's
+  // keychain poll cycle — the CLI blocks --resume --print on them anyway.
+  const resumableInteractive = resumable.filter((s) => !s.isBg);
+  const resumableBg = resumable.filter((s) => s.isBg);
+  for (const s of resumableBg) {
+    log(`[session] PID ${s.pid} is a bg session — will auto-reauth via 30s keychain poll (no action needed)`);
+  }
+  if (resumableInteractive.length > 0) {
+    log(`[session] Sending /login via --resume to ${resumableInteractive.length} non-tmux interactive session(s):`);
+    for (const s of resumableInteractive) {
+      log(`  PID ${s.pid} resumeId=${s.resumeId} terminal=${s.terminal || 'unknown'}`);
+      const ok = await sendViaResume(s);
+      log(`[session] Resume /login for PID ${s.pid}: ${ok ? 'ok' : 'failed'}`);
+      await sleep(500);
+    }
   }
 
   // If Claude relaunches trigger an OAuth browser window (token expired mid-rotation),
@@ -3051,7 +3103,7 @@ async function rotate(targetEmail, opts = {}) {
 
   if (opts.session) {
     if (dryRun) {
-      log('[DRY-RUN] Would restart running Claude sessions with --continue and send resume prompt');
+      log('[DRY-RUN] Would inject /login into reachable running sessions (tmux/iTerm2) + resume-path for non-tmux interactive sessions');
     } else {
       await refreshRunningSession(account, opts.noBrowser);
     }


### PR DESCRIPTION
## What

Salvages local WIP into a clean release. Account rotation now re-authenticates **two disjoint session classes** via independent flags, reconciling this WIP with already-merged #509.

### Strategy (best-practice grounded)
- **`--reload-agents`** (existing, #509): respawn **detached bg agents** — they have no TTY and cannot be steered via `claude --resume --print` (headless `--print` is single-shot, not a steering channel), so respawn is the only reliable re-auth path.
- **`--session`** (this change): inject `/login` into **live TTY-reachable sessions** (tmux + iTerm2) plus a best-effort resume-path (`claude --resume <uuid> --print /login`) for **non-tmux interactive sessions** (Ghostty etc.) that are silently skipped today.

bg sessions are **explicitly skipped** in the `--session` path (they auto-reauth via the 30s keychain poll), so `--reload-agents` (detached) and `--session` (live interactive) never double-act on the same session.

> Re #509's deliberate "NO `--session` from daemon — interrupts active work": the resume-path spawns a *separate* headless process (doesn't touch live stdin), and the TTY `/login` injection is idempotent (re-reads keychain → "Login successful"). Owner directed enabling live-session re-auth so interactive sessions re-auth immediately rather than failing at the wall.

## Changes
- **`rotate.mjs`**: `findClaudeSessions` reads `~/.claude/sessions/*.json` to tag `kind:'bg'` pids; `refreshRunningSession` adds `sendViaResume()` and splits sessions into reachable / resumable-interactive / unreachable (bg resumables → no-op).
- **`daemon.mjs`**: background rotation passes **both** `--reload-agents --session`; timeout 200→240s for combined work.
- **`bin/ops-speedup`**: protect `Supercharge` from demotion/kill (`PROTECTED_RE`).
- **`.gitignore`**: ignore `.gstack/` (gstack browse daemon state).

## Verification
- `node --check` both `.mjs` ✓
- `bash -n ops-speedup` ✓
- no conflict markers ✓
- `tests/test-no-secrets.sh` → 14 passed / 0 failed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-rotation to inject /login into live terminals and spawn resume-path CLI calls, which can disturb active sessions if injection fails; auth/keychain behavior is sensitive but scoped to existing rotation flows.
> 
> **Overview**
> Auto account rotation now re-authenticates **live interactive** Claude Code sessions in addition to respawning detached bg agents, so users hit the auth wall less often after a keychain swap.
> 
> The rotation **daemon** invokes `rotate.mjs` with **`--reload-agents` and `--session`** (timeout **200s → 240s**). **`refreshRunningSession`** tags bg PIDs from `~/.claude/sessions/*.json`, injects `/login` via tmux/iTerm2, and falls back to **`claude --resume <uuid> --print /login`** for non-tmux interactive sessions (e.g. Ghostty); bg sessions are skipped here and still handled by **`--reload-agents`**.
> 
> Minor hygiene: **`.gstack/`** in `.gitignore`, and **`Supercharge`** added to **`ops-speedup`** protected processes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3966db932982753d4b8350a8887f53b54f2e45f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->