### PR TITLE
release: v2.29.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 38 skills, 20 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.28.0",
+      "version": "2.29.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.28.0",
+  "version": "2.29.0",
   "description": "Business operations command center for Claude Code — 39 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.29.0] - 2026-06-11
+
+### Changed
+ops-inbox: Mac WhatsApp.app fallback suite — Tier-4 archive via Mac app (bypasses server-side 429), automatic Mac ground-truth cross-check in the freshness gate, and Tailscale→Cloudflare-tunnel SSH transport chain (wa-mac-transport.sh + setup-wa-mac-cf-tunnel.sh) (#560)
+
+
 ## [2.28.0] - 2026-06-11
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.28.0",
+  "version": "2.29.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.29.0** (was 2.28.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

ops-inbox: Mac WhatsApp.app fallback suite — Tier-4 archive via Mac app (bypasses server-side 429), automatic Mac ground-truth cross-check in the freshness gate, and Tailscale→Cloudflare-tunnel SSH transport chain (wa-mac-transport.sh + setup-wa-mac-cf-tunnel.sh) (#560)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release; functional changes were merged separately (#560). Low risk unless consumers pin on exact marketplace version strings.
> 
> **Overview**
> **Release v2.29.0** bumps the plugin from **2.28.0** across `marketplace.json`, `claude-ops/.claude-plugin/plugin.json`, and `claude-ops/package.json`, and adds a **CHANGELOG** entry for what shipped in this tag.
> 
> The documented product change (from #560, not in this diff) is the **ops-inbox Mac WhatsApp.app fallback suite**: Tier-4 archiving through the Mac app to avoid server **429** limits, an automatic **Mac ground-truth cross-check** in the freshness gate, and **Tailscale → Cloudflare tunnel** SSH plumbing (`wa-mac-transport.sh`, `setup-wa-mac-cf-tunnel.sh`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8625f09eaeca320c1f46dc120f35557911d5855. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->