### PR TITLE
release: v2.34.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 58 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.34.0",
+      "version": "2.34.1",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-2.34.0-blue)
+![Version](https://img.shields.io/badge/version-2.34.1-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-58-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.34.0",
+  "version": "2.34.1",
   "description": "Business operations command center for Claude Code — 58 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, and /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs).",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.34.1] - 2026-06-15
+
+### Changed
+### Fixed
+- `ops-bg` now injects the CRS routing overlay (`--settings ~/.claude/crs-session-settings.json`) into every background session it spawns, so they inherit the sanctioned relay routing instead of going direct. Previously this was only patched in the installed plugin-cache copy and was lost on each plugin upgrade; it now lives in the canonical source. Includes a preflight that refuses to spawn on a half-set overlay or 401-rejected key. Opt out with `CRS_OVERLAY=""`.
+
+
 ## [2.34.0] - 2026-06-15
 
 ### Changed

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-2.34.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.34.1-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 58 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack)_
 
-[![version](https://img.shields.io/badge/version-2.34.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.34.1-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-58-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.34.0",
+  "version": "2.34.1",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.34.1** (was 2.34.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

### Fixed
- `ops-bg` now injects the CRS routing overlay (`--settings ~/.claude/crs-session-settings.json`) into every background session it spawns, so they inherit the sanctioned relay routing instead of going direct. Previously this was only patched in the installed plugin-cache copy and was lost on each plugin upgrade; it now lives in the canonical source. Includes a preflight that refuses to spawn on a half-set overlay or 401-rejected key. Opt out with `CRS_OVERLAY=""`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default API routing for all `ops-bg` spawns and gate startup on CRS preflight, which affects auth and relay behavior for background agents.
> 
> **Overview**
> **Release v2.34.1** bumps the plugin from **2.34.0** across the marketplace registry, `plugin.json`, `package.json`, and version badges in the README and reference docs.
> 
> The changelog records the substantive fix for this patch: **`ops-bg` now passes `--settings` for the CRS routing overlay** (`~/.claude/crs-session-settings.json`) into every background session it spawns so fleet/background agents use the sanctioned relay instead of direct routing. That behavior is intended to live in canonical source (not only the plugin cache after upgrades). Spawning is blocked when overlay preflight fails (half-configured overlay or 401 on the key); disable with `CRS_OVERLAY=""`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3c556c5a17dbb8dd91ecccbbd8432f0324d9068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->