### PR TITLE
fix: pocket-env-broker peer auth on macOS

### DIFF
--- a/claude-ops/scripts/pocket-env-broker.py
+++ b/claude-ops/scripts/pocket-env-broker.py
@@ -11,8 +11,9 @@ Design:
     environment — launched via the same env wrapper as the executor).
   • Listens on a unix-domain socket. Secrets are returned over the socket only —
     they never touch disk.
-  • Every connection is peer-authenticated with SO_PEERCRED: the caller's uid MUST
-    equal the worker user's uid, otherwise the request is denied.
+  • Every connection is peer-authenticated with SO_PEERCRED (Linux) or
+    LOCAL_PEERCRED (macOS/BSD): the caller's uid MUST equal the worker user's uid,
+    otherwise the request is denied.
   • A default-deny allowlist (env-broker-policy.json → {"allow": [...]}) decides
     which variable names are grantable. Values come from this process's own
     environment (so the deployment populates them the same way the executor's
@@ -216,12 +217,21 @@ def audit(record: dict) -> None:
 
 
 def peer_uid(conn: socket.socket) -> int:
-    """Read the connected peer's uid via SO_PEERCRED (Linux). Raises on failure."""
-    creds = conn.getsockopt(
-        socket.SOL_SOCKET, socket.SO_PEERCRED, struct.calcsize("3i")
-    )
-    _pid, uid, _gid = struct.unpack("3i", creds)
-    return uid
+    """Read the connected peer's uid via SO_PEERCRED (Linux) or LOCAL_PEERCRED (macOS)."""
+    if hasattr(socket, "SO_PEERCRED"):
+        creds = conn.getsockopt(
+            socket.SOL_SOCKET, socket.SO_PEERCRED, struct.calcsize("3i")
+        )
+        _pid, uid, _gid = struct.unpack("3i", creds)
+        return uid
+    if hasattr(socket, "LOCAL_PEERCRED"):
+        level = getattr(socket, "SOL_LOCAL", 0)
+        creds = conn.getsockopt(
+            level, socket.LOCAL_PEERCRED, struct.calcsize("2i")
+        )
+        _pid, uid = struct.unpack("2i", creds)
+        return uid
+    raise OSError("peer credential lookup not supported on this platform")
 
 
 def decide(var: str, policy: set[str]) -> tuple[bool, str | None, str]:


### PR DESCRIPTION
## Summary
- `peer_uid()` now uses `SO_PEERCRED` on Linux and `LOCAL_PEERCRED` on macOS/BSD
- Fixes local `run-all.sh` failure where broker threads crashed with `AttributeError: SO_PEERCRED` on Python 3.14/macOS

## Test plan
- [x] `tests/test-pocket-env-broker.sh` — 11/11 on Mac
- [x] `tests/run-all.sh` — 18/18 suites green on Mac
- [ ] CI (ubuntu) unchanged path for Linux

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Peer authentication now supports Linux, macOS, and BSD platforms with proper credential verification across operating systems.

* **Documentation**
  * Updated security documentation to clarify peer credential verification mechanisms and access policies for all supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->