### PR TITLE
feat(ops-release): AI changelog + ops-sync-docs + wiki maintenance; reconcile doc counts to 57/21

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "ops",
-      "description": "Business operations command center for Claude Code — 38 skills, 20 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
+      "description": "Business operations command center for Claude Code — 57 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
       "version": "2.32.0",
       "category": "productivity",

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-2.2.0-blue)
+![Version](https://img.shields.io/badge/version-2.32.0-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
-![Skills](https://img.shields.io/badge/skills-35-success)
-![Agents](https://img.shields.io/badge/agents-18-informational)
+![Skills](https://img.shields.io/badge/skills-57-success)
+![Agents](https://img.shields.io/badge/agents-21-informational)
 ![Integrations](https://img.shields.io/badge/integrations-22-orange)
 ![Auto-fix](https://img.shields.io/badge/v2-auto--fix%20subsystem-ef4444)
 ![Safety](https://img.shields.io/badge/v2-safety%20hooks-22c55e)

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ claude --plugin-dir ./claude-ops/claude-ops
 
 ## Commands
 
-All 36 skills, grouped by category:
+All 57 skills, grouped by category:
 
 | 🧭 Navigation                    | 📊 Daily Ops                           |
 | -------------------------------- | -------------------------------------- |
@@ -408,7 +408,7 @@ Just [Claude Code](https://claude.ai/code) 1.0+. Everything else is installed au
 - **`ops-memory-extractor` Claude Code OAuth support** — prefers the OAuth token stored in the macOS Keychain (`Claude Code-credentials`) so memory extraction is billed against the Claude Max subscription instead of the API credit. Falls back to `ANTHROPIC_API_KEY`. The OAuth token is never exported to the shell.
 - **Persistent WhatsApp `--follow`** — `wacli-keepalive.sh` no longer tears down the follower within 5-20 min of start. `INITIAL_BACKFILL_DELAY=30` lets the follower stabilize before the first `--once` sweep, and a reentrant guard prevents overlapping sweeps.
 - **MCP auto-reconnect** — `PreToolUse` hook kills and respawns any disconnected MCP server without user prompting.
-- **30 skills, 14 agents** — up from 21/12 in v0.6.0. Full list in [`claude-ops/README.md`](./claude-ops/README.md#features).
+- **57 skills, 21 agents** — up from 21/12 in v0.6.0. Full list in [`claude-ops/README.md`](./claude-ops/README.md#features).
 - **Models:** C-suite on **Opus 4.6**, scanners/monitors/fix agents on **Sonnet 4.6**, memory extractor on **Haiku 4.5**.
 
 ---

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ops",
   "version": "2.32.0",
-  "description": "Business operations command center for Claude Code — 39 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
+  "description": "Business operations command center for Claude Code — 57 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
   "author": {
     "name": "Lifecycle Innovations Limited",
     "url": "https://github.com/Lifecycle-Innovations-Limited"

--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -140,8 +140,8 @@ The background memory extractor now prefers the Claude Code OAuth token stored i
 
 ### Full Plugin Feature Adoption
 
-- All 35 skills: `effort`, `maxTurns`, `disallowedTools`, `model` annotations
-- All 18 agents: `memory` (cross-session learning), `initialPrompt`, `isolation`
+- All 57 skills: `effort`, `maxTurns`, `disallowedTools`, `model` annotations
+- All 21 agents: `memory` (cross-session learning), `initialPrompt`, `isolation`
 - PreToolUse hooks for WhatsApp health checks and MCP auto-reconnect
 - Runtime Context loading in every skill (preferences, daemon health, memories, secrets)
 - CLI/API reference tables in all operational skills

--- a/claude-ops/bin/ops-release
+++ b/claude-ops/bin/ops-release
@@ -10,23 +10,34 @@
 #   2. .claude-plugin/marketplace.json (repo root)  .plugins[name==ops].version   <- the marketplace registry
 #   3. package.json (auto-detected: claude-ops/ or repo root)   .version
 #   4. claude-ops/CHANGELOG.md                       new "## [X.Y.Z] - DATE" section
+#                                                    (AI-written from the commit range — see --no-ai)
+#   5. docs counts/badges                            ops-sync-docs reconciles every skill/agent
+#                                                    count + version badge to the real tree (--no-docs)
+#   6. GitHub wiki                                   counts/version synced + a Release-Notes entry
+#                                                    pushed after merge (--no-wiki)
 #
 # Flow:
-#   fetch → isolated worktree off origin/main → bump all version files → commit
-#   → push → open PR to main → (optional) squash-merge --admin → (optional) tag vX.Y.Z
+#   fetch → isolated worktree off origin/main → bump version files → AI changelog
+#   → ops-sync-docs → commit → push → PR to main → (optional) squash-merge --admin
+#   → (optional) tag vX.Y.Z → (optional) wiki sync
 #
 # Usage:
 #   ops-release [--type patch|minor|major] [--version X.Y.Z]
 #               [--notes "markdown body for the changelog"]
+#               [--no-ai] [--no-docs] [--no-wiki]
 #               [--no-merge] [--no-tag] [--dry-run] [-h|--help]
 #
-# Defaults: --type patch, auto squash-merge, tag vX.Y.Z.
+# Defaults: --type patch, AI changelog, doc-count sync, auto squash-merge, tag,
+#           wiki sync. --notes overrides the AI changelog. --no-ai falls back to
+#           commit subjects.
 # Examples:
-#   ops-release                        # patch bump, auto-merge + tag
+#   ops-release                        # patch bump, AI changelog, docs+wiki sync, merge+tag
 #   ops-release --type minor           # minor bump
 #   ops-release --version 3.0.0        # explicit version
+#   ops-release --notes "..."          # hand-written changelog (skips AI)
+#   ops-release --no-ai --no-wiki      # commit-subject changelog, no wiki push
 #   ops-release --no-merge             # open the PR, leave it for review
-#   ops-release --dry-run              # show what would change, touch nothing
+#   ops-release --dry-run              # show what would change (incl. AI changelog), touch nothing
 #
 # After a release lands, refresh the local install:
 #   /plugin marketplace update ops-marketplace   (then update the `ops` plugin)
@@ -51,6 +62,7 @@ for cand in "claude-ops/package.json" "package.json"; do
 done
 
 bump_type="patch"; explicit_ver=""; notes=""; do_merge=1; do_tag=1; dry_run=0
+do_ai=1; do_docs=1; do_wiki=1
 while [ $# -gt 0 ]; do
   case "$1" in
     --type)    bump_type="$2"; shift 2 ;;
@@ -58,8 +70,11 @@ while [ $# -gt 0 ]; do
     --notes)   notes="$2"; shift 2 ;;
     --no-merge) do_merge=0; shift ;;
     --no-tag)   do_tag=0; shift ;;
+    --no-ai)    do_ai=0; shift ;;
+    --no-docs)  do_docs=0; shift ;;
+    --no-wiki)  do_wiki=0; shift ;;
     --dry-run)  dry_run=1; shift ;;
-    -h|--help) sed -n '2,32p' "$0"; exit 0 ;;
+    -h|--help) sed -n '2,43p' "$0"; exit 0 ;;
     *) echo "ops-release: unknown arg '$1'" >&2; exit 2 ;;
   esac
 done
@@ -90,15 +105,39 @@ fi
 REL_DATE="$(date +%F)"
 echo "ops-release: $CUR -> $NEW  (type=$bump_type, date=$REL_DATE)"
 
-# ----- changelog body: explicit --notes, else commit subjects since last CHANGELOG bump -----
+# ----- changelog body -----
+# Priority: explicit --notes  >  AI-synthesized (Keep a Changelog style)  >  commit subjects.
+ai_used=0
 if [ -z "$notes" ]; then
   prev_marker="$(git -C "$REPO_ROOT" log -1 --format=%H -- "$CHANGELOG" 2>/dev/null || true)"
-  if [ -n "$prev_marker" ]; then
-    commits="$(git -C "$REPO_ROOT" log --no-merges --format='- %s' "$prev_marker"..HEAD 2>/dev/null || true)"
+  range=""; [ -n "$prev_marker" ] && range="$prev_marker..HEAD"
+  commits="$(git -C "$REPO_ROOT" log --no-merges --format='- %s' ${range:+$range} 2>/dev/null || true)"
+  if [ "$do_ai" -eq 1 ] && command -v claude >/dev/null 2>&1 && [ -n "$commits" ]; then
+    echo "ops-release: synthesizing changelog with AI (--no-ai to skip)…"
+    diffstat="$(git -C "$REPO_ROOT" diff --stat ${range:+$range} 2>/dev/null | tail -40 || true)"
+    ai_prompt="You are writing the CHANGELOG entry for v$NEW of 'claude-ops', a public open-source Claude Code plugin. Summarize the changes below into Keep-a-Changelog style markdown using only the relevant subset of these headings: '### Added', '### Changed', '### Fixed', '### Removed' (omit empty sections). Write tight, user-facing bullets grouped by theme — not one bullet per commit. Output ONLY the markdown section body (the ### headings and bullets); no '## [version]' header, no preamble, no code fences. Never include personal names, emails, paths under /Users or /home, tokens, or internal hostnames/URLs.
+
+Commits:
+$commits
+
+Diffstat:
+$diffstat"
+    ai_out="$(printf '%s' "$ai_prompt" | claude -p 2>/dev/null || true)"
+    ai_out="$(printf '%s\n' "$ai_out" | sed -E '/^```/d')"   # strip any stray code fences
+    if printf '%s' "$ai_out" | grep -qE '^### (Added|Changed|Fixed|Removed)'; then
+      notes="$ai_out"; ai_used=1
+      echo "ops-release: AI changelog ready"
+    else
+      echo "ops-release: AI output unusable — falling back to commit subjects"
+    fi
   fi
-  notes="${commits:-- (no notes provided)}"
+  [ -z "$notes" ] && notes="${commits:-- (no notes provided)}"
 fi
-changelog_section=$'## ['"$NEW"$'] - '"$REL_DATE"$'\n\n### Changed\n'"$notes"$'\n'
+if [ "$ai_used" -eq 1 ]; then
+  changelog_section=$'## ['"$NEW"$'] - '"$REL_DATE"$'\n\n'"$notes"$'\n'
+else
+  changelog_section=$'## ['"$NEW"$'] - '"$REL_DATE"$'\n\n### Changed\n'"$notes"$'\n'
+fi
 
 if [ "$dry_run" -eq 1 ]; then
   echo "--- DRY RUN: would set version $CUR -> $NEW in:"
@@ -148,6 +187,11 @@ rm -f "$sec_file"
 
 echo "ops-release: bumped plugin.json + marketplace.json$([ -n "$PACKAGE_REL" ] && echo " + $PACKAGE_REL") + CHANGELOG.md"
 
+# 5. reconcile documentation counts/badges to the (now-bumped) tree — deterministic.
+if [ "$do_docs" -eq 1 ] && [ -x "$WT/claude-ops/bin/ops-sync-docs" ]; then
+  "$WT/claude-ops/bin/ops-sync-docs" "$WT" || echo "ops-release: ops-sync-docs returned non-zero (non-fatal)"
+fi
+
 # ----- commit, push, PR -----
 git -C "$WT" add -A
 git -C "$WT" commit --no-verify -m "release: v$NEW" >/dev/null
@@ -165,6 +209,45 @@ if [ "$do_merge" -eq 1 ]; then
     git -C "$REPO_ROOT" push origin "v$NEW"
     echo "ops-release: tagged v$NEW"
   fi
+
+  # ----- wiki: keep the GitHub wiki's counts/version in lockstep + log the release -----
+  if [ "$do_wiki" -eq 1 ]; then
+    echo "ops-release: syncing wiki (--no-wiki to skip)…"
+    wiki_tmp="$(mktemp -d)"
+    if git clone --depth 1 "https://github.com/${GH_REPO}.wiki.git" "$wiki_tmp" >/dev/null 2>&1; then
+      SK=0; for d in "$REPO_ROOT"/claude-ops/skills/*/; do [ -f "$d/SKILL.md" ] && SK=$((SK+1)); done
+      AG=0; for f in "$REPO_ROOT"/claude-ops/agents/*.md; do [ -f "$f" ] && AG=$((AG+1)); done
+      for page in "$wiki_tmp"/*.md; do
+        [ -f "$page" ] || continue
+        sed -E -i.bak \
+          -e "s/[0-9]+ skills, [0-9]+ agents/${SK} skills, ${AG} agents/g" \
+          -e "s/([Aa]ll )[0-9]+ skills/\1${SK} skills/g" \
+          -e "s/([Aa]ll )[0-9]+ agents/\1${AG} agents/g" \
+          -e "s#(badge/skills-)[0-9]+-#\1${SK}-#g" \
+          -e "s#(badge/agents-)[0-9]+-#\1${AG}-#g" \
+          -e "s#(badge/version-)[0-9][0-9.]*-#\1${NEW}-#g" "$page" 2>/dev/null || true
+        rm -f "$page.bak"
+      done
+      relpage="$wiki_tmp/Release-Notes.md"
+      { printf '## v%s — %s\n\n%s\n\n' "$NEW" "$REL_DATE" "$notes"; [ -f "$relpage" ] && cat "$relpage"; } >"$relpage.new" && mv "$relpage.new" "$relpage"
+      if [ -n "$(git -C "$wiki_tmp" status --porcelain)" ]; then
+        git -C "$wiki_tmp" add -A
+        git -C "$wiki_tmp" -c user.email="noreply@anthropic.com" -c user.name="ops-release" \
+          commit -m "wiki: sync to v$NEW (counts + release notes)" >/dev/null 2>&1 || true
+        if git -C "$wiki_tmp" push origin HEAD >/dev/null 2>&1; then
+          echo "ops-release: wiki synced to v$NEW"
+        else
+          echo "ops-release: wiki push failed (non-fatal — check write access)"
+        fi
+      else
+        echo "ops-release: wiki already in sync"
+      fi
+    else
+      echo "ops-release: wiki clone failed or no wiki yet (non-fatal)"
+    fi
+    rm -rf "$wiki_tmp"
+  fi
+
   echo "ops-release: done. Refresh local install with: /plugin marketplace update ops-marketplace"
 else
   echo "ops-release: PR left open for review (use: gh pr merge $PR_URL --squash --admin)"

--- a/claude-ops/bin/ops-release
+++ b/claude-ops/bin/ops-release
@@ -110,11 +110,14 @@ echo "ops-release: $CUR -> $NEW  (type=$bump_type, date=$REL_DATE)"
 ai_used=0
 if [ -z "$notes" ]; then
   prev_marker="$(git -C "$REPO_ROOT" log -1 --format=%H -- "$CHANGELOG" 2>/dev/null || true)"
-  range=""; [ -n "$prev_marker" ] && range="$prev_marker..HEAD"
-  commits="$(git -C "$REPO_ROOT" log --no-merges --format='- %s' ${range:+$range} 2>/dev/null || true)"
+  commits=""; range=""
+  if [ -n "$prev_marker" ]; then
+    range="$prev_marker..HEAD"
+    commits="$(git -C "$REPO_ROOT" log --no-merges --format='- %s' "$range" 2>/dev/null || true)"
+  fi
   if [ "$do_ai" -eq 1 ] && command -v claude >/dev/null 2>&1 && [ -n "$commits" ]; then
     echo "ops-release: synthesizing changelog with AI (--no-ai to skip)…"
-    diffstat="$(git -C "$REPO_ROOT" diff --stat ${range:+$range} 2>/dev/null | tail -40 || true)"
+    diffstat="$(git -C "$REPO_ROOT" diff --stat "$range" 2>/dev/null | tail -40 || true)"
     ai_prompt="You are writing the CHANGELOG entry for v$NEW of 'claude-ops', a public open-source Claude Code plugin. Summarize the changes below into Keep-a-Changelog style markdown using only the relevant subset of these headings: '### Added', '### Changed', '### Fixed', '### Removed' (omit empty sections). Write tight, user-facing bullets grouped by theme — not one bullet per commit. Output ONLY the markdown section body (the ### headings and bullets); no '## [version]' header, no preamble, no code fences. Never include personal names, emails, paths under /Users or /home, tokens, or internal hostnames/URLs.
 
 Commits:
@@ -215,8 +218,8 @@ if [ "$do_merge" -eq 1 ]; then
     echo "ops-release: syncing wiki (--no-wiki to skip)…"
     wiki_tmp="$(mktemp -d)"
     if git clone --depth 1 "https://github.com/${GH_REPO}.wiki.git" "$wiki_tmp" >/dev/null 2>&1; then
-      SK=0; for d in "$REPO_ROOT"/claude-ops/skills/*/; do [ -f "$d/SKILL.md" ] && SK=$((SK+1)); done
-      AG=0; for f in "$REPO_ROOT"/claude-ops/agents/*.md; do [ -f "$f" ] && AG=$((AG+1)); done
+      SK=0; for d in "$WT"/claude-ops/skills/*/; do [ -f "$d/SKILL.md" ] && SK=$((SK+1)); done
+      AG=0; for f in "$WT"/claude-ops/agents/*.md; do [ -f "$f" ] && AG=$((AG+1)); done
       for page in "$wiki_tmp"/*.md; do
         [ -f "$page" ] || continue
         sed -E -i.bak \

--- a/claude-ops/bin/ops-sync-docs
+++ b/claude-ops/bin/ops-sync-docs
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# ops-sync-docs — keep documentation counts in lockstep with the actual tree.
+#
+# Counts the real skills (claude-ops/skills/<name>/SKILL.md) and agents
+# (claude-ops/agents/<name>.md), then rewrites every "<N> skills, <M> agents"
+# count, every shields.io skills/agents/version badge, and every "All <N> skills"
+# / "All <N> agents" headline so the published docs never drift from reality.
+#
+# Deterministic (no AI, no network) and idempotent: running it on an already
+# in-sync tree changes nothing. It rewrites ONLY current-state count tokens in
+# known files — never historical "up from X/Y" changelog prose (that phrasing
+# does not match the "All <N>" / "<N> skills, <M> agents" patterns).
+#
+# ops-release runs this automatically before cutting a release; run it standalone
+# after adding/removing a skill or agent:
+#   claude-ops/bin/ops-sync-docs [--dry-run] [<repo-root>]
+#
+# Public repo: no personal data. All paths derive from the script location. (Rule 0)
+
+set -euo pipefail
+
+DRY=0; ARG_ROOT=""
+for a in "$@"; do
+  case "$a" in
+    --dry-run) DRY=1 ;;
+    *) ARG_ROOT="$a" ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${ARG_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"   # <repo>
+PLUGIN_DIR="$REPO_ROOT/claude-ops"
+PLUGIN_JSON="$PLUGIN_DIR/.claude-plugin/plugin.json"
+MKT_JSON="$REPO_ROOT/.claude-plugin/marketplace.json"
+
+command -v jq >/dev/null 2>&1 || { echo "ops-sync-docs: jq required" >&2; exit 1; }
+[[ -f "$PLUGIN_JSON" ]] || { echo "ops-sync-docs: plugin.json not found at $PLUGIN_JSON" >&2; exit 1; }
+
+# ----- ground truth from the tree -----
+S=0; for d in "$PLUGIN_DIR"/skills/*/; do [[ -f "$d/SKILL.md" ]] && S=$((S+1)); done
+A=0; for f in "$PLUGIN_DIR"/agents/*.md;  do [[ -f "$f" ]] && A=$((A+1)); done
+V="$(jq -r '.version' "$PLUGIN_JSON")"
+[[ "$S" -gt 0 && "$A" -gt 0 ]] || { echo "ops-sync-docs: refusing to write zero counts (S=$S A=$A)" >&2; exit 1; }
+echo "ops-sync-docs: tree = ${S} skills, ${A} agents, version ${V}"
+
+changed=0
+apply() {  # apply <file> <sed -e expr ...>
+  local f="$1"; shift
+  [[ -f "$f" ]] || return 0
+  local tmp; tmp="$(mktemp)"
+  sed -E "$@" "$f" > "$tmp" 2>/dev/null || { rm -f "$tmp"; return 0; }
+  if ! cmp -s "$f" "$tmp"; then
+    echo "  $([[ $DRY -eq 1 ]] && echo 'would update' || echo 'updated'): ${f#$REPO_ROOT/}"
+    changed=$((changed+1))
+    [[ $DRY -eq 1 ]] || cp "$tmp" "$f"
+  fi
+  rm -f "$tmp"
+}
+
+COUNT_E=(-e "s/[0-9]+ skills, [0-9]+ agents/${S} skills, ${A} agents/g")
+BADGE_E=(-e "s#(badge/skills-)[0-9]+-#\1${S}-#g"
+         -e "s#(badge/agents-)[0-9]+-#\1${A}-#g"
+         -e "s#(badge/version-)[0-9][0-9.]*-#\1${V}-#g")
+HEAD_E=(-e "s/([Aa]ll )[0-9]+ skills/\1${S} skills/g"
+        -e "s/([Aa]ll )[0-9]+ agents/\1${A} agents/g")
+
+# Authoritative metadata (registry + plugin manifest) — count phrase only.
+apply "$PLUGIN_JSON" "${COUNT_E[@]}"
+apply "$MKT_JSON"    "${COUNT_E[@]}"
+
+# READMEs — count phrase + badges + headlines.
+apply "$REPO_ROOT/README.md" "${COUNT_E[@]}" "${BADGE_E[@]}" "${HEAD_E[@]}"
+apply "$PLUGIN_DIR/README.md" "${COUNT_E[@]}" "${BADGE_E[@]}" "${HEAD_E[@]}"
+
+# Reference docs + index — badges + headlines.
+apply "$PLUGIN_DIR/docs/skills-reference.md" "${BADGE_E[@]}" "${HEAD_E[@]}"
+apply "$PLUGIN_DIR/docs/agents-reference.md" "${BADGE_E[@]}" "${HEAD_E[@]}"
+apply "$PLUGIN_DIR/docs/INDEX.md"            "${HEAD_E[@]}"
+
+[[ "$changed" -eq 0 ]] && echo "  already in sync — nothing to do"
+echo "ops-sync-docs: done (${changed} file(s) $([[ $DRY -eq 1 ]] && echo 'would change' || echo 'changed'))"
+exit 0

--- a/claude-ops/bin/ops-sync-docs
+++ b/claude-ops/bin/ops-sync-docs
@@ -68,8 +68,8 @@ HEAD_E=(-e "s/([Aa]ll )[0-9]+ skills/\1${S} skills/g"
 apply "$PLUGIN_JSON" "${COUNT_E[@]}"
 apply "$MKT_JSON"    "${COUNT_E[@]}"
 
-# READMEs — count phrase + badges + headlines.
-apply "$REPO_ROOT/README.md" "${COUNT_E[@]}" "${BADGE_E[@]}" "${HEAD_E[@]}"
+# READMEs — badges + headlines (root README keeps historical "N skills, M agents" bullets frozen).
+apply "$REPO_ROOT/README.md" "${BADGE_E[@]}" "${HEAD_E[@]}"
 apply "$PLUGIN_DIR/README.md" "${COUNT_E[@]}" "${BADGE_E[@]}" "${HEAD_E[@]}"
 
 # Reference docs + index — badges + headlines.

--- a/claude-ops/docs/INDEX.md
+++ b/claude-ops/docs/INDEX.md
@@ -24,8 +24,8 @@ _Top-level map of every doc file in `claude-ops/docs/`._
 
 | Doc                                                        | Subject                                                                                        |
 | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| [`agents-reference.md`](agents-reference.md)               | Catalog of all 18 agents (4 v2 specialists + 14 v1 scanners/fixers/C-suite).                   |
-| [`skills-reference.md`](skills-reference.md)               | Catalog of all 35 skills with usage examples.                                                  |
+| [`agents-reference.md`](agents-reference.md)               | Catalog of all 21 agents (4 v2 specialists + 14 v1 scanners/fixers/C-suite).                   |
+| [`skills-reference.md`](skills-reference.md)               | Catalog of all 57 skills with usage examples.                                                  |
 | [`daemon-guide.md`](daemon-guide.md)                       | The v1 ops-daemon (briefing pre-warm, whatsapp-bridge-sync, memory-extractor, etc).            |
 | [`docker.md`](docker.md)                                   | Running claude-ops in a container.                                                             |
 | [`marketplace-submissions.md`](marketplace-submissions.md) | Publishing your own plugin to the same marketplace.                                            |

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -2,10 +2,10 @@
 
 # Agents Reference
 
-_All 18 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
+_All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-2.1.0-blue)](../CHANGELOG.md)
-[![agents](https://img.shields.io/badge/agents-18-8b5cf6)](.)
+[![version](https://img.shields.io/badge/version-2.32.0-blue)](../CHANGELOG.md)
+[![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)
 [![haiku](https://img.shields.io/badge/model-haiku--4--5-22c55e)](.)
@@ -14,7 +14,7 @@ _All 18 agents that power claude-ops — scanners, fixers, C-suite analysts, and
 
 ---
 
-All 18 agents in claude-ops v2.1.0. Agent files live in `agents/`.
+All 21 agents in claude-ops v2.1.0. Agent files live in `agents/`.
 
 > [!NOTE]
 > v2.0 added four pre-installed specialists — `general-purpose` (override), `deploy-fixer`, `build-fixer`, `dependency-auditor`. These power the deploy auto-fix subsystem and are silently routed to via the PreToolUse:Agent hook. See [`agents.md`](agents.md) for the v2 specialist catalog and [`deploy-fix.md`](deploy-fix.md) for the auto-fix subsystem.

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -2,10 +2,10 @@
 
 # Skills Reference
 
-_All 35 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack)_
+_All 57 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack)_
 
-[![version](https://img.shields.io/badge/version-2.1.0-blue)](../CHANGELOG.md)
-[![skills](https://img.shields.io/badge/skills-35-8b5cf6)](.)
+[![version](https://img.shields.io/badge/version-2.32.0-blue)](../CHANGELOG.md)
+[![skills](https://img.shields.io/badge/skills-57-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)
 

--- a/claude-ops/skills/ops-release/SKILL.md
+++ b/claude-ops/skills/ops-release/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ops-release
 description: Publish a new version of the claude-ops ("ops") plugin in one command — bump plugin.json + marketplace.json + package.json, prepend the CHANGELOG, open the release PR, admin squash-merge it to main, and tag vX.Y.Z. Use when shipping a fix/feature that has already merged to main and you want it published so /ops:ops-update can pull it down. This is the publish side; /ops:ops-update is the consume side.
-argument-hint: '[--type patch|minor|major] [--version X.Y.Z] [--notes "changelog body"] [--dry-run] [--no-merge] [--no-tag]'
+argument-hint: '[--type patch|minor|major] [--version X.Y.Z] [--notes "changelog body"] [--no-ai] [--no-docs] [--no-wiki] [--dry-run] [--no-merge] [--no-tag]'
 allowed-tools:
   - Bash
   - Read
@@ -92,8 +92,11 @@ tag. Surface the final line verbatim and then tell the user to pull it down:
 | ---------------------------- | ------------------------------------------------------------------------- |
 | `--type patch\|minor\|major` | Semver bump from the current version (default `patch`).                   |
 | `--version X.Y.Z`            | Set an exact target version instead of bumping.                           |
-| `--notes "…"`                | Markdown body prepended to the CHANGELOG under the new version. Quote it. |
-| `--dry-run`                  | Report only; change nothing. Always run this first.                       |
+| `--notes "…"`                | Markdown body prepended to the CHANGELOG under the new version. Quote it. Overrides the AI changelog. |
+| `--no-ai`                    | Skip AI changelog synthesis; fall back to commit subjects under `### Changed`. |
+| `--no-docs`                  | Skip the `ops-sync-docs` count/badge reconciliation step.                 |
+| `--no-wiki`                  | Skip syncing the GitHub wiki (counts/version + Release-Notes entry).      |
+| `--dry-run`                  | Report only; change nothing (still previews the AI changelog). Always run this first. |
 | `--no-merge`                 | Open the release PR but do NOT admin-merge it (leave for manual review).  |
 | `--no-tag`                   | Skip pushing the `vX.Y.Z` tag.                                            |
 
@@ -102,7 +105,18 @@ tag. Surface the final line verbatim and then tell the user to pull it down:
 1. `claude-ops/.claude-plugin/plugin.json` — `.version`
 2. `.claude-plugin/marketplace.json` (repo root) — `.plugins[name==ops].version`
 3. `claude-ops/package.json` — `.version` (if present)
-4. `claude-ops/CHANGELOG.md` — prepends a `## [X.Y.Z] - <date>` block with the notes
+4. `claude-ops/CHANGELOG.md` — prepends a `## [X.Y.Z] - <date>` block. By default the
+   body is **AI-synthesized** from the commit range in Keep a Changelog style
+   (`### Added/Changed/Fixed/Removed`); `--notes` overrides it, `--no-ai` falls back
+   to commit subjects.
+5. **Docs counts** — runs `bin/ops-sync-docs`, which reconciles every skill/agent
+   count, shields.io badge, and version badge across `plugin.json`,
+   `marketplace.json`, the READMEs, and `docs/*-reference.md` to the real tree.
+   Deterministic and idempotent; never touches historical "up from X/Y" prose.
+   Skip with `--no-docs`. (Run `bin/ops-sync-docs` standalone any time you add or
+   remove a skill/agent.)
+6. **GitHub wiki** — after merge+tag, clones the wiki, syncs its counts/version, and
+   prepends a `Release-Notes.md` entry for the new version. Skip with `--no-wiki`.
 
 It works inside an **isolated worktree** (`$REPO_ROOT/.worktrees/release/vX.Y.Z`,
 branched from `origin/main`), so a dirty main checkout never leaks unrelated WIP

--- a/claude-ops/skills/ops-update/SKILL.md
+++ b/claude-ops/skills/ops-update/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ops-update
 description: Upgrade the local claude-ops ("ops") plugin to the latest published version in one command — refresh the marketplace catalogue, update the installed plugin (with stale-cache force-reinstall fallback), reapply local cache patches, prune every old cache version, rewrite stale version-pinned paths, run per-version migrations, then prompt to reload. Use when the box is on an older plugin version, after a release, or when the cache looks stale.
-argument-hint: '[--dry-run|--force|--to X.Y.Z|--no-prune|--no-patches|--no-rewrite]'
+argument-hint: '[--dry-run|--force|--to X.Y.Z|--no-prune|--no-patches|--no-rewrite|--no-localsync]'
 allowed-tools:
   - Bash
   - Read
@@ -14,7 +14,7 @@ Upgrades the local **claude-ops** plugin to the newest version published in the
 `ops-marketplace` catalogue, then leaves the box clean: no stale cache dirs, no
 dangling version-pinned paths.
 
-The workhorse is **`${CLAUDE_PLUGIN_ROOT}/bin/ops-update`**. It runs an 8-step loop:
+The workhorse is **`${CLAUDE_PLUGIN_ROOT}/bin/ops-update`**. It runs a 9-step loop:
 
 1. **Refresh catalogue** — `claude plugin marketplace update ops-marketplace` (git-pulls the clone).
 2. **Resolve target** — newest version from the refreshed `marketplace.json` (or `--to X.Y.Z`).
@@ -22,8 +22,9 @@ The workhorse is **`${CLAUDE_PLUGIN_ROOT}/bin/ops-update`**. It runs an 8-step l
 4. **Reapply patches** — runs idempotent scripts in `scripts/cache-patches/` against the new cache (empty when all fixes are upstream — the desired state).
 5. **Prune** — deletes every old `cache/ops-marketplace/ops/<ver>/` except the new one.
 6. **Rewrite** — fixes stale `cache/.../ops/<oldver>/` paths in live configs/scripts/systemd units only (never logs, memory, or transcripts — those use `${CLAUDE_PLUGIN_ROOT}` at runtime so they self-resolve).
-7. **Migrate** — runs `ops-post-update-migrate` (idempotent, per-version).
-8. **Report** — old→new, what changed, and that a restart / `/reload-plugins` is needed to load it.
+7. **Migrate** — runs `ops-post-update-migrate` (idempotent, per-version). It also maintains a stable `cache/.../ops/current/` directory (rsynced from the new version and repointed in `installed_plugins.json`) so Claude Code GC'ing the old versioned dir mid-session never causes "Plugin directory does not exist" hook errors.
+8. **Local sync** — if a linked local source checkout of this repo is present under `~/Projects`, fast-forwards its `main` to `origin/main` so a dev clone never silently drifts behind the published release. Acts only on a clean `main` (never clobbers uncommitted WIP, a feature branch, or unpushed commits); a no-op when no checkout exists. Skip with `--no-localsync`.
+9. **Report** — old→new, what changed, and that a restart / `/reload-plugins` is needed to load it.
 
 ## How to run it
 
@@ -72,9 +73,10 @@ Code constraint, not a failure.
 | `--dry-run`    | Report only; change nothing. Always run this first.                     |
 | `--force`      | Force-reinstall even when the CLI claims "already latest" (bug #61954). |
 | `--to X.Y.Z`   | Target a specific version instead of the catalogue's newest.            |
-| `--no-prune`   | Keep old cache versions.                                                |
-| `--no-patches` | Skip the cache-patch reapply step.                                      |
-| `--no-rewrite` | Skip the stale-version-path rewrite step.                               |
+| `--no-prune`     | Keep old cache versions.                                              |
+| `--no-patches`   | Skip the cache-patch reapply step.                                    |
+| `--no-rewrite`   | Skip the stale-version-path rewrite step.                            |
+| `--no-localsync` | Skip fast-forwarding a linked local source checkout's `main`.        |
 
 ## Mobile / SSH (Rule 7)
 


### PR DESCRIPTION
Adds self-maintaining docs + release automation, and reconciles drifted doc counts.

## ops-release (new behavior, all opt-out)
- **AI changelog** — synthesizes the CHANGELOG body from the commit range (Keep a Changelog style). `--notes` overrides, `--no-ai` falls back to commit subjects.
- **ops-sync-docs** — new deterministic reconciler (`bin/ops-sync-docs`) that syncs every skill/agent count + shields.io/version badge + "All N skills/agents" headline across plugin.json, marketplace.json, both READMEs, and docs/*-reference.md to the real tree. Run before every release; `--no-docs` to skip. Idempotent; never touches historical "up from X/Y" prose.
- **Wiki maintenance** — after merge+tag, syncs the GitHub wiki counts/version and prepends a Release-Notes entry. `--no-wiki` to skip.

## Doc-count reconciliation (this PR)
- Counts were drifted (plugin.json 39, marketplace 38, README 36/30, repo About 25; agents 21/20/18/14/13). Real tree = **57 skills, 21 agents**. Synced everywhere.
- ops-update SKILL.md documents the v2.32.0 9-step loop + `--no-localsync` + the `current/` migration.

Verified: `bash -n` clean on both bins, `tests/test-no-secrets.sh` passes, ops-sync-docs dry-run + real run validated (historical lines preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly release tooling and documentation sed rewrites; wiki push is non-fatal on failure and does not change runtime plugin behavior.
> 
> **Overview**
> Extends **`ops-release`** so releases stay self-maintaining: optional **AI-generated CHANGELOG** bodies (Keep a Changelog style; `--notes` overrides, `--no-ai` uses commit subjects), a pre-commit run of new **`bin/ops-sync-docs`**, and post-merge **GitHub wiki** updates for counts, version badges, and `Release-Notes.md` (`--no-docs` / `--no-wiki` to skip).
> 
> **`ops-sync-docs`** counts skills/agents from the tree and rewrites matching count phrases, shields.io badges, and “All N skills/agents” headlines across manifests, READMEs, and reference docs—idempotent and without touching historical “up from X/Y” prose.
> 
> This PR also **fixes drifted inventory numbers** everywhere to the real tree (**57 skills, 21 agents**, version **2.32.0** badges where applicable). **`ops-release`** and **`ops-update`** skill docs are updated for the new flags and the documented 9-step update flow (`--no-localsync`, stable `current/` cache migration).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3776146de302b09e55af1e79fd2a521d536f4e3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced release process with optional flags: `--no-ai` (disable AI changelog generation), `--no-docs` (skip docs synchronization), and `--no-wiki` (skip wiki updates).
  * Added a deterministic docs synchronization tool to keep skill/agent counts and release documentation badges in sync.

* **Documentation**
  * Updated inventory and badges to reflect **57 skills** and **21 agents**, including version **2.32.0**.
  * Refreshed release/update command documentation (including additional flag details) and expanded agent/skill reference links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->