### PR TITLE
release: v2.30.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 38 skills, 20 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.30.3",
+      "version": "2.30.4",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.30.3",
+  "version": "2.30.4",
   "description": "Business operations command center for Claude Code — 39 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.30.4] - 2026-06-14
+
+### Changed
+telegram channel-mcp: env-templated single-owner leader gate (PID -> DEVBOT_TELEGRAM_OWNER) with TELEGRAM_CHANNEL_POLL opt-out; fix ops-deploy-monitor missing deploy-fix-common source; prettier account-rotation scripts
+
+
 ## [2.30.3] - 2026-06-14
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.30.3",
+  "version": "2.30.4",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.30.4** (was 2.30.3).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

telegram channel-mcp: env-templated single-owner leader gate (PID -> DEVBOT_TELEGRAM_OWNER) with TELEGRAM_CHANNEL_POLL opt-out; fix ops-deploy-monitor missing deploy-fix-common source; prettier account-rotation scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This PR only changes version pins and changelog; underlying fixes affect multi-session Telegram polling and deploy auto-fix monitoring but are not re-introduced in the diff itself.
> 
> **Overview**
> **Release v2.30.4** — bumps the ops plugin from **2.30.3 → 2.30.4** in `.claude-plugin/marketplace.json`, `claude-ops/.claude-plugin/plugin.json`, and `claude-ops/package.json`, and adds a **CHANGELOG** section for this version.
> 
> The changelog records three functional themes shipped under this tag (code may already be on the branch; this PR is the registry/version cut):
> 
> - **Telegram `channel-mcp`**: replaces a PID-based leader gate with an **env-templated single-owner** contract (`DEVBOT_TELEGRAM_OWNER=1` on the designated session; unset fails open for single-session installs). Optional **`TELEGRAM_CHANNEL_POLL=0`** turns off `getUpdates` polling while keeping leader-gated outbound/reply tools.
> - **`ops-deploy-monitor`**: fixes a missing **`deploy-fix-common`** source so the deploy monitor can load shared deploy-fix helpers like the merge/build triggers.
> - **Account rotation**: Prettier formatting on rotation scripts only.
> 
> No skill/agent counts or plugin behavior metadata change in `plugin.json` beyond the version field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43c53421411fa81d4fcfdc5f445e42edc72ef667. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->