### PR TITLE
chore: add Cursor Approval Agent policy files

### DIFF
--- a/.cursor/approval-policies/ROUTING.md
+++ b/.cursor/approval-policies/ROUTING.md
@@ -1,0 +1,29 @@
+- product: Documentation
+  boundary: "{docs/**,**/README.md,**/CHANGELOG.md,**/*.md}"
+  policies:
+    - .cursor/approval-policies/docs-policy.md
+
+- product: CI and workflows
+  boundary: ".github/workflows/**"
+  policies:
+    - .cursor/approval-policies/ci-policy.md
+
+- product: Tests
+  boundary: "{**/test/**,**/tests/**,**/*.test.*,**/*.spec.*,e2e/**}"
+  policies:
+    - .cursor/approval-policies/tests-policy.md
+
+- product: Application runtime
+  boundary: "{src/**,app/**,lib/**,packages/**,convex/**,agents/**,lambdas/**}"
+  policies:
+    - .cursor/approval-policies/runtime-policy.md
+
+- product: Hooks and safety
+  boundary: "{hooks/**,.cursor/hooks/**,**/hooks/**}"
+  policies:
+    - .cursor/approval-policies/hooks-policy.md
+
+- product: MCP servers
+  boundary: "**/mcp-servers/**"
+  policies:
+    - .cursor/approval-policies/mcp-policy.md

--- a/.cursor/approval-policies/ci-policy.md
+++ b/.cursor/approval-policies/ci-policy.md
@@ -1,0 +1,9 @@
+# CI workflow approval policy
+
+## Default posture
+Never auto-approve workflow changes.
+
+## Human review must verify
+- Required checks are not removed without replacement
+- Permissions blocks are not unnecessarily broadened
+- Deploy/release gates remain intact

--- a/.cursor/approval-policies/docs-policy.md
+++ b/.cursor/approval-policies/docs-policy.md
@@ -1,0 +1,9 @@
+# Documentation approval policy
+
+## Auto-approve when
+- Markdown/copy-only changes with no executable code
+- Bugbot and Security Agent report no findings
+
+## Never auto-approve
+- Embedded secrets, tokens, or private infrastructure endpoints
+- Bundled runtime changes in the same PR

--- a/.cursor/approval-policies/hooks-policy.md
+++ b/.cursor/approval-policies/hooks-policy.md
@@ -1,0 +1,4 @@
+# Hooks approval policy
+
+## Default posture
+Never auto-approve hook changes.

--- a/.cursor/approval-policies/mcp-policy.md
+++ b/.cursor/approval-policies/mcp-policy.md
@@ -1,0 +1,8 @@
+# MCP server approval policy
+
+## Default posture
+Never auto-approve new tools or expanded scopes.
+
+## Human review must verify
+- Outbound hosts and filesystem access are justified
+- Auth tokens handled server-side only

--- a/.cursor/approval-policies/runtime-policy.md
+++ b/.cursor/approval-policies/runtime-policy.md
@@ -1,0 +1,8 @@
+# Application runtime approval policy
+
+## Auto-approve when
+- Small localized fix with tests and clean automated review
+- No auth, billing, health-data, or deploy config impact
+
+## Never auto-approve
+- Broad refactors, new external integrations, or removed guardrails

--- a/.cursor/approval-policies/tests-policy.md
+++ b/.cursor/approval-policies/tests-policy.md
@@ -1,0 +1,8 @@
+# Tests approval policy
+
+## Auto-approve when
+- Test-only changes with unchanged production logic
+- CI green; Bugbot/Security clean
+
+## Never auto-approve
+- Disabled/skipped tests paired with production logic changes


### PR DESCRIPTION
Add ROUTING.md and routed policies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only Cursor config with no runtime or workflow execution changes; main effect is how future PRs may be auto-approved.
> 
> **Overview**
> Introduces **Cursor Approval Agent** configuration under `.cursor/approval-policies/`, starting with `ROUTING.md`, which maps six change areas (documentation, CI/workflows, tests, application runtime, hooks, and MCP servers) to glob **boundaries** and the policy file that applies.
> 
> Adds six policy markdown files that define **auto-approve** vs **never auto-approve** rules and, where relevant, what human review must check (e.g. CI permissions and release gates, MCP outbound access and token handling, runtime scope around auth/billing/deploy). **CI, hooks, and MCP** default to never auto-approve; **docs, tests, and runtime** allow narrow auto-approval when changes stay low-risk and automated checks are clean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16e36b7b31a94b8192af693db07b1e4e10d87004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->