### PR TITLE
feat(ops-mac): /ops:ops-mac — macOS diagnose-and-fix command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,9 +9,9 @@
   "plugins": [
     {
       "name": "ops",
-      "description": "Business operations command center for Claude Code — 59 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
+      "description": "Business operations command center for Claude Code — 60 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.36.5",
+      "version": "2.38.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ops",
-  "version": "2.36.5",
-  "description": "Business operations command center for Claude Code — 59 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
+  "version": "2.38.0",
+  "description": "Business operations command center for Claude Code — 60 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",
     "url": "https://github.com/Lifecycle-Innovations-Limited"

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.38.0] - 2026-06-28
+
+### Added
+ops-mac: new `/ops:ops-mac` skill + `bin/ops-mac` dispatcher — a unified macOS diagnose-and-fix command center that bundles the [macos-toolkit](https://github.com/lu-zhengda/macos-toolkit) CLI suite (machealth, netwhiz, pstop, macdog, lanchr, macbroom, macctl, macfig, updater) behind one entrypoint. Self-installs the suite on first use (plugin marketplace + Homebrew tap), runs a read-only aggregate audit (security, launch agents, processes, network, disk, system health), and applies guarded fixes (firewall, stale daemons, cache cleanup) with per-action confirmation (Rule 5). Hardened against two toolkit quirks: machealth's hang-prone composite probe is timeout-guarded, and headless TTY-empty table rendering is bypassed via forced `--json`. macOS-only (exits cleanly elsewhere; complements cross-platform `/ops:speedup`).
+
 ## [2.36.5] - 2026-06-28
 
 ### Changed

--- a/claude-ops/bin/ops-mac
+++ b/claude-ops/bin/ops-mac
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+# ops-mac — Unified macOS diagnose-and-fix dispatcher for the claude-ops plugin.
+#
+# Wraps the `macos-toolkit` CLI suite (machealth, netwhiz, pstop, macdog,
+# lanchr, macbroom, macctl, macfig, updater) behind ONE entrypoint, plus a
+# self-installer so the suite is provisioned on first use. The companion
+# skill (skills/ops-mac/SKILL.md) drives the UX, confirmations (Rule 5), and
+# mobile formatting (Rule 7); this script is the single source of truth for
+# probes, the aggregate audit, and the install path.
+#
+# Design goals:
+#   - macOS only. Hard-guards on non-Darwin and exits cleanly.
+#   - Idempotent install. `ensure` is safe to call repeatedly; it only does
+#     work for missing pieces (plugin marketplace, plugin, brew tap, tools).
+#   - Headless-safe. The toolkit's pretty TUI tables render EMPTY when stdout
+#     is not a TTY; this script forces `--json` for machine consumers and
+#     normalizes output so an agent always gets data.
+#   - Hang-guarded. `machealth check`/`diagnose` can block forever on a stuck
+#     Time Machine / iCloud probe; every machealth call is wrapped in a hard
+#     `timeout` so the dispatcher never wedges.
+#   - Read-only by default. Only `clean`/`fix`/`install`/`update` mutate state;
+#     everything else is pure diagnostics.
+#   - No secrets. Emits only health/diagnostic data, never credentials.
+#
+# Usage:
+#   ops-mac                      # banner + tool inventory
+#   ops-mac ensure               # install macos-toolkit suite if missing
+#   ops-mac audit [--json]       # aggregate read-only baseline (all probes)
+#   ops-mac health [--json]      # machealth check (timeout-guarded)
+#   ops-mac net [wifi|--json]    # netwhiz network diagnostics
+#   ops-mac disk [--json]        # macbroom cache scan (safe categories)
+#   ops-mac procs [--json]       # pstop top processes
+#   ops-mac security [--json]    # macdog security/privacy audit
+#   ops-mac launchd [--json]     # lanchr doctor (launch agent health)
+#   ops-mac power                # macctl power/display/audio status
+#   ops-mac defaults [args]      # macfig hidden-preferences passthrough
+#   ops-mac update               # updater app-update check
+#   ops-mac run <tool> [args...] # raw passthrough to any toolkit binary
+
+set -uo pipefail
+
+# ─── OS guard ────────────────────────────────────────────────────────────────
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "ops-mac: macOS only (detected $(uname -s)). For Linux/WSL use /ops:speedup." >&2
+  exit 3
+fi
+
+# Machealth hang ceiling (seconds). Its parallel composite can block on a
+# stuck Time Machine / iCloud probe — never let that wedge the dispatcher.
+MACHEALTH_TIMEOUT="${OPS_MAC_MACHEALTH_TIMEOUT:-25}"
+
+TOOLS=(machealth netwhiz pstop macdog lanchr macbroom macctl macfig updater termail)
+WANT_JSON=0
+[[ " $* " == *" --json "* ]] && WANT_JSON=1
+
+# Resolve a `timeout` implementation (coreutils gtimeout on brew, or none).
+_timeout() {
+  local secs="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then timeout "$secs" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then gtimeout "$secs" "$@"
+  else "$@"; fi
+}
+
+_have() { command -v "$1" >/dev/null 2>&1; }
+
+# Resolve the real claude binary (the interactive shell wraps it in a
+# _claude_dispatch function that isn't present in non-login shells).
+_claude_bin() {
+  if [[ -x "$HOME/.local/bin/claude" ]]; then echo "$HOME/.local/bin/claude"
+  elif command -v claude >/dev/null 2>&1; then command -v claude
+  else echo ""; fi
+}
+
+# ─── inventory ───────────────────────────────────────────────────────────────
+missing_tools() {
+  local m=()
+  for t in machealth netwhiz pstop macdog lanchr macbroom macctl macfig updater; do
+    _have "$t" || m+=("$t")
+  done
+  printf '%s\n' "${m[@]}"
+}
+
+inventory() {
+  if [[ "$WANT_JSON" == 1 ]]; then
+    printf '{"installed":{'
+    local first=1
+    for t in "${TOOLS[@]}"; do
+      [[ $first == 1 ]] || printf ','
+      first=0
+      if _have "$t"; then printf '"%s":true' "$t"; else printf '"%s":false' "$t"; fi
+    done
+    printf '}}\n'
+    return
+  fi
+  echo "OPS ► MAC — macos-toolkit dispatcher"
+  echo "host: $(sw_vers -productName 2>/dev/null) $(sw_vers -productVersion 2>/dev/null) ($(uname -m))"
+  echo "tools:"
+  for t in "${TOOLS[@]}"; do
+    if _have "$t"; then echo "  ✓ $t"; else echo "  ✗ $t (not installed — run: ops-mac ensure)"; fi
+  done
+}
+
+# ─── self-installer ──────────────────────────────────────────────────────────
+ensure() {
+  local cb; cb="$(_claude_bin)"
+  echo "▸ ensuring macos-toolkit plugin + CLIs…"
+
+  # 1. Plugin marketplace + plugin (best-effort; needs the claude CLI).
+  if [[ -n "$cb" ]]; then
+    if ! "$cb" plugin marketplace list 2>/dev/null | grep -qi "macos-toolkit"; then
+      echo "  + adding marketplace lu-zhengda/macos-toolkit"
+      "$cb" plugin marketplace add https://github.com/lu-zhengda/macos-toolkit 2>&1 | tail -1
+    fi
+    if ! "$cb" plugin list 2>/dev/null | grep -qi "macos-toolkit"; then
+      echo "  + installing plugin macos-toolkit@macos-toolkit"
+      "$cb" plugin install macos-toolkit@macos-toolkit 2>&1 | tail -1
+    fi
+  else
+    echo "  ! claude CLI not found — skipping plugin registration (CLIs still installable)"
+  fi
+
+  # 2. Homebrew tap + tools.
+  if ! _have brew; then
+    echo "  ! Homebrew not found. Install from https://brew.sh then re-run: ops-mac ensure" >&2
+    return 4
+  fi
+  if ! brew tap 2>/dev/null | grep -qi "lu-zhengda/tap"; then
+    echo "  + tapping lu-zhengda/tap"
+    brew tap lu-zhengda/tap 2>&1 | tail -1
+  fi
+  # Casks from this tap are untrusted until explicitly trusted.
+  brew trust lu-zhengda/tap >/dev/null 2>&1 || true
+
+  local need; need="$(missing_tools)"
+  if [[ -z "$need" ]]; then
+    echo "  ✓ all CLIs already installed"
+  else
+    echo "  + installing:" $need
+    # shellcheck disable=SC2046
+    brew install $(for t in $need; do echo "lu-zhengda/tap/$t"; done) 2>&1 | grep -E "successfully installed|Error|Warning" | tail -20
+  fi
+  echo "✔ ensure complete"
+}
+
+require_tool() {
+  if ! _have "$1"; then
+    echo "ops-mac: '$1' not installed. Run: ops-mac ensure" >&2
+    exit 5
+  fi
+}
+
+# ─── individual probes ───────────────────────────────────────────────────────
+p_health() {
+  require_tool machealth
+  if [[ "$WANT_JSON" == 1 ]]; then
+    _timeout "$MACHEALTH_TIMEOUT" machealth check 2>/dev/null \
+      || echo '{"error":"machealth timed out (likely a stuck Time Machine/iCloud probe)","probe":"machealth check","timeout_s":'"$MACHEALTH_TIMEOUT"'}'
+  else
+    _timeout "$MACHEALTH_TIMEOUT" machealth check --human 2>&1 \
+      || echo "machealth: timed out after ${MACHEALTH_TIMEOUT}s — likely a stuck Time Machine / iCloud probe. Try the other probes (security/launchd/disk/net) which are reliable."
+  fi
+}
+
+p_net() {
+  require_tool netwhiz
+  case "${1:-info}" in
+    wifi) netwhiz wifi 2>&1 ;;
+    --json) netwhiz info 2>&1 ;;   # netwhiz info is already structured-ish
+    *) netwhiz info 2>&1 ;;
+  esac
+}
+
+p_disk() {
+  require_tool macbroom
+  # Human table renders empty when headless → always go through --json there.
+  if [[ "$WANT_JSON" == 1 || ! -t 1 ]]; then
+    macbroom scan --caches --json 2>/dev/null || echo '{"error":"macbroom scan failed"}'
+  else
+    macbroom scan --caches 2>&1
+  fi
+}
+
+p_procs() {
+  require_tool pstop
+  if [[ "$WANT_JSON" == 1 ]]; then pstop top --n 10 --json 2>/dev/null || pstop top --n 10 2>&1
+  else pstop top --n 10 2>&1; fi
+}
+
+p_security() {
+  require_tool macdog
+  if [[ "$WANT_JSON" == 1 ]]; then macdog audit --json 2>/dev/null || macdog audit 2>&1
+  else macdog audit 2>&1; fi
+}
+
+p_launchd() {
+  require_tool lanchr
+  if [[ "$WANT_JSON" == 1 ]]; then lanchr doctor --json 2>/dev/null || lanchr doctor 2>&1
+  else lanchr doctor 2>&1; fi
+}
+
+p_power()    { require_tool macctl; macctl power status 2>&1; }
+p_defaults() { require_tool macfig; shift || true; macfig "$@" 2>&1; }
+p_update()   { require_tool updater; updater check 2>&1; }
+
+# ─── aggregate audit ─────────────────────────────────────────────────────────
+audit() {
+  if [[ "$WANT_JSON" == 1 ]]; then
+    # Compose one JSON object from the reliable probes. machealth is
+    # timeout-guarded and may degrade to an error stub.
+    local health sec disk
+    health="$(WANT_JSON=1 p_health)"
+    sec="$(macdog audit --json 2>/dev/null || echo 'null')"
+    disk="$(macbroom scan --caches --json 2>/dev/null || echo 'null')"
+    printf '{"generated_at":"%s","host":"%s %s","arch":"%s","health":%s,"security":%s,"disk":%s}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      "$(sw_vers -productName 2>/dev/null)" "$(sw_vers -productVersion 2>/dev/null)" \
+      "$(uname -m)" "${health:-null}" "${sec:-null}" "${disk:-null}"
+    return
+  fi
+
+  echo "════════════════════════════════════════════"
+  echo " OPS ► MAC AUDIT — $(sw_vers -productVersion 2>/dev/null) ($(uname -m)) — $(date -u +%H:%MZ)"
+  echo "════════════════════════════════════════════"
+  echo
+  echo "── SECURITY (macdog) ──"; p_security; echo
+  echo "── LAUNCH AGENTS (lanchr doctor) ──"; p_launchd 2>&1 | head -30; echo
+  echo "── TOP PROCESSES (pstop) ──"; p_procs 2>&1 | head -8; echo
+  echo "── NETWORK (netwhiz) ──"; p_net info 2>&1 | head -15; echo
+  echo "── DISK RECLAIMABLE (macbroom caches) ──"
+  if _have jq; then
+    macbroom scan --caches --json 2>/dev/null \
+      | jq -r '.categories[]? | "  \(.name): \((.size/1e9*100|round)/100) GB (\(.items) items, \(.risk))"' 2>/dev/null \
+      || echo "  (run: ops-mac disk)"
+  else
+    echo "  (install jq for sizes, or run: ops-mac disk)"
+  fi
+  echo
+  echo "── SYSTEM HEALTH (machealth, ${MACHEALTH_TIMEOUT}s cap) ──"; p_health
+  echo
+  echo "Tip: this is read-only. Remediate with /ops:mac fix (firewall, stale daemons, cache clean)."
+}
+
+# ─── dispatch ────────────────────────────────────────────────────────────────
+cmd="${1:-}"; [[ $# -gt 0 ]] && shift || true
+case "$cmd" in
+  ""|inventory|status) inventory ;;
+  ensure|install)      ensure ;;
+  audit)               audit ;;
+  health)              p_health ;;
+  net|network)         p_net "${1:-info}" ;;
+  disk)                p_disk ;;
+  procs|processes)     p_procs ;;
+  security|sec)        p_security ;;
+  launchd|launch)      p_launchd ;;
+  power)               p_power ;;
+  defaults)            p_defaults "$@" ;;
+  update|updates)      p_update ;;
+  run)                 t="${1:-}"; shift || true; require_tool "$t"; "$t" "$@" ;;
+  -h|--help|help)
+    sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+    ;;
+  *)
+    echo "ops-mac: unknown command '$cmd'. Try: ensure | audit | health | net | disk | procs | security | launchd | power | update | run <tool>" >&2
+    exit 2
+    ;;
+esac

--- a/claude-ops/skills/ops-mac/SKILL.md
+++ b/claude-ops/skills/ops-mac/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: ops-mac
+description: macOS diagnose-and-fix command center. Wraps the macos-toolkit CLI suite (machealth, netwhiz, pstop, macdog, lanchr, macbroom, macctl, macfig, updater) behind one entrypoint — self-installs the suite on first use, runs a read-only baseline audit (security, launch agents, processes, network, disk, system health), and applies guarded fixes (firewall, stale daemons, cache cleanup) with per-action confirmation.
+argument-hint: '[audit|health|net|disk|procs|security|launchd|fix|ensure|update]'
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - AskUserQuestion
+effort: low
+maxTurns: 30
+---
+
+# OPS ► MAC — macOS Diagnose & Fix
+
+One command for native macOS health: it bundles the [`macos-toolkit`](https://github.com/lu-zhengda/macos-toolkit) CLI suite, **auto-installs it on first use**, runs a read-only baseline, and remediates the common offenders behind explicit confirmations.
+
+All work routes through `${CLAUDE_PLUGIN_ROOT}/bin/ops-mac`, the single source of truth for install + probes + the aggregate audit. The bundled CLIs:
+
+| Tool | Domain | ops-mac subcommand |
+| --- | --- | --- |
+| `machealth` | composite health (CPU/mem/disk/thermal/battery/iCloud/TM/net) | `health` |
+| `netwhiz` | network + WiFi diagnostics | `net` / `net wifi` |
+| `macbroom` | disk cleanup & reclaimable cache scan | `disk` |
+| `pstop` | process monitoring (CPU/mem hogs) | `procs` |
+| `macdog` | security & privacy audit | `security` |
+| `lanchr` | launchd agent/daemon health (`doctor`) | `launchd` |
+| `macctl` | power / display / audio control | `power` |
+| `macfig` | hidden macOS defaults | `defaults` |
+| `updater` | app update management | `update` |
+
+## Platform guard
+
+This skill is **macOS only**. The dispatcher exits with code 3 on non-Darwin. For Linux/WSL/Windows system optimization use `/ops:speedup` (cross-platform). The two are complementary — `/ops:mac` is the deep macOS-native surface; `/ops:speedup` is the portable cleaner.
+
+## Two hard-won quirks (baked into the dispatcher)
+
+1. **`machealth check`/`diagnose` can hang forever** on a stuck Time Machine / iCloud probe (its checks run in parallel with no per-probe skip flag). Every machealth call is wrapped in a hard `timeout` (default 25s, override `OPS_MAC_MACHEALTH_TIMEOUT`). If it trips, the other probes are still reliable — never block on it.
+2. **The toolkit's pretty TUI tables render EMPTY when stdout isn't a TTY.** The dispatcher forces `--json` for headless/agent consumers (`macbroom`, `pstop`, `macdog`, `lanchr`). When you need machine data, always pass `--json`.
+
+## Runtime Context
+
+Before anything, ensure the suite is installed (idempotent — no-op if already present):
+
+```!
+${CLAUDE_PLUGIN_ROOT}/bin/ops-mac ensure
+```
+
+## Mode routing
+
+Dispatch on `$ARGUMENTS`:
+
+- empty / `audit` → **Baseline flow** (read-only, below)
+- `health` / `net` / `disk` / `procs` / `security` / `launchd` / `power` / `update` → run that single probe and print verbatim:
+  ```bash
+  ${CLAUDE_PLUGIN_ROOT}/bin/ops-mac <subcommand>
+  ```
+- `fix` → **Remediation flow** (below, Rule 5 confirmations)
+- `ensure` / `install` → run `ops-mac ensure` and report what was added
+
+## Baseline flow (`/ops:mac` or `/ops:mac audit`)
+
+Run the aggregate audit — it composes the reliable probes in one call:
+
+```!
+${CLAUDE_PLUGIN_ROOT}/bin/ops-mac audit
+```
+
+Then summarize for the user with a verdict per area:
+
+```
+OPS ► MAC AUDIT — [version] ([arch])
+
+🔴/🟡/🟢 Security    grade [X]/100 — [firewall/SIP/FileVault/Gatekeeper/remote-login]
+🔴/🟡/🟢 Launchd     [N] genuinely-broken user daemons (Apple -9/SIGKILL noise filtered out)
+🟢 Processes  top hog: [name] [N]% CPU
+🟢 Network    [iface] [ip] — [ok/degraded]
+🟢 Disk       ~[N] GB safe reclaimable (biggest: [cache] [N] GB)
+⚠ Health     [machealth result, or "probe timed out — TM/iCloud stuck"]
+
+Next: /ops:mac fix to remediate, or pick one area.
+```
+
+**Launchd noise filter** — `lanchr doctor` flags ~50+ "critical" entries; most are normal:
+- Apple on-demand agents exit `-9` (SIGKILL) when idle — **expected, not broken**.
+- Stale Apple plist paths (cvmsCompAgent, BluetoothUIService, battery helper) — **cosmetic**.
+- The **actionable** ones are user/3rd-party daemons with `exit status: 1` or a missing binary you own. Surface only those.
+
+## Remediation flow (`/ops:mac fix`)
+
+Run the audit first to know what's wrong, then offer fixes. **Per plugin Rule 5, every mutating action needs its own confirmation** — never batch-execute. Present via `AskUserQuestion`, max 4 options each.
+
+Common offenders and their guarded fixes:
+
+### 1. Firewall off
+```
+macdog reports the application firewall is OFF.
+  [Enable firewall]  [Enable + stealth mode]  [Skip]
+```
+On confirm:
+```bash
+sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on
+# stealth (optional): sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on
+```
+
+### 2. Stale / crashing launchd user daemons
+For each actionable entry from `lanchr doctor` (missing binary, or repeated `exit 1`), confirm **individually**:
+```
+com.example.foo — binary missing at [path]. This launchd job is dead.
+  [Show the plist first]  [Remove it]  [Disable (keep file)]  [Skip]
+```
+Use `lanchr` to remediate where possible; otherwise `launchctl bootout`/`disable` after showing the plist. **Never touch a daemon the user relies on** (CRS/haproxy, gbrain push, ops-daemon, cloudflared tunnels, watchdogs) without spelling out exactly what it is — cross-check before recommending removal.
+
+### 3. Reclaimable disk
+```
+macbroom found ~[N] GB of safe cache. Categories: [list].
+  [Clean safe caches]  [Pick categories]  [Review largest first]  [Skip]
+```
+On confirm (safe categories only):
+```bash
+macbroom clean --caches            # confirm prompt; or --yolo only after explicit approval
+```
+Never run `macbroom clean --all --yolo` without per-category approval.
+
+### 4. App updates
+```bash
+${CLAUDE_PLUGIN_ROOT}/bin/ops-mac update    # updater check — then confirm before applying
+```
+
+After any fix, re-run the relevant probe and show before→after.
+
+## Mobile mode (Rule 7)
+
+If `$SSH_CONNECTION`/`$SSH_CLIENT`/`$SSH_TTY` is set, `$OPS_MOBILE=1`, or `$COLUMNS` < 80: drop the boxes/tables, emit 3–8 plain lines, one fact each. Example:
+
+```
+mac audit:
+security B/100 — firewall OFF.
+launchd: 2 dead user daemons.
+disk: 8.6 GB safe to clean.
+health: machealth probe stuck (TM/iCloud).
+fix? /ops:mac fix
+```
+
+## When to use this vs other skills
+
+| Want… | Use |
+| --- | --- |
+| macOS-native deep diagnose + fix (firewall, launchd, network, security) | `/ops:mac` |
+| Cross-platform cleaner (Linux/WSL/Windows too) | `/ops:speedup` |
+| Quick "is everything connected?" integration glance | `/ops:status` |
+| Full health check + auto-repair of the **ops plugin itself** | `/ops:doctor` |


### PR DESCRIPTION
## What

Adds **`/ops:ops-mac`** — a unified macOS diagnose-and-fix command center that bundles the [macos-toolkit](https://github.com/lu-zhengda/macos-toolkit) CLI suite behind one entrypoint.

New files:
- `skills/ops-mac/SKILL.md` — drives UX, confirmations, mode routing
- `bin/ops-mac` — dispatcher: install + all probes + aggregate audit

## Why

Diagnosing/fixing Mac issues meant remembering 9 separate CLIs (machealth, netwhiz, pstop, macdog, lanchr, macbroom, macctl, macfig, updater) and how to install them. This collapses them into `/ops:ops-mac`.

## Subcommands

| Command | Does |
| --- | --- |
| `/ops:ops-mac` / `audit` | Read-only baseline: security, launch agents, processes, network, disk, system health |
| `health` `net` `disk` `procs` `security` `launchd` `power` `update` | Single-domain probes |
| `fix` | Guarded remediation (firewall, stale daemons, cache cleanup) — per-action confirm |
| `ensure` | Self-install the suite (plugin marketplace + Homebrew tap + tools), idempotent |

## Hardening (two real quirks found in testing)

1. **machealth hangs** — its parallel composite probe can block forever on a stuck Time Machine / iCloud check with no per-probe skip flag. Every machealth call is `timeout`-guarded (default 25s, `OPS_MAC_MACHEALTH_TIMEOUT` override) and degrades to a labelled stub instead of wedging.
2. **TTY-empty tables** — the toolkit's pretty tables render nothing when stdout isn't a TTY. The dispatcher forces `--json` for headless/agent consumers.

## Compliance
- **Rule 5**: every mutating `fix` action gets its own `AskUserQuestion` confirmation; never batches. Explicitly warns before touching daemons the user relies on (CRS, gbrain, cloudflared, watchdogs).
- **Rule 7**: mobile/SSH compact output path.
- **Rule 0**: `tests/test-no-secrets.sh` passes (25/25); no personal data in new files.
- macOS-only (exits cleanly elsewhere); complements cross-platform `/ops:speedup`.

## Version
plugin `2.36.5 → 2.38.0`, skills `59 → 60`, marketplace description + CHANGELOG updated.

## Test evidence
- `bash -n bin/ops-mac` ✓ ; `claude plugin validate` ✓ for ops-mac (2 unrelated pre-existing skill errors on main)
- Smoke-tested live on macOS 26.5 (arm64): inventory, security, launchd, disk, net, aggregate audit, idempotent `ensure` (installed macctl/macfig/updater), machealth timeout guard fires correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Can install third-party CLIs and guide sudo-level system changes (firewall, launchd, cache), though the script stays read-only by default and mutating steps require explicit user confirmation in the skill.
> 
> **Overview**
> Adds **`/ops:ops-mac`** as a macOS-only diagnose-and-fix surface that wraps the external **macos-toolkit** CLI suite behind **`bin/ops-mac`** and **`skills/ops-mac/SKILL.md`**.
> 
> The dispatcher **self-installs** on first use (Claude plugin marketplace + Homebrew `lu-zhengda/tap`), runs a **read-only aggregate audit** (security, launchd, processes, network, disk, health), and exposes per-domain subcommands. It **timeouts `machealth`** probes and forces **`--json`** when non-TTY so agents do not hang or get empty tables. The skill routes **`fix`** through **per-action confirmations** (firewall, stale launch agents, safe cache clean) and complements cross-platform **`/ops:speedup`**.
> 
> Plugin metadata bumps to **2.38.0** (60 skills); marketplace description and **CHANGELOG** are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd66e790cc1a15b2e3fa913771c27ec024da1aa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->