### PR TITLE
fix(ops-inbox-scan): treat WhatsApp as remote-only when no local store

### DIFF
--- a/claude-ops/bin/ops-inbox-scan
+++ b/claude-ops/bin/ops-inbox-scan
@@ -234,7 +234,20 @@ def ro(path):
 def scan_whatsapp():
     out = {"needs_reply": [], "waiting": [], "groups": [], "fyi": []}
     if not os.path.exists(MSGDB):
-        notes.append(f"whatsapp: store not found ({MSGDB}) — bridge not installed?")
+        # No local WhatsApp store. Treat WhatsApp as REMOTE-ONLY: the canonical
+        # bridge may run on a remote host, reached via the live MCP tools
+        # (mcp__whatsapp__*). An absent local sqlite store must NOT be read as
+        # "no messages" — signal the orchestrator to scan WhatsApp via live MCP.
+        out["reachable"] = False
+        out["source"] = "remote"
+        out["scan_via"] = "live-mcp"
+        notes.append(
+            "whatsapp: no local store — scan via the LIVE MCP tools "
+            "(mcp__whatsapp__list_chats / list_messages), which read the canonical "
+            "bridge. Do NOT treat these empty buckets as 'no messages'. WA replies are "
+            "DRAFT-ONLY: never auto-send based on store state (the store can lag "
+            "phone-sent messages)."
+        )
         return out
     con = ro(MSGDB)
     con.row_factory = sqlite3.Row


### PR DESCRIPTION
## What
When the local whatsmeow sqlite store is absent, `scan_whatsapp()` now signals the orchestrator to scan WhatsApp via the live MCP tools (`mcp__whatsapp__*`) which read the canonical **remote** bridge — instead of reporting empty buckets that look like "no messages."

Emits `reachable=false`, `source=remote`, `scan_via=live-mcp`, plus a draft-only note.

## Why
A stale/de-paired **local** store froze and produced phantom `needs_reply` entries and a duplicate outbound send. WhatsApp should be treated as remote-only; an absent local store is the expected state, not a failure.

## Notes
- No hardcoded identifiers: remote endpoint/creds stay in private config; store paths remain env-configurable (`WHATSAPP_BRIDGE_DIR`/`WHATSAPP_BRIDGE_DB`); only localhost is referenced.
- `tests/test-no-secrets.sh`: 20 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only orchestration metadata in ops-inbox-scan; reduces misclassification risk without changing send paths.
> 
> **Overview**
> When the local whatsmeow `messages.db` is missing, **`scan_whatsapp()`** no longer returns silent empty buckets that read like “no WhatsApp activity.” It now marks WhatsApp as **remote-only**: `reachable: false`, `source: "remote"`, and `scan_via: "live-mcp"`, and adds a **`notes`** entry directing `/ops-inbox` to classify via **`mcp__whatsapp__list_chats` / `list_messages`** on the canonical bridge instead of trusting offline sqlite.
> 
> The note also stresses **draft-only** replies and that store state can lag phone-sent messages, so empty local buckets must not drive auto-send or “all clear” conclusions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a3a9ac1df20728ec7f54e4c5fd8e49b2dc42ac8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->