### PR TITLE
fix(autopilot): emit + read funnel_total_7d so canary gate can unblock

### DIFF
--- a/claude-ops/bin/ops-marketing-autopilot
+++ b/claude-ops/bin/ops-marketing-autopilot
@@ -1505,7 +1505,10 @@ gather_amplitude() {
     case "$val" in ''|*[!0-9.]*) val=0;; esac
     agg="$(printf '%s' "$agg" | jq -c --arg k "$ev" --argjson v "${val:-0}" '.[$k]=$v' 2>/dev/null || echo "$agg")"
   done < <(printf '%s' "$events" | jq -r '.[]?' 2>/dev/null || true)
-  jq -nc --argjson ev "$agg" '{events:$ev,_window:"7d"}' > "$out" 2>/dev/null || printf '%s' '{"events":{}}' > "$out"
+  # Emit funnel_total_7d (sum of all funnel-event counts) alongside the per-event
+  # breakdown. The canary auto-unpause gate reads .funnel_total_7d; without it the
+  # gate fell back to 0 and held campaigns paused forever despite real funnel signal.
+  jq -nc --argjson ev "$agg" '{events:$ev, funnel_total_7d: ([$ev[]?] | add // 0), _window:"7d"}' > "$out" 2>/dev/null || printf '%s' '{"events":{},"funnel_total_7d":0}' > "$out"
   local summary
   summary="$(printf '%s' "$agg" | jq -r 'to_entries | map("\(.key)=\(.value)") | join(", ")' 2>/dev/null || echo '')"
   report "- amplitude: intent funnel 7d → ${summary:-no events} → ${out##*/}"
@@ -1748,7 +1751,10 @@ canary_gate_unpause() {
   local amp_f="${STATE_DIR}/${proj}-amplitude.json"
   local amp_total=0
   if [ -f "$amp_f" ]; then
-    amp_total="$(jq -r '.funnel_total_7d // 0' "$amp_f" 2>/dev/null || echo 0)"
+    # Prefer the emitted funnel_total_7d; fall back to summing the per-event
+    # breakdown so already-cached files (written before this field existed) still
+    # pass the gate instead of reading a missing field as 0.
+    amp_total="$(jq -r '(.funnel_total_7d // ([.events[]?] | add) // 0)' "$amp_f" 2>/dev/null || echo 0)"
   fi
   if ! awk "BEGIN{exit !(${amp_total:-0} > 0)}" 2>/dev/null; then
     report "- canary gate: HOLD — Amplitude funnel_total_7d=${amp_total} (need >0)"


### PR DESCRIPTION
## Problem
`gather_amplitude` wrote `{events, _window}` but **never** the `funnel_total_7d` field that the canary auto-unpause gate reads. The gate did `jq '.funnel_total_7d // 0'` → always **0** → campaigns held PAUSED indefinitely despite real Amplitude funnel signal. Net effect: paid spend silently never started after launch.

## Fix
- `gather_amplitude` now emits `funnel_total_7d = ([events[]] | add)`.
- Canary gate falls back to summing `.events` for files cached before the field existed, so it recovers immediately without waiting for a fresh gather.

## Verify
- `bash -n` clean; `tests/test-no-secrets.sh` 25/25.
- Gate fallback against a live cache (`{session_start:154, onboarding:6, bloodwork_processed:5, ...}`) → **167 > 0** → gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when Meta campaigns can auto-unpause (paid spend), but the logic is a narrow data-field fix with backward-compatible reads—not new cap or mutation rules.
> 
> **Overview**
> Fixes a **schema mismatch** that kept the canary auto-unpause gate on **HOLD** even when Amplitude showed real funnel activity.
> 
> `gather_amplitude` now writes **`funnel_total_7d`** (sum of per-event counts in `events`) into the amplitude state JSON, which `canary_gate_unpause` already required for condition 3. **`canary_gate_unpause`** also **falls back** to summing `.events` when older cache files lack the new field, so the gate can pass without waiting for a fresh gather.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30da8328e3f7200fa6f795e89bd0321f1640ef08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved funnel event tracking reliability with enhanced fallback mechanisms to support backward compatibility with previously saved snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->