### PR TITLE
fix(rotation): invalidate stored OAuth token on 401 from /oauth/usage

### DIFF
--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -390,6 +390,14 @@ async function queryAllUtilization(config) {
         fetchWithRetry('https://api.anthropic.com/api/oauth/profile'),
       ]);
 
+      // 401 = the stored token is revoked/expired. Drop it from the vault so we
+      // stop polling a dead token every tick and the next rotation re-acquires.
+      if (usageRes.status === 401) {
+        log(`[query] Account ${a.email || accountKey(a)} returned 401 on /oauth/usage — invalidating stored token`);
+        deleteStoredToken(a);
+        return null;
+      }
+
       if (!usageRes.ok) return null;
       const data = await usageRes.json();
       let extraUsageEnabled = null;
@@ -908,6 +916,29 @@ function readStoredToken(account) {
 
 function writeStoredToken(account, json) {
   writeKeychain(json, tokenService(account));
+}
+
+// Remove an account's stored OAuth token from the local vault (keychain entry
+// on macOS, the JSON cred store on Linux). Called when Anthropic returns 401 on
+// /oauth/usage — the token is revoked/expired, so polling it again just wastes a
+// round-trip and lets a dead account silently fail every tick. Dropping it forces
+// the next rotation to re-acquire a fresh token instead of retrying a dead one
+// forever. Best-effort: a missing entry is not an error.
+function deleteStoredToken(account) {
+  const svc = tokenService(account);
+  if (IS_LINUX) {
+    try {
+      const store = JSON.parse(readFileSync(LINUX_CRED_PATH, 'utf8'));
+      delete store[svc];
+      writeFileSync(LINUX_CRED_PATH, JSON.stringify(store, null, 2), { mode: 0o600 });
+    } catch {}
+    return;
+  }
+  try {
+    execFileSync('security', ['delete-generic-password', '-s', svc, '-a', VAULT_KEYCHAIN_ACCOUNT], {
+      stdio: 'ignore',
+    });
+  } catch {}
 }
 
 function hasStoredToken(account) {


### PR DESCRIPTION
## What

Ports the **401-token-invalidation** behavior that exists only in the *live deployed* `~/.claude/scripts/account-rotation/rotate.mjs` into the **tracked** source. This is the genuinely-live-only behavior surfaced by the deploy↔git drift audit.

## Why

Tracked `rotate.mjs` had **zero 401 handling** (`grep -n 401 rotate.mjs` → empty). The per-account `/oauth/usage` utilization poll in `queryAllUtilization` would re-poll a **revoked/expired token every tick forever** — a dead account silently fails each utilization query and is never re-acquired. The live box already fixed this; the tracked source regressed because the two copies drifted (tracked surpassed live on most axes — CRS-awareness, `redactSecrets`, SDK-credit tier — but live kept this one behavior).

Directly serves the fleet-stability goal: prevent 401/quota states from silently degrading the rotation pool.

## Changes

- **`deleteStoredToken(account)`** — drops the account's vault entry (macOS `security delete-generic-password`; Linux JSON cred store at `LINUX_CRED_PATH`), mirroring the existing `writeKeychain` `IS_LINUX` branching. Best-effort; a missing entry is not an error.
- **401 guard in `queryAccount`** — on `usageRes.status === 401`: log + `deleteStoredToken(a)` + `return null`, so the next rotation re-acquires a fresh token instead of retrying a dead one.

## Explicitly NOT ported

- `injectLoginToGhostty` (live-only) — **superseded** by tracked's generic `detectTerminalForPid` (covers Ghostty/iTerm2/Terminal/Alacritty/WezTerm/kitty). No regression.
- No wholesale file overwrite — tracked's `redactSecrets`, SDK-credit tier, and `CONFIG_USER_PATH` (all absent from the older live fork) are preserved.

## Testing

`rotate.mjs` is a non-importable CLI entrypoint — it has **zero exports** and runs `ensureMCPServersAndTools()` + CLI arg dispatch at top-level on import, so its internals are not unit-tested by convention (no existing test touches `writeKeychain`/`tokenService`/etc.). Making `deleteStoredToken` importable would require wrapping both top-level side-effects in an `import.meta` main-guard — an invasive refactor of money/auth-critical startup code, out of scope here.

Gated instead by:
- `node --check scripts/account-rotation/rotate.mjs` → **OK**
- Full rotation test suite (per-file; dir-glob gives a false single-fail): **79/79 pass, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, defensive change to OAuth vault cleanup on explicit 401; mirrors existing daemon logic and does not alter rotation selection or token write paths beyond removing dead entries.
> 
> **Overview**
> Adds **401 handling** to tracked `rotate.mjs` so utilization polling matches the behavior already in `daemon.mjs` and the live-deployed rotator.
> 
> When **`/oauth/usage` returns 401**, `queryAccount` now logs, calls new **`deleteStoredToken`**, and returns `null` instead of treating the account as a perpetual failed query. **`deleteStoredToken`** removes the per-account vault entry (macOS keychain via `security delete-generic-password`, Linux via `~/.claude/.credentials.json`), using the same `IS_LINUX` / `tokenService` pattern as `writeStoredToken`. Deletion is best-effort so a missing entry is not an error.
> 
> **Effect:** revoked or expired vault tokens are dropped from the pool; the next rotation can re-acquire via `swapToken` / browser OAuth instead of silently failing every tick.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76fcd11cec006c815267d68d994456459c5b34b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->