### PR TITLE
fix(account-rotation): repair post-rotation bg-session refresh (homedir import + respawn-id from content, not PID)

### DIFF
--- a/claude-ops/scripts/account-rotation/bg-respawn.mjs
+++ b/claude-ops/scripts/account-rotation/bg-respawn.mjs
@@ -89,7 +89,11 @@ export function listLiveBgSessions() {
       const pid = Number(s.pid) || 0;
       if (!pidAlive(pid)) continue;
       if (pid === process.pid || pid === process.ppid) continue; // never respawn ourselves
-      const id = s.id || f.replace(/\.json$/, '');
+      // Session-state files are PID-named, but `claude respawn` needs the job/
+      // session id, NOT the PID. Resolve from file CONTENT (OS-agnostic, no
+      // reliance on the PID filename): prefer jobId (short id in the fleet UI),
+      // then full sessionId, then any explicit id; filename is last-resort only.
+      const id = s.jobId || s.sessionId || s.id || f.replace(/\.json$/, '');
       out.push({ id, pid, status: s.status || 'unknown' });
     } catch {}
   }

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -43,7 +43,7 @@ import { persistBedrockClaudeSettings } from './claude-settings-mode.mjs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync, execFileSync, spawnSync, spawn } from 'child_process';
-import { tmpdir } from 'os';
+import { tmpdir, homedir } from 'os';
 import { createHmac } from 'node:crypto';
 import { askAIBrain, executeAIAction, AI_BRAIN_MAX_DECISIONS, scrapeBillingState } from './ai-brain.mjs';
 import { destinationUtilHardBlock } from './rotation-policy.mjs';


### PR DESCRIPTION
Two surgical fixes to the post-rotation background-session refresh path, both regressions/latent bugs from the daemon-hosted bg-session feature (#557). Together they restore the daemon's ability to move running `claude --bg` sessions onto a freshly-rotated account token. OS-agnostic; no reliance on PID-named files for identity.

## Bug 1 — `homedir is not defined` (acute: enumeration crash)
`rotate.mjs` calls `homedir()` in `enumerateSessions()` but only imported `tmpdir` from `'os'`. Every enumeration threw → `[session] Failed to enumerate sessions` → `No running Claude Code sessions found` → the respawn path fell back to a stale roster and fired dead `claude respawn <pid>` subprocesses each cycle (`No job matching` spam + CPU burn; observed driving a host load spike to ~68).

```diff
-import { tmpdir } from 'os';
+import { tmpdir, homedir } from 'os';
```

## Bug 2 — respawn id resolved from PID filename, not job id
`bg-respawn.mjs` `listLiveBgSessions()` set `id = s.id || <filename>`. Session-state files in `~/.claude/sessions/` are **PID-named** (e.g. `13194.json`) and carry no top-level `id` — they expose `jobId` + `sessionId`. So respawn ran `claude respawn <pid>` → `No job matching`, and rotated bg sessions never picked up the new token (the whole fleet can wedge on one account's 5h cap at the same reset time).

```diff
-      const id = s.id || f.replace(/\.json$/, '');
+      const id = s.jobId || s.sessionId || s.id || f.replace(/\.json$/, '');
```

Resolve identity from file **content** (OS-agnostic): `jobId` → `sessionId` → `id` → filename. `pidAlive()` already uses cross-platform `process.kill(pid, 0)`.

## Verification
- `node --check` passes on both files.
- Live: `claude respawn <jobId>` → `respawned <id>` exit 0; `claude respawn <pid>` → `No job matching`.
- After deploying both fixes + daemon restart on the affected host: `enumerateSessions()` returns cleanly, `No job matching` storm stops, host load dropped 68→10, and `claude respawn --all` successfully refreshed 15 wedged bg sessions.
- Doc-confirmed mechanism (code.claude.com/docs agent-view): respawn re-execs a fresh process that reads the post-rotation keychain. Caveat for reviewers: respawn can silently no-op on oversized-context sessions (upstream issue #59806) — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)