### PR TITLE
feat(ops-resume): reopen recently-closed sessions, one per Ghostty tab

### DIFF
--- a/claude-ops/bin/ops-resume
+++ b/claude-ops/bin/ops-resume
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# ops-resume — reopen recently-closed Claude Code sessions, one per Ghostty tab.
+#
+# For every recent session transcript in ~/.claude/projects it opens a new
+# Ghostty tab (via cmd+t) and types `cd <cwd> && claude --resume <sessionId>`,
+# so each session resumes in its own tab — from whatever directory or repo it
+# was originally running in.
+#
+# Default: every session touched in the last 60 minutes, from ANY directory.
+#
+# Usage:
+#   ops-resume                 # all sessions from the last 60 min, any dir
+#   ops-resume -m 30           # last 30 minutes
+#   ops-resume -H 6            # last 6 hours
+#   ops-resume -n 8            # cap at 8 tabs (newest first)
+#   ops-resume --here          # only sessions whose cwd == current directory
+#   ops-resume --dry-run       # list what would open, open nothing
+#
+# Env overrides:
+#   OPS_RESUME_MINUTES (60)   lookback window in minutes
+#   OPS_RESUME_MAX (20)       safety cap on number of tabs
+#   OPS_RESUME_MIN_AGE_SEC (45)  skip sessions touched more recently than this
+#                                (avoids reopening the session you're in right now)
+
+set -uo pipefail
+
+PROJECTS_ROOT="$HOME/.claude/projects"
+MINUTES="${OPS_RESUME_MINUTES:-60}"
+MAX="${OPS_RESUME_MAX:-20}"
+MIN_AGE_SEC="${OPS_RESUME_MIN_AGE_SEC:-45}"
+DRY=0
+HERE=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -m|--minutes) MINUTES="$2"; shift 2 ;;
+    -H|--hours)   MINUTES=$(( $2 * 60 )); shift 2 ;;
+    -n|--max)     MAX="$2"; shift 2 ;;
+    --dry-run)    DRY=1; shift ;;
+    --here)       HERE=1; shift ;;
+    -h|--help)    sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+[ "$(uname -s)" = "Darwin" ] || { echo "ops-resume currently supports macOS + Ghostty only." >&2; exit 1; }
+[ -d "$PROJECTS_ROOT" ] || { echo "No sessions directory at $PROJECTS_ROOT." >&2; exit 1; }
+command -v ghostty >/dev/null 2>&1 || [ -d /Applications/Ghostty.app ] || {
+  echo "Ghostty not found. Install it from https://ghostty.org first." >&2; exit 1; }
+
+NOW=$(date +%s)
+CUTOFF_OLD=$(( NOW - MINUTES * 60 ))   # don't go older than this
+CUTOFF_NEW=$(( NOW - MIN_AGE_SEC ))    # don't grab sessions that are still live
+HEREDIR="$PWD"
+
+# Collect candidates: jsonl whose mtime is within (CUTOFF_OLD, CUTOFF_NEW], newest
+# first. We filter on stat(1) mtime rather than `find -newermt @epoch`, because the
+# @epoch form is GNU-only and BSD/macOS find rejects it.
+# Output line: <mtime>\t<sessionId>\t<cwd>
+candidates=()
+while IFS= read -r line; do
+  candidates+=("$line")
+done < <(
+  find "$PROJECTS_ROOT" -name '*.jsonl' -type f 2>/dev/null \
+  | while IFS= read -r f; do
+      mtime=$(stat -f %m "$f" 2>/dev/null) || continue
+      [ "$mtime" -gt "$CUTOFF_OLD" ] || continue   # too old
+      [ "$mtime" -le "$CUTOFF_NEW" ] || continue   # too fresh (still live)
+      sid=$(basename "$f" .jsonl)
+      # Only real interactive sessions have UUID filenames; this skips subagent
+      # transcripts (agent-*), workflow journals, and other non-resumable jsonl.
+      [[ "$sid" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]] || continue
+      lines=$(wc -l < "$f" 2>/dev/null | tr -d ' '); lines=${lines:-0}
+      [ "$lines" -lt 3 ] && continue               # skip empty / junk sessions
+      cwd=$(grep -m1 -o '"cwd":"[^"]*"' "$f" 2>/dev/null | sed 's/"cwd":"//; s/"$//')
+      [ -n "$cwd" ] || cwd="$HOME"
+      printf '%s\t%s\t%s\n' "$mtime" "$sid" "$cwd"
+    done \
+  | sort -rn
+)
+
+# Apply --here filter + MAX cap.
+selected=()
+truncated=0
+for line in "${candidates[@]}"; do
+  IFS=$'\t' read -r mtime sid cwd <<< "$line"
+  if [ "$HERE" -eq 1 ] && [ "$cwd" != "$HEREDIR" ]; then continue; fi
+  if [ "${#selected[@]}" -ge "$MAX" ]; then truncated=1; break; fi
+  selected+=("$line")
+done
+
+if [ "${#selected[@]}" -eq 0 ]; then
+  echo "No recent sessions found (last ${MINUTES} min, older than ${MIN_AGE_SEC}s)."
+  exit 0
+fi
+
+echo "Sessions to resume (${#selected[@]}):"
+for line in "${selected[@]}"; do
+  IFS=$'\t' read -r mtime sid cwd <<< "$line"
+  ago=$(( (NOW - mtime) / 60 ))
+  printf '  • %s  (%dm ago)  %s\n' "${sid:0:8}" "$ago" "$cwd"
+done
+[ "$truncated" -eq 1 ] && echo "  … more matched; capped at ${MAX} (raise with -n / OPS_RESUME_MAX)."
+
+if [ "$DRY" -eq 1 ]; then
+  echo "(--dry-run: nothing opened)"
+  exit 0
+fi
+
+# Make sure Ghostty is running, then bring it to the front.
+if ! pgrep -x ghostty >/dev/null 2>&1; then
+  open -a Ghostty
+  sleep 1.2
+fi
+osascript -e 'tell application "Ghostty" to activate' >/dev/null 2>&1 || true
+sleep 0.3
+
+# Escape a string for an AppleScript double-quoted literal.
+esc() { printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+
+opened=0
+for line in "${selected[@]}"; do
+  IFS=$'\t' read -r mtime sid cwd <<< "$line"
+  cmd="cd \"$cwd\" && claude --resume $sid"
+  cmd_esc="$(esc "$cmd")"
+  osascript <<APPLESCRIPT
+tell application "Ghostty" to activate
+delay 0.25
+tell application "System Events"
+  keystroke "t" using command down
+  delay 0.45
+  keystroke "$cmd_esc"
+  delay 0.1
+  key code 36
+end tell
+APPLESCRIPT
+  opened=$(( opened + 1 ))
+  sleep 0.5
+done
+
+echo "✓ Opened ${opened} tab(s) in Ghostty."

--- a/claude-ops/skills/ops-resume/SKILL.md
+++ b/claude-ops/skills/ops-resume/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: ops-resume
+description: Reopen recently-closed Claude Code sessions, one per Ghostty tab. Finds recent session transcripts in ~/.claude/projects and resumes each in its own new tab via `claude --resume`, from the directory it was running in. macOS + Ghostty only.
+argument-hint: "[-m minutes | -H hours | -n max | --here | --dry-run]"
+allowed-tools:
+  - Bash
+---
+
+# ops-resume
+
+Reopen recently-closed Claude Code sessions — **one session per Ghostty tab**.
+
+For every recent session transcript under `~/.claude/projects`, the helper opens a
+new Ghostty tab (`cmd+t`) and types `cd <cwd> && claude --resume <sessionId>`, so each
+session resumes in its own tab from whatever directory or repo it was running in.
+
+**Default:** every session touched in the **last 60 minutes**, from **any directory**.
+
+Platform: macOS + [Ghostty](https://ghostty.org) only. Tabs are driven via AppleScript
+System Events, so Accessibility permission must be granted to the terminal running this.
+
+## How it works
+
+1. Scans `~/.claude/projects/**/*.jsonl` and keeps files whose mtime is inside the
+   lookback window (default 60 min) but older than `OPS_RESUME_MIN_AGE_SEC` (default
+   45s — so the session you are *currently* in is not reopened).
+2. Keeps only real interactive sessions (UUID filenames); skips subagent transcripts
+   (`agent-*`), workflow journals, and empty/junk sessions.
+3. Reads each session's original `cwd` from the transcript.
+4. For each, opens a fresh Ghostty tab and resumes the session there.
+
+## Usage
+
+Run the bundled helper. Pass through any flags the user gave (`$ARGUMENTS`).
+
+Always preview first with `--dry-run`, show the user the list, and — unless they
+clearly asked to "just open them" — confirm before opening real tabs (opening many
+tabs is hard to undo).
+
+```bash
+# Preview what would be resumed
+${CLAUDE_PLUGIN_ROOT}/bin/ops-resume --dry-run $ARGUMENTS
+```
+
+```bash
+# Actually open the tabs
+${CLAUDE_PLUGIN_ROOT}/bin/ops-resume $ARGUMENTS
+```
+
+### Flags
+
+| Flag | Meaning |
+|---|---|
+| `-m, --minutes N` | Lookback window in minutes (default 60) |
+| `-H, --hours N` | Lookback window in hours |
+| `-n, --max N` | Cap number of tabs (default 20, newest first) |
+| `--here` | Only sessions whose `cwd` == current directory |
+| `--dry-run` | List matches, open nothing |
+
+### Env overrides
+
+- `OPS_RESUME_MINUTES` (60) — lookback window
+- `OPS_RESUME_MAX` (20) — safety cap on tabs
+- `OPS_RESUME_MIN_AGE_SEC` (45) — skip sessions touched more recently than this
+
+## Reporting
+
+After running, report concisely: how many sessions matched, how many tabs were
+opened, and any that were capped/skipped. If `--dry-run`, just show the list and ask
+whether to open them for real.


### PR DESCRIPTION
## Summary

Adds **`/ops:ops-resume`** — reopens recently-closed Claude Code sessions, **one session per Ghostty tab**.

For every recent session transcript under `~/.claude/projects`, it opens a new Ghostty tab (`cmd+t`) and types `cd <cwd> && claude --resume <sessionId>`, so each session resumes in its own tab from whatever directory or repo it was running in.

**Default:** every interactive session touched in the **last 60 minutes**, from **any directory**.

## What's included

- `claude-ops/bin/ops-resume` — the helper script
- `claude-ops/skills/ops-resume/SKILL.md` — the skill definition

## Behavior

- Filters sessions on `stat(1)` mtime rather than `find -newermt @epoch` (the `@epoch` form is GNU-only and BSD/macOS `find` rejects it).
- Skips the session you're currently in (mtime guard, `OPS_RESUME_MIN_AGE_SEC`, default 45s).
- Keeps only real interactive sessions (UUID filenames); skips subagent transcripts (`agent-*`), workflow journals, and empty/junk jsonl.
- Safety cap on number of tabs (`OPS_RESUME_MAX`, default 20).

## Flags

| Flag | Meaning |
|---|---|
| `-m, --minutes N` | Lookback window in minutes (default 60) |
| `-H, --hours N` | Lookback window in hours |
| `-n, --max N` | Cap number of tabs (default 20) |
| `--here` | Only sessions whose `cwd` == current directory |
| `--dry-run` | List matches, open nothing |

## Platform

macOS + [Ghostty](https://ghostty.org) only. Tabs are driven via AppleScript System Events, so the terminal needs Accessibility permission. Cleanly errors out on non-Darwin or when Ghostty is missing.

## Testing

Verified `--dry-run` locally: correctly lists recent UUID sessions with their original `cwd`, excludes `agent-*` transcripts and the `journal` file, respects the lookback window and `-n` cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ops-resume` command to reopen recently closed Claude Code sessions in separate Ghostty tabs
  * Supports filtering by time window (`--minutes`, `--hours`), tab count limits (`--max`), current directory filtering (`--here`), and dry-run preview mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->