### PR TITLE
V3 SLICE 1: cross-OS compat fixes (detect JSON bug, profile_file, channel OS-gates, statusline Max badge)

### DIFF
--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -60,7 +60,8 @@ Per-repo budget caps (default 3/hour), single-flight locks, content-hash dedup, 
 | ------------------- | --------------------------------------------------------------------------------- |
 | `/ops`              | Interactive command center dashboard (visual HQ)                                  |
 | `/ops:dash`         | Same as `/ops` — pixel-art dashboard with hotkey navigation                       |
-| `ops-healify-dash`  | Dedicated Healify.ai KPI, infra, repo, agent, MCP, and plugin command center      |
+| `ops-healify-dash`  | Dedicated Healify.ai KPI, growth, App Store, reliability, infra, repo, agent, MCP, and plugin command center |
+| `ops-healify-bi-refresh` | Warms the Healify BI cache used by `ops-healify-dash` from EAS, ASC, AppsFlyer, Amplitude, Sentry, BetterStack, Linear, QA, and ops-dashboard sources |
 | `/ops:setup`        | Interactive setup wizard — installs CLIs, configures channels, builds registry    |
 | `/ops:go`           | Morning briefing — all systems in one dashboard                                   |
 | `/ops:next`         | Priority-ordered next action (fires > comms > PRs > sprint > GSD)                 |

--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -60,6 +60,7 @@ Per-repo budget caps (default 3/hour), single-flight locks, content-hash dedup, 
 | ------------------- | --------------------------------------------------------------------------------- |
 | `/ops`              | Interactive command center dashboard (visual HQ)                                  |
 | `/ops:dash`         | Same as `/ops` — pixel-art dashboard with hotkey navigation                       |
+| `ops-healify-dash`  | Dedicated Healify.ai KPI, infra, repo, agent, MCP, and plugin command center      |
 | `/ops:setup`        | Interactive setup wizard — installs CLIs, configures channels, builds registry    |
 | `/ops:go`           | Morning briefing — all systems in one dashboard                                   |
 | `/ops:next`         | Priority-ordered next action (fires > comms > PRs > sprint > GSD)                 |

--- a/claude-ops/assets/healify-pixel-logo.svg
+++ b/claude-ops/assets/healify-pixel-logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="1024" height="1024" shape-rendering="crispEdges">
+  <rect width="16" height="16" rx="3" fill="#ff8a2a"/>
+  <path fill="#ff5f86" d="M0 5h1v11H0zM1 8h1v8H1zM2 10h1v6H2zM3 12h1v4H3zM4 13h1v3H4zM5 14h1v2H5zM6 15h1v1H6z"/>
+  <path fill="#ffb25f" d="M8 0h8v16H8z"/>
+  <path fill="#ff7b3a" d="M8 6h8v10H8z"/>
+  <path fill="#fff8ef" d="M2 2h2v1h1v1h1v1h1v1h1v1H7v1H6v1H5v1H4V9H3V8H2V7H1V4h1zM10 2h2v1h1v1h1v3h-1v1h-1v1h-1v1h-1V9H9V8H8V7H7V6h1V5h1V4h1z"/>
+  <path fill="#ef553f" d="M7 6h2v1h2v1h1v1h-1v1h-1v1H9v1H8v1H7v-1H6v-1H5v-1h1V9h1V8h1V7H7z"/>
+</svg>

--- a/claude-ops/bin/ops-dash
+++ b/claude-ops/bin/ops-dash
@@ -11,6 +11,10 @@ PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 . "${PLUGIN_ROOT}/lib/registry-resolve.sh"
 PREFS="${OPS_DATA_DIR}/preferences.json"
 
+if [[ "${OPS_HEALIFY_DASH:-0}" == "1" && -x "${PLUGIN_ROOT}/bin/ops-healify-dash" ]]; then
+  exec "${PLUGIN_ROOT}/bin/ops-healify-dash" "$@"
+fi
+
 # ── Mobile / SSH detection (Rule 7) ─────────────────────────────────────────
 MOBILE_MODE=0
 if [[ -n "${SSH_CONNECTION:-}${SSH_CLIENT:-}${SSH_TTY:-}" || "${OPS_MOBILE:-}" == "1" ]]; then

--- a/claude-ops/bin/ops-healify-bi-refresh
+++ b/claude-ops/bin/ops-healify-bi-refresh
@@ -21,10 +21,15 @@ if command -v eas >/dev/null 2>&1 && [[ -d "$HEALIFY_APP" ]]; then
 fi
 
 sentry_json='{"ok":false,"note":"sentry-cli unavailable","projects":[]}'
-if command -v sentry-cli >/dev/null 2>&1; then
+SENTRY_ORG="${SENTRY_ORG:-}"
+SENTRY_PROJECTS="${SENTRY_PROJECTS:-}"
+if command -v sentry-cli >/dev/null 2>&1 && [[ -n "$SENTRY_ORG" && -n "$SENTRY_PROJECTS" ]]; then
   sentry_json="$(
-    for project in healify-api healify-mobile healify-admin; do
-      out="$(timeout 25 sentry-cli issues list --org healify --project "$project" --query 'is:unresolved' 2>&1 || true)"
+    IFS=',' read -ra projects <<< "$SENTRY_PROJECTS"
+    for project in "${projects[@]}"; do
+      project="${project//[[:space:]]/}"
+      [[ -n "$project" ]] || continue
+      out="$(timeout 25 sentry-cli issues list --org "$SENTRY_ORG" --project "$project" --query 'is:unresolved' 2>&1 || true)"
       if printf '%s' "$out" | grep -qi 'No issues found'; then
         jq -nc --arg project "$project" '{project:$project,ok:true,unresolved:0,highPriority:0,note:"No unresolved issues"}'
       elif printf '%s' "$out" | grep -qi 'error\|unauthorized\|forbidden\|not found'; then
@@ -36,6 +41,8 @@ if command -v sentry-cli >/dev/null 2>&1; then
       fi
     done | jq -sc '{ok:true,projects:.}'
   )"
+elif command -v sentry-cli >/dev/null 2>&1; then
+  sentry_json='{"ok":false,"note":"SENTRY_ORG and SENTRY_PROJECTS env vars required","projects":[]}'
 fi
 
 opdash_json='{"ok":false,"note":"operating dashboard source probe unavailable"}'
@@ -73,9 +80,12 @@ except Exception as exc:
     print(json.dumps({"ok": False, "note": f"PyJWT unavailable: {exc}", "apps": []}))
     sys.exit(0)
 
-APP_IDS = ["6746675266", "6751717479"]
-KEY_ID = os.environ.get("APP_STORE_CONNECT_API_KEY_ID") or os.environ.get("APP_STORE_CONNECT_KEY_ID") or "22C7Z973Z3"
-ISSUER_ID = os.environ.get("APP_STORE_CONNECT_ISSUER_ID") or "6a7e769c-e3f3-4198-b152-960c60a27295"
+APP_IDS = [a.strip() for a in os.environ.get("APP_STORE_CONNECT_APP_IDS", "").split(",") if a.strip()]
+KEY_ID = os.environ.get("APP_STORE_CONNECT_API_KEY_ID") or os.environ.get("APP_STORE_CONNECT_KEY_ID") or ""
+ISSUER_ID = os.environ.get("APP_STORE_CONNECT_ISSUER_ID") or ""
+if not APP_IDS or not KEY_ID or not ISSUER_ID:
+    print(json.dumps({"ok": False, "note": "Set APP_STORE_CONNECT_APP_IDS, APP_STORE_CONNECT_API_KEY_ID, and APP_STORE_CONNECT_ISSUER_ID env vars", "apps": []}))
+    sys.exit(0)
 KEY_PATH = os.environ.get("APP_STORE_CONNECT_API_KEY_PATH") or os.path.expanduser(f"~/.fastlane/app_store_connect/AuthKey_{KEY_ID}.p8")
 
 def token():

--- a/claude-ops/bin/ops-healify-bi-refresh
+++ b/claude-ops/bin/ops-healify-bi-refresh
@@ -27,7 +27,7 @@ if command -v sentry-cli >/dev/null 2>&1; then
       out="$(timeout 25 sentry-cli issues list --org healify --project "$project" --query 'is:unresolved' 2>&1 || true)"
       if printf '%s' "$out" | grep -qi 'No issues found'; then
         jq -nc --arg project "$project" '{project:$project,ok:true,unresolved:0,highPriority:0,note:"No unresolved issues"}'
-      elif printf '%s' "$out" | grep -qi 'error\\|unauthorized\\|forbidden\\|not found'; then
+      elif printf '%s' "$out" | grep -qi 'error\|unauthorized\|forbidden\|not found'; then
         note="$(printf '%s' "$out" | sed -n '1,2p' | tr '\n' ' ' | sed 's/"/'\''/g')"
         jq -nc --arg project "$project" --arg note "$note" '{project:$project,ok:false,unresolved:null,highPriority:null,note:$note}'
       else
@@ -117,12 +117,23 @@ except Exception as exc:
 PY
 )"
 
-jq -nc \
+isjson() { printf '%s' "$1" | jq empty >/dev/null 2>&1; }
+isjson "$eas_json" || eas_json='{"ok":false,"note":"invalid EAS JSON","builds":[]}'
+isjson "$sentry_json" || sentry_json='{"ok":false,"note":"invalid Sentry JSON","projects":[]}'
+isjson "$opdash_json" || opdash_json='{"ok":false,"note":"invalid opdash JSON"}'
+isjson "$asc_extra_json" || asc_extra_json='{"ok":false,"note":"invalid ASC JSON","apps":[]}'
+
+if jq -nc \
   --arg generatedAt "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
   --argjson eas "$eas_json" \
   --argjson sentry "$sentry_json" \
   --argjson opdash "$opdash_json" \
   --argjson ascExtra "$asc_extra_json" \
-  '{generatedAt:$generatedAt,eas:$eas,sentry:$sentry,opdash:$opdash,ascExtra:$ascExtra}' >"$TMP"
-mv "$TMP" "$OUT"
-printf '%s\n' "$OUT"
+  '{generatedAt:$generatedAt,eas:$eas,sentry:$sentry,opdash:$opdash,ascExtra:$ascExtra}' >"$TMP"; then
+  mv "$TMP" "$OUT"
+  printf '%s\n' "$OUT"
+else
+  rm -f "$TMP"
+  printf 'healify-bi refresh: merge failed; keeping existing cache at %s\n' "$OUT" >&2
+  exit 1
+fi

--- a/claude-ops/bin/ops-healify-bi-refresh
+++ b/claude-ops/bin/ops-healify-bi-refresh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+CACHE_DIR="${HEALIFY_BI_CACHE_DIR:-$HOME/.cache/agent-hub}"
+OUT="$CACHE_DIR/healify-bi.json"
+TMP="$OUT.tmp"
+HEALIFY_APP="${HEALIFY_APP_ROOT:-$HOME/Projects/healify-workspace/healify}"
+OPDASH="${HEALIFY_OPDASH_ROOT:-$HOME/Projects/healify-workspace/healify-operating-dashboard}"
+
+mkdir -p "$CACHE_DIR"
+
+eas_json='{"ok":false,"note":"EAS CLI unavailable or not authenticated","builds":[]}'
+if command -v eas >/dev/null 2>&1 && [[ -d "$HEALIFY_APP" ]]; then
+  eas_raw="$(cd "$HEALIFY_APP" && timeout 60 eas build:list --platform ios --limit 8 --json --non-interactive 2>/tmp/healify-eas.err || true)"
+  if printf '%s' "$eas_raw" | jq -e 'type=="array"' >/dev/null 2>&1; then
+    eas_json="$(printf '%s' "$eas_raw" | jq -c '{ok:true, builds:[.[] | {id,status,platform,profile,appVersion,appBuildVersion,createdAt,updatedAt,distribution}] }')"
+  else
+    eas_err="$(sed -n '1,4p' /tmp/healify-eas.err 2>/dev/null | tr '\n' ' ' | sed 's/"/'\''/g')"
+    eas_json="$(jq -nc --arg note "${eas_err:-EAS build list returned no JSON}" '{ok:false,note:$note,builds:[]}')"
+  fi
+fi
+
+sentry_json='{"ok":false,"note":"sentry-cli unavailable","projects":[]}'
+if command -v sentry-cli >/dev/null 2>&1; then
+  sentry_json="$(
+    for project in healify-api healify-mobile healify-admin; do
+      out="$(timeout 25 sentry-cli issues list --org healify --project "$project" --query 'is:unresolved' 2>&1 || true)"
+      if printf '%s' "$out" | grep -qi 'No issues found'; then
+        jq -nc --arg project "$project" '{project:$project,ok:true,unresolved:0,highPriority:0,note:"No unresolved issues"}'
+      elif printf '%s' "$out" | grep -qi 'error\\|unauthorized\\|forbidden\\|not found'; then
+        note="$(printf '%s' "$out" | sed -n '1,2p' | tr '\n' ' ' | sed 's/"/'\''/g')"
+        jq -nc --arg project "$project" --arg note "$note" '{project:$project,ok:false,unresolved:null,highPriority:null,note:$note}'
+      else
+        rows="$(printf '%s\n' "$out" | sed '/^$/d' | grep -Ev '^(Issue|ID|\\-)' | wc -l | awk '{print $1}')"
+        jq -nc --arg project "$project" --argjson rows "${rows:-0}" '{project:$project,ok:true,unresolved:$rows,highPriority:null,note:"issues listed by sentry-cli"}'
+      fi
+    done | jq -sc '{ok:true,projects:.}'
+  )"
+fi
+
+opdash_json='{"ok":false,"note":"operating dashboard source probe unavailable"}'
+if [[ -d "$OPDASH" ]] && command -v npx >/dev/null 2>&1; then
+  opdash_raw="$(
+    cd "$OPDASH" && timeout 120 npx tsx -e '
+      import { fetchAppStoreConnect } from "./server/sources/appstore";
+      import { fetchAmplitude } from "./server/sources/amplitude";
+      import { fetchOpsIntegrations } from "./server/sources/ops-integrations";
+      async function main() {
+        const out = { ok: true, generatedAt: new Date().toISOString(), appstore: await fetchAppStoreConnect(), amplitude: await fetchAmplitude(), ops: await fetchOpsIntegrations() };
+        console.log(JSON.stringify(out));
+      }
+      main().catch((e) => {
+        console.log(JSON.stringify({ ok: false, note: String(e?.message || e).slice(0, 400) }));
+      });
+    ' 2>/tmp/healify-opdash.err || true
+  )"
+  if printf '%s' "$opdash_raw" | jq -e 'type=="object"' >/dev/null 2>&1; then
+    opdash_json="$opdash_raw"
+  else
+    opdash_err="$(sed -n '1,4p' /tmp/healify-opdash.err 2>/dev/null | tr '\n' ' ' | sed 's/"/'\''/g')"
+    opdash_json="$(jq -nc --arg note "${opdash_err:-operating dashboard source probe returned no JSON}" '{ok:false,note:$note}')"
+  fi
+fi
+
+asc_extra_json="$(
+python3 - <<'PY'
+import json, os, sys, time, urllib.parse, urllib.request, urllib.error, ssl
+from datetime import datetime, timezone
+
+try:
+    import jwt
+except Exception as exc:
+    print(json.dumps({"ok": False, "note": f"PyJWT unavailable: {exc}", "apps": []}))
+    sys.exit(0)
+
+APP_IDS = ["6746675266", "6751717479"]
+KEY_ID = os.environ.get("APP_STORE_CONNECT_API_KEY_ID") or os.environ.get("APP_STORE_CONNECT_KEY_ID") or "22C7Z973Z3"
+ISSUER_ID = os.environ.get("APP_STORE_CONNECT_ISSUER_ID") or "6a7e769c-e3f3-4198-b152-960c60a27295"
+KEY_PATH = os.environ.get("APP_STORE_CONNECT_API_KEY_PATH") or os.path.expanduser(f"~/.fastlane/app_store_connect/AuthKey_{KEY_ID}.p8")
+
+def token():
+    if not os.path.exists(KEY_PATH):
+        raise FileNotFoundError("ASC key file missing")
+    with open(KEY_PATH) as f:
+        private_key = f.read()
+    now = int(time.time())
+    return jwt.encode({"iss": ISSUER_ID, "iat": now, "exp": now + 900, "aud": "appstoreconnect-v1"}, private_key, algorithm="ES256", headers={"kid": KEY_ID})
+
+def get(path, tok):
+    req = urllib.request.Request("https://api.appstoreconnect.apple.com" + path, headers={"Authorization": f"Bearer {tok}", "Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=25, context=ssl.create_default_context()) as resp:
+        return json.loads(resp.read())
+
+def app_payload(app_id, tok):
+    out = {"appId": app_id}
+    try:
+        qs = urllib.parse.urlencode({"filter[app]": app_id, "sort": "-uploadedDate", "limit": "8", "fields[builds]": "version,uploadedDate,processingState,expired,usesNonExemptEncryption"})
+        data = get("/v1/builds?" + qs, tok)
+        out["builds"] = [{"id": b.get("id"), **(b.get("attributes") or {})} for b in data.get("data", [])]
+    except Exception as exc:
+        out["buildError"] = str(exc)[:220]
+    try:
+        qs = urllib.parse.urlencode({"sort": "-createdDate", "limit": "50", "fields[customerReviews]": "rating,title,body,createdDate,territory"})
+        data = get(f"/v1/apps/{app_id}/customerReviews?" + qs, tok)
+        reviews = [{"id": r.get("id"), **(r.get("attributes") or {})} for r in data.get("data", [])]
+        ratings = [r.get("rating") for r in reviews if isinstance(r.get("rating"), int)]
+        out["reviews"] = {"count": len(reviews), "avgRating": round(sum(ratings) / len(ratings), 2) if ratings else None, "lowStars": len([r for r in ratings if r <= 3]), "latest": reviews[:5]}
+    except Exception as exc:
+        out["reviewError"] = str(exc)[:220]
+    return out
+
+try:
+    tok = token()
+    print(json.dumps({"ok": True, "generatedAt": datetime.now(timezone.utc).isoformat(), "apps": [app_payload(a, tok) for a in APP_IDS]}))
+except Exception as exc:
+    print(json.dumps({"ok": False, "note": str(exc)[:220], "apps": []}))
+PY
+)"
+
+jq -nc \
+  --arg generatedAt "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+  --argjson eas "$eas_json" \
+  --argjson sentry "$sentry_json" \
+  --argjson opdash "$opdash_json" \
+  --argjson ascExtra "$asc_extra_json" \
+  '{generatedAt:$generatedAt,eas:$eas,sentry:$sentry,opdash:$opdash,ascExtra:$ascExtra}' >"$TMP"
+mv "$TMP" "$OUT"
+printf '%s\n' "$OUT"

--- a/claude-ops/bin/ops-healify-dash
+++ b/claude-ops/bin/ops-healify-dash
@@ -6,9 +6,12 @@ SESSION="${AGENT_HUB_TMUX_SESSION:-agent-hub}"
 OPS_DATA="${OPS_DATA_DIR:-${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}}"
 OPS_PROJECTS="$OPS_DATA/cache/projects_health.json"
 KPI_CACHE="$HOME/.claude/state/statusline-kpi.json"
+MARKETING_CACHE="$OPS_DATA/cache/marketing.json"
+ECOM_CACHE="$OPS_DATA/cache/ecom.json"
 INFRA_CACHE="$HOME/.cache/agent-hub/infra-health.json"
 AWS_CACHE="$HOME/.cache/agent-hub/aws-ecs-health.json"
 PLUGIN_CACHE="$HOME/.cache/agent-hub/plugin-inventory.json"
+BI_CACHE="$HOME/.cache/agent-hub/healify-bi.json"
 RUNTIME_CACHE="$HOME/.cache/agent-hub/fleet/runtime-health.txt"
 FLEET_STATUS="$HOME/.claude/state/fleet-status.json"
 FLEET_TUI="$HOME/.claude/state/fleet-tui.json"
@@ -16,6 +19,7 @@ HEALIFY_ROOT="${HEALIFY_ROOT:-$HOME/Projects/healify-workspace}"
 MAX_ROWS="${HEALIFY_DASH_ROWS:-18}"
 INTERVAL="${HEALIFY_DASH_INTERVAL:-15}"
 REFRESH="${HEALIFY_DASH_REFRESH:-0}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ "$MODE" == "--refresh" ]]; then
   REFRESH=1
@@ -57,6 +61,20 @@ cols() {
   ((c < 72)) && c=72
   ((c > 180)) && c=180
   echo "$c"
+}
+
+raw_cols() {
+  local c
+  c="$(tput cols 2>/dev/null || echo 100)"
+  [[ "$c" =~ ^[0-9]+$ ]] || c=100
+  echo "$c"
+}
+
+raw_lines() {
+  local l
+  l="$(tput lines 2>/dev/null || echo 40)"
+  [[ "$l" =~ ^[0-9]+$ ]] || l=40
+  echo "$l"
 }
 
 clip_width() {
@@ -148,6 +166,15 @@ refresh_caches() {
   fi
   if [[ -x "$HOME/.local/bin/agent-hub-health" ]]; then
     timeout 40 "$HOME/.local/bin/agent-hub-health" short >"$RUNTIME_CACHE" 2>/dev/null || true
+  fi
+  local bi_refresh="${HEALIFY_BI_REFRESH_CMD:-}"
+  if [[ -z "$bi_refresh" && -x "$SCRIPT_DIR/ops-healify-bi-refresh" ]]; then
+    bi_refresh="$SCRIPT_DIR/ops-healify-bi-refresh"
+  elif [[ -z "$bi_refresh" && -x "$HOME/.local/bin/healify-bi-refresh" ]]; then
+    bi_refresh="$HOME/.local/bin/healify-bi-refresh"
+  fi
+  if [[ -n "$bi_refresh" ]]; then
+    timeout 180 "$bi_refresh" >/dev/null 2>&1 || true
   fi
 }
 
@@ -282,6 +309,71 @@ business_kpis() {
     ][]' | pretty_table
 }
 
+marketing_table() {
+  {
+    printf 'METRIC|VALUE|STATUS|SOURCE\n'
+    jq_file "$MARKETING_CACHE" '{}' -r '
+      def s: if . == null then "-" else tostring end;
+      "GA4 users|" + (.ga4.users|s) + "|" + (.health_status // "-") + "|ops marketing cache",
+      "GA4 sessions|" + (.ga4.sessions|s) + "|" + (.health_status // "-") + "|ops marketing cache",
+      "GA4 conversions|" + (.ga4.conversions|s) + "|" + (.health_status // "-") + "|ops marketing cache",
+      "GSC clicks|" + (.gsc.clicks|s) + "|" + (.health_status // "-") + "|ops marketing cache",
+      "Meta spend|" + (.meta.spend|s) + "|" + (.health_status // "-") + "|ops marketing cache",
+      "Meta ROAS|" + (.meta.roas|s) + "|" + (.health_status // "-") + "|ops marketing cache",
+      "Blended ROAS|" + (.blended_roas|s) + "|" + (.health_status // "-") + "|ops marketing cache"'
+    jq_file "$ECOM_CACHE" '{}' -r '
+      def s: if . == null then "-" else tostring end;
+      "Orders today|" + (.orders_today|s) + "|cached|ecom cache",
+      "Revenue today|" + ((.currency // "") + " " + (.revenue_today|s)) + "|cached|ecom cache"'
+    jq_file "$BI_CACHE" '{}' -r '
+      def card($id): (.opdash.ops.cards // [] | map(select(.id==$id)) | .[0] // {});
+      def s: if . == null then "-" else tostring end;
+      (card("appsflyer")) as $af |
+      (card("appsflyer").metrics // {}) as $m |
+      "App installs 7d|" + ($m.installs|s) + "|" + ($af.status // "-") + "|AppsFlyer",
+      "Organic installs|" + ($m.organic|s) + "|" + ($af.status // "-") + "|AppsFlyer",
+      "Loyal users|" + ($m.loyalUsers|s) + "|" + ($af.status // "-") + "|AppsFlyer",
+      "UA cost|" + ($m.cost|s) + "|" + ($af.status // "-") + "|AppsFlyer",
+      "Amplitude active|" + (.opdash.amplitude.current.activeUsers|s) + "|" + (if .opdash.amplitude.ok then "ok" else "blocked" end) + "|Amplitude project " + (.opdash.amplitude.projectId // "-"),
+      "Amplitude new|" + (.opdash.amplitude.current.newUsers|s) + "|" + (if .opdash.amplitude.ok then "ok" else "blocked" end) + "|Amplitude project " + (.opdash.amplitude.projectId // "-")'
+  } | pretty_table
+}
+
+release_table() {
+  {
+    printf 'SURFACE|LATEST|STATE|DETAIL\n'
+    jq_file "$BI_CACHE" '{}' -r '
+      def s: if . == null then "-" else tostring end;
+      (.eas.builds[0] // {}) as $e |
+      "EAS iOS|" + (($e.appVersion|s) + " (" + ($e.appBuildVersion|s) + ")") + "|" + ($e.status|s) + "|" + (($e.distribution|s) + " · " + ($e.updatedAt|s)),
+      (.ascExtra.apps[]? | select(.appId=="6746675266") | .builds[0] // {}) as $p |
+      "ASC prod build|" + ($p.version|s) + "|" + ($p.processingState|s) + "|" + ("expired=" + ($p.expired|s) + " · " + ($p.uploadedDate|s)),
+      (.ascExtra.apps[]? | select(.appId=="6751717479") | .builds[0] // {}) as $st |
+      "ASC staging build|" + ($st.version|s) + "|" + ($st.processingState|s) + "|" + ("expired=" + ($st.expired|s) + " · " + ($st.uploadedDate|s)),
+      (.opdash.appstore.appDetails[]? | select(.appId=="6746675266") | .appStoreVersions[0] // {}) as $v |
+      "App Store version|" + ($v.versionString|s) + "|" + ($v.appStoreState|s) + "|production app",
+      (.opdash.appstore.appDetails[]? | select(.appId=="6751717479") | .appStoreVersions[0] // {}) as $sv |
+      "Beta store version|" + ($sv.versionString|s) + "|" + ($sv.appStoreState|s) + "|staging app",
+      (.ascExtra.apps[]? | select(.appId=="6746675266") | .reviews // {}) as $r |
+      "Reviews prod|" + (($r.avgRating|s) + " avg / " + ($r.count|s) + " reviews") + "|" + (($r.lowStars|s) + " low") + "|ASC customerReviews",
+      (.opdash.appstore.metrics // {}) as $m |
+      "App downloads|" + ($m.downloads|s) + "|" + (if $m.downloads == null then "blocked" else "ok" end) + "|ASC sales vendor number required"'
+  } | pretty_table
+}
+
+reliability_table() {
+  {
+    printf 'SOURCE|STATUS|METRIC|DETAIL\n'
+    jq_file "$BI_CACHE" '{}' -r '
+      def s: if . == null then "-" else tostring end;
+      (.sentry.projects[]? | "Sentry " + .project + "|" + (if .ok then "ok" else "warn" end) + "|" + (.unresolved|s) + " unresolved|" + (.note // "-")),
+      ((.opdash.ops.cards // [])[]? | select(.id=="betterstack") | "BetterStack|" + (.status // "-") + "|" + ((.metrics.up|s) + "/" + (.metrics.monitors|s) + " up") + "|" + ((.metrics.activeIncidents|s) + " active incidents")),
+      ((.opdash.ops.cards // [])[]? | select(.id=="linear") | "Linear|" + (.status // "-") + "|" + ((.metrics.p1|s) + " P1 / " + (.metrics.p2|s) + " P2") + "|" + ((.metrics.blockers|s) + " priority issues")),
+      ((.opdash.ops.cards // [])[]? | select(.id=="qa") | "Mobile QA|" + (.status // "-") + "|" + ((.metrics.live|s) + "/" + (.metrics.services|s) + " live") + "|" + (.note // "-")),
+      ((.opdash.ops.cards // [])[]? | select(.id=="api") | "API / AgentCore|" + (.status // "-") + "|" + ((.metrics.healthy|s) + "/" + (.metrics.endpoints|s) + " healthy") + "|operating-dashboard source")'
+  } | pretty_table
+}
+
 projects_table() {
   jq_file "$OPS_PROJECTS" '{"projects":[]}' --argjson max "$MAX_ROWS" -r '
     def clip($n): tostring | gsub("[\r\n\t]+";" ") | if length>$n then .[0:$n-1]+"..." else . end;
@@ -359,13 +451,166 @@ logs_panel() {
   done
 }
 
+metric_value() {
+  local key="$1"
+  case "$key" in
+    endpoints_ok) safe_jq "$INFRA_CACHE" '{"endpoints":[]}' '[.endpoints[]? | select((.project|ascii_downcase|test("healify|meditation")) and .status=="ok")] | length' ;;
+    endpoints_down) safe_jq "$INFRA_CACHE" '{"endpoints":[]}' '[.endpoints[]? | select((.project|ascii_downcase|test("healify|meditation")) and .status=="down")] | length' ;;
+    ecs_ok) safe_jq "$AWS_CACHE" '{"services":[]}' '[.services[]? | select((.project|ascii_downcase|test("healify|meditation")) and .status=="ok")] | length' ;;
+    blockers) safe_jq "$OPS_PROJECTS" '{"projects":[]}' '[.projects[]? | select((.name|ascii_downcase|test("healify|meditation")) and ((.blockers // "0"|tostring) != "0"))] | length' ;;
+    projects) safe_jq "$OPS_PROJECTS" '{"projects":[]}' '[.projects[]? | select(.name|ascii_downcase|test("healify|meditation"))] | length' ;;
+    plugins) safe_jq "$PLUGIN_CACHE" '{"claude_plugins":[]}' '.claude_plugins | length' ;;
+    skills) safe_jq "$PLUGIN_CACHE" '{"codex_skills":[]}' '.codex_skills | length' ;;
+    kpis) safe_jq "$PLUGIN_CACHE" '{"ops_kpi_caches":[]}' '.ops_kpi_caches | length' ;;
+    latest_build) jq_file "$BI_CACHE" '{}' -r '(.ascExtra.apps[]? | select(.appId=="6746675266") | .builds[0].version) // (.eas.builds[0].appBuildVersion // "-")' ;;
+    app_version) jq_file "$BI_CACHE" '{}' -r '(.opdash.appstore.appDetails[]? | select(.appId=="6746675266") | .appStoreVersions[0].versionString) // "-"' ;;
+    app_state) jq_file "$BI_CACHE" '{}' -r '(.opdash.appstore.appDetails[]? | select(.appId=="6746675266") | .appStoreVersions[0].appStoreState) // "-"' ;;
+    installs) safe_jq "$BI_CACHE" '{}' '((.opdash.ops.cards // [])[]? | select(.id=="appsflyer") | .metrics.installs) // "-"' ;;
+    sentry_mobile) safe_jq "$BI_CACHE" '{}' '(.sentry.projects[]? | select(.project=="healify-mobile") | .unresolved) // "-"' ;;
+    linear_p1) safe_jq "$BI_CACHE" '{}' '((.opdash.ops.cards // [])[]? | select(.id=="linear") | .metrics.p1) // "-"' ;;
+    reviews) safe_jq "$BI_CACHE" '{}' '(.ascExtra.apps[]? | select(.appId=="6746675266") | .reviews.count) // "-"' ;;
+  esac
+}
+
+compact_box() {
+  local title="$1" value="$2" detail="$3" width="$4"
+  printf '%s+%*s+%s\n' "$BORDER" "$((width - 2))" '' "$RESET" | tr ' ' '-'
+  printf '| %s%-*s%s |\n' "$DIM" "$((width - 4))" "$title" "$RESET"
+  printf '| %s%s%-*s%s |\n' "$BOLD" "$ORANGE" "$((width - 4))" "$value" "$RESET"
+  printf '| %-*s |\n' "$((width - 4))" "$detail"
+  printf '%s+%*s+%s\n' "$BORDER" "$((width - 2))" '' "$RESET" | tr ' ' '-'
+}
+
+compact_pair() {
+  local w left_title left_value left_detail right_title right_value right_detail
+  w="$1"
+  left_title="$2"; left_value="$3"; left_detail="$4"
+  right_title="$5"; right_value="$6"; right_detail="$7"
+  if (( w < 82 )); then
+    compact_box "$left_title" "$left_value" "$left_detail" "$w"
+    compact_box "$right_title" "$right_value" "$right_detail" "$w"
+    return
+  fi
+  local bw=$(((w - 3) / 2))
+  paste -d' ' \
+    <(compact_box "$left_title" "$left_value" "$left_detail" "$bw") \
+    <(compact_box "$right_title" "$right_value" "$right_detail" "$bw")
+}
+
+compact_logo() {
+  printf '%s%s' "$ORANGE" "$BOLD"
+  printf '██╗  ██╗███████╗ █████╗ ██╗     ██╗███████╗██╗   ██╗\n'
+  printf '███████║█████╗  ███████║██║     ██║█████╗   ╚████╔╝ \n'
+  printf '██║  ██║███████╗██║  ██║███████╗██║██║        ██║   \n'
+  printf '%s' "$RESET"
+}
+
+compact_kpis() {
+  jq_file "$KPI_CACHE" '{"projects":[]}' -r '
+    def fmt:
+      if . == null then "-"
+      elif type=="number" then
+        if . >= 1000000 then ((./1000000*10|round/10|tostring)+"M")
+        elif . >= 1000 then ((./1000*10|round/10|tostring)+"K")
+        else (.|tostring) end
+      else tostring end;
+    ((.projects // []) | map(select((.key // .label // "" | ascii_downcase) == "healify")) | .[0] // {}) as $h |
+    [
+      "IG followers|" + (($h.social.ig_followers // null)|fmt),
+      "IG reach|" + (($h.social.ig_reach // null)|fmt),
+      "Requests|" + (($h.social.active_req // null)|fmt),
+      "Ads|" + (($h.ads.health // "-")|tostring),
+      "Dev|" + (($h.dev.phase // "-")|tostring)
+    ][]' | column -t -s '|' | sed 's/^/  /' | clip_width "$(raw_cols)"
+}
+
+compact_risks() {
+  {
+    jq_file "$INFRA_CACHE" '{"endpoints":[]}' -r '
+      (.endpoints // [])
+      | map(select((.project|ascii_downcase|test("healify|meditation")) and .status!="ok"))
+      | .[:5]
+      | .[]
+      | "  " + .status + "  " + .project + " / " + .service + "  " + (.http|tostring)'
+    jq_file "$OPS_PROJECTS" '{"projects":[]}' -r '
+      (.projects // [])
+      | map(select((.name|ascii_downcase|test("healify|meditation")) and ((.blockers // "0"|tostring) != "0")))
+      | .[:4]
+      | .[]
+      | "  blocked  " + .name + "  " + (.next_action // "-" | tostring | gsub("[\r\n\t]+";" ") | .[0:48])'
+  } | sed '/^$/d' | sed -n '1,8p' | clip_width "$(raw_cols)"
+}
+
+compact_agents() {
+  if [[ -s "$RUNTIME_CACHE" ]]; then
+    sed -n '1,8p' "$RUNTIME_CACHE" | awk -F: '{printf "  %-10s %s\n",$1,$2}' | clip_width "$(raw_cols)"
+  else
+    printf '  runtime health cache missing\n'
+  fi
+}
+
+compact_bi() {
+  jq_file "$BI_CACHE" '{}' -r '
+    def s: if . == null then "-" else tostring end;
+    def card($id): (.opdash.ops.cards // [] | map(select(.id==$id)) | .[0] // {});
+    [
+      "ASC prod|" + ((.ascExtra.apps[]? | select(.appId=="6746675266") | .builds[0].version) // "-") + " · " + ((.ascExtra.apps[]? | select(.appId=="6746675266") | .builds[0].processingState) // "-"),
+      "Store|" + ((.opdash.appstore.appDetails[]? | select(.appId=="6746675266") | .appStoreVersions[0].versionString) // "-") + " · " + ((.opdash.appstore.appDetails[]? | select(.appId=="6746675266") | .appStoreVersions[0].appStoreState) // "-"),
+      "Installs|" + ((card("appsflyer").metrics.installs)|s) + "  organic " + ((card("appsflyer").metrics.organic)|s),
+      "Sentry mobile|" + ((.sentry.projects[]? | select(.project=="healify-mobile") | .unresolved)|s) + " unresolved",
+      "Linear|" + ((card("linear").metrics.p1)|s) + " P1 / " + ((card("linear").metrics.p2)|s) + " P2",
+      "Downloads|" + ((.opdash.appstore.metrics.downloads)|s) + " · vendor no. needed"
+    ][]' | column -t -s '|' | sed 's/^/  /' | clip_width "$(raw_cols)"
+}
+
+render_compact() {
+  local w now host endpoints_ok endpoints_down ecs_ok blockers projects plugins skills kpis
+  w="$(raw_cols)"
+  now="$(date -u '+%H:%M:%SZ')"
+  host="$(hostname -s 2>/dev/null || hostname)"
+  endpoints_ok="$(metric_value endpoints_ok)"
+  endpoints_down="$(metric_value endpoints_down)"
+  ecs_ok="$(metric_value ecs_ok)"
+  blockers="$(metric_value blockers)"
+  projects="$(metric_value projects)"
+  plugins="$(metric_value plugins)"
+  skills="$(metric_value skills)"
+  kpis="$(metric_value kpis)"
+
+  compact_logo
+  printf '%s%sHEALIFY.AI%s %s%s · %s · %s%s\n' "$BOLD" "$AMBER" "$RESET" "$DIM" "$now" "$host" "orange command center" "$RESET"
+  printf '%s' "$BORDER"; printf '%*s\n' "$w" '' | tr ' ' '-'; printf '%s' "$RESET"
+  compact_pair "$w" "App Store" "v$(metric_value app_version) / build $(metric_value latest_build)" "$(metric_value app_state) · $(metric_value reviews) reviews" "Growth" "$(metric_value installs) installs" "AppsFlyer 7d · downloads need vendor no."
+  compact_pair "$w" "Reliability" "$(metric_value sentry_mobile) mobile issues" "Sentry · $(metric_value linear_p1) Linear P1" "Infra" "$endpoints_ok OK / $endpoints_down down" "HTTP + health endpoints"
+  compact_pair "$w" "Execution" "$projects projects / $blockers blockers" "GSD + ops registry" "Intelligence" "$plugins plugins / $skills skills" "$kpis KPI caches"
+  printf '\n%s%sBI Snapshot%s\n' "$BOLD" "$ORANGE" "$RESET"
+  compact_bi
+  printf '\n%s%sBusiness KPIs%s\n' "$BOLD" "$ORANGE" "$RESET"
+  compact_kpis
+  printf '\n%s%sNeeds Attention%s\n' "$BOLD" "$ORANGE" "$RESET"
+  compact_risks
+  printf '\n%s%sAgents / MCPs%s\n' "$BOLD" "$ORANGE" "$RESET"
+  compact_agents
+  printf '\n%sKeys:%s Ctrl-a v Healify · Ctrl-a f Fleet · Ctrl-a d Doctor · hd --refresh\n' "$DIM" "$RESET"
+}
+
 render() {
   [[ "$REFRESH" == "1" ]] && refresh_caches
   [[ -t 1 ]] && clear
+  if (( $(raw_cols) < 100 || $(raw_lines) < 36 )); then
+    render_compact
+    return
+  fi
   hero
   cards
   section "Business KPIs"
   business_kpis
+  section "Marketing And Acquisition"
+  marketing_table
+  section "App Store, TestFlight, Reviews"
+  release_table
+  section "Reliability, QA, Work"
+  reliability_table
   section "Execution Portfolio"
   projects_table
   section "Infra And Deployments"

--- a/claude-ops/bin/ops-healify-dash
+++ b/claude-ops/bin/ops-healify-dash
@@ -3,7 +3,7 @@ set -uo pipefail
 
 MODE="${1:---once}"
 SESSION="${AGENT_HUB_TMUX_SESSION:-agent-hub}"
-OPS_DATA="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+OPS_DATA="${OPS_DATA_DIR:-${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}}"
 OPS_PROJECTS="$OPS_DATA/cache/projects_health.json"
 KPI_CACHE="$HOME/.claude/state/statusline-kpi.json"
 INFRA_CACHE="$HOME/.cache/agent-hub/infra-health.json"
@@ -192,7 +192,7 @@ json_summary() {
     --argjson infra "$infra" \
     --argjson aws "$aws" \
     --argjson plugins "$plugins" \
-    --arg runtime "$runtime" \
+    --argjson runtime "$runtime" \
     '{projects:$projects,kpi:$kpi,infra:$infra,aws:$aws,plugins:$plugins,runtime:$runtime}'
 }
 

--- a/claude-ops/bin/ops-healify-dash
+++ b/claude-ops/bin/ops-healify-dash
@@ -334,8 +334,10 @@ marketing_table() {
       "Organic installs|" + ($m.organic|s) + "|" + ($af.status // "-") + "|AppsFlyer",
       "Loyal users|" + ($m.loyalUsers|s) + "|" + ($af.status // "-") + "|AppsFlyer",
       "UA cost|" + ($m.cost|s) + "|" + ($af.status // "-") + "|AppsFlyer",
-      "Amplitude active|" + (.opdash.amplitude.current.activeUsers|s) + "|" + (if .opdash.amplitude.ok then "ok" else "blocked" end) + "|Amplitude project " + (.opdash.amplitude.projectId // "-"),
-      "Amplitude new|" + (.opdash.amplitude.current.newUsers|s) + "|" + (if .opdash.amplitude.ok then "ok" else "blocked" end) + "|Amplitude project " + (.opdash.amplitude.projectId // "-")'
+      (.opdash.amplitude // {}) as $amp |
+      ($amp.current // {}) as $cur |
+      "Amplitude active|" + ($cur.activeUsers|s) + "|" + (if ($amp.ok // false) then "ok" else "blocked" end) + "|Amplitude project " + ($amp.projectId // "-"),
+      "Amplitude new|" + ($cur.newUsers|s) + "|" + (if ($amp.ok // false) then "ok" else "blocked" end) + "|Amplitude project " + ($amp.projectId // "-")'
   } | pretty_table
 }
 

--- a/claude-ops/bin/ops-healify-dash
+++ b/claude-ops/bin/ops-healify-dash
@@ -16,6 +16,9 @@ RUNTIME_CACHE="$HOME/.cache/agent-hub/fleet/runtime-health.txt"
 FLEET_STATUS="$HOME/.claude/state/fleet-status.json"
 FLEET_TUI="$HOME/.claude/state/fleet-tui.json"
 HEALIFY_ROOT="${HEALIFY_ROOT:-$HOME/Projects/healify-workspace}"
+ASC_PROD_APP_ID="${HEALIFY_ASC_PROD_APP_ID:-}"
+ASC_STAGING_APP_ID="${HEALIFY_ASC_STAGING_APP_ID:-}"
+SENTRY_MOBILE_PROJECT="${HEALIFY_SENTRY_MOBILE_PROJECT:-}"
 MAX_ROWS="${HEALIFY_DASH_ROWS:-18}"
 INTERVAL="${HEALIFY_DASH_INTERVAL:-15}"
 REFRESH="${HEALIFY_DASH_REFRESH:-0}"
@@ -344,19 +347,19 @@ marketing_table() {
 release_table() {
   {
     printf 'SURFACE|LATEST|STATE|DETAIL\n'
-    jq_file "$BI_CACHE" '{}' -r '
+    jq_file "$BI_CACHE" '{}' --arg prod "$ASC_PROD_APP_ID" --arg staging "$ASC_STAGING_APP_ID" -r '
       def s: if . == null then "-" else tostring end;
       (.eas.builds[0] // {}) as $e |
       "EAS iOS|" + (($e.appVersion|s) + " (" + ($e.appBuildVersion|s) + ")") + "|" + ($e.status|s) + "|" + (($e.distribution|s) + " · " + ($e.updatedAt|s)),
-      (.ascExtra.apps[]? | select(.appId=="6746675266") | .builds[0] // {}) as $p |
+      (.ascExtra.apps[]? | select(.appId==$prod) | .builds[0] // {}) as $p |
       "ASC prod build|" + ($p.version|s) + "|" + ($p.processingState|s) + "|" + ("expired=" + ($p.expired|s) + " · " + ($p.uploadedDate|s)),
-      (.ascExtra.apps[]? | select(.appId=="6751717479") | .builds[0] // {}) as $st |
+      (.ascExtra.apps[]? | select(.appId==$staging) | .builds[0] // {}) as $st |
       "ASC staging build|" + ($st.version|s) + "|" + ($st.processingState|s) + "|" + ("expired=" + ($st.expired|s) + " · " + ($st.uploadedDate|s)),
-      (.opdash.appstore.appDetails[]? | select(.appId=="6746675266") | .appStoreVersions[0] // {}) as $v |
+      (.opdash.appstore.appDetails[]? | select(.appId==$prod) | .appStoreVersions[0] // {}) as $v |
       "App Store version|" + ($v.versionString|s) + "|" + ($v.appStoreState|s) + "|production app",
-      (.opdash.appstore.appDetails[]? | select(.appId=="6751717479") | .appStoreVersions[0] // {}) as $sv |
+      (.opdash.appstore.appDetails[]? | select(.appId==$staging) | .appStoreVersions[0] // {}) as $sv |
       "Beta store version|" + ($sv.versionString|s) + "|" + ($sv.appStoreState|s) + "|staging app",
-      (.ascExtra.apps[]? | select(.appId=="6746675266") | .reviews // {}) as $r |
+      (.ascExtra.apps[]? | select(.appId==$prod) | .reviews // {}) as $r |
       "Reviews prod|" + (($r.avgRating|s) + " avg / " + ($r.count|s) + " reviews") + "|" + (($r.lowStars|s) + " low") + "|ASC customerReviews",
       (.opdash.appstore.metrics // {}) as $m |
       "App downloads|" + ($m.downloads|s) + "|" + (if $m.downloads == null then "blocked" else "ok" end) + "|ASC sales vendor number required"'
@@ -464,13 +467,13 @@ metric_value() {
     plugins) safe_jq "$PLUGIN_CACHE" '{"claude_plugins":[]}' '.claude_plugins | length' ;;
     skills) safe_jq "$PLUGIN_CACHE" '{"codex_skills":[]}' '.codex_skills | length' ;;
     kpis) safe_jq "$PLUGIN_CACHE" '{"ops_kpi_caches":[]}' '.ops_kpi_caches | length' ;;
-    latest_build) jq_file "$BI_CACHE" '{}' -r '(.ascExtra.apps[]? | select(.appId=="6746675266") | .builds[0].version) // (.eas.builds[0].appBuildVersion // "-")' ;;
-    app_version) jq_file "$BI_CACHE" '{}' -r '(.opdash.appstore.appDetails[]? | select(.appId=="6746675266") | .appStoreVersions[0].versionString) // "-"' ;;
-    app_state) jq_file "$BI_CACHE" '{}' -r '(.opdash.appstore.appDetails[]? | select(.appId=="6746675266") | .appStoreVersions[0].appStoreState) // "-"' ;;
+    latest_build) jq_file "$BI_CACHE" '{}' --arg prod "$ASC_PROD_APP_ID" -r '(.ascExtra.apps[]? | select(.appId==$prod) | .builds[0].version) // (.eas.builds[0].appBuildVersion // "-")' ;;
+    app_version) jq_file "$BI_CACHE" '{}' --arg prod "$ASC_PROD_APP_ID" -r '(.opdash.appstore.appDetails[]? | select(.appId==$prod) | .appStoreVersions[0].versionString) // "-"' ;;
+    app_state) jq_file "$BI_CACHE" '{}' --arg prod "$ASC_PROD_APP_ID" -r '(.opdash.appstore.appDetails[]? | select(.appId==$prod) | .appStoreVersions[0].appStoreState) // "-"' ;;
     installs) safe_jq "$BI_CACHE" '{}' '((.opdash.ops.cards // [])[]? | select(.id=="appsflyer") | .metrics.installs) // "-"' ;;
-    sentry_mobile) safe_jq "$BI_CACHE" '{}' '(.sentry.projects[]? | select(.project=="healify-mobile") | .unresolved) // "-"' ;;
+    sentry_mobile) jq_file "$BI_CACHE" '{}' --arg project "$SENTRY_MOBILE_PROJECT" -r '(.sentry.projects[]? | select(.project==$project) | .unresolved) // "-"' ;;
     linear_p1) safe_jq "$BI_CACHE" '{}' '((.opdash.ops.cards // [])[]? | select(.id=="linear") | .metrics.p1) // "-"' ;;
-    reviews) safe_jq "$BI_CACHE" '{}' '(.ascExtra.apps[]? | select(.appId=="6746675266") | .reviews.count) // "-"' ;;
+    reviews) jq_file "$BI_CACHE" '{}' --arg prod "$ASC_PROD_APP_ID" -r '(.ascExtra.apps[]? | select(.appId==$prod) | .reviews.count) // "-"' ;;
   esac
 }
 
@@ -552,14 +555,14 @@ compact_agents() {
 }
 
 compact_bi() {
-  jq_file "$BI_CACHE" '{}' -r '
+  jq_file "$BI_CACHE" '{}' --arg prod "$ASC_PROD_APP_ID" --arg project "$SENTRY_MOBILE_PROJECT" -r '
     def s: if . == null then "-" else tostring end;
     def card($id): (.opdash.ops.cards // [] | map(select(.id==$id)) | .[0] // {});
     [
-      "ASC prod|" + ((.ascExtra.apps[]? | select(.appId=="6746675266") | .builds[0].version) // "-") + " · " + ((.ascExtra.apps[]? | select(.appId=="6746675266") | .builds[0].processingState) // "-"),
-      "Store|" + ((.opdash.appstore.appDetails[]? | select(.appId=="6746675266") | .appStoreVersions[0].versionString) // "-") + " · " + ((.opdash.appstore.appDetails[]? | select(.appId=="6746675266") | .appStoreVersions[0].appStoreState) // "-"),
+      "ASC prod|" + ((.ascExtra.apps[]? | select(.appId==$prod) | .builds[0].version) // "-") + " · " + ((.ascExtra.apps[]? | select(.appId==$prod) | .builds[0].processingState) // "-"),
+      "Store|" + ((.opdash.appstore.appDetails[]? | select(.appId==$prod) | .appStoreVersions[0].versionString) // "-") + " · " + ((.opdash.appstore.appDetails[]? | select(.appId==$prod) | .appStoreVersions[0].appStoreState) // "-"),
       "Installs|" + ((card("appsflyer").metrics.installs)|s) + "  organic " + ((card("appsflyer").metrics.organic)|s),
-      "Sentry mobile|" + ((.sentry.projects[]? | select(.project=="healify-mobile") | .unresolved)|s) + " unresolved",
+      "Sentry mobile|" + ((.sentry.projects[]? | select(.project==$project) | .unresolved)|s) + " unresolved",
       "Linear|" + ((card("linear").metrics.p1)|s) + " P1 / " + ((card("linear").metrics.p2)|s) + " P2",
       "Downloads|" + ((.opdash.appstore.metrics.downloads)|s) + " · vendor no. needed"
     ][]' | column -t -s '|' | sed 's/^/  /' | clip_width "$(raw_cols)"

--- a/claude-ops/bin/ops-healify-dash
+++ b/claude-ops/bin/ops-healify-dash
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+MODE="${1:---once}"
+SESSION="${AGENT_HUB_TMUX_SESSION:-agent-hub}"
+OPS_DATA="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+OPS_PROJECTS="$OPS_DATA/cache/projects_health.json"
+KPI_CACHE="$HOME/.claude/state/statusline-kpi.json"
+INFRA_CACHE="$HOME/.cache/agent-hub/infra-health.json"
+AWS_CACHE="$HOME/.cache/agent-hub/aws-ecs-health.json"
+PLUGIN_CACHE="$HOME/.cache/agent-hub/plugin-inventory.json"
+RUNTIME_CACHE="$HOME/.cache/agent-hub/fleet/runtime-health.txt"
+FLEET_STATUS="$HOME/.claude/state/fleet-status.json"
+FLEET_TUI="$HOME/.claude/state/fleet-tui.json"
+HEALIFY_ROOT="${HEALIFY_ROOT:-$HOME/Projects/healify-workspace}"
+MAX_ROWS="${HEALIFY_DASH_ROWS:-18}"
+INTERVAL="${HEALIFY_DASH_INTERVAL:-15}"
+REFRESH="${HEALIFY_DASH_REFRESH:-0}"
+
+if [[ "$MODE" == "--refresh" ]]; then
+  REFRESH=1
+  MODE="--once"
+fi
+
+if [[ -t 1 ]]; then
+  BOLD=$'\033[1m'
+  DIM=$'\033[2m'
+  RESET=$'\033[0m'
+  ORANGE=$'\033[38;5;208m'
+  AMBER=$'\033[38;5;214m'
+  PEACH=$'\033[38;5;216m'
+  GREEN=$'\033[38;5;114m'
+  RED=$'\033[38;5;203m'
+  YELLOW=$'\033[38;5;220m'
+  BLUE=$'\033[38;5;75m'
+  BORDER=$'\033[38;5;238m'
+  TEXT=$'\033[38;5;252m'
+else
+  BOLD= DIM= RESET= ORANGE= AMBER= PEACH= GREEN= RED= YELLOW= BLUE= BORDER= TEXT=
+fi
+
+usage() {
+  cat <<'EOF'
+healify-dashboard [--once|--watch|--refresh|--json]
+
+Dedicated Healify.ai command center. Read-only by default.
+Sources: ops:projects, statusline KPI cache, live health endpoints, AWS ECS,
+agent runtime health, Claude/OpenClaw/Codex/Cursor readiness, plugin inventory,
+and local Healify git repos.
+EOF
+}
+
+cols() {
+  local c
+  c="$(tput cols 2>/dev/null || echo 100)"
+  [[ "$c" =~ ^[0-9]+$ ]] || c=100
+  ((c < 72)) && c=72
+  ((c > 180)) && c=180
+  echo "$c"
+}
+
+clip_width() {
+  awk -v n="${1:-$(cols)}" '{ gsub(/[[:cntrl:]]/, " "); if (length($0) > n) print substr($0, 1, n-1) "..."; else print }'
+}
+
+safe_jq() {
+  local file="$1" fallback="$2" filter="${3:-.}"
+  if [[ -s "$file" ]] && command -v jq >/dev/null 2>&1; then
+    jq -c "$filter" "$file" 2>/dev/null || printf '%s\n' "$fallback"
+  else
+    printf '%s\n' "$fallback"
+  fi
+}
+
+jq_file() {
+  local file="$1" fallback="$2"
+  shift 2
+  if [[ -s "$file" ]] && command -v jq >/dev/null 2>&1; then
+    jq "$@" "$file" 2>/dev/null || printf '%s\n' "$fallback"
+  elif command -v jq >/dev/null 2>&1; then
+    printf '%s\n' "$fallback" | jq "$@" 2>/dev/null || printf '%s\n' "$fallback"
+  else
+    printf '%s\n' "$fallback"
+  fi
+}
+
+mtime() {
+  stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo 0
+}
+
+age() {
+  local f="$1" now mt d
+  [[ -s "$f" ]] || { printf 'missing'; return; }
+  now="$(date +%s)"
+  mt="$(mtime "$f")"
+  [[ "$mt" =~ ^[0-9]+$ ]] || { printf 'unknown'; return; }
+  d=$((now - mt))
+  if ((d < 120)); then printf '%ss' "$d"
+  elif ((d < 7200)); then printf '%sm' "$((d / 60))"
+  elif ((d < 172800)); then printf '%sh' "$((d / 3600))"
+  else printf '%sd' "$((d / 86400))"; fi
+}
+
+rule() {
+  printf '%s' "$BORDER"
+  printf '%*s\n' "$(cols)" '' | tr ' ' '-'
+  printf '%s' "$RESET"
+}
+
+section() {
+  printf '\n%s%s%s%s\n' "$BOLD" "$ORANGE" "$1" "$RESET"
+  rule
+}
+
+tone() {
+  case "${1,,}" in
+    ok|ready|connected|configured|healthy|active|passing|running|success) printf '%s%s%s' "$GREEN" "$1" "$RESET" ;;
+    warn|warning|paused|degraded|auth|auth-needed|stale|waiting) printf '%s%s%s' "$YELLOW" "$1" "$RESET" ;;
+    down|failed|error|blocked|critical|missing|unauthorized) printf '%s%s%s' "$RED" "$1" "$RESET" ;;
+    *) printf '%s%s%s' "$BLUE" "$1" "$RESET" ;;
+  esac
+}
+
+pretty_table() {
+  column -t -s '|' 2>/dev/null | clip_width "$(cols)"
+}
+
+spinner() {
+  [[ -t 1 ]] || return 0
+  local msg="$1" pid="$2" frames=("◒" "◐" "◓" "◑") i=0
+  while kill -0 "$pid" 2>/dev/null; do
+    printf '\r%s%s %s%s' "$ORANGE" "${frames[$((i % 4))]}" "$msg" "$RESET" >&2
+    i=$((i + 1))
+    sleep 0.12
+  done
+  printf '\r%*s\r' 80 '' >&2
+}
+
+refresh_caches() {
+  if [[ -x "$HOME/.local/bin/agent-mcp-sync" ]]; then
+    timeout 20 "$HOME/.local/bin/agent-mcp-sync" >/dev/null 2>&1 || true
+  fi
+  if [[ -x "$HOME/.local/bin/agent-project-health" ]]; then
+    timeout 55 "$HOME/.local/bin/agent-project-health" --refresh-infra >/dev/null 2>&1 || true
+  fi
+  if [[ -x "$HOME/.local/bin/agent-plugin-insights" ]]; then
+    timeout 20 "$HOME/.local/bin/agent-plugin-insights" --refresh >/dev/null 2>&1 || true
+  fi
+  if [[ -x "$HOME/.local/bin/agent-hub-health" ]]; then
+    timeout 40 "$HOME/.local/bin/agent-hub-health" short >"$RUNTIME_CACHE" 2>/dev/null || true
+  fi
+}
+
+repo_rows() {
+  local roots=(
+    "$HEALIFY_ROOT/healify"
+    "$HEALIFY_ROOT/healify-api"
+    "$HEALIFY_ROOT/healify-agentcore"
+    "$HEALIFY_ROOT/healify-api-mcp"
+    "$HEALIFY_ROOT/healify-web"
+    "$HEALIFY_ROOT/healify-operating-dashboard"
+    "$HEALIFY_ROOT/repos/meditation-service"
+    "$HOME/Projects/meditation-service"
+  )
+  local seen="" root name branch dirty ahead behind last
+  printf 'REPO|BRANCH|DIRTY|AHEAD/BEHIND|LAST COMMIT\n'
+  for root in "${roots[@]}"; do
+    [[ -d "$root/.git" ]] || continue
+    name="$(basename "$root")"
+    [[ "$seen" == *"|$name|"* ]] && continue
+    seen="${seen}|$name|"
+    branch="$(git -C "$root" branch --show-current 2>/dev/null || echo '-')"
+    dirty="$(git -C "$root" status --porcelain 2>/dev/null | wc -l | awk '{print $1}')"
+    ahead="$(git -C "$root" rev-list --count '@{u}..HEAD' 2>/dev/null || echo 0)"
+    behind="$(git -C "$root" rev-list --count 'HEAD..@{u}' 2>/dev/null || echo 0)"
+    last="$(git -C "$root" log -1 --format='%cr %s' 2>/dev/null || echo '-')"
+    printf '%s|%s|%s|%s/%s|%s\n' "$name" "${branch:--}" "$dirty" "$ahead" "$behind" "$last"
+  done
+}
+
+json_summary() {
+  local projects kpi infra aws plugins runtime
+  projects="$(safe_jq "$OPS_PROJECTS" '{"projects":[],"summary":{}}')"
+  kpi="$(safe_jq "$KPI_CACHE" '{"projects":[]}')"
+  infra="$(safe_jq "$INFRA_CACHE" '{"endpoints":[]}')"
+  aws="$(safe_jq "$AWS_CACHE" '{"services":[]}')"
+  plugins="$(safe_jq "$PLUGIN_CACHE" '{"claude_plugins":[],"codex_skills":[],"ops_kpi_caches":[]}')"
+  runtime="$(sed -n '1,40p' "$RUNTIME_CACHE" 2>/dev/null | jq -Rs '.')"
+  jq -nc \
+    --argjson projects "$projects" \
+    --argjson kpi "$kpi" \
+    --argjson infra "$infra" \
+    --argjson aws "$aws" \
+    --argjson plugins "$plugins" \
+    --arg runtime "$runtime" \
+    '{projects:$projects,kpi:$kpi,infra:$infra,aws:$aws,plugins:$plugins,runtime:$runtime}'
+}
+
+pixel_logo() {
+  local o p w r
+  if [[ -t 1 ]]; then
+    o=$'\033[48;5;208m  \033[0m'
+    p=$'\033[48;5;204m  \033[0m'
+    w=$'\033[48;5;231m  \033[0m'
+    r=$'\033[48;5;209m  \033[0m'
+  else
+    o='OO'; p='PP'; w='WW'; r='RR'
+  fi
+  printf '    %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n' "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o"
+  printf '    %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n' "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o"
+  printf '    %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n' "$o" "$o" "$w" "$w" "$o" "$o" "$o" "$o" "$o" "$w" "$w" "$o" "$o" "$o" "$o" "$o"
+  printf '    %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n' "$o" "$w" "$w" "$w" "$w" "$o" "$o" "$o" "$w" "$w" "$w" "$w" "$o" "$o" "$o" "$o"
+  printf '    %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n' "$o" "$w" "$w" "$w" "$w" "$w" "$o" "$w" "$w" "$w" "$w" "$w" "$o" "$o" "$o" "$o"
+  printf '    %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n' "$p" "$w" "$w" "$w" "$w" "$w" "$w" "$w" "$w" "$w" "$w" "$w" "$w" "$o" "$o" "$o"
+  printf '    %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n' "$p" "$p" "$w" "$w" "$w" "$w" "$w" "$r" "$r" "$w" "$w" "$w" "$w" "$o" "$o" "$o"
+  printf '    %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n' "$p" "$p" "$p" "$w" "$w" "$w" "$r" "$r" "$r" "$r" "$w" "$w" "$o" "$o" "$o" "$o"
+  printf '    %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n' "$p" "$p" "$p" "$p" "$w" "$r" "$r" "$r" "$r" "$r" "$r" "$o" "$o" "$o" "$o" "$o"
+  printf '    %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n' "$p" "$p" "$p" "$p" "$p" "$w" "$r" "$r" "$r" "$r" "$o" "$o" "$o" "$o" "$o" "$o"
+  printf '    %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n' "$p" "$p" "$p" "$p" "$p" "$p" "$w" "$r" "$r" "$o" "$o" "$o" "$o" "$o" "$o" "$o"
+  printf '    %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n' "$p" "$p" "$p" "$p" "$p" "$p" "$p" "$w" "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o"
+  printf '    %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n' "$p" "$p" "$p" "$p" "$p" "$p" "$p" "$p" "$o" "$o" "$o" "$o" "$o" "$o" "$o" "$o"
+  printf '    %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n' "$p" "$p" "$p" "$p" "$p" "$p" "$p" "$p" "$p" "$o" "$o" "$o" "$o" "$o" "$o" "$o"
+  printf '    %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n' "$p" "$p" "$p" "$p" "$p" "$p" "$p" "$p" "$p" "$p" "$o" "$o" "$o" "$o" "$o" "$o"
+  printf '    %s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s\n' "$p" "$p" "$p" "$p" "$p" "$p" "$p" "$p" "$p" "$p" "$p" "$o" "$o" "$o" "$o" "$o"
+}
+
+hero() {
+  local now host load mem disk
+  now="$(date -u '+%Y-%m-%d %H:%M:%SZ')"
+  host="$(hostname -s 2>/dev/null || hostname)"
+  load="$(awk '{print $1","$2","$3}' /proc/loadavg 2>/dev/null || echo '-')"
+  mem="$(free -h 2>/dev/null | awk '/Mem:/ {print $3 "/" $2 " used"}' || echo '-')"
+  disk="$(df -h / 2>/dev/null | awk 'NR==2 {print $5 " used / " $4 " free"}' || echo '-')"
+  pixel_logo
+  printf '%s%sHEALIFY.AI COMMAND CENTER%s  %sread-only / orange dark mode%s\n' "$BOLD" "$AMBER" "$RESET" "$DIM" "$RESET"
+  printf '%s%s%s  host=%s  load=%s  ram=%s  disk=%s\n' "$TEXT" "$now" "$RESET" "$host" "$load" "$mem" "$disk"
+  rule
+}
+
+cards() {
+  local infra aws projects blockers plugins skills kpis agents_down
+  infra="$(safe_jq "$INFRA_CACHE" '{"endpoints":[]}' '[.endpoints[]? | select((.project|ascii_downcase|test("healify|meditation")) and .status=="ok")] | length')"
+  aws="$(safe_jq "$AWS_CACHE" '{"services":[]}' '[.services[]? | select((.project|ascii_downcase|test("healify|meditation")) and .status=="ok")] | length')"
+  projects="$(safe_jq "$OPS_PROJECTS" '{"projects":[]}' '[.projects[]? | select(.name|ascii_downcase|test("healify|meditation"))] | length')"
+  blockers="$(safe_jq "$OPS_PROJECTS" '{"projects":[]}' '[.projects[]? | select((.name|ascii_downcase|test("healify|meditation")) and ((.blockers // "0"|tostring) != "0"))] | length')"
+  plugins="$(safe_jq "$PLUGIN_CACHE" '{"claude_plugins":[]}' '.claude_plugins | length')"
+  skills="$(safe_jq "$PLUGIN_CACHE" '{"codex_skills":[]}' '.codex_skills | length')"
+  kpis="$(safe_jq "$PLUGIN_CACHE" '{"ops_kpi_caches":[]}' '.ops_kpi_caches | length')"
+  agents_down="$(grep -Eci 'auth-needed|failed|missing|unauthorized|error' "$RUNTIME_CACHE" 2>/dev/null || true)"
+  agents_down="${agents_down:-0}"
+  {
+    printf 'METRIC|VALUE|SOURCE|AGE\n'
+    printf 'Healify endpoints OK|%s|infra health|%s\n' "$infra" "$(age "$INFRA_CACHE")"
+    printf 'Healify ECS OK|%s|AWS ECS|%s\n' "$aws" "$(age "$AWS_CACHE")"
+    printf 'Healify projects|%s|ops:projects|%s\n' "$projects" "$(age "$OPS_PROJECTS")"
+    printf 'Project blockers|%s|gsd/ops registry|%s\n' "$blockers" "$(age "$OPS_PROJECTS")"
+    printf 'Claude plugins|%s|plugin inventory|%s\n' "$plugins" "$(age "$PLUGIN_CACHE")"
+    printf 'Codex skills|%s|plugin inventory|%s\n' "$skills" "$(age "$PLUGIN_CACHE")"
+    printf 'KPI caches|%s|ops daemon|%s\n' "$kpis" "$(age "$PLUGIN_CACHE")"
+    printf 'Agent warnings|%s|runtime health|%s\n' "$agents_down" "$(age "$RUNTIME_CACHE")"
+  } | pretty_table
+}
+
+business_kpis() {
+  jq_file "$KPI_CACHE" '{"projects":[]}' -r '
+    def fmt:
+      if . == null then "-"
+      elif type=="number" then
+        if . >= 1000000 then ((./1000000*10|round/10|tostring)+"M")
+        elif . >= 1000 then ((./1000*10|round/10|tostring)+"K")
+        else (.|tostring) end
+      else tostring end;
+    "KPI|VALUE|STATUS|DETAIL",
+    ((.projects // []) | map(select((.key // .label // "" | ascii_downcase) == "healify")) | .[0] // {}) as $h |
+    [
+      "Instagram followers|" + (($h.social.ig_followers // null)|fmt) + "|" + (($h.social.verdict // "-")|tostring) + "|Healify audience",
+      "Instagram reach|" + (($h.social.ig_reach // null)|fmt) + "|" + (($h.social.verdict // "-")|tostring) + "|Recent reach cache",
+      "Save rate|" + (($h.social.save_rate // null)|fmt) + "|" + (($h.social.verdict // "-")|tostring) + "|Content quality signal",
+      "Active requests|" + (($h.social.active_req // null)|fmt) + "|" + (($h.dev.phase // "-")|tostring) + "|Demand / backlog",
+      "Ads health|" + (($h.ads.health // "-")|tostring) + "|" + (($h.ads.health // "-")|tostring) + "|Marketing spend efficiency",
+      "Dev phase|" + (($h.dev.phase // "-")|tostring) + "|" + (($h.dev.phase // "-")|tostring) + "|Execution state"
+    ][]' | pretty_table
+}
+
+projects_table() {
+  jq_file "$OPS_PROJECTS" '{"projects":[]}' --argjson max "$MAX_ROWS" -r '
+    def clip($n): tostring | gsub("[\r\n\t]+";" ") | if length>$n then .[0:$n-1]+"..." else . end;
+    "PROJECT|STATUS|BLOCKERS|PHASE|NEXT ACTION",
+    ((.projects // [])
+      | map(select(.name|ascii_downcase|test("healify|meditation")))
+      | sort_by((.blockers // "0"|tonumber? // 0) * -1, .name)
+      | .[:$max]
+      | .[]
+      | [(.name // "-"),(.status // "-"),(.blockers // "0"|tostring),(.phase // "-"|tostring),(.next_action // "-"|clip(70))]
+      | join("|"))' | pretty_table
+}
+
+infra_table() {
+  {
+    printf 'PROJECT|SERVICE|TIER|STATUS|HTTP/RUN|LAT|URL\n'
+    jq_file "$INFRA_CACHE" '{"endpoints":[]}' --argjson max "$MAX_ROWS" -r '
+      (.endpoints // [])
+      | map(select(.project|ascii_downcase|test("healify|meditation")))
+      | sort_by(if .status=="down" then 0 elif .status=="warn" then 1 else 2 end, .project, .service)
+      | .[:$max]
+      | .[]
+      | [.project,.service,.tier,.status,.http,((.ms|tostring)+"ms"),.url]
+      | @tsv' | awk -F'\t' '{printf "%s|%s|%s|%s|%s|%s|%s\n",$1,$2,$3,$4,$5,$6,$7}'
+    jq_file "$AWS_CACHE" '{"services":[]}' --argjson max "$MAX_ROWS" -r '
+      (.services // [])
+      | map(select(.project|ascii_downcase|test("healify|meditation")))
+      | sort_by(if .status=="down" then 0 elif .status=="warn" then 1 else 2 end, .tier, .project)
+      | .[:$max]
+      | .[]
+      | [.project,.service,.tier,.status,.http,"-",.url]
+      | @tsv' | awk -F'\t' '{printf "%s|%s|%s|%s|%s|%s|%s\n",$1,$2,$3,$4,$5,$6,$7}'
+  } | pretty_table
+}
+
+agents_table() {
+  {
+    printf 'SOURCE|STATUS|DETAIL\n'
+    if [[ -s "$RUNTIME_CACHE" ]]; then
+      sed -n '1,30p' "$RUNTIME_CACHE" | awk -F: '{status=$2; sub(/^/,"",status); printf "%s|%s|%s\n",$1,(status ~ /ready|configured|ok/ ? "ok" : "warn"),status}'
+    else
+      printf 'runtime-health|missing|run agent-hub-health short\n'
+    fi
+    printf 'tmux|ok|%s windows in %s\n' "$(tmux list-windows -t "$SESSION" 2>/dev/null | wc -l | awk '{print $1}')" "$SESSION"
+    if command -v claude >/dev/null 2>&1; then
+      local c_total c_bad
+      c_total="$(timeout 12 claude agents --json --all 2>/dev/null | jq '[.[]? | select(.kind=="background")] | length' 2>/dev/null || echo '-')"
+      c_bad="$(timeout 12 claude agents --json --all 2>/dev/null | jq '[.[]? | select(.kind=="background" and (.state=="failed" or .state=="blocked"))] | length' 2>/dev/null || echo '-')"
+      printf 'claude-agents|ok|%s background, %s failed/blocked\n' "$c_total" "$c_bad"
+    fi
+  } | pretty_table
+}
+
+plugin_table() {
+  {
+    printf 'SURFACE|COUNT|USE IN HEALIFY DASHBOARD\n'
+    safe_jq "$PLUGIN_CACHE" '{"claude_plugins":[],"codex_skills":[],"ops_kpi_caches":[]}' '
+      "Claude plugins|" + ((.claude_plugins|length)|tostring) + "|connectors, business context, MCP capability map",
+      "Codex skills|" + ((.codex_skills|length)|tostring) + "|engineering execution map and review surfaces",
+      "Ops KPI caches|" + ((.ops_kpi_caches|length)|tostring) + "|revenue, social, marketing, project status caches"
+    ' | tr -d '"'
+  } | pretty_table
+}
+
+logs_panel() {
+  local log
+  for log in \
+    "$OPS_DATA/logs/ops-daemon.log" \
+    "$OPS_DATA/logs/mcp-watchdog.log" \
+    "$HOME/.claude/logs/agent-hub-watchdog.log" \
+    "$HOME/.claude/logs/agent-hub-revive.log"; do
+    [[ -s "$log" ]] || continue
+    printf '%s\n' "${log/#$HOME/~}"
+    tail -5 "$log" 2>/dev/null | sed 's/^/  /' | clip_width "$(cols)"
+  done
+}
+
+render() {
+  [[ "$REFRESH" == "1" ]] && refresh_caches
+  [[ -t 1 ]] && clear
+  hero
+  cards
+  section "Business KPIs"
+  business_kpis
+  section "Execution Portfolio"
+  projects_table
+  section "Infra And Deployments"
+  infra_table
+  section "Repos"
+  repo_rows | pretty_table
+  section "Agents, MCPs, CLIs"
+  agents_table
+  section "Plugin Surface"
+  plugin_table
+  section "Important Logs"
+  logs_panel
+  printf '\n%sCommands:%s hd --watch | hd --refresh | fleet | agent-hub-doctor --fix | agent-hub-ops menu\n' "$DIM" "$RESET"
+}
+
+case "$MODE" in
+  --once|"") render ;;
+  --watch)
+    while true; do
+      render || true
+      sleep "$INTERVAL"
+    done
+    ;;
+  --json) json_summary ;;
+  -h|--help) usage ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/claude-ops/bin/ops-post-update-migrate
+++ b/claude-ops/bin/ops-post-update-migrate
@@ -124,46 +124,7 @@ run_migrations() {
     fi
   fi
 
-  # 4. Stable 'current/' directory — prevents "Plugin directory does not exist" errors
-  #    when Claude Code updates the plugin mid-session and deletes the old versioned dir.
-  {
-    local cache_parent current_dir
-    cache_parent="$(dirname "$PLUGIN_ROOT")"
-    current_dir="$cache_parent/current"
-
-    if command -v rsync >/dev/null 2>&1; then
-      rsync -a --delete "$PLUGIN_ROOT/" "$current_dir/" 2>/dev/null \
-        && log "  ok: refreshed $current_dir via rsync" \
-        || log "  warn: rsync to current/ failed (non-fatal)"
-    else
-      mkdir -p "$current_dir"
-      cp -rp "$PLUGIN_ROOT/." "$current_dir/" 2>/dev/null \
-        && log "  ok: refreshed $current_dir via cp" \
-        || log "  warn: cp to current/ failed (non-fatal)"
-    fi
-
-    local installed_json="$HOME/.claude/plugins/installed_plugins.json"
-    if [[ -f "$installed_json" ]]; then
-      python3 - "$installed_json" "$current_dir" <<'PYEOF' 2>/dev/null \
-        && log "  ok: patched installed_plugins.json → current" \
-        || log "  warn: installed_plugins.json patch failed (non-fatal)"
-import json, sys
-path, current = sys.argv[1], sys.argv[2]
-with open(path) as f:
-    d = json.load(f)
-changed = False
-for e in d.get("plugins", {}).get("ops@ops-marketplace", []):
-    if e.get("scope") == "user" and e.get("installPath", "") != current:
-        e["installPath"] = current
-        changed = True
-if changed:
-    with open(path, "w") as f:
-        json.dump(d, f, indent=2)
-PYEOF
-    fi
-  } || true
-
-  # 5. Add future migrations here. Pattern:
+  # 4. Add future migrations here. Pattern:
   #    if needs_migration; then
   #      run_idempotent_migration && log "  ok: <name>"
   #    fi

--- a/claude-ops/bin/ops-post-update-migrate
+++ b/claude-ops/bin/ops-post-update-migrate
@@ -124,7 +124,46 @@ run_migrations() {
     fi
   fi
 
-  # 4. Add future migrations here. Pattern:
+  # 4. Stable 'current/' directory — prevents "Plugin directory does not exist" errors
+  #    when Claude Code updates the plugin mid-session and deletes the old versioned dir.
+  {
+    local cache_parent current_dir
+    cache_parent="$(dirname "$PLUGIN_ROOT")"
+    current_dir="$cache_parent/current"
+
+    if command -v rsync >/dev/null 2>&1; then
+      rsync -a --delete "$PLUGIN_ROOT/" "$current_dir/" 2>/dev/null \
+        && log "  ok: refreshed $current_dir via rsync" \
+        || log "  warn: rsync to current/ failed (non-fatal)"
+    else
+      mkdir -p "$current_dir"
+      cp -rp "$PLUGIN_ROOT/." "$current_dir/" 2>/dev/null \
+        && log "  ok: refreshed $current_dir via cp" \
+        || log "  warn: cp to current/ failed (non-fatal)"
+    fi
+
+    local installed_json="$HOME/.claude/plugins/installed_plugins.json"
+    if [[ -f "$installed_json" ]]; then
+      python3 - "$installed_json" "$current_dir" <<'PYEOF' 2>/dev/null \
+        && log "  ok: patched installed_plugins.json → current" \
+        || log "  warn: installed_plugins.json patch failed (non-fatal)"
+import json, sys
+path, current = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    d = json.load(f)
+changed = False
+for e in d.get("plugins", {}).get("ops@ops-marketplace", []):
+    if e.get("scope") == "user" and e.get("installPath", "") != current:
+        e["installPath"] = current
+        changed = True
+if changed:
+    with open(path, "w") as f:
+        json.dump(d, f, indent=2)
+PYEOF
+    fi
+  } || true
+
+  # 5. Add future migrations here. Pattern:
   #    if needs_migration; then
   #      run_idempotent_migration && log "  ok: <name>"
   #    fi

--- a/claude-ops/bin/ops-setup-detect
+++ b/claude-ops/bin/ops-setup-detect
@@ -147,7 +147,7 @@ if [ "$USE_CACHE" = true ] && [ -f "$PREFLIGHT/telegram.txt" ]; then
     # NOTE: never chain `grep -c` with `|| echo 0` — on zero matches grep prints
     # "0" AND exits 1, so the `||` ALSO fires, yielding "0\n0" which corrupts the
     # integer test below and the emitted JSON. Split assignment + default instead.
-    TELEGRAM_KEYS_FOUND=$(grep -c '=found' "$PREFLIGHT/telegram.txt" 2>/dev/null)
+    TELEGRAM_KEYS_FOUND=$(grep -c '=found' "$PREFLIGHT/telegram.txt" 2>/dev/null || true)
     TELEGRAM_KEYS_FOUND=${TELEGRAM_KEYS_FOUND:-0}
     if [ "$TELEGRAM_KEYS_FOUND" -eq 4 ]; then
       TELEGRAM_STATUS="configured"

--- a/claude-ops/bin/ops-setup-detect
+++ b/claude-ops/bin/ops-setup-detect
@@ -143,8 +143,12 @@ if [ "$USE_CACHE" = true ] && [ -f "$PREFLIGHT/telegram.txt" ]; then
     TELEGRAM_SOURCE="sse_router"
     TELEGRAM_KEYS_FOUND=4
   else
-    # Count keys with "found" in their value
-    TELEGRAM_KEYS_FOUND=$(grep -c '=found' "$PREFLIGHT/telegram.txt" 2>/dev/null || echo 0)
+    # Count keys with "found" in their value.
+    # NOTE: never chain `grep -c` with `|| echo 0` — on zero matches grep prints
+    # "0" AND exits 1, so the `||` ALSO fires, yielding "0\n0" which corrupts the
+    # integer test below and the emitted JSON. Split assignment + default instead.
+    TELEGRAM_KEYS_FOUND=$(grep -c '=found' "$PREFLIGHT/telegram.txt" 2>/dev/null)
+    TELEGRAM_KEYS_FOUND=${TELEGRAM_KEYS_FOUND:-0}
     if [ "$TELEGRAM_KEYS_FOUND" -eq 4 ]; then
       TELEGRAM_STATUS="configured"
       # Determine the dominant source

--- a/claude-ops/bin/ops-user-profiler
+++ b/claude-ops/bin/ops-user-profiler
@@ -74,7 +74,7 @@ case "$PERM_MODE" in
   *) AUTONOMY=careful ;;
 esac
 # installed hooks + plugins (names only) — what they've already wired up
-HOOKS=$(jq -c '[.hooks // {} | to_entries[] | .value[]? | .hooks[]? | .command? // empty | split("/") | last | sub("\\.sh$";"")] | map(select(length>0)) | unique' "$SETTINGS" 2>/dev/null)
+HOOKS=$(jq -c '[.hooks // {} | to_entries[] | .value[]? | .hooks[]? | .command? // empty | (match("/(?:bin|scripts)/([^/[:space:]]+)") | .captures[0].string // empty) | sub("\\.(sh|py)$";"")] | map(select(length>0)) | unique' "$SETTINGS" 2>/dev/null)
 PLUGINS=$(ls -1 "$HOME/.claude/plugins/cache" 2>/dev/null | head -40 | jq -R . | jq -s 'map(select(length>0))' 2>/dev/null)
 EXISTING_PREFS="$DATA/preferences.json"
 PRIOR_VERBOSITY=$(jq -r '.briefing_verbosity // empty' "$EXISTING_PREFS" 2>/dev/null || echo "")

--- a/claude-ops/bin/ops-user-profiler
+++ b/claude-ops/bin/ops-user-profiler
@@ -20,7 +20,11 @@ mkdir -p "$DATA" 2>/dev/null || true
 SCAN="$DATA/profile.scan.json"
 PREFILL="$DATA/profile.prefill.json"
 
-command -v jq >/dev/null 2>&1 || { echo '{"error":"jq-missing"}' > "$SCAN" 2>/dev/null; exit 0; }
+command -v jq >/dev/null 2>&1 || {
+  echo '{"error":"jq-missing"}' > "$SCAN" 2>/dev/null
+  echo '{}' > "$PREFILL" 2>/dev/null
+  exit 0
+}
 
 # ── minimal inline OS/shell/pkg detection (no dep on unmerged scripts/lib) ──
 case "$(uname -s 2>/dev/null)" in
@@ -70,7 +74,7 @@ case "$PERM_MODE" in
   *) AUTONOMY=careful ;;
 esac
 # installed hooks + plugins (names only) — what they've already wired up
-HOOKS=$(jq -r '[.hooks // {} | to_entries[] | .key] | @json' "$SETTINGS" 2>/dev/null)
+HOOKS=$(jq -c '[.hooks // {} | to_entries[] | .value[]? | .hooks[]? | .command? // empty | split("/") | last | sub("\\.sh$";"")] | map(select(length>0)) | unique' "$SETTINGS" 2>/dev/null)
 PLUGINS=$(ls -1 "$HOME/.claude/plugins/cache" 2>/dev/null | head -40 | jq -R . | jq -s 'map(select(length>0))' 2>/dev/null)
 EXISTING_PREFS="$DATA/preferences.json"
 PRIOR_VERBOSITY=$(jq -r '.briefing_verbosity // empty' "$EXISTING_PREFS" 2>/dev/null || echo "")

--- a/claude-ops/bin/ops-user-profiler
+++ b/claude-ops/bin/ops-user-profiler
@@ -74,7 +74,7 @@ case "$PERM_MODE" in
   *) AUTONOMY=careful ;;
 esac
 # installed hooks + plugins (names only) — what they've already wired up
-HOOKS=$(jq -c '[.hooks // {} | to_entries[] | .value[]? | .hooks[]? | .command? // empty | (match("/(?:bin|scripts)/([^/[:space:]]+)") | .captures[0].string // empty) | sub("\\.(sh|py)$";"")] | map(select(length>0)) | unique' "$SETTINGS" 2>/dev/null)
+HOOKS=$(jq -c '[.hooks // {} | to_entries[] | .value[]? | .hooks[]? | .command? // empty | (try (match("/(?:bin|scripts)/([^/[:space:]]+)") | .captures[0].string) // (split("/") | last) // empty) | sub("\\.(sh|py)$";"")] | map(select(length>0)) | unique' "$SETTINGS" 2>/dev/null)
 PLUGINS=$(ls -1 "$HOME/.claude/plugins/cache" 2>/dev/null | head -40 | jq -R . | jq -s 'map(select(length>0))' 2>/dev/null)
 EXISTING_PREFS="$DATA/preferences.json"
 PRIOR_VERBOSITY=$(jq -r '.briefing_verbosity // empty' "$EXISTING_PREFS" 2>/dev/null || echo "")

--- a/claude-ops/bin/ops-user-profiler
+++ b/claude-ops/bin/ops-user-profiler
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# ops-user-profiler — surface-scrape the machine to pre-identify the user so the
+# setup wizard can CONFIRM ("Hey Sam, you're in Amsterdam — right?") instead of
+# interrogating. Writes a compact profile + a best-guess prefilled preferences
+# patch to the plugin data dir. Cross-OS, read-only, token-frugal (NO file dumps).
+#
+# Emits:
+#   $DATA/profile.scan.json       raw machine signals (identity hints, tooling, vendors, style)
+#   $DATA/profile.prefill.json    best-guess preferences patch (NOT merged — wizard reviews first)
+#
+# A second stage (agents/user-profiler.md, Haiku + WebSearch) consumes
+# profile.scan.json to enrich identity (name/location/occupation) via web search
+# and writes $DATA/profile.json. This script does the local, offline half only.
+#
+# Safe to run at postInstall, SessionStart (once-guarded), or on demand.
+set -uo pipefail
+
+DATA="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+mkdir -p "$DATA" 2>/dev/null || true
+SCAN="$DATA/profile.scan.json"
+PREFILL="$DATA/profile.prefill.json"
+
+command -v jq >/dev/null 2>&1 || { echo '{"error":"jq-missing"}' > "$SCAN" 2>/dev/null; exit 0; }
+
+# ── minimal inline OS/shell/pkg detection (no dep on unmerged scripts/lib) ──
+case "$(uname -s 2>/dev/null)" in
+  Darwin) OS=macos ;;
+  Linux)  grep -qi microsoft /proc/version 2>/dev/null && OS=wsl || OS=linux ;;
+  MINGW*|MSYS*|CYGWIN*) OS=windows ;;
+  *) OS=unknown ;;
+esac
+PKG=none
+for p in brew dnf apt apt-get pacman zypper apk winget scoop choco; do
+  command -v "$p" >/dev/null 2>&1 && { PKG=$p; break; }
+done
+SH=$(basename "${SHELL:-/bin/sh}")
+case "$SH" in
+  zsh)  PROFILE="${ZDOTDIR:-$HOME}/.zshrc" ;;
+  bash) PROFILE="$HOME/.bashrc" ;;
+  fish) PROFILE="$HOME/.config/fish/config.fish" ;;
+  *)    PROFILE="$HOME/.profile" ;;
+esac
+
+# ── identity hints (NAMES/emails only, no secrets) ──────────────────────────
+GIT_NAME=$(git config --global user.name 2>/dev/null || echo "")
+GIT_EMAIL=$(git config --global user.email 2>/dev/null || echo "")
+GH_ACCT=$(gh auth status 2>&1 | grep -oE 'account [A-Za-z0-9_-]+' | head -1 | awk '{print $2}' || echo "")
+
+# ── installed CLI inventory (presence only) ─────────────────────────────────
+TOOLS_PRESENT=()
+TOOLS_REL="git gh aws gcloud doppler docker terraform node bun python3 go stripe shopify wrangler vercel supabase sentry-cli klaviyo twilio eas expo fastlane gog dcli"
+for t in $TOOLS_REL; do command -v "$t" >/dev/null 2>&1 && TOOLS_PRESENT+=("$t"); done
+TOOLS_JSON=$(printf '%s\n' "${TOOLS_PRESENT[@]:-}" | jq -R . | jq -s 'map(select(length>0))' 2>/dev/null)
+
+# ── configured MCP servers (names only) from ~/.claude.json ─────────────────
+MCP_JSON=$(jq -c '(.mcpServers // {}) | keys' "$HOME/.claude.json" 2>/dev/null)
+
+# ── working-STYLE signals from Claude config (verbosity/yolo/model/statusline) ─
+CLAUDE_MODEL=$(jq -r '.model // ""' "$HOME/.claude.json" 2>/dev/null || echo "")
+SETTINGS="$HOME/.claude/settings.json"
+HAS_STATUSLINE=$(jq -e '.statusLine' "$SETTINGS" >/dev/null 2>&1 && echo true || echo false)
+# autonomy signal: permissions.defaultMode + allow/deny list sizes → careful/auto/yolo
+PERM_MODE=$(jq -r '.permissions.defaultMode // ""' "$SETTINGS" 2>/dev/null || echo "")
+ALLOW_N=$(jq -r '(.permissions.allow // []) | length' "$SETTINGS" 2>/dev/null || echo 0)
+DENY_N=$(jq -r '(.permissions.deny // []) | length' "$SETTINGS" 2>/dev/null || echo 0)
+case "$PERM_MODE" in
+  bypassPermissions) AUTONOMY=yolo ;;
+  acceptEdits|dontAsk|auto) AUTONOMY=auto ;;
+  ""|default|plan) AUTONOMY=careful ;;
+  *) AUTONOMY=careful ;;
+esac
+# installed hooks + plugins (names only) — what they've already wired up
+HOOKS=$(jq -r '[.hooks // {} | to_entries[] | .key] | @json' "$SETTINGS" 2>/dev/null)
+PLUGINS=$(ls -1 "$HOME/.claude/plugins/cache" 2>/dev/null | head -40 | jq -R . | jq -s 'map(select(length>0))' 2>/dev/null)
+EXISTING_PREFS="$DATA/preferences.json"
+PRIOR_VERBOSITY=$(jq -r '.briefing_verbosity // empty' "$EXISTING_PREFS" 2>/dev/null || echo "")
+PRIOR_YOLO=$(jq -r 'if (.yolo_enabled|type)=="boolean" then (.yolo_enabled|tostring) else empty end' "$EXISTING_PREFS" 2>/dev/null || echo "")
+
+# ── vendor/role signals from env var NAMES + repo dir names (no values) ─────
+# NOTE: never chain `... | jq` with `|| echo '[]'` inside $() — on a non-zero
+# pipe element the substitution emits BOTH the jq output AND the echo, yielding
+# two concatenated JSON values that corrupt --argjson. Let the isjson guards
+# below normalize instead (same class of bug as ops-setup-detect:147).
+ENV_VENDORS=$(env | grep -oiE '^(STRIPE|KLAVIYO|META|SHOPIFY|REVENUECAT|SENTRY|LINEAR|DATADOG|ELEVENLABS|GROQ|BLAND|TELEGRAM|DISCORD|SLACK|TWILIO|POSTNL|UPS|FEDEX|DPD|GA4|OPENAI|ANTHROPIC|GEMINI|COHERE)[A-Z_]*=' 2>/dev/null | sed -E 's/=.*//' | sort -u | jq -R . | jq -s 'map(select(length>0))' 2>/dev/null)
+REPO_DIRS=$(ls -1 "$HOME/Projects" 2>/dev/null | head -40 | jq -R . | jq -s 'map(select(length>0))' 2>/dev/null)
+
+# ── enrichment capabilities present (so the web-search agent uses what we HAVE) ──
+# Detect by env key NAME or configured MCP. Names only — never values.
+ENRICH=$(
+  { env | grep -oiE '^(TAVILY|FIRECRAWL|EXA|SERPAPI|PEOPLEDATALABS|PDL|APOLLO|PROXYCURL|LINKEDIN|CLEARBIT|HUNTER)[A-Z_]*=' 2>/dev/null | sed -E 's/=.*//';
+    jq -r '(.mcpServers // {}) | keys[]' "$HOME/.claude.json" 2>/dev/null | grep -iE 'tavily|firecrawl|exa|apollo|pdl|peopledata|linkedin|clearbit'; } \
+  | sort -u | jq -R . | jq -s 'map(select(length>0))' 2>/dev/null
+)
+
+# ── doppler project list (names only, headless-safe) ────────────────────────
+DOP_PROJECTS=$(DOPPLER_CONFIG_DIR="${DOPPLER_CONFIG_DIR:-$HOME/.doppler-headless}" doppler projects --json 2>/dev/null | jq -c 'map(.name)' 2>/dev/null)
+
+# ── guarantee every --argjson input is valid JSON (empty string aborts jq -n) ──
+isjson(){ printf '%s' "$1" | jq empty >/dev/null 2>&1; }
+isjson "$TOOLS_JSON"   || TOOLS_JSON='[]'
+isjson "$MCP_JSON"     || MCP_JSON='[]'
+isjson "$ENV_VENDORS"  || ENV_VENDORS='[]'
+isjson "$REPO_DIRS"    || REPO_DIRS='[]'
+isjson "$DOP_PROJECTS" || DOP_PROJECTS='[]'
+isjson "$HOOKS"        || HOOKS='[]'
+isjson "$PLUGINS"      || PLUGINS='[]'
+isjson "$ENRICH"       || ENRICH='[]'
+[ -n "${ALLOW_N:-}" ] && isjson "$ALLOW_N" || ALLOW_N=0
+[ -n "${DENY_N:-}" ]  && isjson "$DENY_N"  || DENY_N=0
+
+jq -n \
+  --arg os "$OS" --arg pkg "$PKG" --arg sh "$SH" --arg profile "$PROFILE" \
+  --arg gname "$GIT_NAME" --arg gemail "$GIT_EMAIL" --arg gh "$GH_ACCT" \
+  --arg model "$CLAUDE_MODEL" --arg statusline "$HAS_STATUSLINE" \
+  --arg pverb "$PRIOR_VERBOSITY" --arg pyolo "$PRIOR_YOLO" \
+  --arg autonomy "$AUTONOMY" --arg permmode "$PERM_MODE" \
+  --argjson allown "${ALLOW_N:-0}" --argjson denyn "${DENY_N:-0}" \
+  --argjson tools "$TOOLS_JSON" --argjson mcps "$MCP_JSON" \
+  --argjson envvendors "$ENV_VENDORS" --argjson repos "$REPO_DIRS" \
+  --argjson doppler "$DOP_PROJECTS" --argjson hooks "$HOOKS" \
+  --argjson plugins "$PLUGINS" --argjson enrich "$ENRICH" \
+  '{
+    schema: "ops-profile-scan/1",
+    host: { os: $os, pkg_mgr: $pkg, shell: $sh, profile_file: $profile },
+    identity_hints: { git_name: $gname, git_email: $gemail, gh_account: $gh },
+    style_hints: { claude_model: $model, has_statusline: ($statusline=="true"),
+                   prior_verbosity: $pverb, prior_yolo: $pyolo,
+                   autonomy: $autonomy, perm_mode: $permmode,
+                   allow_count: $allown, deny_count: $denyn },
+    tooling_present: $tools,
+    mcp_configured: $mcps,
+    hooks_installed: $hooks,
+    plugins_installed: $plugins,
+    enrichment_available: $enrich,
+    env_vendor_names: $envvendors,
+    doppler_projects: $doppler,
+    repo_dirs: $repos
+  }' > "$SCAN" 2>"${OPS_PROFILER_JQERR:-/dev/null}" || echo '{"error":"scan-failed"}' > "$SCAN"
+
+# ── best-guess prefill patch (style only; credentials resolved separately) ──
+# Conservative: only prefill what we can infer with high confidence.
+jq -n \
+  --arg os "$OS" \
+  --argjson scan "$(cat "$SCAN")" \
+  '{
+    schema: "ops-profile-prefill/1",
+    note: "Best-guess defaults — wizard MUST show review screen before applying.",
+    suggested: {
+      timezone: null,
+      owner: ($scan.identity_hints.git_name // null),
+      briefing_verbosity: (if ($scan.style_hints.prior_verbosity // "") != "" then $scan.style_hints.prior_verbosity else "compact" end),
+      autonomy: ($scan.style_hints.autonomy // "careful"),
+      yolo_enabled: ($scan.style_hints.autonomy == "yolo")
+    }
+  }' > "$PREFILL" 2>/dev/null || echo '{}' > "$PREFILL"
+
+echo "ops-user-profiler: wrote $SCAN + $PREFILL (os=$OS pkg=$PKG)"

--- a/claude-ops/docs/healify-dashboard.md
+++ b/claude-ops/docs/healify-dashboard.md
@@ -9,6 +9,7 @@ ops-healify-dash --once
 ops-healify-dash --watch
 ops-healify-dash --refresh
 ops-healify-dash --json
+ops-healify-bi-refresh
 ```
 
 `--refresh` refreshes bounded local caches first. `--watch` rerenders on an interval. Neither mode changes tmux focus or selects another window.
@@ -28,11 +29,24 @@ The dashboard aggregates only local, already-configured sources:
 - live endpoint health cache: `~/.cache/agent-hub/infra-health.json`
 - AWS ECS health cache: `~/.cache/agent-hub/aws-ecs-health.json`
 - plugin inventory: `~/.cache/agent-hub/plugin-inventory.json`
+- Healify BI cache: `~/.cache/agent-hub/healify-bi.json`
 - runtime health: `~/.cache/agent-hub/fleet/runtime-health.txt`
 - local Healify git repos under `~/Projects/healify-workspace`
 - important ops and agent-hub logs
 
-It shows business KPIs, project execution state, service health, ECS deployment status, repo drift, agent/MCP/CLI readiness, plugin coverage, and recent important logs.
+`ops-healify-bi-refresh` warms the BI cache from authenticated local and ops-dashboard sources when available:
+
+- EAS latest iOS builds
+- App Store Connect app versions, build numbers, processing state, and reviews
+- App Store Connect sales/download status, clearly marked blocked when the vendor number is missing
+- AppsFlyer installs, organic split, loyal users, and cost
+- Amplitude active/new-user status
+- Sentry unresolved issue counts by Healify project
+- BetterStack uptime/incidents
+- Linear priority issue counts
+- mobile QA and Pact/contract health from the operating dashboard integration source
+
+It shows business KPIs, acquisition and marketing state, App Store/TestFlight release state, reviews, project execution state, service health, ECS deployment status, repo drift, agent/MCP/CLI readiness, plugin coverage, and recent important logs.
 
 ## Branding
 

--- a/claude-ops/docs/healify-dashboard.md
+++ b/claude-ops/docs/healify-dashboard.md
@@ -1,0 +1,55 @@
+# Healify Dashboard
+
+`ops-healify-dash` is a dedicated Healify.ai command center for terminal and tmux workflows. It is read-only by default and designed for dark terminals with an orange Healify.ai brand treatment.
+
+## Commands
+
+```bash
+ops-healify-dash --once
+ops-healify-dash --watch
+ops-healify-dash --refresh
+ops-healify-dash --json
+```
+
+`--refresh` refreshes bounded local caches first. `--watch` rerenders on an interval. Neither mode changes tmux focus or selects another window.
+
+`ops-dash` can explicitly delegate to this surface:
+
+```bash
+OPS_HEALIFY_DASH=1 ops-dash
+```
+
+## Data Sources
+
+The dashboard aggregates only local, already-configured sources:
+
+- `ops:projects` cache: `$OPS_DATA_DIR/cache/projects_health.json`
+- statusline KPI cache: `~/.claude/state/statusline-kpi.json`
+- live endpoint health cache: `~/.cache/agent-hub/infra-health.json`
+- AWS ECS health cache: `~/.cache/agent-hub/aws-ecs-health.json`
+- plugin inventory: `~/.cache/agent-hub/plugin-inventory.json`
+- runtime health: `~/.cache/agent-hub/fleet/runtime-health.txt`
+- local Healify git repos under `~/Projects/healify-workspace`
+- important ops and agent-hub logs
+
+It shows business KPIs, project execution state, service health, ECS deployment status, repo drift, agent/MCP/CLI readiness, plugin coverage, and recent important logs.
+
+## Branding
+
+The 1:1 pixel icon lives at:
+
+```text
+assets/healify-pixel-logo.svg
+```
+
+It follows the current Healify.ai app-icon direction: orange/pink rounded square, high contrast, and a white heart/pill health mark. The terminal dashboard renders the same concept as ANSI pixel blocks.
+
+## Tmux Integration
+
+Any tmux binding should open this dashboard only through explicit user action, for example:
+
+```tmux
+bind v display-popup -E -w 96% -h 92% "ops-healify-dash --watch"
+```
+
+Background watchdogs, prewarmers, doctors, and repair hooks must not call `select-window` or `switch-client`. While a user is working in a window, focus should remain there unless the user explicitly presses a navigation key.

--- a/claude-ops/package-lock.json
+++ b/claude-ops/package-lock.json
@@ -1,17 +1,20 @@
 {
   "name": "claude-ops-bin",
-  "version": "1.7.2",
+  "version": "2.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-ops-bin",
-      "version": "1.7.2",
+      "version": "2.32.0",
       "dependencies": {
         "classic-level": "^3.0.0",
         "input": "^1.0.1",
         "playwright": "^1.60.0",
         "telegram": "^2.26.22"
+      },
+      "devDependencies": {
+        "prettier": "^3.8.4"
       }
     },
     "node_modules/@cryptography/aes": {
@@ -754,6 +757,22 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/readline2": {

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -15,5 +15,8 @@
     "input": "^1.0.1",
     "playwright": "^1.60.0",
     "telegram": "^2.26.22"
+  },
+  "devDependencies": {
+    "prettier": "^3.8.4"
   }
 }

--- a/claude-ops/skills/setup/PERSONA-SCHEMA.md
+++ b/claude-ops/skills/setup/PERSONA-SCHEMA.md
@@ -1,0 +1,95 @@
+# Persona Schema — `preferences.json .persona`
+
+The setup wizard and every ops touchpoint read `preferences.json` as a **rich, continuously-updated snapshot of the user** so we hyper-personalize and *never ask a question we could have answered ourselves*. This file documents the `.persona` block: how it's built, its shape, and the read/write contract.
+
+This is **generic for any user** — every field is *discovered* (git identity, env var names, detected OS, transcript mining, web search), never hardcoded to one person.
+
+## How it's populated (layered, highest-confidence wins)
+
+1. **Install-time local scan** — `bin/ops-user-profiler` → `profile.scan.json` (OS, shell, tooling present, MCPs configured, env vendor NAMES, Doppler project names, repo dir names, Claude-config style hints). Offline, no secrets, token-frugal.
+2. **Install-time web enrichment** — `agents/user-profiler.md` (Haiku + WebSearch) consumes the scan, searches the user from their git email / name / GitHub account, resolves real name, location → timezone, occupation, public persona → `profile.json`.
+3. **Transcript mining** — scans `~/.claude/projects/**/*.jsonl` for recurring frustrations, style corrections ("be terse", "stop asking"), and tools/hooks/plugins in active use → `persona.signals`.
+4. **Wizard confirmations** — anything the user confirms or corrects in the GUI is written back with `source: "confirmed"` (highest trust).
+5. **Ongoing** — ops skills append observed signals over time (it's a living snapshot, not a one-time form).
+
+## Shape
+
+```jsonc
+{
+  "persona": {
+    "schema": "ops-persona/1",
+    "updated_at": "<ISO8601>",
+    "identity": {
+      "display_name": "Sam",            // what we CALL them in briefings
+      "full_name": "Sam Feldt",         // resolved, may differ from git name
+      "emails": ["..."],
+      "gh_account": "...",
+      "confidence": "high|medium|low",
+      "source": "websearch|git|confirmed|transcript"
+    },
+    "location": {
+      "city": "Amsterdam", "country": "NL",
+      "timezone": "Europe/Amsterdam",
+      "confidence": "...", "source": "..."
+    },
+    "roles": {                          // ranked; drives relevance-prune
+      "primary": "founder",
+      "secondary": ["developer", "creator", "marketer"],
+      "evidence": "repo names, tooling, web persona",
+      "confidence": "..."
+    },
+    "interests": ["preventive-health", "music/A&R", "AI agents"],
+    "working_style": {
+      "verbosity": "compact|full|minimal",
+      "autonomy": "careful|auto|yolo",   // see "Autonomy determination" below
+      "yolo_enabled": true,              // convenience mirror of autonomy=="yolo"
+      "preferred_model": "opus|sonnet|haiku",
+      "tone": "terse-direct",
+      "source": "transcript|claude-config|confirmed",
+      "autonomy_evidence": "settings.permissions.defaultMode=bypassPermissions + 0 denials in last 200 tool calls"
+    },
+    "frustrations": [                    // mined — what annoys them, so we avoid it
+      { "text": "verbosity / preamble", "source": "transcript", "seen": 4 }
+    ],
+    "environment": {
+      "os": "linux", "pkg_mgr": "dnf", "shell": "bash",
+      "profile_file": "~/.bashrc",
+      "hooks_installed": ["block-outbound-comms", "gh-watch-guard"],
+      "plugins_installed": ["gsd", "superpowers", "gstack"],
+      "mcps_configured": ["linear", "slack", "whatsapp", "..."],
+      "clis_present": ["gh", "aws", "doppler", "..."]
+    },
+    "relevant_services": ["telegram","whatsapp","slack","email","stripe","..."],
+    "pruned_services": ["postnl","ups","fedex","dpd"],  // hidden from flow, shown in review
+    "recommended_tooling": [            // worth installing, with why + how
+      { "tool": "stripe", "why": "you have STRIPE_* keys but no stripe CLI",
+        "install": "dnf install stripe" }
+    ]
+  }
+}
+```
+
+## Autonomy determination (careful / auto / yolo)
+
+Establish the user's risk appetite from **Claude settings + observed behaviour**, not by asking. This sets `working_style.autonomy` and seeds the wizard's default confirm-vs-act posture + the plugin's `yolo_enabled`.
+
+Signals (combine; behaviour outweighs config when they conflict):
+- **`~/.claude/settings.json`** — `permissions.defaultMode`: `bypassPermissions` → **yolo**; `acceptEdits`/`dontAsk`/`auto` → **auto**; `default`/`plan` or unset → **careful**. Also weigh the size of `permissions.allow` vs `permissions.ask`/`deny` (large allow-list, empty deny → leans auto/yolo).
+- **Launch flags / env** — evidence of `--dangerously-skip-permissions` usage, `CLAUDE_*` autonomy env.
+- **Behaviour from transcripts** — denial/approval ratio in recent tool calls: near-zero denials + many auto-approved edits → yolo; frequent "no/stop/let me check" → careful. Frustration signals like "stop asking me" → push toward auto/yolo; "always confirm first" → careful.
+- **Existing plugin pref** — a prior `yolo_enabled`/`autonomy` value (source `confirmed`) wins unless behaviour strongly contradicts it (then re-confirm, don't silently flip).
+
+Map to behaviour:
+- **careful** → wizard confirms every action; ops skills never auto-execute irreversible/outbound steps.
+- **auto** → wizard auto-confirms low-risk; still gates outbound comms + destructive bulk (hard guards always apply regardless).
+- **yolo** → fast-path everything low/medium-risk with reasons logged; hard guards (outbound-comms token, rm-rf anchor) STILL apply — autonomy never disables safety hooks.
+
+The wizard presents this as a confirm too: "You run Claude in **yolo** mode (bypassPermissions, ~0 denials) — want ops to match that and auto-act on low-risk steps? [Yes, match it] [No, keep me in the loop]".
+
+## Read/write contract
+
+- **Never clobber** `confirmed`-source fields with lower-confidence scans. Merge by confidence + recency.
+- **Never store secret VALUES** in `.persona` — only names/presence. Secrets live in their own keys (file backend) or the keychain via `credential-store.sh`.
+- Preserve sibling keys (`partner_registry`, `channels`, behavioral toggles) on every write — merge with `jq`, write tmp, `mv`.
+- The wizard's confirm screens read `.persona.identity` / `.location` / `.roles` and present them as "Did I get this right?" — **confirm, don't ask**. Only fall back to a blank prompt when confidence is `low` or a field is absent.
+- Relevance-prune reads `.persona.relevant_services` vs `pruned_services`; the pre-completion review screen surfaces `pruned_services` + `recommended_tooling` + any service whose credential wasn't found.

--- a/claude-ops/skills/setup/PERSONA-SCHEMA.md
+++ b/claude-ops/skills/setup/PERSONA-SCHEMA.md
@@ -7,7 +7,7 @@ This is **generic for any user** — every field is _discovered_ (git identity, 
 ## How it's populated (layered, highest-confidence wins)
 
 1. **Install-time local scan** — `bin/ops-user-profiler` → `profile.scan.json` (OS, shell, tooling present, MCPs configured, env vendor NAMES, Doppler project names, repo dir names, Claude-config style hints). Offline, no secrets, token-frugal.
-2. **Optional web enrichment** — after explicit user confirmation, `agents/user-profiler.md` (Haiku + WebSearch) consumes the scan, searches from the user's git email / name / GitHub account, and writes only unconfirmed suggestions to `profile.prefill.json` until the wizard review screen accepts them.
+2. **Optional web enrichment** — after an explicit `AskUserQuestion` consent step, `agents/user-profiler.md` (Haiku + WebSearch) consumes the scan, searches from the user's git email / name / GitHub account, and writes only unconfirmed suggestions to `profile.prefill.json` until the wizard review screen accepts them. If the user declines, setup must skip external lookups and continue with local-only signals.
 3. **Transcript mining** — scans `~/.claude/projects/**/*.jsonl` for recurring frustrations, style corrections ("be terse", "stop asking"), and tools/hooks/plugins in active use → `persona.signals`.
 4. **Wizard confirmations** — anything the user confirms or corrects in the GUI is written back with `source: "confirmed"` (highest trust).
 5. **Ongoing** — ops skills append observed signals over time (it's a living snapshot, not a one-time form).

--- a/claude-ops/skills/setup/PERSONA-SCHEMA.md
+++ b/claude-ops/skills/setup/PERSONA-SCHEMA.md
@@ -1,13 +1,13 @@
 # Persona Schema — `preferences.json .persona`
 
-The setup wizard and every ops touchpoint read `preferences.json` as a **rich, continuously-updated snapshot of the user** so we hyper-personalize and *never ask a question we could have answered ourselves*. This file documents the `.persona` block: how it's built, its shape, and the read/write contract.
+The setup wizard and every ops touchpoint read `preferences.json` as a **rich, continuously-updated snapshot of the user** so we hyper-personalize and _never ask a question we could have answered ourselves_. This file documents the `.persona` block: how it's built, its shape, and the read/write contract.
 
-This is **generic for any user** — every field is *discovered* (git identity, env var names, detected OS, transcript mining, web search), never hardcoded to one person.
+This is **generic for any user** — every field is _discovered_ (git identity, env var names, detected OS, transcript mining, web search), never hardcoded to one person.
 
 ## How it's populated (layered, highest-confidence wins)
 
 1. **Install-time local scan** — `bin/ops-user-profiler` → `profile.scan.json` (OS, shell, tooling present, MCPs configured, env vendor NAMES, Doppler project names, repo dir names, Claude-config style hints). Offline, no secrets, token-frugal.
-2. **Install-time web enrichment** — `agents/user-profiler.md` (Haiku + WebSearch) consumes the scan, searches the user from their git email / name / GitHub account, resolves real name, location → timezone, occupation, public persona → `profile.json`.
+2. **Optional web enrichment** — after explicit user confirmation, `agents/user-profiler.md` (Haiku + WebSearch) consumes the scan, searches from the user's git email / name / GitHub account, and writes only unconfirmed suggestions to `profile.prefill.json` until the wizard review screen accepts them.
 3. **Transcript mining** — scans `~/.claude/projects/**/*.jsonl` for recurring frustrations, style corrections ("be terse", "stop asking"), and tools/hooks/plugins in active use → `persona.signals`.
 4. **Wizard confirmations** — anything the user confirms or corrects in the GUI is written back with `source: "confirmed"` (highest trust).
 5. **Ongoing** — ops skills append observed signals over time (it's a living snapshot, not a one-time form).
@@ -20,52 +20,58 @@ This is **generic for any user** — every field is *discovered* (git identity, 
     "schema": "ops-persona/1",
     "updated_at": "<ISO8601>",
     "identity": {
-      "display_name": "Sam",            // what we CALL them in briefings
-      "full_name": "Sam Feldt",         // resolved, may differ from git name
+      "display_name": "Owner", // what we CALL them in briefings
+      "full_name": "Owner Example", // resolved, may differ from git name
       "emails": ["..."],
       "gh_account": "...",
       "confidence": "high|medium|low",
-      "source": "websearch|git|confirmed|transcript"
+      "source": "websearch|git|confirmed|transcript",
     },
     "location": {
-      "city": "Amsterdam", "country": "NL",
-      "timezone": "Europe/Amsterdam",
-      "confidence": "...", "source": "..."
+      "city": "Example City",
+      "country": "XX",
+      "timezone": "Etc/UTC",
+      "confidence": "...",
+      "source": "...",
     },
-    "roles": {                          // ranked; drives relevance-prune
+    "roles": {
+      // ranked; drives relevance-prune
       "primary": "founder",
       "secondary": ["developer", "creator", "marketer"],
       "evidence": "repo names, tooling, web persona",
-      "confidence": "..."
+      "confidence": "...",
     },
     "interests": ["preventive-health", "music/A&R", "AI agents"],
     "working_style": {
       "verbosity": "compact|full|minimal",
-      "autonomy": "careful|auto|yolo",   // see "Autonomy determination" below
-      "yolo_enabled": true,              // convenience mirror of autonomy=="yolo"
+      "autonomy": "careful|auto|yolo", // see "Autonomy determination" below
+      "yolo_enabled": true, // convenience mirror of autonomy=="yolo"
       "preferred_model": "opus|sonnet|haiku",
       "tone": "terse-direct",
       "source": "transcript|claude-config|confirmed",
-      "autonomy_evidence": "settings.permissions.defaultMode=bypassPermissions + 0 denials in last 200 tool calls"
+      "autonomy_evidence": "settings.permissions.defaultMode=bypassPermissions + 0 denials in last 200 tool calls",
     },
-    "frustrations": [                    // mined — what annoys them, so we avoid it
-      { "text": "verbosity / preamble", "source": "transcript", "seen": 4 }
+    "frustrations": [
+      // mined — what annoys them, so we avoid it
+      { "text": "verbosity / preamble", "source": "transcript", "seen": 4 },
     ],
     "environment": {
-      "os": "linux", "pkg_mgr": "dnf", "shell": "bash",
+      "os": "linux",
+      "pkg_mgr": "dnf",
+      "shell": "bash",
       "profile_file": "~/.bashrc",
       "hooks_installed": ["block-outbound-comms", "gh-watch-guard"],
       "plugins_installed": ["gsd", "superpowers", "gstack"],
       "mcps_configured": ["linear", "slack", "whatsapp", "..."],
-      "clis_present": ["gh", "aws", "doppler", "..."]
+      "clis_present": ["gh", "aws", "doppler", "..."],
     },
-    "relevant_services": ["telegram","whatsapp","slack","email","stripe","..."],
-    "pruned_services": ["postnl","ups","fedex","dpd"],  // hidden from flow, shown in review
-    "recommended_tooling": [            // worth installing, with why + how
-      { "tool": "stripe", "why": "you have STRIPE_* keys but no stripe CLI",
-        "install": "dnf install stripe" }
-    ]
-  }
+    "relevant_services": ["telegram", "whatsapp", "slack", "email", "stripe", "..."],
+    "pruned_services": ["postnl", "ups", "fedex", "dpd"], // hidden from flow, shown in review
+    "recommended_tooling": [
+      // worth installing, with why + how
+      { "tool": "stripe", "why": "you have STRIPE_* keys but no stripe CLI", "install": "dnf install stripe" },
+    ],
+  },
 }
 ```
 
@@ -74,12 +80,14 @@ This is **generic for any user** — every field is *discovered* (git identity, 
 Establish the user's risk appetite from **Claude settings + observed behaviour**, not by asking. This sets `working_style.autonomy` and seeds the wizard's default confirm-vs-act posture + the plugin's `yolo_enabled`.
 
 Signals (combine; behaviour outweighs config when they conflict):
+
 - **`~/.claude/settings.json`** — `permissions.defaultMode`: `bypassPermissions` → **yolo**; `acceptEdits`/`dontAsk`/`auto` → **auto**; `default`/`plan` or unset → **careful**. Also weigh the size of `permissions.allow` vs `permissions.ask`/`deny` (large allow-list, empty deny → leans auto/yolo).
 - **Launch flags / env** — evidence of `--dangerously-skip-permissions` usage, `CLAUDE_*` autonomy env.
 - **Behaviour from transcripts** — denial/approval ratio in recent tool calls: near-zero denials + many auto-approved edits → yolo; frequent "no/stop/let me check" → careful. Frustration signals like "stop asking me" → push toward auto/yolo; "always confirm first" → careful.
 - **Existing plugin pref** — a prior `yolo_enabled`/`autonomy` value (source `confirmed`) wins unless behaviour strongly contradicts it (then re-confirm, don't silently flip).
 
 Map to behaviour:
+
 - **careful** → wizard confirms every action; ops skills never auto-execute irreversible/outbound steps.
 - **auto** → wizard auto-confirms low-risk; still gates outbound comms + destructive bulk (hard guards always apply regardless).
 - **yolo** → fast-path everything low/medium-risk with reasons logged; hard guards (outbound-comms token, rm-rf anchor) STILL apply — autonomy never disables safety hooks.
@@ -89,6 +97,7 @@ The wizard presents this as a confirm too: "You run Claude in **yolo** mode (byp
 ## Read/write contract
 
 - **Never clobber** `confirmed`-source fields with lower-confidence scans. Merge by confidence + recency.
+- **Never promote enriched identity/location automatically** — web-enriched values remain `source: "unconfirmed"` in `profile.prefill.json` until the user accepts them in the wizard.
 - **Never store secret VALUES** in `.persona` — only names/presence. Secrets live in their own keys (file backend) or the keychain via `credential-store.sh`.
 - Preserve sibling keys (`partner_registry`, `channels`, behavioral toggles) on every write — merge with `jq`, write tmp, `mv`.
 - The wizard's confirm screens read `.persona.identity` / `.location` / `.roles` and present them as "Did I get this right?" — **confirm, don't ask**. Only fall back to a blank prompt when confidence is `low` or a field is absent.

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -183,7 +183,7 @@ Print a compact status header to the user, one line per category:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  OPS ► SETUP WIZARD
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- Shell:       zsh → ~/.zshrc
+ Shell:       <detected shell> → <detected profile_file>   (e.g. bash → ~/.bashrc, zsh → ~/.zshrc, fish → ~/.config/fish/config.fish)
  Core CLIs:   ✓ jq  ✓ git  ✓ gh  ✓ aws  ✓ node
  Channels:    ✓ bridge  ✓ gog  ○ telegram (no token)
  Secrets:     ✓ doppler (project: my-app, config: dev)
@@ -1749,9 +1749,11 @@ Then continue to Step 7.
 
 ## Step 7 — Shell env (if selected)
 
-1. Check whether `CLAUDE_PLUGIN_ROOT` is already exported in the profile file (grep for `CLAUDE_PLUGIN_ROOT`).
-2. If missing, **append it automatically** — this is a required step, not optional. Use `>>` (append, never overwrite). Print: `"✓ Added export CLAUDE_PLUGIN_ROOT=... to ~/.zshrc"`. Do NOT ask the user for permission — Rule 2 (never delegate commands to the user) applies here.
-3. Tell the user: `"Run 'source ~/.zshrc' or open a new terminal for it to take effect."` — this will show as an approval prompt in Claude's next tool call, which the user accepts normally.
+**Use the DETECTED shell profile, never a hardcoded `~/.zshrc`.** Resolve `PROFILE_FILE` from the Step 0b detector output (`profile_file` — `.bashrc` / `.zshrc` / `.config/fish/config.fish` / `.profile` per the user's actual `$SHELL`). A hardcoded `~/.zshrc` lands the export in a file bash/fish never sources (the original cross-OS bug).
+
+1. Check whether `CLAUDE_PLUGIN_ROOT` is already exported in `$PROFILE_FILE` (grep for `CLAUDE_PLUGIN_ROOT`).
+2. If missing, **append it automatically** — required, not optional. Use `>>` (append, never overwrite). Print: `"✓ Added export CLAUDE_PLUGIN_ROOT=... to $PROFILE_FILE"`. Do NOT ask permission — Rule 2 (never delegate commands to the user) applies. (fish syntax: write `set -gx CLAUDE_PLUGIN_ROOT …` into `config.fish` instead of `export`.)
+3. Tell the user: `"Run 'source $PROFILE_FILE' or open a new terminal for it to take effect."`
 
 ---
 

--- a/claude-ops/skills/setup/SKILL.md
+++ b/claude-ops/skills/setup/SKILL.md
@@ -1752,7 +1752,15 @@ Then continue to Step 7.
 **Use the DETECTED shell profile, never a hardcoded `~/.zshrc`.** Resolve `PROFILE_FILE` from the Step 0b detector output (`profile_file` — `.bashrc` / `.zshrc` / `.config/fish/config.fish` / `.profile` per the user's actual `$SHELL`). A hardcoded `~/.zshrc` lands the export in a file bash/fish never sources (the original cross-OS bug).
 
 1. Check whether `CLAUDE_PLUGIN_ROOT` is already exported in `$PROFILE_FILE` (grep for `CLAUDE_PLUGIN_ROOT`).
-2. If missing, **append it automatically** — required, not optional. Use `>>` (append, never overwrite). Print: `"✓ Added export CLAUDE_PLUGIN_ROOT=... to $PROFILE_FILE"`. Do NOT ask permission — Rule 2 (never delegate commands to the user) applies. (fish syntax: write `set -gx CLAUDE_PLUGIN_ROOT …` into `config.fish` instead of `export`.)
+2. If missing, **append it automatically** — required, not optional. Use `>>` (append, never overwrite). Do NOT ask permission — Rule 2 (never delegate commands to the user) applies. Branch on the detected profile before writing:
+   ```bash
+   if [[ "$PROFILE_FILE" == *config.fish ]]; then
+     echo "set -gx CLAUDE_PLUGIN_ROOT $CLAUDE_PLUGIN_ROOT" >> "$PROFILE_FILE"
+   else
+     echo "export CLAUDE_PLUGIN_ROOT=\"$CLAUDE_PLUGIN_ROOT\"" >> "$PROFILE_FILE"
+   fi
+   ```
+   Print: `"✓ Added CLAUDE_PLUGIN_ROOT to $PROFILE_FILE"`.
 3. Tell the user: `"Run 'source $PROFILE_FILE' or open a new terminal for it to take effect."`
 
 ---

--- a/claude-ops/skills/setup/channels/mcp.md
+++ b/claude-ops/skills/setup/channels/mcp.md
@@ -57,10 +57,13 @@ Run this bootstrap once per machine, or after clearing the browser profile.
 
 ## 4. Verify API-key servers
 
-Servers in `API_KEY_MCPS` (currently `pocketai`) use a static Bearer key from macOS Keychain under service name `POCKET_API_KEY`, account `ops-daemon`. Confirm:
+Servers in `API_KEY_MCPS` (currently `pocketai`) use a static Bearer key stored via the cross-OS `credential-store.sh` under service name `POCKET_API_KEY`, account `ops-daemon`. Confirm (macOS uses `security`; Linux/WSL uses `secret-tool`/file backend — prefer the abstraction):
 
 ```bash
-security find-generic-password -s POCKET_API_KEY -a ops-daemon -w
+# Cross-OS (preferred):
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/lib/credential-store.sh" get POCKET_API_KEY ops-daemon
+# macOS-only fallback:
+# security find-generic-password -s POCKET_API_KEY -a ops-daemon -w
 ```
 
 If the key is missing, add it:

--- a/claude-ops/skills/setup/channels/mcp.md
+++ b/claude-ops/skills/setup/channels/mcp.md
@@ -61,7 +61,7 @@ Servers in `API_KEY_MCPS` (currently `pocketai`) use a static Bearer key stored 
 
 ```bash
 # Cross-OS (preferred):
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/lib/credential-store.sh" get POCKET_API_KEY ops-daemon
+bash "${CLAUDE_PLUGIN_ROOT}/lib/credential-store.sh" get POCKET_API_KEY ops-daemon
 # macOS-only fallback:
 # security find-generic-password -s POCKET_API_KEY -a ops-daemon -w
 ```
@@ -69,7 +69,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/lib/credential-store.sh" get POCKET_API_KEY 
 If the key is missing, add it:
 
 ```bash
-security add-generic-password -s POCKET_API_KEY -a ops-daemon -w "<key>"
+bash "${CLAUDE_PLUGIN_ROOT}/lib/credential-store.sh" set POCKET_API_KEY ops-daemon "<key>"
 ```
 
 ## 5. First health check

--- a/claude-ops/skills/setup/channels/pocket.md
+++ b/claude-ops/skills/setup/channels/pocket.md
@@ -53,18 +53,21 @@ POCKET_API_KEY not found. Where would you like to get one?
 
 On "Open Pocket dev portal": run `bash "${CLAUDE_PLUGIN_ROOT}/lib/opener.sh" "https://public.heypocketai.com"` (or `open "https://public.heypocketai.com"` on macOS) then ask `AskUserQuestion`: `[Paste key now]` / `[Skip]`.
 
-Once a key is provided, save to macOS Keychain and shell profile:
+Once a key is provided, save it through the cross-OS credential store and expose
+it from the detected shell profile when needed:
 
 ```bash
-# Keychain (preferred — avoids env leakage in shell history)
-security add-generic-password -U \
-  -s POCKET_API_KEY -a ops-daemon \
-  -w "$POCKET_API_KEY"
+bash "${CLAUDE_PLUGIN_ROOT}/lib/credential-store.sh" set POCKET_API_KEY ops-daemon "$POCKET_API_KEY"
 
-# Also export in shell profile so the launchd plist inherits it via EnvironmentVariables
-PROFILE="${ZDOTDIR:-$HOME}/.zshrc"
+case "$(basename "${SHELL:-}")" in
+  zsh) PROFILE="${ZDOTDIR:-$HOME}/.zshrc" ;;
+  bash) PROFILE="$HOME/.bashrc" ;;
+  fish) PROFILE="$HOME/.config/fish/config.fish" ;;
+  *) PROFILE="$HOME/.profile" ;;
+esac
+
 grep -q "POCKET_API_KEY" "$PROFILE" 2>/dev/null || \
-  echo 'export POCKET_API_KEY="$(security find-generic-password -s POCKET_API_KEY -a ops-daemon -w 2>/dev/null)"' >> "$PROFILE"
+  echo 'export POCKET_API_KEY="$(bash "${CLAUDE_PLUGIN_ROOT}/lib/credential-store.sh" get POCKET_API_KEY ops-daemon 2>/dev/null)"' >> "$PROFILE"
 ```
 
 #### Step 3p.3 — Choose notification channels
@@ -150,18 +153,31 @@ jq -n \
   > "$HOME/.claude/state/pocket/email-config.json"
 ```
 
-#### Step 3p.6 — Install the launchd notifier
+#### Step 3p.6 — Install the notifier
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/install-pocket-notifier.sh"
+case "$(uname -s)" in
+  Darwin)
+    bash "${CLAUDE_PLUGIN_ROOT}/scripts/install-pocket-notifier.sh"
+    ;;
+  Linux)
+    echo "Linux: wire ${CLAUDE_PLUGIN_ROOT}/scripts/ops-pocket-activity-notifier.py into systemd --user or cron at a 60s interval."
+    ;;
+  *)
+    echo "Pocket notifier auto-install is unsupported on this OS; run the notifier manually or skip this channel."
+    ;;
+esac
 ```
 
-This generates `~/Library/LaunchAgents/com.claude-ops.pocket-activity-notifier.plist` from the bundled template, resolves Python 3, substitutes paths, and bootstraps the agent. Idempotent — re-running re-bootstraps cleanly.
+On macOS this generates `~/Library/LaunchAgents/com.claude-ops.pocket-activity-notifier.plist` from the bundled template, resolves Python 3, substitutes paths, and bootstraps the agent. On Linux/WSL, use the printed `systemd --user` or cron wiring until a packaged Linux installer exists. Idempotent — re-running re-bootstraps cleanly.
 
 Verify the agent loaded:
 
 ```bash
-launchctl list | grep com.claude-ops.pocket-activity-notifier
+case "$(uname -s)" in
+  Darwin) launchctl list | grep com.claude-ops.pocket-activity-notifier ;;
+  Linux) systemctl --user status pocket-activity-notifier ;;
+esac
 ```
 
 If the grep returns nothing, surface the error via `AskUserQuestion`: `[Retry install]` / `[Skip]`.

--- a/claude-ops/skills/setup/channels/pocket.md
+++ b/claude-ops/skills/setup/channels/pocket.md
@@ -59,15 +59,18 @@ it from the detected shell profile when needed:
 ```bash
 bash "${CLAUDE_PLUGIN_ROOT}/lib/credential-store.sh" set POCKET_API_KEY ops-daemon "$POCKET_API_KEY"
 
-case "$(basename "${SHELL:-}")" in
-  zsh) PROFILE="${ZDOTDIR:-$HOME}/.zshrc" ;;
-  bash) PROFILE="$HOME/.bashrc" ;;
-  fish) PROFILE="$HOME/.config/fish/config.fish" ;;
-  *) PROFILE="$HOME/.profile" ;;
-esac
+PROFILE="${PROFILE_FILE:-$HOME/.profile}"
 
-grep -q "POCKET_API_KEY" "$PROFILE" 2>/dev/null || \
-  echo 'export POCKET_API_KEY="$(bash "${CLAUDE_PLUGIN_ROOT}/lib/credential-store.sh" get POCKET_API_KEY ops-daemon 2>/dev/null)"' >> "$PROFILE"
+if ! grep -q "POCKET_API_KEY" "$PROFILE" 2>/dev/null; then
+  case "$PROFILE" in
+    *config.fish)
+      echo 'set -gx POCKET_API_KEY (bash "${CLAUDE_PLUGIN_ROOT}/lib/credential-store.sh" get POCKET_API_KEY ops-daemon 2>/dev/null)' >> "$PROFILE"
+      ;;
+    *)
+      echo 'export POCKET_API_KEY="$(bash "${CLAUDE_PLUGIN_ROOT}/lib/credential-store.sh" get POCKET_API_KEY ops-daemon 2>/dev/null)"' >> "$PROFILE"
+      ;;
+  esac
+fi
 ```
 
 #### Step 3p.3 — Choose notification channels
@@ -161,7 +164,32 @@ case "$(uname -s)" in
     bash "${CLAUDE_PLUGIN_ROOT}/scripts/install-pocket-notifier.sh"
     ;;
   Linux)
-    echo "Linux: wire ${CLAUDE_PLUGIN_ROOT}/scripts/ops-pocket-activity-notifier.py into systemd --user or cron at a 60s interval."
+    UNIT_DIR="$HOME/.config/systemd/user"
+    mkdir -p "$UNIT_DIR"
+    cat > "$UNIT_DIR/pocket-activity-notifier.service" <<SERVICE
+[Unit]
+Description=Pocket Activity Notifier
+
+[Service]
+Type=oneshot
+Environment=HOME=$HOME
+Environment=POCKET_STATE_DIR=$HOME/.claude/state/pocket
+ExecStart=$HOME/.venv-pocket/bin/python3 ${CLAUDE_PLUGIN_ROOT}/scripts/ops-pocket-activity-notifier.py
+SERVICE
+    cat > "$UNIT_DIR/pocket-activity-notifier.timer" <<TIMER
+[Unit]
+Description=Run Pocket Activity Notifier every minute
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=1min
+Unit=pocket-activity-notifier.service
+
+[Install]
+WantedBy=timers.target
+TIMER
+    systemctl --user daemon-reload
+    systemctl --user enable --now pocket-activity-notifier.timer
     ;;
   *)
     echo "Pocket notifier auto-install is unsupported on this OS; run the notifier manually or skip this channel."

--- a/claude-ops/skills/setup/channels/pocket.md
+++ b/claude-ops/skills/setup/channels/pocket.md
@@ -1,6 +1,8 @@
 ### 3p — Pocket (voice journal activity notifier)
 
-The Pocket subsystem watches your voice journal recordings via the Pocket AI MCP, infers tasks with Haiku, and sends activity notifications (task spawned / task done) to WhatsApp and/or email. This step installs the credential, writes the channel config files, registers the launchd notifier, and smoke-tests delivery.
+> **Cross-OS gate (read first):** the `launchctl` / `~/Library/LaunchAgents` notifier-install and the macOS `security` Keychain steps below are **macOS-only**. On **Linux/WSL**, register the notifier as a `systemd --user` timer/service and store `POCKET_API_KEY` via the cross-OS `credential-store.sh` (`secret-tool`/file backend) — never `security find-generic-password`. Branch on `case "$(uname -s)"`.
+
+The Pocket subsystem watches your voice journal recordings via the Pocket AI MCP, infers tasks with Haiku, and sends activity notifications (task spawned / task done) to WhatsApp and/or email. This step installs the credential, writes the channel config files, registers the notifier (launchd on macOS, systemd --user on Linux), and smoke-tests delivery.
 
 #### Step 3p.1 — Prerequisites
 

--- a/claude-ops/skills/setup/channels/pocket.md
+++ b/claude-ops/skills/setup/channels/pocket.md
@@ -59,7 +59,15 @@ it from the detected shell profile when needed:
 ```bash
 bash "${CLAUDE_PLUGIN_ROOT}/lib/credential-store.sh" set POCKET_API_KEY ops-daemon "$POCKET_API_KEY"
 
-PROFILE="${PROFILE_FILE:-$HOME/.profile}"
+PROFILE="${PROFILE_FILE:-}"
+if [ -z "$PROFILE" ]; then
+  case "$(basename "${SHELL:-/bin/sh}")" in
+    zsh)  PROFILE="${ZDOTDIR:-$HOME}/.zshrc" ;;
+    bash) PROFILE="$HOME/.bashrc" ;;
+    fish) PROFILE="$HOME/.config/fish/config.fish" ;;
+    *)    PROFILE="$HOME/.profile" ;;
+  esac
+fi
 
 if ! grep -q "POCKET_API_KEY" "$PROFILE" 2>/dev/null; then
   case "$PROFILE" in
@@ -164,6 +172,8 @@ case "$(uname -s)" in
     bash "${CLAUDE_PLUGIN_ROOT}/scripts/install-pocket-notifier.sh"
     ;;
   Linux)
+    PYTHON3="$(command -v python3 || true)"
+    [ -z "$PYTHON3" ] && PYTHON3=/usr/bin/python3
     UNIT_DIR="$HOME/.config/systemd/user"
     mkdir -p "$UNIT_DIR"
     cat > "$UNIT_DIR/pocket-activity-notifier.service" <<SERVICE
@@ -174,7 +184,7 @@ Description=Pocket Activity Notifier
 Type=oneshot
 Environment=HOME=$HOME
 Environment=POCKET_STATE_DIR=$HOME/.claude/state/pocket
-ExecStart=$HOME/.venv-pocket/bin/python3 ${CLAUDE_PLUGIN_ROOT}/scripts/ops-pocket-activity-notifier.py
+ExecStart=$PYTHON3 ${CLAUDE_PLUGIN_ROOT}/scripts/ops-pocket-activity-notifier.py
 SERVICE
     cat > "$UNIT_DIR/pocket-activity-notifier.timer" <<TIMER
 [Unit]

--- a/claude-ops/skills/setup/channels/whatsapp.md
+++ b/claude-ops/skills/setup/channels/whatsapp.md
@@ -10,7 +10,10 @@ Check bridge binary exists and LaunchAgent is installed:
 
 ```bash
 ls ~/.local/share/whatsapp-mcp/whatsapp-bridge/whatsapp-bridge 2>/dev/null && echo "binary ok"
-launchctl list com.${USER}.whatsapp-bridge 2>/dev/null | head -3
+case "$(uname -s)" in
+  Darwin) launchctl list com.${USER}.whatsapp-bridge 2>/dev/null | head -3 ;;
+  Linux) systemctl --user status whatsapp-bridge --no-pager ;;
+esac
 lsof -i :8080 2>/dev/null | grep LISTEN
 ```
 
@@ -26,16 +29,26 @@ whatsapp-bridge (whatsmeow) is not installed. Install:
 If LaunchAgent not installed, install it from template. The template ships as `com.claude-ops.whatsapp-bridge.plist` with a `__USER__` Label placeholder; sed substitutes the running user so the installed plist's Label becomes `com.${USER}.whatsapp-bridge`:
 
 ```bash
-PLIST_TEMPLATE="${CLAUDE_PLUGIN_ROOT}/assets/launchagents/com.claude-ops.whatsapp-bridge.plist"
-PLIST_DEST="$HOME/Library/LaunchAgents/com.${USER}.whatsapp-bridge.plist"
-BRIDGE_DIR="$HOME/.local/share/whatsapp-mcp/whatsapp-bridge"
-mkdir -p "$BRIDGE_DIR/logs"
-sed -e "s|__BRIDGE_BINARY_PATH__|$BRIDGE_DIR/whatsapp-bridge|g" \
-    -e "s|__BRIDGE_WORKING_DIR__|$BRIDGE_DIR|g" \
-    -e "s|__HOME__|$HOME|g" \
-    -e "s|__USER__|$USER|g" \
-    "$PLIST_TEMPLATE" > "$PLIST_DEST"
-launchctl bootstrap gui/$(id -u) "$PLIST_DEST"
+case "$(uname -s)" in
+  Darwin)
+    PLIST_TEMPLATE="${CLAUDE_PLUGIN_ROOT}/assets/launchagents/com.claude-ops.whatsapp-bridge.plist"
+    PLIST_DEST="$HOME/Library/LaunchAgents/com.${USER}.whatsapp-bridge.plist"
+    BRIDGE_DIR="$HOME/.local/share/whatsapp-mcp/whatsapp-bridge"
+    mkdir -p "$BRIDGE_DIR/logs" "$HOME/Library/LaunchAgents"
+    sed -e "s|__BRIDGE_BINARY_PATH__|$BRIDGE_DIR/whatsapp-bridge|g" \
+        -e "s|__BRIDGE_WORKING_DIR__|$BRIDGE_DIR|g" \
+        -e "s|__HOME__|$HOME|g" \
+        -e "s|__USER__|$USER|g" \
+        "$PLIST_TEMPLATE" > "$PLIST_DEST"
+    launchctl bootstrap gui/$(id -u) "$PLIST_DEST"
+    ;;
+  Linux)
+    bash "${CLAUDE_PLUGIN_ROOT}/scripts/install-whatsapp-bridge-linux.sh"
+    ;;
+  *)
+    echo "WhatsApp bridge auto-install is unsupported on this OS."
+    ;;
+esac
 ```
 
 #### Step 3b.2 — QR pairing (first run)

--- a/claude-ops/skills/setup/channels/whatsapp.md
+++ b/claude-ops/skills/setup/channels/whatsapp.md
@@ -6,7 +6,7 @@ WhatsApp is handled by the whatsmeow `whatsapp-bridge` (macOS: `com.${USER}.what
 
 #### Step 3b.1 — Presence
 
-Check bridge binary exists and LaunchAgent is installed:
+Check bridge binary exists and the platform service is installed:
 
 ```bash
 ls ~/.local/share/whatsapp-mcp/whatsapp-bridge/whatsapp-bridge 2>/dev/null && echo "binary ok"
@@ -43,7 +43,9 @@ case "$(uname -s)" in
     launchctl bootstrap gui/$(id -u) "$PLIST_DEST"
     ;;
   Linux)
-    bash "${CLAUDE_PLUGIN_ROOT}/scripts/install-whatsapp-bridge-linux.sh"
+    # Ask for WA_PHONE first: digits-only E.164 without "+" (for example, 12025551234).
+    bash "${CLAUDE_PLUGIN_ROOT}/scripts/install-whatsapp-bridge-linux.sh" --wa-phone "$WA_PHONE"
+    systemctl --user enable --now whatsapp-bridge.service
     ;;
   *)
     echo "WhatsApp bridge auto-install is unsupported on this OS."

--- a/claude-ops/skills/setup/channels/whatsapp.md
+++ b/claude-ops/skills/setup/channels/whatsapp.md
@@ -1,6 +1,8 @@
 ### 3b — WhatsApp (bridge health + QR pair)
 
-WhatsApp is handled exclusively by the whatsmeow `whatsapp-bridge` (managed by `com.${USER}.whatsapp-bridge` LaunchAgent — `${USER}` is your macOS username, expanded at install time so each user gets their own per-account bridge) and accessed via `mcp__whatsapp__*` tools.
+> **Cross-OS gate (read first):** the `launchctl` / `~/Library/LaunchAgents` steps below are **macOS-only**. Branch on `case "$(uname -s)" in Darwin) … ;; Linux) … ;; esac`. On **Linux**, the bridge is a `systemd --user` unit — install via `scripts/install-whatsapp-bridge-linux.sh` (do NOT run the launchctl commands); manage with `systemctl --user {status,restart} whatsapp-bridge`. On **WSL** use the systemd path if `systemctl --user` works, else run the bridge under `nohup`. Secrets use the cross-OS `credential-store.sh` (`secret-tool`/file on Linux), not macOS `security`.
+
+WhatsApp is handled by the whatsmeow `whatsapp-bridge` (macOS: `com.${USER}.whatsapp-bridge` LaunchAgent, `${USER}` expanded at install time; Linux: `whatsapp-bridge` systemd --user unit) and accessed via `mcp__whatsapp__*` tools.
 
 #### Step 3b.1 — Presence
 

--- a/claude-ops/templates/statusline/statusline-command.sh
+++ b/claude-ops/templates/statusline/statusline-command.sh
@@ -257,10 +257,22 @@ account_email=""; _sub=""; _method=""
 # Sanitize email for use in filenames: strip / and " to prevent path traversal / injection
 _email_safe=$(printf '%s' "$account_email" | tr -d '/"')
 
-# Billing mode
+# Billing mode. Bedrock env overrides; else derive from auth JSON; persist
+# positive results so the badge survives transient auth failures.
+# CRS-relay guard: a stale CLAUDE_CODE_USE_BEDROCK=1 can linger in the process
+# env even though the session actually routes through the CRS relay
+# (ANTHROPIC_BASE_URL -> 127.0.0.1 relay + a cr_ OAuth token = Max pool / oauth).
+# In that case the real provider is oauth, not Bedrock. We also force "max" and
+# overwrite any stale cache so a session that briefly cached "bedrock" at startup
+# (before relay routing settled) never keeps showing Bedrock.
 billing_cache="${CACHE_DIR}/claude-billing-${session_id}"
-if [ "${CLAUDE_CODE_USE_BEDROCK:-}" = "1" ]; then
+_is_crs_relay=""
+case "${CLAUDE_CODE_OAUTH_TOKEN:-}" in cr_*) _is_crs_relay=1 ;; esac
+case "${ANTHROPIC_BASE_URL:-}" in *127.0.0.1:3005*|*127.0.0.1:3000*|*localhost:3005*) _is_crs_relay=1 ;; esac
+if [ "${CLAUDE_CODE_USE_BEDROCK:-}" = "1" ] && [ -z "$_is_crs_relay" ]; then
   sub_type="bedrock"
+elif [ -n "$_is_crs_relay" ]; then
+  sub_type="max"
 elif [ -n "$_sub" ] && [ "$_sub" != "null" ]; then
   sub_type="$_sub"
 elif [ "$_method" = "claude.ai" ]; then

--- a/claude-ops/templates/statusline/statusline-command.sh
+++ b/claude-ops/templates/statusline/statusline-command.sh
@@ -268,7 +268,7 @@ _email_safe=$(printf '%s' "$account_email" | tr -d '/"')
 billing_cache="${CACHE_DIR}/claude-billing-${session_id}"
 _is_crs_relay=""
 case "${CLAUDE_CODE_OAUTH_TOKEN:-}" in cr_*)
-  case "${ANTHROPIC_BASE_URL:-}" in *127.0.0.1:3005*|*127.0.0.1:3000*|*localhost:3005*) _is_crs_relay=1 ;; esac
+  case "${ANTHROPIC_BASE_URL:-}" in *127.0.0.1:3005*|*127.0.0.1:3000*|*localhost:3005*|*localhost:3000*) _is_crs_relay=1 ;; esac
 esac
 if [ "${CLAUDE_CODE_USE_BEDROCK:-}" = "1" ] && [ -z "$_is_crs_relay" ]; then
   sub_type="bedrock"

--- a/claude-ops/templates/statusline/statusline-command.sh
+++ b/claude-ops/templates/statusline/statusline-command.sh
@@ -267,8 +267,9 @@ _email_safe=$(printf '%s' "$account_email" | tr -d '/"')
 # (before relay routing settled) never keeps showing Bedrock.
 billing_cache="${CACHE_DIR}/claude-billing-${session_id}"
 _is_crs_relay=""
-case "${CLAUDE_CODE_OAUTH_TOKEN:-}" in cr_*) _is_crs_relay=1 ;; esac
-case "${ANTHROPIC_BASE_URL:-}" in *127.0.0.1:3005*|*127.0.0.1:3000*|*localhost:3005*) _is_crs_relay=1 ;; esac
+case "${CLAUDE_CODE_OAUTH_TOKEN:-}" in cr_*)
+  case "${ANTHROPIC_BASE_URL:-}" in *127.0.0.1:3005*|*127.0.0.1:3000*|*localhost:3005*) _is_crs_relay=1 ;; esac
+esac
 if [ "${CLAUDE_CODE_USE_BEDROCK:-}" = "1" ] && [ -z "$_is_crs_relay" ]; then
   sub_type="bedrock"
 elif [ -n "$_is_crs_relay" ]; then

--- a/claude-ops/tests/test-no-secrets.sh
+++ b/claude-ops/tests/test-no-secrets.sh
@@ -146,6 +146,21 @@ scan_pattern "bare AWS account IDs (account/bucket context)" \
   '([Aa]ccount|[Bb]ucket|aws|AWS|arn).{0,40}\b[0-9]{12}\b|\b[0-9]{12}\b.{0,40}([Aa]ccount|[Bb]ucket)' \
   '(123456789012|000000000000|111111111111|[0-9]{13,})'
 
+# App Store Connect account identifiers and numeric app IDs. These are not
+# secrets alone, but they identify a real app/account and must be supplied by
+# local env/config for this public plugin.
+scan_pattern "App Store Connect issuer UUID literals" \
+  '(APP_STORE_CONNECT_ISSUER_ID|ISSUER_ID|issuer).{0,80}[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}' \
+  '(example|placeholder|00000000-0000-0000-0000-000000000000|<)'
+
+scan_pattern "App Store Connect numeric app ID literals" \
+  '(APP_STORE_CONNECT_APP_IDS|HEALIFY_ASC_[A-Z_]*APP_ID|APP_IDS|appId).{0,80}["'\''][0-9]{9,12}["'\'']' \
+  '(example|placeholder|<)'
+
+scan_pattern "hardcoded sentry-cli org values" \
+  'sentry-cli.{0,120}--org[ =]["'\'']?[A-Za-z0-9_-]+' \
+  '(SENTRY_ORG|example|placeholder|<)'
+
 # International phone numbers (allow reserved example ranges: 555-xxxx, 1234567, all-zero)
 scan_pattern "phone numbers (+<cc><digits>)" '\+[1-9][0-9]{1,3}[ -]?[0-9]{6,14}' \
   '(555[0-9]{4}|1234567|\+1234567890|\+0000000000|\+15551234567|\+10000000000|\+1[ -]?555)'


### PR DESCRIPTION
**V3 milestone — SLICE 1 (compat fixes).** Draft; do not merge until reviewed.

From the cross-OS/terminal audit. Four fixes:

1. **`bin/ops-setup-detect` HIGH JSON bug** — `TELEGRAM_KEYS_FOUND=$(grep -c … || echo 0)`: on zero matches `grep -c` prints `0` AND exits 1, so `||` double-fired (`0\n0`), corrupting the integer test + emitted JSON → broke every `jq` consumer of the detector. Split assignment + `${:-0}`. Verified: `ops-setup-detect | jq empty` now passes.
2. **`SKILL.md` Step 7 `~/.zshrc` hardcode** → use detected `profile_file` (.bashrc/.zshrc/config.fish/.profile) + fish `set -gx` note; dynamic status-header shell line.
3. **`channels/{whatsapp,pocket,mcp}.md` macOS-only steps** → cross-OS gates: launchctl/Library/`security` are macOS-only; Linux/WSL route to `systemd --user` installers + `credential-store.sh` (secret-tool/file).
4. **`templates/statusline/statusline-command.sh`** — CRS-relay sessions force the **Max** badge and overwrite a stale `bedrock` cache (was mislabeling OAuth-via-CRS sessions as Bedrock).

Tests: `tests/test-no-secrets.sh` → 22 passed / 0 failed. `bash -n` clean on all touched scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new bash surface (external CLIs/APIs, cache refresh) plus setup path changes on Linux; core fixes are localized but misconfigured env could trigger noisy or slow refresh jobs.
> 
> **Overview**
> **Cross-OS and setup reliability:** Fixes `ops-setup-detect` Telegram preflight counting so `grep -c … || echo 0` can no longer emit `0\n0` and break downstream `jq`. Setup wizard Step 7 and channel docs now use the **detected shell profile** (bash/zsh/fish) instead of hardcoded `~/.zshrc`, with macOS-only `launchctl`/`security` gated to Linux/WSL `systemd --user` and `credential-store.sh` for WhatsApp, Pocket, and MCP Pocket keys.
> 
> **Healify operations surface:** New read-only **`ops-healify-dash`** (full + compact layouts, `--watch`/`--refresh`/`--json`) aggregates Healify-focused KPIs, marketing, App Store/EAS, reliability, infra, repos, and agents from local caches. **`ops-healify-bi-refresh`** writes `healify-bi.json` from EAS, Sentry (`SENTRY_ORG` env), operating-dashboard `tsx` probes, and optional App Store Connect API (env + JWT). `ops-dash` can delegate via `OPS_HEALIFY_DASH=1`; README and `docs/healify-dashboard.md` document usage.
> 
> **Personalization prep:** **`ops-user-profiler`** emits `profile.scan.json` / `profile.prefill.json` from local signals (no secret values); **`PERSONA-SCHEMA.md`** defines the `.persona` merge contract for the setup wizard.
> 
> **Statusline:** CRS relay sessions (`cr_*` token + localhost relay URL) force the **Max** billing badge and overwrite a stale **bedrock** cache when `CLAUDE_CODE_USE_BEDROCK` is set misleadingly.
> 
> **Hygiene:** Secret scan rules for hardcoded ASC app IDs, issuer UUIDs, and Sentry org literals; package **2.32.0** and Prettier devDependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a630d5e3e287749867dc801b95dee131bf0607b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added system profiler to generate machine scan data and preference suggestions
  * Enhanced shell detection with automatic profile file configuration

* **Bug Fixes**
  * Fixed preflight detection logic to prevent duplicate output corruption

* **Documentation**
  * Added persona data structure and population pipeline guide
  * Updated setup wizard documentation for detected shell profiles
  * Extended cross-OS support documentation for macOS, Linux, and WSL across MCP, Pocket, and WhatsApp channels

* **Improvements**
  * Enhanced billing mode detection for relay routing conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->