### PR TITLE
release: v2.36.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 59 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.36.2",
+      "version": "2.36.3",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-2.36.2-blue)
+![Version](https://img.shields.io/badge/version-2.36.3-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-59-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.36.2",
+  "version": "2.36.3",
   "description": "Business operations command center for Claude Code — 59 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.36.3] - 2026-06-28
+
+### Changed
+Fixed: claude-ops-daemon.service now loads the gog file-keyring env via EnvironmentFile (mcp-secrets.env), so memory-extractor can decrypt Gmail OAuth tokens and collect email. Resolves silent "gog returned no data — nothing to extract" skips on headless Linux installs (#636).
+
+
 ## [2.36.2] - 2026-06-24
 
 ### Changed

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-2.36.2-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.36.3-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 59 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-2.36.2-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.36.3-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-59-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.36.2",
+  "version": "2.36.3",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.36.3** (was 2.36.2).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

Fixed: claude-ops-daemon.service now loads the gog file-keyring env via EnvironmentFile (mcp-secrets.env), so memory-extractor can decrypt Gmail OAuth tokens and collect email. Resolves silent "gog returned no data — nothing to extract" skips on headless Linux installs (#636).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and documentation only in the visible diff; the described systemd env change is a targeted ops fix with optional EnvironmentFile and no broad behavior change elsewhere.
> 
> **Overview**
> **Release v2.36.3** — bumps the plugin from **2.36.2** to **2.36.3** in `plugin.json`, marketplace registry, `package.json`, and version badges in the README and reference docs.
> 
> The new **CHANGELOG** entry documents the user-facing fix for **#636**: on headless Linux, `memory-extractor` was skipping email because `gog` could not decrypt Gmail OAuth tokens without the file-keyring env. The release notes state that **`claude-ops-daemon.service`** now loads **`EnvironmentFile`** from **`mcp-secrets.env`** so daemon-spawned jobs get variables like **`GOG_KEYRING_PASSWORD`**, restoring Gmail collection instead of silent “gog returned no data” skips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ecbee9ce4628d98b872fd7e5b953d85b013b44c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue that could prevent certain token decryption workflows from running correctly on headless Linux setups.
  * Improved reliability so the affected process no longer skips work silently in this scenario.

* **Documentation**
  * Updated version labels and release notes across the project to reflect the new **2.36.3** release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->