### PR TITLE
release: v2.31.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 38 skills, 20 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.30.5",
+      "version": "2.31.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.30.5",
+  "version": "2.31.0",
   "description": "Business operations command center for Claude Code — 39 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.31.0] - 2026-06-14
+
+### Changed
+Rotation: never use Bedrock while any OAuth (Claude Max) account has a usable token. Adds provider-env model/AWS-var scrub on provider swap (no more invalid Bedrock model id leaking into OAuth sessions), bedrock-lease purge on OAuth recovery, a live-session Bedrock force-swap watchdog (no defer for metered spend) with ss-based bedrock-runtime network scanner, and default-off post-swap continuation injection (PR #582).
+
+
 ## [2.30.5] - 2026-06-14
 
 ### Changed

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.30.5",
+  "version": "2.31.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.31.0** (was 2.30.5).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

Rotation: never use Bedrock while any OAuth (Claude Max) account has a usable token. Adds provider-env model/AWS-var scrub on provider swap (no more invalid Bedrock model id leaking into OAuth sessions), bedrock-lease purge on OAuth recovery, a live-session Bedrock force-swap watchdog (no defer for metered spend) with ss-based bedrock-runtime network scanner, and default-off post-swap continuation injection (PR #582).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release; functional rotation changes are not in this diff and should be reviewed in PR #582 if needed.
> 
> **Overview**
> **Release v2.31.0** (from **2.30.5**): bumps the plugin registry, marketplace manifest, and `claude-ops/package.json`, and prepends the **2.31.0** changelog entry.
> 
> There are **no runtime or rotation-script changes in this diff** — it ships the version tags and documents behavior landed in **PR #582** (account rotation: prefer OAuth over Bedrock when Max tokens are available; scrub Bedrock model/AWS env on provider swap; bedrock-lease purge on OAuth recovery; live-session Bedrock force-swap watchdog with `ss`-based `bedrock-runtime` scanning; post-swap continuation injection off by default).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8222a265e2368ffd166b8674c3d2d655919583b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->