### PR TITLE
fix(ops-inbox): contact dedup, Gmail -a placement, todo label matching

### DIFF
--- a/claude-ops/bin/ops-contact-registry
+++ b/claude-ops/bin/ops-contact-registry
@@ -176,9 +176,11 @@ def build(with_gmail=False, with_slack=False, out=DEFAULT_OUT):
                 break
         if target is None:
             target = new_record(name)
-            records.append(target)
-            for ph in phones:
-                by_phone[ph] = target
+            if phones:
+                for ph in phones:
+                    by_phone[ph] = target
+            else:
+                records.append(target)
         merge_into(target, name=name, emails=emails, phones=phones,
                    slack_id=(slack[0] if slack else ""), context=ctx, tone=tone,
                    sources="memory")
@@ -191,7 +193,7 @@ def build(with_gmail=False, with_slack=False, out=DEFAULT_OUT):
         cmd = ["gog", "gmail", "search", "in:anywhere newer_than:120d",
                "-j", "--results-only", "--no-input", "--max", "300"]
         if acct:
-            cmd[2:2] = ["-a", acct]
+            cmd[3:3] = ["-a", acct]
         try:
             p = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
             data = json.loads(p.stdout) if p.stdout.strip() else []

--- a/claude-ops/bin/ops-inbox-scan
+++ b/claude-ops/bin/ops-inbox-scan
@@ -459,6 +459,8 @@ PROTECTED_SUBSTRINGS = (
 )
 # a 'done/completed' label clears protection even if a stale todo label lingers
 COMPLETION_SUBSTRINGS = ("ACTIONED", "DONE", "COMPLETED", "RESOLVED", "HANDLED", "ARCHIVED")
+PROTECTED_PHRASES = tuple(s for s in PROTECTED_SUBSTRINGS if " " in s)
+PROTECTED_WORDS = tuple(s for s in PROTECTED_SUBSTRINGS if " " not in s)
 def protected_todo_labels(labels):
     """Return the list of protected todo/action labels on a message (empty if none/done)."""
     hits, done = [], False
@@ -466,9 +468,13 @@ def protected_todo_labels(labels):
         if str(raw).upper() in SYSTEM_LABELS or str(raw).upper().startswith("CATEGORY_"):
             continue
         n = _norm_label(raw)
-        if any(c in n for c in COMPLETION_SUBSTRINGS):
-            done = True
-        if any(s in n for s in PROTECTED_SUBSTRINGS):
+        words = set(n.split())
+        tokens = n.split()
+        for i, t in enumerate(tokens):
+            if t in COMPLETION_SUBSTRINGS and (i == 0 or tokens[i - 1] != "NOT"):
+                done = True
+                break
+        if any(p in n for p in PROTECTED_PHRASES) or any(w in words for w in PROTECTED_WORDS):
             hits.append(str(raw))
     return [] if done else hits
 


### PR DESCRIPTION
## Summary
Cherry-picks the incremental fix from closed PR #625 (`4586fd37`) that was not fully covered by #626/#627.

- Only bucket memory contacts with phones in `by_phone`; phoneless records stay in `records`
- Insert `gog -a` after the gmail search subcommand (repo convention)
- Match completion/protected labels by whole tokens with NOT negation

## Test plan
- [x] Cherry-pick applied cleanly on current `main`
- [ ] CI green

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inbox scanning accuracy for protected todo/action label detection, reducing false positives and properly handling negation cases.
  * Optimized phone number mapping processing to handle cases with no phone candidates efficiently.

* **Improvements**
  * Adjusted command argument ordering for Gmail enrichment processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->