### PR TITLE
slice3b-route-suggest

### DIFF
--- a/claude-ops/bin/ops-healify-dash
+++ b/claude-ops/bin/ops-healify-dash
@@ -88,6 +88,8 @@ safe_jq() {
   local file="$1" fallback="$2" filter="${3:-.}"
   if [[ -s "$file" ]] && command -v jq >/dev/null 2>&1; then
     jq -c "$filter" "$file" 2>/dev/null || printf '%s\n' "$fallback"
+  elif command -v jq >/dev/null 2>&1; then
+    printf '%s\n' "$fallback" | jq -c "$filter" 2>/dev/null || printf '%s\n' "$fallback"
   else
     printf '%s\n' "$fallback"
   fi

--- a/claude-ops/bin/ops-post-update-migrate
+++ b/claude-ops/bin/ops-post-update-migrate
@@ -124,46 +124,7 @@ run_migrations() {
     fi
   fi
 
-  # 4. Stable 'current/' directory — prevents "Plugin directory does not exist" errors
-  #    when Claude Code updates the plugin mid-session and deletes the old versioned dir.
-  {
-    local cache_parent current_dir
-    cache_parent="$(dirname "$PLUGIN_ROOT")"
-    current_dir="$cache_parent/current"
-
-    if command -v rsync >/dev/null 2>&1; then
-      rsync -a --delete "$PLUGIN_ROOT/" "$current_dir/" 2>/dev/null \
-        && log "  ok: refreshed $current_dir via rsync" \
-        || log "  warn: rsync to current/ failed (non-fatal)"
-    else
-      mkdir -p "$current_dir"
-      cp -rp "$PLUGIN_ROOT/." "$current_dir/" 2>/dev/null \
-        && log "  ok: refreshed $current_dir via cp" \
-        || log "  warn: cp to current/ failed (non-fatal)"
-    fi
-
-    local installed_json="$HOME/.claude/plugins/installed_plugins.json"
-    if [[ -f "$installed_json" ]]; then
-      python3 - "$installed_json" "$current_dir" <<'PYEOF' 2>/dev/null \
-        && log "  ok: patched installed_plugins.json → current" \
-        || log "  warn: installed_plugins.json patch failed (non-fatal)"
-import json, sys
-path, current = sys.argv[1], sys.argv[2]
-with open(path) as f:
-    d = json.load(f)
-changed = False
-for e in d.get("plugins", {}).get("ops@ops-marketplace", []):
-    if e.get("scope") == "user" and e.get("installPath", "") != current:
-        e["installPath"] = current
-        changed = True
-if changed:
-    with open(path, "w") as f:
-        json.dump(d, f, indent=2)
-PYEOF
-    fi
-  } || true
-
-  # 5. Add future migrations here. Pattern:
+  # 4. Add future migrations here. Pattern:
   #    if needs_migration; then
   #      run_idempotent_migration && log "  ok: <name>"
   #    fi

--- a/claude-ops/bin/ops-post-update-migrate
+++ b/claude-ops/bin/ops-post-update-migrate
@@ -124,7 +124,46 @@ run_migrations() {
     fi
   fi
 
-  # 4. Add future migrations here. Pattern:
+  # 4. Stable 'current/' directory — prevents "Plugin directory does not exist" errors
+  #    when Claude Code updates the plugin mid-session and deletes the old versioned dir.
+  {
+    local cache_parent current_dir
+    cache_parent="$(dirname "$PLUGIN_ROOT")"
+    current_dir="$cache_parent/current"
+
+    if command -v rsync >/dev/null 2>&1; then
+      rsync -a --delete "$PLUGIN_ROOT/" "$current_dir/" 2>/dev/null \
+        && log "  ok: refreshed $current_dir via rsync" \
+        || log "  warn: rsync to current/ failed (non-fatal)"
+    else
+      mkdir -p "$current_dir"
+      cp -rp "$PLUGIN_ROOT/." "$current_dir/" 2>/dev/null \
+        && log "  ok: refreshed $current_dir via cp" \
+        || log "  warn: cp to current/ failed (non-fatal)"
+    fi
+
+    local installed_json="$HOME/.claude/plugins/installed_plugins.json"
+    if [[ -f "$installed_json" ]]; then
+      python3 - "$installed_json" "$current_dir" <<'PYEOF' 2>/dev/null \
+        && log "  ok: patched installed_plugins.json → current" \
+        || log "  warn: installed_plugins.json patch failed (non-fatal)"
+import json, sys
+path, current = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    d = json.load(f)
+changed = False
+for e in d.get("plugins", {}).get("ops@ops-marketplace", []):
+    if e.get("scope") == "user" and e.get("installPath", "") != current:
+        e["installPath"] = current
+        changed = True
+if changed:
+    with open(path, "w") as f:
+        json.dump(d, f, indent=2)
+PYEOF
+    fi
+  } || true
+
+  # 5. Add future migrations here. Pattern:
   #    if needs_migration; then
   #      run_idempotent_migration && log "  ok: <name>"
   #    fi


### PR DESCRIPTION
Salvaged local branch `slice3b-route-suggest` (9 commits ahead of main).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small read-only shell helper change with no auth, data writes, or production runtime impact.
> 
> **Overview**
> **`safe_jq` in `ops-healify-dash`** now runs the jq filter against the JSON **fallback** when the cache file is missing or empty but `jq` is installed, instead of returning the raw fallback string.
> 
> That keeps metric counts and derived output (e.g. `cards()`, `json_summary`, `plugin_table`) consistent when infra/AWS/project/plugin caches have not been populated yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6053a9f8af0e81710ee8dddeabe6396cef9c47c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of fallback values to ensure filtering and formatting are consistently applied when primary data sources are missing or empty, resulting in more predictable and reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->