### PR TITLE
fix(ci): exclude .gitleaks.toml from the PII self-scan

### DIFF
--- a/claude-ops/tests/test-no-secrets.sh
+++ b/claude-ops/tests/test-no-secrets.sh
@@ -26,10 +26,21 @@ EXCLUDE_DIRS=(
   "tests"
 )
 
+# Individual files to exclude. `.gitleaks.toml` is the secrets-scanner's OWN
+# allowlist/regex config — it intentionally carries secret-shaped placeholder
+# patterns (e.g. an all-zeros sample phone number) that must NOT be flagged by
+# our own PII gate, exactly as `tests/` is excluded above.
+EXCLUDE_FILES=(
+  ".gitleaks.toml"
+)
+
 build_exclude_args() {
   local args=()
   for d in "${EXCLUDE_DIRS[@]}"; do
     args+=("--exclude-dir=$d")
+  done
+  for f in "${EXCLUDE_FILES[@]}"; do
+    args+=("--exclude=$f")
   done
   echo "${args[@]}"
 }
@@ -139,7 +150,7 @@ scan_pattern "AWS account IDs (ARN context)" \
 
 # International phone numbers (allow reserved example ranges: 555-xxxx, 1234567, all-zero)
 scan_pattern "phone numbers (+<cc><digits>)" '\+[1-9][0-9]{1,3}[ -]?[0-9]{6,14}' \
-  '(555[0-9]{4}|1234567|\+1234567890|\+0000000000|\+15551234567|\+1[ -]?555)'
+  '(555[0-9]{4}|1234567|\+1234567890|\+0000000000|\+10000000000|\+15551234567|\+1[ -]?555)'
 
 # --- Tests-only narrow sweep ---
 # We allow regex literals + assembled patterns in tests/ but flag anything that


### PR DESCRIPTION
## Problem

The `pii-gate` CI check (`tests/test-no-secrets.sh`) scans the whole tree for secret-shaped strings — including the secrets-scanner's **own** `.gitleaks.toml` config, which intentionally carries placeholder patterns. Its all-zeros sample number (`+10000000000`) trips the phone-number rule, so the gate has been **failing on every PR** (and on main).

## Fix

- Add `.gitleaks.toml` to a new `EXCLUDE_FILES` list so the gate skips its own config (same rationale already applied to `tests/`).
- Allowlist the `+10000000000` placeholder in the phone-number rule as defense-in-depth.

`tests/test-no-secrets.sh` now exits 0 (20 passed, 0 failed). Unblocks the PII gate for all PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes the local grep-based CI check and its allowlists; no runtime auth, data, or production behavior.
> 
> **Overview**
> Fixes **false positives in the PII/secrets CI gate** (`tests/test-no-secrets.sh`) that were failing every run because the main tree scan included **`.gitleaks.toml`**, whose intentional placeholder phone `+10000000000` matched the phone-number rule.
> 
> The script now maintains an **`EXCLUDE_FILES`** list (starting with `.gitleaks.toml`) and passes **`--exclude`** for each entry through `build_exclude_args`, mirroring how `tests/` is skipped. The phone-number scan allowlist also adds **`+10000000000`** so that placeholder stays ignored even if the file is scanned elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81dd38beebe2de2277de621b01e7900c536bd564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->