### PR TITLE
fix(account-rotation): jitter the /login session-inject cadence

### DIFF
--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -2580,6 +2580,13 @@ function detectTerminalForPid(pid) {
 
 async function refreshRunningSession(rotatedAccount = null, noBrowser = false) {
   const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  // /login is injected into each reachable session in sequence. Space the injects
+  // by a base gap + random jitter so N sessions don't all re-read the keychain and
+  // fire their first call onto the freshly-rotated account in the same instant.
+  // Env-overridable; jitter=0 keeps the legacy fixed 500ms cadence.
+  const INJECT_BASE_MS = Math.max(0, Number(process.env.CLAUDE_SESSION_INJECT_MS ?? 500));
+  const INJECT_JITTER_MS = Math.max(0, Number(process.env.CLAUDE_SESSION_INJECT_JITTER_MS ?? 1_000));
+  const injectGap = () => INJECT_BASE_MS + Math.floor(Math.random() * (INJECT_JITTER_MS + 1));
   const sessions = findClaudeSessions();
 
   if (sessions.length === 0) {
@@ -2651,7 +2658,7 @@ async function refreshRunningSession(rotatedAccount = null, noBrowser = false) {
         log(`[session] Resume fallback for PID ${s.pid}: ${ok ? 'ok' : 'failed'}`);
       }
     }
-    await sleep(500);
+    await sleep(injectGap());
   }
 
   // Non-tmux sessions with a resumeId (non-bg interactive sessions in Ghostty etc):
@@ -2669,7 +2676,7 @@ async function refreshRunningSession(rotatedAccount = null, noBrowser = false) {
       log(`  PID ${s.pid} resumeId=${s.resumeId} terminal=${s.terminal || 'unknown'}`);
       const ok = await sendViaResume(s);
       log(`[session] Resume /login for PID ${s.pid}: ${ok ? 'ok' : 'failed'}`);
-      await sleep(500);
+      await sleep(injectGap());
     }
   }
 


### PR DESCRIPTION
## What

`refreshRunningSession` injects `/login` into reachable sessions in sequence with a fixed 500ms gap. This adds random jitter (`≤CLAUDE_SESSION_INJECT_JITTER_MS`, default 1s) on top of the base gap.

## Why

Companion to #536 (respawn-stagger jitter). The `/login` path re-reads the keychain per session; a deterministic 500ms cadence makes N sessions fire their first call onto the freshly-rotated account in near-lockstep. Jitter fans those onsets out so the new account isn't hit by a synchronized burst.

## Scope

- Hardening only; `CLAUDE_SESSION_INJECT_JITTER_MS=0` restores the exact legacy 500ms cadence.
- `node --check` + prettier clean; `test-no-secrets.sh` 20/20; no PII/paths (Rule 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Timing-only hardening in session refresh; legacy behavior is preserved when jitter env is set to zero.
> 
> **Overview**
> **`refreshRunningSession`** no longer waits a fixed **500ms** between sequential `/login` injects (tmux/iTerm2 and `--resume` paths). It now uses **`injectGap()`**: base delay from **`CLAUDE_SESSION_INJECT_MS`** (default 500ms) plus uniform random jitter up to **`CLAUDE_SESSION_INJECT_JITTER_MS`** (default 1s), so multiple sessions don’t re-read the keychain and hit the newly rotated account in lockstep.
> 
> Setting **`CLAUDE_SESSION_INJECT_JITTER_MS=0`** restores the previous fixed 500ms spacing. This mirrors the respawn-stagger jitter pattern elsewhere in account rotation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37c9c8d3214b97cb47bd3c422696c5245a4a8b13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->