### PR TITLE
fix(rotation): reconcile box-live behaviors into tracked daemon (clean superset)

### DIFF
--- a/claude-ops/scripts/account-rotation/daemon.mjs
+++ b/claude-ops/scripts/account-rotation/daemon.mjs
@@ -393,7 +393,10 @@ async function detectLiveAccountFromVault(config) {
 // ── Real utilization from Anthropic (via statusline export) ──────────────────
 
 const RATE_LIMITS_FILE = join(__dirname, '.rate-limits.json');
-const UTILIZATION_ROTATE_THRESHOLD = 95; // Rotate when near exhaustion
+const UTILIZATION_ROTATE_THRESHOLD = 90; // Rotate at 90% — 95%+ is always too late: Claude
+// surfaces its own limit warnings ~75%, and an in-flight session crossing ~95% is already
+// throttling before the daemon can rescue it. Destination viability bars (DAEMON_SAFE_*=95/94)
+// stay ABOVE this so there is always a cooler account to land on. (owner directive 2026-06-13.)
 
 function readRealUtilization() {
   try {
@@ -437,9 +440,9 @@ function checkRateLimited() {
         utilization: real,
       };
     }
-    // 7d weekly cap — also rotate at 80% (was 95%, but Claude itself surfaces
-    // the warning at ~75%, so 95% is too late and the active session sees
-    // "you've used X% of your weekly limit" before the daemon acts).
+    // 7d weekly cap — same 90% trigger (UTILIZATION_ROTATE_THRESHOLD). Claude surfaces
+    // its weekly-limit warning at ~75%, so anything ≥95% is too late: the active session
+    // sees "you've used X% of your weekly limit" before the daemon can act.
     if (pct7d >= UTILIZATION_ROTATE_THRESHOLD) {
       return {
         limited: true,
@@ -1257,6 +1260,9 @@ async function dynamicRefresh(config, state) {
   for (const account of config.accounts) {
     const key = accountKey(account);
     if (key === state.activeAccount) continue; // Don't refresh active account mid-session
+    if (account.disabled === true) continue; // hands-off: a disabled account is owned
+    // elsewhere (e.g. a CRS relay pool). Refreshing its OAuth token rotates the
+    // refresh token and INVALIDATES the copy CRS holds → CRS "Invalid API key" 401s.
 
     const tokenJson = readStoredToken(account);
     if (!tokenJson) continue;


### PR DESCRIPTION
## What

The Frankfurt box (`dev-sandbox-fra`) was running a **forked** `daemon.mjs` (108 lines behind tracked) that carried three live-only behaviors never upstreamed — a genuine **bidirectional fork** (neither side a superset). This makes tracked a clean superset so **the box can track git again**, ending the fork.

## Reconcile direction (verified, not assumed)

`origin/main`'s `daemon.mjs` already **supersedes** almost everything the fork had:
- bedrock-watchdog wiring (`sweepBedrockSessions`/`verifyBedrockSwaps`, 45s sweep)
- 401 token-invalidation (#590-era)
- `isLoopSession` busy/loop respawn defer
- active-account self-probe rotation trigger
- settings.json effective-Bedrock detection
- label sanitization (`account-main`, `owner`)

…and **deliberately removed** two fork behaviors that newer directives override:
- `--session` `/login` injection — removed in #582/#586 (2026-06-14, *newer* than the fork's 2026-06-13 `--session`). Background rotation must never inject `/login` into running sessions.
- `checkFleetStuckAgents` (fleet-recovery) — **dormant on the box**: the systemd unit sets only `ALLOW_EXTRA_USAGE=1`; none of the `CLAUDE_ENABLE_FLEET_RECOVERY` / `_BG_RESPAWN` / `_BG_SESSION_ROUTER` gates are set. `fleet-recovery.mjs` is not tracked. Porting it back would regress.

So this lands **only the two non-superseded functional wins** (10 insertions, 4 deletions):

### 1. `dynamicRefresh()` skips `account.disabled === true`
A disabled account is owned elsewhere (a **CRS relay pool**). Refreshing its OAuth token rotates the refresh token and **invalidates the copy CRS holds** → CRS `"Invalid API key"` 401 storms. This guard never existed in tracked.

### 2. `UTILIZATION_ROTATE_THRESHOLD` 95 → 90 (owner directive 2026-06-13)
95%+ is always too late — Claude surfaces its own limit warnings ~75%, and an in-flight session crossing ~95% is already throttling before the daemon can rescue it. The `DAEMON_SAFE_*`=95/94 destination-viability bars stay **above** 90, so there is always a cooler account to land on. The stale 7d-cap comment ("80%") is corrected to match.

## Validation
- `node --check claude-ops/scripts/account-rotation/daemon.mjs` → OK
- account-rotation test suite: **79/79 pass** (`bedrock-watchdog` 5, `claude-p-as` 26, `daily-credit-digest` 26, `monthly-credit-reclaim` 9, `inject-continuation` 1, `provider-env` 12)

## Not in scope
Does **not** merge — review first. Box redeploy (so it tracks git) is a follow-up once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when the daemon rotates active sessions and whether vault tokens refresh for disabled accounts—both affect live Claude usage and external CRS auth, but the diff is small and aligned with existing rotation policy.
> 
> **Overview**
> Upstreams two behaviors from the Frankfurt box fork into tracked `daemon.mjs` so the host can follow git again.
> 
> **Utilization rotation** now fires at **90%** for both 5h and 7d caps (`UTILIZATION_ROTATE_THRESHOLD` was 95%). Comments document that Claude warns around ~75% and sessions are often already throttling near 95% before a rescue swap. Destination viability bars (`DAEMON_SAFE_*` at 95/94) stay above 90% so cooler targets should still exist. The 7d comment no longer implies a separate 80% trigger.
> 
> **Dynamic OAuth refresh** skips accounts with `disabled === true`. Those accounts may be owned by an external CRS relay pool; refreshing rotates the refresh token and can invalidate CRS’s copy, causing **Invalid API key** 401s. Rotation paths already excluded disabled accounts; this closes the gap in `dynamicRefresh()` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42fb9de6c535014154736db3b2ac84b6775aad2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Account rotation now triggers earlier to ensure viable backup accounts remain available during periods of high system utilization and peak demand.
  * Rate limit detection logic has been refined to apply consistent thresholds across different utilization measurement windows, improving rotation decisions.
  * Token refresh handling now skips disabled accounts to prevent unnecessary token invalidation for accounts not in active service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->