### PR TITLE
slice5a-frontier-scout

### DIFF
--- a/claude-ops/bin/ops-healify-dash
+++ b/claude-ops/bin/ops-healify-dash
@@ -278,7 +278,7 @@ cards() {
   plugins="$(safe_jq "$PLUGIN_CACHE" '{"claude_plugins":[]}' '.claude_plugins | length')"
   skills="$(safe_jq "$PLUGIN_CACHE" '{"codex_skills":[]}' '.codex_skills | length')"
   kpis="$(safe_jq "$PLUGIN_CACHE" '{"ops_kpi_caches":[]}' '.ops_kpi_caches | length')"
-  agents_down="$(grep -Eci 'auth-needed|failed|missing|unauthorized|error' "$RUNTIME_CACHE" 2>/dev/null || true)"
+  agents_down="$(grep -Eci 'auth-needed|failed|missing|unauthorized|\berror\b' "$RUNTIME_CACHE" 2>/dev/null || true)"
   agents_down="${agents_down:-0}"
   {
     printf 'METRIC|VALUE|SOURCE|AGE\n'

--- a/claude-ops/bin/ops-post-update-migrate
+++ b/claude-ops/bin/ops-post-update-migrate
@@ -124,46 +124,7 @@ run_migrations() {
     fi
   fi
 
-  # 4. Stable 'current/' directory — prevents "Plugin directory does not exist" errors
-  #    when Claude Code updates the plugin mid-session and deletes the old versioned dir.
-  {
-    local cache_parent current_dir
-    cache_parent="$(dirname "$PLUGIN_ROOT")"
-    current_dir="$cache_parent/current"
-
-    if command -v rsync >/dev/null 2>&1; then
-      rsync -a --delete "$PLUGIN_ROOT/" "$current_dir/" 2>/dev/null \
-        && log "  ok: refreshed $current_dir via rsync" \
-        || log "  warn: rsync to current/ failed (non-fatal)"
-    else
-      mkdir -p "$current_dir"
-      cp -rp "$PLUGIN_ROOT/." "$current_dir/" 2>/dev/null \
-        && log "  ok: refreshed $current_dir via cp" \
-        || log "  warn: cp to current/ failed (non-fatal)"
-    fi
-
-    local installed_json="$HOME/.claude/plugins/installed_plugins.json"
-    if [[ -f "$installed_json" ]]; then
-      python3 - "$installed_json" "$current_dir" <<'PYEOF' 2>/dev/null \
-        && log "  ok: patched installed_plugins.json → current" \
-        || log "  warn: installed_plugins.json patch failed (non-fatal)"
-import json, sys
-path, current = sys.argv[1], sys.argv[2]
-with open(path) as f:
-    d = json.load(f)
-changed = False
-for e in d.get("plugins", {}).get("ops@ops-marketplace", []):
-    if e.get("scope") == "user" and e.get("installPath", "") != current:
-        e["installPath"] = current
-        changed = True
-if changed:
-    with open(path, "w") as f:
-        json.dump(d, f, indent=2)
-PYEOF
-    fi
-  } || true
-
-  # 5. Add future migrations here. Pattern:
+  # 4. Add future migrations here. Pattern:
   #    if needs_migration; then
   #      run_idempotent_migration && log "  ok: <name>"
   #    fi

--- a/claude-ops/bin/ops-post-update-migrate
+++ b/claude-ops/bin/ops-post-update-migrate
@@ -124,7 +124,46 @@ run_migrations() {
     fi
   fi
 
-  # 4. Add future migrations here. Pattern:
+  # 4. Stable 'current/' directory — prevents "Plugin directory does not exist" errors
+  #    when Claude Code updates the plugin mid-session and deletes the old versioned dir.
+  {
+    local cache_parent current_dir
+    cache_parent="$(dirname "$PLUGIN_ROOT")"
+    current_dir="$cache_parent/current"
+
+    if command -v rsync >/dev/null 2>&1; then
+      rsync -a --delete "$PLUGIN_ROOT/" "$current_dir/" 2>/dev/null \
+        && log "  ok: refreshed $current_dir via rsync" \
+        || log "  warn: rsync to current/ failed (non-fatal)"
+    else
+      mkdir -p "$current_dir"
+      cp -rp "$PLUGIN_ROOT/." "$current_dir/" 2>/dev/null \
+        && log "  ok: refreshed $current_dir via cp" \
+        || log "  warn: cp to current/ failed (non-fatal)"
+    fi
+
+    local installed_json="$HOME/.claude/plugins/installed_plugins.json"
+    if [[ -f "$installed_json" ]]; then
+      python3 - "$installed_json" "$current_dir" <<'PYEOF' 2>/dev/null \
+        && log "  ok: patched installed_plugins.json → current" \
+        || log "  warn: installed_plugins.json patch failed (non-fatal)"
+import json, sys
+path, current = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    d = json.load(f)
+changed = False
+for e in d.get("plugins", {}).get("ops@ops-marketplace", []):
+    if e.get("scope") == "user" and e.get("installPath", "") != current:
+        e["installPath"] = current
+        changed = True
+if changed:
+    with open(path, "w") as f:
+        json.dump(d, f, indent=2)
+PYEOF
+    fi
+  } || true
+
+  # 5. Add future migrations here. Pattern:
   #    if needs_migration; then
   #      run_idempotent_migration && log "  ok: <name>"
   #    fi


### PR DESCRIPTION
Salvaged local branch `slice5a-frontier-scout` (9 commits ahead of main).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line read-only monitoring regex tweak with no auth, data, or deployment impact.
> 
> **Overview**
> The **Agent warnings** metric in `ops-healify-dash` (`cards()`) counts lines in the fleet runtime health cache that match failure-related tokens. This change updates that `grep -Eci` pattern so **`error` is matched only as a whole word** (`\berror\b`), not as a substring inside unrelated text.
> 
> Other tokens (`auth-needed`, `failed`, `missing`, `unauthorized`) are unchanged. The intent is a more accurate **agents_down** count for the command-center summary table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 597f1475d7391fb1d8d58f43df8eeebf01fc6f3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error detection accuracy across monitoring systems and operational dashboards through refined pattern matching. Improved Sentry integration for more precise issue identification and classification. Refined agent health metrics to provide more accurate system status assessment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->