### PR TITLE
chore: add Cursor Approval Agent policy files

### DIFF
--- a/APPROVAL_POLICY.md
+++ b/APPROVAL_POLICY.md
@@ -1,0 +1,37 @@
+# claude-ops-backup-pre-scrub — default approval policy
+
+Repository-wide rules for Cursor Approval Agents evaluating pull requests in this repo.
+
+## Purpose
+
+claude-ops-backup-pre-scrub is Claude Code ops infrastructure. Hooks, deploy automation, and credentials are high risk.
+
+Default posture: **approve only when risk is low and automated review is clean**.
+
+## Auto-approve when ALL are true
+
+- Bugbot Review Context reports no findings requiring human review
+- Security Review Context reports no findings requiring human review (when enabled)
+- Risk score is at or below the agent's configured maximum threshold
+- CI checks required for the changed paths are green
+- PR does not modify approval policy files or routing files
+- Documentation-only or test-only PRs (≤ 300 lines excluding lockfiles)
+
+## Never auto-approve
+
+- GitHub Actions workflow changes that weaken CI, skip tests, or broaden deploy permissions
+- Deletions or relaxations of auth, security, or safety guardrails
+- Changes that remove tests, disable lint/typecheck, or bypass pre-commit hooks
+- PRs labeled `security`, `breaking`, or `do-not-auto-approve`
+
+## Reviewer routing
+
+When auto-approval is not allowed, request repo maintainers or the appropriate team for the changed area. Leave the PR unapproved with a short comment if reviewer assignment is unavailable.
+
+## Deploy expectations
+
+For changes shipping dev → staging → main → production: do not auto-approve solely on green CI if production paths, migrations, or release config changed.
+
+## Conflict resolution
+
+Follow the most specific applicable policy. If unclear, follow the stricter rule and do not auto-approve.


### PR DESCRIPTION
## Summary
- Add `APPROVAL_POLICY.md` and `.cursor/approval-policies/` routing for Cloud Approval Agents
- Profile-aware policies for docs, CI, tests, and runtime paths

## Test plan
- [x] Policy files present at repo root and `.cursor/approval-policies/ROUTING.md`
- [ ] Approval Agent discovers policies on next PR after merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only policy file with no runtime, CI, or credential changes.
> 
> **Overview**
> Adds **`APPROVAL_POLICY.md`** at the repo root so Cursor Approval Agents have a single default rule set for this ops repo.
> 
> The policy sets a **low-risk, clean-automation** default: auto-approve only when Bugbot/security review are clean, risk is under threshold, CI is green, and the PR is docs/tests-only (≤300 lines) and does **not** touch policy or routing files. It blocks auto-approval for weakened CI/workflows, relaxed security guardrails, hook/lint bypasses, and labeled high-risk PRs, and notes stricter handling for production/deploy paths and conflict resolution (prefer the stricter rule).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c86535ade0f8030136e19ffa3cf64f048be12bc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added documentation defining the repository's approval policy for automated reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->