### PR TITLE
fix: resolve rotation daemon park check (Bug A) and logging noise (Bug B)

### DIFF
--- a/claude-ops/scripts/account-rotation/bg-respawn.mjs
+++ b/claude-ops/scripts/account-rotation/bg-respawn.mjs
@@ -19,14 +19,23 @@
 //
 // Used by rotate.mjs (post-rotation) and daemon.mjs (periodic deferred sweep).
 
-import { readFileSync, readdirSync, writeFileSync, unlinkSync, statSync, existsSync } from 'fs';
+import { readFileSync, readdirSync, writeFileSync, unlinkSync, statSync, existsSync, mkdirSync } from 'fs';
 import { execFileSync, execSync } from 'child_process';
 import { join } from 'path';
 import { homedir } from 'os';
 
 const SESSIONS_DIR = join(homedir(), '.claude', 'sessions');
-const RESPAWNED_MARKER = (id) => `/tmp/claude-rotation-respawned-${id}`;
-const DEFERRED_MARKER = (id) => `/tmp/claude-respawn-deferred-${id}`;
+// Markers live in a user-private dir (0700), not the world-writable OS temp dir,
+// to avoid symlink/predictable-name attacks on the shared /tmp.
+const MARKER_DIR = join(homedir(), '.claude', 'rotation-markers');
+function ensureMarkerDir() {
+  try {
+    mkdirSync(MARKER_DIR, { recursive: true, mode: 0o700 });
+  } catch {}
+}
+const DEFERRED_PREFIX = 'claude-respawn-deferred-';
+const RESPAWNED_MARKER = (id) => join(MARKER_DIR, `claude-rotation-respawned-${id}`);
+const DEFERRED_MARKER = (id) => join(MARKER_DIR, `${DEFERRED_PREFIX}${id}`);
 const RESPAWN_THROTTLE_MS = 10 * 60_000; // never respawn the same session twice in 10 min
 const BUSY_FORCE_AFTER_MS = 90 * 60_000; // busy this long after rotation → respawn anyway
 
@@ -109,7 +118,8 @@ function doRespawn(session, log) {
     try {
       process.kill(session.pid, 'SIGTERM');
       try {
-        writeFileSync(RESPAWNED_MARKER(session.id), String(Date.now()));
+        ensureMarkerDir();
+        writeFileSync(RESPAWNED_MARKER(session.id), String(Date.now()), { mode: 0o600 });
       } catch {}
       try {
         unlinkSync(DEFERRED_MARKER(session.id));
@@ -124,7 +134,8 @@ function doRespawn(session, log) {
   try {
     execFileSync(claudeBin(), ['respawn', String(session.id)], { timeout: 30_000, stdio: 'pipe' });
     try {
-      writeFileSync(RESPAWNED_MARKER(session.id), String(Date.now()));
+      ensureMarkerDir();
+      writeFileSync(RESPAWNED_MARKER(session.id), String(Date.now()), { mode: 0o600 });
     } catch {}
     try {
       unlinkSync(DEFERRED_MARKER(session.id));
@@ -156,7 +167,9 @@ export function respawnBgSessions(log = () => {}) {
     }
     if (s.status === 'busy') {
       try {
-        if (!existsSync(DEFERRED_MARKER(s.id))) writeFileSync(DEFERRED_MARKER(s.id), String(Date.now()));
+        ensureMarkerDir();
+        if (!existsSync(DEFERRED_MARKER(s.id)))
+          writeFileSync(DEFERRED_MARKER(s.id), String(Date.now()), { mode: 0o600 });
       } catch {}
       deferred++;
       log(`[bg-respawn] ${s.id} busy — deferred (daemon sweep will retry, force after 90min)`);
@@ -175,7 +188,7 @@ export function respawnBgSessions(log = () => {}) {
 export function sweepDeferredRespawns(log = () => {}) {
   let markers = [];
   try {
-    markers = readdirSync('/tmp').filter((f) => f.startsWith('claude-respawn-deferred-'));
+    markers = readdirSync(MARKER_DIR).filter((f) => f.startsWith(DEFERRED_PREFIX));
   } catch {
     return 0;
   }
@@ -183,8 +196,8 @@ export function sweepDeferredRespawns(log = () => {}) {
   const live = new Map(listLiveBgSessions().map((s) => [String(s.id), s]));
   let handled = 0;
   for (const m of markers) {
-    const id = m.replace('claude-respawn-deferred-', '');
-    const markerPath = `/tmp/${m}`;
+    const id = m.replace(DEFERRED_PREFIX, '');
+    const markerPath = join(MARKER_DIR, m);
     const s = live.get(id);
     if (!s) {
       // session exited or state file gone — nothing to refresh

--- a/claude-ops/scripts/account-rotation/bg-respawn.mjs
+++ b/claude-ops/scripts/account-rotation/bg-respawn.mjs
@@ -19,7 +19,7 @@
 //
 // Used by rotate.mjs (post-rotation) and daemon.mjs (periodic deferred sweep).
 
-import { readFileSync, readdirSync, writeFileSync, unlinkSync, statSync, existsSync, mkdirSync } from 'fs';
+import { readFileSync, readdirSync, writeFileSync, unlinkSync, statSync, existsSync, mkdirSync, renameSync } from 'fs';
 import { execFileSync, execSync } from 'child_process';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -33,9 +33,29 @@ function ensureMarkerDir() {
     mkdirSync(MARKER_DIR, { recursive: true, mode: 0o700 });
   } catch {}
 }
+const LEGACY_TMP_DIR = '/tmp';
 const DEFERRED_PREFIX = 'claude-respawn-deferred-';
 const RESPAWNED_MARKER = (id) => join(MARKER_DIR, `claude-rotation-respawned-${id}`);
 const DEFERRED_MARKER = (id) => join(MARKER_DIR, `${DEFERRED_PREFIX}${id}`);
+
+/** Move deferred markers left under /tmp by pre-upgrade daemons into MARKER_DIR. */
+function migrateLegacyDeferredMarkers() {
+  ensureMarkerDir();
+  let legacy = [];
+  try {
+    legacy = readdirSync(LEGACY_TMP_DIR).filter((f) => f.startsWith(DEFERRED_PREFIX));
+  } catch {
+    return;
+  }
+  for (const f of legacy) {
+    const from = join(LEGACY_TMP_DIR, f);
+    const to = join(MARKER_DIR, f);
+    try {
+      if (existsSync(to)) unlinkSync(from);
+      else renameSync(from, to);
+    } catch {}
+  }
+}
 const RESPAWN_THROTTLE_MS = 10 * 60_000; // never respawn the same session twice in 10 min
 const BUSY_FORCE_AFTER_MS = 90 * 60_000; // busy this long after rotation → respawn anyway
 
@@ -186,6 +206,7 @@ export function respawnBgSessions(log = () => {}) {
  * BUSY_FORCE_AFTER_MS, and clears markers for sessions that exited.
  */
 export function sweepDeferredRespawns(log = () => {}) {
+  migrateLegacyDeferredMarkers();
   let markers = [];
   try {
     markers = readdirSync(MARKER_DIR).filter((f) => f.startsWith(DEFERRED_PREFIX));

--- a/claude-ops/scripts/account-rotation/bg-respawn.mjs
+++ b/claude-ops/scripts/account-rotation/bg-respawn.mjs
@@ -1,0 +1,213 @@
+// ── Background-session respawn after rotation ────────────────────────────────
+// Daemon-hosted `claude --bg` sessions have no TTY, so the /login-injection
+// path in rotate.mjs can never reach them. They also never register in the
+// statusline pidfile (`/tmp/claude-pids-<email>`), so the SIGHUP hot-swap
+// misses them too. Net effect (observed 2026-06-11): after a rotation the bg
+// fleet keeps running on the outgoing account's token until it expires
+// (~1-2h), then wedges on 401s until a human runs /login.
+//
+// The supported refresh path for bg sessions is `claude respawn <id>` — the
+// supervisor re-execs the session (transcript preserved, session resumes) and
+// the fresh process reads the post-rotation keychain.
+//
+// Policy:
+//   idle / waiting  → respawn immediately (nothing in flight, zero disruption)
+//   busy            → defer (marker file); the daemon sweep retries until the
+//                     session goes idle, or force-respawns after
+//                     BUSY_FORCE_AFTER_MS (better to lose one tool call than
+//                     wedge on an expired token for hours)
+//
+// Used by rotate.mjs (post-rotation) and daemon.mjs (periodic deferred sweep).
+
+import { readFileSync, readdirSync, writeFileSync, unlinkSync, statSync, existsSync } from 'fs';
+import { execFileSync, execSync } from 'child_process';
+import { join } from 'path';
+import { homedir } from 'os';
+
+const SESSIONS_DIR = join(homedir(), '.claude', 'sessions');
+const RESPAWNED_MARKER = (id) => `/tmp/claude-rotation-respawned-${id}`;
+const DEFERRED_MARKER = (id) => `/tmp/claude-respawn-deferred-${id}`;
+const RESPAWN_THROTTLE_MS = 10 * 60_000; // never respawn the same session twice in 10 min
+const BUSY_FORCE_AFTER_MS = 90 * 60_000; // busy this long after rotation → respawn anyway
+
+let _claudeBin = null;
+function claudeBin() {
+  if (_claudeBin) return _claudeBin;
+  const candidates = [
+    process.env.CLAUDE_BIN,
+    join(homedir(), '.local', 'bin', 'claude'),
+    '/usr/local/bin/claude',
+  ].filter(Boolean);
+  for (const c of candidates) {
+    if (existsSync(c)) {
+      _claudeBin = c;
+      return c;
+    }
+  }
+  try {
+    const w = execSync('which claude', { timeout: 3000 }).toString().trim();
+    if (w) {
+      _claudeBin = w;
+      return w;
+    }
+  } catch {}
+  _claudeBin = 'claude'; // last resort: rely on PATH
+  return _claudeBin;
+}
+
+function pidAlive(pid) {
+  if (!pid || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function markerFresh(path, maxAgeMs) {
+  try {
+    return Date.now() - statSync(path).mtimeMs < maxAgeMs;
+  } catch {
+    return false;
+  }
+}
+
+/** Enumerate live daemon-hosted bg sessions from ~/.claude/sessions/*.json. */
+export function listLiveBgSessions() {
+  const out = [];
+  let files = [];
+  try {
+    files = readdirSync(SESSIONS_DIR).filter((f) => f.endsWith('.json'));
+  } catch {
+    return out;
+  }
+  for (const f of files) {
+    try {
+      const s = JSON.parse(readFileSync(join(SESSIONS_DIR, f), 'utf8'));
+      if (s.kind !== 'bg') continue;
+      const pid = Number(s.pid) || 0;
+      if (!pidAlive(pid)) continue;
+      if (pid === process.pid || pid === process.ppid) continue; // never respawn ourselves
+      // Session-state files are PID-named, but `claude respawn` needs the job/
+      // session id, NOT the PID. Resolve from file CONTENT (OS-agnostic, no
+      // reliance on the PID filename): prefer jobId (short id in the fleet UI),
+      // then full sessionId, then any explicit id; filename is last-resort only.
+      const id = s.jobId || s.sessionId || s.id || f.replace(/\.json$/, '');
+      out.push({ id, pid, status: s.status || 'unknown' });
+    } catch {}
+  }
+  return out;
+}
+
+function doRespawn(session, log) {
+  const stateFile = join(homedir(), '.claude', 'jobs', String(session.id), 'state.json');
+  if (!existsSync(stateFile)) {
+    log(
+      `[bg-respawn] session ${session.id} (pid ${session.pid}) has no saved state (spare) — terminating process to refresh`,
+    );
+    try {
+      process.kill(session.pid, 'SIGTERM');
+      try {
+        writeFileSync(RESPAWNED_MARKER(session.id), String(Date.now()));
+      } catch {}
+      try {
+        unlinkSync(DEFERRED_MARKER(session.id));
+      } catch {}
+      return true;
+    } catch (e) {
+      log(`[bg-respawn] failed to terminate spare session ${session.id} (pid ${session.pid}): ${e.message}`);
+      return false;
+    }
+  }
+
+  try {
+    execFileSync(claudeBin(), ['respawn', String(session.id)], { timeout: 30_000, stdio: 'pipe' });
+    try {
+      writeFileSync(RESPAWNED_MARKER(session.id), String(Date.now()));
+    } catch {}
+    try {
+      unlinkSync(DEFERRED_MARKER(session.id));
+    } catch {}
+    log(`[bg-respawn] respawned bg session ${session.id} (pid ${session.pid}, was ${session.status})`);
+    return true;
+  } catch (e) {
+    log(`[bg-respawn] respawn ${session.id} failed: ${e.message?.slice(0, 80)}`);
+    return false;
+  }
+}
+
+/**
+ * Post-rotation pass: respawn idle/waiting bg sessions so they pick up the
+ * new keychain token; defer busy ones to the daemon sweep.
+ */
+export function respawnBgSessions(log = () => {}) {
+  const sessions = listLiveBgSessions();
+  if (sessions.length === 0) {
+    log('[bg-respawn] no live bg sessions to refresh');
+    return { respawned: 0, deferred: 0 };
+  }
+  let respawned = 0;
+  let deferred = 0;
+  for (const s of sessions) {
+    if (markerFresh(RESPAWNED_MARKER(s.id), RESPAWN_THROTTLE_MS)) {
+      log(`[bg-respawn] ${s.id} respawned <10min ago — skipping`);
+      continue;
+    }
+    if (s.status === 'busy') {
+      try {
+        if (!existsSync(DEFERRED_MARKER(s.id))) writeFileSync(DEFERRED_MARKER(s.id), String(Date.now()));
+      } catch {}
+      deferred++;
+      log(`[bg-respawn] ${s.id} busy — deferred (daemon sweep will retry, force after 90min)`);
+      continue;
+    }
+    if (doRespawn(s, log)) respawned++;
+  }
+  return { respawned, deferred };
+}
+
+/**
+ * Daemon sweep: retry deferred (busy-at-rotation-time) sessions. Respawns when
+ * the session goes idle/waiting, force-respawns if it stayed busy past
+ * BUSY_FORCE_AFTER_MS, and clears markers for sessions that exited.
+ */
+export function sweepDeferredRespawns(log = () => {}) {
+  let markers = [];
+  try {
+    markers = readdirSync('/tmp').filter((f) => f.startsWith('claude-respawn-deferred-'));
+  } catch {
+    return 0;
+  }
+  if (markers.length === 0) return 0;
+  const live = new Map(listLiveBgSessions().map((s) => [String(s.id), s]));
+  let handled = 0;
+  for (const m of markers) {
+    const id = m.replace('claude-respawn-deferred-', '');
+    const markerPath = `/tmp/${m}`;
+    const s = live.get(id);
+    if (!s) {
+      // session exited or state file gone — nothing to refresh
+      try {
+        unlinkSync(markerPath);
+      } catch {}
+      continue;
+    }
+    const deferredAgo = (() => {
+      try {
+        return Date.now() - statSync(markerPath).mtimeMs;
+      } catch {
+        return 0;
+      }
+    })();
+    if (s.status !== 'busy' || deferredAgo > BUSY_FORCE_AFTER_MS) {
+      if (s.status === 'busy') {
+        log(
+          `[bg-respawn] ${id} still busy after ${Math.round(deferredAgo / 60000)}min — force-respawning before token expiry`,
+        );
+      }
+      if (doRespawn(s, log)) handled++;
+    }
+  }
+  return handled;
+}

--- a/claude-ops/scripts/account-rotation/daemon.mjs
+++ b/claude-ops/scripts/account-rotation/daemon.mjs
@@ -285,9 +285,12 @@ function readStoredToken(account) {
     }
   }
   try {
-    const out = execSync(`security find-generic-password -s "${svc}" -a "${VAULT_KEYCHAIN_ACCOUNT}" -g 2>&1`, {
+    // spawnSync (no shell) — svc/account can't break out into a shell command.
+    // `security -g` prints "password: ..." on stderr, so read both streams.
+    const r = spawnSync('security', ['find-generic-password', '-s', svc, '-a', VAULT_KEYCHAIN_ACCOUNT, '-g'], {
       timeout: 5000,
-    }).toString();
+    });
+    const out = `${r.stdout?.toString() || ''}${r.stderr?.toString() || ''}`;
     const m = out.match(/^password: "?(.*?)"?$/m);
     return m ? m[1].replace(/\\"/g, '"') : null;
   } catch {

--- a/claude-ops/scripts/account-rotation/daemon.mjs
+++ b/claude-ops/scripts/account-rotation/daemon.mjs
@@ -10,6 +10,12 @@
  *
  * Auto-rotates to the most cooled-down account when any threshold is hit.
  *
+ * Rotation path: `node rotate.mjs --no-browser --to <key>` only (keychain swap,
+ * no browser). That path does not invoke ai-brain.mjs. Full ai-brain (Bedrock
+ * Converse, stall recovery, optional Context7 + web research, billing scrape)
+ * runs inside `rotate.mjs` when a browser OAuth flow is used — e.g. force-rotate.sh
+ * after fast path fails, `node rotate.mjs --magic-link --force --to …`, or setup --auto.
+ *
  * Usage:
  *   node daemon.mjs           # Run in foreground
  *   node daemon.mjs --bg      # Daemonize
@@ -18,10 +24,22 @@
  */
 
 import { readFileSync, writeFileSync, existsSync, unlinkSync, appendFileSync, statSync } from 'fs';
+import { persistBedrockClaudeSettings, clearHardcodedModelsForOAuthClaudeSettings } from './claude-settings-mode.mjs';
+import {
+  destinationUtilHardBlock,
+  DAEMON_SAFE_5H_PCT,
+  DAEMON_SAFE_7D_PCT,
+  DAEMON_RELAXED_BAR,
+  isDaemonRotationViable,
+  isLiveUtilOk,
+  liveUtilMax,
+} from './rotation-policy.mjs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { execFileSync, spawn, spawnSync } from 'child_process';
+import { execSync, execFileSync, spawn, spawnSync } from 'child_process';
 import { tmpdir } from 'os';
+import { applyAccountLeases, writeLease } from './account-leases.mjs';
+import { sweepDeferredRespawns } from './bg-respawn.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CONFIG_PATH = join(__dirname, 'config.json');
@@ -30,20 +48,60 @@ const LOG_PATH = join(__dirname, 'rotation.log');
 const PID_FILE = join(__dirname, '.daemon.pid');
 const ROTATE_SCRIPT = join(__dirname, 'rotate.mjs');
 
-// ── Platform ─────────────────────────────────────────────────────────────────
-const IS_LINUX = process.platform === 'linux';
-// Top-level await: pre-load vault on Linux so credential helpers stay synchronous.
-const _vault = IS_LINUX ? await import('./vault-linux.mjs') : null;
+// Keychain account name — must match rotate.mjs convention.
+const ACTIVE_KEYCHAIN_ACCOUNT = 'unknown';
+const VAULT_KEYCHAIN_ACCOUNT = process.env.CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT || process.env.USER || 'claude-ops';
 
-// Keychain account name — must match rotate.mjs convention (macOS only).
-const KEYCHAIN_ACCOUNT =
-  process.env.CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT || process.env.USER || process.env.LOGNAME || 'claude-ops';
+const RECOVERY_STATUS_PATH = join(__dirname, '.bedrock-recovery-status.json');
+const USAGE_PROBE_CONCURRENCY = 3;
+const BEDROCK_RECOVERY_MIN_INTERVAL_MS = 25_000;
+const BEDROCK_RECOVERY_DEFAULT_INTERVAL_MS = 50_000;
+const BEDROCK_RECOVERY_MAX_INTERVAL_MS = 180_000;
 
-const POLL_INTERVAL = 15_000; // Check every 15s — fast enough to catch hook-triggered 429 signals (fireAt = now+15s)
+function writeRecoveryStatus(payload) {
+  try {
+    writeFileSync(RECOVERY_STATUS_PATH, JSON.stringify({ ...payload, written_at: new Date().toISOString() }, null, 2));
+  } catch {}
+}
 const RATE_LIMIT_COOLDOWN = 10_000; // 10s after rate limit before rotating
+const POLL_INTERVAL = 30_000; // 30s main-loop tick
 const POST_ROTATION_BLACKOUT = 180_000; // 3min after rotation: ignore ALL triggers
+// Hard anti-thrash cap: file-driven rotations limited to 1 per 2min. Explicit
+// 429 / 401 hooks bypass this (those are real-time signals from a tool failure
+// and cannot be stale). Without this, .rate-limits.json poisoning by stale-token
+// sessions caused 30+ rotations/hour against a cool active account (2026-05-06).
+const FILE_ROTATION_MIN_INTERVAL = 120_000;
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ── Exhausted-account park map ────────────────────────────────────────────────
+// Prevents rescue-loop thrashing on accounts stuck at >=95% for the full reset
+// window. Maps accountKey → epoch-ms timestamp before which the account is
+// "parked" (skipped for rescue). Reset automatically when the window resets.
+// In-memory only — intentionally resets on daemon restart so stale parks don't
+// persist across a full reset cycle.
+const PARK_THRESHOLD_PCT = 95; // park when max(5h,7d) >= this
+const _parkedUntil = new Map(); // accountKey → epoch-ms
+
+function isParked(key) {
+  const until = _parkedUntil.get(key);
+  if (!until) return false;
+  if (Date.now() >= until) {
+    _parkedUntil.delete(key);
+    return false;
+  }
+  return true;
+}
+
+function parkAccount(key, resetEpochSec, reason) {
+  // Park until reset time, with a 2-min buffer so the first poll after reset
+  // re-probes rather than immediately triggering. If no reset info, park for
+  // 10 minutes as a conservative fallback.
+  const resetMs = resetEpochSec ? resetEpochSec * 1000 + 2 * 60_000 : Date.now() + 10 * 60_000;
+  _parkedUntil.set(key, resetMs);
+  const minsUntil = Math.ceil((resetMs - Date.now()) / 60_000);
+  log(`[park] ${key} parked for ${minsUntil}min (${reason})`);
+}
 
 const MAX_LOG_SIZE = 50_000; // 50KB — ~500 lines, enough for debugging
 function log(msg) {
@@ -68,32 +126,76 @@ function notify(title, msg) {
     if (IS_LINUX) {
       spawnSync('notify-send', [title, msg], { timeout: 3000 });
     } else {
-      execFileSync(
-        'osascript',
-        [
-          '-e',
-          `display notification "${msg.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}" with title "${title.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`,
-        ],
-        { timeout: 5000 },
-      );
+      const escaped = msg.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      const titleEsc = title.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      spawnSync('osascript', ['-e', `display notification "${escaped}" with title "${titleEsc}"`], { timeout: 5000 });
     }
   } catch {}
 }
 
+// Cross-machine account leases (Sam 2026-06-06): NOT a static per-machine split.
+// Both machines may use ALL accounts; the only constraint is the same account is
+// never ACTIVE on both at once. readConfig() drops accounts a FOREIGN host holds
+// a fresh lease on; the loop heartbeats THIS machine's active-account lease.
+// Never drop our own active key. Fail-open. Mirror of rotate.mjs. See
+// account-leases.mjs for the S3 store + TTL semantics.
 function readConfig() {
-  return JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
-}
-function readState() {
+  const config = JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
+  let keepKey = null;
   try {
-    return JSON.parse(readFileSync(STATE_PATH, 'utf8'));
+    const st = JSON.parse(readFileSync(STATE_PATH, 'utf8'));
+    keepKey = st.activeAccount || null;
+  } catch {}
+  return applyAccountLeases(config, {
+    keepKey,
+    log: (m) => {
+      try {
+        log(m);
+      } catch {}
+    },
+  });
+}
+// Legacy account-key renames: old label → new canonical key.
+// Applied once per readState() call to keep state.json consistent as labels evolve.
+// Safe to run repeatedly (no-op when the old key doesn't exist).
+const STATE_KEY_MIGRATIONS = {
+  'heartfeldt-personal': 'heartfeldt', // label changed: personal org is now just "heartfeldt"
+};
+
+function readState() {
+  let state;
+  try {
+    state = JSON.parse(readFileSync(STATE_PATH, 'utf8'));
   } catch {
-    return {
-      activeAccount: null,
-      accounts: {},
-      toolUses: 0,
-      totalRotations: 0,
-    };
+    return { activeAccount: null, accounts: {}, toolUses: 0, totalRotations: 0 };
   }
+  // Apply key migrations: rename stale keys to canonical keys.
+  let migrated = false;
+  if (state.accounts) {
+    for (const [oldKey, newKey] of Object.entries(STATE_KEY_MIGRATIONS)) {
+      if (state.accounts[oldKey] && !state.accounts[newKey]) {
+        state.accounts[newKey] = state.accounts[oldKey];
+        delete state.accounts[oldKey];
+        migrated = true;
+        log(`[state-migration] renamed account key "${oldKey}" → "${newKey}"`);
+      } else if (state.accounts[oldKey]) {
+        // Both exist — drop the stale key, keep the newer canonical one.
+        delete state.accounts[oldKey];
+        migrated = true;
+        log(`[state-migration] dropped stale key "${oldKey}" (canonical "${newKey}" already exists)`);
+      }
+    }
+    if (state.activeAccount && STATE_KEY_MIGRATIONS[state.activeAccount]) {
+      state.activeAccount = STATE_KEY_MIGRATIONS[state.activeAccount];
+      migrated = true;
+    }
+  }
+  if (migrated) {
+    try {
+      writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+    } catch {}
+  }
+  return state;
 }
 
 // ── Account cooldown tracking ───────────────────────────────────────────────
@@ -129,6 +231,29 @@ function accountKey(a) {
   return a.label || a.email;
 }
 
+// account_email in .rate-limits.json is usually an email, while state.activeAccount
+// is the canonical key (label || email). Match both forms.
+function utilizationTagMatchesActive(tag, activeKey, accounts) {
+  if (!tag) return true;
+  if (tag === activeKey) return true;
+  const active = accounts.find((a) => accountKey(a) === activeKey);
+  return !!(active && tag === active.email);
+}
+
+function resolveAccountFromUtilizationTag(tag, config, activeKey) {
+  if (!tag) return getActiveAccount(config, activeKey);
+  const byKey = config.accounts.find((a) => accountKey(a) === tag);
+  if (byKey) return byKey;
+  const matches = config.accounts.filter((a) => a.email === tag);
+  if (matches.length === 1) return matches[0];
+  if (matches.length > 1) {
+    const notActive = matches.find((a) => accountKey(a) !== activeKey);
+    if (notActive) return notActive;
+    return matches[0];
+  }
+  return getActiveAccount(config, activeKey);
+}
+
 function tokenExpired(json) {
   try {
     const exp = JSON.parse(json)?.claudeAiOauth?.expiresAt;
@@ -140,21 +265,29 @@ function tokenExpired(json) {
   }
 }
 
+// Linux backend: tokens live in ~/.claude/.credentials.json keyed by service
+// name (mirrors rotate.mjs _linuxReadCred). The macOS `security` keychain only
+// exists on Darwin — without this branch every probe returned null tokens and
+// logged "skipped N expired-token" for all accounts on EC2.
+const IS_LINUX = process.platform === 'linux';
+const LINUX_CRED_PATH = join(process.env.HOME || '', '.claude', '.credentials.json');
+
 function readStoredToken(account) {
   const svc = `Claude-Rotation-${accountKey(account)}`;
   if (IS_LINUX) {
     try {
-      return _vault.readEntry(svc);
+      const store = JSON.parse(readFileSync(LINUX_CRED_PATH, 'utf8'));
+      const val = store[svc];
+      if (!val) return null;
+      return typeof val === 'string' ? val : JSON.stringify(val);
     } catch {
       return null;
     }
   }
   try {
-    const result = spawnSync('security', ['find-generic-password', '-s', svc, '-a', KEYCHAIN_ACCOUNT, '-g'], {
+    const out = execSync(`security find-generic-password -s "${svc}" -a "${VAULT_KEYCHAIN_ACCOUNT}" -g 2>&1`, {
       timeout: 5000,
-      encoding: 'utf8',
-    });
-    const out = (result.stdout || '') + (result.stderr || '');
+    }).toString();
     const m = out.match(/^password: "?(.*?)"?$/m);
     return m ? m[1].replace(/\\"/g, '"') : null;
   } catch {
@@ -165,18 +298,20 @@ function readStoredToken(account) {
 function readActiveKeychainToken() {
   if (IS_LINUX) {
     try {
-      return _vault.readEntry('Claude Code-credentials');
+      const store = JSON.parse(readFileSync(LINUX_CRED_PATH, 'utf8'));
+      if (!store.claudeAiOauth) return null;
+      return JSON.stringify({ claudeAiOauth: store.claudeAiOauth, mcpOAuth: store.mcpOAuth || {} });
     } catch {
       return null;
     }
   }
   try {
-    const r = spawnSync(
-      'security',
-      ['find-generic-password', '-s', 'Claude Code-credentials', '-a', KEYCHAIN_ACCOUNT, '-g'],
-      { encoding: 'utf8', timeout: 5000 },
-    );
-    const out = `${r.stdout || ''}${r.stderr || ''}`;
+    const out = execSync(
+      `security find-generic-password -s "Claude Code-credentials" -a "${ACTIVE_KEYCHAIN_ACCOUNT}" -g 2>&1`,
+      {
+        timeout: 5000,
+      },
+    ).toString();
     const m = out.match(/^password: "?(.*?)"?$/m);
     return m ? m[1].replace(/\\"/g, '"') : null;
   } catch {
@@ -220,7 +355,7 @@ async function detectLiveAccountFromVault(config) {
     const matches = config.accounts.filter((a) => a.email.toLowerCase() === liveEmail);
     if (matches.length === 1) return accountKey(matches[0]);
     if (matches.length > 1) {
-      // Multiple labels for same email (e.g. user-personal vs -team).
+      // Multiple labels for same email (e.g. heartfeldt vs heartfeldt-team).
       // Use orgName from profile to disambiguate.
       const orgName = body?.organization?.name?.toLowerCase() || '';
       const byOrg = matches.find((a) => (a.orgName || '').toLowerCase() === orgName);
@@ -235,7 +370,7 @@ async function detectLiveAccountFromVault(config) {
 // ── Real utilization from Anthropic (via statusline export) ──────────────────
 
 const RATE_LIMITS_FILE = join(__dirname, '.rate-limits.json');
-const UTILIZATION_ROTATE_THRESHOLD = 80; // Rotate at 80% — with 8+ concurrent sessions burning tokens fast, 95% was too late (hit 100% between statusline updates)
+const UTILIZATION_ROTATE_THRESHOLD = 95; // Rotate when near exhaustion
 
 function readRealUtilization() {
   try {
@@ -243,6 +378,21 @@ function readRealUtilization() {
     const data = JSON.parse(readFileSync(RATE_LIMITS_FILE, 'utf8'));
     const age = Date.now() - data.ts * 1000;
     if (age > 5 * 60_000) return null; // Stale (>5min) — session may be dead
+    // Anti-thrash A: discard reads that predate the most recent rotation (+60s
+    // buffer for statusline render lag) BUT ONLY when the file's tagged
+    // account matches the active. A mismatched-tag write (from a parallel
+    // session on a different account) is independently valid and must pass
+    // through so we can rescue that session before it 429s — see shouldRotate.
+    try {
+      const st = JSON.parse(readFileSync(STATE_PATH, 'utf8'));
+      const lastRotMs = st.lastRotation ? new Date(st.lastRotation).getTime() : 0;
+      let accounts = [];
+      try {
+        accounts = JSON.parse(readFileSync(CONFIG_PATH, 'utf8')).accounts || [];
+      } catch {}
+      const tagMatchesActive = utilizationTagMatchesActive(data.account_email, st.activeAccount, accounts);
+      if (tagMatchesActive && lastRotMs && data.ts * 1000 < lastRotMs + 60_000) return null;
+    } catch {}
     return data;
   } catch {
     return null;
@@ -313,9 +463,120 @@ function getActiveAccount(config, activeKey) {
 const AUTH_ERROR_FILE = join(tmpdir(), 'claude-auth-error.json');
 
 async function shouldRotate(config, state) {
+  // 0. Browser pin: claude-in-chrome requires CLI account == claude.ai login.
+  // While the PreToolUse hook holds a fresh .browser-pin sentinel, never rotate
+  // away — it would break the extension pairing mid-use. Short TTL (refreshed
+  // per browser tool call) bounds the window where a hot account can't rotate.
+  try {
+    const pinPath = join(__dirname, '.browser-pin');
+    if (existsSync(pinPath)) {
+      const pin = JSON.parse(readFileSync(pinPath, 'utf8'));
+      if (pin?.until && Date.now() < pin.until) {
+        return { should: false, reason: `browser-pinned to ${pin.email}` };
+      }
+      // Pin TTL lapsed — restore the pre-pin oauthAccount/chromeExtension
+      // blocks in ~/.claude.json so terminal Claude Code returns to the prior
+      // identity before any keychain swap below. Fire-and-forget; the daemon
+      // does not need to await the restore to make a rotation decision.
+      try {
+        const rotateScript = join(__dirname, 'rotate.mjs');
+        spawn('node', [rotateScript, '--release-browser-pin'], {
+          detached: true,
+          stdio: 'ignore',
+        }).unref();
+        log(`[browser-pin] TTL lapsed (was pinned to ${pin?.email || 'unknown'}) — release dispatched`);
+      } catch {}
+    }
+  } catch {}
+
   // 1. Real utilization from statusline (PRIMARY signal for rotation)
   const rl = checkRateLimited();
-  if (rl.limited) return { should: true, reason: `Rate limited: ${rl.reason}` };
+  if (rl.limited) {
+    // Anti-thrash A: confirm the trigger against the account that the
+    // statusline write was actually tagged for. Two paths:
+    //   1. Tag matches active (or absent) → verify active's live util.
+    //      If active is fine, file is stale/poisoned — skip + unlink.
+    //   2. Tag is a DIFFERENT account → that's a parallel Claude Code
+    //      session reporting its own saturation. Live-probe THAT account
+    //      via vault token. If confirmed hot → rotate (rescues the hot
+    //      session via keychain swap; Claude Code re-reads keychain per
+    //      request). If not confirmed hot → silently discard.
+    const taggedEmail = rl.utilization?.account_email;
+    const isMismatched = taggedEmail && !utilizationTagMatchesActive(taggedEmail, state.activeAccount, config.accounts);
+    const probeAccount = isMismatched
+      ? resolveAccountFromUtilizationTag(taggedEmail, config, state.activeAccount)
+      : getActiveAccount(config, state.activeAccount);
+    if (probeAccount) {
+      const probeKey = accountKey(probeAccount);
+
+      // Park check: if this account is already known-exhausted and parked until
+      // its reset window, skip the rescue entirely — don't re-probe live API
+      // every 30s just to confirm it's still at 100%.
+      if (isParked(probeKey) && isMismatched) {
+        const until = _parkedUntil.get(probeKey);
+        const minsLeft = Math.ceil((until - Date.now()) / 60_000);
+        log(`[park] ${probeKey} is parked for ${minsLeft}min more — suppressing rescue trigger`);
+        return { should: false };
+      }
+
+      const live = await queryLiveUtilization(probeAccount);
+      if (live.ok) {
+        const triggered7d = /7d utilization/.test(rl.reason);
+        const triggered5h = /5h utilization/.test(rl.reason);
+        const overProbed =
+          (triggered5h && live.pct5h >= UTILIZATION_ROTATE_THRESHOLD) ||
+          (triggered7d && live.pct7d >= UTILIZATION_ROTATE_THRESHOLD);
+        if (!overProbed) {
+          if (!isMismatched) {
+            log(
+              `[anti-thrash] file says ${rl.reason} but active ${state.activeAccount} live 5h=${live.pct5h}% 7d=${live.pct7d}% — skipping (stale .rate-limits.json)`,
+            );
+            try {
+              unlinkSync(RATE_LIMITS_FILE);
+            } catch {}
+          }
+          // Mismatched + not hot = just a low-util parallel session; silent skip.
+          return { should: false };
+        }
+        if (isMismatched) {
+          // If the mismatched account is fully exhausted (>=PARK_THRESHOLD_PCT),
+          // park it so we don't rescue-loop on every 30s tick. The keychain
+          // swap won't help — there's nowhere to rotate TO for that session.
+          const liveMax = Math.max(live.pct5h, live.pct7d);
+          if (liveMax >= PARK_THRESHOLD_PCT) {
+            // Prefer the 5h reset (shorter) so the park clears as soon as possible.
+            const resetEpoch = live.reset5h || live.reset7d || null;
+            parkAccount(
+              probeKey,
+              resetEpoch,
+              `live ${liveMax.toFixed(0)}% >= ${PARK_THRESHOLD_PCT}% exhausted (5h=${live.pct5h.toFixed(0)}% 7d=${live.pct7d.toFixed(0)}%)`,
+            );
+            return { should: false };
+          }
+          log(
+            `[multi-session] parallel session on ${probeKey} (${taggedEmail}) is hot (live 5h=${live.pct5h}% 7d=${live.pct7d}%) — rotating keychain to rescue`,
+          );
+        }
+      }
+    }
+    // Anti-thrash B: hard rate-cap on UTILIZATION-driven rotations regardless
+    // of verification outcome (covers live-query failures). Explicit 429
+    // signals from the rate-limit-detector hook bypass — they're real-time
+    // ground truth and cannot be poisoned by a stale-token session.
+    const isUtilizationTrigger = /utilization/.test(rl.reason);
+    if (isUtilizationTrigger) {
+      const lastRotMs = state.lastRotation ? new Date(state.lastRotation).getTime() : 0;
+      const sinceLast = Date.now() - lastRotMs;
+      if (lastRotMs && sinceLast < FILE_ROTATION_MIN_INTERVAL) {
+        const remaining = Math.ceil((FILE_ROTATION_MIN_INTERVAL - sinceLast) / 1000);
+        log(
+          `[anti-thrash] utilization-rotation cap: skipping "${rl.reason}" (last rotation ${Math.floor(sinceLast / 1000)}s ago, ${remaining}s until cap clears)`,
+        );
+        return { should: false };
+      }
+    }
+    return { should: true, reason: `Rate limited: ${rl.reason}` };
+  }
 
   // 2. Auth error signal (401) from PostToolUseFailure hook
   try {
@@ -343,24 +604,61 @@ async function shouldRotate(config, state) {
       log('[active-refresh] Active token expiring — attempting in-place refresh');
       const refreshed = await refreshSingleToken(account);
       if (refreshed) {
-        // Also update the active credential store so running sessions pick it up on next /login
+        // Also update the active keychain so running sessions pick it up on next /login
+        // Merge mcpOAuth from the current active keychain before overwriting — vault
+        // tokens have mcpOAuth:{} stripped by design; without this merge the active
+        // keychain loses all MCP OAuth tokens (giga, Amplitude, higgsfield) on every
+        // in-place refresh, forcing CC to re-auth them on the next session launch.
         try {
           const freshToken = readStoredToken(account);
           if (freshToken) {
             const svc = 'Claude Code-credentials';
+            let tokenToWrite = freshToken;
+            try {
+              // Use readActiveKeychainToken() — already platform-aware (macOS
+              // security(1) on darwin, file vault on Linux). Avoids require()
+              // which is not available in ESM modules.
+              const currentRaw = readActiveKeychainToken();
+              if (currentRaw) {
+                const currentParsed = JSON.parse(currentRaw);
+                const freshParsed = JSON.parse(freshToken);
+                if (currentParsed.mcpOAuth) {
+                  freshParsed.mcpOAuth = { ...freshParsed.mcpOAuth, ...currentParsed.mcpOAuth };
+                }
+                tokenToWrite = JSON.stringify(freshParsed);
+              }
+            } catch (_mergeErr) {
+              /* merge failed — fall through to raw write */
+            }
+            // Write via platform-aware path: Linux credentials file or macOS keychain.
             if (IS_LINUX) {
-              _vault.writeEntry(svc, freshToken);
+              // On Linux the active token lives in LINUX_CRED_PATH as a flat
+              // JSON object. Merge the updated token into it preserving any
+              // other fields (mcpOAuth, etc.) already present in the file.
+              try {
+                let existing = {};
+                try {
+                  existing = JSON.parse(readFileSync(LINUX_CRED_PATH, 'utf8'));
+                } catch {}
+                const merged = { ...existing, ...JSON.parse(tokenToWrite) };
+                writeFileSync(LINUX_CRED_PATH, JSON.stringify(merged, null, 2), { mode: 0o600 });
+              } catch (_writeErr) {
+                /* non-fatal — best-effort */
+              }
             } else {
-              execFileSync(
+              // macOS: use spawnSync (no shell, no injection) instead of execSync.
+              spawnSync(
                 'security',
-                ['add-generic-password', '-U', '-s', svc, '-a', KEYCHAIN_ACCOUNT, '-w', freshToken],
-                { timeout: 5000 },
+                ['add-generic-password', '-U', '-s', svc, '-a', ACTIVE_KEYCHAIN_ACCOUNT, '-w', tokenToWrite],
+                {
+                  timeout: 5000,
+                },
               );
             }
-            log('[active-refresh] Active credentials updated — sessions will auto-recover');
+            log('[active-refresh] Active keychain updated with mcpOAuth preserved — sessions will auto-recover');
           }
         } catch (err) {
-          log(`[active-refresh] Credential update failed: ${err.message?.substring(0, 60)}`);
+          log(`[active-refresh] Keychain update failed: ${err.message?.substring(0, 60)}`);
         }
         return { should: false }; // Refreshed in-place, no rotation needed
       }
@@ -374,14 +672,16 @@ async function shouldRotate(config, state) {
 
 // ── Execute rotation ──────────────────────────────────────────────────────────
 
-// Fetch live 5h/7d utilization for one account (no cache). Returns
-// {pct5h, pct7d} or null on failure. Cheap — single GET, 4s timeout.
+// Fetch live 5h/7d utilization for one account. Returns:
+//   { ok: true, pct5h, pct7d, reset5h, reset7d } | { ok: false, rateLimited?: true }
+// reset* fields are epoch seconds for the window reset; null when the API
+// omits resets_at (e.g. fresh windows below reporting threshold).
 async function queryLiveUtilization(account) {
   try {
     const tokenJson = readStoredToken(account);
-    if (!tokenJson) return null;
+    if (!tokenJson) return { ok: false };
     const accessToken = JSON.parse(tokenJson)?.claudeAiOauth?.accessToken;
-    if (!accessToken) return null;
+    if (!accessToken) return { ok: false };
     const res = await fetch('https://api.anthropic.com/api/oauth/usage', {
       method: 'GET',
       headers: {
@@ -390,22 +690,33 @@ async function queryLiveUtilization(account) {
       },
       signal: AbortSignal.timeout(4000),
     });
-    if (!res.ok) return null;
+    if (res.status === 429) return { ok: false, rateLimited: true };
+    if (!res.ok) return { ok: false };
     const data = await res.json();
+    // resets_at comes back as ISO 8601 string — convert to epoch seconds so
+    // it matches state.accounts[].lastUtilization.reset format (numeric)
+    // used by accountCooldownStatus and findValidRotationTarget.
+    const toEpoch = (v) => {
+      if (v == null) return null;
+      if (typeof v === 'number') return v;
+      const parsed = Date.parse(v);
+      return Number.isFinite(parsed) ? Math.floor(parsed / 1000) : null;
+    };
     return {
-      pct5h: data?.five_hour?.utilization || 0,
-      pct7d: data?.seven_day?.utilization || 0,
+      ok: true,
+      pct5h: data?.five_hour?.utilization ?? 0,
+      pct7d: data?.seven_day?.utilization ?? 0,
+      reset5h: toEpoch(data?.five_hour?.resets_at),
+      reset7d: toEpoch(data?.seven_day?.resets_at),
     };
   } catch {
-    return null;
+    return { ok: false };
   }
 }
 
 async function findValidRotationTarget(config, state) {
   const now = Date.now();
   const activeKey = state.activeAccount;
-  const SAFE_UTIL_5H_PCT = 70; // 5h window is what we rotate around — strict
-  const SAFE_UTIL_7D_PCT = 95; // 7d resets weekly — only hard-skip if truly capped
 
   // Build candidate list: all accounts except the active one AND disabled ones.
   const candidates = config.accounts.filter((a) => accountKey(a) !== activeKey && a.disabled !== true);
@@ -452,14 +763,18 @@ async function findValidRotationTarget(config, state) {
     // Live util check — never rotate to a high-utilization account.
     // The cached snapshot may be stale (e.g. lic had pct:0 but live was 100%).
     const live = await queryLiveUtilization(account);
-    if (live) {
-      const max = Math.max(live.pct5h, live.pct7d);
-      const tooHot5h = live.pct5h >= SAFE_UTIL_5H_PCT;
-      const tooHot7d = live.pct7d >= SAFE_UTIL_7D_PCT;
+    if (live?.rateLimited) {
+      log(`[pre-rotate] ${key}: usage API 429 — skipping this candidate this pass`);
+      continue;
+    }
+    if (isLiveUtilOk(live)) {
+      const max = liveUtilMax(live);
+      const tooHot5h = live.pct5h >= DAEMON_SAFE_5H_PCT;
+      const tooHot7d = live.pct7d >= DAEMON_SAFE_7D_PCT;
       if (tooHot5h || tooHot7d) {
         const reason = tooHot5h
-          ? `5h ${live.pct5h.toFixed(0)}% >= ${SAFE_UTIL_5H_PCT}%`
-          : `7d ${live.pct7d.toFixed(0)}% >= ${SAFE_UTIL_7D_PCT}%`;
+          ? `5h ${live.pct5h.toFixed(0)}% >= ${DAEMON_SAFE_5H_PCT}%`
+          : `7d ${live.pct7d.toFixed(0)}% >= ${DAEMON_SAFE_7D_PCT}%`;
         log(
           `[pre-rotate] ${key}: live util 5h=${live.pct5h.toFixed(0)}% 7d=${live.pct7d.toFixed(0)}% — skipping (${reason})`,
         );
@@ -475,13 +790,176 @@ async function findValidRotationTarget(config, state) {
       }
       log(`[pre-rotate] ${key}: live util 5h=${live.pct5h.toFixed(0)}% 7d=${live.pct7d.toFixed(0)}% — OK`);
     } else {
-      log(`[pre-rotate] ${key}: live util query failed — accepting anyway`);
+      // Live query failed (Anthropic 429 or network). DO NOT accept blindly —
+      // that's how we picked an exhausted account and bricked Sam's session.
+      // Fall back to cached util; refuse if cached is unknown OR >=90%.
+      const cached = state.accounts?.[key]?.lastUtilization;
+      const cachedPct = cached?.pct;
+      const cachedAge = cached?.ts ? (now - cached.ts) / 60_000 : Infinity;
+      if (cachedPct == null) {
+        log(`[pre-rotate] ${key}: live query FAILED + no cache — REFUSING`);
+        continue;
+      }
+      if (cachedPct >= 90) {
+        log(
+          `[pre-rotate] ${key}: live query FAILED + cached ${cachedPct.toFixed(0)}% (${cachedAge.toFixed(0)}min old) — REFUSING`,
+        );
+        continue;
+      }
+      if (cachedAge > 30) {
+        log(`[pre-rotate] ${key}: live query FAILED + cache stale (${cachedAge.toFixed(0)}min) — REFUSING (safety)`);
+        continue;
+      }
+      log(
+        `[pre-rotate] ${key}: live query failed but cached ${cachedPct.toFixed(0)}% (${cachedAge.toFixed(0)}min old) — accepting`,
+      );
     }
 
     return account;
   }
 
+  // SECOND PASS: strict bar (70%/95%) excluded everyone. Try a relaxed bar
+  // (94%/94%) so we still rotate to "warm but not exhausted" rather than
+  // stalling. Only Bedrock fallback when even the relaxed bar fails.
+  log('[pre-rotate] strict-bar pass empty — trying relaxed (sub-95%) bar');
+  for (const account of candidates) {
+    const key = accountKey(account);
+    const tokenJson = readStoredToken(account);
+    if (!tokenJson) continue;
+    const live = await queryLiveUtilization(account);
+    if (!isLiveUtilOk(live)) continue;
+    const max = liveUtilMax(live);
+    if (max < DAEMON_RELAXED_BAR) {
+      log(`[pre-rotate-relaxed] ${key}: 5h=${live.pct5h.toFixed(0)}% 7d=${live.pct7d.toFixed(0)}% — accepting`);
+      return account;
+    }
+  }
   return null; // No valid candidate found
+}
+
+// Exhaustion check across ALL non-active, non-disabled accounts.
+// Two acceptance modes:
+//   1. LIVE-confirmed: every candidate live-queried >= 95% (preferred).
+//   2. CACHED-evidence: when API is throttling us (live fails) BUT every
+//      candidate has fresh (<15min) cached util >= 95% AND a recent rate-limit
+//      signal exists, we accept cached evidence — refusing to fall back when
+//      Anthropic API is dead would just leave Sam stuck.
+async function allCandidatesExhausted(config, state) {
+  const EXHAUSTED_THRESHOLD = 95;
+  const now = Date.now();
+  const activeKey = state.activeAccount;
+  const candidates = config.accounts.filter((a) => accountKey(a) !== activeKey && a.disabled !== true);
+  if (candidates.length === 0) return false;
+
+  let liveOk = true;
+  let allLiveExhausted = true;
+  for (const a of candidates) {
+    const live = await queryLiveUtilization(a);
+    if (!isLiveUtilOk(live)) {
+      liveOk = false;
+      break;
+    }
+    if (Math.max(live.pct5h, live.pct7d) < EXHAUSTED_THRESHOLD) {
+      allLiveExhausted = false;
+      break;
+    }
+  }
+  if (liveOk && allLiveExhausted) return true;
+
+  // CACHED fallback: only when we have recent rate-limit evidence
+  let recentRateLimit = false;
+  try {
+    if (existsSync(RATE_LIMITS_FILE)) {
+      const rl = JSON.parse(readFileSync(RATE_LIMITS_FILE, 'utf8'));
+      const rlMs = rl.timestamp ? new Date(rl.timestamp).getTime() : (rl.ts || 0) * 1000;
+      const age = now - rlMs;
+      if (age < 5 * 60_000) recentRateLimit = true;
+    }
+  } catch {}
+  if (!recentRateLimit) return false;
+
+  // All cached >=95% AND fresh? Then we're truly stuck.
+  for (const a of candidates) {
+    const cached = state.accounts?.[accountKey(a)]?.lastUtilization;
+    if (!cached?.pct || !cached?.ts) return false;
+    if (now - cached.ts > 15 * 60_000) return false;
+    if (cached.pct < EXHAUSTED_THRESHOLD) return false;
+  }
+  log(
+    '[allCandidatesExhausted] cached-evidence path: live unreachable but cached + rate-limit signal confirm exhaustion',
+  );
+  return true;
+}
+
+function stopClaudeDaemon() {
+  log('[daemon-stop] Stopping Claude daemon to clear cached environment...');
+  try {
+    const result = execSync('claude daemon stop --any', {
+      encoding: 'utf8',
+      env: { ...process.env, PATH: process.env.PATH || '/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin' }
+    });
+    log(`[daemon-stop] Daemon stop success: ${result.trim()}`);
+  } catch (err) {
+    log(`[daemon-stop] Daemon stop failed: ${err.message}`);
+  }
+}
+
+// Activate Bedrock fallback from inside daemon. Probes AWS reachability,
+// writes the sentinel + sends a desktop notification. Returns true on success.
+function activateBedrockFallbackFromDaemon(reason) {
+  // disabled 2026-05-08 — Max plan handles this, see audit ($600-1.2k/mo bleed via Bedrock)
+  // Set CLAUDE_DISABLE_BEDROCK_FALLBACK=0 in launchd plist to re-enable.
+  if (process.env.CLAUDE_DISABLE_BEDROCK_FALLBACK !== '0') {
+    log(`[bedrock-fallback] BLOCKED by CLAUDE_DISABLE_BEDROCK_FALLBACK (reason was: ${reason})`);
+    notify('Bedrock Fallback BLOCKED', 'Kill-switch active — Max-only mode. Wait for reset window or rotate manually.');
+    return false;
+  }
+  const region = process.env.AWS_BEDROCK_REGION || 'us-east-1';
+  try {
+    execFileSync('aws', ['sts', 'get-caller-identity', '--output', 'json'], {
+      stdio: 'pipe',
+      timeout: 5000,
+    });
+    execFileSync('aws', ['bedrock', 'list-inference-profiles', '--region', region, '--max-results', '1'], {
+      stdio: 'pipe',
+      timeout: 6000,
+    });
+  } catch (e) {
+    log(`[bedrock-fallback] AWS unreachable: ${(e.message || '').slice(0, 80)}`);
+    notify('Bedrock Fallback FAILED', 'aws sts/bedrock unreachable — manual intervention needed');
+    return false;
+  }
+  try {
+    const sentinel = join(process.env.HOME || '', '.claude', '.bedrock-fallback.json');
+    const payload = {
+      activated_at: new Date().toISOString(),
+      reason,
+      region,
+      available: true,
+      activated_by: 'daemon',
+    };
+    writeFileSync(sentinel, JSON.stringify(payload, null, 2));
+    try {
+      persistBedrockClaudeSettings(region);
+      log(`[bedrock-fallback] settings.json → Bedrock env (${region})`);
+    } catch (e) {
+      log(`[bedrock-fallback] settings persist failed: ${e.message?.slice(0, 80)}`);
+    }
+    try {
+      stopClaudeDaemon();
+    } catch (e) {
+      log(`[bedrock-fallback] stopClaudeDaemon failed: ${e.message}`);
+    }
+    log(`[bedrock-fallback] ACTIVATED region=${region} reason=${reason}`);
+    notify(
+      'Bedrock Fallback Active',
+      `Max rotation stuck — settings.json → Bedrock (${region}). New shells pick it up; optional: source use-bedrock.sh`,
+    );
+    return true;
+  } catch (e) {
+    log(`[bedrock-fallback] write error: ${e.message?.slice(0, 80)}`);
+    return false;
+  }
 }
 
 async function doRotation(reason) {
@@ -522,8 +1000,40 @@ async function doRotation(reason) {
   const target = await findValidRotationTarget(config, state);
 
   if (!target) {
-    log('ROTATION ABORTED: no candidate has a valid or refreshable token');
-    notify('Account Rotation', 'ABORTED — all candidate tokens expired/invalid');
+    log('ROTATION ABORTED: no viable Max target after pre-rotate (util bars, tokens, or live query refusals)');
+    // Live-confirm exhaustion before flipping to Bedrock — Sam's rule.
+    const exhausted = await allCandidatesExhausted(config, state);
+    if (exhausted) {
+      log('All candidates LIVE-CONFIRMED exhausted (>=95%) — engaging Bedrock fallback');
+      activateBedrockFallbackFromDaemon(`auto_rotation: ${reason}`);
+      return;
+    }
+    // Same as rotate.mjs --force: destination cap stuck (e.g. every non-active >=90%)
+    // leaves OAuth tokens valid but no swap target — daemon must flip Bedrock without manual rotate-magic.
+    let rec = null;
+    try {
+      const r = spawnSync(process.execPath, [ROTATE_SCRIPT, '--recommend', '--json'], {
+        cwd: __dirname,
+        encoding: 'utf8',
+        maxBuffer: 2_000_000,
+        env: { ...process.env, NODE_NO_WARNINGS: '1' },
+        timeout: 90_000,
+      });
+      if (r.stdout?.trim()) {
+        rec = JSON.parse(r.stdout.trim());
+      }
+    } catch (e) {
+      log(`[bedrock-eval] --recommend --json parse/exec failed: ${(e.message || '').slice(0, 100)}`);
+    }
+    if (rec && (rec.destinationCapStuck === true || rec.allExhausted === true)) {
+      const label = rec.allExhausted ? 'allExhausted' : 'destinationCapStuck';
+      log(
+        `[bedrock-eval] recommend JSON confirms ${label} (destCap=${rec.destinationMaxUtilPercent ?? '?'}) — engaging Bedrock fallback`,
+      );
+      activateBedrockFallbackFromDaemon(`auto_rotation_${label}: ${reason}`);
+      return;
+    }
+    notify('Account Rotation', 'ABORTED — no Max headroom; Bedrock not confirmed (check tokens / live util queries)');
     return;
   }
 
@@ -534,26 +1044,16 @@ async function doRotation(reason) {
   try {
     // --no-browser: no Chrome, no API calls (works when rate limited)
     // --to: daemon controls which account to rotate to (pre-validated token)
-    // Two re-auth strategies, targeting DISJOINT session classes (best practice:
-    // detached headless sessions cannot be steered via `--resume --print`, so they
-    // must be respawned; live TTY sessions can take a direct /login injection):
-    //   --reload-agents → sequentially respawn running *detached* bg agents (no TTY,
-    //     no human mid-keystroke) onto the fresh token. Sequential + 15s stagger;
-    //     max 4/invocation (anti-stampede).
-    //   --session → inject /login into live TTY-reachable sessions (tmux panes +
-    //     iTerm2) plus a best-effort resume-path for non-tmux interactive sessions,
-    //     so they re-auth immediately instead of failing at the auth wall.
-    // refreshRunningSession explicitly skips bg sessions (they auto-reauth via the
-    // 30s keychain poll), so the two flags never double-act on the same session.
-    const result = execFileSync(
-      process.execPath,
-      [ROTATE_SCRIPT, '--no-browser', '--to', targetKey, '--reload-agents', '--session'],
-      {
-        cwd: __dirname,
-        timeout: 240_000, // 120s swap + up to 4×15s reload stagger + session inject; headroom
-        env: { ...process.env, NODE_NO_WARNINGS: '1' },
-      },
-    ).toString();
+    // NO --session: keychain swap only. Background rotation must NEVER inject /login
+    // into running sessions — that interrupts active work. Sessions pick up the new
+    // token on next 401 (auto-retry) or when the user voluntarily runs /login.
+    // execFileSync (not execSync) — no shell, no injection risk on targetKey.
+    const result = execFileSync('node', [ROTATE_SCRIPT, '--no-browser', '--to', targetKey], {
+      cwd: __dirname,
+      timeout: 120_000, // 2min — keychain swap is fast; no per-session injection
+      env: { ...process.env, NODE_NO_WARNINGS: '1' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).toString();
     log(`Rotation result: ${result.substring(0, 200)}`);
   } catch (err) {
     log(`Rotation failed: ${err.message}`);
@@ -561,11 +1061,50 @@ async function doRotation(reason) {
   }
 }
 
-// ── Token refresh (vault entries) ───────────────────────────────────────────
-// In-place refresh via OAuth; invoked from shouldRotate / findValidRotationTarget.
+// ── Auto-sync: detect if live auth drifted from state ────────────────────────
+
+function syncDriftedState(state, config, lastRotatedAt = 0) {
+  // After a rotation, `claude auth status` still returns the OLD session's email
+  // until the user restarts Claude Code. Don't undo the rotation by "correcting"
+  // state back to the stale live email — wait for the blackout to pass.
+  // Use the shared state.lastRotation (written by rotate.mjs) so duplicate daemon
+  // instances both respect the blackout, even if one of them didn't do the rotation.
+  const stateLastRotation = state.lastRotation ? new Date(state.lastRotation).getTime() : 0;
+  const effectiveLastRotation = Math.max(lastRotatedAt, stateLastRotation);
+  if (effectiveLastRotation && Date.now() - effectiveLastRotation < POST_ROTATION_BLACKOUT) return false;
+
+  try {
+    const liveAuth = execSync('claude auth status 2>&1', {
+      timeout: 5_000,
+    }).toString();
+    const liveEmail = JSON.parse(liveAuth)?.email;
+    if (!liveEmail) return false;
+
+    const liveKey = config.accounts.find((a) => a.email === liveEmail);
+    if (!liveKey) return false;
+
+    const liveAccountKey = accountKey(liveKey);
+    if (state.activeAccount !== liveAccountKey) {
+      log(
+        `⚠️ DRIFT DETECTED: state says ${state.activeAccount || 'none'}, live auth is ${liveAccountKey} — syncing state`,
+      );
+      state.activeAccount = liveAccountKey;
+      writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+      return true; // Drift was corrected
+    }
+  } catch {}
+  return false;
+}
+
+// ── Dynamic token refresh ────────────────────────────────────────────────────
+// Instead of a fixed hourly launchd job refreshing all accounts, refresh
+// on-demand: when utilization is climbing (50%+), pre-refresh candidate
+// accounts so they're ready for rotation. Also refresh any token within
+// 1h of expiry regardless of utilization.
 
 const TOKEN_ENDPOINT = 'https://platform.claude.com/v1/oauth/token';
-const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e'; // gitleaks:allow — public OAuth client ID, not a secret
+const REFRESH_URGENCY_MS = 1 * 3_600_000; // Refresh if <1h remaining
 
 function parseTokenExpiry(tokenJson) {
   try {
@@ -600,7 +1139,6 @@ async function refreshSingleToken(account) {
         refresh_token: refreshToken,
         client_id: OAUTH_CLIENT_ID,
       }),
-      signal: AbortSignal.timeout(5000),
     });
     const body = await res.json();
     if (!res.ok || !body.access_token) return false;
@@ -610,14 +1148,26 @@ async function refreshSingleToken(account) {
     if (body.refresh_token) parsed.claudeAiOauth.refreshToken = body.refresh_token;
     parsed.claudeAiOauth.expiresAt = body.expires_in ? Date.now() + body.expires_in * 1000 : Date.now() + 8 * 3_600_000;
 
-    // Save back to vault
+    // Save back to vault — platform-aware (Linux: credentials file; macOS: Keychain)
     const svc = `Claude-Rotation-${key}`;
-    // Use execFileSync to avoid shell-escaping issues with JSON tokens
-    execFileSync(
-      'security',
-      ['add-generic-password', '-U', '-s', svc, '-a', KEYCHAIN_ACCOUNT, '-w', JSON.stringify(parsed)],
-      { timeout: 5000 },
-    );
+    const tokenStr = JSON.stringify(parsed);
+    if (IS_LINUX) {
+      try {
+        let store = {};
+        try {
+          store = JSON.parse(readFileSync(LINUX_CRED_PATH, 'utf8'));
+        } catch {}
+        store[svc] = tokenStr;
+        writeFileSync(LINUX_CRED_PATH, JSON.stringify(store, null, 2), { mode: 0o600 });
+      } catch (writeErr) {
+        throw new Error(`Linux vault write failed: ${writeErr.message}`);
+      }
+    } else {
+      // Use spawnSync (no shell) to avoid injection risk on tokenStr.
+      spawnSync('security', ['add-generic-password', '-U', '-s', svc, '-a', VAULT_KEYCHAIN_ACCOUNT, '-w', tokenStr], {
+        timeout: 5000,
+      });
+    }
     log(
       `[refresh] ${key}: refreshed (${((parsed.claudeAiOauth.expiresAt - Date.now()) / 3_600_000).toFixed(1)}h remaining)`,
     );
@@ -628,15 +1178,268 @@ async function refreshSingleToken(account) {
   }
 }
 
+async function dynamicRefresh(config, state) {
+  const now = Date.now();
+  const real = readRealUtilization();
+  const pct5h = real?.five_hour?.pct || 0;
+
+  for (const account of config.accounts) {
+    const key = accountKey(account);
+    if (key === state.activeAccount) continue; // Don't refresh active account mid-session
+
+    const tokenJson = readStoredToken(account);
+    if (!tokenJson) continue;
+    const expiry = parseTokenExpiry(tokenJson);
+    const remaining = expiry - now;
+
+    // Refresh if: token expiring within 1h, OR utilization >50% and token <3h
+    const urgent = remaining > 0 && remaining < REFRESH_URGENCY_MS;
+    const preemptive = pct5h >= 50 && remaining > 0 && remaining < 3 * 3_600_000;
+
+    if (urgent || preemptive) {
+      await refreshSingleToken(account);
+      await sleep(2000); // Don't hammer the token endpoint
+    }
+  }
+}
+
+/** Lowest cached util + reset-window first — fastest path to a cooled account. */
+function prioritizeAccountsForRecovery(state, accounts) {
+  const now = Date.now();
+  return [...accounts].sort((a, b) => {
+    const ua = state.accounts?.[accountKey(a)]?.lastUtilization;
+    const ub = state.accounts?.[accountKey(b)]?.lastUtilization;
+    const ra = ua?.pct == null ? 999 : ua.pct;
+    const rb = ub?.pct == null ? 999 : ub.pct;
+    if (ra !== rb) return ra - rb;
+    const wA = ua?.reset && ua.reset * 1000 < now ? 0 : 1;
+    const wB = ub?.reset && ub.reset * 1000 < now ? 0 : 1;
+    if (wA !== wB) return wA - wB;
+    return (ua?.ts ?? 0) - (ub?.ts ?? 0);
+  });
+}
+
+/**
+ * When Bedrock sentinel exists: probe prioritized accounts (parallel batches),
+ * same viability bars as pre-rotate. Adaptive interval + 429 backoff.
+ */
+async function maybeRecoverOAuthFromBedrock(config, state, sentinelPath, ctx) {
+  const now = Date.now();
+  if (now < ctx.backoffUntil) {
+    writeRecoveryStatus({ phase: 'backoff', until: ctx.backoffUntil });
+    return { didRecover: false };
+  }
+  if (now - ctx.lastCheck < ctx.intervalMs) return { didRecover: false };
+  ctx.lastCheck = now;
+
+  const withTokens = config.accounts
+    .filter((a) => a.disabled !== true)
+    .filter((a) => {
+      const t = readStoredToken(a);
+      return t && !tokenExpired(t);
+    });
+  if (withTokens.length === 0) {
+    log('[bedrock-recovery] no non-expired vault tokens — skip probe batch');
+    writeRecoveryStatus({ phase: 'no_tokens', probed: [] });
+    ctx.intervalMs = Math.min(BEDROCK_RECOVERY_MAX_INTERVAL_MS, Math.floor((ctx.intervalMs || 60_000) * 1.12));
+    return { didRecover: false };
+  }
+
+  const ordered = prioritizeAccountsForRecovery(state, withTokens);
+  const maxAccounts = Math.min(ordered.length, 8);
+  const cap = Math.max(1, Math.min(ctx.concurrency || USAGE_PROBE_CONCURRENCY, USAGE_PROBE_CONCURRENCY));
+  let saw429 = false;
+  /** @type {{ key: string, ok?: boolean, rateLimited?: boolean }[]} */
+  const rows = [];
+  let maxLiveUtil = 0;
+
+  for (let i = 0; i < maxAccounts; i += cap) {
+    const slice = ordered.slice(i, i + cap);
+    const results = await Promise.all(
+      slice.map(async (acct) => {
+        const live = await queryLiveUtilization(acct);
+        return { acct, live };
+      }),
+    );
+    for (const { acct, live } of results) {
+      const probeKey = accountKey(acct);
+      if (live?.rateLimited) saw429 = true;
+      rows.push({ key: probeKey, ok: isLiveUtilOk(live), rateLimited: live?.rateLimited === true });
+      if (isLiveUtilOk(live)) {
+        const max = liveUtilMax(live);
+        maxLiveUtil = Math.max(maxLiveUtil, max);
+        state.accounts = state.accounts || {};
+        state.accounts[probeKey] = state.accounts[probeKey] || {};
+        state.accounts[probeKey].lastUtilization = { pct: max, reset: null, ts: Date.now() };
+        log(`[bedrock-recovery] probe ${probeKey}: 5h=${live.pct5h.toFixed(0)}% 7d=${live.pct7d.toFixed(0)}%`);
+        if (isDaemonRotationViable(live)) {
+          const tokenJson = readStoredToken(acct);
+          if (tokenJson && !tokenExpired(tokenJson)) {
+            log(
+              `[bedrock-recovery] ${probeKey} viable (daemon 5h<${DAEMON_SAFE_5H_PCT}% & 7d<${DAEMON_SAFE_7D_PCT}%) — exiting Bedrock fallback`,
+            );
+            try {
+              unlinkSync(sentinelPath);
+            } catch {}
+            try {
+              clearHardcodedModelsForOAuthClaudeSettings();
+              log('[bedrock-recovery] settings.json → OAuth (hardcoded models cleared)');
+            } catch (e) {
+              log(`[bedrock-recovery] settings clear failed: ${e.message?.slice(0, 80)}`);
+            }
+            try {
+              stopClaudeDaemon();
+            } catch (e) {
+              log(`[bedrock-recovery] stopClaudeDaemon failed: ${e.message}`);
+            }
+            notify(
+              'OAuth Restored',
+              `${probeKey} has Max headroom — settings.json OAuth; Bedrock shells: source use-oauth.sh`,
+            );
+            try {
+              writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+            } catch {}
+            if (state.activeAccount !== probeKey) {
+              await doRotation(`bedrock-recovery: ${probeKey} viable Max headroom`);
+            }
+            ctx.intervalMs = BEDROCK_RECOVERY_DEFAULT_INTERVAL_MS;
+            ctx.concurrency = USAGE_PROBE_CONCURRENCY;
+            ctx.backoffUntil = 0;
+            writeRecoveryStatus({ phase: 'recovered', account: probeKey, probed: rows });
+            return { didRecover: true };
+          }
+          log(`[bedrock-recovery] ${probeKey} util OK but token missing/expired — staying on Bedrock`);
+        }
+      }
+    }
+    if (i + cap < maxAccounts) await sleep(90 + Math.floor(Math.random() * 110));
+  }
+
+  try {
+    writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+  } catch {}
+
+  if (saw429) {
+    ctx.backoffUntil = Date.now() + 50_000;
+    ctx.concurrency = 1;
+    log('[bedrock-recovery] usage API 429 — backoff 50s, concurrency=1 next cycle');
+  } else {
+    ctx.concurrency = USAGE_PROBE_CONCURRENCY;
+    ctx.backoffUntil = 0;
+  }
+
+  let nextMs = BEDROCK_RECOVERY_DEFAULT_INTERVAL_MS;
+  if (maxLiveUtil >= 95) nextMs = 140_000;
+  else if (maxLiveUtil >= 85) nextMs = 72_000;
+  else if (maxLiveUtil > 0 && maxLiveUtil < 72) nextMs = 38_000;
+
+  try {
+    const st = statSync(sentinelPath);
+    if (now - st.mtimeMs < 3 * 60_000) nextMs = Math.min(nextMs, 42_000);
+  } catch {}
+
+  ctx.intervalMs = Math.max(BEDROCK_RECOVERY_MIN_INTERVAL_MS, Math.min(BEDROCK_RECOVERY_MAX_INTERVAL_MS, nextMs));
+
+  writeRecoveryStatus({
+    phase: 'watching',
+    next_interval_ms: ctx.intervalMs,
+    max_live_util_batch: maxLiveUtil,
+    dest_cap: destinationUtilHardBlock(config),
+    probed: rows,
+  });
+  return { didRecover: false };
+}
+
+// ── Periodic fleet-wide live-util probe ──────────────────────────────────────
+// Keeps state.accounts[*].lastUtilization fresh for ALL accounts so the
+// cooldown status report and findValidRotationTarget candidate sort have
+// recent data. Sequential to avoid parallel keychain + API hits.
+async function runFullProbe(config, state) {
+  const start = Date.now();
+  let probed = 0;
+  let updated = 0;
+  let skippedExpired = 0;
+  try {
+    for (const a of config.accounts) {
+      const key = accountKey(a);
+      if (key === state.activeAccount) continue; // active already covered by shouldRotate path
+      probed += 1;
+      const tokenJson = readStoredToken(a);
+      if (!tokenJson || tokenExpired(tokenJson)) {
+        skippedExpired += 1;
+        continue;
+      }
+      const live = await queryLiveUtilization(a);
+      if (!live?.ok) continue;
+      // Pick the higher-util window's reset epoch — that's the one that
+      // gates next-rotate eligibility. Falls back to whichever has a reset.
+      const pct5h = live.pct5h || 0;
+      const pct7d = live.pct7d || 0;
+      const pct = Math.max(pct5h, pct7d);
+      const reset = pct5h >= pct7d ? (live.reset5h ?? live.reset7d ?? null) : (live.reset7d ?? live.reset5h ?? null);
+      state.accounts = state.accounts || {};
+      state.accounts[key] = state.accounts[key] || {};
+      state.accounts[key].lastUtilization = { pct, reset, ts: Date.now() };
+      updated += 1;
+    }
+    // Compute and persist the next-rotation candidate for statusline display.
+    // Pick the lowest-util non-active account with a non-expired vault token.
+    try {
+      let bestKey = null;
+      let bestEmail = null;
+      let bestPct = Infinity;
+      for (const a of config.accounts) {
+        const k = accountKey(a);
+        if (k === state.activeAccount) continue;
+        if (a.disabled === true) continue;
+        const tok = readStoredToken(a);
+        if (!tok || tokenExpired(tok)) continue;
+        const u = state.accounts?.[k]?.lastUtilization;
+        const p = u?.pct ?? 0;
+        if (p < bestPct) {
+          bestPct = p;
+          bestKey = k;
+          bestEmail = a.email;
+        }
+      }
+      if (bestKey) {
+        writeFileSync(
+          join(__dirname, '.next-rotation-target.json'),
+          JSON.stringify({ key: bestKey, email: bestEmail, pct: bestPct, ts: Date.now() }),
+        );
+      }
+    } catch {}
+    try {
+      writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+    } catch {}
+    log(
+      `[periodic-probe] probed ${probed} accounts in ${Date.now() - start}ms (updated ${updated} snapshots, skipped ${skippedExpired} expired-token)`,
+    );
+  } catch (err) {
+    log(`[periodic-probe] error: ${err.message?.substring(0, 120)}`);
+  }
+}
+
 // ── Main loop ─────────────────────────────────────────────────────────────────
 
 async function mainLoop() {
-  log('Daemon started (v3 — on-demand token refresh)');
-  notify('Claude Rotation Daemon', 'Monitoring usage — on-demand refresh');
+  log('Daemon started (v4 — recovery: prioritized usage probes, adaptive interval, 429 backoff)');
+  notify('Claude Rotation Daemon', 'Monitoring usage — dynamic refresh');
 
   let lastRotatedAt = 0; // track when we last rotated
   let lastStatusLog = 0; // periodic status logging
+  let lastLeaseBeat = 0; // cross-machine lease heartbeat (S3)
+  let lastRefreshCheck = 0; // dynamic refresh check
   let lastDriftCheck = 0; // cheap vault-based drift detection
+  let lastFullProbe = 0; // periodic fleet-wide live-util snapshot refresh
+  let lastRespawnSweep = 0; // deferred bg-session respawn retry (busy at rotation time)
+  const FULL_PROBE_INTERVAL = 5 * 60_000;
+  const bedrockRecCtx = {
+    lastCheck: 0,
+    intervalMs: BEDROCK_RECOVERY_DEFAULT_INTERVAL_MS,
+    backoffUntil: 0,
+    concurrency: USAGE_PROBE_CONCURRENCY,
+  };
 
   while (true) {
     try {
@@ -654,12 +1457,35 @@ async function mainLoop() {
         lastStatusLog = Date.now();
       }
 
+      // Cross-machine lease heartbeat (every 3 min, << 2h TTL): refresh THIS
+      // machine's claim on its active account so the other machine keeps
+      // excluding it. Best-effort / fail-open (S3 down => no-op). (Sam 2026-06-06)
+      if (state.activeAccount && Date.now() - lastLeaseBeat > 180_000) {
+        lastLeaseBeat = Date.now();
+        try {
+          writeLease(state.activeAccount, (m) => log(m));
+        } catch {}
+      }
+
       // Drift detection — every 2 min, find the actual live account.
       // 1) Cheap vault-token compare first (zero network).
       // 2) Fall back to /api/oauth/profile when Claude Code has refreshed
       //    its own token and the live no longer matches any vault.
       // Self-heals when state.json disagrees with the actual active account
       // (crashed rotation, manual /login, leftover lock).
+      // Deferred bg-session respawn sweep (every 2 min): sessions that were
+      // busy at rotation time get respawned once they go idle, or force-
+      // respawned after 90 min so they never wedge on an expired token.
+      if (Date.now() - lastRespawnSweep > 120_000) {
+        lastRespawnSweep = Date.now();
+        try {
+          const handled = sweepDeferredRespawns((m) => log(m));
+          if (handled > 0) log(`[bg-respawn] sweep refreshed ${handled} deferred bg session(s)`);
+        } catch (e) {
+          log(`[bg-respawn] sweep error: ${e.message?.substring(0, 80)}`);
+        }
+      }
+
       if (Date.now() - lastDriftCheck > 120_000) {
         lastDriftCheck = Date.now();
         const stateLastRotation2 = state.lastRotation ? new Date(state.lastRotation).getTime() : 0;
@@ -679,12 +1505,30 @@ async function mainLoop() {
       // findValidRotationTarget refreshes candidates lazily). Avoids keychain
       // churn that was disconnecting HTTP MCP sessions every 5 min.
 
+      // Periodic fleet-wide live-util probe (every 5 min). Side-channel
+      // snapshot refresh only — does NOT trigger rotation. Keeps the cooldown
+      // status report accurate and feeds findValidRotationTarget's pre-sort.
+      if (Date.now() - lastFullProbe >= FULL_PROBE_INTERVAL) {
+        await runFullProbe(config, state);
+        lastFullProbe = Date.now();
+      }
+
+      const sentinelPath = join(process.env.HOME || '', '.claude', '.bedrock-fallback.json');
+      if (existsSync(sentinelPath)) {
+        const { didRecover } = await maybeRecoverOAuthFromBedrock(config, state, sentinelPath, bedrockRecCtx);
+        if (didRecover) lastRotatedAt = Date.now();
+      } else {
+        bedrockRecCtx.intervalMs = BEDROCK_RECOVERY_DEFAULT_INTERVAL_MS;
+        bedrockRecCtx.backoffUntil = 0;
+        bedrockRecCtx.concurrency = USAGE_PROBE_CONCURRENCY;
+      }
+
       const { should, reason } = await shouldRotate(config, state);
 
       // Post-rotation blackout: ALL rotation triggers are suppressed for 90s
       // after any rotation. `claude auth status` returns stale data during this
       // window, which causes drift detection → re-rotation thrashing loops.
-      const stateLastRotation = state.lastRotation ? new Date(state.lastRotation).getTime() : 0;
+      const stateLastRotation = readState().lastRotation ? new Date(readState().lastRotation).getTime() : 0;
       const effectiveLastRotated = Math.max(lastRotatedAt, stateLastRotation);
       const inBlackout = effectiveLastRotated && Date.now() - effectiveLastRotated < POST_ROTATION_BLACKOUT;
 

--- a/claude-ops/scripts/account-rotation/daemon.mjs
+++ b/claude-ops/scripts/account-rotation/daemon.mjs
@@ -826,6 +826,14 @@ async function findValidRotationTarget(config, state) {
     const key = accountKey(account);
     const tokenJson = readStoredToken(account);
     if (!tokenJson) continue;
+
+    const expiry = parseTokenExpiry(tokenJson);
+    const isExpired = expiry > 0 && now > expiry - 5 * 60_000;
+    if (isExpired) {
+      const refreshed = await refreshSingleToken(account);
+      if (!refreshed) continue;
+    }
+
     const live = await queryLiveUtilization(account);
     if (!isLiveUtilOk(live)) continue;
     const max = liveUtilMax(live);
@@ -896,7 +904,7 @@ function stopClaudeDaemon() {
   try {
     const result = execSync('claude daemon stop --any', {
       encoding: 'utf8',
-      env: { ...process.env, PATH: process.env.PATH || '/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin' }
+      env: { ...process.env, PATH: process.env.PATH || '/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin' },
     });
     log(`[daemon-stop] Daemon stop success: ${result.trim()}`);
   } catch (err) {
@@ -1048,7 +1056,7 @@ async function doRotation(reason) {
     // into running sessions — that interrupts active work. Sessions pick up the new
     // token on next 401 (auto-retry) or when the user voluntarily runs /login.
     // execFileSync (not execSync) — no shell, no injection risk on targetKey.
-    const result = execFileSync('node', [ROTATE_SCRIPT, '--no-browser', '--to', targetKey], {
+    const result = execFileSync(process.execPath, [ROTATE_SCRIPT, '--no-browser', '--to', targetKey], {
       cwd: __dirname,
       timeout: 120_000, // 2min — keychain swap is fast; no per-session injection
       env: { ...process.env, NODE_NO_WARNINGS: '1' },
@@ -1139,6 +1147,7 @@ async function refreshSingleToken(account) {
         refresh_token: refreshToken,
         client_id: OAUTH_CLIENT_ID,
       }),
+      signal: AbortSignal.timeout(5000),
     });
     const body = await res.json();
     if (!res.ok || !body.access_token) return false;
@@ -1164,9 +1173,15 @@ async function refreshSingleToken(account) {
       }
     } else {
       // Use spawnSync (no shell) to avoid injection risk on tokenStr.
-      spawnSync('security', ['add-generic-password', '-U', '-s', svc, '-a', VAULT_KEYCHAIN_ACCOUNT, '-w', tokenStr], {
-        timeout: 5000,
-      });
+      const kcResult = spawnSync(
+        'security',
+        ['add-generic-password', '-U', '-s', svc, '-a', VAULT_KEYCHAIN_ACCOUNT, '-w', tokenStr],
+        { timeout: 5000 },
+      );
+      if (kcResult.error || kcResult.status !== 0) {
+        const msg = kcResult.error?.message || kcResult.stderr?.toString() || `security exit ${kcResult.status}`;
+        throw new Error(`Keychain write failed: ${msg}`);
+      }
     }
     log(
       `[refresh] ${key}: refreshed (${((parsed.claudeAiOauth.expiresAt - Date.now()) / 3_600_000).toFixed(1)}h remaining)`,

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -24,7 +24,7 @@
  *   node rotate.mjs --capture                 # save current active token (print for Dashlane)
  *   node rotate.mjs --session                 # also send /login to running iTerm2 session
  *   node rotate.mjs --magic-link --to <email> # re-auth via email magic link (no Google OAuth)
- *   node rotate.mjs --allow-extra-usage       # BYPASS extra_usage billing guard (opt-in only)
+ *   Note: --allow-extra-usage is ignored if passed (legacy); extra_usage is per-org in Claude console only.
  */
 
 import {
@@ -36,55 +36,45 @@ import {
   chmodSync,
   readdirSync,
   renameSync,
+  mkdirSync,
+  statSync,
 } from 'fs';
+import { persistBedrockClaudeSettings } from './claude-settings-mode.mjs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { execSync, execFileSync, spawnSync, spawn } from 'child_process';
 import { tmpdir, homedir } from 'os';
 import { createHmac } from 'node:crypto';
-import { askAIBrain, executeAIAction, AI_BRAIN_MAX_DECISIONS } from './ai-brain.mjs';
-
-// ── Platform: Linux uses file-based vault; macOS uses security(1) keychain ───
-const IS_LINUX = process.platform === 'linux';
-// Top-level await: pre-load vault synchronously at module init so all
-// readKeychain/writeKeychain calls below can use it without being async.
-let _linuxVault = IS_LINUX ? await import('./vault-linux.mjs') : null;
+import { askAIBrain, executeAIAction, AI_BRAIN_MAX_DECISIONS, scrapeBillingState } from './ai-brain.mjs';
+import { destinationUtilHardBlock } from './rotation-policy.mjs';
+import { applyAccountLeases, writeLease } from './account-leases.mjs';
+import { respawnBgSessions } from './bg-respawn.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-// Config resolution (Rule 0): real accounts live in the gitignored plugin data
-// dir (where setup-account.mjs writes them); the in-repo config.json is
-// gitignored + untracked and used only as a local fallback; config.example.json
-// is the shipped empty template. Preferring the override keeps the read path in
-// sync with the write path and prevents real emails landing in a tracked file.
-const ROTATION_DATA_DIR =
-  process.env.CLAUDE_PLUGIN_DATA_DIR || join(homedir(), '.claude', 'plugins', 'data', 'ops-ops-marketplace');
-const CONFIG_OVERRIDE = join(ROTATION_DATA_DIR, 'account-rotation-config.json');
-const CONFIG_LOCAL = join(__dirname, 'config.json');
-const CONFIG_EXAMPLE = join(__dirname, 'config.example.json');
-const CONFIG_PATH = existsSync(CONFIG_OVERRIDE)
-  ? CONFIG_OVERRIDE
-  : existsSync(CONFIG_LOCAL)
-    ? CONFIG_LOCAL
-    : CONFIG_EXAMPLE;
+const CONFIG_PATH = join(__dirname, 'config.json');
 const STATE_PATH = join(__dirname, 'state.json');
 const LOCK_PATH = join(__dirname, '.rotating');
 const LOG_PATH = join(__dirname, 'rotation.log');
+const OAUTH_SNAPSHOTS_DIR = join(__dirname, 'oauth-snapshots');
+const BROWSER_PIN_PATH = join(__dirname, '.browser-pin');
+const BROWSER_PIN_BACKUP_PATH = join(__dirname, '.browser-pin-backup.json');
+const CLAUDE_JSON_PATH = join(process.env.HOME || '', '.claude.json');
 
 const KEYCHAIN_SERVICE = 'Claude Code-credentials';
-// Use the OS username so multiple users on the same Mac don't collide on
-// keychain entries. Override with CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT if needed.
-const KEYCHAIN_ACCOUNT =
-  process.env.CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT || process.env.USER || process.env.LOGNAME || 'claude-ops';
+const ACTIVE_KEYCHAIN_ACCOUNT = 'unknown';
+const VAULT_KEYCHAIN_ACCOUNT = process.env.CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT || process.env.USER || 'claude-ops';
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // ── Bootstrap: verify dependencies ───────────────────────────────────────────
-// macOS: Playwright-over-CDP to Chrome or Chrome Beta (never Comet/bundled Chromium).
-// Linux: Playwright headless Chromium (no real Chrome required).
-function _hasCmd(bin) {
-  return spawnSync('which', [bin], { timeout: 2000 }).status === 0;
-}
-
+// Browser driver tiers (Playwright):
+//   1. CDP-attach to an already-running Chrome on :9222
+//   2. Spawn Chrome Beta with an isolated automation profile (preferred — has
+//      real-Chrome network stack so claude.ai/Google don't flag it)
+//   3. Fallback: Playwright's bundled Chromium with launchPersistentContext on
+//      an ISOLATED profile dir (used when no Chrome/Chrome Beta binary, or when
+//      Chrome Beta launch fails). Never depends on / touches Sam's daily Chrome
+//      or Comet — Comet stays reserved for the user.
 function ensureMCPServersAndTools() {
   const actions = [];
   const earlyLog = (m) => {
@@ -93,46 +83,48 @@ function ensureMCPServersAndTools() {
     } catch {}
   };
 
-  if (IS_LINUX) {
-    // Linux: headless Chromium via Playwright — no real Chrome binary needed
-    actions.push('platform: linux — headless Chromium mode');
-    if (_hasCmd('npx')) {
-      actions.push('playwright: available via npx');
-    } else {
-      actions.push('playwright: WARNING — npx not found; browser fallback may fail');
-    }
+  // 1. Chrome or Chrome Beta binary (Comet is off-limits)
+  const realChromes = [
+    '/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta',
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  ];
+  const foundChrome = realChromes.find((p) => existsSync(p));
+  if (foundChrome) {
+    actions.push(`chrome-binary: ${foundChrome.split('/').pop()}`);
   } else {
-    // macOS: require real Chrome/Chrome Beta binary + CDP
-    const realChromes = [
-      '/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta',
-      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-    ];
-    const foundChrome = realChromes.find((p) => existsSync(p));
-    if (foundChrome) {
-      actions.push(`chrome-binary: ${foundChrome.split('/').pop()}`);
-    } else {
-      actions.push('chrome-binary: WARNING — no Chrome/Chrome Beta found');
-    }
-
-    // Chrome CDP port 9222 — probe (driver will launch Chrome if needed)
-    const cdpProbe = spawnSync('curl', ['-sf', 'http://localhost:9222/json/version'], { timeout: 1500 });
-    if (cdpProbe.status === 0) {
-      actions.push('chrome-cdp: reachable on :9222');
-    } else {
-      actions.push('chrome-cdp: not reachable (driver will launch Chrome)');
-    }
-
-    // security(1) keychain — required for token writes on macOS
-    if (!_hasCmd('security')) {
-      actions.push('security(1): MISSING — keychain writes will fail');
-    }
+    actions.push('chrome-binary: WARNING — no Chrome/Chrome Beta found');
   }
 
-  // dcli (Dashlane) — primary token path on both platforms
-  if (_hasCmd('dcli')) {
+  // 2. Chrome CDP port 9222 — probe (driver will launch Chrome if needed)
+  try {
+    execSync(`curl -sf http://localhost:9222/json/version >/dev/null 2>&1`, {
+      timeout: 1500,
+    });
+    actions.push('chrome-cdp: reachable on :9222');
+  } catch {
+    actions.push('chrome-cdp: not reachable (driver will launch Chrome)');
+  }
+
+  // 3. dcli (Dashlane) — required for primary token path
+  try {
+    execSync(`command -v dcli >/dev/null 2>&1`, { timeout: 1000 });
     actions.push('dcli: available');
+  } catch {
+    actions.push('dcli: MISSING — primary token path will fail');
+  }
+
+  // 4. security (macOS keychain) — required for token writes ON MACOS ONLY.
+  // On Linux the token store is the file-based ~/.claude/.credentials.json
+  // (see _linuxWriteCred / IS_LINUX), so a missing `security` binary is benign
+  // here — don't emit a misleading warning. (Sam 2026-06-06: box-local separation.)
+  if (process.platform === 'darwin') {
+    try {
+      execSync(`command -v security >/dev/null 2>&1`, { timeout: 1000 });
+    } catch {
+      actions.push('security(1): MISSING — keychain writes will fail');
+    }
   } else {
-    actions.push('dcli: MISSING — primary token path will fall back to browser');
+    actions.push('token-store: file (~/.claude/.credentials.json) — Linux, keychain not required');
   }
 
   for (const a of actions) earlyLog(a);
@@ -140,7 +132,11 @@ function ensureMCPServersAndTools() {
 
 // Unconditional warmup: every rotate.mjs run starts its MCP servers + tools FIRST.
 // Skip only for --help (where nothing runs downstream).
-if (!process.argv.slice(2).includes('--help') && !process.argv.slice(2).includes('--no-browser')) {
+if (
+  !process.argv.slice(2).includes('--help') &&
+  !process.argv.slice(2).includes('--no-browser') &&
+  !process.argv.slice(2).includes('--pin-browser')
+) {
   ensureMCPServersAndTools();
 }
 
@@ -156,32 +152,35 @@ function log(msg) {
 
 function notify(title, msg) {
   try {
-    if (IS_LINUX) {
-      // notify-send (libnotify) — no-op if display is unavailable (e.g. headless server)
-      spawnSync('notify-send', [title, msg], { timeout: 3000 });
-    } else {
-      // Use execFileSync to avoid shell interpretation of quotes in title/msg
-      execFileSync(
-        'osascript',
-        [
-          '-e',
-          `display notification "${msg.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}" with title "${title.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`,
-        ],
-        { timeout: 5000 },
-      );
-    }
+    execSync(`osascript -e 'display notification "${msg.replace(/"/g, '\\"')}" with title "${title}"'`);
   } catch {}
 }
 
+// Cross-machine account leases (Sam 2026-06-06): NOT a static per-machine split.
+// Both machines may use ALL accounts; the only constraint is that the same
+// account is never ACTIVE on both at once. readConfig() drops accounts a FOREIGN
+// host currently holds a fresh lease on. We never drop the account we're
+// staying on (the live/tracked active key) so a heartbeat-write can refresh it.
+// Fail-open: lease store unreachable => no exclusion. See account-leases.mjs.
 function readConfig() {
-  return JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
+  const config = JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
+  let keepKey = null;
+  try {
+    const st = JSON.parse(readFileSync(STATE_PATH, 'utf8'));
+    keepKey = st.activeAccount || null;
+  } catch {}
+  return applyAccountLeases(config, {
+    keepKey,
+    log: (m) => {
+      try {
+        log(m);
+      } catch {}
+    },
+  });
 }
 
 // All accounts' Claude login emails forward to ONE Gmail inbox, so every
-// magic-link poll queries that single account rather than each account's own
-// mailbox. Resolve it from env or the gitignored override config — never
-// hardcode a real address in the public repo (Rule 0). Returns '' if
-// unconfigured, in which case callers fall back to the per-account mailbox.
+// magic-link poll queries that single account. Resolve it from env or config.
 function magicLinkInbox() {
   if ((process.env.CLAUDE_ROT_GMAIL_ACCOUNT || '').trim()) return process.env.CLAUDE_ROT_GMAIL_ACCOUNT.trim();
   if ((process.env.GOG_ACCOUNT || '').trim()) return process.env.GOG_ACCOUNT.trim();
@@ -191,17 +190,43 @@ function magicLinkInbox() {
     return '';
   }
 }
+// Legacy account-key renames: old label → new canonical key.
+// Keep in sync with daemon.mjs STATE_KEY_MIGRATIONS.
+const STATE_KEY_MIGRATIONS = {
+  'heartfeldt-personal': 'heartfeldt',
+};
+
 function readState() {
+  let state;
   try {
-    return JSON.parse(readFileSync(STATE_PATH, 'utf8'));
+    state = JSON.parse(readFileSync(STATE_PATH, 'utf8'));
   } catch {
-    return {
-      activeAccount: null,
-      accounts: {},
-      toolUses: 0,
-      totalRotations: 0,
-    };
+    return { activeAccount: null, accounts: {}, toolUses: 0, totalRotations: 0 };
   }
+  let migrated = false;
+  if (state.accounts) {
+    for (const [oldKey, newKey] of Object.entries(STATE_KEY_MIGRATIONS)) {
+      if (state.accounts[oldKey] && !state.accounts[newKey]) {
+        state.accounts[newKey] = state.accounts[oldKey];
+        delete state.accounts[oldKey];
+        migrated = true;
+      } else if (state.accounts[oldKey]) {
+        delete state.accounts[oldKey];
+        migrated = true;
+      }
+    }
+    if (state.activeAccount && STATE_KEY_MIGRATIONS[state.activeAccount]) {
+      state.activeAccount = STATE_KEY_MIGRATIONS[state.activeAccount];
+      migrated = true;
+    }
+  }
+  if (migrated) {
+    try {
+      writeFileSync(STATE_PATH + '.tmp.' + process.pid, JSON.stringify(state, null, 2));
+      renameSync(STATE_PATH + '.tmp.' + process.pid, STATE_PATH);
+    } catch {}
+  }
+  return state;
 }
 function writeState(s, dryRun = false) {
   if (dryRun) {
@@ -268,6 +293,39 @@ function accountKey(a) {
   return a.label || a.email;
 }
 
+/** After OAuth completes in the same Playwright session, scrape console billing into state. */
+async function maybeScrapeBillingAfterOAuth(driver, account, log) {
+  if (process.env.CLAUDE_ROTATOR_SKIP_BILLING_SCRAPE === '1') return;
+  const page = driver?._page;
+  if (!page || typeof page.goto !== 'function') return;
+  const key = accountKey(account);
+  try {
+    log(`[billing-scrape] console billing for ${key}...`);
+    const billing = await scrapeBillingState(page, (m) => log(m));
+    if (!billing) return;
+    const state = readState();
+    state.accounts[key] = state.accounts[key] || {};
+    const prev = state.accounts[key].lastBilling || {};
+    state.accounts[key].lastBilling = {
+      ...prev,
+      credits_usd: billing.credits_usd,
+      auto_reload_enabled: billing.auto_reload_enabled,
+      extra_usage_enabled:
+        billing.extra_usage_enabled !== null && billing.extra_usage_enabled !== undefined
+          ? billing.extra_usage_enabled === true
+          : prev.extra_usage_enabled,
+      ts: Date.now(),
+      source: 'console_scrape',
+    };
+    writeState(state);
+    log(
+      `[billing-scrape] merged credits=${billing.credits_usd} auto_reload=${billing.auto_reload_enabled} extra_usage=${billing.extra_usage_enabled}`,
+    );
+  } catch (e) {
+    log(`[billing-scrape] error: ${String(e.message || e).slice(0, 100)}`);
+  }
+}
+
 // ── Live utilization query ────────────────────────────────────────────────────
 
 // Query all accounts in parallel — best-effort, uses cached fallback.
@@ -292,12 +350,12 @@ async function queryAllUtilization(config) {
         const res = await fetch(url, {
           method: 'GET',
           headers,
-          signal: AbortSignal.timeout(5000),
+          signal: AbortSignal.timeout(10000),
         });
         // Retry once on 429 — happens transiently right after token refresh
         // or when multiple accounts query in parallel
         if (res.status === 429 && attempt < 2) {
-          await new Promise((r) => setTimeout(r, 1500 * (attempt + 1)));
+          await new Promise((r) => setTimeout(r, 2000 * (attempt + 1)));
           return fetchWithRetry(url, attempt + 1);
         }
         return res;
@@ -333,13 +391,13 @@ async function queryAllUtilization(config) {
     }
   }
 
-  // Stagger account queries by 150ms to avoid bursting /oauth/usage endpoint,
+  // Stagger account queries by 250ms to avoid bursting /oauth/usage endpoint,
   // which otherwise 429s on ~5-7 parallel requests from the same IP.
   const results = await Promise.allSettled(
     config.accounts
       .filter((a) => a.disabled !== true)
       .map(async (a, idx) => {
-        if (idx > 0) await new Promise((r) => setTimeout(r, 150 * idx));
+        if (idx > 0) await new Promise((r) => setTimeout(r, 250 * idx));
         return { key: accountKey(a), util: await queryAccount(a) };
       }),
   );
@@ -352,22 +410,53 @@ async function queryAllUtilization(config) {
   return map;
 }
 
+function currentActiveIsOnlyViableTarget(config, state, liveUtil) {
+  const activeKey = state.activeAccount;
+  if (!activeKey) return false;
+  const activeAcc = config.accounts.find((a) => accountKey(a) === activeKey);
+  if (!activeAcc || activeAcc.disabled === true) return false;
+  const key = accountKey(activeAcc);
+  const live = liveUtil[key];
+  const u5 = live?.five_hour_pct;
+  const u7 = live?.seven_day_pct;
+  if (u5 == null || u7 == null) return false;
+  const cap = destinationUtilHardBlock(config);
+  return Math.max(u5, u7) < cap;
+}
+
 // liveUtil: optional map from queryAllUtilization() — key → { five_hour_pct, ... }
-function pickNextAccount(config, state, liveUtil = {}, opts = {}) {
+function pickNextAccount(config, state, liveUtil = {}) {
   const activeKey = state.activeAccount;
   const windowMs = (config.rateLimits?.windowHours || 5) * 3_600_000;
   const now = Date.now();
 
-  // Hard block: account has Anthropic-side extra-usage (pay-per-use overage) enabled.
-  // Rotating to such an account risks credit-card charges when the weekly cap is hit.
-  // Override with opts.allowExtraUsage=true (CLI flag --allow-extra-usage) only when
-  // the user has explicitly opted in for this run.
-  const allowExtraUsage = opts.allowExtraUsage === true;
+  // extra_usage is informational only — manage pay-per-use per org in the Claude console;
+  // it does not affect who we can rotate to.
   function hasExtraUsageEnabled(a) {
     const key = accountKey(a);
+    // Per-account safe override (Sam 2026-06-11): when auto-reload/auto-billing is
+    // OFF on the org, extra_usage cannot leak money — at 0 credits Claude simply
+    // stops, it does NOT pay-per-use. Such accounts are first-class rotation
+    // targets, not last-resort EU-pool. Honors the config `extraUsageSafeOverride`
+    // field (previously declared but never wired).
+    if (a.extraUsageSafeOverride === true) return false;
     const live = liveUtil[key];
-    return live && live.extra_usage_enabled === true;
+    if (live && live.extra_usage_enabled === true) return true;
+    // Fallback to last-known extra_usage state from state.json
+    const cached = state.accounts?.[key]?.lastBilling?.extra_usage_enabled;
+    if (cached === true) return true;
+    return false;
   }
+
+  // Money-leak guard (Sam doctrine): by default NEVER rotate to an account with
+  // Anthropic-side extra_usage (pay-per-use overage) enabled — when its weekly cap
+  // is hit, further tokens silently bill the card. Opt out for a single run with
+  // --allow-extra-usage or ALLOW_EXTRA_USAGE=1. EU accounts remain reachable only
+  // as an absolute last resort (see euNormal/euLow pools below) so rotation never
+  // bricks when every non-EU account is exhausted.
+  const allowExtraUsage =
+    process.argv.slice(2).includes('--allow-extra-usage') || process.env.ALLOW_EXTRA_USAGE === '1';
+  const blockExtra = (a) => !allowExtraUsage && hasExtraUsageEnabled(a);
 
   // Check if an account's quota window has been exhausted (local tool-use tracking)
   function isExhausted(a) {
@@ -412,65 +501,97 @@ function pickNextAccount(config, state, liveUtil = {}, opts = {}) {
     return null;
   }
 
-  // Score: max of (5h, 7d) — an account is only viable if BOTH windows have
-  // headroom. Both unknown → 50 (neutral). Partial data → 100 (never treat a
-  // missing window as 0%). Lower is better.
+  // Score: max of (5h, 7d) — both windows must be known or we penalize heavily.
+  // Never treat a missing window as 0%: old bug was max(0, null→0)=0, so an account
+  // with live 7d=100% but a transient live miss became "best" pick via stale 5h cache.
   function score(a) {
     const u5 = getUtil5h(a);
     const u7 = getUtil7d(a);
+    // If both unknown, return 50 (middle of the pack)
     if (u5 === null && u7 === null) return 50;
-    if (u5 === null || u7 === null) return 100;
+    // If one is unknown, use the known one instead of penalizing at 100.
+    // This fixes the "query_failed blocks rotation" issue for transient API misses.
+    if (u5 === null) return u7;
+    if (u7 === null) return u5;
     return Math.max(u5, u7);
   }
 
-  // Log + hard-exclude accounts with extra_usage enabled (pay-per-use overage billing).
-  // These are the accounts that silently charge your credit card when the weekly cap
-  // is exceeded. Unless --allow-extra-usage was passed, we refuse to rotate to them.
   const extraUsageAccounts = config.accounts.filter(hasExtraUsageEnabled);
   if (extraUsageAccounts.length > 0) {
     log(
       `⚠  EXTRA USAGE ENABLED on ${extraUsageAccounts.length} account(s): ${extraUsageAccounts
         .map((a) => accountKey(a))
-        .join(', ')} — these can incur overage charges. Disable at console.anthropic.com/settings/billing.`,
+        .join(', ')} — overage billing possible; ${
+        allowExtraUsage
+          ? 'rotation NOT blocked (--allow-extra-usage set)'
+          : 'excluded as rotation targets by default (pass --allow-extra-usage to override)'
+      }. Disable per org at console.anthropic.com/settings/billing.`,
     );
   }
 
-  const excludeKey = (a) =>
-    a.disabled === true || accountKey(a) === activeKey || (!allowExtraUsage && hasExtraUsageEnabled(a));
+  const excludeKey = (a) => a.disabled === true || accountKey(a) === activeKey;
 
-  // Prefer PRIVATE (personal) accounts over TEAMS/org accounts. Org accounts
-  // (those carrying orgName/orgUuid) route through claude.ai's org chooser and
-  // Google Workspace push-2FA, which headless browser auth cannot clear — so a
-  // team account that wins on raw utilization still fails to rotate. Treat
-  // team-ness as the PRIMARY sort key (private first), utilization secondary,
-  // so a team account is only ever picked when no private account is viable.
-  const isTeamAccount = (a) =>
-    !!(a.orgUuid || (a.orgName && String(a.orgName).toLowerCase() !== String(a.email || '').toLowerCase()));
-  const byPrivateThenScore = (a, b) => {
-    const ta = isTeamAccount(a) ? 1 : 0;
-    const tb = isTeamAccount(b) ? 1 : 0;
-    if (ta !== tb) return ta - tb; // private (0) before team (1)
-    return score(a) - score(b);
-  };
+  // Separate refreshable accounts from accounts that are usable today but cannot
+  // be unattended-reauthenticated when their stored token dies. Manual-reauth
+  // accounts stay as a fallback, but should not win just because they are at 0%
+  // while other healthy refreshable accounts have headroom.
+  const refreshableNormal = config.accounts.filter(
+    (a) => a.priority !== 'low' && a.autoAuthDisabled !== true && !excludeKey(a) && !blockExtra(a),
+  );
+  const refreshableLow = config.accounts.filter(
+    (a) => a.priority === 'low' && a.autoAuthDisabled !== true && !excludeKey(a) && !blockExtra(a),
+  );
+  const manualReauthNormal = config.accounts.filter(
+    (a) => a.priority !== 'low' && a.autoAuthDisabled === true && !excludeKey(a) && !blockExtra(a),
+  );
+  const manualReauthLow = config.accounts.filter(
+    (a) => a.priority === 'low' && a.autoAuthDisabled === true && !excludeKey(a) && !blockExtra(a),
+  );
 
-  // Separate normal and low-priority, excluding current active + extra-usage accounts
-  const normal = config.accounts.filter((a) => a.priority !== 'low' && !excludeKey(a));
-  const low = config.accounts.filter((a) => a.priority === 'low' && !excludeKey(a));
+  // Absolute last-resort pools: accounts blocked ONLY because extra_usage is on.
+  // Empty when allowExtraUsage (they already live in the pools above). Tried after
+  // every non-EU pool, so an overage account is only ever picked when nothing else
+  // is viable — better a paid token than a fully stalled session on an exhausted key.
+  const euNormal = config.accounts.filter((a) => a.priority !== 'low' && !excludeKey(a) && blockExtra(a));
+  const euLow = config.accounts.filter((a) => a.priority === 'low' && !excludeKey(a) && blockExtra(a));
 
-  const UTIL_HARD_BLOCK = 90; // Skip accounts at/above this util% if possible
+  // Hard refusal for rotation *destination*: max(5h,7d) must stay below this.
+  // Default 95 (matches EXHAUSTED for Bedrock). Lower with
+  // rateLimits.destinationMaxUtilPercent (e.g. 90) if 90% 5h still feels empty in practice.
+  const UTIL_HARD_BLOCK = destinationUtilHardBlock(config);
 
-  for (const pool of [normal, low]) {
+  for (const pool of [refreshableNormal, refreshableLow, manualReauthNormal, manualReauthLow, euNormal, euLow]) {
     const fresh = pool.filter((a) => !isExhausted(a));
     const exhausted = pool.filter((a) => isExhausted(a));
 
     for (const candidates of [fresh, exhausted]) {
-      const viable = candidates.filter((a) => score(a) < UTIL_HARD_BLOCK);
-      const blocked = candidates.filter((a) => score(a) >= UTIL_HARD_BLOCK);
-      const sorted = [...viable].sort(byPrivateThenScore);
-      const pool2 = sorted.length ? sorted : [...blocked].sort(byPrivateThenScore);
+      // Per-account destination cap: an account may set `maxUtilPercent` in config to be
+      // refused as a rotation target at a STRICTER threshold than the global UTIL_HARD_BLOCK.
+      // min() ensures it can only tighten, never loosen, the global hard block.
+      // An account may set maxUtilPercent to cap it stricter than the global block (e.g. ≥50%).
+      const capFor = (a) => Math.min(UTIL_HARD_BLOCK, a.maxUtilPercent ?? Infinity);
+      const viable = candidates.filter((a) => score(a) < capFor(a));
+      // Primary key: utilization score (freshest first). Tie-breaker: when two
+      // accounts are within TIE_EPSILON percentage points of each other, prefer
+      // the least-recently-active (LRU) one. Without this, a pool of equally-low
+      // accounts (e.g. two tied at 3% 7d) ping-pongs forever — the active one is
+      // excluded, so the other is always "the minimum", and repeated /rotate just
+      // swaps the same pair. LRU spreads load across the whole low-util pool.
+      const TIE_EPSILON = 5;
+      const lastActiveMs = (a) => {
+        const la = state.accounts?.[accountKey(a)]?.lastActive;
+        const t = la ? new Date(la).getTime() : 0;
+        return Number.isFinite(t) ? t : 0;
+      };
+      const sorted = [...viable].sort((a, b) => {
+        const d = score(a) - score(b);
+        if (Math.abs(d) >= TIE_EPSILON) return d;
+        // Within the tie band: oldest lastActive (smallest ms) wins.
+        return lastActiveMs(a) - lastActiveMs(b);
+      });
 
-      if (pool2.length > 0) {
-        const best = pool2[0];
+      if (sorted.length > 0) {
+        const best = sorted[0];
         const u5 = getUtil5h(best);
         const u7 = getUtil7d(best);
         const src = liveUtil[accountKey(best)]
@@ -478,29 +599,231 @@ function pickNextAccount(config, state, liveUtil = {}, opts = {}) {
           : state.accounts[accountKey(best)]?.lastUtilization
             ? 'cached'
             : 'unknown';
-        const utilStr = ` 5h=${u5 ?? '?'}% 7d=${u7 ?? '?'}% [${src}]`;
-        if (score(best) >= UTIL_HARD_BLOCK) {
-          log(`WARNING: All candidates near limit — rotating to ${accountKey(best)}${utilStr}`);
-        } else {
-          log(`Picked ${accountKey(best)}${utilStr}`);
+        const reauthNote = best.autoAuthDisabled === true ? ', manual-reauth fallback' : '';
+        if (blockExtra(best)) {
+          log(
+            `⚠  LAST-RESORT: only viable target ${accountKey(best)} has extra_usage ON — rotating to it may incur paid overage (every non-overage account is exhausted/excluded). Disable extra_usage in the console to avoid this.`,
+          );
         }
+        log(`Picked ${accountKey(best)} 5h=${u5 ?? '?'}% 7d=${u7 ?? '?'}% [${src}${reauthNote}]`);
         return best;
       }
     }
   }
+  // Already on the only account with API headroom (non-active pool is empty of viable targets).
+  if (activeKey && currentActiveIsOnlyViableTarget(config, state, liveUtil)) {
+    const aa = config.accounts.find((a) => accountKey(a) === activeKey);
+    const u5 = aa ? getUtil5h(aa) : null;
+    const u7 = aa ? getUtil7d(aa) : null;
+    log(
+      `Only viable Max account is already active (${activeKey}, 5h=${u5 ?? '?'}% 7d=${u7 ?? '?'}%) — no rotation target (others exceed ${UTIL_HARD_BLOCK}% max(5h,7d) destination cap or tool-window exhausted).`,
+    );
+    return null;
+  }
+  // All non-active candidates exceed UTIL_HARD_BLOCK — refuse to pick. Caller handles
+  // Bedrock fallback. Sam's rule: never rotate to an account that will
+  // immediately say token-limit-reached.
+  log(
+    `All non-active candidates score ≥${UTIL_HARD_BLOCK}% max(5h,7d) (or pool empty) — refusing to pick (use Bedrock fallback)`,
+  );
   return null;
 }
 
-// ── Keychain / vault ──────────────────────────────────────────────────────────
-// macOS: security(1) Keychain.  Linux: file-based vault (vault-linux.mjs).
+// ── Smart recommend / Bedrock fallback ────────────────────────────────────────
+// "Will immediately say token-limit-reached" guard. Anything at/above this
+// 5h or 7d util is refused as a rotation target.
+const EXHAUSTED_THRESHOLD = 95;
 
-function readKeychain(svc = KEYCHAIN_SERVICE, acct = KEYCHAIN_ACCOUNT) {
+/** True when every non-active account with complete live util is at/above destination cap (no swap target). */
+function allNonActiveLiveConfirmedOverDestinationCap(config, state, liveUtil) {
+  const destCap = destinationUtilHardBlock(config);
+  const activeKey = state.activeAccount;
+  const others = config.accounts.filter((a) => a.disabled !== true && accountKey(a) !== activeKey);
+  if (others.length === 0) return false;
+  let nConfirmed = 0;
+  for (const a of others) {
+    const u = liveUtil[accountKey(a)];
+    if (!u || u.five_hour_pct == null || u.seven_day_pct == null) continue;
+    nConfirmed++;
+    if (Math.max(u.five_hour_pct, u.seven_day_pct) < destCap) return false;
+  }
+  return nConfirmed > 0;
+}
+
+// Returns { pick, allExhausted, allHaveLive, onlyActiveViable, destinationCapStuck } using LIVE util only.
+// allExhausted is true ONLY when every viable candidate has live data AND
+// max(5h,7d) >= EXHAUSTED_THRESHOLD. Per Sam's rule: never assume exhaustion
+// from cached / unknown data — Bedrock fallback must be live-confirmed.
+function recommendAccount(config, state, liveUtil) {
+  const candidates = config.accounts.filter((a) => a.disabled !== true);
+  const pick = pickNextAccount(config, state, liveUtil);
+  const onlyActiveViable = !pick && currentActiveIsOnlyViableTarget(config, state, liveUtil);
+  const allHaveLive =
+    candidates.length > 0 &&
+    candidates.every((a) => {
+      const u = liveUtil[accountKey(a)];
+      return u && u.five_hour_pct != null && u.seven_day_pct != null;
+    });
+  const allExhausted =
+    !onlyActiveViable &&
+    allHaveLive &&
+    candidates.every((a) => {
+      const u = liveUtil[accountKey(a)];
+      return Math.max(u.five_hour_pct, u.seven_day_pct) >= EXHAUSTED_THRESHOLD;
+    });
+  const destinationCapStuck =
+    !pick && !onlyActiveViable && !allExhausted && allNonActiveLiveConfirmedOverDestinationCap(config, state, liveUtil);
+  return { pick, allExhausted, allHaveLive, onlyActiveViable, destinationCapStuck };
+}
+
+// True if AWS Bedrock is reachable (sts + bedrock list).
+function checkBedrockAvailable(region) {
+  const reg = region || process.env.AWS_BEDROCK_REGION || 'us-east-1';
+  try {
+    execFileSync('aws', ['sts', 'get-caller-identity', '--output', 'json'], {
+      stdio: 'pipe',
+      timeout: 5000,
+    });
+    execFileSync('aws', ['bedrock', 'list-inference-profiles', '--region', reg, '--max-results', '1'], {
+      stdio: 'pipe',
+      timeout: 6000,
+    });
+    return { ok: true, region: reg };
+  } catch (e) {
+    return { ok: false, region: reg, error: (e.message || '').slice(0, 120) };
+  }
+}
+
+function stopClaudeDaemon() {
+  log('[daemon-stop] Stopping Claude daemon...');
+  try {
+    const result = execSync('claude daemon stop --any', {
+      encoding: 'utf8',
+      env: { ...process.env, PATH: process.env.PATH || '/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin' }
+    });
+    log(`[daemon-stop] Daemon stop success: ${result.trim()}`);
+  } catch (err) {
+    log(`[daemon-stop] Daemon stop failed: ${err.message}`);
+  }
+}
+
+// Activate Bedrock fallback. Writes a sentinel + prints source instructions.
+// Cannot mutate env of an already-running session — user must start a new
+// one with `source ~/.claude/scripts/account-rotation/use-bedrock.sh`.
+async function activateBedrockFallback(reason, dryRun = false) {
+  const region = process.env.AWS_BEDROCK_REGION || 'us-east-1';
+  const result = checkBedrockAvailable(region);
+  const sentinel = join(process.env.HOME || '', '.claude', '.bedrock-fallback.json');
+  if (dryRun) {
+    log(
+      `[DRY-RUN] Bedrock fallback branch taken (reason=${reason} region=${region} aws_ok=${result.ok}) — no sentinel/settings writes`,
+    );
+    if (!result.ok) {
+      log(`[DRY-RUN] AWS probe failed: ${result.error || 'unknown'}`);
+    } else {
+      log(`[DRY-RUN] Would write ${sentinel} + persistBedrockClaudeSettings(${region})`);
+    }
+    console.log('');
+    console.log('━━━ [DRY-RUN] BEDROCK FALLBACK (no files written) ━━━');
+    console.log(`Reason : ${reason}`);
+    console.log(`Region : ${region}`);
+    console.log(`AWS    : ${result.ok ? 'reachable' : 'NOT reachable'}`);
+    if (result.error) console.log(`Detail : ${result.error}`);
+    console.log('');
+    return result.ok;
+  }
+  const payload = {
+    activated_at: new Date().toISOString(),
+    reason,
+    region,
+    available: result.ok,
+    error: result.error || null,
+  };
+  try {
+    writeFileSync(sentinel, JSON.stringify(payload, null, 2));
+  } catch {}
+  if (result.ok) {
+    try {
+      persistBedrockClaudeSettings(region);
+      log(`✅ settings.json → Bedrock env (${region})`);
+    } catch (e) {
+      log(`⚠ settings.json Bedrock persist failed: ${(e.message || e).toString().slice(0, 120)}`);
+    }
+    try {
+      stopClaudeDaemon();
+    } catch (e) {
+      log(`⚠ stopClaudeDaemon failed: ${e.message}`);
+    }
+    log(`✅ BEDROCK FALLBACK ACTIVATED region=${region} reason=${reason}`);
+    notify('Bedrock Fallback Active', `All Anthropic accounts exhausted — switched to Bedrock (${region}).`);
+    console.log('');
+    console.log('━━━ BEDROCK FALLBACK ACTIVE ━━━');
+    console.log(`Reason : ${reason}`);
+    console.log(`Region : ${region}`);
+    console.log('Use it : source ~/.claude/scripts/account-rotation/use-bedrock.sh');
+    console.log(`Clear  : rm ${sentinel}`);
+    console.log('');
+  } else {
+    log(`❌ Bedrock fallback FAILED reason=${reason} aws_error=${result.error}`);
+    notify('Bedrock Fallback FAILED', `aws sts/bedrock unreachable in ${region} — manual intervention needed`);
+  }
+  return result.ok;
+}
+
+// ── Keychain ─────────────────────────────────────────────────────────────────
+
+// Linux fallback: ~/.claude/.credentials.json keyed by service name
+const LINUX_CRED_PATH = join(process.env.HOME || '', '.claude', '.credentials.json');
+const IS_LINUX = process.platform === 'linux';
+
+function _linuxReadCred(svc) {
+  try {
+    const store = JSON.parse(readFileSync(LINUX_CRED_PATH, 'utf8'));
+    const val = store[svc];
+    if (!val) throw new Error(`No entry for ${svc}`);
+    return typeof val === 'string' ? val : JSON.stringify(val);
+  } catch (e) {
+    throw new Error(`No Linux cred entry ${svc}: ${e.message}`);
+  }
+}
+
+function _linuxWriteCred(svc, json) {
+  let store = {};
+  try {
+    store = JSON.parse(readFileSync(LINUX_CRED_PATH, 'utf8'));
+  } catch {}
+  if (svc === KEYCHAIN_SERVICE) {
+    // Main slot: merge claudeAiOauth only, preserve mcpOAuth
+    try {
+      const incoming = JSON.parse(json);
+      store.claudeAiOauth = incoming.claudeAiOauth || incoming;
+    } catch {
+      store[svc] = json;
+    }
+  } else {
+    // Per-account vault slot
+    try {
+      store[svc] = JSON.parse(json);
+    } catch {
+      store[svc] = json;
+    }
+  }
+  writeFileSync(LINUX_CRED_PATH, JSON.stringify(store, null, 2), { mode: 0o600 });
+}
+
+function readKeychain(svc = KEYCHAIN_SERVICE, acct = svc === KEYCHAIN_SERVICE ? ACTIVE_KEYCHAIN_ACCOUNT : VAULT_KEYCHAIN_ACCOUNT) {
   if (IS_LINUX) {
-    const vault = _linuxVault;
-    if (!vault) throw new Error('vault-linux not loaded yet');
-    const json = vault.readEntry(svc);
-    if (!json) throw new Error(`No vault entry for ${svc}`);
-    return json;
+    if (svc === KEYCHAIN_SERVICE) {
+      // Main slot: return full credentials JSON
+      try {
+        const store = JSON.parse(readFileSync(LINUX_CRED_PATH, 'utf8'));
+        if (!store.claudeAiOauth) throw new Error('No claudeAiOauth in credentials');
+        return JSON.stringify({ claudeAiOauth: store.claudeAiOauth, mcpOAuth: store.mcpOAuth || {} });
+      } catch (e) {
+        throw new Error(`No Linux cred entry ${svc}: ${e.message}`);
+      }
+    }
+    return _linuxReadCred(svc);
   }
   const result = spawnSync('security', ['find-generic-password', '-s', svc, '-a', acct, '-g'], {
     timeout: 5000,
@@ -512,11 +835,9 @@ function readKeychain(svc = KEYCHAIN_SERVICE, acct = KEYCHAIN_ACCOUNT) {
   return m[1].replace(/\\"/g, '"');
 }
 
-function writeKeychain(json, svc = KEYCHAIN_SERVICE, acct = KEYCHAIN_ACCOUNT) {
+function writeKeychain(json, svc = KEYCHAIN_SERVICE, acct = svc === KEYCHAIN_SERVICE ? ACTIVE_KEYCHAIN_ACCOUNT : VAULT_KEYCHAIN_ACCOUNT) {
   if (IS_LINUX) {
-    const vault = _linuxVault;
-    if (!vault) throw new Error('vault-linux not loaded yet');
-    vault.writeEntry(svc, json);
+    _linuxWriteCred(svc, json);
     return;
   }
   try {
@@ -563,6 +884,341 @@ function hasStoredToken(account) {
     readKeychain(tokenService(account));
     return true;
   } catch {
+    return false;
+  }
+}
+
+// ── OAuth snapshots (chrome-bridge sync) ─────────────────────────────────────
+//
+// `~/.claude.json` carries an `oauthAccount` block + `chromeExtension` pairing
+// block that Claude Code uses to identify "who am I?" to the browser-extension
+// bridge. The bridge refuses to connect when claude.ai (in the paired Chrome
+// profile) is logged in as account A but Claude Code's oauthAccount says B.
+//
+// `swapToken()` only rotates the macOS keychain entry — it does NOT touch
+// `.claude.json`, so terminal rotation leaves the chrome-bridge auth stale.
+// Snapshots capture each account's `oauthAccount` + `chromeExtension` blocks
+// (one file per accountKey under `oauth-snapshots/`) so `--pin-browser` can
+// atomically swap both keychain AND `.claude.json` blocks before the extension
+// retries its handshake.
+
+function ensureSnapshotsDir() {
+  try {
+    mkdirSync(OAUTH_SNAPSHOTS_DIR, { recursive: true });
+  } catch {}
+}
+
+function snapshotPathFor(key) {
+  // Sanitize for filesystem: replace any path-hostile chars
+  const safe = String(key).replace(/[/\\\0]/g, '_');
+  return join(OAUTH_SNAPSHOTS_DIR, `${safe}.json`);
+}
+
+// Per-account Chrome profile name. One profile per account keeps each account
+// signed into claude.ai independently and lets each profile own its own
+// extension pairing (pairedDeviceId). Pin-browser swaps `.claude.json`
+// chromeExtension to the snapshot's deviceId; only the matching profile's
+// extension service worker will then authenticate against the CLI bridge.
+function chromeProfileDirFor(accountKey) {
+  // Chrome profile dir names tolerate most chars but we keep them shell-clean.
+  const safe = String(accountKey)
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+  return `ClaudeCode-${safe || 'unknown'}`;
+}
+
+function isChromeProfileRunning(profileDir) {
+  // Exact dir match — `profile-directory=ClaudeCode` must NOT match the longer
+  // `profile-directory=ClaudeCode-support-healify.ai`. Chrome appends the dir
+  // name and then a space (next CLI flag) or EOL. We parse the pgrep output
+  // and check the full arg.
+  try {
+    const out = spawnSync('pgrep', ['-fl', `profile-directory=${profileDir}`], {
+      encoding: 'utf8',
+      timeout: 3000,
+    });
+    const lines = (out.stdout || '').split('\n').filter(Boolean);
+    const needle = `profile-directory=${profileDir}`;
+    return lines.some((line) => {
+      const idx = line.indexOf(needle);
+      if (idx < 0) return false;
+      const tail = line.charAt(idx + needle.length);
+      // Match only when the next char is whitespace, end-of-string, or a
+      // shell-quote — not when it's part of a longer profile name.
+      return tail === '' || tail === ' ' || tail === '\t' || tail === '"' || tail === "'";
+    });
+  } catch {
+    return false;
+  }
+}
+
+const CHROME_PROFILES_BASE = join(process.env.HOME || '', 'Library', 'Application Support', 'Google', 'Chrome');
+
+function chromeProfilePath(profileDir) {
+  return join(CHROME_PROFILES_BASE, profileDir);
+}
+
+function isChromeProfileBootstrapped(profileDir) {
+  return existsSync(chromeProfilePath(profileDir));
+}
+
+// Clone an existing Chrome profile dir (extension + cookies + bookmarks
+// preserved). Caller is responsible for ensuring Chrome isn't running against
+// the source profile at clone time — otherwise leveldb/Network state may be
+// captured mid-write and corrupt the destination.
+function cloneChromeProfile(srcProfileDir, dstProfileDir) {
+  const src = chromeProfilePath(srcProfileDir);
+  const dst = chromeProfilePath(dstProfileDir);
+  if (!existsSync(src)) {
+    log(`[chrome-profile] clone source missing: ${src}`);
+    return { ok: false, reason: 'src-missing' };
+  }
+  if (existsSync(dst)) {
+    return { ok: true, reason: 'already-exists' };
+  }
+  // Refuse to clone while the source profile is in use — leveldb corruption.
+  if (isChromeProfileRunning(srcProfileDir)) {
+    return { ok: false, reason: 'src-running' };
+  }
+  const cp = spawnSync('cp', ['-R', src, dst], { timeout: 120_000 });
+  if (cp.status !== 0) {
+    log(`[chrome-profile] cp -R failed (exit ${cp.status}): ${(cp.stderr || '').toString().slice(0, 200)}`);
+    return { ok: false, reason: 'cp-failed' };
+  }
+  return { ok: existsSync(dst), reason: 'cloned' };
+}
+
+const CHROME_LOCAL_STATE_PATH = join(CHROME_PROFILES_BASE, 'Local State');
+
+// Hand-picked, visually distinct Chrome theme colors. The numeric form is
+// Chrome's signed-int packed sRGB used in `profile.info_cache.<dir>.profile_highlight_color`.
+// Hex shown for human-readability; converted via colorIntFromHex().
+const PROFILE_COLOR_PALETTE = [
+  { name: 'Cyan', hex: '#00ACC1' },
+  { name: 'Indigo', hex: '#3949AB' },
+  { name: 'Pink', hex: '#D81B60' },
+  { name: 'Green', hex: '#43A047' },
+  { name: 'Orange', hex: '#F4511E' },
+  { name: 'Purple', hex: '#8E24AA' },
+  { name: 'Teal', hex: '#00897B' },
+  { name: 'Red', hex: '#E53935' },
+  { name: 'Blue', hex: '#1E88E5' },
+];
+
+function colorIntFromHex(hex) {
+  const h = hex.replace('#', '');
+  // Chrome stores as 0xFF<R><G><B> (alpha=255), then interprets via int32 signed.
+  const argb = 0xff000000 | parseInt(h, 16);
+  // Convert to signed int32 the way Chrome serializes it
+  return argb | 0;
+}
+
+function readChromeLocalState() {
+  if (!existsSync(CHROME_LOCAL_STATE_PATH)) return null;
+  try {
+    return JSON.parse(readFileSync(CHROME_LOCAL_STATE_PATH, 'utf8'));
+  } catch (e) {
+    log(`[chrome-localstate] parse failed: ${e.message?.slice(0, 100)}`);
+    return null;
+  }
+}
+
+function writeChromeLocalStateAtomic(obj) {
+  const tmp = `${CHROME_LOCAL_STATE_PATH}.tmp.${process.pid}.${Date.now()}`;
+  writeFileSync(tmp, JSON.stringify(obj, null, 2));
+  renameSync(tmp, CHROME_LOCAL_STATE_PATH);
+}
+
+// Human-friendly display name from an accountKey. Best-effort:
+//   `support@example.ai`            → `Example Support`
+//   `info@myorg.nl`                 → `Myorg`
+//   `team-label`                    → `Team-Label`
+//   `user@example.foundation`       → `Example Foundation`
+function displayNameFor(account) {
+  const key = accountKey(account);
+  if (account.displayName) return account.displayName;
+  if (!key.includes('@')) {
+    return key.charAt(0).toUpperCase() + key.slice(1);
+  }
+  const [local, domain] = key.split('@');
+  const domainParts = (domain || '').split('.');
+  // For user@example.com → "Example"
+  // For info@myorg.nl → "Myorg"
+  // For support@example.ai → "Example Support"
+  const orgRaw = domainParts[0] || '';
+  // CamelCase split of org: "auroracapital" → "Aurora Capital"
+  const org = orgRaw
+    .replace(/[-_]+/g, ' ')
+    .replace(/([a-z])([A-Z])/g, '$1 $2')
+    .replace(/(^|\s)\S/g, (s) => s.toUpperCase());
+  // For info@/support@/sales@ etc., prefix the local part as a role suffix
+  const roleLocals = new Set(['info', 'support', 'sales', 'hello', 'team', 'admin', 'help']);
+  if (roleLocals.has(local.toLowerCase())) {
+    return `${org} ${local.charAt(0).toUpperCase() + local.slice(1)}`;
+  }
+  // For personal mailboxes (sam@…), use Org only if org is meaningful, else email local
+  return org || local.charAt(0).toUpperCase() + local.slice(1);
+}
+
+function launchChromeProfile(profileDir, url) {
+  // Use macOS `open -na` to launch a fresh Chrome instance bound to the named
+  // profile. Multiple Chrome instances on different profile-directories
+  // coexist; each gets its own extension service-worker scope.
+  try {
+    const args = [
+      '-na',
+      'Google Chrome',
+      '--args',
+      `--profile-directory=${profileDir}`,
+      '--no-first-run',
+      '--no-default-browser-check',
+    ];
+    if (url) args.push(url);
+    spawnSync('open', args, { timeout: 8000 });
+    return true;
+  } catch (e) {
+    log(`[chrome-profile] launch failed for ${profileDir}: ${e.message?.slice(0, 100)}`);
+    return false;
+  }
+}
+
+function readClaudeJson() {
+  if (!existsSync(CLAUDE_JSON_PATH)) return null;
+  try {
+    return JSON.parse(readFileSync(CLAUDE_JSON_PATH, 'utf8'));
+  } catch (e) {
+    log(`[oauth-snapshot] failed to parse ~/.claude.json: ${e.message?.slice(0, 100)}`);
+    return null;
+  }
+}
+
+function writeClaudeJsonAtomic(obj) {
+  const tmp = `${CLAUDE_JSON_PATH}.tmp.${process.pid}.${Date.now()}`;
+  writeFileSync(tmp, JSON.stringify(obj, null, 2));
+  try {
+    renameSync(tmp, CLAUDE_JSON_PATH);
+  } catch (e) {
+    try {
+      unlinkSync(tmp);
+    } catch {}
+    throw e;
+  }
+}
+
+function extractOauthBlocks(claudeJson) {
+  if (!claudeJson) return null;
+  return {
+    oauthAccount: claudeJson.oauthAccount || null,
+    chromeExtension: claudeJson.chromeExtension || null,
+  };
+}
+
+function captureOauthSnapshot(accountEmail) {
+  ensureSnapshotsDir();
+  const cj = readClaudeJson();
+  if (!cj) {
+    log(`[oauth-snapshot] cannot capture: ~/.claude.json missing/unreadable`);
+    return false;
+  }
+  const blocks = extractOauthBlocks(cj);
+  if (!blocks?.oauthAccount?.emailAddress) {
+    log(`[oauth-snapshot] cannot capture: no oauthAccount.emailAddress in ~/.claude.json`);
+    return false;
+  }
+  const currentEmail = blocks.oauthAccount.emailAddress.toLowerCase();
+  const wantedEmail = (accountEmail || '').toLowerCase();
+  if (wantedEmail && currentEmail !== wantedEmail) {
+    log(
+      `[oauth-snapshot] refuse capture: ~/.claude.json oauthAccount=${currentEmail} but caller asked to capture for ${wantedEmail}. Restart Claude Code while CLI keychain is on ${wantedEmail} to refresh oauthAccount, then re-run --capture-oauth-snapshot.`,
+    );
+    return false;
+  }
+  // Always key the snapshot file by the .claude.json email — that's the truth.
+  const cfg = readConfig();
+  const matched = cfg.accounts.find((a) => (a.email || '').toLowerCase() === currentEmail);
+  const key = matched ? accountKey(matched) : currentEmail;
+  const out = snapshotPathFor(key);
+  const payload = {
+    capturedAt: new Date().toISOString(),
+    accountKey: key,
+    email: currentEmail,
+    chromeProfileDir: chromeProfileDirFor(key),
+    blocks,
+  };
+  writeFileSync(out, JSON.stringify(payload, null, 2));
+  log(`[oauth-snapshot] captured ${key} → ${out}`);
+  return true;
+}
+
+function loadOauthSnapshot(accountKeyOrEmail) {
+  const direct = snapshotPathFor(accountKeyOrEmail);
+  if (existsSync(direct)) {
+    try {
+      return JSON.parse(readFileSync(direct, 'utf8'));
+    } catch {}
+  }
+  // Fallback: resolve via config (label↔email)
+  const cfg = readConfig();
+  const acct = cfg.accounts.find(
+    (a) =>
+      (a.email || '').toLowerCase() === String(accountKeyOrEmail).toLowerCase() ||
+      (a.label || '').toLowerCase() === String(accountKeyOrEmail).toLowerCase(),
+  );
+  if (acct) {
+    const alt = snapshotPathFor(accountKey(acct));
+    if (existsSync(alt)) {
+      try {
+        return JSON.parse(readFileSync(alt, 'utf8'));
+      } catch {}
+    }
+  }
+  return null;
+}
+
+function applyOauthSnapshotToClaudeJson(snapshot) {
+  if (!snapshot?.blocks) return false;
+  const cj = readClaudeJson();
+  if (!cj) return false;
+  let changed = false;
+  if (snapshot.blocks.oauthAccount) {
+    cj.oauthAccount = snapshot.blocks.oauthAccount;
+    changed = true;
+  }
+  if (snapshot.blocks.chromeExtension) {
+    cj.chromeExtension = snapshot.blocks.chromeExtension;
+    changed = true;
+  }
+  if (changed) writeClaudeJsonAtomic(cj);
+  return changed;
+}
+
+function backupCurrentOauthBlocks() {
+  const cj = readClaudeJson();
+  if (!cj) return false;
+  const blocks = extractOauthBlocks(cj);
+  if (!blocks?.oauthAccount?.emailAddress) return false;
+  const payload = {
+    backedUpAt: new Date().toISOString(),
+    email: blocks.oauthAccount.emailAddress,
+    blocks,
+  };
+  writeFileSync(BROWSER_PIN_BACKUP_PATH, JSON.stringify(payload, null, 2));
+  return true;
+}
+
+function restoreOauthBlocksFromBackup() {
+  if (!existsSync(BROWSER_PIN_BACKUP_PATH)) return false;
+  try {
+    const backup = JSON.parse(readFileSync(BROWSER_PIN_BACKUP_PATH, 'utf8'));
+    const applied = applyOauthSnapshotToClaudeJson({ blocks: backup.blocks });
+    if (applied) log(`[oauth-snapshot] restored backup oauthAccount=${backup.email}`);
+    try {
+      unlinkSync(BROWSER_PIN_BACKUP_PATH);
+    } catch {}
+    return applied;
+  } catch (e) {
+    log(`[oauth-snapshot] backup restore failed: ${e.message?.slice(0, 100)}`);
     return false;
   }
 }
@@ -677,40 +1333,130 @@ function readLatestSMSCode({ maxAgeSec = 300 } = {}) {
 
 // ── PRIMARY: local keychain token swap ───────────────────────────────────────
 
+// OAuth refresh_token grant — same client/endpoint as refresh-tokens.mjs.
+// Critical on headless Linux: the browser-OAuth fallback can never complete
+// there, so an expired vault token must be refreshable in-process or the
+// rotation dies ("Cascade exhausted: All browser drivers failed").
+const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const OAUTH_TOKEN_ENDPOINT = 'https://platform.claude.com/v1/oauth/token';
+
+async function refreshExpiredStoredToken(account, tokenJson) {
+  try {
+    const parsed = JSON.parse(tokenJson);
+    const o = parsed?.claudeAiOauth;
+    if (!o?.refreshToken) return null;
+    const res = await fetch(OAUTH_TOKEN_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'refresh_token',
+        refresh_token: o.refreshToken,
+        client_id: OAUTH_CLIENT_ID,
+      }),
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok || !body.access_token) {
+      log(
+        `[refresh] ${accountKey(account)}: refresh_token grant failed — ${body?.error?.message || `HTTP ${res.status}`}`,
+      );
+      return null;
+    }
+    const updated = {
+      claudeAiOauth: {
+        accessToken: body.access_token,
+        refreshToken: body.refresh_token || o.refreshToken,
+        expiresAt: body.expires_in ? Date.now() + body.expires_in * 1000 : Date.now() + 8 * 3_600_000,
+        scopes: o.scopes || [],
+        subscriptionType: body.subscription_type || o.subscriptionType,
+        rateLimitTier: body.rate_limit_tier || o.rateLimitTier,
+      },
+      mcpOAuth: {},
+    };
+    const json = JSON.stringify(updated);
+    writeStoredToken(account, json);
+    return json;
+  } catch (e) {
+    log(`[refresh] ${accountKey(account)}: refresh error — ${e.message?.slice(0, 100)}`);
+    return null;
+  }
+}
+
 async function swapToken(account) {
-  const token = readStoredToken(account);
+  let token = readStoredToken(account);
   if (!token) {
     log('[primary] No stored token — need browser fallback');
     return false;
   }
   if (tokenExpired(token)) {
-    log('[primary] Token expired — need browser fallback');
-    return false;
+    const refreshed = await refreshExpiredStoredToken(account, token);
+    if (refreshed) {
+      token = refreshed;
+      log('[primary] Expired token renewed via refresh_token grant');
+    } else {
+      log('[primary] Token expired and refresh failed — need browser fallback');
+      return false;
+    }
   }
   log(`[primary] Swapping active keychain for ${accountKey(account)}...`);
 
-  // Preserve mcpOAuth from current active token (Figma, Shake etc.)
-  // so MCP connectors don't break on account swap
+  // Save-back: preserve any silent OAuth refresh Claude Code performed mid-session
+  // by writing the current main-slot token back to the source account's vault entry.
+  try {
+    const swapState = readState();
+    const sourceKey = swapState.activeAccount;
+    if (sourceKey && sourceKey !== accountKey(account)) {
+      const swapConfig = readConfig();
+      const sourceAccount = swapConfig.accounts.find((a) => accountKey(a) === sourceKey);
+      if (sourceAccount) {
+        const currentJson = (() => {
+          try {
+            return readKeychain(KEYCHAIN_SERVICE, ACTIVE_KEYCHAIN_ACCOUNT);
+          } catch {
+            return null;
+          }
+        })();
+        if (currentJson && currentJson.includes('claudeAiOauth')) {
+          try {
+            const parsed = JSON.parse(currentJson);
+            const clean = JSON.stringify({ claudeAiOauth: parsed.claudeAiOauth, mcpOAuth: {} });
+            writeKeychain(clean, tokenService(sourceAccount));
+            log(`[save-back] preserved current token for ${sourceKey}`);
+          } catch (e) {
+            log(`[save-back] skipped: parse/write error — ${e.message?.slice(0, 80)}`);
+          }
+        } else {
+          log(`[save-back] skipped: no claudeAiOauth in current main slot`);
+        }
+      } else {
+        log(`[save-back] skipped: source account ${sourceKey} not found in config`);
+      }
+    } else if (!sourceKey) {
+      log(`[save-back] skipped: no active account tracked in state`);
+    }
+  } catch (e) {
+    log(`[save-back] skipped: ${e.message?.slice(0, 80)}`);
+  }
+
+  // Preserve mcpOAuth from current active token (giga, Amplitude, higgsfield etc.)
+  // Always merge — even if current mcpOAuth appears empty it may be populated by CC
+  // between writes; the guard Object.keys>0 caused silent wipes when a prior rotation
+  // had already zeroed the field.
   try {
     const current = readKeychain();
     const currentParsed = JSON.parse(current);
     const newParsed = JSON.parse(token);
-    // Unconditional merge: vault tokens ship mcpOAuth:{} by design (stripped at
-    // save time). The previous `Object.keys > 0` guard was self-reinforcing —
-    // once a wipe wrote mcpOAuth:{}, the next rotation read empty, skipped the
-    // merge, and wiped again forever, forcing every OAuth MCP server
-    // (giga/Amplitude/higgsfield) to browser-reauth on the next CC launch.
     if (currentParsed.mcpOAuth) {
+      // Unconditional merge: keep all current mcpOAuth entries, only swap claudeAiOauth
       newParsed.mcpOAuth = { ...newParsed.mcpOAuth, ...currentParsed.mcpOAuth };
-      writeKeychain(JSON.stringify(newParsed));
-      log('[primary] Wrote token (mcpOAuth merged from current session)');
-      return true;
     }
+    writeKeychain(JSON.stringify(newParsed));
+    log('[primary] Wrote token (mcpOAuth merged from current session)');
+    return true;
   } catch {}
 
   // Defensive fallback: catch path or falsy currentParsed.mcpOAuth lands here.
-  // Re-attempt the merge once before writing so a transient read/parse error
-  // doesn't wipe mcpOAuth and force every MCP OAuth server to reauth.
+  // Re-attempt the merge once more before writing — without this, a transient
+  // read/parse error wipes mcpOAuth and forces every MCP OAuth server to reauth.
   let outToken = token;
   try {
     const cur = readKeychain();
@@ -933,7 +1679,7 @@ async function makeKaptureDriver() {
         }
         const clean = t
           .replace(/button:has-text\("?([^"]+)"?\)/g, '$1')
-          .replace(/['"]/g, '')
+          .replace(/"/g, '')
           .trim();
         const escaped = clean.replace(/'/g, "\\'");
         const xpaths = [
@@ -1049,7 +1795,7 @@ async function makeKaptureDriver() {
               for (const t of texts) {
                 const clean = t
                   .replace(/button:has-text\("?([^"]+)"?\)/g, '$1')
-                  .replace(/['"]/g, '')
+                  .replace(/"/g, '')
                   .trim();
                 const xpaths = [
                   `//*[normalize-space(text())='${clean}']`,
@@ -1105,15 +1851,14 @@ function extractText(result) {
   return JSON.stringify(result);
 }
 
-// ─── Driver 2: Playwright attached to REAL Chrome via CDP ───────────────────
-// Attaches to the user's real Chrome/Comet profile (with all Google logins).
-// Strategy:
+// ─── Driver 2: Playwright (CDP → Chrome Beta → bundled Chromium) ────────────
+// Tiered strategy — never touches Sam's daily Chrome / Comet profile:
 //   1. If CDP is already up on :9222 → attach directly
-//   2. Else: gracefully quit Chrome, relaunch with CDP + the real user profile
-//   3. NEVER uses bundled Chromium, NEVER uses a separate profile dir
-//
-// The real user profile has all Google accounts signed in, so claude.ai's
-// OAuth account picker shows all of them.
+//   2. Else: spawn Chrome Beta (REAL_BROWSERS) with an ISOLATED automation
+//      profile (.chrome-beta-automation) and CDP enabled
+//   3. Fallback: Playwright's bundled Chromium via launchPersistentContext on
+//      its own ISOLATED profile (.chromium-automation). Used when no Chrome
+//      Beta binary is found, or its launch fails.
 
 // Chrome Beta ONLY — dedicated automation browser.
 // Uses an ISOLATED profile (not linked to Chrome Beta's default). Starts empty;
@@ -1179,118 +1924,116 @@ function isAppRunning(appName) {
 }
 
 function gracefullyQuitApp(appName) {
-  if (IS_LINUX) {
-    // No AppleScript on Linux — send SIGTERM and wait
-    spawnSync('pkill', ['-f', appName], { timeout: 3000 });
-    for (let i = 0; i < 10; i++) {
-      if (!isAppRunning(appName)) return true;
-      spawnSync('sleep', ['0.5']);
-    }
-    return false;
-  }
   try {
-    execFileSync('osascript', ['-e', `tell application "${appName}" to quit`], { timeout: 8000 });
+    execSync(`osascript -e 'tell application "${appName}" to quit' 2>/dev/null`, { timeout: 8000 });
+    // Wait up to 5s for it to actually quit
     for (let i = 0; i < 10; i++) {
       if (!isAppRunning(appName)) return true;
-      spawnSync('sleep', ['0.5']);
+      execSync('sleep 0.5');
     }
   } catch {}
   return false;
 }
 
+// Isolated profile dir for the bundled-Chromium fallback. Distinct from
+// .chrome-beta-automation so the two tiers can coexist without stepping on each
+// other's Cookies/LoginData files.
+const CHROMIUM_FALLBACK_PROFILE = join(__dirname, '.chromium-automation');
+
 async function makePlaywrightDriver() {
   const { chromium } = await import('playwright');
 
-  // ── Linux: headless Chromium (no real Chrome on servers) ─────────────────
-  if (IS_LINUX) {
-    log('[playwright] Linux mode — launching headless Chromium');
-    const profileDir = join(__dirname, '.chromium-linux-profile');
-    const browser = await chromium.launchPersistentContext(profileDir, {
-      headless: true,
-      executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH || undefined,
-      args: [
-        '--no-sandbox',
-        '--disable-setuid-sandbox',
-        '--disable-dev-shm-usage',
-        '--disable-blink-features=AutomationControlled',
-        '--disable-background-networking',
-        '--disable-component-update',
-        '--disable-default-apps',
-        '--disable-sync',
-        '--disable-notifications',
-      ],
-    });
-    const page = browser.pages()[0] || (await browser.newPage());
-    return buildPageDriver(
-      'playwright-linux',
-      page,
-      async () => {
-        try {
-          await browser.close();
-        } catch {}
-      },
-      browser,
-    );
-  }
-
-  // ── macOS: attach to real Chrome via CDP ──────────────────────────────────
-  // 1. Try attaching to already-running Chrome on CDP
+  // Tier 1: attach to an already-running Chrome on CDP :9222 (cheapest).
   let attached = await tryConnectCDP(chromium);
   let weSpawnedChrome = false;
   let spawnedProfile = null;
 
   if (!attached) {
+    // Tier 2: spawn Chrome Beta with CDP + isolated profile, if installed.
     const browser = findRealBrowser();
-    if (!browser) throw new Error('No Comet / Chrome Beta / Chrome binary found');
+    if (browser) {
+      ensureSymlinkedProfile(browser);
 
-    // 2. Ensure symlinked profile exists (Chrome CDP requires non-default user-data-dir)
-    ensureSymlinkedProfile(browser);
+      // Quit any running Chrome Beta holding the profile files
+      // (the symlinked profile shares Cookies/LoginData files with the real one).
+      if (isAppRunning(browser.appName)) {
+        log(`[playwright] ${browser.name} running — quitting to release profile files...`);
+        gracefullyQuitApp(browser.appName);
+        await sleep(1500);
+        try {
+          execSync(`pkill -f "${browser.appName}.app/Contents/MacOS"`);
+        } catch {}
+        await sleep(500);
+      }
 
-    // 3. Quit any running Chrome Beta that might be holding the real profile
-    //    (the symlinked profile shares Cookies/LoginData files with the real one).
-    if (isAppRunning(browser.appName)) {
-      log(`[playwright] ${browser.name} running — quitting to release profile files...`);
-      gracefullyQuitApp(browser.appName);
-      await sleep(1500);
-      // Force kill if still alive
-      try {
-        execSync(`pkill -f "${browser.appName}.app/Contents/MacOS"`);
-      } catch {}
-      await sleep(500);
+      // Launch visible (NOT headless — Cloudflare blocks headless Chrome).
+      // Off-screen + 1x1 so the window is effectively invisible on multi-monitor/retina
+      // setups where 3000,3000 can clamp back onto a display.
+      log(`[playwright] Launching ${browser.name} hidden (1x1 off-screen) with CDP :${CDP_PORT}...`);
+      spawn(
+        browser.bin,
+        [
+          `--remote-debugging-port=${CDP_PORT}`,
+          `--user-data-dir=${browser.profile}`,
+          '--no-first-run',
+          '--no-default-browser-check',
+          '--disable-blink-features=AutomationControlled',
+          '--disable-background-networking',
+          '--disable-component-update',
+          '--disable-default-apps',
+          '--disable-sync',
+          '--disable-notifications',
+          '--window-position=9000,9000',
+          '--window-size=1,1',
+        ],
+        { detached: true, stdio: 'ignore' },
+      ).unref();
+      weSpawnedChrome = true;
+      spawnedProfile = browser.profile;
+
+      // Poll CDP until it comes up
+      for (let i = 0; i < 30; i++) {
+        await sleep(500);
+        attached = await tryConnectCDP(chromium);
+        if (attached) break;
+      }
+      if (!attached) {
+        log(
+          `[playwright] Chrome Beta CDP didn't come up on :${CDP_PORT} within 15s — falling back to bundled Chromium`,
+        );
+      }
+    } else {
+      log('[playwright] No Chrome Beta / Chrome binary found — falling back to bundled Chromium');
     }
+  }
 
-    // 4. Launch visible (NOT headless — Cloudflare blocks headless Chrome)
-    //    Positioned off-screen + 1x1 size so the window is effectively invisible
-    //    even on multi-monitor / retina setups where 3000,3000 clamps onto a display.
-    log(`[playwright] Launching ${browser.name} hidden (1x1 off-screen) with CDP :${CDP_PORT}...`);
-    spawn(
-      browser.bin,
-      [
-        `--remote-debugging-port=${CDP_PORT}`,
-        `--user-data-dir=${browser.profile}`,
-        '--no-first-run',
-        '--no-default-browser-check',
+  // Tier 3: Playwright's bundled Chromium with an isolated persistent profile.
+  // launchPersistentContext returns a BrowserContext directly (no Browser handle);
+  // the close-fn below handles both shapes.
+  let bundledCtx = null;
+  if (!attached) {
+    if (!existsSync(CHROMIUM_FALLBACK_PROFILE)) {
+      execSync(`mkdir -p "${CHROMIUM_FALLBACK_PROFILE}"`, { timeout: 2000 });
+    }
+    log(`[playwright] Launching bundled Chromium (persistent profile: ${CHROMIUM_FALLBACK_PROFILE})...`);
+    bundledCtx = await chromium.launchPersistentContext(CHROMIUM_FALLBACK_PROFILE, {
+      headless: false,
+      args: [
         '--disable-blink-features=AutomationControlled',
         '--disable-background-networking',
         '--disable-component-update',
         '--disable-default-apps',
         '--disable-sync',
         '--disable-notifications',
+        '--no-first-run',
+        '--no-default-browser-check',
         '--window-position=9000,9000',
         '--window-size=1,1',
       ],
-      { detached: true, stdio: 'ignore' },
-    ).unref();
-    weSpawnedChrome = true;
-    spawnedProfile = browser.profile;
-
-    // 4. Poll CDP until it comes up
-    for (let i = 0; i < 30; i++) {
-      await sleep(500);
-      attached = await tryConnectCDP(chromium);
-      if (attached) break;
-    }
-    if (!attached) throw new Error(`CDP didn't come up on :${CDP_PORT} within 15s`);
+    });
+    const page = bundledCtx.pages()[0] || (await bundledCtx.newPage());
+    attached = { browser: null, ctx: bundledCtx, page };
+    log('[playwright] Attached to bundled Chromium');
   }
 
   const { browser: pwBrowser, ctx, page } = attached;
@@ -1298,8 +2041,14 @@ async function makePlaywrightDriver() {
     'playwright',
     page,
     async () => {
+      if (bundledCtx) {
+        try {
+          await bundledCtx.close();
+        } catch {}
+        return;
+      }
       try {
-        await pwBrowser.close();
+        if (pwBrowser) await pwBrowser.close();
       } catch {}
       // Kill Chrome Beta if WE spawned it — don't leave zombie Chromes
       if (weSpawnedChrome && spawnedProfile) {
@@ -1360,7 +2109,7 @@ async function makeChromeJXADriver() {
       for (const t of texts) {
         const clean = t
           .replace(/button:has-text\("?([^"]+)"?\)/g, '$1')
-          .replace(/['"]/g, '')
+          .replace(/"/g, '')
           .trim();
         try {
           const r = jxaJs(
@@ -1455,7 +2204,7 @@ function buildPageDriver(name, page, closeFn, ctx) {
         // and ARIA roles (Google 2FA pages use <li> for options, not <button>)
         const clean = t
           .replace(/button:has-text\("?([^"]+)"?\)/g, '$1')
-          .replace(/['"]/g, '')
+          .replace(/"/g, '')
           .trim();
         try {
           // Try each element type individually so we don't get strict-mode violations
@@ -1546,34 +2295,31 @@ async function pollGmailForMagicLink(accountEmail, maxWaitMs = 120_000) {
   // Track skipped (stale/wrong-target) thread IDs so we don't re-evaluate them every poll
   const seenSkip = new Set();
 
-  // All accounts forward their Claude login emails to one inbox; query that
-  // single account. Falls back to the per-account mailbox if unconfigured.
-  // The per-link target-email check below still disambiguates which link
-  // belongs to the account being rotated, so a shared inbox is safe.
-  const inbox = magicLinkInbox() || accountEmail;
-  if (inbox !== accountEmail) {
-    log(`[magic-link] Using shared forwarding inbox for ${accountEmail}'s link`);
+  // gog requires an explicit --account in daemon/launchd env. All Claude login
+  // emails forward to one inbox, so we always query that single account.
+  const inbox = magicLinkInbox();
+  const acctArgs = inbox ? ['--account', inbox] : [];
+  if (!inbox) {
+    log(
+      `[magic-link] WARNING: no Gmail inbox configured (set CLAUDE_ROT_GMAIL_ACCOUNT or config.magicLinkGmailAccount)`,
+    );
   }
 
   while (Date.now() - startTime < maxWaitMs) {
     try {
       // Pull up to 10 recent matches so a stale top-result doesn't block us.
-      // Use --account so we search the correct inbox, not the default gog account.
-      const gogEnv = { ...process.env, GOG_KEYRING_PASSWORD: process.env.GOG_KEYRING_PASSWORD || '' };
       const searchResult = execFileSync(
         'gog',
         [
-          '--account',
-          inbox,
           'gmail',
           'search',
           'subject:"Secure link to log in to Claude" newer_than:5m',
           '--max',
           '10',
           '-j',
-          '--no-input',
+          ...acctArgs,
         ],
-        { timeout: 15_000, stdio: ['ignore', 'pipe', 'pipe'], env: gogEnv },
+        { timeout: 15_000, stdio: ['ignore', 'pipe', 'pipe'] },
       )
         .toString()
         .trim();
@@ -1588,19 +2334,13 @@ async function pollGmailForMagicLink(accountEmail, maxWaitMs = 120_000) {
         if (!/^[A-Za-z0-9_-]+$/.test(threadIdRaw)) continue;
         if (seenSkip.has(threadIdRaw)) continue;
 
-        const threadJson = execFileSync(
-          'gog',
-          ['--account', inbox, 'gmail', 'thread', 'get', threadIdRaw, '-j', '--no-input'],
-          {
-            timeout: 15_000,
-            stdio: ['ignore', 'pipe', 'pipe'],
-            env: gogEnv,
-          },
-        ).toString();
+        const threadJson = execFileSync('gog', ['gmail', 'read', threadIdRaw, '-j', ...acctArgs], {
+          timeout: 15_000,
+          stdio: ['ignore', 'pipe', 'pipe'],
+        }).toString();
 
         const parsed = JSON.parse(threadJson);
-        // gog gmail thread get returns { messages: [...] } directly (not nested under .thread)
-        const messages = parsed?.messages || parsed?.thread?.messages || [];
+        const messages = parsed?.thread?.messages || [];
 
         // Reject any message older than our requestedAt (stale link from prior call)
         const msgTimes = messages.map((m) => parseInt(m.internalDate || '0', 10) / 1000).filter((t) => t > 0);
@@ -1700,10 +2440,132 @@ async function runAuthFlow(driver, account) {
   const aiBrainHistory = [];
   const aiBrainEnabled = driver._page && process.env.CLAUDE_ROTATOR_DISABLE_AI_BRAIN !== '1';
 
+  async function finishMagicLinkLogin(magicLink) {
+    if (!magicLink) return false;
+    if (magicLink.startsWith('code:')) {
+      const code = magicLink.replace('code:', '');
+      log(`[magic-link] Entering verification code: ${code}`);
+      await driver.fillInput(
+        'input[type="text"], input[type="number"], input[name="code"], input[placeholder*="code" i]',
+        code,
+      );
+      await driver.findAndClick(['Continue', 'Verify', 'Submit', 'button[type="submit"]']);
+    } else {
+      log(`[magic-link] Navigating to login link`);
+      await driver.goto(magicLink);
+    }
+    await sleep(4000);
+    // After magic link login, session is now valid — re-navigate to authUrl
+    // so the OAuth flow can complete (org chooser → authorize → callback)
+    if (driver._authUrl) {
+      // For multi-org accounts (same email, multiple workspaces like
+      // user-personal vs user-team), force an explicit org
+      // pick BEFORE hitting /oauth/authorize. Otherwise claude.ai uses
+      // the "last active" org silently, and both sibling vaults end up
+      // holding the same org's token.
+      const isMultiOrg =
+        account.label && account.orgName && account.orgName.toLowerCase() !== account.email.toLowerCase();
+      if (isMultiOrg) {
+        log(`[magic-link] Multi-org account — forcing org pick for "${account.orgName}" via claude.ai/home detour`);
+        try {
+          await driver.goto('https://claude.ai/home');
+        } catch {}
+        await sleep(3500);
+        // Try to click the configured orgName if a chooser is showing.
+        // The broadened org-chooser logic in the main loop will also
+        // pick this up on the next iteration, but an immediate attempt
+        // here short-circuits silently-skipped cases.
+        const picked = await driver.findAndClick([
+          `button:has-text("${account.orgName}")`,
+          `[role="button"]:has-text("${account.orgName}")`,
+          `text="${account.orgName}"`,
+          account.orgName,
+        ]);
+        if (picked) {
+          log(`[magic-link] Pre-selected org "${account.orgName}" before OAuth`);
+          await sleep(2500);
+        } else {
+          log(`[magic-link] No immediate match for "${account.orgName}" — will rely on org-chooser loop / ai-brain`);
+        }
+      }
+      log(`[magic-link] Re-navigating to OAuth authorize URL`);
+      try {
+        await driver.goto(driver._authUrl);
+      } catch {}
+      await sleep(3000);
+    }
+    return true;
+  }
+
+  async function handleClaudeMagicLinkEmailPrompt(reason) {
+    if (!account.useMagicLink) return false;
+    const filled = await driver.fillInput('[data-testid="email"], #email, input[type="email"]', account.email);
+    if (!filled) return false;
+    log(`[magic-link] ${reason ? `${reason} — ` : ''}Filled email: ${account.email}`);
+    await sleep(500);
+    const submitted = await driver.findAndClick([
+      '[data-testid="continue"]',
+      'button[data-testid="continue"]',
+      'button[type="submit"]:has-text("Continue with email")',
+      'button:has-text("Continue with email")',
+      'button:has-text("Continue")',
+    ]);
+    if (!submitted) return false;
+    log(`[magic-link] Submitted email — magic link should be sent`);
+    await sleep(3000);
+
+    const magicLink = await pollGmailForMagicLink(account.email);
+    if (await finishMagicLinkLogin(magicLink)) return true;
+
+    log(`[magic-link] No magic link found in Gmail — magic-link-only, no Google fallback`);
+    return false;
+  }
+
+  async function isClaudeLoginCodePage() {
+    if (!driver.readPageText) return false;
+    try {
+      const text = (await driver.readPageText()).toLowerCase();
+      return (
+        text.includes('verification code') ||
+        text.includes('enter the code') ||
+        text.includes('check your email') ||
+        text.includes('we sent') ||
+        text.includes('code sent')
+      );
+    } catch {
+      return false;
+    }
+  }
+
   for (let step = 0; step < 20; step++) {
     await sleep(2500);
     const url = await driver.currentUrl().catch(() => '');
     log(`Step ${step} [${driver.name}]: ${url.substring(0, 100)}`);
+
+    // Claude sometimes renders the email login form while preserving the
+    // /oauth/authorize URL. Handle known Claude auth prompts before the generic
+    // stall detector, otherwise AI-brain burns multiple decisions waiting for a
+    // verification code that the deterministic Gmail poller can resolve or fail.
+    if (account.useMagicLink && url.includes('claude.ai')) {
+      if (
+        await handleClaudeMagicLinkEmailPrompt(
+          url.includes('/oauth/authorize') ? 'OAuth page rendered login prompt' : 'Login prompt',
+        )
+      ) {
+        stallCount = 0;
+        continue;
+      }
+      if (url.includes('/login') && (await isClaudeLoginCodePage())) {
+        log(`[magic-link] Claude login is waiting for an email verification code; polling Gmail once before aborting`);
+        const magicLink = await pollGmailForMagicLink(account.email, 30_000);
+        if (await finishMagicLinkLogin(magicLink)) {
+          stallCount = 0;
+          continue;
+        }
+        log(`[magic-link] Verification-code page could not be completed automatically for ${account.email}`);
+        return false;
+      }
+    }
 
     // Stall check — run BEFORE the URL pattern dispatcher so an unknown
     // challenge page gets escalated to the AI brain. Skip on the very first
@@ -2065,49 +2927,80 @@ async function runAuthFlow(driver, account) {
       oauthPath = new URL(url).pathname;
     } catch {}
     if (oauthPath.includes('/oauth/authorize') || (oauthPath.endsWith('/authorize') && url.includes('claude'))) {
-      // Step 1: Read page to verify "Logged in as <correct email>"
-      let pageText = '';
-      if (driver.readPageText) {
-        try {
-          pageText = (await driver.readPageText()).toLowerCase();
-        } catch {}
-      }
-
-      const hasCorrectAccount = pageText && pageText.includes(account.email.toLowerCase());
-      const hasAnyOtherEmail = pageText && /[\w.+-]+@[\w.-]+\.\w+/.test(pageText) && !hasCorrectAccount;
-
-      // If we can't read the page OR we see the wrong account, force switch
-      if (!pageText || hasAnyOtherEmail) {
-        log(`Page text: ${pageText ? 'wrong account' : 'unreadable'} — clicking Switch account / Logout`);
-        const switched = await driver.findAndClick([
-          'Switch account',
-          'Log out',
-          'Logout',
-          'Sign out',
-          'Use another account',
-        ]);
-        if (switched) {
-          await sleep(3000);
-          continue;
+      // Magic-link route: we authenticated via a single-use link delivered to
+      // account.email's inbox, so the session on this page is guaranteed to be
+      // the right account. Skip the readPageText "verify" dance — it failed to
+      // read DOM ~50% of the time and triggered useless Switch-account/Logout
+      // detours that broke the flow. Just go click Authorize.
+      if (account.useMagicLink) {
+        log(`[magic-link] On /oauth/authorize — proceeding straight to Authorize`);
+      } else {
+        // Step 1: Read page to verify "Logged in as <correct email>"
+        let pageText = '';
+        if (driver.readPageText) {
+          try {
+            pageText = (await driver.readPageText()).toLowerCase();
+          } catch {}
         }
-        // Couldn't find switch button — the page may already be the account chooser
-        // Try clicking the email we want directly
-        const picked = await driver.findAndClick([account.email]);
-        if (picked) {
-          await sleep(3000);
-          continue;
+
+        const hasCorrectAccount = pageText && pageText.includes(account.email.toLowerCase());
+        const hasAnyOtherEmail = pageText && /[\w.+-]+@[\w.-]+\.\w+/.test(pageText) && !hasCorrectAccount;
+
+        // If we can't read the page OR we see the wrong account, force switch
+        if (!pageText || hasAnyOtherEmail) {
+          log(`Page text: ${pageText ? 'wrong account' : 'unreadable'} — clicking Switch account / Logout`);
+          const switched = await driver.findAndClick([
+            'Switch account',
+            'Log out',
+            'Logout',
+            'Sign out',
+            'Use another account',
+          ]);
+          if (switched) {
+            await sleep(3000);
+            continue;
+          }
+          // Couldn't find switch button — the page may already be the account chooser
+          // Try clicking the email we want directly
+          const picked = await driver.findAndClick([account.email]);
+          if (picked) {
+            await sleep(3000);
+            continue;
+          }
+          // Last resort: log and click authorize anyway (may fail)
+          log(`WARNING: Could not verify account — clicking Authorize blind`);
+        } else if (hasCorrectAccount) {
+          log(`Correct account confirmed: ${account.email}`);
         }
-        // Last resort: log and click authorize anyway (may fail)
-        log(`WARNING: Could not verify account — clicking Authorize blind`);
-      } else if (hasCorrectAccount) {
-        log(`Correct account confirmed: ${account.email}`);
       }
 
       // Step 2: Click Authorize — wait for button to become enabled (up to 30s)
       let authorized = false;
       for (let wait = 0; wait < 6; wait++) {
-        if (await driver.findAndClick(['Authorize', 'Allow', 'Approve', 'Accept'])) {
+        if (
+          await driver.findAndClick([
+            '[data-testid="continue"]',
+            'button[data-testid="continue"]',
+            'Authorize',
+            'Allow',
+            'Approve',
+            'Accept',
+            'Continue',
+          ])
+        ) {
           log('Clicked Authorize');
+          authorized = true;
+          break;
+        }
+        // Check if the prior click (or magic-link) already navigated us off
+        // the authorize page. If we're on /oauth/code/success or any non-claude.ai
+        // URL, auth is done — stop hunting for a button that no longer exists.
+        const currentUrl = await driver.currentUrl().catch(() => '');
+        if (
+          currentUrl.includes('/oauth/code/success') ||
+          (currentUrl && !currentUrl.includes('claude.ai') && !currentUrl.includes('claude.com'))
+        ) {
+          log(`Auth already succeeded — URL moved to ${currentUrl.substring(0, 80)}`);
           authorized = true;
           break;
         }
@@ -2121,8 +3014,8 @@ async function runAuthFlow(driver, account) {
       }
       log('Authorize button still not clickable after 30s — escalating to ai-brain');
       // Fast-path ai-brain escalation: don't wait for stall detector to catch up
-      // on the next loop iter. The page is stuck on OAuth authorize and Haiku
-      // can usually pick the right org/continue button immediately.
+      // on the next loop iter. The page is stuck on OAuth authorize — Bedrock
+      // vision + optional Context7 / web research picks the next action.
       if (aiBrainEnabled && aiBrainHistory.length < AI_BRAIN_MAX_DECISIONS) {
         const action = await askAIBrain({
           page: driver._page,
@@ -2237,36 +3130,17 @@ async function runAuthFlow(driver, account) {
             }
             continue;
           }
-          // Magic-link is the ONLY auth method on every platform — never fall
-          // through to Google OAuth (it stalls on push-2FA and the user wants
-          // magic-link only). Fail the account so the missing link surfaces.
-          log(`[magic-link] No magic link found in Gmail — failing account (magic-link-only, no Google fallback).`);
-          throw new Error(`magic-link timeout for ${account.email} (magic-link-only)`);
+          log(
+            `[magic-link] No magic link found in Gmail — magic-link-only, will re-poll next step (no Google fallback)`,
+          );
         }
       }
     }
 
-    // Claude.ai login → Continue with Google (button has data-testid="login-with-google")
-    const popupP = driver.waitForPopup ? driver.waitForPopup(15_000) : Promise.resolve(null);
-    if (
-      await driver.findAndClick(['[data-testid="login-with-google"]', 'Continue with Google', 'Sign in with Google'])
-    ) {
-      const popup = await popupP;
-      if (popup) {
-        // Kapture popup is already a full driver; Playwright returns a raw Page
-        const pd = popup.name ? popup : buildPageDriver(driver.name + '-popup', popup, () => {}, null);
-        await runAuthFlow(pd, account);
-        if (popup.waitForEvent) {
-          await popup.waitForEvent('close', { timeout: 30_000 }).catch(() => {});
-        }
-      }
-      continue;
-    }
-
-    // Email input
-    if (await driver.fillInput('#identifierId, input[type="email"]', account.email)) {
-      await driver.findAndClick(['Next', '#identifierNext button']);
-    }
+    // Google OAuth is DISABLED — magic-link is the only auth method. We never
+    // click "Continue with Google" or drive accounts.google.com. If the magic
+    // link could not be completed above, keep looping (re-poll Gmail) until the
+    // step budget is exhausted, then fail this driver.
   }
 
   // Loop exhausted — final AI-brain attempt before giving up. Some flows
@@ -2275,11 +3149,7 @@ async function runAuthFlow(driver, account) {
   if (aiBrainEnabled && aiBrainHistory.length < AI_BRAIN_MAX_DECISIONS) {
     const url = await driver.currentUrl().catch(() => '');
     log(`[ai-brain] loop exhausted — final rescue attempt`);
-    // Snapshot remaining budget before the loop — aiBrainHistory grows each
-    // iteration, so re-evaluating inside the condition would shrink the bound
-    // twice as fast (once from rescue++, once from the growing length).
-    const rescueBudget = Math.min(3, AI_BRAIN_MAX_DECISIONS - aiBrainHistory.length);
-    for (let rescue = 0; rescue < rescueBudget; rescue++) {
+    for (let rescue = 0; rescue < AI_BRAIN_MAX_DECISIONS - aiBrainHistory.length && rescue < 3; rescue++) {
       const action = await askAIBrain({
         page: driver._page,
         account,
@@ -2419,6 +3289,10 @@ async function browserOAuthFallback(account) {
       }
       success = await runAuthFlow(driver, account);
 
+      if (success) {
+        await maybeScrapeBillingAfterOAuth(driver, account, log);
+      }
+
       if (!success) {
         log(`[${driver._driverName}] runAuthFlow returned false — trying next driver`);
         failed.add(driver._driverName);
@@ -2458,25 +3332,53 @@ async function browserOAuthFallback(account) {
 function findClaudeSessions() {
   const sessions = [];
   try {
-    const psOut = execSync(
-      `ps -eo pid,tty,args | grep -E '[c]laude.*--dangerously' | grep -v 'mcp ' | grep -v '\\-p '`,
-      { timeout: 5000 },
-    )
+    // Use pid,args only — no tty column. On macOS, background processes show
+    // tty as "??" which never matches the ttys?\d+ pattern, and the old
+    // `grep -` (empty pattern) at the end of the pipeline caused the whole
+    // execSync to throw "Command failed" on every call.
+    // ps -eo pid,args works identically on macOS (BSD) and Linux (GNU).
+    //
+    // Match ANY claude CLI process, not just `--dangerously-skip-permissions`
+    // ones — plain interactive sessions, `claude --resume`, and headless
+    // `claude -p` runs all hold tokens that go stale after rotation (observed
+    // 2026-06-11: live agent sessions were invisible to this enum and wedged
+    // on the expired outgoing token). The first ps token must BE the claude
+    // binary — matching `claude` anywhere in args would false-positive on
+    // `tail -f .../claude/...log`, `node .../account-rotation/daemon.mjs`, etc.
+    // Utility invocations (daemon supervisor, respawn/attach/logs/agents, mcp)
+    // are excluded here; daemon-hosted bg sessions are refreshed separately
+    // via respawnBgSessions() (they have no TTY to inject /login into).
+    const psRaw = execSync(`ps -eo pid,args | grep -E '[c]laude' | grep -v 'grep'`, {
+      timeout: 5000,
+    })
       .toString()
       .trim();
+    const CLAUDE_CMD_RE = /^(?:\S*\/)?claude(?:\s|$)/;
+    const UTILITY_SUBCMD_RE = /^(?:\S*\/)?claude\s+(?:daemon|respawn|attach|logs|agents|mcp|doctor|update|config)\b/;
+    const psOut = psRaw
+      .split('\n')
+      .filter((line) => {
+        const args = line.trim().replace(/^\d+\s+/, '');
+        return CLAUDE_CMD_RE.test(args) && !UTILITY_SUBCMD_RE.test(args);
+      })
+      .join('\n');
     if (!psOut) return sessions;
 
-    const ttyMap = {};
+    // Build pid→tty map from tmux (best-effort; tty used only for tmux pane lookup)
+    const ttyByPid = {};
     try {
       const paneOut = execSync(
-        `tmux list-panes -a -F '#{pane_tty}|#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null`,
+        `tmux list-panes -a -F '#{pane_pid}|#{pane_tty}|#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null`,
         { timeout: 3000 },
       )
         .toString()
         .trim();
       for (const line of paneOut.split('\n')) {
-        const [tty, pane] = line.split('|');
-        if (tty && pane) ttyMap[tty] = pane;
+        const parts = line.split('|');
+        if (parts.length >= 3) {
+          const [panePid, tty, pane] = parts;
+          if (panePid && tty && pane) ttyByPid[panePid.trim()] = { tty: tty.trim(), pane: pane.trim() };
+        }
       }
     } catch {}
 
@@ -2487,20 +3389,22 @@ function findClaudeSessions() {
       for (const f of readdirSync(sessionStateDir).filter((f) => f.endsWith('.json'))) {
         try {
           const s = JSON.parse(readFileSync(join(sessionStateDir, f), 'utf8'));
-          if (s.kind === 'bg' && s.pid) bgPids.add(s.pid);
+          if (s.kind === 'bg' && s.pid) bgPids.add(String(s.pid));
         } catch {}
       }
     } catch {}
 
     for (const line of psOut.split('\n')) {
-      const match = line.trim().match(/^(\d+)\s+(ttys?\d+)\s+(.+)$/);
+      // Format: "  <pid> <args...>"
+      const match = line.trim().match(/^(\d+)\s+(.+)$/);
       if (!match) continue;
-      const [, pid, ttyShort, args] = match;
-      const tty = `/dev/${ttyShort}`;
+      const [, pid, args] = match;
+      const tmux = ttyByPid[pid] || null;
+      const tty = tmux?.tty || null;
+      const pane = tmux?.pane || null;
       const resumeMatch = args.match(/--resume\s+(\S+)/);
       const resumeId = resumeMatch ? resumeMatch[1] : null;
-      const pane = ttyMap[tty] || null;
-      const isBg = bgPids.has(parseInt(pid));
+      const isBg = bgPids.has(pid);
       sessions.push({ pid: parseInt(pid), tty, pane, resumeId, args, isBg });
     }
   } catch (e) {
@@ -2580,25 +3484,18 @@ function detectTerminalForPid(pid) {
 
 async function refreshRunningSession(rotatedAccount = null, noBrowser = false) {
   const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
-  // /login is injected into each reachable session in sequence. Space the injects
-  // by a base gap + random jitter so N sessions don't all re-read the keychain and
-  // fire their first call onto the freshly-rotated account in the same instant.
-  // Env-overridable; jitter=0 keeps the legacy fixed 500ms cadence.
-  const INJECT_BASE_MS = Math.max(0, Number(process.env.CLAUDE_SESSION_INJECT_MS ?? 500));
-  const INJECT_JITTER_MS = Math.max(0, Number(process.env.CLAUDE_SESSION_INJECT_JITTER_MS ?? 1_000));
-  const injectGap = () => INJECT_BASE_MS + Math.floor(Math.random() * (INJECT_JITTER_MS + 1));
+
   const sessions = findClaudeSessions();
 
   if (sessions.length === 0) {
     log('[session] No running Claude Code sessions found');
+    return;
   }
 
-  // Tag each session with its owning terminal app.
-  // Injection paths (in priority order):
-  //   1. tmux pane — most reliable, works from any terminal including Ghostty
-  //   2. iTerm2 AppleScript — for non-tmux iTerm2 sessions
-  //   3. claude --resume --print /login — for bg sessions (no TTY) or any
-  //      session that has a resumeId but no reachable TTY
+  // Tag each session with its owning terminal app. We only have a reliable
+  // AppleScript injection path for tmux + iTerm2. For Ghostty/Terminal/others,
+  // writing to the raw TTY shows as OUTPUT (garbles the live display) and
+  // `tell application "iTerm2"` would spuriously *launch* iTerm2 — so we skip.
   for (const s of sessions) {
     if (!s.pane && s.pid) s.terminal = detectTerminalForPid(s.pid);
   }
@@ -2606,78 +3503,42 @@ async function refreshRunningSession(rotatedAccount = null, noBrowser = false) {
   const sendKeys = (s, txt) => {
     if (s.pane) return sendKeysToPane(s.pane, txt);
     if (s.terminal === 'iTerm2' && s.tty) return sendKeysToITerm(s.tty, txt);
-    // Ghostty, Terminal.app, Alacritty, WezTerm, kitty, unknown: fall through
-    // to resume-path below; raw TTY write garbles the display.
+    // Ghostty, Terminal.app, Alacritty, WezTerm, kitty, unknown: skip.
+    // Raw TTY write would render "/login" as on-screen output text, not
+    // stdin — corrupting the session without triggering the re-auth.
     return false;
   };
 
-  // Resume path: sessions that have a --resume UUID can receive /login via
-  // `claude --resume <uuid> --print /login`. Works for claude --bg sessions
-  // (no TTY, detached) and Ghostty / non-tmux sessions where AppleScript is unavailable.
-  async function sendViaResume(s) {
-    if (!s.resumeId) return false;
-    try {
-      spawnSync('claude', ['--resume', s.resumeId, '--print', '/login'], { timeout: 15_000, stdio: 'ignore' });
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
+  // Reachable = tmux pane OR known-good terminal (iTerm2). Everyone else
+  // is logged + skipped so we never pop a visual window or garble Ghostty.
   const reachable = sessions.filter((s) => s.pane || (s.terminal === 'iTerm2' && s.tty));
-  const resumable = sessions.filter((s) => !s.pane && !(s.terminal === 'iTerm2' && s.tty) && s.resumeId);
-  const unreachable = sessions.filter((s) => !s.pane && !(s.terminal === 'iTerm2' && s.tty) && !s.resumeId);
-
-  for (const s of unreachable) {
-    log(`[session] Skipping PID ${s.pid} (${s.terminal || 'unknown'}) — no tmux pane, no iTerm2, no resumeId`);
+  const skipped = sessions.filter((s) => !s.pane && s.terminal && s.terminal !== 'iTerm2');
+  for (const s of skipped) {
+    log(
+      `[session] Skipping PID ${s.pid} (${s.terminal}) — no safe inject path; token-refresh daemon keeps keys fresh so restart isn't required`,
+    );
   }
-
-  const totalActionable = reachable.length + resumable.length;
-  if (totalActionable === 0 && sessions.length > 0) {
-    log(`[session] Found ${sessions.length} session(s) but none have a reachable inject path`);
-  } else if (sessions.length === 0) {
+  if (reachable.length === 0) {
+    log(`[session] Found ${sessions.length} sessions but none have a reachable TTY`);
     return;
   }
 
-  if (reachable.length > 0) {
-    log(`[session] Injecting /login into ${reachable.length} TTY-reachable session(s):`);
-    for (const s of reachable) {
-      log(`  PID ${s.pid} ${s.pane ? 'pane=' + s.pane : 'tty=' + s.tty}`);
-    }
+  log(`[session] Injecting /login into ${reachable.length} session(s):`);
+  for (const s of reachable) {
+    log(`  PID ${s.pid} ${s.pane ? 'pane=' + s.pane : 'tty=' + s.tty}`);
   }
 
   // Keychain was already swapped to the fresh account's valid token.
   // /login re-reads the keychain → picks up the new token → "Login successful" instantly.
+  // No /exit, no process restart, no OAuth browser flow needed (token is already valid).
+  // Stagger slightly to avoid all sessions hitting the API at the exact same millisecond.
   for (const s of reachable) {
     if (sendKeys(s, '/login')) {
       log(`[session] Sent /login to PID ${s.pid} (${s.pane || s.tty})`);
     } else {
-      log(`[session] Failed TTY inject for PID ${s.pid} — trying resume path`);
-      if (s.resumeId) {
-        const ok = await sendViaResume(s);
-        log(`[session] Resume fallback for PID ${s.pid}: ${ok ? 'ok' : 'failed'}`);
-      }
+      log(`[session] Failed to inject /login to PID ${s.pid} (${s.pane || s.tty})`);
     }
-    await sleep(injectGap());
-  }
-
-  // Non-tmux sessions with a resumeId (non-bg interactive sessions in Ghostty etc):
-  // use claude --resume --print /login.
-  // NOTE: claude --bg daemon sessions auto-reauth within 30s via Claude Code's
-  // keychain poll cycle — the CLI blocks --resume --print on them anyway.
-  const resumableInteractive = resumable.filter((s) => !s.isBg);
-  const resumableBg = resumable.filter((s) => s.isBg);
-  for (const s of resumableBg) {
-    log(`[session] PID ${s.pid} is a bg session — will auto-reauth via 30s keychain poll (no action needed)`);
-  }
-  if (resumableInteractive.length > 0) {
-    log(`[session] Sending /login via --resume to ${resumableInteractive.length} non-tmux interactive session(s):`);
-    for (const s of resumableInteractive) {
-      log(`  PID ${s.pid} resumeId=${s.resumeId} terminal=${s.terminal || 'unknown'}`);
-      const ok = await sendViaResume(s);
-      log(`[session] Resume /login for PID ${s.pid}: ${ok ? 'ok' : 'failed'}`);
-      await sleep(injectGap());
-    }
+    await sleep(500); // 500ms stagger between sessions
   }
 
   // If Claude relaunches trigger an OAuth browser window (token expired mid-rotation),
@@ -2692,7 +3553,10 @@ async function refreshRunningSession(rotatedAccount = null, noBrowser = false) {
         const url = await driver.currentUrl().catch(() => '');
         if (url && (url.includes('oauth') || url.includes('authorize') || url.includes('claude.ai/login'))) {
           log(`[session] Detected post-restart OAuth page (${url.substring(0, 60)}) — driving flow`);
-          if (rotatedAccount) await runAuthFlow(driver, rotatedAccount);
+          if (rotatedAccount) {
+            const authOk = await runAuthFlow(driver, rotatedAccount);
+            if (authOk) await maybeScrapeBillingAfterOAuth(driver, rotatedAccount, log);
+          }
         }
         try {
           await driver.close?.();
@@ -2713,76 +3577,109 @@ async function rotate(targetEmail, opts = {}) {
   const state = readState();
   const dryRun = opts.dryRun || false;
 
-  if (!targetEmail) {
-    // Query live utilization for all accounts before picking — best-effort, ~2s
-    log('Querying live utilization for all accounts...');
-    const liveUtil = await queryAllUtilization(config);
-    const utilSummary = Object.entries(liveUtil)
-      .map(([k, v]) => `${k}:5h=${v.five_hour_pct}%/7d=${v.seven_day_pct}%`)
-      .join(', ');
-    if (utilSummary) log(`Live util: ${utilSummary}`);
-    // Snapshot live data into state for future daemon decisions
-    for (const [key, util] of Object.entries(liveUtil)) {
-      state.accounts[key] = state.accounts[key] || {};
-      state.accounts[key].lastUtilization = {
-        pct: util.five_hour_pct,
-        reset: util.resets_at_5h ? Math.floor(new Date(util.resets_at_5h).getTime() / 1000) : null,
+  // ALWAYS query live util — needed for picker (no target) AND for
+  // target-validation (with --to). This is the safety net that makes sure
+  // we never rotate to an account that will immediately say "token-limit".
+  log('Querying live utilization for all accounts...');
+  const liveUtil = await queryAllUtilization(config);
+  const utilSummary = Object.entries(liveUtil)
+    .map(([k, v]) => `${k}:5h=${v.five_hour_pct}%/7d=${v.seven_day_pct}%`)
+    .join(', ');
+  if (utilSummary) log(`Live util: ${utilSummary}`);
+  // Snapshot live data into state for future daemon decisions.
+  // Includes BOTH 5h util AND extra_usage_enabled — the latter is sticky-true
+  // so EU accounts stay refused even when subsequent live queries fail.
+  for (const [key, util] of Object.entries(liveUtil)) {
+    state.accounts[key] = state.accounts[key] || {};
+    state.accounts[key].lastUtilization = {
+      pct: util.five_hour_pct,
+      reset: util.resets_at_5h ? Math.floor(new Date(util.resets_at_5h).getTime() / 1000) : null,
+      ts: Date.now(),
+    };
+    if (util.extra_usage_enabled !== null && util.extra_usage_enabled !== undefined) {
+      state.accounts[key].lastBilling = {
+        extra_usage_enabled: util.extra_usage_enabled === true,
+        billing_type: util.billing_type || null,
         ts: Date.now(),
       };
     }
-    writeState(state, dryRun);
-    const next = pickNextAccount(config, state, liveUtil, {
-      allowExtraUsage: opts.allowExtraUsage === true,
-    });
-    if (!next) {
-      log('No account available (all excluded — extra_usage enabled?)');
+  }
+  try {
+    writeState(state);
+  } catch {}
+  const bedrockOnExhausted = opts.bedrockOnExhausted !== false; // default ON
+
+  if (!targetEmail) {
+    const { pick, allExhausted, onlyActiveViable, destinationCapStuck } = recommendAccount(config, state, liveUtil);
+    if (!pick) {
+      if (onlyActiveViable) {
+        log('Rotation skipped — already on the only viable Max account (API headroom; other accounts exhausted).');
+        return true;
+      }
+      if (allExhausted || destinationCapStuck) {
+        if (allExhausted) {
+          log('All accounts live-confirmed EXHAUSTED — engaging Bedrock fallback');
+        } else {
+          log(
+            `Every live-confirmed non-active account is ≥${destinationUtilHardBlock(config)}% max(5h,7d) — no rotation target; engaging Bedrock fallback`,
+          );
+        }
+        if (bedrockOnExhausted)
+          await activateBedrockFallback(
+            allExhausted ? 'all_accounts_exhausted_picker_null' : 'destination_cap_no_headroom',
+            dryRun,
+          );
+      } else {
+        log('No account available (see utilization / query logs above)');
+      }
       return false;
     }
-    targetEmail = accountKey(next);
-  }
-
-  // Hard safety gate: even when the user passes --to <email> explicitly,
-  // refuse to activate a Max account where the Anthropic org has
-  // has_extra_usage_enabled=true (overage billing). Requires --allow-extra-usage
-  // to bypass.
-  try {
-    if (!opts.allowExtraUsage) {
-      const target = config.accounts.find((a) => accountKey(a) === targetEmail || a.email === targetEmail);
-      if (target) {
-        const tokenJson = readStoredToken(target);
-        if (tokenJson) {
-          const parsed = JSON.parse(tokenJson);
-          const accessToken = parsed?.claudeAiOauth?.accessToken;
-          if (accessToken) {
-            const res = await fetch('https://api.anthropic.com/api/oauth/profile', {
-              method: 'GET',
-              headers: {
-                Authorization: `Bearer ${accessToken}`,
-                'anthropic-beta': 'oauth-2025-04-20',
-                'Content-Type': 'application/json',
-              },
-              signal: AbortSignal.timeout(5000),
-            });
-            if (res.ok) {
-              const prof = await res.json();
-              const euEnabled = prof?.organization?.has_extra_usage_enabled === true;
-              if (euEnabled) {
-                log(
-                  `REFUSED: target ${targetEmail} has extra_usage enabled (pay-per-use). Pass --allow-extra-usage to override.`,
-                );
-                notify(
-                  'Rotation BLOCKED',
-                  `${targetEmail}: extra_usage enabled — would risk credit-card overage. Disable at console.anthropic.com/settings/billing`,
-                );
-                return false;
-              }
-            }
+    targetEmail = accountKey(pick);
+  } else {
+    // Target validation: refuse exhausted API targets unless overridden.
+    const targetAcct =
+      config.accounts.find((a) => accountKey(a) === targetEmail) ||
+      config.accounts.find((a) => a.email === targetEmail);
+    if (targetAcct) {
+      const tKey = accountKey(targetAcct);
+      const tu = liveUtil[tKey];
+      const targetExhausted =
+        tu &&
+        tu.five_hour_pct != null &&
+        tu.seven_day_pct != null &&
+        Math.max(tu.five_hour_pct, tu.seven_day_pct) >= EXHAUSTED_THRESHOLD;
+      if (targetExhausted && !opts.allowExhausted) {
+        log(
+          `⚠  --to ${targetEmail} is EXHAUSTED (5h=${tu.five_hour_pct}% 7d=${tu.seven_day_pct}%) — auto-falling back to picker`,
+        );
+        const { pick, allExhausted, onlyActiveViable, destinationCapStuck } = recommendAccount(config, state, liveUtil);
+        if (!pick) {
+          if (onlyActiveViable) {
+            log('Rotation skipped — already on the only viable Max account.');
+            return true;
           }
+          if (allExhausted || destinationCapStuck) {
+            if (allExhausted) log('No alternative — all accounts exhausted');
+            else {
+              log(
+                `No alternative under destination cap (${destinationUtilHardBlock(config)}%) — engaging Bedrock fallback`,
+              );
+            }
+            if (bedrockOnExhausted) {
+              await activateBedrockFallback(
+                allExhausted ? 'target_and_all_others_exhausted' : 'destination_cap_after_exhausted_target',
+                dryRun,
+              );
+            }
+          } else {
+            log('No alternative — see utilization / query logs above');
+          }
+          return false;
         }
+        targetEmail = accountKey(pick);
+        log(`→ Picker chose ${targetEmail} instead`);
       }
     }
-  } catch (e) {
-    log(`Extra-usage preflight error (non-fatal): ${e.message?.slice(0, 80)}`);
   }
 
   // Find by label first, then by email
@@ -2792,7 +3689,10 @@ async function rotate(targetEmail, opts = {}) {
     log(`Account ${targetEmail} not in config`);
     return false;
   }
-  if (opts.magicLink) account.useMagicLink = true;
+  // Magic-link is the ONLY supported auth method for every account/path
+  // (quickest; all login emails forward to one inbox). opts.magicLink is now
+  // implied — we never fall through to Google OAuth.
+  account.useMagicLink = true;
   const key = accountKey(account);
 
   log(`=== ROTATING: ${state.activeAccount || 'none'} → ${key} (${account.email}) ===`);
@@ -2937,70 +3837,6 @@ async function rotate(targetEmail, opts = {}) {
     return false;
   }
 
-  // POST-SWAP BILLING SAFETY CHECK
-  // The fresh token is now in the active keychain. Query /api/oauth/profile to
-  // verify has_extra_usage_enabled=false. If true, revert the swap by restoring
-  // the previous account's token — this prevents silent credit-card overages.
-  if (!opts.allowExtraUsage && !dryRun) {
-    try {
-      const freshJson = readKeychain();
-      const fresh = JSON.parse(freshJson);
-      const freshToken = fresh?.claudeAiOauth?.accessToken;
-      if (freshToken) {
-        const res = await fetch('https://api.anthropic.com/api/oauth/profile', {
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${freshToken}`,
-            'anthropic-beta': 'oauth-2025-04-20',
-            'Content-Type': 'application/json',
-          },
-          signal: AbortSignal.timeout(5000),
-        });
-        if (res.ok) {
-          const prof = await res.json();
-          const euOn = prof?.organization?.has_extra_usage_enabled === true;
-          if (euOn) {
-            log(`POST-SWAP BLOCK: ${targetEmail} has extra_usage=ON (overage billing). Reverting swap.`);
-            notify(
-              'Rotation REVERTED',
-              `${targetEmail}: extra_usage enabled — charges would hit your card. Rollback in progress.`,
-            );
-            // Revert: restore previous account's stored token to active slot
-            const prevKey = state.activeAccount;
-            const prevAccount = prevKey ? config.accounts.find((a) => accountKey(a) === prevKey) : null;
-            if (prevAccount) {
-              const prevToken = readStoredToken(prevAccount);
-              if (prevToken) {
-                // prevToken came from the vault (mcpOAuth:{} stripped by design).
-                // Merge the current active keychain's mcpOAuth before rollback,
-                // otherwise this revert wipes giga/Amplitude/higgsfield OAuth.
-                let outToken = prevToken;
-                try {
-                  const cur = readKeychain();
-                  const cp = JSON.parse(cur);
-                  if (cp.mcpOAuth && Object.keys(cp.mcpOAuth).length > 0) {
-                    const np = JSON.parse(prevToken);
-                    np.mcpOAuth = { ...np.mcpOAuth, ...cp.mcpOAuth };
-                    outToken = JSON.stringify(np);
-                  }
-                } catch {}
-                writeKeychain(outToken);
-                log(`Reverted keychain to previous account ${prevKey} (mcpOAuth preserved)`);
-              }
-            }
-            return false;
-          }
-        } else {
-          log(
-            `POST-SWAP profile check returned ${res.status} — unable to verify extra_usage; proceeding (fail-open for transient errors)`,
-          );
-        }
-      }
-    } catch (e) {
-      log(`POST-SWAP billing check error (non-fatal): ${e.message?.slice(0, 80)}`);
-    }
-  }
-
   // Verify by reading back what's now in the active keychain
   let verified = false;
   try {
@@ -3010,12 +3846,28 @@ async function rotate(targetEmail, opts = {}) {
     // Guard against empty `stored` — substring("", 20, 80) === "" and
     // active.includes("") is always true, which would spuriously verify.
     if (stored && stored.length > 80 && active.includes(stored.substring(20, 80))) verified = true;
-    // Browser fallback: verify via CLI (skip in --no-browser mode — API may be rate limited)
+    // Fallback: verify via /oauth/profile (skip in --no-browser mode — API may
+    // be rate limited). `claude auth status` no longer returns email on
+    // Claude Code >=2.1.144, so it can't be used for identity here.
     if (!verified && !opts.noBrowser) {
-      const out = execSync('claude auth status 2>&1', {
-        timeout: 10_000,
-      }).toString();
-      verified = out.includes(account.email);
+      try {
+        const accessToken = JSON.parse(active)?.claudeAiOauth?.accessToken;
+        if (accessToken) {
+          const res = await fetch('https://api.anthropic.com/api/oauth/profile', {
+            method: 'GET',
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              'anthropic-beta': 'oauth-2025-04-20',
+            },
+            signal: AbortSignal.timeout(8000),
+          });
+          if (res.ok) {
+            const prof = await res.json();
+            const liveEmail = prof?.account?.email || '';
+            verified = liveEmail.toLowerCase() === account.email.toLowerCase();
+          }
+        }
+      } catch {}
     }
   } catch {}
   log(`Rotation ${verified ? 'VERIFIED' : 'UNVERIFIED'}: ${key} (${account.email})`);
@@ -3098,247 +3950,121 @@ async function rotate(targetEmail, opts = {}) {
     target.windowToolUses = 0;
   }
   // else: keep existing window data (cumulative uses carry over)
+  const sourceKeyForHotSwap = state.activeAccount;
   state.activeAccount = key;
   state.toolUses = 0;
   state.lastRotation = now;
   state.totalRotations = (state.totalRotations || 0) + 1;
   writeState(state, dryRun);
 
+  // Claim the cross-machine lease for the account we just activated so the other
+  // machine's rotation excludes it. Best-effort / fail-open. Skip on dry-run.
+  if (!dryRun) {
+    try {
+      writeLease(key, (m) => log(m));
+    } catch {}
+  }
+
   notify('Claude Account Rotation', `${verified ? '✓' : '⚠'} Now using ${key}`);
+
+  // SIGHUP hot-swap: signal running Claude Code sessions on the rotated-FROM account
+  // to reload their keychain (Claude Code catches SIGHUP and re-execs, ~1s restart).
+  if (ok && sourceKeyForHotSwap && !dryRun) {
+    try {
+      const sourceAccountForSwap = config.accounts.find((a) => accountKey(a) === sourceKeyForHotSwap);
+      const sourceEmail = sourceAccountForSwap?.email;
+      if (sourceEmail) {
+        const pidFile = `/tmp/claude-pids-${sourceEmail}`;
+        if (existsSync(pidFile)) {
+          const pids = readFileSync(pidFile, 'utf8')
+            .split('\n')
+            .map((l) => parseInt(l.trim(), 10))
+            .filter((p) => !isNaN(p) && p > 0);
+          // Confirm each pid is actually a live Claude Code process before SIGHUP.
+          // kill(pid,0) only proves the pid EXISTS — on Linux pids recycle fast, so a
+          // stale pidfile entry can point at an unrelated reused pid, and SIGHUP's
+          // default disposition is terminate. Verify via /proc/<pid>/cmdline (Linux)
+          // or `ps` (fallback) that the command is `claude`, and prune dead/stale
+          // entries so the pidfile self-heals and "signaled N" can't overcount.
+          const isClaudePid = (pid) => {
+            let cmd = '';
+            try {
+              cmd = readFileSync(`/proc/${pid}/cmdline`, 'utf8').replace(/\0/g, ' ');
+            } catch {
+              try {
+                cmd = execFileSync('ps', ['-o', 'args=', '-p', String(pid)], { timeout: 2000 }).toString();
+              } catch {
+                return false;
+              }
+            }
+            return /(^|\/)claude(\s|$)/.test(cmd) || cmd.includes('claude ');
+          };
+          let signaled = 0;
+          const livePids = [];
+          for (const pid of pids) {
+            if (pid === process.pid || pid === process.ppid) continue;
+            try {
+              process.kill(pid, 0); // exists?
+            } catch {
+              continue; // dead → drop from pidfile
+            }
+            if (!isClaudePid(pid)) continue; // alive but NOT claude (recycled pid) → never SIGHUP
+            // Busy-session hold: a session orchestrating in-flight subagents can place
+            // /tmp/claude-hotswap-hold-<pid> to opt out of SIGHUP — re-exec would kill
+            // its in-process agents (observed 2026-06-06: rotation churn killed 4 agent
+            // fleets mid-task). Holds auto-expire after 6h (stale holds must never block
+            // token reloads forever). Held pids stay in the pidfile for future rotations.
+            try {
+              const hold = statSync(`/tmp/claude-hotswap-hold-${pid}`);
+              if (Date.now() - hold.mtimeMs < 6 * 3600 * 1000) {
+                log(`[hot-swap] skipping pid ${pid} — busy hold present`);
+                livePids.push(pid);
+                continue;
+              }
+            } catch {}
+            try {
+              process.kill(pid, 'SIGHUP');
+              signaled++;
+              livePids.push(pid);
+            } catch {}
+          }
+          // Self-heal the pidfile: keep only confirmed-live Claude pids, else remove it.
+          try {
+            if (livePids.length > 0) writeFileSync(pidFile, `${livePids.join('\n')}\n`);
+            else unlinkSync(pidFile);
+          } catch {}
+          if (signaled > 0) {
+            log(`[hot-swap] signaled ${signaled} Claude session(s) on ${sourceEmail} to reload after rotation`);
+          } else if (pids.length > 0) {
+            log(`[hot-swap] no live Claude sessions to signal on ${sourceEmail} (pruned stale pidfile)`);
+          }
+        }
+      }
+    } catch (e) {
+      log(`[hot-swap] skipped: ${e.message?.slice(0, 80)}`);
+    }
+  }
+
+  // Daemon-hosted `claude --bg` sessions have no TTY for /login injection and
+  // don't register in the pidfile SIGHUP path — respawn after every successful
+  // rotation (including daemon --no-browser without --session).
+  if (ok && !dryRun) {
+    try {
+      const { respawned, deferred } = respawnBgSessions(log);
+      if (respawned || deferred) log(`[bg-respawn] fleet: ${respawned} respawned, ${deferred} deferred (busy)`);
+    } catch (e) {
+      log(`[bg-respawn] pass skipped: ${e.message?.slice(0, 80)}`);
+    }
+  }
 
   if (opts.session) {
     if (dryRun) {
-      log(
-        '[DRY-RUN] Would inject /login into reachable running sessions (tmux/iTerm2) + resume-path for non-tmux interactive sessions',
-      );
+      log('[DRY-RUN] Would restart running Claude sessions with --continue and send resume prompt');
     } else {
       await refreshRunningSession(account, opts.noBrowser);
     }
   }
-
-  // Post-rotation: reload running bg agents onto the new token.
-  // Gated on opts.reloadAgents (set via --reload-agents CLI flag or daemon call)
-  // so that existing callers that don't pass the flag retain their current
-  // behavior unchanged. The stagger adds up to 4 × 15 s = 60 s of extra wall
-  // time — callers must account for this in their timeout budgets.
-  if (opts.reloadAgents) {
-    if (dryRun) {
-      log('[DRY-RUN] Would reload running bg agents onto new token');
-    } else {
-      await reloadRunningAgents({ initiatorSessionId: opts.initiatorSessionId });
-    }
-  }
-
   return verified;
-}
-
-// ── Reload running bg agents after rotation ───────────────────────────────────
-//
-// After a successful keychain swap, already-running `claude --bg` agents keep
-// using their in-memory (now stale) OAuth token. `claude respawn <shortId>`
-// restarts a bg session keeping its conversation intact and re-reads auth from
-// the keychain — this is the mechanism that makes a running agent adopt the
-// new token.
-//
-// Anti-stampede guarantees:
-//   - Hard cap: at most RESPAWN_CAP agents per invocation (default 4).
-//   - Sequential: agents are respawned one at a time (no parallel fan-out).
-//   - Stagger: RESPAWN_STAGGER_MS + random jitter (≤RESPAWN_JITTER_MS) between
-//     each respawn, so re-exec'd agents don't re-issue their first calls onto the
-//     freshly-rotated account in a deterministic lockstep (jitter de-correlates the
-//     onset from other rotation-time staggers — e.g. the /login session inject).
-//   - Skips orchestrator (keepalive owns it), bare spares (name===sessionId[:8]),
-//     and the session that initiated the rotation (opts.initiatorSessionId).
-//   - jobId divergence: if resolve-jobid.sh exists, resolve sessionId→jobId
-//     before respawn. "No job matching" is non-fatal — log + continue.
-//   - Fully guarded: if `claude agents` fails → log + no-op. Rotation success
-//     never depends on this step.
-//
-// opts.initiatorSessionId — short (8-char) or full sessionId of the session
-//   that triggered the rotation; skipped to avoid respawning our own caller.
-// opts.dryRun — log selections but skip actual respawn calls (for harness testing).
-async function reloadRunningAgents(opts = {}) {
-  const RESPAWN_CAP = 4; // hard anti-stampede cap per invocation
-  const RESPAWN_STAGGER_MS = 15_000; // ≥15s between each respawn (memory rule)
-  // Added random jitter on top of the fixed stagger so N respawns don't onset in
-  // lockstep onto the just-rotated account. Env-overridable for ops tuning; 0 = off.
-  const RESPAWN_JITTER_MS = Math.max(0, Number(process.env.CLAUDE_RESPAWN_JITTER_MS ?? 5_000));
-  const RESPAWN_TIMEOUT_MS = 60_000; // per-respawn timeout
-  const dryRun = opts.dryRun === true;
-
-  const RESOLVE_JOBID = join(homedir(), '.claude', 'scripts', 'resolve-jobid.sh');
-  const resolveJobIdAvailable = existsSync(RESOLVE_JOBID);
-
-  // Resolve the claude binary path once (execFileSync: no shell).
-  let claudeBin = 'claude';
-  try {
-    claudeBin = execFileSync('which', ['claude'], { encoding: 'utf8', timeout: 5000 }).trim() || 'claude';
-  } catch {}
-
-  log(`[reload-agents] Starting post-rotation agent reload...${dryRun ? ' (DRY-RUN)' : ''}`);
-
-  // 1. Enumerate running bg agents with a hard timeout.
-  // Use execFileSync (no shell) so the args are passed directly to the binary —
-  // avoids shell-injection risk and the stderr redirect (2>/dev/null) is handled
-  // by capturing stderr separately instead.
-  let agents;
-  try {
-    const raw = execFileSync(claudeBin, ['agents', '--json'], {
-      timeout: 15_000,
-      encoding: 'utf8',
-      // Swallow stderr (e.g. update notices) so JSON parse doesn't choke on it.
-      stdio: ['ignore', 'pipe', 'pipe'],
-    }).trim();
-    if (!raw) {
-      log('[reload-agents] `claude agents --json` returned empty — no-op');
-      return;
-    }
-    // Handle both bare array and {sessions|agents:[]} wrapper shapes.
-    const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) {
-      agents = parsed;
-    } else if (Array.isArray(parsed?.sessions)) {
-      agents = parsed.sessions;
-    } else if (Array.isArray(parsed?.agents)) {
-      agents = parsed.agents;
-    } else {
-      log('[reload-agents] Unexpected `claude agents --json` shape — no-op');
-      return;
-    }
-  } catch (e) {
-    log(`[reload-agents] Failed to list agents (non-fatal): ${e.message?.slice(0, 80)} — no-op`);
-    return;
-  }
-
-  if (!agents.length) {
-    log('[reload-agents] No running bg agents — no-op');
-    return;
-  }
-
-  // 2. Select candidates to respawn.
-  const initiatorShort = opts.initiatorSessionId
-    ? opts.initiatorSessionId.length === 8
-      ? opts.initiatorSessionId
-      : opts.initiatorSessionId.slice(0, 8)
-    : null;
-
-  const candidates = [];
-  const deferred = [];
-
-  for (const agent of agents) {
-    const sessionId = agent.sessionId || '';
-    const shortId = sessionId.slice(0, 8);
-    const name = (agent.name || '').trim();
-    const status = (agent.status || '').toLowerCase();
-
-    // Skip orchestrator — the 60s keepalive owns it; respawning it from inside
-    // rotation risks a fight.
-    if (name === 'orchestrator') {
-      log(`[reload-agents] Skipping orchestrator (${shortId})`);
-      continue;
-    }
-
-    // Skip bare bg-spares (name === sessionId[:8]) and unnamed/just-spawned
-    // sessions (empty name) — neither has a meaningful conversation to reload.
-    if (!name || name === shortId) {
-      log(`[reload-agents] Skipping bare/unnamed spare (${shortId})`);
-      continue;
-    }
-
-    // Skip the session that triggered this rotation (avoid respawning our caller).
-    if (initiatorShort && shortId === initiatorShort) {
-      log(`[reload-agents] Skipping initiator session (${shortId})`);
-      continue;
-    }
-
-    // Include all remaining background agents (both busy + idle can be stale).
-    if (candidates.length < RESPAWN_CAP) {
-      candidates.push({ sessionId, shortId, name, status });
-    } else {
-      deferred.push({ sessionId, shortId, name, status });
-    }
-  }
-
-  if (!candidates.length) {
-    log('[reload-agents] No eligible agents to respawn — no-op');
-    return;
-  }
-
-  if (deferred.length) {
-    log(
-      `[reload-agents] ${deferred.length} agent(s) deferred (cap=${RESPAWN_CAP}): ` +
-        deferred.map((a) => `${a.shortId}(${a.name})`).join(', ') +
-        ' — daemon next-pass / next rotation will pick them up',
-    );
-  }
-
-  log(
-    `[reload-agents] Respawning ${candidates.length} agent(s): ${candidates.map((a) => `${a.shortId}(${a.name})`).join(', ')}`,
-  );
-
-  // 3. Sequential respawn with stagger.
-  for (let i = 0; i < candidates.length; i++) {
-    const { sessionId, shortId, name, status } = candidates[i];
-
-    // Resolve jobId if possible (sessionId and jobId diverge — see memory note
-    // bg-session-addressing-by-jobid). Use jobId for respawn; fall back to shortId.
-    // execFileSync with argument array: no shell, no injection risk.
-    let respawnId = shortId;
-    if (resolveJobIdAvailable) {
-      try {
-        const resolved = execFileSync('bash', [RESOLVE_JOBID, shortId], {
-          timeout: 5000,
-          encoding: 'utf8',
-          stdio: ['ignore', 'pipe', 'pipe'],
-        }).trim();
-        if (resolved) {
-          log(`[reload-agents] ${shortId}(${name}) jobId resolved: ${resolved}`);
-          respawnId = resolved;
-        }
-      } catch {
-        // resolve-jobid.sh exits non-zero when no match — fall back to shortId
-        log(`[reload-agents] ${shortId}(${name}): jobId resolution failed — using shortId`);
-      }
-    }
-
-    log(
-      `[reload-agents] ${dryRun ? '[DRY-RUN] Would respawn' : 'Respawning'} ${shortId}(${name}) [status=${status}] via id=${respawnId}...`,
-    );
-    if (!dryRun) {
-      try {
-        // execFileSync: no shell — respawnId is passed as a literal argument.
-        const out = execFileSync(claudeBin, ['respawn', respawnId], {
-          timeout: RESPAWN_TIMEOUT_MS,
-          encoding: 'utf8',
-          stdio: ['ignore', 'pipe', 'pipe'],
-        }).trim();
-        log(`[reload-agents] Respawn ${shortId}(${name}): ${out.slice(0, 120)}`);
-      } catch (e) {
-        const msg = (e.stdout || e.stderr || e.message || '').slice(0, 120);
-        // "No job matching" is non-fatal — keepalive will catch stragglers.
-        log(`[reload-agents] Respawn ${shortId}(${name}) non-fatal error: ${msg} — continuing`);
-      }
-    }
-
-    // Stagger: sleep between respawns to avoid stampede. Skip after the last one.
-    // Base stagger + random jitter so onsets don't align. In dry-run mode we skip
-    // the actual sleep so the harness exits quickly.
-    if (i < candidates.length - 1) {
-      const waitMs = RESPAWN_STAGGER_MS + Math.floor(Math.random() * (RESPAWN_JITTER_MS + 1));
-      if (dryRun) {
-        log(`[reload-agents] [DRY-RUN] Would wait ~${(waitMs / 1000).toFixed(1)}s before next respawn`);
-      } else {
-        log(
-          `[reload-agents] Waiting ${(waitMs / 1000).toFixed(1)}s (base ${RESPAWN_STAGGER_MS / 1000}s + jitter) before next respawn...`,
-        );
-        await sleep(waitMs);
-      }
-    }
-  }
-
-  log(
-    `[reload-agents] Done.${dryRun ? ' [DRY-RUN]' : ''} ${candidates.length} respawn(s) ${dryRun ? 'selected' : 'issued'}. ${deferred.length} deferred.`,
-  );
 }
 
 // ── Setup ─────────────────────────────────────────────────────────────────────
@@ -3399,6 +4125,14 @@ async function setup() {
       } catch {}
     }
 
+    if (magicLinkMode && account.autoAuthDisabled === true && !filter) {
+      console.log(
+        `⏭  Skipped: automated reauth disabled (${account.autoAuthDisabledReason || 'manual reauth required'}).`,
+      );
+      results.push({ key, ok: true, skipped: true, reason: 'auto-auth-disabled' });
+      continue;
+    }
+
     let oauthOk = true;
     if (magicLinkMode) {
       // Fully automated: claude auth login subprocess + browser driver cascade
@@ -3424,17 +4158,64 @@ async function setup() {
       await new Promise((r) => child.on('exit', r));
     }
 
-    // Verify the login succeeded and matches the expected account
+    // Verify the login succeeded and matches the expected account.
+    // NOTE: Claude Code >=2.1.144 returns {email:null,orgId:null,orgName:null}
+    // from `claude auth status` even when logged in, so it can no longer be
+    // used for identity verification. Verify against the freshly-written
+    // keychain token via the OAuth profile API instead, which still returns
+    // the real account email.
     try {
-      const status = JSON.parse(execSync('claude auth status 2>&1', { timeout: 10_000 }).toString());
-      if (status.email !== account.email) {
-        console.error(`\n❌ MISMATCH: expected ${account.email}, got ${status.email}. Skipping save.`);
-        results.push({ key, ok: false, reason: `mismatch:${status.email}` });
-        continue;
-      }
-      console.log(`✅ Verified: ${status.email}`);
-      // Save to vault (strip mcpOAuth to keep vault clean)
       const token = readKeychain();
+      let liveEmail = null;
+      let profErr = null;
+      try {
+        const accessToken = JSON.parse(token)?.claudeAiOauth?.accessToken;
+        if (accessToken) {
+          const res = await fetch('https://api.anthropic.com/api/oauth/profile', {
+            method: 'GET',
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              'anthropic-beta': 'oauth-2025-04-20',
+              'Content-Type': 'application/json',
+            },
+            signal: AbortSignal.timeout(8000),
+          });
+          if (res.ok) {
+            const prof = await res.json();
+            liveEmail = prof?.account?.email ?? null;
+          } else {
+            profErr = `profile HTTP ${res.status}`;
+          }
+        } else {
+          profErr = 'no accessToken in keychain';
+        }
+      } catch (e) {
+        profErr = String(e.message || e).slice(0, 80);
+      }
+
+      if (liveEmail) {
+        if (liveEmail.toLowerCase() !== account.email.toLowerCase()) {
+          console.error(`\n❌ MISMATCH: expected ${account.email}, got ${liveEmail}. Skipping save.`);
+          results.push({ key, ok: false, reason: `mismatch:${liveEmail}` });
+          continue;
+        }
+        console.log(`✅ Verified: ${liveEmail}`);
+      } else {
+        // Profile fetch failed (rate limit / transient). Fail-open ONLY if the
+        // keychain token is structurally valid and unexpired — otherwise the
+        // rotation would never save a single account whenever the profile API
+        // is throttled (which is common mid-rotation).
+        if (token && token.includes('claudeAiOauth') && !tokenExpired(token)) {
+          console.log(
+            `⚠  Identity unverified (${profErr || 'no email'}) — token valid & unexpired, saving with caveat.`,
+          );
+        } else {
+          console.error(`\n❌ Verify failed (${profErr || 'no email'}) and token invalid/expired. Skipping save.`);
+          results.push({ key, ok: false, reason: `verify-failed:${profErr || 'no-email'}` });
+          continue;
+        }
+      }
+      // Save to vault (strip mcpOAuth to keep vault clean)
       try {
         const parsed = JSON.parse(token);
         const clean = { claudeAiOauth: parsed.claudeAiOauth, mcpOAuth: {} };
@@ -3501,24 +4282,33 @@ async function setup() {
     }
   }
   console.log(`\nSetup done. Run \`node rotate.mjs --audit-billing\` anytime to re-check.\n`);
-
-  if (filter && accounts.length === 0) return false;
-  if (results.some((r) => !r.ok)) return false;
-  if (filter && results.length === 0) return false;
-  return true;
 }
 
 // ── Status ────────────────────────────────────────────────────────────────────
 
-function showStatus() {
+async function showStatus() {
   const config = readConfig();
   const state = readState();
+  // `claude auth status` no longer returns email on CC >=2.1.144 — derive
+  // from the live keychain token via /oauth/profile instead.
   let liveEmail = null;
   try {
-    const m = execSync('claude auth status 2>&1', { timeout: 10_000 })
-      .toString()
-      .match(/"email":\s*"([^"]+)"/);
-    if (m) liveEmail = m[1];
+    const tok = readKeychain();
+    const accessToken = JSON.parse(tok)?.claudeAiOauth?.accessToken;
+    if (accessToken) {
+      const res = await fetch('https://api.anthropic.com/api/oauth/profile', {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'anthropic-beta': 'oauth-2025-04-20',
+        },
+        signal: AbortSignal.timeout(6000),
+      });
+      if (res.ok) {
+        const prof = await res.json();
+        liveEmail = prof?.account?.email || null;
+      }
+    }
   } catch {}
 
   const since = (d) => {
@@ -3541,14 +4331,10 @@ function showStatus() {
     }
   } catch {}
 
-  // Determine if the mismatch is expected (rotation just ran, session hasn't reloaded)
-  const recentRotation = state.lastRotation ? Date.now() - new Date(state.lastRotation).getTime() < 90_000 : false;
-  const mismatch =
-    liveEmail &&
-    state.activeAccount &&
-    !state.activeAccount.startsWith(liveEmail) &&
-    !liveEmail.startsWith(state.activeAccount);
-  const liveNote = mismatch && recentRotation ? ' (stale session — restart Claude Code to apply)' : '';
+  // Statusline must not depend on Claude Code restart. Token swap is keychain-level;
+  // any live/tracked mismatch is surfaced silently via the two separate lines below —
+  // no prescriptive "restart Claude Code" nag in the statusline.
+  const liveNote = '';
 
   console.log('\n=== Claude Account Rotation ===\n');
   console.log(`Live auth:       ${liveEmail || 'unknown'}${liveNote}`);
@@ -3626,7 +4412,7 @@ function captureCmd(targetEmail = null) {
 const args = process.argv.slice(2);
 
 if (args.includes('--setup')) {
-  process.exit((await setup()) ? 0 : 1);
+  await setup();
 } else if (args.includes('--utilization')) {
   // Live utilization query for all accounts
   const config = readConfig();
@@ -3695,12 +4481,562 @@ if (args.includes('--setup')) {
     console.log(`\n⚠  Disable extra_usage at https://console.anthropic.com/settings/billing for each risky account.`);
   }
   console.log('');
+} else if (args.includes('--recommend') || args.includes('--pick')) {
+  // Live-query all accounts and print the recommended next account WITHOUT
+  // swapping. Used as preflight by force-rotate.sh / rotate-magic / daemon-log.
+  const config = readConfig();
+  const state = readState();
+  const json = args.includes('--json');
+  if (!json) console.log('Querying live utilization for recommendation...');
+  const liveUtil = await queryAllUtilization(config);
+  const destCap = destinationUtilHardBlock(config);
+  const { pick, allExhausted, allHaveLive, onlyActiveViable, destinationCapStuck } = recommendAccount(
+    config,
+    state,
+    liveUtil,
+  );
+  const accountsOut = {};
+  for (const a of config.accounts) {
+    if (a.disabled === true) continue;
+    const k = accountKey(a);
+    const u = liveUtil[k];
+    if (!u) {
+      accountsOut[k] = { error: 'query_failed' };
+      continue;
+    }
+    const worst = Math.max(u.five_hour_pct ?? 0, u.seven_day_pct ?? 0);
+    accountsOut[k] = {
+      five_hour: u.five_hour_pct,
+      seven_day: u.seven_day_pct,
+      extra_usage: u.extra_usage_enabled,
+      worst,
+      viable: worst < destCap,
+      destination_cap_pct: destCap,
+      resets_at_5h: u.resets_at_5h,
+    };
+  }
+  // Bedrock readiness probe (fast — ~2s), only when needed
+  let bedrock = null;
+  if (allExhausted || destinationCapStuck) {
+    bedrock = checkBedrockAvailable();
+  }
+  const out = {
+    activeAccount: state.activeAccount || null,
+    pick: pick ? accountKey(pick) : null,
+    pick_email: pick ? pick.email : null,
+    allExhausted,
+    allHaveLive,
+    onlyActiveViable,
+    destinationCapStuck,
+    destinationMaxUtilPercent: destCap,
+    bedrock_ready: bedrock ? bedrock.ok : null,
+    bedrock_region: bedrock ? bedrock.region : null,
+    accounts: accountsOut,
+  };
+  if (json) {
+    console.log(JSON.stringify(out, null, 2));
+  } else {
+    console.log('');
+    console.log(
+      `Active: <${out.activeAccount || '(none)'}>  ·  rotation targets need max(5h,7d) < ${destCap}% (see rateLimits.destinationMaxUtilPercent; Bedrock exhaustion is still ≥${EXHAUSTED_THRESHOLD}%)`,
+    );
+    for (const [k, v] of Object.entries(accountsOut)) {
+      if (v.error) {
+        console.log(`  ❌ <${k}>: ${v.error}`);
+        continue;
+      }
+      let icon;
+      if (v.extra_usage === true) icon = '💳';
+      else if (v.worst >= EXHAUSTED_THRESHOLD) icon = '🔴';
+      else if (!v.viable) icon = '🟡';
+      else if (v.worst >= 70) icon = '🟡';
+      else icon = '🟢';
+      const tags = [];
+      if (v.extra_usage === true) tags.push('EU-ON');
+      if (v.worst >= EXHAUSTED_THRESHOLD) tags.push('EXHAUSTED');
+      else if (!v.viable) tags.push(`≥${destCap}%cap`);
+      const tag = tags.length ? ' ' + tags.join(' ') : '';
+      const star = k === out.activeAccount ? ' ◀ active' : '';
+      console.log(`  ${icon} <${k}>: 5h=${v.five_hour ?? '?'}% 7d=${v.seven_day ?? '?'}%${tag}${star}`);
+    }
+    console.log('');
+    if (allExhausted) {
+      console.log(`⚠  ALL ACCOUNTS EXHAUSTED (live-confirmed, threshold ${EXHAUSTED_THRESHOLD}%)`);
+      if (bedrock?.ok) {
+        console.log(`✅ Bedrock fallback READY in ${bedrock.region}`);
+        console.log('   Next session: source ~/.claude/scripts/account-rotation/use-bedrock.sh');
+      } else {
+        console.log(`❌ Bedrock NOT reachable: ${bedrock?.error || 'unknown'}`);
+      }
+    } else if (destinationCapStuck) {
+      console.log(
+        `⚠  STUCK: every live-confirmed non-active account is ≥${destCap}% — no Max rotation target (Bedrock or lower destinationMaxUtilPercent).`,
+      );
+      if (bedrock?.ok) {
+        console.log(`✅ Bedrock fallback READY in ${bedrock.region}`);
+        console.log('   Next rotation: will activate Bedrock; then source use-bedrock.sh in new shells.');
+      } else {
+        console.log(`❌ Bedrock NOT reachable: ${bedrock?.error || 'unknown'}`);
+      }
+    } else if (out.onlyActiveViable) {
+      console.log(
+        `→ Already optimal: only account under ${destCap}% destination cap is active (${out.activeAccount || '?'}) — stay put.`,
+      );
+    } else if (out.pick) {
+      console.log(`→ Recommended: ${out.pick}`);
+    } else {
+      console.log('→ No viable account (all API-exhausted or missing utilization data)');
+    }
+    console.log('');
+  }
+  // Exit codes: 0 = viable pick available, 2 = Bedrock path (exhausted or destination-cap stuck),
+  // 3 = no viable pick but not confirmed for Bedrock (some queries failed — investigate).
+  process.exit(pick || onlyActiveViable ? 0 : allExhausted || destinationCapStuck ? 2 : 3);
 } else if (args.includes('--status')) {
-  showStatus();
+  await showStatus();
 } else if (args.includes('--capture')) {
   const capToIdx = args.indexOf('--to');
   const captureTo = capToIdx !== -1 && args[capToIdx + 1] ? args[capToIdx + 1] : null;
   captureCmd(captureTo);
+} else if (args.includes('--pin-browser-active')) {
+  // Resolve the currently-active rotating account from state.json and delegate
+  // to --pin-browser. This is what the PreToolUse hook calls so the chrome
+  // bridge follows wherever rotation lands, instead of being hardcoded to a
+  // single account. Falls back to a default (env CLAUDE_PIN_BROWSER_DEFAULT or
+  // first config account) when state is empty/unreadable.
+  const ttlIdx = args.indexOf('--ttl');
+  const ttlSec = ttlIdx !== -1 && args[ttlIdx + 1] ? parseInt(args[ttlIdx + 1], 10) : 600;
+  let email = null;
+  try {
+    const st = readState();
+    const cfg = readConfig();
+    const acct = cfg.accounts.find((a) => accountKey(a) === st.activeAccount);
+    email = acct?.email || null;
+  } catch {}
+  if (!email) {
+    email = process.env.CLAUDE_PIN_BROWSER_DEFAULT || (readConfig().accounts[0]?.email ?? null);
+  }
+  if (!email) {
+    log('[pin-browser-active] no resolvable active account — skipping');
+    process.exit(0);
+  }
+  // Re-dispatch into the --pin-browser branch by spawning ourselves. Cleaner
+  // than refactoring the whole branch into a function for now; cost is one
+  // extra fork. Stays best-effort/silent like the original hook contract.
+  const child = spawnSync(
+    process.execPath,
+    [join(__dirname, 'rotate.mjs'), '--pin-browser', email, '--ttl', String(ttlSec)],
+    { stdio: 'ignore', timeout: 30_000 },
+  );
+  process.exit(child.status || 0);
+} else if (args.includes('--pin-browser')) {
+  // Pin the active CLI keychain to the browser-extension account and freeze the
+  // daemon briefly. claude-in-chrome requires CLI account == claude.ai login, so
+  // while the bridge is in use the CLI must stay on the extension's account.
+  // Invoked by the PreToolUse hook on mcp__claude-in-chrome__*. Best-effort and
+  // fast: never throws, always exits 0 so it can't block the browser tool call.
+  //
+  // Sync ~/.claude.json oauthAccount + chromeExtension blocks to match the
+  // pinned account so the chrome bridge handshake succeeds — see snapshot
+  // helpers above. Existing pre-pin blocks are backed up to
+  // `.browser-pin-backup.json` and restored on `--release-browser-pin` (called
+  // by the daemon once the pin TTL lapses).
+  const pinIdx = args.indexOf('--pin-browser');
+  const pinEmail = args[pinIdx + 1];
+  const ttlIdx = args.indexOf('--ttl');
+  const ttlSec = ttlIdx !== -1 && args[ttlIdx + 1] ? parseInt(args[ttlIdx + 1], 10) : 300;
+  try {
+    const cfg = readConfig();
+    const acct = cfg.accounts.find((a) => (a.email || '').toLowerCase() === (pinEmail || '').toLowerCase());
+    if (!acct) {
+      log(`[pin-browser] no account matching ${pinEmail} — writing pin sentinel only`);
+    } else if (acquireLock()) {
+      try {
+        const swapped = await swapToken(acct);
+        if (swapped) {
+          const st = readState();
+          st.activeAccount = accountKey(acct);
+          writeState(st);
+          log(`[pin-browser] CLI pinned to ${accountKey(acct)}`);
+        } else {
+          log(
+            `[pin-browser] swapToken false for ${accountKey(acct)} (vault token missing/expired) — likely already active; pinning anyway`,
+          );
+        }
+        // Sync .claude.json oauthAccount/chromeExtension blocks to match.
+        const targetKey = accountKey(acct);
+        const snapshot = loadOauthSnapshot(targetKey) || loadOauthSnapshot(acct.email);
+        const cj = readClaudeJson();
+        const currentEmail = cj?.oauthAccount?.emailAddress?.toLowerCase() || null;
+        const wantEmail = (acct.email || '').toLowerCase();
+        if (currentEmail === wantEmail) {
+          // Already in sync — opportunistically capture as snapshot baseline if missing.
+          if (!snapshot) {
+            captureOauthSnapshot(acct.email);
+          }
+          log(`[pin-browser] .claude.json oauthAccount already=${currentEmail} — no swap needed`);
+        } else if (snapshot) {
+          // Back up the outgoing blocks once per pin window (don't clobber existing backup).
+          if (!existsSync(BROWSER_PIN_BACKUP_PATH)) backupCurrentOauthBlocks();
+          const applied = applyOauthSnapshotToClaudeJson(snapshot);
+          if (applied) {
+            log(
+              `[pin-browser] .claude.json oauthAccount swapped ${currentEmail || 'unknown'} → ${wantEmail}. Restart Claude Code session to apply (chrome bridge reads on startup).`,
+            );
+          } else {
+            log(`[pin-browser] snapshot found but apply failed for ${wantEmail}`);
+          }
+          // Ensure the matching Chrome profile is running so its extension
+          // service worker is alive and can authenticate against the swapped
+          // pairedDeviceId. No-op if already running.
+          const profileDir = snapshot.chromeProfileDir || chromeProfileDirFor(targetKey);
+          if (profileDir && !isChromeProfileRunning(profileDir)) {
+            // Navigate to claude.ai/chrome to wake the extension service
+            // worker — it only establishes the native-messaging bridge to
+            // Claude Code when this page loads. Without it, the extension
+            // is installed but dormant and the bridge reports "not connected".
+            launchChromeProfile(profileDir, 'https://claude.ai/chrome');
+            log(`[pin-browser] launched Chrome profile ${profileDir} for ${wantEmail} (@ claude.ai/chrome)`);
+          }
+        } else {
+          log(
+            `[pin-browser] WARNING: no oauth-snapshot for ${targetKey}. Chrome bridge will fail until you: (1) restart Claude Code while keychain is on ${wantEmail}, (2) run: node ${join(__dirname, 'rotate.mjs')} --capture-oauth-snapshot ${wantEmail}`,
+          );
+        }
+      } finally {
+        releaseLock();
+      }
+    } else {
+      log('[pin-browser] rotation lock busy — skipping swap, still writing pin sentinel');
+    }
+    // Always (re)write the freeze sentinel so the daemon won't rotate away while
+    // the browser bridge is in use. The hook refreshes this on every tool call.
+    writeFileSync(
+      BROWSER_PIN_PATH,
+      JSON.stringify({ email: pinEmail, until: Date.now() + ttlSec * 1000, ts: Date.now() }),
+    );
+  } catch (e) {
+    log(`[pin-browser] error (non-fatal): ${(e.message || e).toString().slice(0, 120)}`);
+  }
+  process.exit(0);
+} else if (args.includes('--release-browser-pin')) {
+  // Restore pre-pin ~/.claude.json oauthAccount/chromeExtension blocks. Called by
+  // the daemon once the .browser-pin sentinel's TTL expires. Idempotent: if no
+  // backup exists, exits 0 silently.
+  try {
+    if (existsSync(BROWSER_PIN_BACKUP_PATH)) {
+      restoreOauthBlocksFromBackup();
+    }
+    if (existsSync(BROWSER_PIN_PATH)) {
+      try {
+        unlinkSync(BROWSER_PIN_PATH);
+      } catch {}
+    }
+  } catch (e) {
+    log(`[release-browser-pin] error (non-fatal): ${(e.message || e).toString().slice(0, 120)}`);
+  }
+  process.exit(0);
+} else if (args.includes('--build-snapshot-from-api')) {
+  // Construct an oauth-snapshot for an account using its stored vault token
+  // plus `https://api.anthropic.com/api/oauth/profile`. This bypasses the
+  // Claude Code session restart that --capture-oauth-snapshot requires — the
+  // snapshot is built directly from API metadata. The resulting snapshot is
+  // ready to be applied by --pin-browser the next time rotation lands here.
+  //
+  //   node rotate.mjs --build-snapshot-from-api <email>
+  //   node rotate.mjs --build-snapshot-from-api --all
+  const isAll = args.includes('--all');
+  const idx = args.indexOf('--build-snapshot-from-api');
+  const wantedEmail = !isAll && args[idx + 1] && !args[idx + 1].startsWith('--') ? args[idx + 1] : null;
+  if (!isAll && !wantedEmail) {
+    console.error('Usage: rotate.mjs --build-snapshot-from-api <email>');
+    console.error('       rotate.mjs --build-snapshot-from-api --all');
+    process.exit(2);
+  }
+  const cfg = readConfig();
+  const targets = isAll
+    ? cfg.accounts
+    : cfg.accounts.filter((a) => (a.email || '').toLowerCase() === wantedEmail.toLowerCase());
+  if (!targets.length) {
+    console.error(`No account matching ${wantedEmail}`);
+    process.exit(2);
+  }
+  ensureSnapshotsDir();
+  // Seed chromeExtension from current ~/.claude.json — all clones share the
+  // inherited pairedDeviceId until each profile re-Links. Acceptable for
+  // single-account-at-a-time rotation; multi-account simultaneous bridge
+  // requires per-profile Link clicks.
+  const seedCj = readClaudeJson();
+  const seedExt =
+    seedCj?.chromeExtension && seedCj.chromeExtension.pairedDeviceId
+      ? seedCj.chromeExtension
+      : { pairedDeviceId: '', pairedDeviceName: 'ClaudeCode' };
+  let okCount = 0;
+  let failCount = 0;
+  for (const acct of targets) {
+    const key = accountKey(acct);
+    const tokenJson = readStoredToken(acct);
+    if (!tokenJson) {
+      console.error(`[skip] ${acct.email}: no vault token in keychain`);
+      failCount++;
+      continue;
+    }
+    let accessToken = null;
+    try {
+      accessToken = JSON.parse(tokenJson)?.claudeAiOauth?.accessToken;
+    } catch {}
+    if (!accessToken) {
+      console.error(`[skip] ${acct.email}: vault token has no accessToken`);
+      failCount++;
+      continue;
+    }
+    // Probe /oauth/profile
+    const probe = spawnSync(
+      'curl',
+      [
+        '-sS',
+        '--max-time',
+        '12',
+        '-H',
+        `Authorization: Bearer ${accessToken}`,
+        '-H',
+        'anthropic-beta: oauth-2025-04-20',
+        'https://api.anthropic.com/api/oauth/profile',
+      ],
+      { encoding: 'utf8' },
+    );
+    if (probe.status !== 0 || !probe.stdout) {
+      console.error(`[skip] ${acct.email}: /oauth/profile failed (curl exit ${probe.status})`);
+      failCount++;
+      continue;
+    }
+    let pf;
+    try {
+      pf = JSON.parse(probe.stdout);
+    } catch (e) {
+      console.error(`[skip] ${acct.email}: /oauth/profile non-JSON response`);
+      failCount++;
+      continue;
+    }
+    if (!pf.account?.uuid || !pf.organization?.uuid) {
+      console.error(`[skip] ${acct.email}: /oauth/profile missing account/org UUID (token rejected?)`);
+      failCount++;
+      continue;
+    }
+    const a = pf.account;
+    const o = pf.organization;
+    const snapshot = {
+      capturedAt: new Date().toISOString(),
+      accountKey: key,
+      email: a.email,
+      chromeProfileDir: chromeProfileDirFor(key),
+      blocks: {
+        oauthAccount: {
+          accountUuid: a.uuid,
+          emailAddress: a.email,
+          organizationUuid: o.uuid,
+          hasExtraUsageEnabled: !!o.has_extra_usage_enabled,
+          billingType: o.billing_type || null,
+          accountCreatedAt: a.created_at || null,
+          subscriptionCreatedAt: o.subscription_created_at || null,
+          ccOnboardingFlags: o.cc_onboarding_flags || {},
+          claudeCodeTrialEndsAt: o.claude_code_trial_ends_at || null,
+          claudeCodeTrialDurationDays: o.claude_code_trial_duration_days || null,
+          seatTier: o.seat_tier || null,
+          organizationRole: 'admin',
+          workspaceRole: null,
+          organizationName: o.name || null,
+          organizationType: o.organization_type || null,
+          organizationRateLimitTier: o.rate_limit_tier || null,
+          userRateLimitTier: null,
+        },
+        chromeExtension: seedExt,
+      },
+    };
+    const out = snapshotPathFor(key);
+    writeFileSync(out, JSON.stringify(snapshot, null, 2));
+    console.error(`[ok] ${acct.email.padEnd(38)} → ${out.replace(process.env.HOME || '', '~')}`);
+    okCount++;
+  }
+  console.error(`\nDone: ${okCount} captured, ${failCount} skipped`);
+  process.exit(failCount > 0 && okCount === 0 ? 1 : 0);
+} else if (args.includes('--capture-oauth-snapshot')) {
+  // Manually capture the current ~/.claude.json oauthAccount + chromeExtension
+  // blocks under a snapshot keyed by accountKey. Requires the CLI keychain +
+  // .claude.json to be in sync (i.e. you just restarted Claude Code with the
+  // target account live). Pass --capture-oauth-snapshot <email> to require a
+  // match, or pass no arg to capture whatever .claude.json currently holds.
+  const idx = args.indexOf('--capture-oauth-snapshot');
+  const wantedEmail = args[idx + 1] && !args[idx + 1].startsWith('--') ? args[idx + 1] : null;
+  const ok = captureOauthSnapshot(wantedEmail);
+  process.exit(ok ? 0 : 1);
+} else if (args.includes('--colorize-chrome-profiles')) {
+  // Patch ~/Library/Application Support/Google/Chrome/Local State so each
+  // per-account profile gets a clear display name + distinct theme color in
+  // Chrome's profile picker. Chrome must be QUIT first — it rewrites Local
+  // State on shutdown, clobbering changes made while it is running.
+  if (
+    isChromeProfileRunning('ClaudeCode') ||
+    readdirSync(CHROME_PROFILES_BASE).some((d) => d.startsWith('ClaudeCode') && isChromeProfileRunning(d))
+  ) {
+    console.error('[colorize] Chrome is running with a ClaudeCode profile. Quit all of them first:');
+    console.error('  pkill -f "profile-directory=ClaudeCode"');
+    process.exit(2);
+  }
+  const ls = readChromeLocalState();
+  if (!ls) {
+    console.error(`[colorize] cannot read ${CHROME_LOCAL_STATE_PATH}`);
+    process.exit(2);
+  }
+  ls.profile = ls.profile || {};
+  ls.profile.info_cache = ls.profile.info_cache || {};
+  const cfg = readConfig();
+  let touched = 0;
+  cfg.accounts.forEach((acct, i) => {
+    const dir = chromeProfileDirFor(accountKey(acct));
+    if (!isChromeProfileBootstrapped(dir)) return;
+    const palette = PROFILE_COLOR_PALETTE[i % PROFILE_COLOR_PALETTE.length];
+    const name = displayNameFor(acct);
+    const entry = ls.profile.info_cache[dir] || {};
+    entry.name = name;
+    entry.shortcut_name = name;
+    entry.gaia_name = name;
+    entry.user_name = acct.email;
+    entry.profile_highlight_color = colorIntFromHex(palette.hex);
+    entry.is_using_default_name = false;
+    entry.is_using_default_avatar = false;
+    // Use Chrome's built-in flat-color avatar set; index 26+ are the modern set
+    entry.avatar_icon = `chrome://theme/IDR_PROFILE_AVATAR_${26 + (i % 24)}`;
+    ls.profile.info_cache[dir] = entry;
+    touched++;
+    console.error(`[colorize] ${dir.padEnd(50)} → "${name}" (${palette.name} ${palette.hex})`);
+  });
+  if (touched > 0) writeChromeLocalStateAtomic(ls);
+  console.error(`[colorize] patched ${touched} profile entries in Local State`);
+  process.exit(0);
+} else if (args.includes('--bootstrap-chrome-profile') || args.includes('--bootstrap-all-chrome-profiles')) {
+  // Per-account Chrome profile bootstrap. Two modes:
+  //
+  //   --bootstrap-chrome-profile <email>     — one account
+  //   --bootstrap-all-chrome-profiles        — every account in config.json
+  //
+  // Each per-account profile is cloned from a source profile (default
+  // `ClaudeCode`, override with `--clone-from <dir>`) so the Claude extension
+  // is pre-installed and Sam doesn't have to redo browser setup. After clone,
+  // each profile is launched against claude.ai/chrome so Sam can sign out of
+  // the inherited account, sign in as the target account, and click Link to
+  // pair. A capture step (--capture-oauth-snapshot) then snapshots the new
+  // pairing for use by --pin-browser.
+  const isAll = args.includes('--bootstrap-all-chrome-profiles');
+  const cloneFromIdx = args.indexOf('--clone-from');
+  const cloneFromArg =
+    cloneFromIdx !== -1 && args[cloneFromIdx + 1] && !args[cloneFromIdx + 1].startsWith('--')
+      ? args[cloneFromIdx + 1]
+      : 'ClaudeCode';
+  const cfg = readConfig();
+  let targets;
+  if (isAll) {
+    targets = cfg.accounts.slice();
+  } else {
+    const idx = args.indexOf('--bootstrap-chrome-profile');
+    const targetEmail = args[idx + 1] && !args[idx + 1].startsWith('--') ? args[idx + 1] : null;
+    if (!targetEmail) {
+      console.error('Usage: rotate.mjs --bootstrap-chrome-profile <email>');
+      console.error('       rotate.mjs --bootstrap-all-chrome-profiles [--clone-from <dir>]');
+      process.exit(2);
+    }
+    const acct = cfg.accounts.find((a) => (a.email || '').toLowerCase() === targetEmail.toLowerCase());
+    if (!acct) {
+      console.error(`No account matching ${targetEmail} in config.json`);
+      process.exit(2);
+    }
+    targets = [acct];
+  }
+  // Refuse to proceed if the clone source is currently running — leveldb of
+  // a running Chrome is unsafe to copy and produces a corrupt clone.
+  if (isChromeProfileRunning(cloneFromArg)) {
+    console.error(
+      `[bootstrap-chrome-profile] source profile "${cloneFromArg}" is currently RUNNING.\n` +
+        'Cloning a live profile corrupts leveldb. Quit that Chrome window first, then re-run:\n' +
+        `  pkill -f "profile-directory=${cloneFromArg}"  &&  node ${join(__dirname, 'rotate.mjs')} ${args.join(' ')}`,
+    );
+    process.exit(2);
+  }
+  if (!isChromeProfileBootstrapped(cloneFromArg)) {
+    console.error(
+      `[bootstrap-chrome-profile] source profile "${cloneFromArg}" does not exist at ${chromeProfilePath(cloneFromArg)}`,
+    );
+    process.exit(2);
+  }
+  // Phase 1: clone (no launches yet — Chrome must stay quit while we patch Local State)
+  const results = [];
+  for (const acct of targets) {
+    const key = accountKey(acct);
+    const profileDir = chromeProfileDirFor(key);
+    let cloneStatus = { ok: true, reason: 'existed' };
+    if (!isChromeProfileBootstrapped(profileDir)) {
+      console.error(`[bootstrap] cloning ${cloneFromArg} → ${profileDir} (${acct.email})...`);
+      cloneStatus = cloneChromeProfile(cloneFromArg, profileDir);
+      if (!cloneStatus.ok) {
+        console.error(`[bootstrap] FAILED to clone for ${acct.email}: ${cloneStatus.reason}`);
+        results.push({ email: acct.email, profileDir, clone: cloneStatus.reason, launched: false });
+        continue;
+      }
+    } else {
+      console.error(`[bootstrap] profile ${profileDir} already exists — skipping clone`);
+    }
+    results.push({ email: acct.email, profileDir, clone: cloneStatus.reason, launched: false });
+  }
+  // Phase 2: colorize Local State (display name + theme color + avatar per profile)
+  try {
+    const ls = readChromeLocalState();
+    if (ls) {
+      ls.profile = ls.profile || {};
+      ls.profile.info_cache = ls.profile.info_cache || {};
+      cfg.accounts.forEach((acct, i) => {
+        const dir = chromeProfileDirFor(accountKey(acct));
+        if (!isChromeProfileBootstrapped(dir)) return;
+        const palette = PROFILE_COLOR_PALETTE[i % PROFILE_COLOR_PALETTE.length];
+        const name = displayNameFor(acct);
+        const entry = ls.profile.info_cache[dir] || {};
+        entry.name = name;
+        entry.shortcut_name = name;
+        entry.gaia_name = name;
+        entry.user_name = acct.email;
+        entry.profile_highlight_color = colorIntFromHex(palette.hex);
+        entry.is_using_default_name = false;
+        entry.is_using_default_avatar = false;
+        entry.avatar_icon = `chrome://theme/IDR_PROFILE_AVATAR_${26 + (i % 24)}`;
+        ls.profile.info_cache[dir] = entry;
+        console.error(`[colorize] ${dir.padEnd(50)} → "${name}" (${palette.name})`);
+      });
+      writeChromeLocalStateAtomic(ls);
+    }
+  } catch (e) {
+    console.error(`[colorize] non-fatal: ${(e.message || e).toString().slice(0, 120)}`);
+  }
+  // Phase 3: launch each cloned profile so user can finish manual sign-in
+  for (const r of results) {
+    if (r.clone === 'cp-failed' || r.clone === 'src-running' || r.clone === 'src-missing') continue;
+    r.launched = launchChromeProfile(r.profileDir, 'https://claude.ai/chrome');
+  }
+  console.error('');
+  console.error('─── Bootstrap summary ───────────────────────────────────────────────────');
+  for (const r of results) {
+    console.error(
+      `  ${r.email.padEnd(38)} profile=${r.profileDir.padEnd(40)} clone=${r.clone.padEnd(10)} launched=${r.launched}`,
+    );
+  }
+  console.error('');
+  console.error('─── Manual finalization (per profile) ───────────────────────────────────');
+  console.error('In each Chrome window that opened:');
+  console.error('  1. Sign out of the inherited claude.ai session');
+  console.error('  2. Sign in as the matching account email');
+  console.error('  3. Click "Link" on claude.ai/chrome to re-pair the extension');
+  console.error('  4. Back in terminal: restart Claude Code while CLI is on that account,');
+  console.error('     then run: rotate.mjs --capture-oauth-snapshot <email>');
+  console.error('─────────────────────────────────────────────────────────────────────────');
+  process.exit(0);
 } else {
   const toIdx = args.indexOf('--to');
   const target = toIdx !== -1 ? args[toIdx + 1] : null;
@@ -3709,22 +5045,8 @@ if (args.includes('--setup')) {
   const force = args.includes('--force');
   const dryRun = args.includes('--dry-run');
   const magicLink = args.includes('--magic-link');
-  const allowExtraUsage = args.includes('--allow-extra-usage');
-  // --reload-agents: after a successful rotation, respawn running bg agents so
-  // they pick up the new token from the keychain. Opt-in so existing callers
-  // that don't pass the flag retain their current behaviour unchanged.
-  const reloadAgents = args.includes('--reload-agents');
-  // --reload-agents-dry-run: parse+select logic only; no actual respawns. Used
-  // for harness testing of the candidate-selection logic.
-  const reloadAgentsDryRun = args.includes('--reload-agents-dry-run');
-
-  if (reloadAgentsDryRun) {
-    // Standalone dry-run: enumerate agents, print selection decisions, exit.
-    log('[reload-agents-dry-run] Running candidate-selection harness...');
-    await reloadRunningAgents({ dryRun: true });
-    process.exit(0);
-  }
-
+  const allowExhausted = args.includes('--allow-exhausted');
+  const bedrockOnExhausted = !args.includes('--no-bedrock-fallback');
   if (dryRun) log('DRY RUN MODE — no changes will be made');
   if (force) {
     log('Force mode — bypassing lock and killing any competing rotations');
@@ -3746,8 +5068,8 @@ if (args.includes('--setup')) {
       noBrowser,
       dryRun,
       magicLink,
-      allowExtraUsage,
-      reloadAgents,
+      allowExhausted,
+      bedrockOnExhausted,
     });
     process.exit(ok ? 0 : 1);
   } catch (err) {

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -142,8 +142,20 @@ if (
 
 // ── Utilities ────────────────────────────────────────────────────────────────
 
+// Strip anything that looks like an OAuth token / bearer secret before it can
+// reach a log sink (console or rotation.log). Operational logs only need the
+// account email/label, never the credential material — this scrubs accidental
+// leakage of token bytes that flow through error messages or oauthAccount blobs.
+function redactSecrets(s) {
+  return String(s)
+    .replace(/sk-ant-[A-Za-z0-9_-]+/g, 'sk-ant-***')
+    .replace(/\bey[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]+/g, '***jwt***')
+    .replace(/"?accessToken"?\s*[:=]\s*"?[A-Za-z0-9._-]{20,}"?/gi, 'accessToken:***')
+    .replace(/"?refreshToken"?\s*[:=]\s*"?[A-Za-z0-9._-]{20,}"?/gi, 'refreshToken:***');
+}
+
 function log(msg) {
-  const line = `[${new Date().toISOString()}] ${msg}`;
+  const line = `[${new Date().toISOString()}] ${redactSecrets(msg)}`;
   console.error(line);
   try {
     appendFileSync(LOG_PATH, line + '\n');
@@ -152,7 +164,10 @@ function log(msg) {
 
 function notify(title, msg) {
   try {
-    execSync(`osascript -e 'display notification "${msg.replace(/"/g, '\\"')}" with title "${title}"'`);
+    // execFileSync (no shell) — title/msg cannot break out into a shell command.
+    // Escape only for the AppleScript string literal (backslash + double-quote).
+    const esc = (s) => String(s).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    execFileSync('osascript', ['-e', `display notification "${esc(msg)}" with title "${esc(title)}"`]);
   } catch {}
 }
 
@@ -4233,11 +4248,11 @@ async function setup() {
       console.log(`✅ Saved to vault: ${tokenService(account)}`);
       results.push({ key, ok: true });
     } catch (e) {
-      console.error(`❌ Error: ${e.message}`);
+      console.error(redactSecrets(`❌ Error: ${e.message}`));
       results.push({
         key,
         ok: false,
-        reason: String(e.message || e).slice(0, 80),
+        reason: redactSecrets(String(e.message || e)).slice(0, 80),
       });
     }
   }
@@ -4248,7 +4263,7 @@ async function setup() {
   const failCount = results.length - okCount;
   for (const r of results) {
     const icon = r.ok ? (r.skipped ? '⏭ ' : '✅') : '❌';
-    console.log(`  ${icon} ${r.key}${r.reason ? `  (${r.reason})` : ''}`);
+    console.log(redactSecrets(`  ${icon} ${r.key}${r.reason ? `  (${r.reason})` : ''}`));
   }
   console.log(`\n${okCount}/${results.length} captured${failCount ? `, ${failCount} failed` : ''}.`);
 
@@ -4409,7 +4424,7 @@ function captureCmd(targetEmail = null) {
     console.log(`✓ Token captured and saved to keychain: ${tokenService(account)}`);
     console.log(`  Account: ${account.email}${account.label ? ' [' + account.label + ']' : ''}`);
   } catch (e) {
-    console.error(e.message);
+    console.error(redactSecrets(e.message));
     process.exit(1);
   }
 }

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -27,6 +27,8 @@ allowed-tools:
   # (no MCP entry needed for those).
   - mcp__claude_ai_Slack__slack_search_public_and_private
   - mcp__claude_ai_Slack__slack_read_channel
+  - mcp__claude_ai_Slack__slack_list_channels
+  - mcp__claude_ai_Slack__channels_list
   # Telegram: user-auth MCP tools added when configured
   # Notion: MCP tools (claude.ai integration or self-hosted)
   - mcp__claude_ai_Notion__notion-search
@@ -82,6 +84,17 @@ Before executing, load available context:
 0. **Auto-sync WhatsApp in the background (DEFAULT — every invocation)** — the FIRST thing this skill does, before any scan or menu, is guarantee the store is fresh, then fire a recent-conversation history backfill **and** a contacts-link in the background, non-blocking.
 
    **0a. Freshness gate (run FIRST, blocking, bounded).** Before classifying anything, run `~/bin/wa-inbox-fresh.sh` (shipped by `scripts/install-whatsapp-bridge-linux.sh`). It probes the bridge with a real **curl connection probe** (`curl -s -m4 http://127.0.0.1:8080/`), forces a backfill, triggers voice-note transcription, and waits (bounded ~32s) for the newest message to settle, then prints a FRESHNESS report (`newest message = … (N min old)`). It **only restarts the bridge if the curl probe genuinely fails twice** — do NOT gate liveness on `ss | grep :8080`, because `ss` renders port 8080 as the service name `webcache`, so the grep never matches and you'd needlessly bounce a healthy bridge. Exit 2 means the bridge is down and unrecoverable → the store is STALE, do not trust last-sender classification.
+
+### Mac WhatsApp.app fallback (bridge-miss recovery)
+
+The whatsmeow bridge can **silently miss inbound messages** when its history/app-state sync lags — most often on `@lid` chats (e.g. 2026-06-11 it missed a reply from a contact that the Mac WhatsApp.app had). The Mac app keeps an **unencrypted** local Core Data store at `~/Library/Group Containers/group.net.whatsapp.WhatsApp.shared/ChatStorage.sqlite`, readable over Tailscale SSH, so it is a reliable ground-truth backstop.
+
+- **When it runs AUTOMATICALLY:** `wa-inbox-fresh.sh` now invokes the Mac cross-check itself whenever the bridge store looks stale — on exit 2 (store unreadable) or when the newest message is >2h old, it prints a `MAC GROUND TRUTH` block (latest 10 messages from the Mac app store) inline in the freshness report. No orchestration needed.
+- **When to use manually:** a contact's *known* reply is missing from the bridge (common on `@lid` chats) — cross-check before classifying that thread as "no reply".
+- **Command:** `bin/wa-mac-latest.sh --contact <name|number> [N]` (also `--recent [N]`, `--since "YYYY-MM-DD HH:MM"`, add `--json` for machine-readable output). It reads `~/Library/Group Containers/group.net.whatsapp.WhatsApp.shared/ChatStorage.sqlite` over SSH. Schema: `ZWAMESSAGE` (`ZTEXT`, `ZISFROMME`, `ZMESSAGEDATE` = seconds since 2001-01-01) joined to `ZWACHATSESSION` (`ZPARTNERNAME`, `ZCONTACTJID`).
+- **Transport chain (`bin/wa-mac-transport.sh`, shared by all wa-mac-* scripts):** ① Tailscale/direct SSH (`WA_MAC_SSH=user@host`) → ② Cloudflare-tunnel SSH (`WA_MAC_CF_HOST=ssh-mac.example.com`, via `cloudflared access ssh` ProxyCommand) when Tailscale is down. One-time wiring: `scripts/setup-wa-mac-cf-tunnel.sh` (installs cloudflared locally + the Mac LaunchDaemon from a remotely-managed tunnel token, then verifies end-to-end). Both env vars live in the shell profile, never in the repo.
+- **READ-ONLY ground truth for reads.** The reader never writes and never sends. Sends still go through the whatsmeow bridge (`mcp__whatsapp__send_message`) under the Rule-6 outbound-approval gate — the Mac store is only consulted to confirm what actually arrived. The ONLY write-capable Mac surface is `wa-mac-archive.sh` (archive-only, see Tier 4 of the archive ladder).
+- **Why no Linux-native alternative:** there is no official WhatsApp Linux desktop app; the third-party Flatpak clients (`whatsapp-for-linux`, ZapZap) are Electron WhatsApp-Web wrappers that need a GUI, consume a linked-device slot, and store data in encrypted IndexedDB (not a queryable SQLite) — so the Mac `ChatStorage.sqlite` is the preferred backstop.
 
    **The FULL-THREAD AWARENESS GATE (in "Processing each channel") depends on this step having run first.** That gate's "read both directions incl. `[voice]`" only works once `wa-inbox-fresh.sh` (freshness + backfill) and the voice-note transcription pass (step 0c) have completed and the store has settled — otherwise outbound rows and `[voice]` bodies are still missing and the gate reads an incomplete thread.
 
@@ -501,7 +514,31 @@ All channel credentials come from env vars or CLI auth — no hardcoded secrets.
 3. **`include_context: true` is the HARD DEFAULT on every `list_messages` read.** Never pass `false` — you must always see the surrounding thread to understand what a message is about before classifying or drafting.
 4. **Verify the bridge is FULLY up before trusting any classification** — run `wa-inbox-fresh.sh`, confirm the systemd unit is `active` and `:8080` LISTEN, and do a real read. A stale store mis-classifies last-sender.
 5. **Don't ask per-archive** once this rule is in play — the user wants efficiency. Archive the DONE set, then report the archived COUNT in one line and keep only the KEEP set visible.
-6. **WhatsApp archive heal:** the bridge `/api/archive` can **hang / 409 with `LTHash mismatch`** when app-state desyncs. The reliable heal is a **one-time phone archive-then-unarchive on any single chat** (re-authors `regular_low` app-state keys) — after that, batch-archive succeeds (verified). Surface that one-step ask to the user when archive blocks; don't abandon inbox-zero.
+6. **WhatsApp archive heal:** the bridge `/api/archive` can **hang / 409 with `LTHash mismatch`** when app-state desyncs. Escalation ladder (try each in order, stop when archive succeeds):
+
+   **Tier 1 — transient desync** (most common): run `mcp__whatsapp__resync_app_state {name:"regular_low", full_sync:true, skip_bad:true}`, wait ~5s, retry archive. `skip_bad:true` skips server-side patches that permanently fail LTHash verification; without it the loop re-fails on the same patch.
+
+   **Tier 2 — still failing after resync**: POST `/api/reconcile_archived` to rebuild `chats.archived` from the phone's authoritative state without re-pairing. Returns `{"archived_count":N,"non_archived_count":M}`. Then retry archives.
+
+   **Tier 3 — massively poisoned chain** (verified 2026-06-10, 31/31 batch archives at ≥2 s pacing):
+   - Stop bridge. In `store/whatsapp.db` run:
+     ```sql
+     DELETE FROM whatsmeow_app_state_sync_keys;
+     DELETE FROM whatsmeow_app_state_version;
+     DELETE FROM whatsmeow_app_state_mutation_macs;
+     ```
+   - Phone must be online. Start bridge — it requests fresh keys; phone reissues them (~114 observed).
+   - Ensure Fix T + Fix V patches applied + bridge **rebuilt** (`apply-patches.py --build`) + restarted (`--restart` or `systemctl --user restart whatsapp-bridge.service`). Without the rebuild the running binary lacks the skip loop.
+   - Expect one 429 rate-overlimit pause (~15–20 min) mid skip-loop; it resumes automatically. Success log: `"regular_low sync complete (skipped N bad patches)"` → `"archive mutations enabled"`.
+   - Upstream: tulir/whatsmeow#1171 (SkipBrokenAppStatePatches). When merged, Fix T + Fix V can be retired.
+
+   **Tier 4 — server-side rate-limit (429 `rate-overlimit`) or tiers 1–3 exhausted**: WhatsApp's servers are throttling app-state fetches for the account, so NO bridge-side mutation can land (this is server-side; resync retries just re-429). Bypass the bridge entirely and archive via the REAL Mac WhatsApp.app:
+   ```bash
+   bin/wa-mac-archive.sh --batch <file-with-one-jid-or-name-per-line>   # or --contact "<name>" / --jid <pn@s.whatsapp.net>
+   ```
+   The Mac app is a first-class client — its archive mutations sync server-side to the phone and propagate back to the bridge once its app-state heals. The script is **archive-only** (scope-guarded; it can never send or delete), resolves chats from the Mac `ChatStorage.sqlite`, drives the app via AppleScript UI automation in the Aqua session, verifies `ZARCHIVED=1` per chat, and paces (default 4s). Transport = `wa-mac-transport.sh` (Tailscale → Cloudflare tunnel). Map `@lid` JIDs to phone JIDs or names first (the scan JSON carries both). Requires the Mac online on either transport + Accessibility permission for the SSH-launched osascript; on failure it reports per-chat `FAIL` — fall back to waiting out the 429 (15–60 min) and retry Tier 1.
+
+   Surface the appropriate tier to the user when archive blocks; don't abandon inbox-zero.
 
 ## Core principle: FULL INBOX SCAN
 


### PR DESCRIPTION
Bumps rotation daemon park check and logging checks to prevent suppression of active rotation and empty logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rotation rescue/park behavior and how active vs vault keychain entries are addressed; incorrect `unknown` keychain alignment or daemon stops could disrupt live Claude sessions.
> 
> **Overview**
> **Rotation daemon (Bug A):** Park suppression now applies only when utilization tags indicate a **mismatched** account (`isParked && isMismatched`), so a parked **active** account no longer blocks normal rotation/rescue.
> 
> **Credentials & hardening:** Active Claude Code keychain reads/writes use account **`unknown`**; per-account vault slots keep **`CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT` / `USER`**. Vault keychain access moves to **`spawnSync`** (no shell); rotation invokes **`process.execPath`**; logs/errors go through **`redactSecrets`**; macOS notifications use **`execFileSync`**. Relaxed pre-rotate candidates get **token refresh** when near expiry; **Bedrock activate/recovery** calls **`claude daemon stop --any`** to drop cached env. Vault keychain writes now **surface failures**.
> 
> **Background respawn:** Deferred/respawned markers move from **`/tmp`** to **`~/.claude/rotation-markers`** (private dir, `0600` files) with **legacy `/tmp` migration**. Sessions **without** `state.json` are **SIGTERM**’d instead of `claude respawn`. Hot-swap logging only emits the “no live sessions” line when the pidfile had entries.
> 
> **Ops inbox:** Adds Slack MCP tools for **channel listing** in the skill manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19b2b5b2f1deeb31a4eb5df44b6b27b2ecb1ada2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic background-session respawn and periodic retry sweep after account rotation
  * Broader rotation daemon improvements: smarter rate-limit/anti-thrash logic, cross-machine lease heartbeats, Bedrock fallback/recovery, and platform-aware credential storage
  * Slack channel listing added to ops-inbox skill

* **Bug Fixes**
  * Robust WhatsApp archive recovery with multi-tier escalation and deferred-respawn handling

* **Documentation**
  * Updated WhatsApp troubleshooting and Slack integration guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->