### PR TITLE
release: v2.30.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 38 skills, 20 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.29.1",
+      "version": "2.30.2",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.29.1",
+  "version": "2.30.2",
   "description": "Business operations command center for Claude Code — 39 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.30.2] - 2026-06-14
+
+### Changed
+Privacy/templating pass: scrubbed all personal data from source + history (generic placeholders), removed project-specific scripts. New: provider-router (hot per-request provider/account swap via ANTHROPIC_BASE_URL) + daemon Bedrock→OAuth drift self-heal.
+
+
 ## [2.29.1] - 2026-06-12
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.29.1",
+  "version": "2.30.2",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.30.2** (was 2.29.1).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

Privacy/templating pass: scrubbed all personal data from source + history (generic placeholders), removed project-specific scripts. New: provider-router (hot per-request provider/account swap via ANTHROPIC_BASE_URL) + daemon Bedrock→OAuth drift self-heal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This diff is release metadata only (version bumps and changelog); no runtime code paths change in the files shown.
> 
> **Overview**
> **Release v2.30.2** — version identifiers are bumped from **2.29.1** to **2.30.2** in the marketplace registry (`.claude-plugin/marketplace.json`), plugin manifest (`claude-ops/.claude-plugin/plugin.json`), and npm package (`claude-ops/package.json`).
> 
> `CHANGELOG.md` adds the **[2.30.2] - 2026-06-14** section, which documents the release as a **privacy/templating pass** (personal data scrubbed to generic placeholders, project-specific scripts removed) plus **provider-router** (per-request provider/account routing via `ANTHROPIC_BASE_URL`) and **daemon Bedrock→OAuth drift self-heal**. Those functional changes are not in this diff—only the version pins and changelog entry are.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f9d6aa13165a99afb027e9afa81d9d0064f2c20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 2.30.2

* **New Features**
  * Added provider-router functionality enabling per-request provider and account swapping.
  * Implemented automatic Bedrock to OAuth drift self-healing mechanism.

* **Chores**
  * Enhanced privacy through improved data scrubbing and templating.
  * Version updated to 2.30.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->