### PR TITLE
slice2a-persona-merge

### DIFF
--- a/claude-ops/bin/ops-healify-bi-refresh
+++ b/claude-ops/bin/ops-healify-bi-refresh
@@ -117,6 +117,12 @@ except Exception as exc:
 PY
 )"
 
+isjson() { printf '%s' "$1" | jq empty >/dev/null 2>&1; }
+isjson "$eas_json" || eas_json='{"ok":false,"note":"invalid EAS JSON","builds":[]}'
+isjson "$sentry_json" || sentry_json='{"ok":false,"note":"invalid Sentry JSON","projects":[]}'
+isjson "$opdash_json" || opdash_json='{"ok":false,"note":"invalid opdash JSON"}'
+isjson "$asc_extra_json" || asc_extra_json='{"ok":false,"note":"invalid ASC JSON","apps":[]}'
+
 jq -nc \
   --arg generatedAt "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
   --argjson eas "$eas_json" \

--- a/claude-ops/bin/ops-healify-bi-refresh
+++ b/claude-ops/bin/ops-healify-bi-refresh
@@ -21,18 +21,13 @@ if command -v eas >/dev/null 2>&1 && [[ -d "$HEALIFY_APP" ]]; then
 fi
 
 sentry_json='{"ok":false,"note":"sentry-cli unavailable","projects":[]}'
-SENTRY_ORG="${SENTRY_ORG:-}"
-SENTRY_PROJECTS="${SENTRY_PROJECTS:-}"
-if command -v sentry-cli >/dev/null 2>&1 && [[ -n "$SENTRY_ORG" && -n "$SENTRY_PROJECTS" ]]; then
+if command -v sentry-cli >/dev/null 2>&1; then
   sentry_json="$(
-    IFS=',' read -ra projects <<< "$SENTRY_PROJECTS"
-    for project in "${projects[@]}"; do
-      project="${project//[[:space:]]/}"
-      [[ -n "$project" ]] || continue
-      out="$(timeout 25 sentry-cli issues list --org "$SENTRY_ORG" --project "$project" --query 'is:unresolved' 2>&1 || true)"
+    for project in healify-api healify-mobile healify-admin; do
+      out="$(timeout 25 sentry-cli issues list --org healify --project "$project" --query 'is:unresolved' 2>&1 || true)"
       if printf '%s' "$out" | grep -qi 'No issues found'; then
         jq -nc --arg project "$project" '{project:$project,ok:true,unresolved:0,highPriority:0,note:"No unresolved issues"}'
-      elif printf '%s' "$out" | grep -qi 'error\|unauthorized\|forbidden\|not found'; then
+      elif printf '%s' "$out" | grep -qi 'error\\|unauthorized\\|forbidden\\|not found'; then
         note="$(printf '%s' "$out" | sed -n '1,2p' | tr '\n' ' ' | sed 's/"/'\''/g')"
         jq -nc --arg project "$project" --arg note "$note" '{project:$project,ok:false,unresolved:null,highPriority:null,note:$note}'
       else
@@ -41,8 +36,6 @@ if command -v sentry-cli >/dev/null 2>&1 && [[ -n "$SENTRY_ORG" && -n "$SENTRY_P
       fi
     done | jq -sc '{ok:true,projects:.}'
   )"
-elif command -v sentry-cli >/dev/null 2>&1; then
-  sentry_json='{"ok":false,"note":"SENTRY_ORG and SENTRY_PROJECTS env vars required","projects":[]}'
 fi
 
 opdash_json='{"ok":false,"note":"operating dashboard source probe unavailable"}'
@@ -80,12 +73,9 @@ except Exception as exc:
     print(json.dumps({"ok": False, "note": f"PyJWT unavailable: {exc}", "apps": []}))
     sys.exit(0)
 
-APP_IDS = [a.strip() for a in os.environ.get("APP_STORE_CONNECT_APP_IDS", "").split(",") if a.strip()]
-KEY_ID = os.environ.get("APP_STORE_CONNECT_API_KEY_ID") or os.environ.get("APP_STORE_CONNECT_KEY_ID") or ""
-ISSUER_ID = os.environ.get("APP_STORE_CONNECT_ISSUER_ID") or ""
-if not APP_IDS or not KEY_ID or not ISSUER_ID:
-    print(json.dumps({"ok": False, "note": "Set APP_STORE_CONNECT_APP_IDS, APP_STORE_CONNECT_API_KEY_ID, and APP_STORE_CONNECT_ISSUER_ID env vars", "apps": []}))
-    sys.exit(0)
+APP_IDS = ["6746675266", "6751717479"]
+KEY_ID = os.environ.get("APP_STORE_CONNECT_API_KEY_ID") or os.environ.get("APP_STORE_CONNECT_KEY_ID") or "22C7Z973Z3"
+ISSUER_ID = os.environ.get("APP_STORE_CONNECT_ISSUER_ID") or "6a7e769c-e3f3-4198-b152-960c60a27295"
 KEY_PATH = os.environ.get("APP_STORE_CONNECT_API_KEY_PATH") or os.path.expanduser(f"~/.fastlane/app_store_connect/AuthKey_{KEY_ID}.p8")
 
 def token():
@@ -127,23 +117,18 @@ except Exception as exc:
 PY
 )"
 
-isjson() { printf '%s' "$1" | jq empty >/dev/null 2>&1; }
-isjson "$eas_json" || eas_json='{"ok":false,"note":"invalid EAS JSON","builds":[]}'
-isjson "$sentry_json" || sentry_json='{"ok":false,"note":"invalid Sentry JSON","projects":[]}'
-isjson "$opdash_json" || opdash_json='{"ok":false,"note":"invalid opdash JSON"}'
-isjson "$asc_extra_json" || asc_extra_json='{"ok":false,"note":"invalid ASC JSON","apps":[]}'
-
-if jq -nc \
+jq -nc \
   --arg generatedAt "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
   --argjson eas "$eas_json" \
   --argjson sentry "$sentry_json" \
   --argjson opdash "$opdash_json" \
   --argjson ascExtra "$asc_extra_json" \
-  '{generatedAt:$generatedAt,eas:$eas,sentry:$sentry,opdash:$opdash,ascExtra:$ascExtra}' >"$TMP"; then
-  mv "$TMP" "$OUT"
-  printf '%s\n' "$OUT"
-else
+  '{generatedAt:$generatedAt,eas:$eas,sentry:$sentry,opdash:$opdash,ascExtra:$ascExtra}' >"$TMP"
+JQ_RC=$?
+if [ "$JQ_RC" -ne 0 ] || ! jq empty "$TMP" 2>/dev/null; then
   rm -f "$TMP"
-  printf 'healify-bi refresh: merge failed; keeping existing cache at %s\n' "$OUT" >&2
+  echo "ops-healify-bi-refresh: cache assembly failed (rc=$JQ_RC) — $OUT left unchanged" >&2
   exit 1
 fi
+mv "$TMP" "$OUT"
+printf '%s\n' "$OUT"

--- a/claude-ops/bin/ops-post-update-migrate
+++ b/claude-ops/bin/ops-post-update-migrate
@@ -124,46 +124,7 @@ run_migrations() {
     fi
   fi
 
-  # 4. Stable 'current/' directory — prevents "Plugin directory does not exist" errors
-  #    when Claude Code updates the plugin mid-session and deletes the old versioned dir.
-  {
-    local cache_parent current_dir
-    cache_parent="$(dirname "$PLUGIN_ROOT")"
-    current_dir="$cache_parent/current"
-
-    if command -v rsync >/dev/null 2>&1; then
-      rsync -a --delete "$PLUGIN_ROOT/" "$current_dir/" 2>/dev/null \
-        && log "  ok: refreshed $current_dir via rsync" \
-        || log "  warn: rsync to current/ failed (non-fatal)"
-    else
-      mkdir -p "$current_dir"
-      cp -rp "$PLUGIN_ROOT/." "$current_dir/" 2>/dev/null \
-        && log "  ok: refreshed $current_dir via cp" \
-        || log "  warn: cp to current/ failed (non-fatal)"
-    fi
-
-    local installed_json="$HOME/.claude/plugins/installed_plugins.json"
-    if [[ -f "$installed_json" ]]; then
-      python3 - "$installed_json" "$current_dir" <<'PYEOF' 2>/dev/null \
-        && log "  ok: patched installed_plugins.json → current" \
-        || log "  warn: installed_plugins.json patch failed (non-fatal)"
-import json, sys
-path, current = sys.argv[1], sys.argv[2]
-with open(path) as f:
-    d = json.load(f)
-changed = False
-for e in d.get("plugins", {}).get("ops@ops-marketplace", []):
-    if e.get("scope") == "user" and e.get("installPath", "") != current:
-        e["installPath"] = current
-        changed = True
-if changed:
-    with open(path, "w") as f:
-        json.dump(d, f, indent=2)
-PYEOF
-    fi
-  } || true
-
-  # 5. Add future migrations here. Pattern:
+  # 4. Add future migrations here. Pattern:
   #    if needs_migration; then
   #      run_idempotent_migration && log "  ok: <name>"
   #    fi

--- a/claude-ops/bin/ops-post-update-migrate
+++ b/claude-ops/bin/ops-post-update-migrate
@@ -124,7 +124,46 @@ run_migrations() {
     fi
   fi
 
-  # 4. Add future migrations here. Pattern:
+  # 4. Stable 'current/' directory — prevents "Plugin directory does not exist" errors
+  #    when Claude Code updates the plugin mid-session and deletes the old versioned dir.
+  {
+    local cache_parent current_dir
+    cache_parent="$(dirname "$PLUGIN_ROOT")"
+    current_dir="$cache_parent/current"
+
+    if command -v rsync >/dev/null 2>&1; then
+      rsync -a --delete "$PLUGIN_ROOT/" "$current_dir/" 2>/dev/null \
+        && log "  ok: refreshed $current_dir via rsync" \
+        || log "  warn: rsync to current/ failed (non-fatal)"
+    else
+      mkdir -p "$current_dir"
+      cp -rp "$PLUGIN_ROOT/." "$current_dir/" 2>/dev/null \
+        && log "  ok: refreshed $current_dir via cp" \
+        || log "  warn: cp to current/ failed (non-fatal)"
+    fi
+
+    local installed_json="$HOME/.claude/plugins/installed_plugins.json"
+    if [[ -f "$installed_json" ]]; then
+      python3 - "$installed_json" "$current_dir" <<'PYEOF' 2>/dev/null \
+        && log "  ok: patched installed_plugins.json → current" \
+        || log "  warn: installed_plugins.json patch failed (non-fatal)"
+import json, sys
+path, current = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    d = json.load(f)
+changed = False
+for e in d.get("plugins", {}).get("ops@ops-marketplace", []):
+    if e.get("scope") == "user" and e.get("installPath", "") != current:
+        e["installPath"] = current
+        changed = True
+if changed:
+    with open(path, "w") as f:
+        json.dump(d, f, indent=2)
+PYEOF
+    fi
+  } || true
+
+  # 5. Add future migrations here. Pattern:
   #    if needs_migration; then
   #      run_idempotent_migration && log "  ok: <name>"
   #    fi

--- a/claude-ops/bin/ops-user-profiler
+++ b/claude-ops/bin/ops-user-profiler
@@ -222,9 +222,9 @@ MERGED=$(jq -n \
             source: "scan_inferred"
           } }
       ) | from_entries ) as $cmd_base
-  | ( ($prefs.persona.command_expertise // {})
-      | with_entries(select(.value.source == "confirmed")) ) as $cmd_confirmed
-  | ( $cmd_base + $cmd_confirmed ) as $command_expertise
+  | ( (($cmd_base | keys) + (($prefs.persona.command_expertise // {}) | keys) | unique)
+    | map(. as $k | { key: $k, value: keep($prefs.persona.command_expertise[$k]; $cmd_base[$k]) })
+    | from_entries ) as $command_expertise
 
   | { display_name: ($scan.identity_hints.git_name // "Owner"),
       full_name: null,
@@ -235,7 +235,9 @@ MERGED=$(jq -n \
 
   | { verbosity: ( ($scan.style_hints.prior_verbosity // "") | if . == "" then "compact" else . end ),
       autonomy: ($scan.style_hints.autonomy // "careful"),
-      yolo_enabled: (($scan.style_hints.autonomy // "") == "yolo"),
+      yolo_enabled: ( if ($scan.style_hints.prior_yolo // "") == "true" then true
+                       elif ($scan.style_hints.prior_yolo // "") == "false" then false
+                       else (($scan.style_hints.autonomy // "") == "yolo") end ),
       preferred_model: ( ($scan.style_hints.claude_model // "")
                          | if . == "" then null
                            elif test("opus";"i") then "opus"
@@ -286,8 +288,12 @@ else
       until mkdir "$PREFS.mutex" 2>/dev/null; do
         _tries=$((_tries+1)); [ "$_tries" -ge 50 ] && break; sleep 0.1
       done
-      mv -f "$TMP" "$PREFS"
-      rmdir "$PREFS.mutex" 2>/dev/null || true
+      if [ -d "$PREFS.mutex" ]; then
+        mv -f "$TMP" "$PREFS"
+        rmdir "$PREFS.mutex" 2>/dev/null || true
+      else
+        echo "ops-user-profiler: could not acquire preferences lock — skipping persona write" >&2
+      fi
     fi
     [ -f "$TMP" ] && rm -f "$TMP" 2>/dev/null || true
     echo "ops-user-profiler: merged .persona into $PREFS (ws_source=$WS_SOURCE)"

--- a/claude-ops/bin/ops-user-profiler
+++ b/claude-ops/bin/ops-user-profiler
@@ -222,9 +222,8 @@ MERGED=$(jq -n \
             source: "scan_inferred"
           } }
       ) | from_entries ) as $cmd_base
-  | ( (($cmd_base | keys) + (($prefs.persona.command_expertise // {}) | keys) | unique)
-    | map(. as $k | { key: $k, value: keep($prefs.persona.command_expertise[$k]; $cmd_base[$k]) })
-    | from_entries ) as $command_expertise
+  | ($cmd_base + (($prefs.persona.command_expertise // {})
+      | with_entries(select(rank(.value.source) > rank("scan_inferred"))))) as $command_expertise
 
   | { display_name: ($scan.identity_hints.git_name // "Owner"),
       full_name: null,
@@ -280,8 +279,10 @@ else
   else
     printf '%s\n' "$MERGED" > "$TMP"
     LOCK="$PREFS.lock"
+    _WROTE=0
     if command -v flock >/dev/null 2>&1; then
       ( flock -x 200; mv -f "$TMP" "$PREFS" ) 200>"$LOCK"
+      _WROTE=1
     else
       # mkdir-mutex fallback (mkdir is atomic on POSIX)
       _tries=0
@@ -291,11 +292,12 @@ else
       if [ -d "$PREFS.mutex" ]; then
         mv -f "$TMP" "$PREFS"
         rmdir "$PREFS.mutex" 2>/dev/null || true
+        _WROTE=1
       else
         echo "ops-user-profiler: could not acquire preferences lock — skipping persona write" >&2
       fi
     fi
     [ -f "$TMP" ] && rm -f "$TMP" 2>/dev/null || true
-    echo "ops-user-profiler: merged .persona into $PREFS (ws_source=$WS_SOURCE)"
+    [ "$_WROTE" -eq 1 ] && echo "ops-user-profiler: merged .persona into $PREFS (ws_source=$WS_SOURCE)"
   fi
 fi

--- a/claude-ops/bin/ops-user-profiler
+++ b/claude-ops/bin/ops-user-profiler
@@ -159,3 +159,137 @@ jq -n \
   }' > "$PREFILL" 2>/dev/null || echo '{}' > "$PREFILL"
 
 echo "ops-user-profiler: wrote $SCAN + $PREFILL (os=$OS pkg=$PKG)"
+
+# ── persona merge write-back (R7: atomic + locked + confidence ladder) ──────
+# Merge a `.persona` block (ops-persona/1) INTO preferences.json without
+# clobbering higher-confidence data. Confidence ladder (highest wins):
+#   confirmed > user_config > web_enriched > scan_inferred
+# This profiler only ever produces scan_inferred / user_config-tier values, so
+# `confirmed` and web-enriched fields written by the wizard/enrichment agent are
+# never overwritten here. Siblings (partner_registry, channels, toggles, mined
+# persona subkeys) are preserved. Idempotent: re-running converges.
+PREFS="$DATA/preferences.json"
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "")
+
+EXIST_PREFS=$(cat "$PREFS" 2>/dev/null); isjson "$EXIST_PREFS" || EXIST_PREFS='{}'
+SCAN_JSON=$(cat "$SCAN" 2>/dev/null);   isjson "$SCAN_JSON"   || SCAN_JSON='{}'
+
+# Style values read from the user's OWN prior preferences are user_config-tier;
+# values inferred from Claude config alone are scan_inferred-tier.
+WS_SOURCE="claude-config"
+{ [ -n "$PRIOR_VERBOSITY" ] || [ -n "$PRIOR_YOLO" ]; } && WS_SOURCE="user_config"
+
+MERGED=$(jq -n \
+  --arg now "$NOW" \
+  --arg ws_source "$WS_SOURCE" \
+  --argjson prefs "$EXIST_PREFS" \
+  --argjson scan "$SCAN_JSON" '
+  # source → confidence rank (unknown source = 0, never wins)
+  def rank(s): ({confirmed:4,user_config:3,web_enriched:2,websearch:2,unconfirmed:2,
+                 scan_inferred:1,scan:1,git:1,"claude-config":1,transcript:1}[s]) // 0;
+  # keep existing section unless the incoming one is strictly higher confidence
+  def keep(e; i): if i==null then e
+                  elif e==null then i
+                  elif rank(e.source) >= rank(i.source) then e
+                  else i end;
+
+  # per-command familiarity signal (scan_inferred): "core" = always-relevant,
+  # "familiar" = a dependency the command needs is present, "new" = not seen yet.
+  def cmdspec: [
+    {cmd:"ops:setup",    needs:[]},
+    {cmd:"ops:go",       needs:[]},
+    {cmd:"ops:inbox",    needs:["whatsapp","slack","gog","telegram","discord"]},
+    {cmd:"ops:comms",    needs:["whatsapp","slack","gog","telegram"]},
+    {cmd:"ops:deploy",   needs:["gh","aws","vercel","docker"]},
+    {cmd:"ops:fires",    needs:["aws"]},
+    {cmd:"ops:monitor",  needs:["sentry","datadog"]},
+    {cmd:"ops:revenue",  needs:["stripe","revenuecat"]},
+    {cmd:"ops:marketing",needs:["meta","klaviyo","ga4"]},
+    {cmd:"ops:home",     needs:["homey"]},
+    {cmd:"ops:unifi",    needs:["unifi"]},
+    {cmd:"ops:release",  needs:["gh","eas","fastlane"]}
+  ];
+
+  ( (($scan.tooling_present // []) + ($scan.mcp_configured // []) +
+     ($scan.env_vendor_names // []) + ($scan.hooks_installed // []))
+    | map(ascii_downcase) ) as $present
+  | ( cmdspec | map(
+        { key: .cmd,
+          value: {
+            familiarity: ( if (.needs|length)==0 then "core"
+                           elif any(.needs[]; . as $n | $present | any(test($n))) then "familiar"
+                           else "new" end ),
+            source: "scan_inferred"
+          } }
+      ) | from_entries ) as $cmd_base
+  | ( ($prefs.persona.command_expertise // {})
+      | with_entries(select(.value.source == "confirmed")) ) as $cmd_confirmed
+  | ( $cmd_base + $cmd_confirmed ) as $command_expertise
+
+  | { display_name: ($scan.identity_hints.git_name // "Owner"),
+      full_name: null,
+      emails: ([$scan.identity_hints.git_email] | map(select(. != null and . != ""))),
+      gh_account: ($scan.identity_hints.gh_account // ""),
+      confidence: (if (($scan.identity_hints.git_name // "") != "") then "medium" else "low" end),
+      source: "git" } as $inc_identity
+
+  | { verbosity: ( ($scan.style_hints.prior_verbosity // "") | if . == "" then "compact" else . end ),
+      autonomy: ($scan.style_hints.autonomy // "careful"),
+      yolo_enabled: (($scan.style_hints.autonomy // "") == "yolo"),
+      preferred_model: ( ($scan.style_hints.claude_model // "")
+                         | if . == "" then null
+                           elif test("opus";"i") then "opus"
+                           elif test("haiku";"i") then "haiku"
+                           elif test("sonnet";"i") then "sonnet"
+                           else null end ),
+      tone: null,
+      source: $ws_source,
+      autonomy_evidence: ("perm_mode=" + ($scan.style_hints.perm_mode // "")
+                          + " allow=" + (($scan.style_hints.allow_count // 0)|tostring)
+                          + " deny="  + (($scan.style_hints.deny_count  // 0)|tostring)) } as $inc_ws
+
+  | { os: ($scan.host.os // "unknown"),
+      pkg_mgr: ($scan.host.pkg_mgr // "none"),
+      shell: ($scan.host.shell // "sh"),
+      profile_file: ($scan.host.profile_file // ""),
+      hooks_installed: ($scan.hooks_installed // []),
+      plugins_installed: ($scan.plugins_installed // []),
+      mcps_configured: ($scan.mcp_configured // []),
+      clis_present: ($scan.tooling_present // []) } as $inc_env
+
+  | ($prefs.persona // {}) as $e
+  | $prefs + { persona: (
+        $e
+        + { schema: "ops-persona/1", updated_at: $now }
+        + { identity:      keep($e.identity;      $inc_identity) }
+        + { working_style: keep($e.working_style; $inc_ws) }
+        + { environment:   $inc_env }
+        + { command_expertise: $command_expertise }
+      ) }
+  ' 2>"${OPS_PROFILER_JQERR:-/dev/null}")
+JQ_RC=$?
+
+if [ "$JQ_RC" -ne 0 ] || ! isjson "$MERGED"; then
+  echo "ops-user-profiler: persona merge produced invalid JSON (rc=$JQ_RC) — preferences.json left unchanged" >&2
+else
+  TMP=$(mktemp "$DATA/.preferences.XXXXXX.json" 2>/dev/null) || TMP=""
+  if [ -z "$TMP" ]; then
+    echo "ops-user-profiler: could not create temp file in $DATA — skipping persona write" >&2
+  else
+    printf '%s\n' "$MERGED" > "$TMP"
+    LOCK="$PREFS.lock"
+    if command -v flock >/dev/null 2>&1; then
+      ( flock -x 200; mv -f "$TMP" "$PREFS" ) 200>"$LOCK"
+    else
+      # mkdir-mutex fallback (mkdir is atomic on POSIX)
+      _tries=0
+      until mkdir "$PREFS.mutex" 2>/dev/null; do
+        _tries=$((_tries+1)); [ "$_tries" -ge 50 ] && break; sleep 0.1
+      done
+      mv -f "$TMP" "$PREFS"
+      rmdir "$PREFS.mutex" 2>/dev/null || true
+    fi
+    [ -f "$TMP" ] && rm -f "$TMP" 2>/dev/null || true
+    echo "ops-user-profiler: merged .persona into $PREFS (ws_source=$WS_SOURCE)"
+  fi
+fi

--- a/claude-ops/skills/setup/PERSONA-SCHEMA.md
+++ b/claude-ops/skills/setup/PERSONA-SCHEMA.md
@@ -71,6 +71,20 @@ This is **generic for any user** — every field is _discovered_ (git identity, 
       // worth installing, with why + how
       { "tool": "stripe", "why": "you have STRIPE_* keys but no stripe CLI", "install": "dnf install stripe" },
     ],
+    "command_expertise": {
+      // per ops:command familiarity signal — drives how much the wizard explains
+      // each command and which it surfaces first. Keyed by command id (no slash).
+      // familiarity: "core"     = always-relevant (ops:setup, ops:go) — never pruned
+      //              "familiar" = a dependency the command needs is present (CLI/MCP/
+      //                           env-vendor/hook detected) → user likely uses it
+      //              "new"      = no detected dependency → introduce it, don't assume
+      // source: confidence tier of THIS entry (see merge contract). The profiler
+      //         writes "scan_inferred"; the wizard upgrades to "confirmed" when the
+      //         user corrects/acknowledges it.
+      "ops:setup":   { "familiarity": "core",     "source": "scan_inferred" },
+      "ops:deploy":  { "familiarity": "familiar", "source": "scan_inferred" },
+      "ops:revenue": { "familiarity": "new",      "source": "scan_inferred" },
+    },
   },
 }
 ```


### PR DESCRIPTION
Salvaged local branch `slice2a-persona-merge` (10 commits ahead of main).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Persona merge is guarded but touches live user preferences; healify-bi-refresh embeds org-specific Sentry/ASC identifiers and default API key metadata, which affects portability and secret-handling expectations.
> 
> **Overview**
> **`ops-user-profiler`** now merges an **`ops-persona/1`** block into **`preferences.json`** after each scan: identity, working style, environment, and per-command **`command_expertise`** (`core` / `familiar` / `new` from detected CLIs/MCPs/hooks). Higher-confidence fields (`confirmed`, `user_config`, web-enriched) are preserved via a source rank; writes use a temp file plus **`flock`** or a mkdir mutex, and invalid merge output leaves the file unchanged.
> 
> **`PERSONA-SCHEMA.md`** documents **`command_expertise`** and how familiarity is inferred.
> 
> **`ops-healify-bi-refresh`** drops required **`SENTRY_*`** / **`APP_STORE_CONNECT_*`** env lists in favor of fixed Healify defaults (Sentry org **`healify`**, three projects; two ASC app IDs and fallback key/issuer IDs). Final cache assembly validates **`jq`** output before **`mv`**, with clearer failure messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2258d66e0d2efeb521e373101d652677a5cadd14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User profile scanning now writes enriched persona data, including per-command expertise for ops commands.
* **Improvements**
  * Updated Sentry unresolved-issues handling to use a fixed project set and produce clearer per-project results.
  * App Store Connect “extra” data generation now works with sensible defaults (while still allowing key/issuer overrides).
  * Cache JSON assembly now validates more strictly and avoids overwriting outputs on failure.
  * Profile preference updates are now merged safely with confidence-based preservation and atomic, locked writes.
* **Documentation**
  * Persona schema documentation extended to describe command expertise metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->