### PR TITLE
fix(crs): auto-detect CRS host port in priority daemon health-gate

### DIFF
--- a/claude-ops/scripts/account-rotation/crs-priority-daemon.mjs
+++ b/claude-ops/scripts/account-rotation/crs-priority-daemon.mjs
@@ -72,7 +72,10 @@ const cfg = loadConfig();
 const C = cfg.crs || {};
 const num = (v, d) => (v === undefined || v === null || v === '' || Number.isNaN(+v) ? d : +v);
 
-const BASE = process.env.CRS_BASE || C.baseUrl || 'http://127.0.0.1:3000';
+// CRS_BASE is normally exported by the .sh wrapper after it probes the live host
+// port (:3005 or :3000). config.json "crs".baseUrl overrides next; the literal is
+// only a last resort and matches this fleet's published port (...:3005->3000).
+const BASE = process.env.CRS_BASE || C.baseUrl || 'http://127.0.0.1:3005';
 const ADMIN_USER = process.env.CRS_ADMIN_USER || C.adminUser || 'cradmin';
 const OFF_5H = num(process.env.CRS_OFF_5H ?? C.off5h, 90);
 const OFF_7D = num(process.env.CRS_OFF_7D ?? C.off7d, 95);

--- a/claude-ops/scripts/account-rotation/crs-priority-daemon.sh
+++ b/claude-ops/scripts/account-rotation/crs-priority-daemon.sh
@@ -11,7 +11,13 @@ DATA_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketpla
 LOG_DIR="$DATA_DIR/logs"
 LOG="$LOG_DIR/crs-priority.log"
 NODE="${CRS_NODE_BIN:-$(command -v node || echo /opt/homebrew/bin/node)}"
-BASE="${CRS_BASE:-http://127.0.0.1:3000}"
+# CRS's container port (:3000) is published on the host at either :3000 or :3005
+# depending on the deploy (this fleet maps ...:3005->3000). Honor an explicit
+# CRS_BASE; otherwise probe the known candidates and pick the first that answers
+# /health, so a host port-mapping change can't silently freeze the daemon (it
+# used to default to :3000, get 000 against a :3005-mapped relay, and exit 0
+# every tick — priority scheduling dead until someone noticed).
+BASE="${CRS_BASE:-}"
 
 mkdir -p "$LOG_DIR"
 
@@ -27,7 +33,16 @@ fi
 trap 'rmdir "$LOCK" 2>/dev/null' EXIT
 
 # Skip silently if CRS isn't reachable (don't spam the log while the relay is down).
-curl -sf -o /dev/null --max-time 5 "$BASE/health" || exit 0
+# Auto-detect the host port unless CRS_BASE was set explicitly.
+if [ -n "$BASE" ]; then
+  curl -sf -o /dev/null --max-time 5 "$BASE/health" || exit 0
+else
+  for cand in http://127.0.0.1:3005 http://127.0.0.1:3000; do
+    if curl -sf -o /dev/null --max-time 5 "$cand/health"; then BASE="$cand"; break; fi
+  done
+  [ -n "$BASE" ] || exit 0  # relay unreachable on every candidate
+fi
+export CRS_BASE="$BASE"  # hand the resolved base to the node tick
 
 # Rotate log past ~2MB.
 if [ -f "$LOG" ] && [ "$(wc -c < "$LOG" 2>/dev/null || echo 0)" -gt 2097152 ]; then


### PR DESCRIPTION
## Problem

The CRS priority daemon (`crs-priority-daemon.sh` → `.mjs`) gates every tick on a CRS `/health` probe and `exit 0`s silently if it fails. The `BASE` defaulted to `http://127.0.0.1:3000`, but on this fleet the CRS container's `:3000` is **published on the host at `:3005`** (`...:3005->3000/tcp`). So the gate probed `:3000` → `HTTP 000` → bailed **every tick**.

**Impact:** account prioritization (schedulable on/off toggles across the 10-account Max-20x pool) silently froze after the relay cutover — no toggles for hours. This directly defeats the "max out all available quota + never crash the fleet on 401/rate-limit" goal, because exhausted/over-util accounts stay schedulable and healthy ones aren't re-enabled.

## Fix

- **`crs-priority-daemon.sh`**: when `CRS_BASE` is unset, probe `:3005` then `:3000` and use the first that answers `/health`; export the resolved base to the node tick. An explicit `CRS_BASE` still wins. A future host port-mapping change can no longer silently freeze the daemon.
- **`crs-priority-daemon.mjs`**: last-resort literal aligned to `:3005` (`CRS_BASE` from the wrapper and `config.json` `crs.baseUrl` still take precedence — unchanged).

## Verification (live, against the running relay)

- `bash -n` / `node --check`: pass.
- Wrapper with **no `CRS_BASE`** auto-detects `:3005` and produces real schedulable toggles (`HTTP 200`): e.g. `pool-heartfeldt-team: schedulable false→true [HTTP 200]`, `schedulable=6/10`.
- Confirmed `:3005/health → 200`, `:3000/health → 000` on the box.

Also applied live on dev-sandbox-fra as a systemd drop-in (`CRS_BASE=http://127.0.0.1:3005`) for immediate recovery; this PR makes the script self-correcting so the drop-in is belt-and-suspenders, not required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the live path that gates CRS pool schedulable toggles; mis-detection could still skip ticks, but logic is limited to local health probes and URL defaults with no auth or policy changes.
> 
> **Overview**
> Fixes a silent failure where the CRS priority daemon health-gated every tick against **`http://127.0.0.1:3000`** while this fleet publishes CRS on **`:3005`**, so `/health` failed, the wrapper exited 0, and **account schedulable toggles never ran**.
> 
> **`crs-priority-daemon.sh`** no longer assumes `:3000` when `CRS_BASE` is unset: it probes **`127.0.0.1:3005` then `:3000`**, uses the first healthy base, and **`export CRS_BASE`** for the Node tick. An explicit `CRS_BASE` is unchanged (single health check, then proceed).
> 
> **`crs-priority-daemon.mjs`** updates the last-resort default from `:3000` to **`:3005`** and documents that the wrapper’s `CRS_BASE` and `config.json` `crs.baseUrl` still win.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d41dde93ff33e580715140cb9d939d2a48271d39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->