### PR TITLE
fix(daemon): give claude-ops-daemon the gog file-keyring env so memory-extractor can read email

### DIFF
--- a/claude-ops/scripts/systemd/claude-ops-daemon.service
+++ b/claude-ops/scripts/systemd/claude-ops-daemon.service
@@ -12,6 +12,16 @@ Environment=PATH=%h/.local/bin:/usr/local/bin:/usr/bin:/bin
 # CLAUDE_PLUGIN_ROOT is read by ops-daemon.sh and the services it spawns.
 # Override at install time if your marketplace dir lives elsewhere.
 Environment=CLAUDE_PLUGIN_ROOT=%h/.claude/plugins/marketplaces/ops-marketplace/claude-ops
+# memory-extractor (and any other gog-backed service the daemon spawns) calls
+# `gog gmail search` to collect email. gog stores its OAuth tokens in a file
+# keyring encrypted with GOG_KEYRING_PASSWORD; without GOG_KEYRING_PASSWORD +
+# GOG_KEYRING_BACKEND=file in the unit env, gog cannot decrypt them and returns
+# no data, so extraction silently logs "gog returned no data" and skips email.
+# These creds live in the same mcp-secrets.env used by the pocket/whatsapp
+# helper units. Optional (-) so installs without the file still boot; gog
+# resolves the default account from ~/.config/gogcli/config.json, so no
+# GOG_ACCOUNT is required here.
+EnvironmentFile=-%h/.config/systemd/env/mcp-secrets.env
 ExecStart=/bin/bash %h/.claude/plugins/marketplaces/ops-marketplace/claude-ops/scripts/ops-daemon.sh
 Restart=on-failure
 RestartSec=10


### PR DESCRIPTION
## Problem
`memory-extractor` collects recent email via `gog gmail search` for memory extraction. gog stores Gmail OAuth tokens in a **file keyring encrypted with `$GOG_KEYRING_PASSWORD`**. The `claude-ops-daemon.service` unit only exported `HOME`/`PATH`/`CLAUDE_PLUGIN_ROOT`, so in the headless unit gog could not decrypt the tokens and returned nothing.

Result on a Linux EC2 install: every extractor run logged `gog returned no data` → `No data sources available — nothing to extract`. The email source was silently dead.

## Fix
Add `EnvironmentFile=-%h/.config/systemd/env/mcp-secrets.env` to the daemon unit — the **same secrets file the pocket/whatsapp helper units already consume**. The daemon (and the services it spawns, incl. memory-extractor) then inherit `GOG_KEYRING_PASSWORD` + `GOG_KEYRING_BACKEND=file`.

- gog resolves the default account from `~/.config/gogcli/config.json`, so **no `GOG_ACCOUNT` needed**.
- `-` prefix keeps the unit booting on installs lacking the file.

## Verification
With the env present, the extractor's exact gog call returns email JSON, and a real run advances from `gog returned no data` to:
```
[ops-memory-extractor] Collecting recent emails...
[ops-memory-extractor] Calling Claude Haiku for extraction
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single systemd `EnvironmentFile` line plus docs; secrets path matches existing helper units and remains optional on boot.
> 
> **Overview**
> **Fixes silent email loss in memory extraction** on headless daemon installs by wiring the same optional secrets file pocket/whatsapp units already use.
> 
> The `claude-ops-daemon.service` unit now loads `EnvironmentFile=-%h/.config/systemd/env/mcp-secrets.env`, so spawned services (including **memory-extractor**) inherit `GOG_KEYRING_PASSWORD` and `GOG_KEYRING_BACKEND=file`. Without those, `gog gmail search` cannot decrypt OAuth tokens in the unit environment and returns no data—previously logged as `gog returned no data` with email skipped.
> 
> Inline comments document the gog file-keyring behavior and that the `-` prefix keeps the unit starting when the file is absent; no new `GOG_ACCOUNT` is added because gog uses `~/.config/gogcli/config.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07d139dfb125dbd76d9fb144408ef32fb5d9b529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional user-specific environment file for the daemon, allowing secret values to be loaded at startup.
  * Improved startup guidance with notes on required credentials for services that decrypt stored authentication data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->