### PR TITLE
release: v2.30.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 38 skills, 20 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.30.2",
+      "version": "2.30.3",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.30.2",
+  "version": "2.30.3",
   "description": "Business operations command center for Claude Code — 39 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.30.3] - 2026-06-14
+
+### Changed
+Remove per-session stdio MCP servers (telegram, telegram-channel, doppler, desktop-act) from plugin .mcp.json — they loaded once per Claude session, multiplying processes across all live sessions. telegram was dead (empty creds); doppler + desktop-act relocated to on-demand (mcp-toggle). Daemon telegram-notification and doppler CLI secret-resolution paths are unaffected. MCP cost no longer scales with session count.
+
+
 ## [2.30.2] - 2026-06-14
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.30.2",
+  "version": "2.30.3",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.30.3** (was 2.30.2).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

Remove per-session stdio MCP servers (telegram, telegram-channel, doppler, desktop-act) from plugin .mcp.json — they loaded once per Claude session, multiplying processes across all live sessions. telegram was dead (empty creds); doppler + desktop-act relocated to on-demand (mcp-toggle). Daemon telegram-notification and doppler CLI secret-resolution paths are unaffected. MCP cost no longer scales with session count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> MCP availability shifts from always-on per session to on-demand for Doppler and desktop-act; users must enable them explicitly or workflows that assumed auto-loaded MCP tools may break until toggled.
> 
> **Overview**
> Release **v2.30.3** bumps `plugin.json`, marketplace registry, and `claude-ops/package.json` from **2.30.2** and documents the change in `CHANGELOG.md`.
> 
> The functional change (per changelog) stops registering **telegram**, **telegram-channel**, **doppler**, and **desktop-act** as per-session stdio MCP servers in the plugin `.mcp.json`. Those entries were spawning **one process set per Claude session**, so MCP overhead grew with parallel sessions. **Doppler** and **desktop-act** move to **on-demand** enablement via `mcp-toggle`; the dead **telegram** integration (empty creds) is dropped from auto-load. Daemon Telegram notifications and Doppler CLI secret resolution are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbcb2cad719146ea0cda4145229a6ff81b2fd2f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->