### PR TITLE
fix(ops): route memory-extractor + pocket-watcher Claude calls via CRS

### DIFF
--- a/claude-ops/scripts/ops-cron-pocket-watcher.py
+++ b/claude-ops/scripts/ops-cron-pocket-watcher.py
@@ -353,6 +353,23 @@ def _resolve_anthropic_auth() -> tuple[str, dict] | tuple[None, None]:
     credentials at ~/.claude/.credentials.json) so subscription users don't
     pay metered rates. Falls back to ANTHROPIC_API_KEY env / keychain.
     """
+    # CRS relay first — fleet-sanctioned path. Subscription OAuth tokens 401 on
+    # direct api.anthropic.com after a token rotation; route through the local CRS
+    # relay. token from $ANTHROPIC_AUTH_TOKEN or keychain service CRS_KEY.
+    crs_tok = os.environ.get("ANTHROPIC_AUTH_TOKEN", "").strip()
+    if not crs_tok:
+        try:
+            r = subprocess.run(
+                ["security", "find-generic-password", "-s", "CRS_KEY", "-w"],
+                capture_output=True, text=True, timeout=5,
+            )
+            if r.returncode == 0 and r.stdout.strip():
+                crs_tok = r.stdout.strip()
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            pass
+    if crs_tok:
+        crs_base = os.environ.get("ANTHROPIC_BASE_URL", "http://127.0.0.1:3005/api").strip()
+        return (f"Bearer {crs_tok}", {"_base_url": crs_base})
     # Try Claude Code OAuth — macOS keychain
     try:
         blob = subprocess.run(
@@ -469,10 +486,11 @@ def infer_tasks_from_recording(recording: dict) -> tuple[list[dict], bool]:
     if auth_header:
         headers["Authorization"] = auth_header
         for k, v in (extras or {}).items():
-            if k != "_apikey":
+            if k not in ("_apikey", "_base_url"):
                 headers[k] = v
     else:
         headers["x-api-key"] = (extras or {}).get("_apikey", "")
+    _base_url = (extras or {}).get("_base_url", "https://api.anthropic.com")
 
     payload = {
         "model": "claude-haiku-4-5-20251001",
@@ -481,7 +499,7 @@ def infer_tasks_from_recording(recording: dict) -> tuple[list[dict], bool]:
         "messages": [{"role": "user", "content": user_msg}],
     }
     data = json.dumps(payload).encode("utf-8")
-    req = urlreq.Request("https://api.anthropic.com/v1/messages",
+    req = urlreq.Request(f"{_base_url}/v1/messages",
                          data=data, headers=headers, method="POST")
     try:
         with urlreq.urlopen(req, timeout=30) as resp:

--- a/claude-ops/scripts/ops-memory-extractor.sh
+++ b/claude-ops/scripts/ops-memory-extractor.sh
@@ -80,6 +80,24 @@ resolve_auth() {
   OPS_AUTH_HEADER=""
   OPS_AUTH_MODE=""
   OPS_AUTH_EXTRA_HEADERS=()
+  OPS_BASE_URL="${OPS_BASE_URL:-}"
+
+  # ─ CRS relay first ─ (fleet-sanctioned path; subscription OAuth tokens now 401
+  # on direct api.anthropic.com after a token rotation). base_url defaults to the
+  # local CRS relay; token from $ANTHROPIC_AUTH_TOKEN or keychain service CRS_KEY.
+  local _crs_base="${ANTHROPIC_BASE_URL:-http://127.0.0.1:3005/api}"
+  local _crs_tok="${ANTHROPIC_AUTH_TOKEN:-}"
+  if [[ -z "${_crs_tok}" ]] && command -v security &>/dev/null; then
+    _crs_tok=$(security find-generic-password -s CRS_KEY -w 2>/dev/null || true)
+  fi
+  if [[ -n "${_crs_tok}" ]]; then
+    OPS_BASE_URL="${_crs_base}"
+    OPS_AUTH_HEADER="Authorization: Bearer ${_crs_tok}"
+    OPS_AUTH_MODE="crs"
+    OPS_AUTH_EXTRA_HEADERS=()
+    log "Auth: CRS relay (${_crs_base})"
+    return 0
+  fi
 
   # ─ Try Claude Code OAuth first ─
   # Linux: the OAuth blob lives in ~/.claude/.credentials.json (no macOS Keychain).
@@ -336,7 +354,7 @@ EOF
   log "Calling Claude Haiku for extraction (auth: ${OPS_AUTH_MODE:-unknown})..."
   local http_status
   http_status=$(curl -s -o "${TMP_RESPONSE}" -w "%{http_code}" \
-    https://api.anthropic.com/v1/messages \
+    "${OPS_BASE_URL:-https://api.anthropic.com}/v1/messages" \
     -H "content-type: application/json" \
     -H "${OPS_AUTH_HEADER}" \
     -H "anthropic-version: 2023-06-01" \


### PR DESCRIPTION
## Problem
The `memory-extractor` background daemon was failing **every run with HTTP 401** (`Invalid authentication credentials`) since a token rotation. It (and `pocket-watcher`) call `api.anthropic.com/v1/messages` directly with the Claude Code subscription OAuth token — which Anthropic now rejects on the direct API path. Verified live: direct OAuth = 401, CRS relay = 200.

## Fix
Route the two **inference-consuming** background scripts through the CRS relay, CRS-first:
- base URL from `ANTHROPIC_BASE_URL` (defaults to local CRS `http://127.0.0.1:3005/api`)
- token from `ANTHROPIC_AUTH_TOKEN` or keychain service `CRS_KEY`
- existing OAuth / API-key paths retained as fallback

## Deliberately NOT changed
`account-rotation/*` scripts keep calling `api.anthropic.com` directly — they're the auth infrastructure that *feeds* CRS (OAuth profile/usage, token minting/validation, the relay router). Routing them through CRS would be circular and could brick rotation.

## Verification
- `bash -n` + `py_compile` clean
- Live extractor run now logs `Auth: CRS relay` and completes (no 401)
- No secret literals in diff; `test-no-secrets.sh` 25/0 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how scheduled daemons authenticate to Claude; failures would break memory extraction and pocket implicit-task inference until CRS or fallbacks work, but scope is limited to two scripts with retained fallbacks.
> 
> **Overview**
> Background **Haiku** calls in `ops-memory-extractor.sh` and `ops-cron-pocket-watcher.py` were hitting **HTTP 401** on direct `api.anthropic.com` after subscription OAuth token rotation. Both scripts now try the **CRS relay first** before existing OAuth and API-key paths.
> 
> Auth resolution prefers a **Bearer** token from `ANTHROPIC_AUTH_TOKEN` or keychain `CRS_KEY`, with base URL from `ANTHROPIC_BASE_URL` (default `http://127.0.0.1:3005/api`). Message requests use `{base}/v1/messages` instead of a hardcoded Anthropic host; pocket-watcher passes `_base_url` through extras so internal keys are not sent as headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fc4cf3beff7c9d7ef906ae3c728f0fb31aa7a8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CRS relay authentication as a primary method before other fallback mechanisms
  * Enabled authentication configuration via environment variables and system keychain storage
  * Made API endpoint base URL configurable, allowing custom relay service integration with sensible defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->