### PR TITLE
fix: claude-invoke CRS auth + upgrade headless agents to Sonnet

### DIFF
--- a/claude-ops/agents/build-fixer.md
+++ b/claude-ops/agents/build-fixer.md
@@ -2,7 +2,7 @@
 name: build-fixer
 description: Repairs a SINGLE failed local build (`npm run build:*`, fastlane, expo, etc.). Headless agent dispatched by the build-failure trigger. Use when a local mobile/native/web build script fails. Examples - <example>npm run build:production:local exit 1 with type-check error.</example> <example>fastlane archive failed on iOS Pod compilation.</example> <example>expo-doctor reports SDK version drift.</example>
 tools: Read, Edit, Bash, Grep, Glob
-model: haiku
+model: sonnet
 ---
 
 You are **Build Fixer** — focused mobile/native build engineer persona.

--- a/claude-ops/agents/dependency-auditor.md
+++ b/claude-ops/agents/dependency-auditor.md
@@ -2,7 +2,7 @@
 name: dependency-auditor
 description: Audits project dependencies for security advisories, version drift, and unused packages. Surfaces findings + a recommended action plan. Does NOT auto-upgrade major versions. Examples - <example>Quarterly dep audit before release.</example> <example>After dependabot floods open PRs, decide which to merge first by risk.</example> <example>Inherited codebase — what's vulnerable, what's stale, what's dead.</example>
 tools: Read, Bash, Grep, Glob, WebFetch
-model: haiku
+model: sonnet
 ---
 
 You are a **Dependency Auditor**. Read-only by default — you produce a report, you do not modify the lockfile.

--- a/claude-ops/agents/deploy-fixer.md
+++ b/claude-ops/agents/deploy-fixer.md
@@ -2,7 +2,7 @@
 name: deploy-fixer
 description: Diagnoses and remediates a SINGLE failed post-merge deployment. Headless agent dispatched by ops-deploy-monitor.sh after a `gh pr merge` to dev/main fails its deploy workflow. Use when a CI/CD deploy fails on a recently-merged PR. Examples - <example>GitHub Actions deploy workflow concluded "failure" after PR merge.</example> <example>ECS service health check 503 after rolling deploy.</example> <example>Vercel deployment errored on the merge commit.</example>
 tools: Read, Edit, Bash, Grep, Glob
-model: haiku
+model: sonnet
 ---
 
 You are **Deploy Fixer** — focused infrastructure SRE persona. You execute one repair, open one PR, and exit.

--- a/claude-ops/agents/memory-extractor.md
+++ b/claude-ops/agents/memory-extractor.md
@@ -1,7 +1,7 @@
 ---
 name: memory-extractor
 description: Background agent that extracts user profiles, contact cards, and behavioral patterns from chat history. Runs as a daemon service every 30 min.
-model: claude-haiku-4-5-20251001
+model: sonnet
 effort: low
 maxTurns: 10
 memory: project
@@ -10,7 +10,7 @@ memory: project
 ## Purpose
 
 Builds structured memory from raw chat data so ops skills (inbox, comms, go) can draft
-context-aware messages. Reads WhatsApp (bridge messages.db) and email (gog) history, calls Claude Haiku
+context-aware messages. Reads WhatsApp (bridge messages.db) and email (gog) history, calls Claude Sonnet
 for extraction, and writes/merges structured markdown memory files.
 
 ## Memory Location

--- a/claude-ops/agents/monitor-agent.md
+++ b/claude-ops/agents/monitor-agent.md
@@ -1,7 +1,7 @@
 ---
 name: monitor-agent
 description: Lightweight APM and metrics probe agent. Queries Datadog, New Relic, and OpenTelemetry backends for active alerts, error traces, and entity health. Returns structured JSON. Read-only — used by ops-monitor skill.
-model: claude-haiku-4-5
+model: sonnet
 effort: low
 maxTurns: 15
 tools:

--- a/claude-ops/bin/ops-suggest-specialized-agent
+++ b/claude-ops/bin/ops-suggest-specialized-agent
@@ -52,7 +52,14 @@ if [ -n "$suggest" ]; then
   exit 0
 fi
 
-# No match (or matched agent not installed) — log + spawn Haiku drafter
+installed_agent_names() {
+  {
+    find "${HOME}/.claude/agents" -maxdepth 1 -type f -name '*.md' -printf '%f\n' 2>/dev/null
+    find "$PLUGIN_ROOT/agents" -maxdepth 1 -type f -name '*.md' -printf '%f\n' 2>/dev/null
+  } | sed 's/\.md$//' | sort -u | head -n 120 | sed 's/^/  - /'
+}
+
+# No match (or matched agent not installed) — log + spawn Sonnet drafter
 printf '[%s] no installed specialist match for: %s\n' "$(date '+%H:%M:%S')" "${description:0:80}" \
   >> "${HOME}/.claude/logs/ops/specialized-agent-misses.log"
 
@@ -63,9 +70,8 @@ if command -v claude >/dev/null 2>&1 && [ "$(config auto_draft_new_agents true)"
 DESCRIPTION: ${description:0:200}
 PROMPT EXCERPT: ${prompt:0:600}
 
-Existing installed agents (do not duplicate):
-$(ls -1 ${HOME}/.claude/agents/ 2>/dev/null | sed 's/\.md$//' | sed 's/^/  - /')
-$(ls -1 $PLUGIN_ROOT/agents/ 2>/dev/null | sed 's/\.md$//' | sed 's/^/  - /')
+Existing installed agent names (truncated, do not duplicate):
+$(installed_agent_names)
 
 Task:
 1. Identify the recurring CLASS this task represents (not this one task).
@@ -76,7 +82,7 @@ Task:
 name: <kebab-name>
 description: <one-paragraph: when to use, with 2-3 example scenarios in <example>...</example> tags>
 tools: <comma-separated tool list scoped to genuine needs>
-model: haiku|sonnet|opus
+model: sonnet
 ---
 <persona body — 100-300 words covering capabilities, operating constraints, output format>
 
@@ -84,7 +90,7 @@ Final line of your output: 'NEW: <name>' or 'SKIP: <reason>'."
 
   nohup bash -c "
     . '$PLUGIN_ROOT/scripts/lib/claude-invoke.sh'
-    printf '%s' \"\$1\" | claude_invoke -p --model haiku --dangerously-skip-permissions --no-session-persistence > '$drafter_log' 2>&1
+    printf '%s' \"\$1\" | claude_invoke -p --model claude-sonnet-4-6 --dangerously-skip-permissions --no-session-persistence > '$drafter_log' 2>&1
   " _ "$draft_prompt" </dev/null >/dev/null 2>&1 &
   disown 2>/dev/null || true
 fi

--- a/claude-ops/docs/agents.md
+++ b/claude-ops/docs/agents.md
@@ -98,7 +98,7 @@ Minimal example:
 ---
 name: my-rust-fixer
 description: Diagnoses and fixes Rust compile errors
-model: claude-haiku-4-5
+model: sonnet
 tools: [Bash, Read, Edit, Write]
 ---
 

--- a/claude-ops/scripts/lib/claude-invoke.sh
+++ b/claude-ops/scripts/lib/claude-invoke.sh
@@ -3,7 +3,7 @@
 #
 # Usage (source this file, then call claude_invoke):
 #   . "$PLUGIN_ROOT/scripts/lib/claude-invoke.sh"
-#   claude_invoke --model haiku --no-session-persistence [other claude args]
+#   claude_invoke --model claude-sonnet-4-6 --no-session-persistence [other claude args]
 #
 # Gate:
 #   CLAUDE_OPS_USE_CREDIT_POOL=1  ->  route through claude-p-as.mjs (credit pool)
@@ -42,7 +42,41 @@ _claude_invoke_find_root() {
   return 1
 }
 
+_claude_invoke_sanitize_args() {
+  CLAUDE_INVOKE_ARGS=()
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --model)
+        shift
+        if [[ "${1:-}" =~ [Hh]aiku ]]; then
+          CLAUDE_INVOKE_ARGS+=(--model claude-sonnet-4-6)
+        else
+          CLAUDE_INVOKE_ARGS+=(--model "$1")
+        fi
+        ;;
+      --model=*)
+        local model="${1#--model=}"
+        if [[ "$model" =~ [Hh]aiku ]]; then
+          CLAUDE_INVOKE_ARGS+=(--model=claude-sonnet-4-6)
+        else
+          CLAUDE_INVOKE_ARGS+=("$1")
+        fi
+        ;;
+      *)
+        CLAUDE_INVOKE_ARGS+=("$1")
+        ;;
+    esac
+    shift
+  done
+}
+
+_claude_invoke_exec() {
+  env -u ANTHROPIC_API_KEY -u CLAUDE_API_KEY -u CLAUDE_CODE_OAUTH_TOKEN "$@"
+}
+
 claude_invoke() {
+  local CLAUDE_INVOKE_ARGS
+  _claude_invoke_sanitize_args "$@"
   if [ "${CLAUDE_OPS_USE_CREDIT_POOL:-0}" = "1" ]; then
     local repo_root
     repo_root="$(_claude_invoke_find_root)" || repo_root=""
@@ -51,11 +85,11 @@ claude_invoke() {
       # Wrapper not found — log a warning and fall back to direct claude so
       # daemon jobs are never silently dropped due to misconfiguration.
       printf '[claude-invoke] WARNING: claude-p-as.mjs not found (root=%s) — falling back to direct claude\n' "${repo_root:-unresolved}" >&2
-      claude "$@"
+      _claude_invoke_exec claude "${CLAUDE_INVOKE_ARGS[@]}"
       return $?
     fi
-    node "$wrapper" -- "$@"
+    _claude_invoke_exec node "$wrapper" -- "${CLAUDE_INVOKE_ARGS[@]}"
   else
-    claude "$@"
+    _claude_invoke_exec claude "${CLAUDE_INVOKE_ARGS[@]}"
   fi
 }

--- a/claude-ops/scripts/recap/README.md
+++ b/claude-ops/scripts/recap/README.md
@@ -5,7 +5,7 @@ Background daemon + helpers that synthesize a one-line digest across all paralle
 | Script       | Role                                                                                                              |
 | ------------ | ----------------------------------------------------------------------------------------------------------------- |
 | `daemon.sh`  | Long-lived loop — polls per-session recap inputs, calls `digest.sh` when stale, writes `/tmp/claude-recap-digest` |
-| `digest.sh`  | Synthesizes the one-liner via `claude -p --model haiku` over recent sessions + tool-activity files                |
+| `digest.sh`  | Synthesizes the one-liner via `claude -p --model claude-sonnet-4-6` over recent sessions + tool-activity files    |
 | `marquee.sh` | Tmux-side scroller (called from `status-right`) — reads the digest file and emits a windowed slice                |
 
 ## Display surfaces

--- a/claude-ops/scripts/recap/digest.sh
+++ b/claude-ops/scripts/recap/digest.sh
@@ -76,7 +76,7 @@ ${shell_activity:-(none)}
 
 Produce ONE single line (max 240 chars) describing the CURRENT state of work, weighted heavily toward the most-recent activity (last 1-2 headlines + current session activity + last few shell commands). DROP themes from older headlines that are no longer mentioned in current activity — assume they are resolved or no longer relevant. Only carry forward an older theme if there is concrete evidence in the current activity that it is still in flight. Translate raw shell commands into plain English (e.g., 'ssh into bastion', 'inspecting prod logs', 'running tests'). Plain English ticker style. No bullets, no quotes, no preface, no markdown."
 
-result=$(printf '%s' "$prompt" | claude_invoke -p --model haiku --no-session-persistence --output-format text 2>/dev/null | head -c 260 | LC_ALL=C tr '\n' ' ')
+result=$(printf '%s' "$prompt" | claude_invoke -p --model claude-sonnet-4-6 --no-session-persistence --output-format text 2>/dev/null | head -c 260 | LC_ALL=C tr '\n' ' ')
 
 # Reject Claude error / auth / quota strings — never let them pollute the
 # digest OR the rolling log (which feeds back as PRIOR HEADLINES on next run).

--- a/claude-ops/skills/ops-recap/SKILL.md
+++ b/claude-ops/skills/ops-recap/SKILL.md
@@ -21,7 +21,7 @@ The recap marquee is a launchd-managed daemon that aggregates per-session Claude
 | Path                                                       | Role                                                       |
 | ---------------------------------------------------------- | ---------------------------------------------------------- |
 | `${CLAUDE_PLUGIN_ROOT}/scripts/recap/daemon.sh`            | Background loop — polls inputs, calls digest.sh when stale |
-| `${CLAUDE_PLUGIN_ROOT}/scripts/recap/digest.sh`            | Synthesizes one-line digest via `claude -p --model haiku`  |
+| `${CLAUDE_PLUGIN_ROOT}/scripts/recap/digest.sh`            | Synthesizes one-line digest via `claude -p --model claude-sonnet-4-6` |
 | `${CLAUDE_PLUGIN_ROOT}/scripts/recap/marquee.sh`           | Tmux-side scroller (called from `status-right`)            |
 | `${CLAUDE_PLUGIN_ROOT}/hooks/recap-capture.sh`             | Stop hook → writes `/tmp/claude-recap-<sid>`               |
 | `${CLAUDE_PLUGIN_ROOT}/hooks/recap-tool-activity.sh`       | PostToolUse hook → live activity per session               |

--- a/claude-ops/tests/test-claude-invoke.sh
+++ b/claude-ops/tests/test-claude-invoke.sh
@@ -2,11 +2,12 @@
 # test-claude-invoke.sh — unit tests for scripts/lib/claude-invoke.sh
 #
 # Tests:
-#   T1: CLAUDE_OPS_USE_CREDIT_POOL unset  -> calls `claude` directly
-#   T2: CLAUDE_OPS_USE_CREDIT_POOL=0      -> calls `claude` directly
-#   T3: CLAUDE_OPS_USE_CREDIT_POOL=1      -> calls `node .../claude-p-as.mjs --` with same args
+#   T1: CLAUDE_OPS_USE_CREDIT_POOL unset  -> calls `claude` directly, upgrading Haiku to Sonnet
+#   T2: CLAUDE_OPS_USE_CREDIT_POOL=0      -> calls `claude` directly, upgrading Haiku to Sonnet
+#   T3: CLAUDE_OPS_USE_CREDIT_POOL=1      -> calls `node .../claude-p-as.mjs --` with sanitized args
 #   T4: CLAUDE_OPS_USE_CREDIT_POOL=1 but wrapper missing -> falls back to `claude`, exits non-zero
 #       (warning printed to stderr, direct claude called)
+#   T5: direct invocation strips API-key env so CRS auth token wins
 set -euo pipefail
 
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -27,6 +28,9 @@ make_stubs() {
   # Stub claude: records argv to a capture file and exits 0
   cat > "$tmpdir/claude" <<'SH'
 #!/usr/bin/env bash
+if [[ "${CAPTURE_ENV:-0}" = "1" ]]; then
+  echo "env api=${ANTHROPIC_API_KEY-unset} claude_api=${CLAUDE_API_KEY-unset} oauth=${CLAUDE_CODE_OAUTH_TOKEN-unset}" >> "$CAPTURE_FILE"
+fi
 echo "claude $*" >> "$CAPTURE_FILE"
 exit 0
 SH
@@ -62,6 +66,10 @@ run_invoke() {
   (
     export PATH="$tmpdir:$PATH"
     export CAPTURE_FILE="$capture"
+    unset CLAUDE_OPS_USE_CREDIT_POOL
+    unset ANTHROPIC_API_KEY
+    unset CLAUDE_API_KEY
+    unset CLAUDE_CODE_OAUTH_TOKEN
     for kv in "${env_args[@]:-}"; do
       export "$kv"
     done
@@ -81,10 +89,10 @@ run_invoke() {
 # ---------------------------------------------------------------------------
 echo "T1: gate unset -> direct claude"
 result=$(run_invoke -- -p --model haiku --no-session-persistence)
-if [[ "$result" == "claude -p --model haiku --no-session-persistence" ]]; then
+if [[ "$result" == "claude -p --model claude-sonnet-4-6 --no-session-persistence" ]]; then
   ok "called claude directly with correct args"
 else
-  err "expected 'claude -p --model haiku --no-session-persistence', got: '$result'"
+  err "expected 'claude -p --model claude-sonnet-4-6 --no-session-persistence', got: '$result'"
 fi
 
 # ---------------------------------------------------------------------------
@@ -92,10 +100,10 @@ fi
 # ---------------------------------------------------------------------------
 echo "T2: gate=0 -> direct claude"
 result=$(run_invoke CLAUDE_OPS_USE_CREDIT_POOL=0 -- -p --model haiku)
-if [[ "$result" == "claude -p --model haiku" ]]; then
+if [[ "$result" == "claude -p --model claude-sonnet-4-6" ]]; then
   ok "called claude directly with CREDIT_POOL=0"
 else
-  err "expected 'claude -p --model haiku', got: '$result'"
+  err "expected 'claude -p --model claude-sonnet-4-6', got: '$result'"
 fi
 
 # ---------------------------------------------------------------------------
@@ -104,7 +112,7 @@ fi
 echo "T3: gate=1 -> node ...claude-p-as.mjs -- <args>"
 result=$(run_invoke CLAUDE_OPS_USE_CREDIT_POOL=1 -- -p --model haiku --no-session-persistence)
 wrapper_path="$PLUGIN_ROOT/scripts/account-rotation/claude-p-as.mjs"
-expected="node $wrapper_path -- -p --model haiku --no-session-persistence"
+expected="node $wrapper_path -- -p --model claude-sonnet-4-6 --no-session-persistence"
 if [[ "$result" == "$expected" ]]; then
   ok "routed through claude-p-as.mjs with correct args after --"
 else
@@ -137,15 +145,26 @@ stderr_out=$(
 )
 
 fallback_result=$(cat "$capture_missing")
-if [[ "$fallback_result" == "claude -p --model haiku" ]]; then
+if [[ "$fallback_result" == "claude -p --model claude-sonnet-4-6" ]]; then
   ok "fell back to direct claude when wrapper missing"
 else
-  err "fallback: expected 'claude -p --model haiku', got: '$fallback_result'"
+  err "fallback: expected 'claude -p --model claude-sonnet-4-6', got: '$fallback_result'"
 fi
 if echo "$stderr_out" | grep -q "WARNING"; then
   ok "emitted WARNING to stderr"
 else
   err "no WARNING in stderr output: '$stderr_out'"
+fi
+
+# ---------------------------------------------------------------------------
+# T5: direct invocation strips API-key env
+# ---------------------------------------------------------------------------
+echo "T5: direct claude strips conflicting API-key env"
+result=$(run_invoke ANTHROPIC_API_KEY=bad CLAUDE_API_KEY=bad CLAUDE_CODE_OAUTH_TOKEN=bad CAPTURE_ENV=1 -- -p --model sonnet)
+if echo "$result" | grep -q "env api=unset claude_api=unset oauth=unset"; then
+  ok "stripped conflicting API-key env"
+else
+  err "expected API-key env to be stripped, got: '$result'"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Lands FRA-stashed recap/agent invoke work on current `main`.

- `claude_invoke`: sanitize Haiku → Sonnet, strip conflicting API-key env so CRS OAuth wins
- Headless agent frontmatter: haiku → sonnet for build/deploy/dep-audit/monitor/memory-extractor
- `ops-suggest-specialized-agent`: safer installed-agent listing + Sonnet drafter
- Recap digest/docs/tests aligned with invoke wrapper behavior

## Test plan
- [x] `claude-ops/tests/test-claude-invoke.sh` (6/6) on FRA branch
- [ ] CI green

Made with [Cursor](https://cursor.com)