### PR TITLE
fix(ops-inbox-scan): corrupt archived flag no longer blinds WhatsApp scan

### DIFF
--- a/claude-ops/bin/ops-inbox-scan
+++ b/claude-ops/bin/ops-inbox-scan
@@ -298,10 +298,17 @@ def scan_whatsapp():
                     return cand
         return jid
 
-    # Pull non-archived chats (groups/newsletters separated below).
+    # Working set: non-archived OR any chat with activity in the recency window.
+    # The local `archived` flag has been observed mass-corrupted (every chat
+    # flagged archived=1, including live two-way threads), which silently blinds
+    # the scan into a false "inbox zero". Falling back to recency guarantees a
+    # corrupt flag can NEVER hide an actively-conversing chat; genuinely-archived
+    # OLD chats (no msgs in the window) still stay hidden. (2026-06-09 fix.)
     chats = list(con.execute(
         "SELECT jid, name, last_message_time FROM chats "
-        "WHERE archived=0 ORDER BY last_message_time DESC"
+        "WHERE archived=0 OR last_message_time >= datetime('now', ?) "
+        "ORDER BY last_message_time DESC",
+        (f"-{DAYS} days",)
     ))
 
     # Build merged DM groups keyed by canonical jid.


### PR DESCRIPTION
## Problem
`/ops:ops-inbox` reported **WhatsApp inbox-zero** while the bridge store held 324 chats with live two-way threads minutes old. Root cause: the local `chats.archived` column mass-corrupted — **323/324 chats flagged `archived=1`**, including actively-conversing DMs. `ops-inbox-scan` gates its entire working set on `WHERE archived=0`, so it saw 1 chat (`0@status`) and declared a false inbox-zero, hiding ~30 genuine NEEDS_REPLY.

## Fix
Widen the working-set query so a corrupt `archived` flag can never again hide a live conversation:
```sql
WHERE archived=0 OR last_message_time >= datetime('now', '-{DAYS} days')
```
- Recency fallback (the scan's existing `--days` window) means any chat with activity in-window is always classified, regardless of the flag.
- Genuinely-archived OLD chats (no messages in the window) still stay hidden — archive semantics for stale threads are preserved.
- A new message on an archived chat resurfacing is the documented/desired behavior anyway.

Verified locally: before 0/0/0/0 → after **30 needs_reply / 28 waiting / 23 groups**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single read-only SQL predicate change in offline classification; widens inclusion for recent chats only and does not mutate store or send messages.
> 
> **Overview**
> Fixes **false WhatsApp inbox-zero** when the bridge store’s `chats.archived` column is wrong (e.g. almost every chat marked archived while threads are still active).
> 
> The WhatsApp working-set query in `ops-inbox-scan` no longer relies solely on `archived=0`. It now also includes any chat whose `last_message_time` falls within the existing `--days` window (`archived=0 OR last_message_time >= datetime('now', ?)`). Active conversations stay visible even if the archive flag is corrupt; old archived chats with no recent activity are still excluded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce04e95d8bf065e6a4bf07ac8bf11c90150d7085. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->