### PR TITLE
fix(ops-bg): inject CRS overlay --settings into bg spawns durably

### DIFF
--- a/claude-ops/bin/ops-bg
+++ b/claude-ops/bin/ops-bg
@@ -86,9 +86,23 @@ cmd_dispatch() {
     exit 2
   fi
   local prompt="$*"
-  local -a args=(--bg --model "$model" --effort "$effort" --add-dir "$add_dir")
+  # CRS routing: every bg session ops-bg spawns inherits the sanctioned overlay
+  # (ANTHROPIC_BASE_URL + CLAUDE_CODE_OAUTH_TOKEN). Preflight refuses to spawn if
+  # the overlay is half-set or the key is 401-rejected. Opt out with CRS_OVERLAY="".
+  local CRS_OVERLAY="${CRS_OVERLAY-$HOME/.claude/crs-session-settings.json}"
+  local -a crs_args=()
+  if [ -n "$CRS_OVERLAY" ]; then
+    if [ -x "$HOME/.claude/scripts/crs-overlay-preflight.sh" ]; then
+      if ! bash "$HOME/.claude/scripts/crs-overlay-preflight.sh" "$CRS_OVERLAY" >&2; then
+        echo "ops-bg: CRS overlay preflight failed — refusing to spawn" >&2
+        exit 1
+      fi
+    fi
+    crs_args=(--settings "$CRS_OVERLAY")
+  fi
+  local -a args=(--bg "${crs_args[@]}" --model "$model" --effort "$effort" --add-dir "$add_dir")
   if [ -n "$name" ]; then
-    args=(--bg --name "$name" --model "$model" --effort "$effort" --add-dir "$add_dir")
+    args=(--bg "${crs_args[@]}" --name "$name" --model "$model" --effort "$effort" --add-dir "$add_dir")
   fi
   if [ -n "$agent" ]; then
     args+=(--agent "$agent")


### PR DESCRIPTION
## What
Adds the CRS routing overlay (`--settings $HOME/.claude/crs-session-settings.json`) to `bin/ops-bg` so every background session `ops-bg` spawns inherits the sanctioned relay routing (ANTHROPIC_BASE_URL + CLAUDE_CODE_OAUTH_TOKEN).

## Why
The overlay injection had only been applied to the **installed plugin-cache copy** (`ops/2.31.0/bin/ops-bg`), which is overwritten on the next `/ops:ops-update`. This lands it in the canonical source so future releases carry it natively.

## Details
- Defaults `CRS_OVERLAY` to `~/.claude/crs-session-settings.json` (opt out with `CRS_OVERLAY=""`).
- Runs `crs-overlay-preflight.sh` and refuses to spawn if the overlay is half-set or the key is 401-rejected.
- Injects `--settings` into both the named and unnamed bg arg arrays.

`$HOME`-relative paths only (Rule 0 compliant); `tests/test-no-secrets.sh` → 22 passed / 0 failed; `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every ops-bg background session authenticates and routes API traffic; spawn failures on bad overlay config are intentional but can block dispatches until fixed.
> 
> **Overview**
> **`ops-bg dispatch`** now passes **`--settings`** with the CRS session overlay so background **`claude --bg`** launches use sanctioned relay routing (`ANTHROPIC_BASE_URL` + `CLAUDE_CODE_OAUTH_TOKEN`) instead of only living in a plugin-cache copy that updates wipe.
> 
> By default **`CRS_OVERLAY`** points at **`~/.claude/crs-session-settings.json`**; set **`CRS_OVERLAY=""`** to skip. When an overlay path is set, **`crs-overlay-preflight.sh`** runs first and dispatch **exits 1** if the overlay is misconfigured or auth is rejected. The **`--settings`** args are wired into both named and unnamed dispatch argument arrays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5516b7984f12e7a9f993f58744cf189e46cc616. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Background sessions now support optional custom settings configuration
  * Added preflight validation checks for background session initialization with graceful failure handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->