### PR TITLE
feat: Healify pre-launch metrics grid in ops-dash

### DIFF
--- a/claude-ops/bin/ops-dash
+++ b/claude-ops/bin/ops-dash
@@ -924,32 +924,104 @@ render_section_portfolio() {
 }
 
 # ════════════════════════════════════════════════════════════════════════════
-# SECTION 6 — REVENUE & COSTS  (MRR + Shopify only — FinOps lives in its own block)
+# SECTION 6 — HEALIFY  (pre-launch metrics: ECS · TestFlight · ASC · website)
 # ════════════════════════════════════════════════════════════════════════════
-render_section_revenue() {
-  section_hdr "💰" "REVENUE & COSTS"
+render_section_healify() {
+  section_hdr "🚀" "HEALIFY  (pre-launch metrics)"
 
-  FINOPS_CONFIGURED=$(echo "$REVENUE_JSON" | jq -r '.configured // false' 2>/dev/null || echo "false")
+  local HM_FILE="/tmp/ops-healify-metrics.json"
+  local HM_JSON="{}"
+  if [[ -f "$HM_FILE" ]]; then
+    HM_JSON=$(cat "$HM_FILE" 2>/dev/null || echo "{}")
+  fi
 
-  if [[ "$FINOPS_CONFIGURED" != "true" ]]; then
-    p "  ${DIM2}MRR data not available — FinOps dashboard not configured.${RST}"
+  # — ECS service health ——————————————————————————————————————————————————
+  local ecs_line=""
+  local ecs_count
+  ecs_count=$(echo "$HM_JSON" | jq '.ecs | length' 2>/dev/null || echo 0)
+  if [[ "$ecs_count" -gt 0 ]]; then
+    while IFS= read -r svc_json; do
+      local name running desired
+      name=$(echo "$svc_json" | jq -r '.name' 2>/dev/null || echo "?")
+      running=$(echo "$svc_json" | jq -r '.running' 2>/dev/null || echo 0)
+      desired=$(echo "$svc_json" | jq -r '.desired' 2>/dev/null || echo 0)
+      local icon
+      if [[ "$running" -eq 0 ]]; then
+        icon="${BRED}✗${RST}"
+      elif [[ "$running" -eq "$desired" && "$desired" -gt 0 ]]; then
+        icon="${BGRN}✓${RST}"
+      else
+        icon="${BYLW}~${RST}"
+      fi
+      # Short name: strip cluster prefix, keep last segment
+      local short_name
+      short_name=$(echo "$name" | sed 's/.*-\([a-z0-9-]*\)$/\1/' 2>/dev/null || echo "$name")
+      ecs_line="${ecs_line}  ${icon} ${DIM2}${short_name}${RST}"
+    done < <(echo "$HM_JSON" | jq -c '.ecs[]?' 2>/dev/null || true)
+  fi
+
+  if [[ -n "$ecs_line" ]]; then
+    p "  🖥  ${BWHT}ECS${RST}${ecs_line}"
   else
-    # MRR sparkline from time series if available
-    MRR_SERIES=$(echo "$REVENUE_JSON" | jq -r '.mrr_series[]? // empty' 2>/dev/null | tr '\n' ' ' || echo "")
-    if [[ -n "$MRR_SERIES" ]]; then
-      MRR_SPARK=$(sparkline $MRR_SERIES 2>/dev/null || echo "")
-      p "  💰 ${BWHT}MRR${RST}  ${BCYN}\$${MRR}${RST}  ${BGRN}${MRR_SPARK}${RST}  ${DIM2}${MRR_TREND}${RST}"
+    local ecs_err
+    ecs_err=$(echo "$HM_JSON" | jq -r '.ecs_error? // ""' 2>/dev/null || echo "")
+    if [[ -n "$ecs_err" ]]; then
+      p "  🖥  ${BWHT}ECS${RST}  ${BRED}${ecs_err}${RST}"
     else
-      p "  💰 ${BWHT}MRR${RST}  ${BCYN}\$${MRR}${RST}  ${DIM2}${MRR_TREND}${RST}"
+      p "  🖥  ${BWHT}ECS${RST}  ${DIM2}(run ops-healify-metrics to populate)${RST}"
     fi
   fi
 
-  SHOPIFY_HEALTHY=$(echo "$EXTERNAL_JSON" | jq '[.[] | select(.source=="shopify_admin" and .status=="healthy")] | length' 2>/dev/null || echo "0")
-  SHOPIFY_TOTAL=$(echo "$EXTERNAL_JSON" | jq '[.[] | select(.source | startswith("shopify"))] | length' 2>/dev/null || echo "0")
-  if [[ "$SHOPIFY_TOTAL" -gt 0 ]]; then
-    STATUS_ICON="🟢"
-    [[ "$SHOPIFY_HEALTHY" -lt "$SHOPIFY_TOTAL" ]] && STATUS_ICON="🟡"
-    p "  🛒 ${BWHT}Shopify${RST}  ${STATUS_ICON} ${SHOPIFY_HEALTHY}/${SHOPIFY_TOTAL} stores healthy"
+  # — TestFlight ————————————————————————————————————————————————————————————
+  local tf_7d tf_today tf_err
+  tf_7d=$(echo "$HM_JSON"    | jq -r '.testflight.installs_7d?  // ""' 2>/dev/null || echo "")
+  tf_today=$(echo "$HM_JSON" | jq -r '.testflight.installs_today? // ""' 2>/dev/null || echo "")
+  tf_err=$(echo "$HM_JSON"   | jq -r '.testflight.error? // ""' 2>/dev/null || echo "")
+
+  if [[ -n "$tf_7d" ]]; then
+    p "  ✈️   ${BWHT}TestFlight${RST}  ${BCYN}7d:${RST} ${BWHT}${tf_7d}${RST}  ${BCYN}today:${RST} ${BWHT}${tf_today}${RST}"
+  elif [[ -n "$tf_err" ]]; then
+    p "  ✈️   ${BWHT}TestFlight${RST}  ${DIM2}${tf_err}${RST}"
+  else
+    p "  ✈️   ${BWHT}TestFlight${RST}  ${DIM2}(no data)${RST}"
+  fi
+
+  # — ASC app state ————————————————————————————————————————————————————————
+  local asc_state asc_ver asc_err
+  asc_state=$(echo "$HM_JSON" | jq -r '.asc.state?   // ""' 2>/dev/null || echo "")
+  asc_ver=$(echo "$HM_JSON"   | jq -r '.asc.version? // ""' 2>/dev/null || echo "")
+  asc_err=$(echo "$HM_JSON"   | jq -r '.asc.error?   // ""' 2>/dev/null || echo "")
+
+  if [[ -n "$asc_state" ]]; then
+    local asc_icon
+    case "$asc_state" in
+      IN_REVIEW)               asc_icon="⏳" ;;
+      READY_FOR_REVIEW)        asc_icon="📬" ;;
+      WAITING_FOR_REVIEW)      asc_icon="📬" ;;
+      READY_FOR_SALE)          asc_icon="✅" ;;
+      REJECTED)                asc_icon="${BRED}❌${RST}" ;;
+      DEVELOPER_REJECTED)      asc_icon="${BRED}❌${RST}" ;;
+      *)                       asc_icon="○" ;;
+    esac
+    p "  🍎  ${BWHT}ASC${RST}  ${asc_icon} ${BCYN}${asc_state}${RST}  ${DIM2}${asc_ver}${RST}"
+  elif [[ -n "$asc_err" ]]; then
+    p "  🍎  ${BWHT}ASC${RST}  ${DIM2}${asc_err}${RST}"
+  else
+    p "  🍎  ${BWHT}ASC${RST}  ${DIM2}(no data)${RST}"
+  fi
+
+  # — Website visitors ————————————————————————————————————————————————————
+  local web_vis web_pv web_err
+  web_vis=$(echo "$HM_JSON" | jq -r '.website.visitors_7d?  // ""' 2>/dev/null || echo "")
+  web_pv=$(echo "$HM_JSON"  | jq -r '.website.pageviews_7d? // ""' 2>/dev/null || echo "")
+  web_err=$(echo "$HM_JSON" | jq -r '.website.error?        // ""' 2>/dev/null || echo "")
+
+  if [[ -n "$web_vis" ]]; then
+    p "  🌐  ${BWHT}healify.ai${RST}  ${BCYN}visitors 7d:${RST} ${BWHT}${web_vis}${RST}  ${BCYN}pageviews:${RST} ${BWHT}${web_pv}${RST}"
+  elif [[ -n "$web_err" ]]; then
+    p "  🌐  ${BWHT}healify.ai${RST}  ${DIM2}${web_err}${RST}"
+  else
+    p "  🌐  ${BWHT}healify.ai${RST}  ${DIM2}(no data)${RST}"
   fi
 
   p ""
@@ -1366,7 +1438,7 @@ render_section_calendar
 render_section_inbox
 render_section_prs
 render_section_portfolio
-render_section_revenue
+render_section_healify
 render_section_finops
 render_section_marketing
 render_section_linear

--- a/claude-ops/bin/ops-healify-metrics
+++ b/claude-ops/bin/ops-healify-metrics
@@ -47,7 +47,7 @@ fetch_ecs() {
   local services_json="[]"
 
   if ! command -v aws &>/dev/null; then
-    printf '{"error":"aws CLI not found"}' > "$out"; return
+    printf '{"ecs_error":"aws CLI not found"}' > "$out"; return
   fi
 
   local clusters
@@ -61,31 +61,54 @@ fetch_ecs() {
   local all_services="[]"
   while IFS= read -r cluster_arn; do
     [[ -z "$cluster_arn" ]] && continue
-    local svc_arns
-    svc_arns=$(aws ecs list-services --cluster "$cluster_arn" --region "$ECS_REGION" \
-      --output json 2>/dev/null | jq -r '.serviceArns[]?' || true)
+    local svc_arns="" next_token=""
+    while true; do
+      local list_json
+      if [[ -n "$next_token" ]]; then
+        list_json=$(aws ecs list-services --cluster "$cluster_arn" --region "$ECS_REGION" \
+          --starting-token "$next_token" --output json 2>/dev/null || echo '{}')
+      else
+        list_json=$(aws ecs list-services --cluster "$cluster_arn" --region "$ECS_REGION" \
+          --output json 2>/dev/null || echo '{}')
+      fi
+      local page_arns
+      page_arns=$(echo "$list_json" | jq -r '.serviceArns[]?' || true)
+      if [[ -n "$page_arns" ]]; then
+        svc_arns="${svc_arns}${page_arns}"$'\n'
+      fi
+      next_token=$(echo "$list_json" | jq -r '.nextToken // empty' 2>/dev/null || true)
+      [[ -z "$next_token" ]] && break
+    done
     [[ -z "$svc_arns" ]] && continue
 
-    # Describe up to 10 services at once (API limit)
-    local svc_array
-    svc_array=$(printf '%s\n' "$svc_arns" | head -10 | jq -Rsc 'split("\n") | map(select(. != ""))')
+    local -a arns=()
+    while IFS= read -r arn; do
+      [[ -z "$arn" ]] && continue
+      arns+=("$arn")
+    done <<< "$svc_arns"
 
-    local desc
-    desc=$(aws ecs describe-services \
-      --cluster "$cluster_arn" \
-      --services $(printf '%s\n' "$svc_arns" | head -10 | tr '\n' ' ') \
-      --region "$ECS_REGION" \
-      --output json 2>/dev/null || echo '{"services":[]}')
+    local idx=0
+    while [[ $idx -lt ${#arns[@]} ]]; do
+      local batch=("${arns[@]:idx:10}")
+      idx=$((idx + 10))
 
-    local batch
-    batch=$(echo "$desc" | jq '[.services[]? | {
-      name: (.serviceName // "unknown"),
-      running: (.runningCount // 0),
-      desired: (.desiredCount // 0),
-      status: (.status // "UNKNOWN")
-    }]' 2>/dev/null || echo "[]")
+      local desc
+      desc=$(aws ecs describe-services \
+        --cluster "$cluster_arn" \
+        --services "${batch[@]}" \
+        --region "$ECS_REGION" \
+        --output json 2>/dev/null || echo '{"services":[]}')
 
-    all_services=$(echo "$all_services $batch" | jq -s 'add // []' 2>/dev/null || echo "[]")
+      local batch_json
+      batch_json=$(echo "$desc" | jq '[.services[]? | {
+        name: (.serviceName // "unknown"),
+        running: (.runningCount // 0),
+        desired: (.desiredCount // 0),
+        status: (.status // "UNKNOWN")
+      }]' 2>/dev/null || echo "[]")
+
+      all_services=$(echo "$all_services $batch_json" | jq -s 'add // []' 2>/dev/null || echo "[]")
+    done
   done <<< "$clusters"
 
   printf '{"ecs":%s}' "$all_services" > "$out"
@@ -140,7 +163,7 @@ raw_sig = r.to_bytes(32, "big") + s.to_bytes(32, "big")
 
 print(f"{signing_input}.{b64url(raw_sig)}")
 PYEOF
-)
+) || true
 
   if [[ -z "$token" || "$token" == KEY_ERROR* ]]; then
     printf '{"testflight":{"error":"JWT signing failed"}}' > "$out"
@@ -159,9 +182,9 @@ PYEOF
     2>/dev/null || echo '{}')
 
   local installs_7d installs_today
-  installs_7d=$(echo "$response" | jq '[.data[]?.attributes?.inviteCount? // 0] | add // 0' 2>/dev/null || echo 0)
+  installs_7d=$(echo "$response" | jq '[.data[]?.attributes?.installCount? // 0] | add // 0' 2>/dev/null || echo 0)
   installs_today=$(echo "$response" | \
-    jq --arg d "$today" '[.data[]? | select(.attributes.date? == $d) | .attributes.inviteCount? // 0] | add // 0' \
+    jq --arg d "$today" '[.data[]? | select(.attributes.date? == $d) | .attributes.installCount? // 0] | add // 0' \
     2>/dev/null || echo 0)
 
   printf '{"testflight":{"installs_7d":%s,"installs_today":%s}}' "$installs_7d" "$installs_today" > "$out"
@@ -206,7 +229,7 @@ r, s = decode_dss_signature(sig)
 raw_sig = r.to_bytes(32, "big") + s.to_bytes(32, "big")
 print(f"{signing_input}.{b64url(raw_sig)}")
 PYEOF
-)
+) || true
 
   if [[ -z "$token" ]]; then
     printf '{"asc":{"error":"JWT signing failed"}}' > "$out"

--- a/claude-ops/bin/ops-healify-metrics
+++ b/claude-ops/bin/ops-healify-metrics
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+# ops-healify-metrics — Healify pre-launch metrics fetcher
+# Fetches ECS health, TestFlight installs, ASC app state, and website visitors.
+# Writes merged JSON to /tmp/ops-healify-metrics.json with 10-min cache.
+# Usage: ops-healify-metrics [--force]
+
+set -euo pipefail
+
+CACHE=/tmp/ops-healify-metrics.json
+CACHE_TTL=600  # 10 minutes
+FORCE=0
+
+for arg in "$@"; do
+  [[ "$arg" == "--force" ]] && FORCE=1
+done
+
+# Check cache freshness
+if [[ "$FORCE" -eq 0 && -f "$CACHE" ]]; then
+  age=$(( $(date +%s) - $(stat -c %Y "$CACHE" 2>/dev/null || stat -f %m "$CACHE" 2>/dev/null || echo 0) ))
+  if [[ "$age" -lt "$CACHE_TTL" ]]; then
+    cat "$CACHE"
+    exit 0
+  fi
+fi
+
+# Load credentials — never commit real values
+SECRETS_FILE="${HOME}/.mcp-secrets.env"
+if [[ -f "$SECRETS_FILE" ]]; then
+  # shellcheck disable=SC1090
+  set +u; source "$SECRETS_FILE"; set -u
+fi
+
+ECS_REGION="${ECS_REGION:-us-east-1}"
+ASC_APP_ID="${ASC_APP_ID:-6743893583}"
+
+# ── Temp files for parallel fetches ──────────────────────────────────────────
+TMP_ECS=$(mktemp /tmp/hm-ecs.XXXXXX)
+TMP_TF=$(mktemp /tmp/hm-tf.XXXXXX)
+TMP_ASC=$(mktemp /tmp/hm-asc.XXXXXX)
+TMP_WEB=$(mktemp /tmp/hm-web.XXXXXX)
+cleanup() { rm -f "$TMP_ECS" "$TMP_TF" "$TMP_ASC" "$TMP_WEB"; }
+trap cleanup EXIT
+
+# ── A. ECS service health ─────────────────────────────────────────────────────
+fetch_ecs() {
+  local out="$1"
+  local services_json="[]"
+
+  if ! command -v aws &>/dev/null; then
+    printf '{"error":"aws CLI not found"}' > "$out"; return
+  fi
+
+  local clusters
+  clusters=$(aws ecs list-clusters --region "$ECS_REGION" --output json 2>/dev/null \
+    | jq -r '.clusterArns[]?' || true)
+
+  if [[ -z "$clusters" ]]; then
+    printf '{"ecs":[]}' > "$out"; return
+  fi
+
+  local all_services="[]"
+  while IFS= read -r cluster_arn; do
+    [[ -z "$cluster_arn" ]] && continue
+    local svc_arns
+    svc_arns=$(aws ecs list-services --cluster "$cluster_arn" --region "$ECS_REGION" \
+      --output json 2>/dev/null | jq -r '.serviceArns[]?' || true)
+    [[ -z "$svc_arns" ]] && continue
+
+    # Describe up to 10 services at once (API limit)
+    local svc_array
+    svc_array=$(printf '%s\n' "$svc_arns" | head -10 | jq -Rsc 'split("\n") | map(select(. != ""))')
+
+    local desc
+    desc=$(aws ecs describe-services \
+      --cluster "$cluster_arn" \
+      --services $(printf '%s\n' "$svc_arns" | head -10 | tr '\n' ' ') \
+      --region "$ECS_REGION" \
+      --output json 2>/dev/null || echo '{"services":[]}')
+
+    local batch
+    batch=$(echo "$desc" | jq '[.services[]? | {
+      name: (.serviceName // "unknown"),
+      running: (.runningCount // 0),
+      desired: (.desiredCount // 0),
+      status: (.status // "UNKNOWN")
+    }]' 2>/dev/null || echo "[]")
+
+    all_services=$(echo "$all_services $batch" | jq -s 'add // []' 2>/dev/null || echo "[]")
+  done <<< "$clusters"
+
+  printf '{"ecs":%s}' "$all_services" > "$out"
+}
+
+# ── B. TestFlight installs (last 7d) via ASC API ──────────────────────────────
+fetch_testflight() {
+  local out="$1"
+
+  local key_id="${FASTLANE_ASC_API_KEY_ID:-}"
+  local issuer_id="${FASTLANE_ASC_API_KEY_ISSUER_ID:-}"
+  local p8_b64="${FASTLANE_ASC_API_KEY_P8_BASE64:-}"
+
+  if [[ -z "$key_id" || -z "$issuer_id" || -z "$p8_b64" ]]; then
+    printf '{"testflight":{"error":"ASC credentials not configured — set FASTLANE_ASC_API_KEY_ID, FASTLANE_ASC_API_KEY_ISSUER_ID, FASTLANE_ASC_API_KEY_P8_BASE64"}}' > "$out"
+    return
+  fi
+
+  local token
+  token=$(python3 - "$key_id" "$issuer_id" "$p8_b64" 2>/dev/null <<'PYEOF'
+import sys, base64, time, json
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.asymmetric import ec, padding
+from cryptography.hazmat.backends import default_backend
+
+key_id, issuer_id, p8_b64 = sys.argv[1], sys.argv[2], sys.argv[3]
+
+# Decode P8 key
+try:
+    p8_pem = base64.b64decode(p8_b64)
+    private_key = serialization.load_pem_private_key(p8_pem, password=None, backend=default_backend())
+except Exception as e:
+    print(f"KEY_ERROR:{e}", file=sys.stderr)
+    sys.exit(1)
+
+now = int(time.time())
+header = {"alg": "ES256", "kid": key_id, "typ": "JWT"}
+payload = {"iss": issuer_id, "iat": now, "exp": now + 1200, "aud": "appstoreconnect-v1"}
+
+def b64url(data):
+    if isinstance(data, dict):
+        data = json.dumps(data, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+signing_input = f"{b64url(header)}.{b64url(payload)}"
+sig = private_key.sign(signing_input.encode(), ec.ECDSA(hashes.SHA256()))
+
+# DER -> (r, s) raw 64-byte signature for ES256
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
+r, s = decode_dss_signature(sig)
+raw_sig = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+
+print(f"{signing_input}.{b64url(raw_sig)}")
+PYEOF
+)
+
+  if [[ -z "$token" || "$token" == KEY_ERROR* ]]; then
+    printf '{"testflight":{"error":"JWT signing failed"}}' > "$out"
+    return
+  fi
+
+  local from_date
+  from_date=$(date -d "7 days ago" +%Y-%m-%d 2>/dev/null || date -v-7d +%Y-%m-%d 2>/dev/null || date +%Y-%m-%d)
+  local today
+  today=$(date +%Y-%m-%d)
+
+  local response
+  response=$(curl -sf --max-time 15 \
+    -H "Authorization: Bearer $token" \
+    "https://api.appstoreconnect.apple.com/v1/betaTesterMetrics?filter[apps]=${ASC_APP_ID}&granularity=DAY&limit=7" \
+    2>/dev/null || echo '{}')
+
+  local installs_7d installs_today
+  installs_7d=$(echo "$response" | jq '[.data[]?.attributes?.inviteCount? // 0] | add // 0' 2>/dev/null || echo 0)
+  installs_today=$(echo "$response" | \
+    jq --arg d "$today" '[.data[]? | select(.attributes.date? == $d) | .attributes.inviteCount? // 0] | add // 0' \
+    2>/dev/null || echo 0)
+
+  printf '{"testflight":{"installs_7d":%s,"installs_today":%s}}' "$installs_7d" "$installs_today" > "$out"
+}
+
+# ── C. ASC app review state ───────────────────────────────────────────────────
+fetch_asc_state() {
+  local out="$1"
+
+  local key_id="${FASTLANE_ASC_API_KEY_ID:-}"
+  local issuer_id="${FASTLANE_ASC_API_KEY_ISSUER_ID:-}"
+  local p8_b64="${FASTLANE_ASC_API_KEY_P8_BASE64:-}"
+
+  if [[ -z "$key_id" || -z "$issuer_id" || -z "$p8_b64" ]]; then
+    printf '{"asc":{"error":"ASC credentials not configured"}}' > "$out"
+    return
+  fi
+
+  local token
+  token=$(python3 - "$key_id" "$issuer_id" "$p8_b64" 2>/dev/null <<'PYEOF'
+import sys, base64, time, json
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
+
+key_id, issuer_id, p8_b64 = sys.argv[1], sys.argv[2], sys.argv[3]
+p8_pem = base64.b64decode(p8_b64)
+private_key = serialization.load_pem_private_key(p8_pem, password=None, backend=default_backend())
+now = int(time.time())
+header = {"alg": "ES256", "kid": key_id, "typ": "JWT"}
+payload = {"iss": issuer_id, "iat": now, "exp": now + 1200, "aud": "appstoreconnect-v1"}
+
+def b64url(data):
+    if isinstance(data, dict):
+        data = json.dumps(data, separators=(",", ":")).encode()
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+signing_input = f"{b64url(header)}.{b64url(payload)}"
+sig = private_key.sign(signing_input.encode(), ec.ECDSA(hashes.SHA256()))
+r, s = decode_dss_signature(sig)
+raw_sig = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+print(f"{signing_input}.{b64url(raw_sig)}")
+PYEOF
+)
+
+  if [[ -z "$token" ]]; then
+    printf '{"asc":{"error":"JWT signing failed"}}' > "$out"
+    return
+  fi
+
+  local response
+  response=$(curl -sf --max-time 15 \
+    -H "Authorization: Bearer $token" \
+    "https://api.appstoreconnect.apple.com/v1/apps/${ASC_APP_ID}/appStoreVersions?filter[platform]=IOS&limit=1" \
+    2>/dev/null || echo '{}')
+
+  local state version
+  state=$(echo "$response" | jq -r '.data[0].attributes.appStoreState? // "UNKNOWN"' 2>/dev/null || echo "UNKNOWN")
+  version=$(echo "$response" | jq -r '.data[0].attributes.versionString? // "?"' 2>/dev/null || echo "?")
+
+  printf '{"asc":{"state":"%s","version":"%s"}}' "$state" "$version" > "$out"
+}
+
+# ── D. Website visitors via Vercel Analytics ──────────────────────────────────
+fetch_vercel() {
+  local out="$1"
+
+  local token="${VERCEL_API_TOKEN:-}"
+  if [[ -z "$token" ]]; then
+    printf '{"website":{"error":"VERCEL_API_TOKEN not set"}}' > "$out"
+    return
+  fi
+
+  # Find the healify project
+  local projects
+  projects=$(curl -sf --max-time 15 \
+    -H "Authorization: Bearer $token" \
+    "https://api.vercel.com/v9/projects?limit=20" \
+    2>/dev/null || echo '{}')
+
+  local project_id
+  project_id=$(echo "$projects" | jq -r '
+    (.projects // .)?
+    | .[]?
+    | select(
+        (.name // "" | ascii_downcase | contains("healify")) or
+        ((.alias // [])[]? | ascii_downcase | contains("healify.ai"))
+      )
+    | .id
+    ' 2>/dev/null | head -1 || true)
+
+  if [[ -z "$project_id" ]]; then
+    printf '{"website":{"error":"healify project not found in Vercel"}}' > "$out"
+    return
+  fi
+
+  local now_ms seven_days_ago_ms
+  now_ms=$(( $(date +%s) * 1000 ))
+  seven_days_ago_ms=$(( now_ms - 7 * 24 * 3600 * 1000 ))
+
+  local stats
+  stats=$(curl -sf --max-time 15 \
+    -H "Authorization: Bearer $token" \
+    "https://vercel.com/api/web/insights/stats?projectId=${project_id}&from=${seven_days_ago_ms}&to=${now_ms}&environment=production" \
+    2>/dev/null || echo '{}')
+
+  local visitors pageviews
+  visitors=$(echo "$stats" | jq -r '.data.uniqueVisitors? // .visitors? // .data?.visitors? // 0' 2>/dev/null || echo 0)
+  pageviews=$(echo "$stats" | jq -r '.data.pageviews? // .data?.pageViews? // 0' 2>/dev/null || echo 0)
+
+  printf '{"website":{"visitors_7d":%s,"pageviews_7d":%s}}' "$visitors" "$pageviews" > "$out"
+}
+
+# ── Run all fetches in parallel ───────────────────────────────────────────────
+fetch_ecs     "$TMP_ECS"  &
+PID_ECS=$!
+fetch_testflight "$TMP_TF" &
+PID_TF=$!
+fetch_asc_state  "$TMP_ASC" &
+PID_ASC=$!
+fetch_vercel     "$TMP_WEB" &
+PID_WEB=$!
+
+wait "$PID_ECS"  || true
+wait "$PID_TF"   || true
+wait "$PID_ASC"  || true
+wait "$PID_WEB"  || true
+
+# ── Merge and write ───────────────────────────────────────────────────────────
+ECS_DATA=$(cat "$TMP_ECS"  2>/dev/null || echo '{"ecs":[]}')
+TF_DATA=$(cat  "$TMP_TF"   2>/dev/null || echo '{"testflight":{"error":"fetch failed"}}')
+ASC_DATA=$(cat "$TMP_ASC"  2>/dev/null || echo '{"asc":{"error":"fetch failed"}}')
+WEB_DATA=$(cat "$TMP_WEB"  2>/dev/null || echo '{"website":{"error":"fetch failed"}}')
+
+MERGED=$(jq -s '
+  reduce .[] as $item ({}; . * $item)
+  | .fetched_at = now | .fetched_at = (.fetched_at | todate)
+' \
+  <(echo "$ECS_DATA") \
+  <(echo "$TF_DATA") \
+  <(echo "$ASC_DATA") \
+  <(echo "$WEB_DATA") \
+  2>/dev/null || echo '{"error":"merge failed"}')
+
+printf '%s\n' "$MERGED" > "$CACHE"
+printf '%s\n' "$MERGED"

--- a/claude-ops/scripts/recap/digest.sh
+++ b/claude-ops/scripts/recap/digest.sh
@@ -63,6 +63,25 @@ done
 
 [ -z "$sessions" ] && [ -z "$history" ] && [ -z "$shell_activity" ] && exit 0
 
+# Block D: Healify pre-launch metrics snapshot (from cache — no fetch here)
+healify_snap=""
+if [ -f /tmp/ops-healify-metrics.json ]; then
+  hm_age=$(( now - $(stat -c %Y /tmp/ops-healify-metrics.json 2>/dev/null || stat -f %m /tmp/ops-healify-metrics.json 2>/dev/null || echo 0) ))
+  if [ "$hm_age" -lt 900 ]; then  # only include if <15min old
+    _ecs_ok=$(jq '[.ecs[]? | select(.running == .desired and .running > 0)] | length' /tmp/ops-healify-metrics.json 2>/dev/null || echo 0)
+    _ecs_tot=$(jq '.ecs | length' /tmp/ops-healify-metrics.json 2>/dev/null || echo 0)
+    _tf_today=$(jq -r '.testflight.installs_today? // ""' /tmp/ops-healify-metrics.json 2>/dev/null || echo "")
+    _asc=$(jq -r '.asc.state? // ""' /tmp/ops-healify-metrics.json 2>/dev/null || echo "")
+    _vis=$(jq -r '.website.visitors_7d? // ""' /tmp/ops-healify-metrics.json 2>/dev/null || echo "")
+    _parts=""
+    [ -n "$_ecs_tot" ] && [ "$_ecs_tot" -gt 0 ] && _parts="ECS: ${_ecs_ok}/${_ecs_tot}"
+    [ -n "$_tf_today" ] && _parts="${_parts:+$_parts | }TF: ${_tf_today} today"
+    [ -n "$_asc" ]      && _parts="${_parts:+$_parts | }ASC: ${_asc}"
+    [ -n "$_vis" ]      && _parts="${_parts:+$_parts | }healify.ai: ${_vis} vis"
+    [ -n "$_parts" ] && healify_snap="$_parts"
+  fi
+fi
+
 prompt="You are a newsroom ticker compressing the activity of multiple parallel Claude Code coding sessions AND the user's interactive shell sessions into ONE rolling headline.
 
 PRIOR HEADLINES (oldest → newest, each line a previous digest):
@@ -73,6 +92,9 @@ ${sessions:-(none)}
 
 USER SHELL ACTIVITY (raw recent commands across non-Claude zsh sessions, format: HH:MM:SS|cwd|command):
 ${shell_activity:-(none)}
+
+HEALIFY PRE-LAUNCH METRICS (recent cache):
+${healify_snap:-(none)}
 
 Produce ONE single line (max 240 chars) describing the CURRENT state of work, weighted heavily toward the most-recent activity (last 1-2 headlines + current session activity + last few shell commands). DROP themes from older headlines that are no longer mentioned in current activity — assume they are resolved or no longer relevant. Only carry forward an older theme if there is concrete evidence in the current activity that it is still in flight. Translate raw shell commands into plain English (e.g., 'ssh into bastion', 'inspecting prod logs', 'running tests'). Plain English ticker style. No bullets, no quotes, no preface, no markdown."
 

--- a/claude-ops/skills/ops/SKILL.md
+++ b/claude-ops/skills/ops/SKILL.md
@@ -39,6 +39,7 @@ Route `$ARGUMENTS` to the correct ops skill:
 | next, priority, what                          | `/ops-next`             |
 | triage, issues                                | `/ops-triage`           |
 | linear, sprint, board                         | `/ops-linear`           |
+| healify, ios, testflight, asc, appstore        | `ops-healify-metrics --force` then print JSON |
 | revenue, money, mrr, costs                    | `/ops-revenue`          |
 | deploy, ship                                  | `/ops-deploy`           |
 | merge, prs, ship-prs                          | `/ops-merge $ARGUMENTS` |


### PR DESCRIPTION
## Summary

- **`bin/ops-healify-metrics`** — parallel fetcher for ECS health (all us-east-1 clusters), TestFlight install counts (7d + today via ASC API), ASC app review state, and Vercel website visitors. 10-min cache at `/tmp/ops-healify-metrics.json`; `--force` to bypass.
- **`bin/ops-dash`** — replaces `render_section_revenue` with `render_section_healify`. Shows ECS ✓/✗/~ per service, TestFlight counts, ASC state with contextual icons (⏳ IN_REVIEW, 📬 READY_FOR_REVIEW, ✅ READY_FOR_SALE, ❌ REJECTED), and healify.ai visitor stats. Gracefully degrades to `(no data)` per section when credentials are absent.
- **`scripts/recap/digest.sh`** — Block D appends a one-liner `ECS: N/N | TF: N today | ASC: STATE | healify.ai: N vis` to the Claude recap prompt when the cache is <15 min old.
- **`skills/ops/SKILL.md`** — adds `healify, ios, testflight, asc, appstore` routing row.

## Systemd timer (machine-local, not committed)

```
~/.config/systemd/user/ops-healify-metrics.timer  (OnCalendar=*:0/15)
~/.config/systemd/user/ops-healify-metrics.service
```
Already enabled and running on this box.

## Test plan

- [x] `bin/ops-healify-metrics --force` runs and produces valid JSON (verified: 16 ECS services, TestFlight/ASC graceful error for missing creds, Vercel responds)
- [x] `tests/test-no-secrets.sh` — 20 passed, 0 failed
- [x] Call site in ops-dash updated (`render_section_revenue` → `render_section_healify`)
- [ ] Add `FASTLANE_ASC_API_KEY_*` to `~/.mcp-secrets.env` to populate TestFlight + ASC sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New script calls AWS ECS across clusters and signs ASC JWTs from local secrets; ops-dash no longer surfaces MRR/Shopify in that section (FinOps block still uses revenue JSON).
> 
> **Overview**
> **Replaces the ops-dash “Revenue & Costs” block** (MRR sparkline + Shopify health) with a **Healify pre-launch** section fed by `/tmp/ops-healify-metrics.json`. The dashboard now shows ECS service health icons, TestFlight 7d/today installs, App Store Connect review state with status icons, and healify.ai visitor/pageview stats, with per-source fallbacks when the cache is empty or credentials are missing.
> 
> Adds **`bin/ops-healify-metrics`**, which runs ECS (AWS), TestFlight/ASC (JWT + App Store Connect API), and Vercel web insights in parallel, merges results with a 10-minute cache and `--force` bypass, loading secrets from `~/.mcp-secrets.env`.
> 
> **`scripts/recap/digest.sh`** injects a one-line Healify snapshot into the recap prompt when the cache is under 15 minutes old. **`skills/ops/SKILL.md`** routes healify/ios/testflight/asc keywords to refreshing metrics. FinOps and other `REVENUE_JSON` usage in `ops-dash` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e90de010ac608f3f63c3de946528bcf122dd5650. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a HEALIFY pre-launch metrics panel showing service health, TestFlight installs, App Store state/version, and recent website visitors/pageviews
  * New command to fetch and print Healify metrics on demand

* **Reporting**
  * Daily/recap reports now include a recent Healify pre-launch metrics snapshot (falls back to “(none)” if unavailable)

* **Other Changes**
  * Removed the prior “REVENUE & COSTS” panel while leaving FINOPS intact
<!-- end of auto-generated comment: release notes by coderabbit.ai -->