### PR TITLE
release: v2.38.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 60 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.38.0",
+      "version": "2.38.1",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-2.36.5-blue)
+![Version](https://img.shields.io/badge/version-2.38.1-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
-![Skills](https://img.shields.io/badge/skills-59-success)
+![Skills](https://img.shields.io/badge/skills-60-success)
 ![Agents](https://img.shields.io/badge/agents-21-informational)
 ![Integrations](https://img.shields.io/badge/integrations-22-orange)
 ![Auto-fix](https://img.shields.io/badge/v2-auto--fix%20subsystem-ef4444)
@@ -103,7 +103,7 @@ claude --plugin-dir ./claude-ops/claude-ops
 
 ## Commands
 
-All 59 skills, grouped by category:
+All 60 skills, grouped by category:
 
 | 🧭 Navigation                    | 📊 Daily Ops                           |
 | -------------------------------- | -------------------------------------- |

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.38.0",
+  "version": "2.38.1",
   "description": "Business operations command center for Claude Code — 60 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.38.1] - 2026-06-28
+
+### Changed
+Publish /ops:ops-mac macOS diagnose-and-fix command (skill + bin/ops-mac dispatcher bundling the macos-toolkit CLI suite).
+
+
 ## [2.38.0] - 2026-06-28
 
 ### Added

--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -142,7 +142,7 @@ The background memory extractor now prefers the Claude Code OAuth token stored i
 
 ### Full Plugin Feature Adoption
 
-- All 59 skills: `effort`, `maxTurns`, `disallowedTools`, `model` annotations
+- All 60 skills: `effort`, `maxTurns`, `disallowedTools`, `model` annotations
 - All 21 agents: `memory` (cross-session learning), `initialPrompt`, `isolation`
 - PreToolUse hooks for WhatsApp health checks and MCP auto-reconnect
 - Runtime Context loading in every skill (preferences, daemon health, memories, secrets)

--- a/claude-ops/docs/INDEX.md
+++ b/claude-ops/docs/INDEX.md
@@ -25,7 +25,7 @@ _Top-level map of every doc file in `claude-ops/docs/`._
 | Doc                                                        | Subject                                                                                        |
 | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | [`agents-reference.md`](agents-reference.md)               | Catalog of all 21 agents (4 v2 specialists + 14 v1 scanners/fixers/C-suite).                   |
-| [`skills-reference.md`](skills-reference.md)               | Catalog of all 59 skills with usage examples.                                                  |
+| [`skills-reference.md`](skills-reference.md)               | Catalog of all 60 skills with usage examples.                                                  |
 | [`daemon-guide.md`](daemon-guide.md)                       | The v1 ops-daemon (briefing pre-warm, whatsapp-bridge-sync, memory-extractor, etc).            |
 | [`docker.md`](docker.md)                                   | Running claude-ops in a container.                                                             |
 | [`marketplace-submissions.md`](marketplace-submissions.md) | Publishing your own plugin to the same marketplace.                                            |

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-2.36.5-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.38.1-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -2,10 +2,10 @@
 
 # Skills Reference
 
-_All 59 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
+_All 60 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-2.36.5-blue)](../CHANGELOG.md)
-[![skills](https://img.shields.io/badge/skills-59-8b5cf6)](.)
+[![version](https://img.shields.io/badge/version-2.38.1-blue)](../CHANGELOG.md)
+[![skills](https://img.shields.io/badge/skills-60-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)
 

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.36.5",
+  "version": "2.38.1",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.38.1** (was 2.38.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

Publish /ops:ops-mac macOS diagnose-and-fix command (skill + bin/ops-mac dispatcher bundling the macos-toolkit CLI suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and documentation only; no application logic changes in the diff.
> 
> **Overview**
> **Release v2.38.1** — bumps the ops plugin and `claude-ops/package.json` from **2.38.0** to **2.38.1**, with matching updates in the marketplace registry and README version badges.
> 
> Adds a **CHANGELOG** entry for 2.38.1 framing the release as publishing **`/ops:ops-mac`** (macOS diagnose-and-fix skill plus `bin/ops-mac` dispatcher for the macos-toolkit CLI suite). Documentation and marketplace copy now consistently advertise **60 skills** (was **59**) and reference **`/ops:ops-mac`** in plugin descriptions and the skills index/reference pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df1dd2c278cd8141ddfdb7a522ce5b2601e14233. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new macOS diagnose-and-fix command to expand available troubleshooting options.

* **Documentation**
  * Updated release/version badges across the README and docs to **2.38.1**.
  * Refreshed skill counts and references from **59** to **60** in documentation and indexes.

* **Chores**
  * Bumped the plugin and package version to **2.38.1**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->