### PR TITLE
release: v2.36.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 59 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.35.0",
+      "version": "2.36.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-2.35.0-blue)
+![Version](https://img.shields.io/badge/version-2.36.0-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-59-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.35.0",
+  "version": "2.36.0",
   "description": "Business operations command center for Claude Code — 59 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.36.0] - 2026-06-22
+
+### Changed
+ops-inbox: never archive todo/action-labeled emails until verified done (HARD GUARDRAIL); tone/language matching per contact; full-context cross-channel + already-sent dedup; snooze/follow-up intelligence so commitments & meeting-note todos are never lost; safe autonomous chores (archive already-replied, schedule reminders) with the Rule-6 outbound gate intact; new bin/ops-contact-registry offline cross-channel contact registry (build/lookup/stats).
+
+
 ## [2.35.0] - 2026-06-22
 
 ### Changed

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-2.35.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.36.0-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 59 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-2.35.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.36.0-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-59-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.35.0",
+  "version": "2.36.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.36.0** (was 2.35.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

ops-inbox: never archive todo/action-labeled emails until verified done (HARD GUARDRAIL); tone/language matching per contact; full-context cross-channel + already-sent dedup; snooze/follow-up intelligence so commitments & meeting-note todos are never lost; safe autonomous chores (archive already-replied, schedule reminders) with the Rule-6 outbound gate intact; new bin/ops-contact-registry offline cross-channel contact registry (build/lookup/stats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Inbox behavior changes affect email archival and light autonomous actions on communications; outbound sends remain gated, but misclassification could still leave mail unarchived or over-archive FYI threads.
> 
> **Overview**
> **Release v2.36.0** — version identifiers move from **2.35.0** to **2.36.0** in `plugin.json`, marketplace registry, `package.json`, README, and skills/agents reference badges.
> 
> The new **CHANGELOG** entry for 2.36.0 describes the functional payload: **`/ops:inbox`** gains a **hard guardrail** so todo/action-labeled Gmail is never archived until verified done; per-contact tone/language matching; fuller cross-channel context with already-sent dedup; snooze/follow-up handling for commitments and meeting-note todos; limited autonomous inbox chores (e.g. archive already-replied, schedule reminders) while keeping the **Rule 6** outbound approval gate; and **`bin/ops-contact-registry`** for offline build/lookup/stats of cross-channel contact identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd48bfe9a819a239713f0fe6390af13eebcc7db0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->