### PR TITLE
release: v2.30.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 38 skills, 20 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.30.4",
+      "version": "2.30.5",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.30.4",
+  "version": "2.30.5",
   "description": "Business operations command center for Claude Code — 39 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.30.5] - 2026-06-14
+
+### Changed
+Fix ops-update step-6 version-path rewrite on macOS/BSD: `sed -i -E` consumed `-E` as the -i backup suffix (extended regex off → `\1` undefined → silent rewrite failure). Switched to a portable temp-file rewrite that works on BSD + GNU sed.
+
+
 ## [2.30.4] - 2026-06-14
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.30.4",
+  "version": "2.30.5",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.30.5** (was 2.30.4).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

Fix ops-update step-6 version-path rewrite on macOS/BSD: `sed -i -E` consumed `-E` as the -i backup suffix (extended regex off → `\1` undefined → silent rewrite failure). Switched to a portable temp-file rewrite that works on BSD + GNU sed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only release PR with a localized, portability fix to the update script’s config rewrite step; no auth, data, or runtime behavior changes in the diff itself.
> 
> **Overview**
> **Release v2.30.5** bumps the plugin from **2.30.4** across `plugin.json`, marketplace registry, and `claude-ops/package.json`, and adds a matching **CHANGELOG** entry.
> 
> The documented fix (shipped for this release) is **`ops-update` step 6**: stale cache version paths in live configs are rewritten with a **portable temp-file `sed` flow** instead of `sed -i -E`, which on macOS/BSD treated `-E` as the in-place backup suffix and could **fail silently** without updating pinned paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96b8e280768e28b290ee516aea1e3abf27de6da5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->