### PR TITLE
fix(rotation): block Bedrock fallback + preserve CRS routing on mode flips

### DIFF
--- a/claude-ops/scripts/account-rotation/__tests__/claude-settings-mode-crs.test.mjs
+++ b/claude-ops/scripts/account-rotation/__tests__/claude-settings-mode-crs.test.mjs
@@ -1,0 +1,122 @@
+/**
+ * claude-settings-mode CRS-awareness tests (node --test).
+ *
+ * Run: node --test claude-ops/scripts/account-rotation/__tests__/claude-settings-mode-crs.test.mjs
+ *
+ * Guards the money-leak fix: a CRS-routed box (cr_ token + ANTHROPIC_BASE_URL)
+ * must never be flipped onto metered Bedrock, and an OAuth-mode flip must keep
+ * the CRS relay pair intact (a cr_ token with no base URL 401s the relay).
+ *
+ * These functions read/write ~/.claude/settings.json via $HOME, so each test
+ * points HOME at a fresh temp dir. persistBedrockClaudeSettings on a CRS box
+ * throws BEFORE any `aws` exec, so no AWS mocking is needed for that path.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  persistBedrockClaudeSettings,
+  clearHardcodedModelsForOAuthClaudeSettings,
+} from '../claude-settings-mode.mjs';
+
+const CRS_BASE = 'http://127.0.0.1:3005/api';
+const CRS_TOKEN = 'cr_deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+
+function withTempHome(initialEnv) {
+  const home = mkdtempSync(join(tmpdir(), 'crs-settings-test-'));
+  mkdirSync(join(home, '.claude'), { recursive: true });
+  writeFileSync(join(home, '.claude', 'settings.json'), JSON.stringify({ env: initialEnv }, null, 2));
+  const prevHome = process.env.HOME;
+  process.env.HOME = home;
+  return {
+    readEnv() {
+      return JSON.parse(readFileSync(join(home, '.claude', 'settings.json'), 'utf8')).env || {};
+    },
+    cleanup() {
+      process.env.HOME = prevHome;
+      rmSync(home, { recursive: true, force: true });
+    },
+  };
+}
+
+test('clearHardcodedModelsForOAuth: preserves CRS relay pair across Bedrock→OAuth flip', () => {
+  const ctx = withTempHome({
+    CLAUDE_CODE_USE_BEDROCK: '1',
+    AWS_REGION: 'us-east-1',
+    ANTHROPIC_MODEL: 'us.anthropic.claude-sonnet-4-6',
+    ANTHROPIC_BASE_URL: CRS_BASE,
+    CLAUDE_CODE_OAUTH_TOKEN: CRS_TOKEN,
+  });
+  try {
+    clearHardcodedModelsForOAuthClaudeSettings();
+    const env = ctx.readEnv();
+    assert.equal(env.ANTHROPIC_BASE_URL, CRS_BASE, 'CRS base URL restored');
+    assert.equal(env.CLAUDE_CODE_OAUTH_TOKEN, CRS_TOKEN, 'CRS token retained');
+    assert.equal('CLAUDE_CODE_USE_BEDROCK' in env, false, 'Bedrock flag cleared');
+    assert.equal('ANTHROPIC_MODEL' in env, false, 'hardcoded model cleared');
+    assert.equal('AWS_REGION' in env, false, 'AWS region cleared');
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('clearHardcodedModelsForOAuth: non-CRS box still strips ANTHROPIC_BASE_URL (regression)', () => {
+  const ctx = withTempHome({
+    CLAUDE_CODE_USE_BEDROCK: '1',
+    ANTHROPIC_BASE_URL: 'https://some-proxy.example/api',
+    CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat-not-a-relay-token',
+    ANTHROPIC_MODEL: 'us.anthropic.claude-sonnet-4-6',
+  });
+  try {
+    clearHardcodedModelsForOAuthClaudeSettings();
+    const env = ctx.readEnv();
+    assert.equal('ANTHROPIC_BASE_URL' in env, false, 'non-cr_ base URL stripped (raw OAuth)');
+    assert.equal('CLAUDE_CODE_USE_BEDROCK' in env, false);
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('persistBedrockClaudeSettings: refuses to flip a CRS-routed box onto Bedrock', () => {
+  const ctx = withTempHome({
+    ANTHROPIC_BASE_URL: CRS_BASE,
+    CLAUDE_CODE_OAUTH_TOKEN: CRS_TOKEN,
+  });
+  try {
+    assert.throws(() => persistBedrockClaudeSettings('us-east-1'), /CRS-routed/, 'throws on CRS box');
+    const env = ctx.readEnv();
+    // settings must be untouched — no Bedrock vars written, CRS pair intact.
+    assert.equal('CLAUDE_CODE_USE_BEDROCK' in env, false, 'no Bedrock flag written');
+    assert.equal(env.ANTHROPIC_BASE_URL, CRS_BASE, 'CRS base URL untouched');
+    assert.equal(env.CLAUDE_CODE_OAUTH_TOKEN, CRS_TOKEN, 'CRS token untouched');
+  } finally {
+    ctx.cleanup();
+  }
+});
+
+test('persistBedrockClaudeSettings: CLAUDE_ALLOW_BEDROCK_OVER_CRS=1 overrides the refusal', () => {
+  const ctx = withTempHome({
+    ANTHROPIC_BASE_URL: CRS_BASE,
+    CLAUDE_CODE_OAUTH_TOKEN: CRS_TOKEN,
+  });
+  const prev = process.env.CLAUDE_ALLOW_BEDROCK_OVER_CRS;
+  const prevSkip = process.env.BEDROCK_SKIP_RESOLVE;
+  process.env.CLAUDE_ALLOW_BEDROCK_OVER_CRS = '1';
+  process.env.BEDROCK_SKIP_RESOLVE = '1'; // avoid live `aws bedrock` calls in CI
+  try {
+    persistBedrockClaudeSettings('us-east-1');
+    const env = ctx.readEnv();
+    assert.equal(env.CLAUDE_CODE_USE_BEDROCK, '1', 'override allows Bedrock flip');
+    assert.equal('ANTHROPIC_BASE_URL' in env, false, 'base URL dropped when overridden onto Bedrock');
+  } finally {
+    if (prev === undefined) delete process.env.CLAUDE_ALLOW_BEDROCK_OVER_CRS;
+    else process.env.CLAUDE_ALLOW_BEDROCK_OVER_CRS = prev;
+    if (prevSkip === undefined) delete process.env.BEDROCK_SKIP_RESOLVE;
+    else process.env.BEDROCK_SKIP_RESOLVE = prevSkip;
+    ctx.cleanup();
+  }
+});

--- a/claude-ops/scripts/account-rotation/__tests__/claude-settings-mode-crs.test.mjs
+++ b/claude-ops/scripts/account-rotation/__tests__/claude-settings-mode-crs.test.mjs
@@ -18,10 +18,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'nod
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import {
-  persistBedrockClaudeSettings,
-  clearHardcodedModelsForOAuthClaudeSettings,
-} from '../claude-settings-mode.mjs';
+import { persistBedrockClaudeSettings, clearHardcodedModelsForOAuthClaudeSettings } from '../claude-settings-mode.mjs';
 
 const CRS_BASE = 'http://127.0.0.1:3005/api';
 const CRS_TOKEN = 'cr_deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';

--- a/claude-ops/scripts/account-rotation/claude-settings-mode.mjs
+++ b/claude-ops/scripts/account-rotation/claude-settings-mode.mjs
@@ -31,9 +31,7 @@ function isCrsToken(t) {
 function detectCrsRouting(env) {
   const token = env.CLAUDE_CODE_OAUTH_TOKEN;
   const base = env.ANTHROPIC_BASE_URL;
-  return isCrsToken(token) && typeof base === 'string' && base.length > 0
-    ? { token, base }
-    : null;
+  return isCrsToken(token) && typeof base === 'string' && base.length > 0 ? { token, base } : null;
 }
 
 function readSettings() {

--- a/claude-ops/scripts/account-rotation/claude-settings-mode.mjs
+++ b/claude-ops/scripts/account-rotation/claude-settings-mode.mjs
@@ -15,6 +15,27 @@ function claudeSettingsPath() {
   return join(process.env.HOME || '', '.claude', 'settings.json');
 }
 
+// ── CRS (Claude Relay Service) routing awareness ───────────────────────────────
+// When a box routes through CRS, ANTHROPIC_BASE_URL points at the local relay
+// (e.g. http://127.0.0.1:3005/api) and CLAUDE_CODE_OAUTH_TOKEN holds a static
+// `cr_…` relay token. Both must travel together — a `cr_` token with no base URL
+// 401s. The Bedrock/OAuth settings mutators below were written for the raw-OAuth /
+// Bedrock world and would silently strip ANTHROPIC_BASE_URL, stranding a CRS box.
+// These helpers detect that routing and snapshot/restore the pair so a mode flip
+// never breaks (or money-leaks past) a CRS-routed fleet.
+function isCrsToken(t) {
+  return typeof t === 'string' && t.startsWith('cr_');
+}
+
+/** True when settings.env is wired for CRS relay routing (cr_ token + base URL). */
+function detectCrsRouting(env) {
+  const token = env.CLAUDE_CODE_OAUTH_TOKEN;
+  const base = env.ANTHROPIC_BASE_URL;
+  return isCrsToken(token) && typeof base === 'string' && base.length > 0
+    ? { token, base }
+    : null;
+}
+
 function readSettings() {
   try {
     return JSON.parse(readFileSync(claudeSettingsPath(), 'utf8'));
@@ -228,6 +249,19 @@ export function resolveBedrockClaudeModelIds(region = 'us-east-1') {
 
 /** Match use-bedrock.sh: Bedrock env + strip top-level model lists (OAuth catalog ids break Bedrock). */
 export function persistBedrockClaudeSettings(region = 'us-east-1') {
+  const s0 = readSettings();
+  const env0 = s0.env && typeof s0.env === 'object' ? s0.env : {};
+  // Defense-in-depth behind the activateBedrockFallback kill-switch: a CRS-routed
+  // box must NEVER be flipped onto metered Bedrock — the free relay pool already
+  // multiplexes every Max account. Refuse loudly so callers' try/catch logs a
+  // failure instead of silently claiming "Bedrock active" + money-leaking.
+  // Override with CLAUDE_ALLOW_BEDROCK_OVER_CRS=1 if ever genuinely intended.
+  if (detectCrsRouting(env0) && process.env.CLAUDE_ALLOW_BEDROCK_OVER_CRS !== '1') {
+    throw new Error(
+      'refusing Bedrock flip: box is CRS-routed (cr_ token + ANTHROPIC_BASE_URL). ' +
+        'CRS pool already covers capacity; Bedrock is metered. Set CLAUDE_ALLOW_BEDROCK_OVER_CRS=1 to override.',
+    );
+  }
   const { primary, small, opus, fable } = resolveBedrockClaudeModelIds(region);
   const aws = resolveWorkingAwsEnv(region);
   const s = readSettings();
@@ -262,6 +296,12 @@ export function persistBedrockClaudeSettings(region = 'us-east-1') {
 export function clearHardcodedModelsForOAuthClaudeSettings() {
   const s = readSettings();
   const env = s.env && typeof s.env === 'object' ? { ...s.env } : {};
+  // Preserve CRS relay routing across the flip: a `cr_` token + ANTHROPIC_BASE_URL
+  // must survive together. The generic clear below strips ANTHROPIC_BASE_URL (it
+  // assumes raw OAuth, where base-url must be absent), which on a CRS box would
+  // leave the cr_ token pointing at api.anthropic.com → 401, killing the relay.
+  // Snapshot the pair before clearing, then restore it.
+  const crs = detectCrsRouting(env);
   for (const k of [
     'CLAUDE_CODE_USE_BEDROCK',
     'AWS_BEDROCK_REGION',
@@ -277,6 +317,11 @@ export function clearHardcodedModelsForOAuthClaudeSettings() {
     'ANTHROPIC_DEFAULT_FABLE_MODEL',
   ]) {
     delete env[k];
+  }
+  if (crs) {
+    // Restore the relay pair so the box keeps routing through CRS, not raw OAuth.
+    env.ANTHROPIC_BASE_URL = crs.base;
+    env.CLAUDE_CODE_OAUTH_TOKEN = crs.token;
   }
   s.env = env;
   delete s.model;

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -735,6 +735,22 @@ function stopClaudeDaemon() {
 // Cannot mutate env of an already-running session — user must start a new
 // one with `source ~/.claude/scripts/account-rotation/use-bedrock.sh`.
 async function activateBedrockFallback(reason, dryRun = false) {
+  // Kill-switch — mirror daemon.mjs activateBedrockFallbackFromDaemon (disabled
+  // 2026-05-08, Max/CRS plan handles capacity; Bedrock is metered AWS = $600-1.2k/mo
+  // bleed). BLOCKED by default; set CLAUDE_DISABLE_BEDROCK_FALLBACK=0 to re-enable.
+  // Authoritative here regardless of caller so the rotate path can never silently
+  // flip a CRS/Max-routed box onto metered Bedrock (the bedrockOnExhausted opt
+  // defaults ON, unlike the daemon — this is the backstop).
+  if (process.env.CLAUDE_DISABLE_BEDROCK_FALLBACK !== '0') {
+    log(`[bedrock-fallback] BLOCKED by CLAUDE_DISABLE_BEDROCK_FALLBACK (reason was: ${reason})`);
+    if (!dryRun) {
+      notify(
+        'Bedrock Fallback BLOCKED',
+        'Kill-switch active — Max/CRS-only mode. Wait for reset window or rotate manually.',
+      );
+    }
+    return false;
+  }
   const region = process.env.AWS_BEDROCK_REGION || 'us-east-1';
   const result = checkBedrockAvailable(region);
   const sentinel = join(process.env.HOME || '', '.claude', '.bedrock-fallback.json');


### PR DESCRIPTION
## Summary

Closes two **CRITICAL** money-leak defects in the account-rotation path that let a CRS/Max-routed box silently fall onto **metered AWS Bedrock** (~\$600–1.2k/mo bleed). The free CRS relay pool already multiplexes every Max-20x account, so Bedrock spend here is pure waste.

Found during the fleet token-quota / 401 / rate-limit audit. The live leak was already remediated on the box; this is the durable source-of-truth fix.

## Defects fixed

**1. `rotate.mjs` `activateBedrockFallback()` had no kill-switch.**
Its daemon twin (`activateBedrockFallbackFromDaemon`) blocks Bedrock unless `CLAUDE_DISABLE_BEDROCK_FALLBACK==='0'`. The rotate path was gated only by the `bedrockOnExhausted` option — which **defaults ON**, the opposite of the daemon. Added the same guard, authoritative regardless of caller, as the backstop so the rotate path can never flip a CRS box onto Bedrock.

**2. `claude-settings-mode.mjs` was CRS-unaware.**
Both `persistBedrockClaudeSettings` and `clearHardcodedModelsForOAuthClaudeSettings` delete `ANTHROPIC_BASE_URL` (correct for raw OAuth, fatal for CRS) and never restored the `cr_` token + base-URL pair. After a Bedrock→OAuth flip a CRS box kept the `cr_` token but lost the base URL → **401 against api.anthropic.com**, taking the relay down.
- Added `isCrsToken` / `detectCrsRouting` helpers.
- `persistBedrockClaudeSettings` now **refuses** a CRS-routed box (override with `CLAUDE_ALLOW_BEDROCK_OVER_CRS=1`).
- `clearHardcodedModelsForOAuthClaudeSettings` snapshots and restores the relay pair so the box keeps routing through CRS, not raw OAuth.

## Tests

New `__tests__/claude-settings-mode-crs.test.mjs` (4 tests, `node --test`):
- CRS-refusal in `persistBedrockClaudeSettings` (+ untouched settings on refusal)
- `CLAUDE_ALLOW_BEDROCK_OVER_CRS=1` override path
- relay-pair preservation across a Bedrock→OAuth flip
- non-CRS regression (raw OAuth still strips `ANTHROPIC_BASE_URL`)

Full rotation suite: **83 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes account-rotation and ~/.claude/settings.json auth routing with billing impact; mis-set env overrides could block intended Bedrock or leave CRS misconfigured.
> 
> **Overview**
> Stops CRS/Max-routed fleet boxes from silently switching to **metered Bedrock** and from breaking **CRS relay** settings during OAuth/Bedrock mode flips.
> 
> **`rotate.mjs`:** `activateBedrockFallback` now honors the same **`CLAUDE_DISABLE_BEDROCK_FALLBACK`** kill-switch as the daemon (blocked unless `=0`), with logging/notification instead of proceeding.
> 
> **`claude-settings-mode.mjs`:** Adds **`detectCrsRouting`** (`cr_` token + `ANTHROPIC_BASE_URL`). **`persistBedrockClaudeSettings`** throws on CRS-routed configs (override via **`CLAUDE_ALLOW_BEDROCK_OVER_CRS=1`**). **`clearHardcodedModelsForOAuthClaudeSettings`** snapshots and restores the CRS relay pair so Bedrock→OAuth no longer strips the base URL.
> 
> **Tests:** New **`claude-settings-mode-crs.test.mjs`** covers refusal, override, relay preservation, and non-CRS regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3326d2b45f782f68163d9796b5eec782e93a89b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CRS (Cloud Relay Service) detection to prevent incompatible authentication mode switches
  * CRS relay settings are now preserved during authentication changes
  * New `CLAUDE_ALLOW_BEDROCK_OVER_CRS` flag to override CRS protection when needed
  * New `CLAUDE_DISABLE_BEDROCK_FALLBACK` flag to disable Bedrock fallback activation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->