### PR TITLE
chore(ci): block owner/personal PII at PR time (prevent re-leak)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,12 @@ jobs:
       - name: Run gitleaks
         run: ./gitleaks detect --source . --config claude-ops/.gitleaks.toml --verbose
 
+      # Blocking gate against personal data (PII) reaching this PUBLIC repo:
+      # contributor usernames, home paths, personal emails, AWS account IDs, phone
+      # numbers. Catches the class that previously leaked into history (2026-06-07).
+      - name: PII / personal-data gate
+        run: bash claude-ops/tests/test-no-secrets.sh
+
   test-suite:
     runs-on: ${{ matrix.os }}
     needs: lint-and-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,16 @@ jobs:
       - name: Run gitleaks
         run: ./gitleaks detect --source . --config claude-ops/.gitleaks.toml --verbose
 
-      # Blocking gate against personal data (PII) reaching this PUBLIC repo:
-      # contributor usernames, home paths, personal emails, AWS account IDs, phone
-      # numbers. Catches the class that previously leaked into history (2026-06-07).
-      - name: PII / personal-data gate
+  # Dedicated, INDEPENDENT gate against personal data (PII) reaching this PUBLIC
+  # repo — contributor usernames, home paths, personal emails, AWS account IDs,
+  # phone numbers. Runs with no `needs:` so it executes on every PR regardless of
+  # the secret-scan job's state. Catches the class that leaked into history
+  # (scrubbed 2026-06-07).
+  pii-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: PII / personal-data scan
         run: bash claude-ops/tests/test-no-secrets.sh
 
   test-suite:

--- a/claude-ops/tests/test-no-secrets.sh
+++ b/claude-ops/tests/test-no-secrets.sh
@@ -21,6 +21,8 @@ echo ""
 EXCLUDE_DIRS=(
   "node_modules"
   ".git"
+  ".claude"
+  ".worktrees"
   "tests"
 )
 
@@ -105,6 +107,39 @@ scan_pattern "AWS secret access keys" '(?i)aws.{0,20}secret.{0,20}[A-Za-z0-9/+=]
 
 # Generic high-entropy tokens with common prefixes
 scan_pattern "org_ prefixed tokens (often API keys)" 'org_[a-zA-Z0-9]{20,}'
+
+# === Owner / personal PII (added 2026-06-07) ===
+# This class — a contributor's macOS username, personal email addresses, home
+# paths, and an internal AWS account id — leaked into history before there was a
+# gate for it. These checks fail CI if any of it reappears in the tree.
+# Allowlists keep generic placeholders (user, <user>, $HOME, runner) and the
+# project's own public maintainer contact (info@lifecycleinnovations.limited).
+
+# macOS home-directory paths with a real-looking username
+scan_pattern "macOS home paths (/Users/<name>)" '/Users/[a-z][a-zA-Z0-9_.-]+' \
+  '/Users/(user|username|users|you|your[-_]?user|runner|shared|example|admin)([/"'\''[:space:]]|$)|/Users/[<$\{]'
+
+# Linux home-directory paths with a real-looking username
+scan_pattern "Linux home paths (/home/<name>)" '/home/[a-z][a-zA-Z0-9_.-]+/' \
+  '/home/(user|username|users|you|your[-_]?user|runner|ubuntu|ec2-user|ops|node|app|shared|example)/|/home/[<$\{]'
+
+# Personal / webmail email addresses
+scan_pattern "personal webmail addresses" \
+  '[a-zA-Z0-9._%+-]+@(gmail|yahoo|hotmail|outlook|icloud|proton|protonmail|hey)\.(com|net|org|me)' \
+  '@(example|test|localhost|noreply|anthropic)\.|\b(your|your\.address|youremail|someone|somebody|you|me|name|firstname|lastname|user|username|first\.last)@'
+
+# Owner brand-domain personal emails (the specific domains that leaked)
+scan_pattern "owner brand-domain emails" \
+  '[a-zA-Z0-9._%+-]+@(samfeldt|heartfeldt|heartfeldtrecords|aurora-capital)\.[a-z.]+'
+
+# AWS account IDs embedded in ARNs (12 digits)
+scan_pattern "AWS account IDs (ARN context)" \
+  'arn:aws[a-z-]*:[a-z0-9-]*:[a-z0-9-]*:[0-9]{12}:' \
+  '(:000000000000:|:123456789012:)'
+
+# International phone numbers (allow reserved example ranges: 555-xxxx, 1234567, all-zero)
+scan_pattern "phone numbers (+<cc><digits>)" '\+[1-9][0-9]{1,3}[ -]?[0-9]{6,14}' \
+  '(555[0-9]{4}|1234567|\+1234567890|\+0000000000|\+15551234567|\+1[ -]?555)'
 
 # --- Tests-only narrow sweep ---
 # We allow regex literals + assembled patterns in tests/ but flag anything that


### PR DESCRIPTION
## Why
The username / personal-email / home-path / AWS-account PII that was just scrubbed from git history got in because **nothing gated it** — `test-no-secrets.sh` only checked secret-token prefixes, and `ci.yml` never ran a PII check on PRs. This adds the missing **authoritative gate** so that class can never land again.

## What
- **`tests/test-no-secrets.sh`** — new owner/personal-PII checks:
  - macOS/Linux home paths (`/Users/<name>`, `/home/<name>`)
  - personal webmail + the owner brand domains that leaked (`<OWNER_BRAND>`/`<OWNER_BRAND>`/`<OWNER_BRAND>`/`<OWNER_BRAND>`)
  - AWS account IDs in ARNs
  - international phone numbers
  - Allowlists: generic placeholders (`user`, `<user>`, `$HOME`, `runner`, `ec2-user`, `555-xxxx`, `+1234567890`) and the project's own public maintainer contact (`info@lifecycleinnovations.limited`). Excludes local artifact dirs (`.claude`, `.worktrees`).
- **`.github/workflows/ci.yml`** — explicit, named, fast-fail **"PII / personal-data gate"** step in `lint-and-check` (also runs via `run-all.sh` in `test-suite`).

## Verification
- `20/20` checks pass on the clean tree.
- Per-category **positive** tests: real PII (`<PERSONAL_EMAIL>`, `<WORK_EMAIL>`, `arn:aws:…:<AWS_ACCOUNT_ID>:…`, `+<PHONE>`, `/home/<name>`) → **all caught**.
- **Negative** tests: placeholders (`/Users/user`, `you@example.com`, `+14155550100`) → **pass through**.
- YAML valid; shellcheck clean.

CI runs regardless of machine or `--no-verify`, so this is the unbypassable layer complementing the existing local `.githooks/pre-commit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only CI and a repo scan script; no application runtime, auth, or data-path behavior is modified.
> 
> **Overview**
> Adds an **independent CI job** (`pii-gate`) that runs `claude-ops/tests/test-no-secrets.sh` on every PR with **no `needs:` dependency**, so personal-data scanning is not blocked by other jobs (e.g. gitleaks).
> 
> **`test-no-secrets.sh`** gains owner/personal-PII rules: macOS/Linux home paths, personal webmail and specific owner brand domains, AWS account IDs in ARNs, and international phone numbers, each with placeholder allowlists. Scan exclusions now include **`.claude`** and **`.worktrees`** so local artifact dirs are not false positives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39c50ea9ce71f91103ef575655925c48695031a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced CI pipeline with additional security scanning to prevent personal data and sensitive information from being committed to the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->