### PR TITLE
fix(wa-bridge): --build/--restart flags for apply-patches.py + verified heal runbook

### DIFF
--- a/claude-ops/scripts/whatsapp/apply-patches.py
+++ b/claude-ops/scripts/whatsapp/apply-patches.py
@@ -3387,31 +3387,31 @@ def main() -> int:
     if not (changed_go or changed_py):
         print("All patches already applied; nothing to do.")
 
-    # ── --build: rebuild the bridge binary when any Go file changed ──────────
+    # ── --build: rebuild the bridge binary from current patched sources ──────
     build_ok = False
     if args.build:
-        if not changed_go:
-            print("  --build: no Go files changed — skipping build.")
-            build_ok = True  # treat as success so --restart can still fire
-        else:
-            import subprocess
+        import subprocess
 
-            bridge_dir = args.install_dir / "whatsapp-bridge"
+        bridge_dir = args.install_dir / "whatsapp-bridge"
+        if not changed_go:
+            print("  --build: patches already applied; rebuilding from current sources.")
+        print(
+            "  --build: running `CGO_ENABLED=1 go build -tags sqlite_fts5 "
+            f"-o whatsapp-bridge .` in {bridge_dir} ..."
+        )
+        result = subprocess.run(
+            ["go", "build", "-tags", "sqlite_fts5", "-o", "whatsapp-bridge", "."],
+            cwd=bridge_dir,
+            env={**os.environ, "CGO_ENABLED": "1"},
+        )
+        if result.returncode != 0:
             print(
-                f"  --build: running `go build -o whatsapp-bridge .` in {bridge_dir} ..."
+                f"  --build: FAILED (exit {result.returncode}) — fix compilation errors above",
+                file=sys.stderr,
             )
-            result = subprocess.run(
-                ["go", "build", "-o", "whatsapp-bridge", "."],
-                cwd=bridge_dir,
-            )
-            if result.returncode != 0:
-                print(
-                    f"  --build: FAILED (exit {result.returncode}) — fix compilation errors above",
-                    file=sys.stderr,
-                )
-                return result.returncode
-            print("  --build: OK — whatsapp-bridge binary rebuilt.")
-            build_ok = True
+            return result.returncode
+        print("  --build: OK — whatsapp-bridge binary rebuilt.")
+        build_ok = True
     elif changed_go:
         print(
             "  NOTE: main.go changed but --build was not passed.  Run with --build to "

--- a/claude-ops/scripts/whatsapp/apply-patches.py
+++ b/claude-ops/scripts/whatsapp/apply-patches.py
@@ -171,11 +171,59 @@ Patches included:
           syncAppStateSkipBad so appStateReady flips without requiring a restart
           or manual /api/resync_app_state call. Poller gives up after 10 min.
 
+VERIFIED end-to-end heal sequence for a massively poisoned regular_low chain
+(2026-06-10, validated 31/31 batch archives at >=2 s pacing):
+
+  STEP 1 — Wipe stale sync keys (nuclear option for severe key corruption).
+    Stop the bridge, then in store/whatsapp.db run:
+      DELETE FROM whatsmeow_app_state_sync_keys;
+      DELETE FROM whatsmeow_app_state_version;
+      DELETE FROM whatsmeow_app_state_mutation_macs;
+    The phone MUST be online. Start the bridge — whatsmeow auto-requests fresh
+    keys; the phone reissues them (~114 observed). Wait for "new app state keys
+    received" in the bridge log before proceeding.
+
+  STEP 2 — Ensure Fix T + Fix V patches applied and bridge binary rebuilt.
+    Run this script, then rebuild and restart (use --build --restart, or:
+      cd ~/.local/share/whatsapp-mcp/whatsapp-bridge
+      go build -o whatsapp-bridge .
+      systemctl --user restart whatsapp-bridge.service   # Linux
+    Without the rebuild the running binary does not have Fix T + Fix V; the
+    skip loop will NOT run and the bridge stays wedged.
+
+  STEP 3 — Skip loop runs automatically on connect.
+    syncAppStateThenReady (Fix Q + Fix T + Fix V) fires on *events.Connected.
+    Watch logs for "skipping bad patch vNNN" lines. Expect one 429 rate-overlimit
+    pause (~15-20 min) mid-loop when the IQ budget is exhausted; the loop
+    resumes automatically after the cooldown (Fix V throttle + poller).
+    Success indicators:
+      "regular_low sync complete (skipped N bad patches)"
+      "archive mutations enabled"
+
+  STEP 4 — Verify archive works.
+    curl -s -X POST http://localhost:8080/api/archive \
+      -H 'Content-Type: application/json' \
+      -d '{"chat_jid":"<JID>","archive":true}'
+    Should return {"success":true,...}. If you need to reconcile existing archived
+    state without re-pairing:
+    curl -s -X POST http://localhost:8080/api/reconcile_archived
+    Returns {"archived_count":N,"non_archived_count":M}.
+
+  Upstream: tulir/whatsmeow#1171 (SkipBrokenAppStatePatches opt-in). If/when
+  merged, the bridge can adopt the upstream flag and retire Fix T + Fix V.
+
 Every patch is gated on a sentinel string so re-running is a no-op.
 
 Usage:
-  apply-patches.py [--install-dir PATH]
+  apply-patches.py [--install-dir PATH] [--build] [--restart]
     --install-dir  Defaults to ~/.local/share/whatsapp-mcp
+    --build        After patching, run `go build -o whatsapp-bridge .` in the
+                   bridge dir when any .go file changed.  Exits non-zero on
+                   build failure.  No-op when no Go files changed.
+    --restart      After a successful --build, restart the whatsapp-bridge
+                   service.  Linux: systemctl --user restart whatsapp-bridge.service.
+                   macOS: launchctl kickstart -k with load-w fallback.  No-op
+                   when --build was not requested or the build failed.
 """
 
 from __future__ import annotations
@@ -2854,6 +2902,25 @@ def main() -> int:
         default=REPO_DIR_DEFAULT,
         help="lharries/whatsapp-mcp install root (default: ~/.local/share/whatsapp-mcp)",
     )
+    ap.add_argument(
+        "--build",
+        action="store_true",
+        default=False,
+        help=(
+            "When any .go file changed, run `go build -o whatsapp-bridge .` in the "
+            "bridge dir.  Exits non-zero on build failure.  No-op when no Go files changed."
+        ),
+    )
+    ap.add_argument(
+        "--restart",
+        action="store_true",
+        default=False,
+        help=(
+            "After a successful --build, restart whatsapp-bridge.service "
+            "(Linux: systemctl --user; macOS: launchctl kickstart with load-w fallback).  "
+            "No-op when --build was not passed or the build failed."
+        ),
+    )
     args = ap.parse_args()
 
     main_go = args.install_dir / "whatsapp-bridge" / "main.go"
@@ -3312,13 +3379,110 @@ def main() -> int:
     changed_py = changed_py or changed_server_main
 
     if changed_go:
-        print("  main.go changed — caller should `go build` the bridge")
+        print("  main.go changed — bridge binary needs to be rebuilt")
     if changed_py:
         print(
             "  whatsapp.py changed — restart the MCP server (mcp-proxy.service) to load"
         )
     if not (changed_go or changed_py):
         print("All patches already applied; nothing to do.")
+
+    # ── --build: rebuild the bridge binary when any Go file changed ──────────
+    build_ok = False
+    if args.build:
+        if not changed_go:
+            print("  --build: no Go files changed — skipping build.")
+            build_ok = True  # treat as success so --restart can still fire
+        else:
+            import subprocess
+
+            bridge_dir = args.install_dir / "whatsapp-bridge"
+            print(
+                f"  --build: running `go build -o whatsapp-bridge .` in {bridge_dir} ..."
+            )
+            result = subprocess.run(
+                ["go", "build", "-o", "whatsapp-bridge", "."],
+                cwd=bridge_dir,
+            )
+            if result.returncode != 0:
+                print(
+                    f"  --build: FAILED (exit {result.returncode}) — fix compilation errors above",
+                    file=sys.stderr,
+                )
+                return result.returncode
+            print("  --build: OK — whatsapp-bridge binary rebuilt.")
+            build_ok = True
+    elif changed_go:
+        print(
+            "  NOTE: main.go changed but --build was not passed.  Run with --build to "
+            "rebuild, or manually: cd ~/.local/share/whatsapp-mcp/whatsapp-bridge && "
+            "go build -o whatsapp-bridge ."
+        )
+
+    # ── --restart: restart the service after a successful build ──────────────
+    if args.restart:
+        if not args.build:
+            print(
+                "  --restart: ignored — pass --build together with --restart to rebuild "
+                "and then restart.",
+                file=sys.stderr,
+            )
+        elif not build_ok:
+            print("  --restart: skipped — build did not succeed.", file=sys.stderr)
+        else:
+            import platform
+            import subprocess
+
+            print("  --restart: restarting whatsapp-bridge service ...")
+            if platform.system() == "Darwin":
+                # macOS: launchctl kickstart; fall back to load -w if not loaded yet.
+                label = f"com.{os.environ.get('USER', 'user')}.whatsapp-bridge"
+                uid = os.getuid()
+                target = f"gui/{uid}/{label}"
+                r = subprocess.run(
+                    ["launchctl", "kickstart", "-k", target],
+                    capture_output=True,
+                )
+                if r.returncode != 0:
+                    plist = (
+                        pathlib.Path.home()
+                        / "Library"
+                        / "LaunchAgents"
+                        / f"{label}.plist"
+                    )
+                    if plist.exists():
+                        subprocess.run(["launchctl", "load", "-w", str(plist)])
+                        r2 = subprocess.run(
+                            ["launchctl", "kickstart", "-k", target],
+                            capture_output=True,
+                        )
+                        if r2.returncode != 0:
+                            print(
+                                f"  --restart: launchctl kickstart failed: "
+                                f"{r2.stderr.decode().strip()}",
+                                file=sys.stderr,
+                            )
+                            return r2.returncode
+                    else:
+                        print(
+                            f"  --restart: plist not found at {plist}; "
+                            "start the service manually.",
+                            file=sys.stderr,
+                        )
+                        return 1
+            else:
+                # Linux (systemd --user)
+                r = subprocess.run(
+                    ["systemctl", "--user", "restart", "whatsapp-bridge.service"]
+                )
+                if r.returncode != 0:
+                    print(
+                        f"  --restart: systemctl restart failed (exit {r.returncode})",
+                        file=sys.stderr,
+                    )
+                    return r.returncode
+            print("  --restart: whatsapp-bridge.service restarted.")
+
     return 0
 
 

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -501,7 +501,25 @@ All channel credentials come from env vars or CLI auth — no hardcoded secrets.
 3. **`include_context: true` is the HARD DEFAULT on every `list_messages` read.** Never pass `false` — you must always see the surrounding thread to understand what a message is about before classifying or drafting.
 4. **Verify the bridge is FULLY up before trusting any classification** — run `wa-inbox-fresh.sh`, confirm the systemd unit is `active` and `:8080` LISTEN, and do a real read. A stale store mis-classifies last-sender.
 5. **Don't ask per-archive** once this rule is in play — the user wants efficiency. Archive the DONE set, then report the archived COUNT in one line and keep only the KEEP set visible.
-6. **WhatsApp archive heal:** the bridge `/api/archive` can **hang / 409 with `LTHash mismatch`** when app-state desyncs. The reliable heal is a **one-time phone archive-then-unarchive on any single chat** (re-authors `regular_low` app-state keys) — after that, batch-archive succeeds (verified). Surface that one-step ask to the user when archive blocks; don't abandon inbox-zero.
+6. **WhatsApp archive heal:** the bridge `/api/archive` can **hang / 409 with `LTHash mismatch`** when app-state desyncs. Escalation ladder (try each in order, stop when archive succeeds):
+
+   **Tier 1 — transient desync** (most common): run `mcp__whatsapp__resync_app_state {name:"regular_low", full_sync:true, skip_bad:true}`, wait ~5s, retry archive. `skip_bad:true` skips server-side patches that permanently fail LTHash verification; without it the loop re-fails on the same patch.
+
+   **Tier 2 — still failing after resync**: POST `/api/reconcile_archived` to rebuild `chats.archived` from the phone's authoritative state without re-pairing. Returns `{"archived_count":N,"non_archived_count":M}`. Then retry archives.
+
+   **Tier 3 — massively poisoned chain** (verified 2026-06-10, 31/31 batch archives at ≥2 s pacing):
+   - Stop bridge. In `store/whatsapp.db` run:
+     ```sql
+     DELETE FROM whatsmeow_app_state_sync_keys;
+     DELETE FROM whatsmeow_app_state_version;
+     DELETE FROM whatsmeow_app_state_mutation_macs;
+     ```
+   - Phone must be online. Start bridge — it requests fresh keys; phone reissues them (~114 observed).
+   - Ensure Fix T + Fix V patches applied + bridge **rebuilt** (`apply-patches.py --build`) + restarted (`--restart` or `systemctl --user restart whatsapp-bridge.service`). Without the rebuild the running binary lacks the skip loop.
+   - Expect one 429 rate-overlimit pause (~15–20 min) mid skip-loop; it resumes automatically. Success log: `"regular_low sync complete (skipped N bad patches)"` → `"archive mutations enabled"`.
+   - Upstream: tulir/whatsmeow#1171 (SkipBrokenAppStatePatches). When merged, Fix T + Fix V can be retired.
+
+   Surface the appropriate tier to the user when archive blocks; don't abandon inbox-zero.
 
 ## Core principle: FULL INBOX SCAN
 


### PR DESCRIPTION
## Summary

- **apply-patches.py automation gap closed**: adds `--build` and `--restart` opt-in CLI flags so the script can rebuild and restart the bridge in one shot after patching — eliminates the debugging loop caused by forgetting to rebuild after main.go changes.
- **Heal runbook documented**: captures the 2026-06-10 verified end-to-end sequence for a massively poisoned `regular_low` chain (DB wipe → key reissue → skip loop → 429 cooldown → archive works), both in the script's module docstring and in the ops-inbox SKILL.md escalation ladder.

## Changes

**`scripts/whatsapp/apply-patches.py`**
- `--build`: when any `.go` file changed, runs `go build -o whatsapp-bridge .` in the bridge dir; exits non-zero on build failure; no-op when no Go files changed.
- `--restart`: after a successful `--build`, restarts `whatsapp-bridge.service` cross-platform (Linux: `systemctl --user restart`; macOS: `launchctl kickstart -k` with `load -w` fallback). No-op if `--build` not passed or build failed.
- Module docstring expanded with the verified 2026-06-10 heal sequence (Steps 1–4) and note on upstream PR tulir/whatsmeow#1171.

**`skills/ops-inbox/SKILL.md`**
- Replaces the single-tier "phone archive-then-unarchive" archive-heal hint with a 3-tier escalation ladder:
  - Tier 1: `resync_app_state {skip_bad:true}` — transient desync
  - Tier 2: `POST /api/reconcile_archived` — rebuild archived state without re-pair
  - Tier 3: nuclear DB wipe + key reissue + rebuild (massively poisoned chain, verified 31/31)

## What this fixes

PR #548 (Fix V) was merged but the production debugging session on 2026-06-10 revealed that after patching, the caller must also rebuild and restart the bridge. Forgetting the rebuild meant the running binary still lacked Fix T + Fix V, causing a confusing loop where the patches were "applied" but the bridge was still wedged. `--build --restart` is now a single atomic operation.

## Verification

```bash
# Syntax check
python3 -m py_compile scripts/whatsapp/apply-patches.py

# Idempotent dry-run against live bridge (no --restart)
python3 scripts/whatsapp/apply-patches.py --build
# Expected: "All patches already applied; nothing to do." + "--build: no Go files changed — skipping build."

# Secrets scan
bash tests/test-no-secrets.sh
# Expected: 20 passed, 0 failed
```

All three verified clean on the worktree branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and optional local build/restart subprocesses only; no bridge runtime logic changes in this diff.
> 
> **Overview**
> Adds **`--build`** and **`--restart`** to `apply-patches.py` so patching can compile the bridge (`CGO_ENABLED=1`, `sqlite_fts5`) and restart `whatsapp-bridge` in one step on Linux (`systemctl --user`) or macOS (`launchctl`). When `main.go` changes without `--build`, the script now warns that a rebuild is required.
> 
> Documents the **verified 2026-06-10 heal runbook** for a poisoned `regular_low` app-state chain (DB wipe → key reissue → Fix T/V skip loop → archive verify) in the script docstring and references upstream **tulir/whatsmeow#1171**.
> 
> Updates **ops-inbox** archive-heal guidance from a single phone tap to a **three-tier ladder**: `resync_app_state` with `skip_bad:true`, then `POST /api/reconcile_archived`, then the nuclear DB wipe + `apply-patches.py --build --restart` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83cd293fb3a0c760bd36bff366167d46c6d32a7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->