### PR TITLE
fix(whatsapp): full_sync resync defaults skip_bad=true — wedged LTHash chains self-heal

### DIFF
--- a/claude-ops/scripts/whatsapp/apply-patches.py
+++ b/claude-ops/scripts/whatsapp/apply-patches.py
@@ -2392,6 +2392,14 @@ FIXT_SKIP_BAD_HANDLER = """\t\t// claude-ops Fix T: skip_bad=true (query param O
 \t\tif r.URL.Query().Get(\"skip_bad\") == \"true\" {
 \t\t\treq.SkipBad = true
 \t\t}
+\t\t// Fix T2d: a full_sync resync IS the heal operation - strict-verify full sync
+\t\t// just re-fails on the same unverifiable server-side patches (observed 2026-06-09:
+\t\t// heal loop wedged on \"failed to verify patch v1132: mismatching LTHash\" because
+\t\t// the documented heal omitted skip_bad). Default skip_bad=true for full_sync
+\t\t// unless explicitly skip_bad=false.
+\t\tif req.FullSync && r.URL.Query().Get(\"skip_bad\") != \"false\" {
+\t\t\treq.SkipBad = true
+\t\t}
 \t\tif req.SkipBad {
 \t\t\tsetAppStateReady(false)
 \t\t\tif err := syncAppStateSkipBad(client, appstate.WAPatchName(req.Name)); err != nil {

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -210,7 +210,7 @@ This clones lharries/whatsapp-mcp into `~/.local/share/whatsapp-mcp`, applies th
 | `mcp__whatsapp__get_chat` | `{chat_jid}` | Chat metadata |
 | `mcp__whatsapp__get_message_context` | `{chat_jid, message_id}` | Message context window |
 | `mcp__whatsapp__archive_chat` | `{chat_jid, archive: true}` | Archive (or unarchive with `archive: false`) a chat — sends app-state mutation via whatsmeow |
-| `mcp__whatsapp__resync_app_state` | `{name: "regular_low", full_sync: true}` | Force full app-state resync — run when archive fails with `LTHash mismatch` (server/local desync) |
+| `mcp__whatsapp__resync_app_state` | `{name: "regular_low", full_sync: true, skip_bad: true}` | Force full app-state resync — run when archive fails with `LTHash mismatch` (server/local desync) |
 
 **Bulk archive non-actionable WA chats** — for newsletters, dead group chats, one-word reactions, etc.:
 ```bash
@@ -223,7 +223,7 @@ done
 # The /api/archive endpoint auto-heals LTHash corruption internally (Fix G) and
 # immediately UPSERTs archived=1 into messages.db so the inbox query reflects it.
 # If you still get HTTP 409, the heal failed — run resync manually as a last resort:
-# curl -s -X POST http://localhost:8080/api/resync_app_state -d '{"name":"regular_low","full_sync":true}'
+# curl -s -X POST http://localhost:8080/api/resync_app_state -d '{"name":"regular_low","full_sync":true,"skip_bad":true}'
 ```
 **Archive state is locally queryable** (Fix H — bridge persists `archived` flag in `chats` table):
 ```bash
@@ -745,7 +745,7 @@ The per-channel classify/draft steps below (WhatsApp, iMessage, email) all refer
 6. Assign provisional buckets only (same direction signals as step 4 — use `last_is_from_me` on the chat object; only after the step 5 thread fallback use the last element's `is_from_me`). **Do not confirm NEEDS REPLY here** — step 7 clears the FULL-THREAD AWARENESS GATE first:
    - **NEEDS REPLY candidate**: `last_is_from_me == 0`, or (fallback only) last thread message `is_from_me: false`
    - **WAITING** (provisional): `last_is_from_me == 1`, or (fallback only) last thread message `is_from_me: true`
-   - **ARCHIVE**: Newsletters (`@newsletter` JIDs), dead group chats with no recent activity, one-word reactions, or concluded conversations. Bulk-archive these via `mcp__whatsapp__archive_chat {chat_jid, archive: true}` after user confirmation. The bridge's `/api/archive` endpoint (Fix F) auto-heals LTHash corruption internally and retries once — you no longer need to manually run `resync_app_state` first. If it still returns `409 conflict`, run `mcp__whatsapp__resync_app_state {name: "regular_low", full_sync: true}` as a fallback then retry.
+   - **ARCHIVE**: Newsletters (`@newsletter` JIDs), dead group chats with no recent activity, one-word reactions, or concluded conversations. Bulk-archive these via `mcp__whatsapp__archive_chat {chat_jid, archive: true}` after user confirmation. The bridge's `/api/archive` endpoint (Fix F) auto-heals LTHash corruption internally and retries once — you no longer need to manually run `resync_app_state` first. If it still returns `409 conflict`, run `mcp__whatsapp__resync_app_state {name: "regular_low", full_sync: true, skip_bad: true}` as a fallback (skip_bad skips server-side patches that fail LTHash verification — without it a wedged chain re-fails on the same patch forever) then retry.
 
 7. **Cross-thread answered-elsewhere check (BOTH DIRECTIONS — scan Sam's own sent messages).** Before presenting any chat as NEEDS REPLY, verify it has not already been answered in another channel or in a later message within the same thread that the `last_is_from_me` flag missed. This is the most common source of false NEEDS_REPLY:
    - **Same-thread recheck**: when `last_is_from_me == 0`, call `mcp__whatsapp__list_messages {chat_jid, limit: 25}` and scan ALL of them (capturing `is_from_me=1` rows and `[voice]` transcripts) for `is_from_me: true` after the inbound message — if one exists, reclassify as WAITING. This is part of clearing the FULL-THREAD AWARENESS GATE, not an optional extra.


### PR DESCRIPTION
## Problem
The documented LTHash heal (`/api/resync_app_state {full_sync:true}`) runs with strict verification, so a chain wedged on an unverifiable server-side patch (whatsmeow #382/#858/#1176) re-fails on the same patch on every attempt — observed in production: repeated `failed to verify patch v1132: mismatching LTHash` across version-cache wipes, sync-key wipes, and bridge restarts, while each retry burned WhatsApp rate budget (429 rate-overlimit).

Fix T already shipped `skip_bad=true` for exactly this — but it's opt-in and none of the documented heal recipes passed it.

## Fix
- **apply-patches.py (Fix T2d):** the generated resync handler defaults `skip_bad=true` whenever `full_sync` is requested (a full resync IS the heal moment); opt out with `?skip_bad=false`.
- **ops-inbox SKILL.md:** all three resync heal recipes (MCP tool table, curl fallback, 409-conflict fallback) now pass `skip_bad:true` explicitly, with a one-line rationale — covers bridges installed before this patch.

Verified tonight on a live wedged bridge: strict full_sync failed at v1132 repeatedly; the skip_bad path is the designed escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WhatsApp app-state sync behavior on heal paths; defaulting skip_bad on full_sync can advance past server patches that strict verification would reject, though that is the intended fix for wedged chains.
> 
> **Overview**
> **Fix T2d** changes the generated `/api/resync_app_state` handler so a **`full_sync` heal defaults `skip_bad=true`** (opt out with `?skip_bad=false`). Strict full sync was re-hitting the same unverifiable LTHash patches and leaving the bridge wedged.
> 
> **ops-inbox SKILL.md** now documents **`skip_bad: true`** on every LTHash heal path—MCP `resync_app_state`, curl fallback, and 409 archive fallback—so operators and older bridges use the skip-bad escape hatch explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56d3338cffa561b03fb84639d686282ad95164a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced app-state resync operations to automatically skip unverifiable patches during full synchronization cycles, improving reliability of data recovery workflows.

* **Documentation**
  * Updated WhatsApp resync operational guidance and corresponding API documentation examples to reflect the current behavior of app-state synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->