### PR TITLE
release: v2.27.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 38 skills, 20 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.26.5",
+      "version": "2.27.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.26.5",
+  "version": "2.27.0",
   "description": "Business operations command center for Claude Code — 39 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.27.0] - 2026-06-08
+
+### Changed
+feat(ops): Windsor.ai live marketing/analytics data source — 325+ connectors (Meta Ads, Google Ads, GA4, TikTok, LinkedIn, …) for /ops:marketing, /ops:socials, /ops:ecom, /ops:dash, via MCP (OAuth) or REST (#534). fix(account-rotation): jitter the post-rotation fan-out — random jitter on the respawn stagger (#536) and the /login session-inject cadence (#538) so a freshly-rotated account isn't hit by a synchronized first-call burst. fix(scripts): content + SEO generators work under macOS bash 3.2 / printf leading-dash (#535). docs: README rotation anti-stampede + Windsor.ai notes (#539).
+
+
 ## [2.26.5] - 2026-06-07
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.26.5",
+  "version": "2.27.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.27.0** (was 2.26.5).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

feat(ops): Windsor.ai live marketing/analytics data source — 325+ connectors (Meta Ads, Google Ads, GA4, TikTok, LinkedIn, …) for /ops:marketing, /ops:socials, /ops:ecom, /ops:dash, via MCP (OAuth) or REST (#534). fix(account-rotation): jitter the post-rotation fan-out — random jitter on the respawn stagger (#536) and the /login session-inject cadence (#538) so a freshly-rotated account isn't hit by a synchronized first-call burst. fix(scripts): content + SEO generators work under macOS bash 3.2 / printf leading-dash (#535). docs: README rotation anti-stampede + Windsor.ai notes (#539).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog updates only; functional changes are documented from prior merges, not introduced in this diff.
> 
> **Overview**
> **Release v2.27.0** — bumps the plugin from **2.26.5 → 2.27.0** in `plugin.json`, root `marketplace.json`, and `claude-ops/package.json`, and prepends the **2.27.0** section to `CHANGELOG.md`.
> 
> The changelog documents what ships in this tag (already merged on main): **Windsor.ai** as an optional live marketing/analytics source for `/ops:marketing`, `/ops:socials`, `/ops:ecom`, and `/ops:dash` (MCP OAuth or REST); **account-rotation jitter** on post-rotation respawn and `/login` session-inject timing to avoid synchronized bursts; **bash 3.2 / `printf` fixes** for content and SEO generators; and **README** notes on rotation anti-stampede and Windsor.ai.
> 
> This PR is metadata-only — no application code changes in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce54cda5409bd9fcf8f66e41961b9e9da9e2d936. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->