### PR TITLE
release: v2.27.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 38 skills, 20 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.27.3",
+      "version": "2.27.4",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.27.3",
+  "version": "2.27.4",
   "description": "Business operations command center for Claude Code — 39 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.27.4] - 2026-06-11
+
+### Changed
+WA bridge Fix V: tolerate missing sync keys in LTHash skip loop, 300ms throttle (dodges 429 rate-overlimit), key-arrival poller; default skip_bad=true on full_sync resync. Verified end-to-end 2026-06-10: poisoned regular_low chain healed, archive writes propagate to phone (31/31). Upstream: tulir/whatsmeow#1171.
+
+
 ## [2.27.3] - 2026-06-09
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.27.3",
+  "version": "2.27.4",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.27.4** (was 2.27.3).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

WA bridge Fix V: tolerate missing sync keys in LTHash skip loop, 300ms throttle (dodges 429 rate-overlimit), key-arrival poller; default skip_bad=true on full_sync resync. Verified end-to-end 2026-06-10: poisoned regular_low chain healed, archive writes propagate to phone (31/31). Upstream: tulir/whatsmeow#1171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff is version metadata and changelog only; functional WhatsApp bridge changes ship in the documented Fix V work elsewhere, not in these files.
> 
> **Overview**
> **Release v2.27.4** bumps the ops plugin from **2.27.3 → 2.27.4** in `plugin.json`, `.claude-plugin/marketplace.json`, and `claude-ops/package.json`, and adds a **CHANGELOG** entry for this cut.
> 
> The release notes document **WhatsApp bridge Fix V** (LTHash skip loop tolerates missing sync keys, **300ms** throttle to avoid **429** rate limits, key-arrival poller, **`skip_bad=true`** default on full_sync resync). End-to-end verification is claimed for poisoned `regular_low` chains and archive propagation to the phone; upstream context is **tulir/whatsmeow#1171**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b453edd188345b8b447724052db24fe6bf4020f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->