### PR TITLE
feat(ops-yolo): always consolidate C-suite reports into one master executive report

### DIFF
--- a/claude-ops/skills/ops-yolo/SKILL.md
+++ b/claude-ops/skills/ops-yolo/SKILL.md
@@ -206,7 +206,26 @@ Uses `agents/yolo-coo.md`. Writes `/tmp/yolo-[session]/coo-analysis.md`.
 
 ## Phase 3 — Hard Truths Report (orchestrator synthesis)
 
-**This skill (the main orchestrator) is the synthesizer** — NOT `yolo-ceo`. After all 4 parallel agents complete and have written their analysis files to `/tmp/yolo-[session]/{ceo,cto,cfo,coo}-analysis.md`, read all four files here in the main context and synthesize them into a unified report:
+**This skill (the main orchestrator) is the synthesizer** — NOT `yolo-ceo`. After all 4 parallel agents complete and have written their analysis files to `/tmp/yolo-[session]/{ceo,cto,cfo,coo}-analysis.md`, read all four files here in the main context and synthesize them into a unified report.
+
+### Phase 3a — Consolidated master executive report (MANDATORY)
+
+**Every YOLO run MUST produce one consolidated master executive report — no exceptions.** This is the canonical output of the analysis; the four per-officer files are supporting detail. Do this BEFORE rendering the on-screen Hard Truths block:
+
+1. Read all four `/tmp/yolo-[session]/{ceo,cto,cfo,coo}-analysis.md` files in the main context.
+2. Synthesize them into a single `executive-summary.md` and write it to **`/tmp/yolo-[session]/executive-summary.md`**. Never skip this write, even if one officer file is missing — note any missing officer inline and consolidate the rest.
+3. The master report MUST contain, in this order:
+   - **Title + timestamp** — `YOLO Executive Summary — [date]`.
+   - **TL;DR** — 2–3 sentences a busy founder can read in 10 seconds.
+   - **Consensus #1 action** — the single most important thing today, with the officers who back it.
+   - **Per-officer hard truths** — the 1–2 sharpest truths from each of CEO / CTO / CFO / COO, summarized (not pasted verbatim).
+   - **Cross-cutting themes** — issues ≥2 officers raised independently (these are the highest-signal items).
+   - **Prioritized action list** — ranked, each tagged `[auto]` (YOLO can do it) or `⚠️ REQUIRES CONFIRMATION` (needs human sign-off), with the source officer(s).
+   - **What's healthy** — 1–2 lines so the report isn't all alarm.
+   - **Source files** — relative links to the four officer files.
+4. The on-screen Hard Truths block below is the SHORT view of this same report — keep the two consistent (same consensus, same #1 action).
+
+Render the on-screen report:
 
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -226,7 +245,10 @@ Uses `agents/yolo-coo.md`. Writes `/tmp/yolo-[session]/coo-analysis.md`.
  [single most important action, no sugar-coating]
 ──────────────────────────────────────────────────────
 
- Full analysis files saved to:
+ Master executive report (consolidated):
+ /tmp/yolo-[session]/executive-summary.md
+
+ Supporting per-officer analyses:
  /tmp/yolo-[session]/ceo-analysis.md
  /tmp/yolo-[session]/cto-analysis.md
  /tmp/yolo-[session]/cfo-analysis.md
@@ -247,19 +269,20 @@ Use **batched AskUserQuestion calls** (max 4 options each):
 AskUserQuestion call 1:
 
 ```
-  [Read CEO analysis]
-  [Read CTO analysis]
-  [Read CFO analysis]
+  [Read master executive report]
+  [Read a single officer analysis]
+  [Execute top recommendation now]
   [More...]
 ```
 
 AskUserQuestion call 2 (only if "More..."):
 
 ```
-  [Read COO analysis]
-  [Execute top recommendation now]
   [Type YOLO to go autonomous]
+  [Stop here]
 ```
+
+If the user picks "Read a single officer analysis", present the four officer files (CEO / CTO / CFO / COO) in a follow-up call. The master executive report is the default/recommended read — it already consolidates all four.
 
 ---
 
@@ -313,7 +336,7 @@ Report final summary when done.
 
 If `$ARGUMENTS` is `analyze` or empty, go straight to Phase 1.
 If `$ARGUMENTS` is `YOLO`, skip to Phase 4.
-If `$ARGUMENTS` is `report`, skip to Phase 3 (reads existing analysis files if present).
+If `$ARGUMENTS` is `report`, skip to Phase 3 — read the existing `/tmp/yolo-[session]/executive-summary.md` master report if present (fall back to re-consolidating from the four officer files), and re-render the on-screen Hard Truths block from it.
 
 ---
 


### PR DESCRIPTION
## What
`/ops:yolo` now **always** produces one consolidated master executive report per run, instead of leaving four separate per-officer files for the reader to stitch together.

## Changes (Phase 3 of `skills/ops-yolo/SKILL.md`)
- **New Phase 3a (MANDATORY):** synthesize CEO/CTO/CFO/COO analyses into `/tmp/yolo-[session]/executive-summary.md` before rendering the on-screen block. Never skipped — missing officers are noted inline and the rest consolidated.
- **Required structure:** title+timestamp · TL;DR · consensus #1 action · per-officer hard truths · cross-cutting themes (≥2 officers) · prioritized action list tagged `[auto]` / `⚠️ REQUIRES CONFIRMATION` with source officer · "what's healthy" · source links.
- On-screen Hard Truths block is now the short view of the same report (kept consistent).
- Menu defaults to **Read master executive report**; per-officer files are supporting detail.
- `report` arg re-renders from the saved `executive-summary.md` (falls back to re-consolidating).

## Why
Four parallel C-suite files force the founder to read all four to get the picture. The master report is the 10-second-decision artifact; the per-officer files remain available for depth.

Docs-only change to one SKILL.md. No behavioral code, no secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single SKILL.md documentation change with no runtime code, secrets, or infrastructure impact.
> 
> **Overview**
> **`/ops:yolo` Phase 3** now requires a mandatory **Phase 3a** step: the orchestrator must write `/tmp/yolo-[session]/executive-summary.md` by consolidating the four officer analyses **before** the on-screen Hard Truths block, with a fixed outline (TL;DR, consensus #1 action, cross-cutting themes, tagged action list, etc.).
> 
> The **on-screen report** and **AskUserQuestion** flow are updated so the master report is the primary artifact (listed first in output; default read path), per-officer files are supporting detail, and menus favor **Read master executive report** / **Read a single officer analysis** instead of four separate officer shortcuts.
> 
> The **`report` argument** now prefers re-rendering from an existing `executive-summary.md`, with fallback re-consolidation from officer files if missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b171439bc0fa4d9004ec7533e66af14552dbc314. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consolidated executive summary step so the final report is assembled from all officer analyses before showing the final recommendation.
  * Updated the follow-up prompt options to make it easier to review the master report, inspect a single analysis, or act on the top recommendation.

* **Bug Fixes**
  * Improved report mode so it can reuse an existing executive summary when available, with a fallback to rebuild it if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->