### PR TITLE
release: v2.27.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 38 skills, 20 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.27.2",
+      "version": "2.27.3",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.27.2",
+  "version": "2.27.3",
   "description": "Business operations command center for Claude Code — 39 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.27.3] - 2026-06-09
+
+### Changed
+WhatsApp inbox-scan resilience: corrupt archived flag can no longer blind the scan (recency fallback, #545); full_sync resync defaults skip_bad=true so wedged LTHash chains self-heal, ops-inbox heal recipes updated (#546).
+
+
 ## [2.27.2] - 2026-06-09
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.27.2",
+  "version": "2.27.3",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.27.3** (was 2.27.2).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

WhatsApp inbox-scan resilience: corrupt archived flag can no longer blind the scan (recency fallback, #545); full_sync resync defaults skip_bad=true so wedged LTHash chains self-heal, ops-inbox heal recipes updated (#546).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog updates only; no runtime code in the diff. Operational impact depends on fixes already merged in earlier PRs.
> 
> **Overview**
> **Release v2.27.3** bumps the published plugin version from **2.27.2 → 2.27.3** in `plugin.json`, `.claude-plugin/marketplace.json`, and `claude-ops/package.json`, and prepends a **CHANGELOG** entry for that release.
> 
> The changelog documents WhatsApp **ops-inbox** resilience already landed via #545/#546: inbox scan no longer hides threads when `archived` is corrupt (recency fallback), and **full_sync** resync defaults to **`skip_bad=true`** so wedged LTHash app-state chains can self-heal, with updated ops-inbox heal recipes. **No application code changes appear in this diff**—registry/metadata only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83c7244f46d0bee5ca1fce547ec3e9fd821c7523. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->