### PR TITLE
release: v2.27.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 38 skills, 20 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.27.0",
+      "version": "2.27.1",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.27.0",
+  "version": "2.27.1",
   "description": "Business operations command center for Claude Code — 39 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.27.1] - 2026-06-09
+
+### Changed
+fix(whatsapp): /api/archive now re-pulls the recovered regular_low snapshot between 409-conflict retries so inbox archiving converges without a manual recover→retry; fails fast on a persistently unverifiable server chain instead of burning repeated full-snapshot resyncs (NEVER-LEAK guard) (Fix V, #541).
+
+
 ## [2.27.0] - 2026-06-08
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.27.0",
+  "version": "2.27.1",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.27.1** (was 2.27.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

fix(whatsapp): /api/archive now re-pulls the recovered regular_low snapshot between 409-conflict retries so inbox archiving converges without a manual recover→retry; fails fast on a persistently unverifiable server chain instead of burning repeated full-snapshot resyncs (NEVER-LEAK guard) (Fix V, #541).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only diff; behavioral change is described for the WhatsApp bridge archive path, not modified in this PR.
> 
> **Overview**
> **Release v2.27.1** — bumps the ops plugin from `2.27.0` to `2.27.1` across `plugin.json`, marketplace registry, and `claude-ops/package.json`, and adds a **2.27.1** entry to `CHANGELOG.md`.
> 
> The release note documents **fix(whatsapp) Fix V (#541)**: `POST /api/archive` now **re-fetches the recovered `regular_low` app-state snapshot** (`healLTHash` / `FetchAppState`) between **409 LTHash-conflict** retries so archiving can finish without a manual recover→retry loop. It also **fails fast** when the server patch chain stays unverifiable, avoiding repeated destructive full-snapshot resyncs (NEVER-LEAK guard).
> 
> No application logic changes appear in this diff—only version metadata and changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88282cd88f293c3572dc9522a9424742d43ff117. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->