### PR TITLE
fix(ops-update): BSD-compatible version-path rewrite (sed -i -E bug)

### DIFF
--- a/claude-ops/bin/ops-update
+++ b/claude-ops/bin/ops-update
@@ -182,8 +182,13 @@ else
     if [[ "$DRY" -eq 1 ]]; then
       say "  ${c_dim}[dry-run] would rewrite $f ($(echo "$olds" | tr '\n' ' ')→ $NEW)${c_rst}"; rewrote=$((rewrote+1)); return 0
     fi
-    sed -i -E "s#(cache/$MARKETPLACE/$PLUGIN/)[0-9]+\.[0-9]+\.[0-9]+#\1$NEW#g" "$f" \
-      && { ok "rewrote $f → $NEW"; rewrote=$((rewrote+1)); } || warn "rewrite failed: $f"
+    # Portable in-place rewrite — BSD sed treats `-i -E` as `-i` with suffix "-E"
+    # (extended-regex OFF → `\1` undefined). Use a temp file so it works on macOS + GNU.
+    if sed -E "s#(cache/$MARKETPLACE/$PLUGIN/)[0-9]+\.[0-9]+\.[0-9]+#\1$NEW#g" "$f" > "$f.optmp" 2>/dev/null && mv "$f.optmp" "$f"; then
+      ok "rewrote $f → $NEW"; rewrote=$((rewrote+1))
+    else
+      rm -f "$f.optmp" 2>/dev/null; warn "rewrite failed: $f"
+    fi
   }
   for d in "${SCAN_DIRS[@]}"; do
     [[ -d "$d" ]] || continue


### PR DESCRIPTION
`bin/ops-update` step 6 (rewrite stale version-pinned cache paths) uses `sed -i -E`, which on macOS/BSD sed treats `-E` as the `-i` backup-suffix argument — extended regex stays OFF, so `(...)`/`\1` errors with `\1 not defined in the RE` and the rewrite silently fails on every macOS update. Switched to a portable temp-file rewrite (no `-i`) that works on both BSD and GNU sed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-script portability fix in an upgrade maintenance path; behavior matches intent on GNU sed and only corrects broken rewrites on BSD.
> 
> **Overview**
> Step 6 of **`ops-update`** rewrites hardcoded `cache/ops-marketplace/ops/<version>/` paths in live configs when upgrading. The previous **`sed -i -E`** in-place edit is **broken on macOS/BSD**: `-E` is parsed as the backup suffix for `-i`, so extended regex stays off and captures like `\1` fail—rewrites could fail silently on every macOS run.
> 
> The change uses a **portable temp-file flow** (`sed -E … > "$f.optmp"` then `mv`), with cleanup and the same success/failure messaging as before. GNU and BSD sed both behave correctly; dry-run and scan scope are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecba9967048868963dfdb0a372719ba62d73e2af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cache path rewriting in `ops-update` for improved cross-platform compatibility, particularly on macOS and BSD systems. Updated error handling ensures proper cleanup of temporary files when rewrites fail, improving robustness and reliability across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->