### PR TITLE
feat: CRS OS-wedge auto-reboot stopgap in crs-health-watch

### DIFF
--- a/claude-ops/scripts/account-rotation/crs-health-watch.mjs
+++ b/claude-ops/scripts/account-rotation/crs-health-watch.mjs
@@ -218,12 +218,16 @@ function maybeAutoReboot(st, inFallback, healthy) {
 
   const cooldown = rebootCooldownRemainingMs();
   if (cooldown > 0) {
-    log(`reboot: conditions met (down x${st.down}) but cooldown active (${Math.ceil(cooldown / 60000)}m remaining) → skip`);
+    log(
+      `reboot: conditions met (down x${st.down}) but cooldown active (${Math.ceil(cooldown / 60000)}m remaining) → skip`,
+    );
     return;
   }
   const ping = ssmPingStatus(DEV_US_INSTANCE_ID);
   if (ping !== 'ConnectionLost') {
-    log(`reboot: down x${st.down} + fail-closed, but SSM PingStatus=${ping} (not ConnectionLost) → app-level, NOT rebooting`);
+    log(
+      `reboot: down x${st.down} + fail-closed, but SSM PingStatus=${ping} (not ConnectionLost) → app-level, NOT rebooting`,
+    );
     return;
   }
   try {
@@ -232,7 +236,9 @@ function maybeAutoReboot(st, inFallback, healthy) {
       timeout: 20_000,
     });
     writeFileSync(REBOOT_COOLDOWN_MARKER, String(Date.now()));
-    log(`🔁 OS-WEDGE AUTO-REBOOT: CRS down x${st.down} + SSM ConnectionLost → reboot-instances ${DEV_US_INSTANCE_ID} (30m cooldown armed)`);
+    log(
+      `🔁 OS-WEDGE AUTO-REBOOT: CRS down x${st.down} + SSM ConnectionLost → reboot-instances ${DEV_US_INSTANCE_ID} (30m cooldown armed)`,
+    );
   } catch (e) {
     log(`WARN: auto-reboot failed: ${e.message}`);
   }
@@ -247,7 +253,8 @@ function main() {
     const inFallback = existsSync(MARKER);
     const ping = ssmPingStatus(DEV_US_INSTANCE_ID);
     const cooldownRemMs = rebootCooldownRemainingMs();
-    const wouldReboot = !healthy && st.down >= REBOOT_STRIKES && inFallback && ping === 'ConnectionLost' && cooldownRemMs === 0;
+    const wouldReboot =
+      !healthy && st.down >= REBOOT_STRIKES && inFallback && ping === 'ConnectionLost' && cooldownRemMs === 0;
     console.log(
       JSON.stringify(
         {

--- a/claude-ops/scripts/account-rotation/crs-health-watch.mjs
+++ b/claude-ops/scripts/account-rotation/crs-health-watch.mjs
@@ -37,6 +37,18 @@ const args = new Set(process.argv.slice(2));
 const SETTINGS = join(homedir(), '.claude', 'settings.json');
 const STATE = join(__dirname, 'crs-health-watch.state.json');
 const MARKER = join(__dirname, 'crs-fallback-active'); // legacy marker present while route is fail-closed
+const REBOOT_COOLDOWN_MARKER = join(__dirname, 'crs-reboot-cooldown'); // holds last OS-wedge reboot epoch ms
+
+// dev-us EC2 (us-east-1) serves CRS for the entire fleet. Prefer the canonical
+// instance-id sync file; fall back to the known id from project config.
+const DEV_US_INSTANCE_ID = (() => {
+  const f = join(homedir(), '.claude', 'sync', 'dev-us-instance.id');
+  try {
+    const v = readFileSync(f, 'utf8').trim();
+    if (/^i-[0-9a-f]+$/.test(v)) return v;
+  } catch {}
+  return 'i-01b4d5132c1b167bf';
+})();
 
 function routeCrsConfig() {
   try {
@@ -53,6 +65,10 @@ const CRS_SMOKE_URL = process.env.CRS_SMOKE_URL || `${CRS_BASE}/v1/messages?beta
 const CRS_SMOKE_MODEL = process.env.CRS_SMOKE_MODEL || 'claude-sonnet-4-6';
 const DOWN_STRIKES = +(process.env.CRS_DOWN_STRIKES || 3); // ~3 min at 60s tick
 const UP_STRIKES = +(process.env.CRS_UP_STRIKES || 1);
+// OS-wedge auto-reboot threshold. Must be >= DOWN_STRIKES so we only reboot AFTER
+// fail-closed has already protected the fleet (~5 min sustained-down at 60s tick).
+const REBOOT_STRIKES = Math.max(DOWN_STRIKES, +(process.env.CRS_REBOOT_STRIKES || 5));
+const REBOOT_COOLDOWN_MS = 30 * 60 * 1000; // at most one auto-reboot per 30 min
 
 const ts = () => new Date().toISOString().slice(11, 19);
 const log = (m) => console.log(`${ts()} [crs-health-watch] ${m}`);
@@ -155,7 +171,108 @@ function currentEnvMode() {
   return 'mixed';
 }
 
+// SSM PingStatus for the dev-us instance. "ConnectionLost" => the SSM agent itself
+// is unreachable, i.e. an OS-level wedge (reboot can help). "Online" => OS is fine and
+// CRS is merely app-down (reboot is unwarranted). Returns the literal string, or an
+// "ERROR:<msg>" sentinel on AWS failure (treated as not-ConnectionLost by callers).
+function ssmPingStatus(instanceId) {
+  try {
+    return execFileSync(
+      'aws',
+      [
+        'ssm',
+        'describe-instance-information',
+        '--region',
+        'us-east-1',
+        '--filters',
+        `Key=InstanceIds,Values=${instanceId}`,
+        '--query',
+        'InstanceInformationList[0].PingStatus',
+        '--output',
+        'text',
+      ],
+      { encoding: 'utf8', timeout: 30_000 }, // generous: aws CLI cold-starts each tick; this read decides the reboot
+    ).trim();
+  } catch (e) {
+    return `ERROR:${e.message}`;
+  }
+}
+
+// Milliseconds left on the auto-reboot cooldown (0 = no cooldown / clear to reboot).
+function rebootCooldownRemainingMs() {
+  try {
+    const last = +readFileSync(REBOOT_COOLDOWN_MARKER, 'utf8').trim();
+    if (!Number.isFinite(last)) return 0;
+    const rem = REBOOT_COOLDOWN_MS - (Date.now() - last);
+    return rem > 0 ? rem : 0;
+  } catch {
+    return 0;
+  }
+}
+
+// Fire an EC2 reboot ONLY on a double-confirmed OS wedge: CRS sustained-down past
+// REBOOT_STRIKES, already fail-closed (fleet protected), SSM says ConnectionLost, and
+// no reboot in the last 30 min. Conservative by design — every gate must hold.
+function maybeAutoReboot(st, inFallback, healthy) {
+  if (healthy || st.down < REBOOT_STRIKES || !inFallback) return;
+
+  const cooldown = rebootCooldownRemainingMs();
+  if (cooldown > 0) {
+    log(`reboot: conditions met (down x${st.down}) but cooldown active (${Math.ceil(cooldown / 60000)}m remaining) → skip`);
+    return;
+  }
+  const ping = ssmPingStatus(DEV_US_INSTANCE_ID);
+  if (ping !== 'ConnectionLost') {
+    log(`reboot: down x${st.down} + fail-closed, but SSM PingStatus=${ping} (not ConnectionLost) → app-level, NOT rebooting`);
+    return;
+  }
+  try {
+    execFileSync('aws', ['ec2', 'reboot-instances', '--region', 'us-east-1', '--instance-ids', DEV_US_INSTANCE_ID], {
+      encoding: 'utf8',
+      timeout: 20_000,
+    });
+    writeFileSync(REBOOT_COOLDOWN_MARKER, String(Date.now()));
+    log(`🔁 OS-WEDGE AUTO-REBOOT: CRS down x${st.down} + SSM ConnectionLost → reboot-instances ${DEV_US_INSTANCE_ID} (30m cooldown armed)`);
+  } catch (e) {
+    log(`WARN: auto-reboot failed: ${e.message}`);
+  }
+}
+
 function main() {
+  if (args.has('--dry-run-reboot')) {
+    const st = loadState();
+    const healthOk = probe();
+    const inferenceOk = healthOk ? probeInference() : false;
+    const healthy = healthOk; // mirrors the live tick's health gate
+    const inFallback = existsSync(MARKER);
+    const ping = ssmPingStatus(DEV_US_INSTANCE_ID);
+    const cooldownRemMs = rebootCooldownRemainingMs();
+    const wouldReboot = !healthy && st.down >= REBOOT_STRIKES && inFallback && ping === 'ConnectionLost' && cooldownRemMs === 0;
+    console.log(
+      JSON.stringify(
+        {
+          dryRunReboot: true,
+          instanceId: DEV_US_INSTANCE_ID,
+          healthy,
+          healthOk,
+          inferenceOk,
+          stDown: st.down,
+          rebootStrikes: REBOOT_STRIKES,
+          downThresholdMet: st.down >= REBOOT_STRIKES,
+          inFallback,
+          ssmPingStatus: ping,
+          ssmConnectionLost: ping === 'ConnectionLost',
+          cooldownRemainingMin: Math.ceil(cooldownRemMs / 60000),
+          cooldownActive: cooldownRemMs > 0,
+          WOULD_REBOOT: wouldReboot,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
   if (args.has('--status')) {
     const st = loadState();
     const health = probe();
@@ -243,6 +360,11 @@ function main() {
       `tick: health=${healthOk} inference=${inferenceOk} down=${st.down} up=${st.up} fallback=${inFallback} envMode=${currentEnvMode()}`,
     );
   }
+
+  // OS-wedge auto-reboot (double-confirmed via SSM, 30m cooldown). Only fires when CRS
+  // is sustained-down past REBOOT_STRIKES, we're already fail-closed, and the SSM agent
+  // itself is unreachable (true OS wedge, not an app-level CRS failure).
+  maybeAutoReboot(st, inFallback, healthy);
   saveState(st);
 }
 


### PR DESCRIPTION
## What

Adds a **double-confirmed, cooldown-gated EC2 auto-reboot** to the fleet CRS health watch (`crs-health-watch.mjs`). When the dev-us box (which serves CRS for the entire fleet) suffers a genuine OS wedge, this stopgap reboots it automatically instead of waiting for manual intervention.

## Guardrails (all must hold to fire a reboot)

1. **Sustained-down**: `!healthy && st.down >= REBOOT_STRIKES` — `REBOOT_STRIKES = max(DOWN_STRIKES, CRS_REBOOT_STRIKES||5)` (~5 min at the 60s tick).
2. **Already fail-closed**: `inFallback` true — the fleet is already protected (sessions routed direct), so a reboot can only help.
3. **SSM confirms OS-level wedge**: `aws ssm describe-instance-information` PingStatus `== "ConnectionLost"` (SSM agent itself unreachable). If `Online`, CRS is app-down only → **do NOT reboot**.
4. **Cooldown**: at most one reboot per 30 min, tracked via a `crs-reboot-cooldown` marker file.

When all hold: `aws ec2 reboot-instances --region us-east-1 --instance-ids <id>`, arm the cooldown, and log prominently. AWS failures are caught (`WARN`), never crashing the tick.

## Instance id resolution

Reads `~/.claude/sync/dev-us-instance.id`, falling back to hardcoded `i-01b4d5132c1b167bf`.

## Verification

- `--dry-run-reboot` flag (non-mutating) reports whether all conditions would currently be met. Verified `WOULD_REBOOT: false` (CRS healthy, down=0, not fail-closed, SSM Online).
- AWS read-only confirmed: instance `running`, SSM `Online`.
- `node --check` passes.
- No real reboot triggered; launchd job untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces automated EC2 reboots on the fleet CRS host via AWS CLI; gates are conservative but mistaken SSM signals or wrong instance id could still cause unplanned downtime.
> 
> **Overview**
> Extends **`crs-health-watch.mjs`** so the fleet CRS health tick can **`reboot-instances`** on the dev-us EC2 host when a sustained outage looks like an **OS wedge**, not a CRS app failure.
> 
> After existing fail-closed routing kicks in, reboot only runs when down strikes reach **`REBOOT_STRIKES`** (default 5, env **`CRS_REBOOT_STRIKES`**), the fallback marker is set, SSM **`PingStatus`** is **`ConnectionLost`**, and a **30-minute** cooldown file is clear. Instance id comes from **`~/.claude/sync/dev-us-instance.id`** with a config fallback.
> 
> Adds **`--dry-run-reboot`** JSON output for **`WOULD_REBOOT`** without mutating AWS. Reboot failures log **`WARN`** and do not crash the tick.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e645162907570d2600f8fab014a6e7c41fc8e491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic reboot handling for a development instance when health checks stay unhealthy for an extended period and fallback mode is already active.
  * Added a dry-run option to preview whether a reboot would happen, including cooldown and health-status details.

* **Bug Fixes**
  * Improved recovery from OS-level wedges by requiring repeated confirmation and a cooldown before attempting another reboot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->