### PR TITLE
feat(fleet): /boss agent-dash — unified multi-agent × multi-host command center

### DIFF
--- a/claude-ops/bin/agent-dash
+++ b/claude-ops/bin/agent-dash
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+// agent-dash — unified TUI to see + control every AI agent across hosts.
+// claude bg sessions, agy, codex, cursor, openclaw — on the local Mac and the
+// FRA EC2 box. Collect-on-demand (no daemon); remote cached 30s.
+//
+//   agent-dash                 interactive TUI (auto-refresh 15s)
+//   agent-dash --watch [secs]   non-interactive periodic table (default 15s)
+//   agent-dash --json [--force] machine-readable fleet snapshot
+//   agent-dash --once           print one static table and exit
+//   agent-dash attach  <id>
+//   agent-dash steer   <id> "<message>"
+//   agent-dash revive  <id>
+//   agent-dash kill    <id> [--yes]
+//   agent-dash archive <id> [--yes]
+//
+// <id> = 8-char short id, full sessionId, pid, or name (prefix-matched).
+
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import readline from 'node:readline';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const LIB = join(HERE, '..', 'scripts', 'agent-dash');
+const { collect } = await import(join(LIB, 'collect.mjs'));
+const { renderDashboard, renderPlain, C } = await import(join(LIB, 'render.mjs'));
+const ctrl = await import(join(LIB, 'control.mjs'));
+
+const argv = process.argv.slice(2);
+const has = (f) => argv.includes(f);
+const positional = argv.filter((a) => !a.startsWith('--'));
+
+function termWidth() { return process.stdout.columns || 100; }
+
+// ------------------------------------------------------------------- subcommands
+const SUBCMDS = ['attach', 'steer', 'revive', 'kill', 'archive'];
+if (SUBCMDS.includes(positional[0])) {
+  const [cmd, id, ...rest] = positional;
+  const snap = collect({});
+  const a = ctrl.findAgent(snap, id);
+  if (!a) { console.error(`agent-dash: no agent matching "${id}"`); process.exit(1); }
+
+  if (cmd === 'attach') process.exit(ctrl.attach(a));
+  if (cmd === 'revive') process.exit(ctrl.revive(a));
+  if (cmd === 'steer') {
+    const r = ctrl.steer(a, rest.join(' '));
+    console.log(r.ok ? `${C.green}✓${C.reset} ${r.msg}` : `${C.red}✗${C.reset} ${r.msg}`);
+    process.exit(r.ok ? 0 : 1);
+  }
+  if (cmd === 'kill' || cmd === 'archive') {
+    if (!has('--yes') && !has('-y')) { console.error(`Refusing to ${cmd} ${a.id} (${a.name}) without --yes.`); process.exit(2); }
+    const r = ctrl[cmd](a);
+    console.log(r.ok ? `${C.green}✓${C.reset} ${r.msg}` : `${C.red}✗${C.reset} ${r.msg}`);
+    process.exit(r.ok ? 0 : 1);
+  }
+}
+
+// ------------------------------------------------------------------- --json
+if (has('--json')) {
+  process.stdout.write(JSON.stringify(collect({ force: has('--force') }), null, 2) + '\n');
+  process.exit(0);
+}
+
+// ------------------------------------------------------------------- --watch / --once / non-TTY
+const wantTUI = process.stdout.isTTY && process.stdin.isTTY && !has('--watch') && !has('--once');
+
+if (!wantTUI) {
+  const intervalArg = Number(positional[0]);
+  const secs = Number.isFinite(intervalArg) && intervalArg > 0 ? intervalArg : 15;
+  const draw = () => {
+    const snap = collect({});
+    if (has('--watch')) process.stdout.write('\x1b[2J\x1b[H');
+    process.stdout.write(renderPlain(snap, termWidth()) + '\n');
+  };
+  draw();
+  if (has('--watch')) {
+    const timer = setInterval(draw, secs * 1000);
+    process.on('SIGINT', () => { clearInterval(timer); process.exit(0); });
+  } else {
+    process.exit(0);
+  }
+}
+
+// ------------------------------------------------------------------- interactive TUI
+if (wantTUI) {
+  let snap = collect({});
+  let selected = 0;
+  let indexMap = [];
+  let statusLine = '';
+  let refreshTimer = null;
+  let busy = false;
+
+  const out = process.stdout;
+  const enterAlt = () => out.write('\x1b[?1049h\x1b[?25l');
+  const exitAlt = () => out.write('\x1b[?25h\x1b[?1049l');
+
+  function draw() {
+    const r = renderDashboard(snap, { width: termWidth(), selectedIdx: selected, statusLine });
+    indexMap = r.indexMap;
+    if (selected >= indexMap.length) selected = Math.max(0, indexMap.length - 1);
+    out.write('\x1b[2J\x1b[H' + r.text);
+  }
+
+  function refresh(force = false) {
+    if (busy) return;
+    busy = true;
+    statusLine = `${C.gray}refreshing…${C.reset}`;
+    draw();
+    try { snap = collect({ force }); } catch { /* keep old */ }
+    statusLine = '';
+    busy = false;
+    draw();
+  }
+
+  function setStatus(s) { statusLine = s; draw(); }
+
+  // suspend raw TUI, run a foreground action, then restore
+  function withForeground(fn) {
+    if (refreshTimer) clearInterval(refreshTimer);
+    process.stdin.setRawMode(false);
+    exitAlt();
+    let code;
+    try { code = fn(); } catch (e) { code = 1; process.stderr.write(`${e.message}\n`); }
+    enterAlt();
+    process.stdin.setRawMode(true);
+    startTimer();
+    refresh();
+    return code;
+  }
+
+  // prompt for a line of input within the alt screen
+  function prompt(question) {
+    return new Promise((resolve) => {
+      if (refreshTimer) clearInterval(refreshTimer);
+      process.stdin.setRawMode(false);
+      out.write('\x1b[2J\x1b[H' + question);
+      const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+      rl.question('', (ans) => { rl.close(); process.stdin.setRawMode(true); startTimer(); resolve(ans); });
+    });
+  }
+
+  async function confirm(text) {
+    const ans = await prompt(`${C.brightYellow}${text}${C.reset} ${C.gray}[y/N]${C.reset} `);
+    return /^y(es)?$/i.test(ans.trim());
+  }
+
+  async function doAction(key) {
+    const a = indexMap[selected];
+    if (!a) return;
+    if (key === 'a') { withForeground(() => ctrl.attach(a)); return; }
+    if (key === 'r') { withForeground(() => ctrl.revive(a)); return; }
+    if (key === 's') {
+      const msg = await prompt(`${C.cyan}Steer ${a.name} (${a.id})${C.reset}\nMessage: `);
+      if (msg && msg.trim()) { const res = ctrl.steer(a, msg); setStatus(res.ok ? `${C.green}✓ ${res.msg}${C.reset}` : `${C.red}✗ ${res.msg}${C.reset}`); }
+      else draw();
+      return;
+    }
+    if (key === 'k') {
+      if (await confirm(`Kill ${a.name} (${a.type} ${a.id} on ${a.host})?`)) {
+        const res = ctrl.kill(a); setStatus(res.ok ? `${C.green}✓ ${res.msg}${C.reset}` : `${C.red}✗ ${res.msg}${C.reset}`);
+        setTimeout(() => refresh(true), 400);
+      } else draw();
+      return;
+    }
+    if (key === 'x') {
+      if (await confirm(`Archive ${a.name} (${a.type} ${a.id} on ${a.host})? This removes the session.`)) {
+        const res = ctrl.archive(a); setStatus(res.ok ? `${C.green}✓ ${res.msg}${C.reset}` : `${C.red}✗ ${res.msg}${C.reset}`);
+        setTimeout(() => refresh(true), 400);
+      } else draw();
+      return;
+    }
+  }
+
+  function showDetails() {
+    const a = indexMap[selected];
+    if (!a) return;
+    const rows = [
+      `${C.bold}${C.cyan}${a.name}${C.reset}  ${C.gray}(${a.type} · ${a.host})${C.reset}`,
+      `${'─'.repeat(Math.min(termWidth(), 80))}`,
+      `id        ${a.id}`,
+      `sessionId ${a.sessionId || '—'}`,
+      `pid       ${a.pid ?? '—'}`,
+      `status    ${a.status}${a.needs_user ? '  ◆ NEEDS YOU' : ''}`,
+      `cwd       ${a.cwd || '—'}`,
+      a.isolation ? `isolation ${a.isolation}` : null,
+      `doing     ${a.doing || '—'}`,
+      a.decision ? `${C.brightYellow}decision  ${a.decision}${C.reset}` : null,
+      '',
+      `${C.gray}any key to return${C.reset}`,
+    ].filter(Boolean);
+    out.write('\x1b[2J\x1b[H' + rows.join('\n'));
+  }
+
+  let inDetails = false;
+
+  function onKey(_str, key) {
+    if (inDetails) { inDetails = false; draw(); return; }
+    const name = key?.name;
+    if (key?.ctrl && name === 'c') return quit();
+    if (name === 'q') return quit();
+    if (name === 'up' || name === 'k') { selected = Math.max(0, selected - 1); draw(); return; }
+    if (name === 'down' || name === 'j') { selected = Math.min(indexMap.length - 1, selected + 1); draw(); return; }
+    if (name === 'g') { selected = 0; draw(); return; }
+    if (name === 'G') { selected = indexMap.length - 1; draw(); return; }
+    if (name === 'return') { inDetails = true; showDetails(); return; }
+    if (name === 'R') { refresh(true); return; }
+    if (['a', 's', 'r', 'k', 'x'].includes(name)) { doAction(name); return; }
+  }
+
+  function startTimer() {
+    if (refreshTimer) clearInterval(refreshTimer);
+    refreshTimer = setInterval(() => { if (!inDetails) refresh(false); }, 15000);
+  }
+
+  function quit() {
+    if (refreshTimer) clearInterval(refreshTimer);
+    try { process.stdin.setRawMode(false); } catch { /* ignore */ }
+    exitAlt();
+    process.exit(0);
+  }
+
+  enterAlt();
+  process.stdin.setRawMode(true);
+  readline.emitKeypressEvents(process.stdin);
+  process.stdin.on('keypress', onKey);
+  process.on('SIGTERM', quit);
+  process.stdout.on('resize', () => { if (!inDetails) draw(); });
+  draw();
+  startTimer();
+}

--- a/claude-ops/bin/agent-dash
+++ b/claude-ops/bin/agent-dash
@@ -197,7 +197,7 @@ if (wantTUI) {
     const name = key?.name;
     if (key?.ctrl && name === 'c') return quit();
     if (name === 'q') return quit();
-    if (name === 'up' || name === 'k') { selected = Math.max(0, selected - 1); draw(); return; }
+    if (name === 'up') { selected = Math.max(0, selected - 1); draw(); return; }
     if (name === 'down' || name === 'j') { selected = Math.min(indexMap.length - 1, selected + 1); draw(); return; }
     if (name === 'g') { selected = 0; draw(); return; }
     if (name === 'G') { selected = indexMap.length - 1; draw(); return; }

--- a/claude-ops/bin/ops-bg
+++ b/claude-ops/bin/ops-bg
@@ -97,32 +97,37 @@ cmd_dispatch() {
   args+=("${extra[@]}")
   # Never let agents inherit the API key — force OAuth (subscription) auth.
   unset ANTHROPIC_API_KEY
+  # Doppler-wrap the launch (unless the caller already provisioned the env):
+  # raw `claude --bg` launches skip secret injection, so the session's MCP
+  # servers start credential-less and silently fail auth. Project/config match
+  # the orchestrator keepalive spawn. Override with OPS_BG_ENV_PROVISIONED=1
+  # or OPS_BG_NO_DOPPLER=1.
+  DOPPLER_BIN="${DOPPLER_BIN:-/opt/homebrew/bin/doppler}"
+  if [ -z "${OPS_BG_ENV_PROVISIONED:-}" ] && [ -z "${OPS_BG_NO_DOPPLER:-}" ] && [ -x "$DOPPLER_BIN" ]; then
+    exec env OPS_BG_ENV_PROVISIONED=1 "$DOPPLER_BIN" run -p mcp-servers -c dev -- "$CLAUDE_BIN" "${args[@]}"
+  fi
   exec "$CLAUDE_BIN" "${args[@]}"
 }
 
 cmd_list() {
-  local fmt="pretty"
-  if [ "${1:-}" = "--json" ]; then fmt="json"; fi
+  # Pure pass-through to the native fleet introspection (2026-06-12 shrink):
+  # `claude agents --json` carries native id/state fields since 2.1.169 —
+  # no custom roster parsing needed. `--all` includes completed sessions.
+  if [ "${1:-}" = "--json" ]; then
+    shift
+    exec "$CLAUDE_BIN" agents --json "$@"
+  fi
+  if [ "${1:-}" = "--all" ]; then
+    exec "$CLAUDE_BIN" agents --json --all
+  fi
   local raw
   raw="$("$CLAUDE_BIN" agents --json 2>/dev/null || echo '')"
   if [ -z "$raw" ]; then
     echo "ops-bg: claude agents --json returned empty (supervisor unreachable?)" >&2
     return 1
   fi
-  if [ "$fmt" = "json" ]; then
-    echo "$raw" | jq '[.[] | select(.kind == "background")]'
-    return
-  fi
   command -v jq >/dev/null 2>&1 || { echo "$raw"; return; }
-  local n
-  n=$(echo "$raw" | jq '[.[] | select(.kind == "background")] | length')
-  printf 'background sessions: %s\n' "$n"
-  if [ "$n" -gt 0 ]; then
-    echo "$raw" | jq -r '
-      .[] | select(.kind == "background")
-      | "  \(.sessionId[0:8])  \(.status)  pid=\(.pid)  cwd=\(.cwd)"
-    '
-  fi
+  echo "$raw" | jq -r '.[] | "  \(.sessionId[0:8])  \(.status // .state // "-")  \(.name // "-")  \(.cwd // "-")"'
 }
 
 cmd_status() {

--- a/claude-ops/scripts/agent-dash/collect.mjs
+++ b/claude-ops/scripts/agent-dash/collect.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+// collect.mjs — gather the unified agent fleet (local Mac + FRA EC2) as one JSON
+// array. The same host-probe.mjs runs locally and (piped over ssh) on FRA, so
+// derivation lives in exactly one place. Remote is cached 30s; every probe has a
+// hard timeout so a wedged host degrades to empty rather than hanging the dash.
+//
+// Usage:
+//   node collect.mjs            # pretty-ish JSON of the merged fleet
+//   import { collect } from './collect.mjs'   # programmatic
+//
+// Cache: ~/.claude/state/agent-dash-remote-cache.json (FRA result + timestamp)
+
+import { execFileSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const HOME = homedir();
+const PROBE = join(HERE, 'host-probe.mjs');
+const STATE_DIR = join(HOME, '.claude', 'state');
+const REMOTE_CACHE = join(STATE_DIR, 'agent-dash-remote-cache.json');
+const REMOTE_TTL_MS = 30 * 1000;
+
+// FRA ssh targets, tried in order. dev-sandbox-fra-cf is the Cloudflare-Access
+// fallback when Tailscale/direct is down (see workspace CLAUDE.md).
+const FRA_HOSTS = (process.env.AGENT_DASH_FRA_HOSTS || 'fra-direct,dev-sandbox-fra-cf').split(',');
+
+function readCache() {
+  try {
+    const c = JSON.parse(readFileSync(REMOTE_CACHE, 'utf8'));
+    if (c && Array.isArray(c.agents)) return c;
+  } catch { /* none */ }
+  return null;
+}
+
+function writeCache(agents, meta) {
+  try {
+    if (!existsSync(STATE_DIR)) mkdirSync(STATE_DIR, { recursive: true });
+    writeFileSync(REMOTE_CACHE, JSON.stringify({ agents, meta, ts: nowTs() }));
+  } catch { /* best effort */ }
+}
+
+// nowTs avoids Date.now() (banned in workflow scripts; fine here but keep one source)
+function nowTs() { return Date.now(); }
+
+// --- local -----------------------------------------------------------------
+
+export function collectLocal() {
+  try {
+    const out = execFileSync(process.execPath, [PROBE], {
+      env: { ...process.env, AGENT_DASH_HOST: 'mac' },
+      timeout: 20000,
+      encoding: 'utf8',
+      maxBuffer: 32 * 1024 * 1024,
+    });
+    const arr = JSON.parse(out);
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+}
+
+// --- remote (FRA) ----------------------------------------------------------
+
+function probeRemoteHost(sshHost, probeSrc) {
+  // Ship the probe over stdin, run it with the remote node, label records 'fra'.
+  // One round-trip, hard timeout, read-only on the remote box.
+  const remoteCmd =
+    'cat > /tmp/agent-dash-probe.mjs && AGENT_DASH_HOST=fra ' +
+    'node /tmp/agent-dash-probe.mjs; rm -f /tmp/agent-dash-probe.mjs';
+  const out = execFileSync(
+    'ssh',
+    ['-o', 'ConnectTimeout=8', '-o', 'BatchMode=yes', '-o', 'StrictHostKeyChecking=accept-new', sshHost, remoteCmd],
+    { input: probeSrc, timeout: 25000, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 },
+  );
+  const arr = JSON.parse(out);
+  if (!Array.isArray(arr)) throw new Error('bad remote payload');
+  return arr;
+}
+
+export function collectRemote({ force = false } = {}) {
+  const cache = readCache();
+  if (!force && cache && nowTs() - cache.ts < REMOTE_TTL_MS) {
+    return { agents: cache.agents, stale: false, source: cache.meta?.source || 'cache', cached: true };
+  }
+
+  let probeSrc;
+  try { probeSrc = readFileSync(PROBE, 'utf8'); } catch {
+    return { agents: cache?.agents || [], stale: true, source: 'no-probe', cached: !!cache };
+  }
+
+  for (const h of FRA_HOSTS) {
+    try {
+      const agents = probeRemoteHost(h.trim(), probeSrc);
+      writeCache(agents, { source: h.trim() });
+      return { agents, stale: false, source: h.trim(), cached: false };
+    } catch { /* try next host */ }
+  }
+
+  // all FRA hosts failed — serve last-known cache, flagged stale
+  if (cache) return { agents: cache.agents, stale: true, source: cache.meta?.source || 'cache', cached: true };
+  return { agents: [], stale: true, source: 'unreachable', cached: false };
+}
+
+// --- unified ---------------------------------------------------------------
+
+export function collect({ force = false, localOnly = false } = {}) {
+  const local = collectLocal();
+  let remote = { agents: [], stale: false, source: 'skipped', cached: false };
+  if (!localOnly) remote = collectRemote({ force });
+  return {
+    ts: nowTs(),
+    hosts: {
+      mac: { count: local.length },
+      fra: { count: remote.agents.length, stale: remote.stale, source: remote.source, cached: remote.cached },
+    },
+    agents: [...local, ...remote.agents],
+  };
+}
+
+// CLI entry
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const force = process.argv.includes('--force');
+  const localOnly = process.argv.includes('--local');
+  process.stdout.write(JSON.stringify(collect({ force, localOnly }), null, 2));
+  process.stdout.write('\n');
+}

--- a/claude-ops/scripts/agent-dash/collect.mjs
+++ b/claude-ops/scripts/agent-dash/collect.mjs
@@ -31,7 +31,9 @@ function readCache() {
   try {
     const c = JSON.parse(readFileSync(REMOTE_CACHE, 'utf8'));
     if (c && Array.isArray(c.agents)) return c;
-  } catch { /* none */ }
+  } catch {
+    /* none */
+  }
   return null;
 }
 
@@ -39,11 +41,15 @@ function writeCache(agents, meta) {
   try {
     if (!existsSync(STATE_DIR)) mkdirSync(STATE_DIR, { recursive: true });
     writeFileSync(REMOTE_CACHE, JSON.stringify({ agents, meta, ts: nowTs() }));
-  } catch { /* best effort */ }
+  } catch {
+    /* best effort */
+  }
 }
 
 // nowTs avoids Date.now() (banned in workflow scripts; fine here but keep one source)
-function nowTs() { return Date.now(); }
+function nowTs() {
+  return Date.now();
+}
 
 // --- local -----------------------------------------------------------------
 
@@ -87,7 +93,9 @@ export function collectRemote({ force = false } = {}) {
   }
 
   let probeSrc;
-  try { probeSrc = readFileSync(PROBE, 'utf8'); } catch {
+  try {
+    probeSrc = readFileSync(PROBE, 'utf8');
+  } catch {
     return { agents: cache?.agents || [], stale: true, source: 'no-probe', cached: !!cache };
   }
 
@@ -96,7 +104,9 @@ export function collectRemote({ force = false } = {}) {
       const agents = probeRemoteHost(h.trim(), probeSrc);
       writeCache(agents, { source: h.trim() });
       return { agents, stale: false, source: h.trim(), cached: false };
-    } catch { /* try next host */ }
+    } catch {
+      /* try next host */
+    }
   }
 
   // all FRA hosts failed — serve last-known cache, flagged stale

--- a/claude-ops/scripts/agent-dash/control.mjs
+++ b/claude-ops/scripts/agent-dash/control.mjs
@@ -17,7 +17,9 @@ function fraSshHost() {
   try {
     const host = JSON.parse(readFileSync(REMOTE_CACHE, 'utf8'))?.meta?.source?.trim();
     if (host) return host;
-  } catch { /* use default */ }
+  } catch {
+    /* use default */
+  }
   return FRA_HOSTS[0].trim();
 }
 const OPS_BG = process.env.OPS_BG_BIN || `${HOME}/Projects/claude-ops/claude-ops/bin/ops-bg`;
@@ -51,7 +53,11 @@ function runForeground(cmd, args) {
 // Run a non-interactive command, capture output. { ok, out, err }
 function runCapture(cmd, args, opts = {}) {
   try {
-    const out = execFileSync(cmd, args, { encoding: 'utf8', timeout: opts.timeout || 20000, stdio: ['ignore', 'pipe', 'pipe'] });
+    const out = execFileSync(cmd, args, {
+      encoding: 'utf8',
+      timeout: opts.timeout || 20000,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
     return { ok: true, out: out.trim(), err: '' };
   } catch (e) {
     return { ok: false, out: (e.stdout || '').toString().trim(), err: (e.stderr || e.message || '').toString().trim() };
@@ -78,10 +84,15 @@ export function attach(a) {
   }
   if (a.type === 'agy') {
     const sub = `agy --conversation ${a.sessionId}`;
-    if (a.host === 'fra') { const [c, args] = remote(sub, true); return runForeground(c, args); }
+    if (a.host === 'fra') {
+      const [c, args] = remote(sub, true);
+      return runForeground(c, args);
+    }
     return runForeground('agy', ['--conversation', a.sessionId]);
   }
-  process.stderr.write(`attach: ${a.type} has no attach surface (pid ${a.pid}). Use tmux attach if it runs in a pane.\n`);
+  process.stderr.write(
+    `attach: ${a.type} has no attach surface (pid ${a.pid}). Use tmux attach if it runs in a pane.\n`,
+  );
   return 2;
 }
 
@@ -96,7 +107,7 @@ export function steer(a, message) {
       return { ok: r.ok, msg: r.ok ? `steered ${a.id} on fra` : r.err };
     }
     const r = runCapture(OPS_BG, ['send', a.id, message]);
-    return { ok: r.ok, msg: r.ok ? `steered ${a.id}` : (r.err || r.out) };
+    return { ok: r.ok, msg: r.ok ? `steered ${a.id}` : r.err || r.out };
   }
   if (a.type === 'agy') {
     return { ok: false, msg: 'agy has no live-steer; use revive (--conversation) to resume interactively' };
@@ -110,7 +121,10 @@ export function steer(a, message) {
 export function revive(a) {
   if (a.type === 'claude') {
     if (a.host === 'fra') {
-      const [c, args] = remote(`CLAUDE_NO_TMUX=1 claude attach ${a.id} || CLAUDE_NO_TMUX=1 claude -r ${a.sessionId}`, true);
+      const [c, args] = remote(
+        `CLAUDE_NO_TMUX=1 claude attach ${a.id} || CLAUDE_NO_TMUX=1 claude -r ${a.sessionId}`,
+        true,
+      );
       return runForeground(c, args);
     }
     const code = runForeground(claudeBin(), ['attach', a.id]);
@@ -118,7 +132,10 @@ export function revive(a) {
     return code;
   }
   if (a.type === 'agy') {
-    if (a.host === 'fra') { const [c, args] = remote(`agy --conversation ${a.sessionId}`, true); return runForeground(c, args); }
+    if (a.host === 'fra') {
+      const [c, args] = remote(`agy --conversation ${a.sessionId}`, true);
+      return runForeground(c, args);
+    }
     return runForeground('agy', ['--conversation', a.sessionId]);
   }
   process.stderr.write(`revive: no resume surface for ${a.type}\n`);
@@ -133,7 +150,7 @@ export function kill(a) {
       return { ok: r.ok, msg: r.ok ? `stopped ${a.id} on fra` : r.err };
     }
     const r = runCapture(claudeBin(), ['stop', a.id]);
-    return { ok: r.ok, msg: r.ok ? `stopped ${a.id}` : (r.err || r.out) };
+    return { ok: r.ok, msg: r.ok ? `stopped ${a.id}` : r.err || r.out };
   }
   // procs / agy: kill by pid
   if (a.pid) {
@@ -141,8 +158,12 @@ export function kill(a) {
       const r = runCapture(...remote(`kill ${a.pid}`));
       return { ok: r.ok, msg: r.ok ? `killed pid ${a.pid} on fra` : r.err };
     }
-    try { process.kill(a.pid); return { ok: true, msg: `killed pid ${a.pid}` }; }
-    catch (e) { return { ok: false, msg: e.message }; }
+    try {
+      process.kill(a.pid);
+      return { ok: true, msg: `killed pid ${a.pid}` };
+    } catch (e) {
+      return { ok: false, msg: e.message };
+    }
   }
   return { ok: false, msg: `nothing to kill for ${a.type} (no pid/session)` };
 }
@@ -153,10 +174,13 @@ export function archive(a) {
   let res;
   if (a.type === 'claude') {
     if (a.host === 'fra') {
-      res = (() => { const r = runCapture(...remote(`CLAUDE_NO_TMUX=1 claude rm ${a.id}`)); return { ok: r.ok, msg: r.ok ? `rm ${a.id} on fra` : r.err }; })();
+      res = (() => {
+        const r = runCapture(...remote(`CLAUDE_NO_TMUX=1 claude rm ${a.id}`));
+        return { ok: r.ok, msg: r.ok ? `rm ${a.id} on fra` : r.err };
+      })();
     } else {
       const r = runCapture(claudeBin(), ['rm', a.id]);
-      res = { ok: r.ok, msg: r.ok ? `rm ${a.id}` : (r.err || r.out) };
+      res = { ok: r.ok, msg: r.ok ? `rm ${a.id}` : r.err || r.out };
     }
   } else {
     res = kill(a);
@@ -164,15 +188,28 @@ export function archive(a) {
   if (!res.ok) return res;
   try {
     if (!existsSync(dirname(ARCHIVE_LOG))) mkdirSync(dirname(ARCHIVE_LOG), { recursive: true });
-    appendFileSync(ARCHIVE_LOG, JSON.stringify({
-      ts: new Date().toISOString(), id: a.id, sessionId: a.sessionId, name: a.name,
-      type: a.type, host: a.host, cwd: a.cwd, lastStatus: a.status,
-    }) + '\n');
-  } catch (e) { res.msg += ` (archive-log: ${e.message})`; }
+    appendFileSync(
+      ARCHIVE_LOG,
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        id: a.id,
+        sessionId: a.sessionId,
+        name: a.name,
+        type: a.type,
+        host: a.host,
+        cwd: a.cwd,
+        lastStatus: a.status,
+      }) + '\n',
+    );
+  } catch (e) {
+    res.msg += ` (archive-log: ${e.message})`;
+  }
   return res;
 }
 
 // shell-quote a single arg for remote ssh command strings
-function shq(s) { return `'${String(s).replace(/'/g, `'\\''`)}'`; }
+function shq(s) {
+  return `'${String(s).replace(/'/g, `'\\''`)}'`;
+}
 
 export const ACTIONS = { attach, steer, revive, kill, archive };

--- a/claude-ops/scripts/agent-dash/control.mjs
+++ b/claude-ops/scripts/agent-dash/control.mjs
@@ -29,8 +29,8 @@ export function findAgent(snapshot, idOrName) {
     snapshot.agents.find((a) => a.sessionId === q) ||
     snapshot.agents.find((a) => String(a.pid) === q) ||
     snapshot.agents.find((a) => a.name === q) ||
-    snapshot.agents.find((a) => a.name.startsWith(q)) ||
     snapshot.agents.find((a) => a.id.startsWith(q)) ||
+    snapshot.agents.find((a) => a.name.startsWith(q)) ||
     null
   );
 }

--- a/claude-ops/scripts/agent-dash/control.mjs
+++ b/claude-ops/scripts/agent-dash/control.mjs
@@ -5,12 +5,21 @@
 
 import { spawnSync, execFileSync } from 'node:child_process';
 import { homedir } from 'node:os';
-import { appendFileSync, existsSync, mkdirSync } from 'node:fs';
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 
 const HOME = homedir();
 const ARCHIVE_LOG = join(HOME, '.claude', 'state', 'agent-archive.jsonl');
-const FRA_PRIMARY = (process.env.AGENT_DASH_FRA_HOSTS || 'fra-direct,dev-sandbox-fra-cf').split(',')[0].trim();
+const REMOTE_CACHE = join(HOME, '.claude', 'state', 'agent-dash-remote-cache.json');
+const FRA_HOSTS = (process.env.AGENT_DASH_FRA_HOSTS || 'fra-direct,dev-sandbox-fra-cf').split(',');
+
+function fraSshHost() {
+  try {
+    const host = JSON.parse(readFileSync(REMOTE_CACHE, 'utf8'))?.meta?.source?.trim();
+    if (host) return host;
+  } catch { /* use default */ }
+  return FRA_HOSTS[0].trim();
+}
 const OPS_BG = process.env.OPS_BG_BIN || `${HOME}/Projects/claude-ops/claude-ops/bin/ops-bg`;
 
 export function findAgent(snapshot, idOrName) {
@@ -20,6 +29,7 @@ export function findAgent(snapshot, idOrName) {
     snapshot.agents.find((a) => a.sessionId === q) ||
     snapshot.agents.find((a) => String(a.pid) === q) ||
     snapshot.agents.find((a) => a.name === q) ||
+    snapshot.agents.find((a) => a.name.startsWith(q)) ||
     snapshot.agents.find((a) => a.id.startsWith(q)) ||
     null
   );
@@ -52,7 +62,7 @@ function runCapture(cmd, args, opts = {}) {
 function remote(shell, tty = false) {
   const flags = ['-o', 'ConnectTimeout=8', '-o', 'BatchMode=yes'];
   if (tty) flags.unshift('-t');
-  return ['ssh', [...flags, FRA_PRIMARY, shell]];
+  return ['ssh', [...flags, fraSshHost(), shell]];
 }
 
 // --- ATTACH ----------------------------------------------------------------
@@ -140,7 +150,7 @@ export function kill(a) {
 // --- ARCHIVE ---------------------------------------------------------------
 // claude rm <id> (removes session + worktree) + append a record to the archive log.
 export function archive(a) {
-  let res = { ok: true, msg: '' };
+  let res;
   if (a.type === 'claude') {
     if (a.host === 'fra') {
       res = (() => { const r = runCapture(...remote(`CLAUDE_NO_TMUX=1 claude rm ${a.id}`)); return { ok: r.ok, msg: r.ok ? `rm ${a.id} on fra` : r.err }; })();
@@ -148,7 +158,10 @@ export function archive(a) {
       const r = runCapture(claudeBin(), ['rm', a.id]);
       res = { ok: r.ok, msg: r.ok ? `rm ${a.id}` : (r.err || r.out) };
     }
+  } else {
+    res = kill(a);
   }
+  if (!res.ok) return res;
   try {
     if (!existsSync(dirname(ARCHIVE_LOG))) mkdirSync(dirname(ARCHIVE_LOG), { recursive: true });
     appendFileSync(ARCHIVE_LOG, JSON.stringify({

--- a/claude-ops/scripts/agent-dash/control.mjs
+++ b/claude-ops/scripts/agent-dash/control.mjs
@@ -1,0 +1,165 @@
+// control.mjs — fleet control actions for agent-dash: attach, steer, revive,
+// kill, archive. Resolves an agent by id from a fresh snapshot, then dispatches
+// the right command for its type + host. Remote actions are prefixed with
+// `ssh -t <fra>`. Read-only on remote except these explicit control calls.
+
+import { spawnSync, execFileSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { appendFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+
+const HOME = homedir();
+const ARCHIVE_LOG = join(HOME, '.claude', 'state', 'agent-archive.jsonl');
+const FRA_PRIMARY = (process.env.AGENT_DASH_FRA_HOSTS || 'fra-direct,dev-sandbox-fra-cf').split(',')[0].trim();
+const OPS_BG = process.env.OPS_BG_BIN || `${HOME}/Projects/claude-ops/claude-ops/bin/ops-bg`;
+
+export function findAgent(snapshot, idOrName) {
+  const q = String(idOrName);
+  return (
+    snapshot.agents.find((a) => a.id === q) ||
+    snapshot.agents.find((a) => a.sessionId === q) ||
+    snapshot.agents.find((a) => String(a.pid) === q) ||
+    snapshot.agents.find((a) => a.name === q) ||
+    snapshot.agents.find((a) => a.id.startsWith(q)) ||
+    null
+  );
+}
+
+function claudeBin() {
+  for (const c of [`${HOME}/.local/bin/claude`, '/usr/local/bin/claude', '/opt/homebrew/bin/claude']) {
+    if (existsSync(c)) return c;
+  }
+  return 'claude';
+}
+
+// Run a foreground, TTY-inheriting command (attach/resume). Returns exit code.
+function runForeground(cmd, args) {
+  const r = spawnSync(cmd, args, { stdio: 'inherit' });
+  return r.status ?? 1;
+}
+
+// Run a non-interactive command, capture output. { ok, out, err }
+function runCapture(cmd, args, opts = {}) {
+  try {
+    const out = execFileSync(cmd, args, { encoding: 'utf8', timeout: opts.timeout || 20000, stdio: ['ignore', 'pipe', 'pipe'] });
+    return { ok: true, out: out.trim(), err: '' };
+  } catch (e) {
+    return { ok: false, out: (e.stdout || '').toString().trim(), err: (e.stderr || e.message || '').toString().trim() };
+  }
+}
+
+// Build the [cmd, args] for a remote action: ssh [-t] <fra> "<shell>"
+function remote(shell, tty = false) {
+  const flags = ['-o', 'ConnectTimeout=8', '-o', 'BatchMode=yes'];
+  if (tty) flags.unshift('-t');
+  return ['ssh', [...flags, FRA_PRIMARY, shell]];
+}
+
+// --- ATTACH ----------------------------------------------------------------
+// Hands the terminal to the live session. claude → `claude attach <id>`;
+// agy → resume conversation; procs → no attach surface.
+export function attach(a) {
+  if (a.type === 'claude') {
+    if (a.host === 'fra') {
+      const [c, args] = remote(`CLAUDE_NO_TMUX=1 claude attach ${a.id}`, true);
+      return runForeground(c, args);
+    }
+    return runForeground(claudeBin(), ['attach', a.id]);
+  }
+  if (a.type === 'agy') {
+    const sub = `agy --conversation ${a.sessionId}`;
+    if (a.host === 'fra') { const [c, args] = remote(sub, true); return runForeground(c, args); }
+    return runForeground('agy', ['--conversation', a.sessionId]);
+  }
+  process.stderr.write(`attach: ${a.type} has no attach surface (pid ${a.pid}). Use tmux attach if it runs in a pane.\n`);
+  return 2;
+}
+
+// --- STEER -----------------------------------------------------------------
+// Inject a message without attaching. claude bg → ops-bg send (control.sock).
+// agy → not live-steerable (resume only). Returns {ok, msg}.
+export function steer(a, message) {
+  if (!message || !message.trim()) return { ok: false, msg: 'empty message' };
+  if (a.type === 'claude') {
+    if (a.host === 'fra') {
+      const r = runCapture(...remote(`ops-bg send ${a.id} ${shq(message)}`));
+      return { ok: r.ok, msg: r.ok ? `steered ${a.id} on fra` : r.err };
+    }
+    const r = runCapture(OPS_BG, ['send', a.id, message]);
+    return { ok: r.ok, msg: r.ok ? `steered ${a.id}` : (r.err || r.out) };
+  }
+  if (a.type === 'agy') {
+    return { ok: false, msg: 'agy has no live-steer; use revive (--conversation) to resume interactively' };
+  }
+  return { ok: false, msg: `${a.type} is not steerable` };
+}
+
+// --- REVIVE ----------------------------------------------------------------
+// Bring a stopped/zombie session back. claude → attach (conversation kept), or
+// `claude -r <sessionId>` if attach fails. agy → resume by conversation UUID.
+export function revive(a) {
+  if (a.type === 'claude') {
+    if (a.host === 'fra') {
+      const [c, args] = remote(`CLAUDE_NO_TMUX=1 claude attach ${a.id} || CLAUDE_NO_TMUX=1 claude -r ${a.sessionId}`, true);
+      return runForeground(c, args);
+    }
+    const code = runForeground(claudeBin(), ['attach', a.id]);
+    if (code !== 0 && a.sessionId) return runForeground(claudeBin(), ['-r', a.sessionId]);
+    return code;
+  }
+  if (a.type === 'agy') {
+    if (a.host === 'fra') { const [c, args] = remote(`agy --conversation ${a.sessionId}`, true); return runForeground(c, args); }
+    return runForeground('agy', ['--conversation', a.sessionId]);
+  }
+  process.stderr.write(`revive: no resume surface for ${a.type}\n`);
+  return 2;
+}
+
+// --- KILL ------------------------------------------------------------------
+export function kill(a) {
+  if (a.type === 'claude') {
+    if (a.host === 'fra') {
+      const r = runCapture(...remote(`CLAUDE_NO_TMUX=1 claude stop ${a.id}`));
+      return { ok: r.ok, msg: r.ok ? `stopped ${a.id} on fra` : r.err };
+    }
+    const r = runCapture(claudeBin(), ['stop', a.id]);
+    return { ok: r.ok, msg: r.ok ? `stopped ${a.id}` : (r.err || r.out) };
+  }
+  // procs / agy: kill by pid
+  if (a.pid) {
+    if (a.host === 'fra') {
+      const r = runCapture(...remote(`kill ${a.pid}`));
+      return { ok: r.ok, msg: r.ok ? `killed pid ${a.pid} on fra` : r.err };
+    }
+    try { process.kill(a.pid); return { ok: true, msg: `killed pid ${a.pid}` }; }
+    catch (e) { return { ok: false, msg: e.message }; }
+  }
+  return { ok: false, msg: `nothing to kill for ${a.type} (no pid/session)` };
+}
+
+// --- ARCHIVE ---------------------------------------------------------------
+// claude rm <id> (removes session + worktree) + append a record to the archive log.
+export function archive(a) {
+  let res = { ok: true, msg: '' };
+  if (a.type === 'claude') {
+    if (a.host === 'fra') {
+      res = (() => { const r = runCapture(...remote(`CLAUDE_NO_TMUX=1 claude rm ${a.id}`)); return { ok: r.ok, msg: r.ok ? `rm ${a.id} on fra` : r.err }; })();
+    } else {
+      const r = runCapture(claudeBin(), ['rm', a.id]);
+      res = { ok: r.ok, msg: r.ok ? `rm ${a.id}` : (r.err || r.out) };
+    }
+  }
+  try {
+    if (!existsSync(dirname(ARCHIVE_LOG))) mkdirSync(dirname(ARCHIVE_LOG), { recursive: true });
+    appendFileSync(ARCHIVE_LOG, JSON.stringify({
+      ts: new Date().toISOString(), id: a.id, sessionId: a.sessionId, name: a.name,
+      type: a.type, host: a.host, cwd: a.cwd, lastStatus: a.status,
+    }) + '\n');
+  } catch (e) { res.msg += ` (archive-log: ${e.message})`; }
+  return res;
+}
+
+// shell-quote a single arg for remote ssh command strings
+function shq(s) { return `'${String(s).replace(/'/g, `'\\''`)}'`; }
+
+export const ACTIONS = { attach, steer, revive, kill, archive };

--- a/claude-ops/scripts/agent-dash/host-probe.mjs
+++ b/claude-ops/scripts/agent-dash/host-probe.mjs
@@ -23,7 +23,12 @@ const WORKING_MS = 120 * 1000; // transcript activity within 2min => actively wo
 
 function pidAlive(pid) {
   if (!pid) return false;
-  try { process.kill(pid, 0); return true; } catch (e) { return e.code === 'EPERM'; }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return e.code === 'EPERM';
+  }
 }
 
 // --- helpers ---------------------------------------------------------------
@@ -69,7 +74,13 @@ function tailLines(path, maxBytes = 96 * 1024) {
   } catch {
     return [];
   } finally {
-    if (fd !== undefined) { try { closeSync(fd); } catch { /* ignore */ } }
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* ignore */
+      }
+    }
   }
 }
 
@@ -84,7 +95,9 @@ function deriveFromTranscript(path) {
     try {
       const ts = JSON.parse(lines[i]).timestamp;
       if (ts) out.lastActivity = new Date(ts).getTime();
-    } catch { /* skip */ }
+    } catch {
+      /* skip */
+    }
   }
 
   // Walk backward for the most recent meaningful action; detect an
@@ -95,7 +108,11 @@ function deriveFromTranscript(path) {
 
   for (let i = lines.length - 1; i >= 0; i--) {
     let ev;
-    try { ev = JSON.parse(lines[i]); } catch { continue; }
+    try {
+      ev = JSON.parse(lines[i]);
+    } catch {
+      continue;
+    }
     const msg = ev.message || ev;
     const role = msg.role || ev.type;
     const content = msg.content;
@@ -113,7 +130,9 @@ function deriveFromTranscript(path) {
             try {
               const q = block.input?.questions?.[0]?.question || block.input?.plan;
               if (q && !askText) askText = firstLine(q);
-            } catch { /* skip */ }
+            } catch {
+              /* skip */
+            }
           }
           if (!out.doing) out.doing = `→ ${name}`;
         }
@@ -133,7 +152,8 @@ function deriveFromTranscript(path) {
     out.decision = askText || 'awaiting user decision';
   }
   // any tool_use without a tool_result = work in flight (used for stuck detection)
-  out.pendingToolUse = [...satisfiedToolUseIds].length < lines.length && hasUnsatisfiedToolUse(lines, satisfiedToolUseIds);
+  out.pendingToolUse =
+    [...satisfiedToolUseIds].length < lines.length && hasUnsatisfiedToolUse(lines, satisfiedToolUseIds);
   return out;
 }
 
@@ -141,7 +161,11 @@ function deriveFromTranscript(path) {
 function hasUnsatisfiedToolUse(lines, satisfied) {
   for (let i = lines.length - 1; i >= 0; i--) {
     let ev;
-    try { ev = JSON.parse(lines[i]); } catch { continue; }
+    try {
+      ev = JSON.parse(lines[i]);
+    } catch {
+      continue;
+    }
     const msg = ev.message || ev;
     const content = msg.content;
     if (!Array.isArray(content)) continue;
@@ -174,7 +198,11 @@ function probeClaude() {
   const rosterPath = join(HOME, '.claude', 'daemon', 'roster.json');
   if (!existsSync(rosterPath)) return [];
   let roster;
-  try { roster = JSON.parse(readFileSync(rosterPath, 'utf8')); } catch { return []; }
+  try {
+    roster = JSON.parse(readFileSync(rosterPath, 'utf8'));
+  } catch {
+    return [];
+  }
   const workers = roster.workers || {};
 
   return Object.entries(workers).map(([short, w]) => {
@@ -212,7 +240,8 @@ function probeClaude() {
     }
 
     const idleFor = rec.lastActivity ? NOW - rec.lastActivity : Infinity;
-    if (!alive) rec.status = 'zombie';            // roster entry, dead pid
+    if (!alive)
+      rec.status = 'zombie'; // roster entry, dead pid
     else if (rec.needs_user) rec.status = 'needs-sam';
     else if (pending && idleFor > STUCK_MS) rec.status = 'stuck';
     else if (idleFor < WORKING_MS) rec.status = 'working';
@@ -233,14 +262,20 @@ function probeAgy(psLines) {
   let dbs = [];
   try {
     dbs = readdirSync(convDir).filter((f) => f.endsWith('.db'));
-  } catch { return []; }
+  } catch {
+    return [];
+  }
 
   // surface only the few most-recently-touched conversations to avoid noise
   const ranked = dbs
     .map((f) => {
       const p = join(convDir, f);
       let mt = 0;
-      try { mt = statSync(p).mtimeMs; } catch { /* skip */ }
+      try {
+        mt = statSync(p).mtimeMs;
+      } catch {
+        /* skip */
+      }
       return { uuid: f.replace(/\.db$/, ''), mtime: mt };
     })
     .sort((a, b) => b.mtime - a.mtime)
@@ -314,9 +349,21 @@ function main() {
   const all = [];
   // one shared process snapshot for agy-liveness + other-agent detection
   const psLines = sh('ps -eo pid,command 2>/dev/null || ps awwxo pid,command', 5000).split('\n').filter(Boolean);
-  try { all.push(...probeClaude()); } catch { /* degrade */ }
-  try { all.push(...probeAgy(psLines)); } catch { /* degrade */ }
-  try { all.push(...probeProcs(psLines)); } catch { /* degrade */ }
+  try {
+    all.push(...probeClaude());
+  } catch {
+    /* degrade */
+  }
+  try {
+    all.push(...probeAgy(psLines));
+  } catch {
+    /* degrade */
+  }
+  try {
+    all.push(...probeProcs(psLines));
+  } catch {
+    /* degrade */
+  }
   process.stdout.write(JSON.stringify(all));
 }
 

--- a/claude-ops/scripts/agent-dash/host-probe.mjs
+++ b/claude-ops/scripts/agent-dash/host-probe.mjs
@@ -1,0 +1,323 @@
+#!/usr/bin/env node
+// host-probe.mjs — single-host fleet probe for agent-dash.
+//
+// Emits one JSON array of agent records for THIS host. Runs identically on the
+// local Mac and (piped over ssh) on the FRA EC2 box, so derivation logic lives
+// in exactly one place. No external deps — fs + child_process only.
+//
+// Env:
+//   AGENT_DASH_HOST   host label baked into every record (default: "local")
+//
+// Every probe has a hard timeout; a wedged surface degrades to empty, never hangs.
+
+import { execSync } from 'node:child_process';
+import { homedir } from 'node:os';
+import { readFileSync, readdirSync, statSync, existsSync, openSync, readSync, closeSync } from 'node:fs';
+import { join } from 'node:path';
+
+const HOST = process.env.AGENT_DASH_HOST || 'local';
+const HOME = homedir();
+const NOW = Date.now();
+const STUCK_MS = 10 * 60 * 1000; // pending tool-use + no activity > 10min => stuck
+const WORKING_MS = 120 * 1000; // transcript activity within 2min => actively working
+
+function pidAlive(pid) {
+  if (!pid) return false;
+  try { process.kill(pid, 0); return true; } catch (e) { return e.code === 'EPERM'; }
+}
+
+// --- helpers ---------------------------------------------------------------
+
+function sh(cmd, timeoutMs = 9000) {
+  try {
+    return execSync(cmd, { timeout: timeoutMs, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+  } catch {
+    return '';
+  }
+}
+
+function firstLine(s) {
+  return (s || '').replace(/\s+/g, ' ').trim().slice(0, 140);
+}
+
+// --- claude bg/interactive sessions ---------------------------------------
+
+function encodeCwd(cwd) {
+  return cwd.replace(/[/.]/g, '-');
+}
+
+function transcriptPath(cwd, sessionId) {
+  const dir = join(HOME, '.claude', 'projects', encodeCwd(cwd));
+  const p = join(dir, `${sessionId}.jsonl`);
+  return existsSync(p) ? p : null;
+}
+
+// Read only the last `maxBytes` of a (possibly 50MB+) jsonl transcript via a
+// positioned read — never loads the whole file. Drops the first (partial) line.
+function tailLines(path, maxBytes = 96 * 1024) {
+  let fd;
+  try {
+    const st = statSync(path);
+    const len = Math.min(maxBytes, st.size);
+    const start = st.size - len;
+    fd = openSync(path, 'r');
+    const buf = Buffer.allocUnsafe(len);
+    readSync(fd, buf, 0, len, start);
+    const lines = buf.toString('utf8').split('\n').filter(Boolean);
+    if (start > 0 && lines.length) lines.shift(); // first line is likely partial
+    return lines;
+  } catch {
+    return [];
+  } finally {
+    if (fd !== undefined) { try { closeSync(fd); } catch { /* ignore */ } }
+  }
+}
+
+// Derive "what it's doing now" + needs-user/decision from a transcript tail.
+function deriveFromTranscript(path) {
+  const out = { doing: null, needsUser: false, decision: null, lastActivity: 0, pendingToolUse: false };
+  const lines = tailLines(path);
+  if (!lines.length) return out;
+
+  // last event timestamp
+  for (let i = lines.length - 1; i >= 0 && !out.lastActivity; i--) {
+    try {
+      const ts = JSON.parse(lines[i]).timestamp;
+      if (ts) out.lastActivity = new Date(ts).getTime();
+    } catch { /* skip */ }
+  }
+
+  // Walk backward for the most recent meaningful action; detect an
+  // AskUserQuestion tool_use with no following tool_result (in-flight => needs-sam).
+  const pendingToolUseIds = new Set();
+  const satisfiedToolUseIds = new Set();
+  let askText = null;
+
+  for (let i = lines.length - 1; i >= 0; i--) {
+    let ev;
+    try { ev = JSON.parse(lines[i]); } catch { continue; }
+    const msg = ev.message || ev;
+    const role = msg.role || ev.type;
+    const content = msg.content;
+
+    if (Array.isArray(content)) {
+      for (const block of content) {
+        if (block.type === 'tool_result' && block.tool_use_id) {
+          satisfiedToolUseIds.add(block.tool_use_id);
+        }
+        if (block.type === 'tool_use') {
+          const name = block.name || '';
+          if (/AskUserQuestion|ExitPlanMode/i.test(name) && !satisfiedToolUseIds.has(block.id)) {
+            pendingToolUseIds.add(block.id);
+            // pull a human-readable question
+            try {
+              const q = block.input?.questions?.[0]?.question || block.input?.plan;
+              if (q && !askText) askText = firstLine(q);
+            } catch { /* skip */ }
+          }
+          if (!out.doing) out.doing = `→ ${name}`;
+        }
+        if (block.type === 'text' && !out.doing) {
+          const t = firstLine(block.text);
+          if (t) out.doing = t;
+        }
+      }
+    } else if (typeof content === 'string' && !out.doing) {
+      out.doing = firstLine(content);
+    }
+    if (out.doing && out.lastActivity) break;
+  }
+
+  if (pendingToolUseIds.size > 0) {
+    out.needsUser = true;
+    out.decision = askText || 'awaiting user decision';
+  }
+  // any tool_use without a tool_result = work in flight (used for stuck detection)
+  out.pendingToolUse = [...satisfiedToolUseIds].length < lines.length && hasUnsatisfiedToolUse(lines, satisfiedToolUseIds);
+  return out;
+}
+
+// True if the LAST assistant turn issued a tool_use that has no matching tool_result.
+function hasUnsatisfiedToolUse(lines, satisfied) {
+  for (let i = lines.length - 1; i >= 0; i--) {
+    let ev;
+    try { ev = JSON.parse(lines[i]); } catch { continue; }
+    const msg = ev.message || ev;
+    const content = msg.content;
+    if (!Array.isArray(content)) continue;
+    const role = msg.role || ev.type;
+    if (role === 'assistant') {
+      for (const b of content) {
+        if (b.type === 'tool_use' && !satisfied.has(b.id)) return true;
+      }
+      return false; // most recent assistant turn fully satisfied
+    }
+  }
+  return false;
+}
+
+// Pull the friendly --name / -n value out of a worker's recorded launch args.
+function nameFromFlagArgs(args) {
+  if (!Array.isArray(args)) return null;
+  for (let i = 0; i < args.length; i++) {
+    if ((args[i] === '-n' || args[i] === '--name') && args[i + 1]) return args[i + 1];
+    if (typeof args[i] === 'string' && args[i].startsWith('--name=')) return args[i].slice(7);
+  }
+  return null;
+}
+
+// Inventory claude bg sessions from the daemon roster (instant) — the CLI's
+// `claude agents --json` is authoritative but ~25-30s cold, far too slow for a
+// live dashboard. Roster + transcript + pid-liveness yields the same picture
+// in milliseconds and is actually MORE real-time than the CLI's cached state.
+function probeClaude() {
+  const rosterPath = join(HOME, '.claude', 'daemon', 'roster.json');
+  if (!existsSync(rosterPath)) return [];
+  let roster;
+  try { roster = JSON.parse(readFileSync(rosterPath, 'utf8')); } catch { return []; }
+  const workers = roster.workers || {};
+
+  return Object.entries(workers).map(([short, w]) => {
+    const sessionId = w.sessionId || w.dispatch?.sessionId || null;
+    const name = nameFromFlagArgs(w.dispatch?.launch?.flagArgs) || short;
+    const alive = pidAlive(w.pid);
+    const rec = {
+      type: 'claude',
+      host: HOST,
+      id: short,
+      sessionId,
+      pid: w.pid ?? null,
+      name,
+      cwd: w.cwd || w.dispatch?.cwd || '',
+      kind: 'background',
+      isolation: w.dispatch?.isolation?.mode || null,
+      doing: null,
+      status: 'idle',
+      needs_user: false,
+      decision: null,
+      lastActivity: w.startedAt || 0,
+    };
+
+    let pending = false;
+    if (sessionId && rec.cwd) {
+      const tp = transcriptPath(rec.cwd, sessionId);
+      if (tp) {
+        const d = deriveFromTranscript(tp);
+        if (d.doing) rec.doing = d.doing;
+        if (d.lastActivity) rec.lastActivity = d.lastActivity;
+        rec.needs_user = d.needsUser;
+        rec.decision = d.decision;
+        pending = d.pendingToolUse;
+      }
+    }
+
+    const idleFor = rec.lastActivity ? NOW - rec.lastActivity : Infinity;
+    if (!alive) rec.status = 'zombie';            // roster entry, dead pid
+    else if (rec.needs_user) rec.status = 'needs-sam';
+    else if (pending && idleFor > STUCK_MS) rec.status = 'stuck';
+    else if (idleFor < WORKING_MS) rec.status = 'working';
+    else rec.status = 'idle';
+    return rec;
+  });
+}
+
+// --- agy (Antigravity) conversations --------------------------------------
+
+function probeAgy(psLines) {
+  const convDir = join(HOME, '.gemini', 'antigravity-cli', 'conversations');
+  if (!existsSync(convDir)) return [];
+  // alive agy process? — used to mark the freshest conversation live vs dormant
+  const agyAlive = psLines.some((l) => /\bagy\b/.test(l) && !/grep/.test(l));
+  const logDir = join(HOME, '.gemini', 'antigravity-cli', 'log');
+
+  let dbs = [];
+  try {
+    dbs = readdirSync(convDir).filter((f) => f.endsWith('.db'));
+  } catch { return []; }
+
+  // surface only the few most-recently-touched conversations to avoid noise
+  const ranked = dbs
+    .map((f) => {
+      const p = join(convDir, f);
+      let mt = 0;
+      try { mt = statSync(p).mtimeMs; } catch { /* skip */ }
+      return { uuid: f.replace(/\.db$/, ''), mtime: mt };
+    })
+    .sort((a, b) => b.mtime - a.mtime)
+    .slice(0, 5)
+    .filter((c) => NOW - c.mtime < 24 * 60 * 60 * 1000); // touched in last 24h
+
+  return ranked.map((c, i) => {
+    const fresh = NOW - c.mtime < STUCK_MS;
+    return {
+      type: 'agy',
+      host: HOST,
+      id: c.uuid.slice(0, 8),
+      sessionId: c.uuid,
+      pid: null,
+      name: `agy:${c.uuid.slice(0, 8)}`,
+      cwd: logDir,
+      kind: 'background',
+      doing: agyAlive && i === 0 && fresh ? 'agy session active' : 'conversation (resume w/ --conversation)',
+      status: agyAlive && i === 0 && fresh ? 'working' : 'idle',
+      needs_user: false,
+      decision: null,
+      lastActivity: c.mtime,
+    };
+  });
+}
+
+// --- other CLI agents via process table -----------------------------------
+
+function probeProcs(psLines) {
+  // openclaw, codex (cli app-server), cursor-agent
+  const out = [];
+  const lines = psLines;
+  const seen = new Set();
+  const matchers = [
+    { type: 'openclaw', re: /\bopenclaw\b/, skip: /grep/ },
+    { type: 'codex', re: /codex app-server|Codex\.app.*codex/, skip: /Helper|crashpad|Renderer|grep/ },
+    { type: 'cursor', re: /cursor-agent/, skip: /grep/ },
+  ];
+  for (const line of lines) {
+    for (const m of matchers) {
+      if (m.re.test(line) && !m.skip.test(line)) {
+        const pid = (line.trim().split(/\s+/)[0] || '').trim();
+        const key = `${m.type}:${pid}`;
+        if (!pid || seen.has(key) || seen.has(m.type)) continue;
+        // collapse to one record per type per host (these spawn many helpers)
+        seen.add(m.type);
+        out.push({
+          type: m.type,
+          host: HOST,
+          id: pid,
+          sessionId: null,
+          pid: Number(pid) || null,
+          name: m.type,
+          cwd: '',
+          kind: 'background',
+          doing: `${m.type} process running`,
+          status: 'working',
+          needs_user: false,
+          decision: null,
+          lastActivity: NOW,
+        });
+      }
+    }
+  }
+  return out;
+}
+
+// --- assemble --------------------------------------------------------------
+
+function main() {
+  const all = [];
+  // one shared process snapshot for agy-liveness + other-agent detection
+  const psLines = sh('ps -eo pid,command 2>/dev/null || ps awwxo pid,command', 5000).split('\n').filter(Boolean);
+  try { all.push(...probeClaude()); } catch { /* degrade */ }
+  try { all.push(...probeAgy(psLines)); } catch { /* degrade */ }
+  try { all.push(...probeProcs(psLines)); } catch { /* degrade */ }
+  process.stdout.write(JSON.stringify(all));
+}
+
+main();

--- a/claude-ops/scripts/agent-dash/render.mjs
+++ b/claude-ops/scripts/agent-dash/render.mjs
@@ -1,0 +1,155 @@
+// render.mjs — pure formatting for agent-dash. No I/O; takes a fleet snapshot
+// and returns ANSI strings. Raw escape codes (no deps), statusline-style.
+
+const C = {
+  reset: '\x1b[0m', bold: '\x1b[1m', dim: '\x1b[2m',
+  red: '\x1b[31m', green: '\x1b[32m', yellow: '\x1b[33m', blue: '\x1b[34m',
+  magenta: '\x1b[35m', cyan: '\x1b[36m', white: '\x1b[37m', gray: '\x1b[90m',
+  brightYellow: '\x1b[93m', brightRed: '\x1b[91m', brightGreen: '\x1b[92m',
+  invert: '\x1b[7m',
+};
+
+// status → { dot, color, label }
+const STATUS = {
+  working:    { dot: '●', color: C.green,        label: 'working'  },
+  idle:       { dot: '○', color: C.gray,         label: 'idle'     },
+  'needs-sam':{ dot: '◆', color: C.brightYellow, label: 'NEEDS YOU'},
+  blocked:    { dot: '■', color: C.magenta,      label: 'blocked'  },
+  stuck:      { dot: '▲', color: C.yellow,       label: 'stuck'    },
+  dead:       { dot: '✕', color: C.brightRed,    label: 'dead'     },
+  zombie:     { dot: '☠', color: C.red + C.dim,  label: 'zombie'   },
+};
+
+const TYPE_GLYPH = {
+  claude: 'cc', agy: 'agy', codex: 'cdx', cursor: 'cur', openclaw: 'ocl', other: '·',
+};
+
+export const STATUS_ORDER = ['needs-sam', 'blocked', 'stuck', 'working', 'idle', 'zombie', 'dead'];
+
+function pad(s, n) {
+  s = String(s ?? '');
+  if (s.length > n) return s.slice(0, n - 1) + '…';
+  return s + ' '.repeat(n - s.length);
+}
+
+function ageStr(ms) {
+  if (!ms) return '—';
+  const s = Math.max(0, Math.floor((Date.now() - ms) / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}
+
+// Sort: needs-you first, then by status order, then most-recent activity.
+export function sortAgents(agents) {
+  return [...agents].sort((a, b) => {
+    const ai = STATUS_ORDER.indexOf(a.status);
+    const bi = STATUS_ORDER.indexOf(b.status);
+    if (ai !== bi) return (ai < 0 ? 99 : ai) - (bi < 0 ? 99 : bi);
+    return (b.lastActivity || 0) - (a.lastActivity || 0);
+  });
+}
+
+// Render a single agent row. `width` drives responsive column dropping.
+function row(a, width, selected) {
+  const st = STATUS[a.status] || STATUS.idle;
+  const sel = selected ? C.invert : '';
+  const ty = TYPE_GLYPH[a.type] || a.type.slice(0, 3);
+
+  const dot = `${st.color}${st.dot}${C.reset}${sel}`;
+  const statusLbl = `${st.color}${pad(st.label, 9)}${C.reset}${sel}`;
+  const name = pad(a.name || a.id, 18);
+  const doing = a.needs_user && a.decision ? `${C.brightYellow}? ${a.decision}${C.reset}${sel}` : (a.doing || `${C.gray}—${C.reset}${sel}`);
+  const age = pad(ageStr(a.lastActivity), 4);
+
+  let line;
+  if (width < 80) {
+    // narrow: dot + type + name + status
+    line = ` ${dot} ${C.dim}${pad(ty, 3)}${C.reset}${sel} ${name} ${statusLbl}`;
+  } else if (width < 110) {
+    line = ` ${dot} ${C.dim}${pad(ty, 3)}${C.reset}${sel} ${name} ${statusLbl} ${pad(stripWidth(doing), Math.max(10, width - 48))}`;
+  } else {
+    const doingW = width - 56;
+    line = ` ${dot} ${C.dim}${pad(ty, 3)}${C.reset}${sel} ${name} ${statusLbl} ${age}  ${truncAnsi(doing, doingW)}`;
+  }
+  return selected ? `${C.invert}${line}${C.reset}` : line;
+}
+
+// width of a string ignoring ANSI codes
+function stripWidth(s) { return s.replace(/\x1b\[[0-9;]*m/g, ''); }
+function truncAnsi(s, n) {
+  // crude: if visible length exceeds n, slice the visible text
+  const vis = stripWidth(s);
+  if (vis.length <= n) return s;
+  return vis.slice(0, n - 1) + '…' + C.reset;
+}
+
+export function renderDashboard(snapshot, { width = 100, selectedIdx = 0, statusLine = '' } = {}) {
+  const lines = [];
+  const agents = sortAgents(snapshot.agents);
+  const total = agents.length;
+  const needs = agents.filter((a) => a.status === 'needs-sam').length;
+  const fra = snapshot.hosts?.fra || {};
+  const fraTag = fra.stale ? `${C.red}stale${C.reset}` : fra.cached ? `${C.gray}cached${C.reset}` : `${C.green}live${C.reset}`;
+
+  // header
+  lines.push(
+    `${C.bold}${C.cyan}AGENT-DASH${C.reset}  ${C.bold}${total}${C.reset} agents` +
+    `  ${C.dim}·${C.reset} mac ${snapshot.hosts?.mac?.count ?? 0}` +
+    `  ${C.dim}·${C.reset} fra ${fra.count ?? 0} (${fraTag})` +
+    (needs ? `  ${C.brightYellow}${C.bold}◆ ${needs} need you${C.reset}` : '') +
+    `  ${C.gray}${new Date(snapshot.ts).toLocaleTimeString()}${C.reset}`,
+  );
+  lines.push(`${C.gray}${'─'.repeat(Math.min(width, 120))}${C.reset}`);
+
+  // group by host
+  const byHost = {};
+  agents.forEach((a, i) => { (byHost[a.host] ||= []).push({ a, i }); });
+  const hostOrder = ['mac', 'fra', ...Object.keys(byHost).filter((h) => h !== 'mac' && h !== 'fra')];
+
+  let flat = 0;
+  const indexMap = []; // flat selectable index -> agent
+  for (const host of hostOrder) {
+    const group = byHost[host];
+    if (!group || !group.length) continue;
+    lines.push(`${C.bold}${C.blue}▾ ${host.toUpperCase()}${C.reset} ${C.gray}(${group.length})${C.reset}`);
+    for (const { a } of group) {
+      indexMap.push(a);
+      lines.push(row(a, width, flat === selectedIdx));
+      flat++;
+    }
+  }
+  if (!flat) lines.push(`  ${C.gray}(no agents found)${C.reset}`);
+
+  // footer
+  lines.push(`${C.gray}${'─'.repeat(Math.min(width, 120))}${C.reset}`);
+  lines.push(hotkeyBar());
+  if (statusLine) lines.push(statusLine);
+
+  return { text: lines.join('\n'), indexMap };
+}
+
+export function hotkeyBar() {
+  const k = (key, lbl) => `${C.bold}${C.cyan}${key}${C.reset}${C.gray}${lbl}${C.reset}`;
+  return [
+    k('↑↓/jk', ' move'),
+    k(' a', 'ttach'),
+    k(' s', 'teer'),
+    k(' r', 'evive'),
+    k(' k', 'ill'),
+    k(' x', ' archive'),
+    k(' ↵', ' details'),
+    k(' R', 'efresh'),
+    k(' q', 'uit'),
+  ].join(`${C.gray} ·${C.reset}`);
+}
+
+// Plain (no-ANSI-cursor) one-shot table for non-TTY / --watch logs.
+export function renderPlain(snapshot, width = 100) {
+  return renderDashboard(snapshot, { width, selectedIdx: -1 }).text;
+}
+
+export { C };

--- a/claude-ops/scripts/agent-dash/render.mjs
+++ b/claude-ops/scripts/agent-dash/render.mjs
@@ -2,26 +2,41 @@
 // and returns ANSI strings. Raw escape codes (no deps), statusline-style.
 
 const C = {
-  reset: '\x1b[0m', bold: '\x1b[1m', dim: '\x1b[2m',
-  red: '\x1b[31m', green: '\x1b[32m', yellow: '\x1b[33m', blue: '\x1b[34m',
-  magenta: '\x1b[35m', cyan: '\x1b[36m', white: '\x1b[37m', gray: '\x1b[90m',
-  brightYellow: '\x1b[93m', brightRed: '\x1b[91m', brightGreen: '\x1b[92m',
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+  cyan: '\x1b[36m',
+  white: '\x1b[37m',
+  gray: '\x1b[90m',
+  brightYellow: '\x1b[93m',
+  brightRed: '\x1b[91m',
+  brightGreen: '\x1b[92m',
   invert: '\x1b[7m',
 };
 
 // status → { dot, color, label }
 const STATUS = {
-  working:    { dot: '●', color: C.green,        label: 'working'  },
-  idle:       { dot: '○', color: C.gray,         label: 'idle'     },
-  'needs-sam':{ dot: '◆', color: C.brightYellow, label: 'NEEDS YOU'},
-  blocked:    { dot: '■', color: C.magenta,      label: 'blocked'  },
-  stuck:      { dot: '▲', color: C.yellow,       label: 'stuck'    },
-  dead:       { dot: '✕', color: C.brightRed,    label: 'dead'     },
-  zombie:     { dot: '☠', color: C.red + C.dim,  label: 'zombie'   },
+  working: { dot: '●', color: C.green, label: 'working' },
+  idle: { dot: '○', color: C.gray, label: 'idle' },
+  'needs-sam': { dot: '◆', color: C.brightYellow, label: 'NEEDS YOU' },
+  blocked: { dot: '■', color: C.magenta, label: 'blocked' },
+  stuck: { dot: '▲', color: C.yellow, label: 'stuck' },
+  dead: { dot: '✕', color: C.brightRed, label: 'dead' },
+  zombie: { dot: '☠', color: C.red + C.dim, label: 'zombie' },
 };
 
 const TYPE_GLYPH = {
-  claude: 'cc', agy: 'agy', codex: 'cdx', cursor: 'cur', openclaw: 'ocl', other: '·',
+  claude: 'cc',
+  agy: 'agy',
+  codex: 'cdx',
+  cursor: 'cur',
+  openclaw: 'ocl',
+  other: '·',
 };
 
 export const STATUS_ORDER = ['needs-sam', 'blocked', 'stuck', 'working', 'idle', 'zombie', 'dead'];
@@ -62,7 +77,10 @@ function row(a, width, selected) {
   const dot = `${st.color}${st.dot}${C.reset}${sel}`;
   const statusLbl = `${st.color}${pad(st.label, 9)}${C.reset}${sel}`;
   const name = pad(a.name || a.id, 18);
-  const doing = a.needs_user && a.decision ? `${C.brightYellow}? ${a.decision}${C.reset}${sel}` : (a.doing || `${C.gray}—${C.reset}${sel}`);
+  const doing =
+    a.needs_user && a.decision
+      ? `${C.brightYellow}? ${a.decision}${C.reset}${sel}`
+      : a.doing || `${C.gray}—${C.reset}${sel}`;
   const age = pad(ageStr(a.lastActivity), 4);
 
   let line;
@@ -79,7 +97,9 @@ function row(a, width, selected) {
 }
 
 // width of a string ignoring ANSI codes
-function stripWidth(s) { return s.replace(/\x1b\[[0-9;]*m/g, ''); }
+function stripWidth(s) {
+  return s.replace(/\x1b\[[0-9;]*m/g, '');
+}
 function truncAnsi(s, n) {
   // crude: if visible length exceeds n, slice the visible text
   const vis = stripWidth(s);
@@ -93,21 +113,27 @@ export function renderDashboard(snapshot, { width = 100, selectedIdx = 0, status
   const total = agents.length;
   const needs = agents.filter((a) => a.status === 'needs-sam').length;
   const fra = snapshot.hosts?.fra || {};
-  const fraTag = fra.stale ? `${C.red}stale${C.reset}` : fra.cached ? `${C.gray}cached${C.reset}` : `${C.green}live${C.reset}`;
+  const fraTag = fra.stale
+    ? `${C.red}stale${C.reset}`
+    : fra.cached
+      ? `${C.gray}cached${C.reset}`
+      : `${C.green}live${C.reset}`;
 
   // header
   lines.push(
     `${C.bold}${C.cyan}AGENT-DASH${C.reset}  ${C.bold}${total}${C.reset} agents` +
-    `  ${C.dim}·${C.reset} mac ${snapshot.hosts?.mac?.count ?? 0}` +
-    `  ${C.dim}·${C.reset} fra ${fra.count ?? 0} (${fraTag})` +
-    (needs ? `  ${C.brightYellow}${C.bold}◆ ${needs} need you${C.reset}` : '') +
-    `  ${C.gray}${new Date(snapshot.ts).toLocaleTimeString()}${C.reset}`,
+      `  ${C.dim}·${C.reset} mac ${snapshot.hosts?.mac?.count ?? 0}` +
+      `  ${C.dim}·${C.reset} fra ${fra.count ?? 0} (${fraTag})` +
+      (needs ? `  ${C.brightYellow}${C.bold}◆ ${needs} need you${C.reset}` : '') +
+      `  ${C.gray}${new Date(snapshot.ts).toLocaleTimeString()}${C.reset}`,
   );
   lines.push(`${C.gray}${'─'.repeat(Math.min(width, 120))}${C.reset}`);
 
   // group by host
   const byHost = {};
-  agents.forEach((a, i) => { (byHost[a.host] ||= []).push({ a, i }); });
+  agents.forEach((a, i) => {
+    (byHost[a.host] ||= []).push({ a, i });
+  });
   const hostOrder = ['mac', 'fra', ...Object.keys(byHost).filter((h) => h !== 'mac' && h !== 'fra')];
 
   let flat = 0;

--- a/claude-ops/scripts/agent-dash/render.mjs
+++ b/claude-ops/scripts/agent-dash/render.mjs
@@ -135,7 +135,7 @@ export function renderDashboard(snapshot, { width = 100, selectedIdx = 0, status
 export function hotkeyBar() {
   const k = (key, lbl) => `${C.bold}${C.cyan}${key}${C.reset}${C.gray}${lbl}${C.reset}`;
   return [
-    k('↑↓/jk', ' move'),
+    k('↑↓/j', ' move'),
     k(' a', 'ttach'),
     k(' s', 'teer'),
     k(' r', 'evive'),

--- a/claude-ops/skills/boss/SKILL.md
+++ b/claude-ops/skills/boss/SKILL.md
@@ -43,7 +43,7 @@ For each non-spare agent decide ONE bucket. Verify externally before trusting a 
 
 - **WORKING** — actively progressing → leave alone.
 - **DONE-VERIFIED-LIVE** — goal met AND PR'd + QA'd + verified + LIVE in prod → **ARCHIVE**
-  (`node "$AGENT_DASH"` control archive, or `claude rm <id>` / `ops-bg rm`). Logs to
+  (`node "$AGENT_DASH" archive <id> --yes`, or `claude rm <id>` / `ops-bg rm`). Logs to
   `~/.claude/state/agent-archive.jsonl` so Sam knows it's finished + out of the fleet.
 - **COMPLETED-UNVERIFIED** — claims done but NOT proven live (no PR, CI red, not deployed,
   QA not run) → **RESPAWN**, do NOT archive (Sam directive 2026-06-12). Respawn with a brief

--- a/claude-ops/skills/boss/SKILL.md
+++ b/claude-ops/skills/boss/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: boss
+description: Boss-mode command center over EVERY AI agent on the system — Claude bg, Antigravity (agy), Codex, Cursor, openclaw — across ALL hosts (local Mac + FRA EC2). Use when Sam types /boss or asks "what's the fleet doing / what needs me / boss view". Surfaces ONLY decisions and approvals to Sam as A/B/C/D options with a recommendation + full context; autonomously archives verified-live agents and respawns unverified-completed ones.
+argument-hint: "[--decisions | --full | --archive-sweep]"
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - AskUserQuestion
+  - Task
+effort: medium
+maxTurns: 40
+---
+
+# /boss — you are the boss of the entire agent fleet
+
+Sam made you the SOLE orchestrator of every AI agent on this system, regardless of
+brand (Claude, Antigravity/`agy`, Codex/`cdx`, Cursor, openclaw/`ocl`) or host (local
+Mac + FRA EC2 + any reachable device). `/boss` is how Sam checks in. Your job: drive
+everything to done autonomously and surface to Sam ONLY the decisions and approvals
+that are genuinely his — as clean A/B/C/D options, each with your recommendation and
+the full context behind it.
+
+`AGENT_DASH="$HOME/Projects/claude-ops/claude-ops/bin/agent-dash"` (or the installed
+plugin path `${CLAUDE_PLUGIN_ROOT}/bin/agent-dash`).
+
+## STEP 1 — Snapshot the WHOLE fleet (every brand, every host)
+
+```
+node "$AGENT_DASH" --json          # machine-readable: all agents, mac + FRA, all brands
+node "$AGENT_DASH" --once          # the human table (show this to Sam verbatim)
+```
+
+The JSON carries per-agent: `type` (claude|agy|codex|cursor|openclaw), `host` (mac|fra),
+`id`/`sessionId`/`pid`, `name`, `state` (working|idle|blocked), and a `summary`/last-activity
+line. Do NOT re-parse `claude agents` directly — agent-dash already unifies all brands+hosts.
+
+## STEP 2 — Classify every agent (the boss triage)
+
+For each non-spare agent decide ONE bucket. Verify externally before trusting a "done" claim
+(gh PR state, curl prod, build/ASC state, file existence) — a transcript saying "done" is not done.
+
+- **WORKING** — actively progressing → leave alone.
+- **DONE-VERIFIED-LIVE** — goal met AND PR'd + QA'd + verified + LIVE in prod → **ARCHIVE**
+  (`node "$AGENT_DASH"` control archive, or `claude rm <id>` / `ops-bg rm`). Logs to
+  `~/.claude/state/agent-archive.jsonl` so Sam knows it's finished + out of the fleet.
+- **COMPLETED-UNVERIFIED** — claims done but NOT proven live (no PR, CI red, not deployed,
+  QA not run) → **RESPAWN**, do NOT archive (Sam directive 2026-06-12). Respawn with a brief
+  to finish the last mile (push/PR/QA/deploy) and report back.
+- **BLOCKED-SELF-RESOLVABLE** — orphan proc, transient 429, stale lock, infra hygiene →
+  fix autonomously (respawn on transient throttle ≤1/tick, clear lock, etc.). No Sam ping.
+- **BLOCKED-SAM-GATED** — needs a human decision/approval/2FA/credential/business-or-design
+  call → collect for STEP 4. NEVER guess these.
+- **FAILED** — gave up → decide retry (corrected brief) vs escalate vs archive.
+
+Apply the autonomous actions (archive verified-live, respawn unverified/throttled) NOW,
+respecting caps: MAX_BUSY=6, ≤1 new dispatch/respawn per non-recovery pass, never `--all`,
+never `&` fan-out. Record actions in `~/.claude/state/orchestrator-queue.jsonl`.
+
+## STEP 3 — Render the dashboard for Sam
+
+Show the `--once` table, then a 3-line summary:
+`N agents · mac X / fra Y · working W · archived-this-pass A · respawned R · needs-you D`.
+Keep it scannable. No walls of text.
+
+## STEP 4 — Surface ONLY the decisions (A/B/C/D)
+
+For each BLOCKED-SAM-GATED item, present via **AskUserQuestion** as a real choice:
+- A short header (the agent + what's blocked).
+- 2–4 concrete options labelled, FIRST option = your **recommendation** (mark "(Recommended)").
+- Each option's description = what happens if chosen.
+- Include the FULL context Sam needs to decide in the question body (what the agent did, why
+  it's blocked, the stakes, any deadline). Sam should never have to go digging.
+
+Batch all decisions into ONE AskUserQuestion round (up to 4 questions). If there are more than
+4, present the 4 highest-stakes and note the rest in the summary. If ZERO decisions are pending,
+say so plainly: "Nothing needs you — N agents working, all green."
+
+On Sam's answers: execute each immediately (route to the gated agent via steer/respawn, run the
+approved action, etc.), then confirm one line each.
+
+## Modes
+- `/boss` (default) — full pass: snapshot → triage → autonomous actions → dashboard → decisions.
+- `/boss --decisions` — skip the table; jump straight to the A/B/C/D decisions (fast check-in).
+- `/boss --full` — include spares + per-agent detail (deep look).
+- `/boss --archive-sweep` — only the archive/respawn triage (cleanup pass, no Sam ping unless gated).
+
+## Cross-cutting rules
+- VERIFY before relay (gh/curl/file). Never tell Sam "X is live" without the external check.
+- ARCHIVE = finished + out of fleet (verified live). STOP/respawn = still in play. Never archive
+  unverified work (Sam directive).
+- Outbound to anyone but Sam → staged, never auto-sent. Status to Sam → pre-authorized.
+- Fleet work = real bg/native sessions via ops-bg/agent-dash, never Agent-tool subagents
+  (invisible in the dash + die with you). Agent-tool only for in-context research/verification.
+- FRA-host actions go over the agent-dash remote layer (control.mjs SSH), never a second orchestrator.

--- a/claude-ops/tests/test-bin-scripts.sh
+++ b/claude-ops/tests/test-bin-scripts.sh
@@ -14,11 +14,18 @@ fail=0
 ok()   { echo "  PASS: $1"; pass=$((pass+1)); }
 err()  { echo "  FAIL: $1"; fail=$((fail+1)); }
 
-# Collect all bin scripts (skip .mjs and non-executables that are node/python)
+# Collect all bin scripts (skip .mjs and non-bash interpreters like node/python)
 script_files=()
 while IFS= read -r -d '' f; do
   # Skip .mjs node scripts — they're valid but not bash
   [[ "$f" == *.mjs ]] && continue
+  # Skip non-bash scripts by shebang (node/python entry points live in bin/ too,
+  # e.g. bin/agent-dash uses #!/usr/bin/env node). The bash-only shebang and
+  # lint checks below only apply to shell scripts.
+  first_line=$(head -1 "$f" 2>/dev/null || true)
+  if echo "$first_line" | grep -qE "^#!.*(node|python)"; then
+    continue
+  fi
   script_files+=("$f")
 done < <(find "$BIN_DIR" -maxdepth 1 -type f -print0 2>/dev/null)
 


### PR DESCRIPTION
## What
`agent-dash` — one on-demand view of **every AI agent on the system**, any brand, any box:
- **Brands**: Claude bg (`cc`), Antigravity (`agy`), Codex (`cdx`), Cursor, openclaw (`ocl`)
- **Hosts**: local Mac + FRA EC2 (remote cached 30s, collect-on-demand, no daemon)
- **Controls**: attach / steer / revive / kill / **archive** (archives logged to `~/.claude/state/agent-archive.jsonl`)

Plus `bin/ops-bg`: Doppler-wrap bg launches (fixes credential-less MCP auth-fail) + native `claude agents --json [--all]` passthrough.

## Why
Foundation for the orchestrator (/boss) role: one operator drives the whole multi-brand, multi-host fleet and surfaces only decisions to the human.

## Verified
`node bin/agent-dash` runs clean — rendered 31 agents (mac 13 + FRA 18) across cc/agy/cdx/ocl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Remote SSH control and kill/archive paths can affect live agents on FRA; Doppler-wrapped launches change how bg sessions inherit credentials.
> 
> **Overview**
> Adds **`agent-dash`**, an on-demand fleet console for Claude bg, agy, Codex, Cursor, and openclaw on the Mac and FRA EC2—no daemon. **`collect.mjs`** merges local probes with SSH remote runs (30s cache, timeouts); **`host-probe.mjs`** derives status from daemon roster + transcript tails; **`control.mjs`** implements attach, steer, revive, kill, and archive (with **`agent-archive.jsonl`**). The **`bin/agent-dash`** entry supports interactive TUI, `--watch`/`--once`, `--json`, and CLI subcommands.
> 
> **`ops-bg`** now wraps background launches in **`doppler run`** (unless `OPS_BG_ENV_PROVISIONED` / `OPS_BG_NO_DOPPLER`) so MCP servers get secrets, and **`list`** passes through to **`claude agents --json`** instead of custom jq filtering.
> 
> Documents **`/boss`** in **`skills/boss/SKILL.md`** as the orchestration workflow on top of agent-dash. **`test-bin-scripts.sh`** skips node/python shebangs in **`bin/`** so **`agent-dash`** is not linted as bash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67da9bf9472f0184ce147cc3ca40ecbf295508b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive agent dashboard: TUI + plain/table modes, keyboard navigation, details view, periodic refresh, watch/once modes, and machine-readable JSON output.
  * Per-agent controls: attach, steer/send, revive, stop/kill, archive with confirmations, colored feedback, and non-zero exit on failure.
  * Remote-aware collection: unified local+remote snapshots with caching, TTL, and graceful degraded results.
  * Background-launch wrapper now supports credential injection and simplified listing.

* **Documentation**
  * Added boss-mode orchestration spec describing fleet workflows and decision modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->