### PR TITLE
feat: Windsor.ai as a live marketing data source for ops commands

### DIFF
--- a/claude-ops/skills/ops-dash/SKILL.md
+++ b/claude-ops/skills/ops-dash/SKILL.md
@@ -394,3 +394,12 @@ If the dashboard script outputs `DASH_RENDER_FAILED` or the preferences file doe
 ```
 
 Then invoke `/ops:setup` directly.
+
+## Windsor.ai (optional live data)
+
+If Windsor.ai is connected (`mcp__*Windsor*__*` or a `windsor_api_key`), use it as the
+live cross-channel source for all live KPIs (spend, ROAS, CAC, sessions, social reach) for the command-center tiles, flagging deviations vs 7d/30d.
+Map accounts per project via `registry.json` → `.projects[].windsor`. Prefer **blended
+ROAS** (store/analytics revenue ÷ total ad spend) over platform-reported ROAS. See
+[docs/integrations/windsor-ai.md](../../../docs/integrations/windsor-ai.md) for the full playbook (REST + MCP modes,
+registry mapping, analysis mandate, and caveats).

--- a/claude-ops/skills/ops-ecom/SKILL.md
+++ b/claude-ops/skills/ops-ecom/SKILL.md
@@ -598,3 +598,12 @@ FULFILLMENT   [N] unfulfilled orders pending
  /ops:ops-ecom setup      — configure credentials
 ──────────────────────────────────────────────────────
 ```
+
+## Windsor.ai (optional live data)
+
+If Windsor.ai is connected (`mcp__*Windsor*__*` or a `windsor_api_key`), use it as the
+live cross-channel source for the GA4 acquisition funnel (sessions → checkout → purchase) and ad-driven traffic layered over store orders.
+Map accounts per project via `registry.json` → `.projects[].windsor`. Prefer **blended
+ROAS** (store/analytics revenue ÷ total ad spend) over platform-reported ROAS. See
+[docs/integrations/windsor-ai.md](../../../docs/integrations/windsor-ai.md) for the full playbook (REST + MCP modes,
+registry mapping, analysis mandate, and caveats).

--- a/claude-ops/skills/ops-marketing/SKILL.md
+++ b/claude-ops/skills/ops-marketing/SKILL.md
@@ -2741,3 +2741,12 @@ All five are **disabled by default**. Enable order:
 4. Enable `marketing-autopilot` — first run will be a forced dry-run regardless of `autonomy_level`.
 5. Enable `marketing-autopilot-calibrate` after ≥7 days of autopilot data.
 6. Enable `marketing-health-check` as a weekly safety net once the above are stable.
+
+## Windsor.ai (optional live data)
+
+If Windsor.ai is connected (`mcp__*Windsor*__*` or a `windsor_api_key`), use it as the
+live cross-channel source for paid + analytics: ROAS/CAC/AOV trend (today vs 7d vs 30d), Meta vs Google return, budget shifts, and leaking campaigns (drill down per campaign via the MCP).
+Map accounts per project via `registry.json` → `.projects[].windsor`. Prefer **blended
+ROAS** (store/analytics revenue ÷ total ad spend) over platform-reported ROAS. See
+[docs/integrations/windsor-ai.md](../../../docs/integrations/windsor-ai.md) for the full playbook (REST + MCP modes,
+registry mapping, analysis mandate, and caveats).

--- a/claude-ops/skills/ops-socials/SKILL.md
+++ b/claude-ops/skills/ops-socials/SKILL.md
@@ -268,3 +268,12 @@ If x-mcp returns `000`/timeout: restart the local `mcp-proxy` LaunchAgent (label
 ## When to use this vs going direct
 
 `/ops-socials` is for **mixed/ambiguous intent** ("post about today's AI news", "check X then draft a take", "audit my LinkedIn voice"). For single-purpose calls, go straight to the underlying skill or MCP — this router only adds value when routing IS the work.
+
+## Windsor.ai (optional live data)
+
+If Windsor.ai is connected (`mcp__*Windsor*__*` or a `windsor_api_key`), use it as the
+live cross-channel source for organic reach, followers, and engagement per identity (Instagram, Facebook, TikTok, YouTube) — plus how organic feeds blended CAC.
+Map accounts per project via `registry.json` → `.projects[].windsor`. Prefer **blended
+ROAS** (store/analytics revenue ÷ total ad spend) over platform-reported ROAS. See
+[docs/integrations/windsor-ai.md](../../../docs/integrations/windsor-ai.md) for the full playbook (REST + MCP modes,
+registry mapping, analysis mandate, and caveats).

--- a/docs/integrations/windsor-ai.md
+++ b/docs/integrations/windsor-ai.md
@@ -1,0 +1,115 @@
+# Windsor.ai — live marketing & analytics data for ops commands
+
+[Windsor.ai](https://windsor.ai/) is a marketing data aggregator with 325+
+connectors (Meta Ads, Google Ads, GA4, TikTok Ads, LinkedIn, Microsoft Ads,
+organic social — Instagram / Facebook / TikTok / YouTube / LinkedIn —, Google
+Search Console, Klaviyo, Shopify, Stripe, and many more). It is an optional but
+high-leverage data source for the marketing-facing ops commands
+(`/ops:marketing`, `/ops:socials`, `/ops:ecom`, `/ops:dash`, `/ops:go`,
+`/ops:next`).
+
+This doc is **provider-agnostic and registry-driven**: it describes the wiring
+pattern, not any specific account. All account identifiers below are
+placeholders — every user supplies their own via the project registry.
+
+## Two access modes
+
+| Mode | Use for | Auth | Cost |
+|---|---|---|---|
+| **MCP** (`mcp__*Windsor*__*`) | interactive drill-down inside an ops command — per-campaign / per-day / arbitrary fields | claude.ai OAuth, no key needed | runs in-session |
+| **REST** (`https://connectors.windsor.ai/<connector>`) | headless / cron pulls — feeding a cache, statusline, or dashboard with no model calls | `api_key` (one per Windsor account) | free, no model quota |
+
+REST request shape:
+
+```
+https://connectors.windsor.ai/<connector>?api_key=<KEY>&date_from=YYYY-MM-DD&date_to=YYYY-MM-DD&fields=<comma,separated,field,ids>
+```
+
+- Supported field ids per connector: `https://connectors.windsor.ai/<connector>/fields?api_key=<KEY>`
+- Omitting a date field aggregates over the whole range, one row per account.
+- A response of `{"data":[...]}` means the connector is connected (even if empty);
+  `{"error":"No <connector> account ..."}` means it must be connected first in the
+  Windsor dashboard.
+
+Store the REST key in the OS secret store (e.g. macOS Keychain service
+`windsor_api_key`), never in a repo or in `preferences.json` in plaintext.
+
+## Registry-driven account mapping
+
+Map each project's connector accounts in your **project registry**
+(`registry.json` → `.projects[].windsor`) so every command pulls the right
+numbers per project. Connector slugs are lowercase (`facebook` = Meta Ads,
+`google_ads`, `googleanalytics4` = GA4, `tiktok` = TikTok Ads, `tiktok_organic`,
+`instagram`, `facebook_organic`, `youtube`, `searchconsole`, …):
+
+```jsonc
+{
+  "projects": [
+    {
+      "alias": "<your-project>",
+      "windsor": {
+        "facebook":         "<meta_ad_account_id>",
+        "google_ads":       "<google_ads_account_id>",
+        "googleanalytics4": "<ga4_property_id>",
+        "instagram":        "<ig_account_id>",
+        "searchconsole":    "sc-domain:<your-domain>"
+      }
+    }
+  ]
+}
+```
+
+Optionally register Windsor.ai in the partner registry so `/ops:credentials`
+and `/ops:status` can see it:
+
+```jsonc
+// preferences.json → partner_registry.windsor_ai
+{
+  "category": "marketing-analytics",
+  "auth_type": "api-key+mcp",
+  "mcp_server": "<windsor-mcp-server-id>",
+  "credential_key": "windsor_api_key",
+  "rest_base": "https://connectors.windsor.ai",
+  "read_tools":  ["get_connectors", "get_fields", "get_data", "get_options"],
+  "write_tools": ["list_actions", "execute_action"]
+}
+```
+
+## What the marketing commands should produce
+
+When a command has Windsor data available, return an **analysis**, not a table
+dump:
+
+1. **Trend** — today vs 7-day vs 30-day; what moved and by how much.
+2. **Per channel** — Meta vs Google (vs TikTok …) ROAS / CAC / CPC / CTR; where
+   the return is and where budget leaks.
+3. **Anomalies** — spend / CPC / CTR / conversion spikes & drops; campaigns
+   spending with no conversions (drill down per campaign via the MCP).
+4. **Funnel** — sessions → add-to-cart → checkout → purchase; where it drops.
+5. **Organic ↔ paid** — does organic growth contribute to blended CAC.
+6. **Concrete actions with numbers** — e.g. "pause campaign X (spend, 0 conv,
+   30d)", "shift budget from Meta to Google (ROAS a vs b)". Offer to execute via
+   `list_actions` / `execute_action` (Meta + Google Ads support pause / enable /
+   budget), **only after the user confirms**.
+
+## Caveats to apply before drawing conclusions
+
+- **Blended over platform-reported ROAS.** When server-side conversion APIs
+  (Meta CAPI, GA4 server events, etc.) are partial or off, a platform under-reports
+  its own attributed revenue. Prefer **blended ROAS = analytics/store revenue ÷
+  total ad spend** as the source of truth, and flag the attribution gap.
+- **GA4 lag.** GA4 typically trails several hours, so "today" revenue/orders may
+  read 0. For realtime same-day revenue prefer the store source (Shopify, etc.);
+  use GA4 for 7d/30d.
+- **Connect-before-query.** A connector returns `error: No <connector> account`
+  until it is connected in the Windsor dashboard; some require a separate OAuth
+  per ads vs organic (e.g. `tiktok` vs `tiktok_organic`).
+- **Trial plan limits.** Free/trial Windsor plans cap the number of data sources;
+  adding a new connector may require freeing a slot or upgrading.
+
+## Adding the integration
+
+Run `/ops:integrate windsor.ai` (auth type `api-key`, base
+`https://connectors.windsor.ai`) to register it in the partner registry, then add
+the per-project `windsor` mapping shown above. The marketing commands pick it up
+automatically when the mapping is present.


### PR DESCRIPTION
## What

Adds **Windsor.ai** (a marketing data aggregator with 325+ connectors — Meta/Google/GA4/TikTok/LinkedIn/Microsoft ads, organic social, Search Console, Klaviyo, Shopify, Stripe, …) as an optional, **registry-driven** live data source for the marketing-facing ops commands.

## Changes

- **`docs/integrations/windsor-ai.md`** — a provider-agnostic playbook:
  - Two access modes: **MCP** (`mcp__*Windsor*__*`, interactive per-campaign drill-down) and **REST** (`connectors.windsor.ai`, free headless pulls for caches/statuslines, no model quota).
  - Per-project account mapping via `registry.json` → `.projects[].windsor` and an optional `partner_registry.windsor_ai` seed.
  - Analysis mandate (trend → per-channel ROAS/CAC → anomalies → funnel → executable budget/pause actions via `list_actions`/`execute_action`).
  - Caveats: prefer **blended ROAS** when platform attribution (CAPI/server events) is partial, GA4 lag, connect-before-query, trial data-source limits.
- **`ops-marketing` / `ops-socials` / `ops-ecom` / `ops-dash`** — short pointer so each command uses Windsor data when present.

## Notes

- Fully **account-agnostic**: every user supplies their own connector account ids via the registry. No credentials, account ids, or identifiers are committed (all examples are placeholders).
- Integrates with the existing `/ops:integrate` + `partner_registry` pattern; no behavioural change unless a user has Windsor connected.
- Plugs naturally into `/ops:credentials` and `/ops:status` via the optional partner-registry entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added optional Windsor.ai integration across operations skills (ops-dash, ops-ecom, ops-marketing, ops-socials) to enable live cross-channel KPIs, metrics, and insights
  * Added comprehensive Windsor.ai integration guide with setup instructions and configuration guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->