### PR TITLE
release: v2.29.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 38 skills, 20 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.29.0",
+      "version": "2.29.1",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.29.0",
+  "version": "2.29.1",
   "description": "Business operations command center for Claude Code — 39 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.29.1] - 2026-06-12
+
+### Changed
+- fix(ops): cross-platform gh-orphan-killer for curl/api.github.com poll loops + live installer (#558)
+- fix(wa-mac-archive): owner-idle gate + precise Archive-chat matching + focus restore (#562)
+
+
 ## [2.29.0] - 2026-06-11
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.29.0",
+  "version": "2.29.1",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.29.1** (was 2.29.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

- fix(ops): cross-platform gh-orphan-killer for curl/api.github.com poll loops + live installer (#558)
- fix(wa-mac-archive): owner-idle gate + precise Archive-chat matching + focus restore (#562)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only changes with no runtime code in the diff; low risk aside from users picking up the tagged release that includes the listed fixes.
> 
> **Overview**
> **Release v2.29.1** bumps the published plugin version from **2.29.0 → 2.29.1** everywhere it is registered: `claude-ops/.claude-plugin/plugin.json`, root `.claude-plugin/marketplace.json`, and `claude-ops/package.json` (`claude-ops-bin`).
> 
> `CHANGELOG.md` adds a **2.29.1** section (2026-06-12) documenting what ships in this tag—no other files change in this PR diff:
> 
> - **#558** — cross-platform `gh-orphan-killer` for `curl` / `api.github.com` poll loops, plus live installer wiring
> - **#562** — `wa-mac-archive` owner-idle gate, tighter Archive-chat matching, and focus restore after UI automation
> 
> Treat this as a **metadata + changelog release PR**; the fixes themselves landed in earlier merges and are only summarized here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cf396cad68c1340dba08664322ad42c50994438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->