### PR TITLE
fix(ci): allowlist gitleaks false-positives so secret-scan goes green

### DIFF
--- a/claude-ops/.gitleaks.toml
+++ b/claude-ops/.gitleaks.toml
@@ -129,7 +129,9 @@ allowlist.regexes = [
   '''\+15551234567''',
   '''\+1234567890''',
   '''\+14155550100''',
+  '''\+14155551234''',
   '''\+31612345678''',
+  '''\+10000000000''',
 ]
 [[rules]]
 id = "email-address-personal"
@@ -176,4 +178,8 @@ stopwords = [
 # still runs against scripts/account-rotation/ (handles real auth tokens).
 regexes = [
   '''9d1c250a-e61b-44d9-88ed-5944d1962f5e''',  # Claude Code OAuth client ID (public)
+  # ga4.* are preferences-path key NAMES (config mapping strings), not secrets:
+  #   echo "api_secret:ga4.api_secret"  /  marketing.projects.<p>.ga4.property_id
+  '''ga4\.api_secret''',
+  '''ga4\.property_id''',
 ]


### PR DESCRIPTION
Makes `lint-and-check` pass so CI is genuinely enforcing again (it had failed on every PR → test-suite skipped → --admin merges). Allowlists 4 benign matches in `.gitleaks.toml`: example/scrubbed phone placeholders (`+14155551234`, `+10000000000`) and GA4 prefs-path key names (`ga4.api_secret`, `ga4.property_id`). Verified `gitleaks detect` → no leaks found (exit 0) on full history. No real secret suppressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only gitleaks allowlist tweaks for documented placeholders and config key strings; no runtime or auth behavior changes.
> 
> **Overview**
> Updates **`.gitleaks.toml`** so secret scanning stops failing on known false positives and **`lint-and-check`** can pass again.
> 
> For the **international phone** rule, it adds regex allowlist entries for two example/scrubbed numbers (`+14155551234`, `+10000000000`) alongside the existing placeholder list.
> 
> In the **global allowlist**, it adds `ga4.api_secret` and `ga4.property_id` so gitleaks ignores those **preferences-path key names** (e.g. in marketing/GA4 scripts and error text), not actual API secrets. Inline comments document the GA4 mapping intent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 623087503a2e271d2c3ed31903ae459e4297b036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->