### PR TITLE
release: v2.33.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 57 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.32.0",
+      "version": "2.33.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-2.32.0-blue)
+![Version](https://img.shields.io/badge/version-2.33.0-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-57-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "description": "Business operations command center for Claude Code — 57 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [2.33.0] - 2026-06-15
+
+### Added
+- `ops-sync-docs` helper to reconcile documentation counts (now 57 commands / 21 agents) and keep the wiki in sync.
+- AI-generated changelog support in the release flow, with automatic doc-sync and wiki maintenance.
+
+### Fixed
+- Bedrock leak watchdog now catches runtime-injected and network-only Bedrock usage that previously slipped through.
+- Account rotation no longer falls back to Bedrock and preserves CRS routing across mode flips; box-live daemon behaviors are reconciled into the tracked daemon.
+- Stored OAuth tokens are invalidated on a 401 from `/oauth/usage`, preventing stale-credential loops.
+- CRS priority daemon health-gate now auto-detects the CRS host port instead of assuming a fixed one.
+- Post-update migration uses a stable `current/` directory, eliminating stale plugin-path errors after upgrades.
+
+
 ## [2.32.0] - 2026-06-14
 
 ### Added

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-2.32.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.33.0-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 57 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack)_
 
-[![version](https://img.shields.io/badge/version-2.32.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.33.0-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-57-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.33.0** (was 2.32.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

### Added
- `ops-sync-docs` helper to reconcile documentation counts (now 57 commands / 21 agents) and keep the wiki in sync.
- AI-generated changelog support in the release flow, with automatic doc-sync and wiki maintenance.

### Fixed
- Bedrock leak watchdog now catches runtime-injected and network-only Bedrock usage that previously slipped through.
- Account rotation no longer falls back to Bedrock and preserves CRS routing across mode flips; box-live daemon behaviors are reconciled into the tracked daemon.
- Stored OAuth tokens are invalidated on a 401 from `/oauth/usage`, preventing stale-credential loops.
- CRS priority daemon health-gate now auto-detects the CRS host port instead of assuming a fixed one.
- Post-update migration uses a stable `current/` directory, eliminating stale plugin-path errors after upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The diff is mostly versioning and changelog, but the release notes cover auth/OAuth, model routing (Bedrock/CRS), and plugin install paths—areas that can affect billing and runtime stability after upgrade.
> 
> **Overview**
> **Release v2.33.0** — version strings move from **2.32.0** to **2.33.0** in `plugin.json`, root `marketplace.json`, `claude-ops/package.json`, and version badges in `README.md`, `docs/skills-reference.md`, and `docs/agents-reference.md`.
> 
> `CHANGELOG.md` documents what ships in this release: **`ops-sync-docs`** and AI-assisted changelog/wiki steps in the release flow; tighter **Bedrock leak** detection; **account rotation** that avoids Bedrock fallback and keeps CRS routing stable; **OAuth token invalidation** on `/oauth/usage` 401; **CRS priority** health-gate **port auto-detection**; and post-update migration via a stable **`current/`** plugin path to stop hook errors after upgrades.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88d544002c525d55d51df13c77993b537f2f3d41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->