### PR TITLE
release: v2.26.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 38 skills, 20 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.26.2",
+      "version": "2.26.3",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "description": "Business operations command center for Claude Code — 39 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.26.3] - 2026-06-07
+
+### Changed
+Account rotation now re-auths live TTY sessions (tmux/iTerm2 /login injection + resume-path for non-tmux interactive sessions like Ghostty) in addition to respawning detached bg agents (#527). Protect Supercharge from /speedup demotion; gitignore .gstack/.
+
+
 ## [2.26.2] - 2026-06-07
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.26.2",
+  "version": "2.26.3",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.26.3** (was 2.26.2).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

Account rotation now re-auths live TTY sessions (tmux/iTerm2 /login injection + resume-path for non-tmux interactive sessions like Ghostty) in addition to respawning detached bg agents (#527). Protect Supercharge from /speedup demotion; gitignore .gstack/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release PR; no runtime code changes in the diff itself.
> 
> **Overview**
> **Release v2.26.3** — bumps the ops plugin from **2.26.2 → 2.26.3** in `plugin.json`, marketplace registry, and `claude-ops/package.json`, and adds a **CHANGELOG** entry for the release.
> 
> The changelog documents what ships in this tag (from #527 and related work): **account rotation** now re-authenticates **live TTY sessions** (tmux/iTerm2 `/login` injection plus a resume path for non-tmux terminals like Ghostty), not only respawning detached background agents; **Supercharge** is protected from **`/speedup` demotion**; and **`.gstack/`** is added to **gitignore**.
> 
> This PR does not include those implementation diffs—only version metadata and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebade0b097d3bd120a6aa640c5a8c04f09f06e95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->