### PR TITLE
release: v2.27.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 38 skills, 20 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.27.1",
+      "version": "2.27.2",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.27.1",
+  "version": "2.27.2",
   "description": "Business operations command center for Claude Code — 39 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.27.2] - 2026-06-09
+
+### Changed
+ops-inbox-scan: treat WhatsApp as remote-only when no local store — signal the orchestrator to scan via live MCP (mcp__whatsapp__*) instead of reporting empty buckets as 'no messages'. Prevents stale/de-paired local stores from producing phantom needs_reply and duplicate sends.
+
+
 ## [2.27.1] - 2026-06-09
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.27.1",
+  "version": "2.27.2",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.27.2** (was 2.27.1).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

ops-inbox-scan: treat WhatsApp as remote-only when no local store — signal the orchestrator to scan via live MCP (mcp__whatsapp__*) instead of reporting empty buckets as 'no messages'. Prevents stale/de-paired local stores from producing phantom needs_reply and duplicate sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly version metadata; the inbox-scan change reduces false-positive reply detection and does not broaden auto-send behavior.
> 
> **Overview**
> **Release v2.27.2** — bumps the plugin version from `2.27.1` to `2.27.2` in `plugin.json`, `.claude-plugin/marketplace.json`, and `claude-ops/package.json`, with a matching `CHANGELOG` entry.
> 
> The documented functional change for this release is **`ops-inbox-scan` WhatsApp handling**: when there is **no local** whatsmeow/sqlite store, the scanner no longer implies an empty inbox. It marks WhatsApp as **remote-only** (`reachable: false`, `scan_via: live-mcp`) and tells the orchestrator to classify via **live MCP** (`mcp__whatsapp__*`) instead of trusting empty local buckets—avoiding **phantom `needs_reply`** and **duplicate sends** from stale or de-paired local databases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24cc24bf9b2a04b51ddca69d33ceb9c1677f2013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->