### PR TITLE
fix(crs): preserve schedulable state during token feed

### DIFF
--- a/claude-ops/scripts/account-rotation/crs-priority-daemon.mjs
+++ b/claude-ops/scripts/account-rotation/crs-priority-daemon.mjs
@@ -391,7 +391,9 @@ function decideConservative(accts, nowMs) {
     const rl = genuineRateLimit(a, nowMs);
     const overloaded = genuineOverload(a, nowMs);
 
-    const utilBreach = fresh && ((u5 ?? 0) >= OFF_5H || (u7 ?? 0) >= OFF_7D || (u7o ?? 0) >= OFF_7D);
+    const weeklyBreach =
+      fresh && ((typeof u7 === 'number' && u7 >= OFF_7D) || (typeof u7o === 'number' && u7o >= OFF_7D));
+    const utilBreach = fresh && ((u5 ?? 0) >= OFF_5H || weeklyBreach);
     const utilClear = !fresh || ((u5 ?? 0) < ON_5H && (u7 ?? 0) < ON_7D && (u7o ?? 0) < ON_7D);
 
     let desired = cur;
@@ -410,7 +412,7 @@ function decideConservative(accts, nowMs) {
     } else if (utilBreach) {
       desired = false;
       reason = `util 5h=${u5} 7d=${u7} 7dOpus=${u7o} ≥ off`;
-      soft = true;
+      soft = !weeklyBreach;
     } else if ((sw === 'allowed' || sw === null) && utilClear) {
       desired = true;
       reason = `healthy (sw=${sw ?? 'none'}${fresh ? `, 5h=${u5}` : ', usage stale/absent'})`;

--- a/claude-ops/scripts/account-rotation/crs-token-feed.mjs
+++ b/claude-ops/scripts/account-rotation/crs-token-feed.mjs
@@ -229,10 +229,14 @@ async function main() {
       continue;
     }
     try {
+      const update = { claudeAiOauth: oauth };
+      if ('proxy' in crs) update.proxy = crs.proxy;
+      if ('maxConcurrency' in crs) update.maxConcurrency = crs.maxConcurrency;
+      if ('schedulable' in crs) update.schedulable = crs.schedulable;
       const put = await fetch(`${crsBase}/admin/claude-accounts/${crs.id}`, {
         method: 'PUT',
         headers: H,
-        body: JSON.stringify({ claudeAiOauth: oauth }),
+        body: JSON.stringify(update),
       });
       if (put.ok) {
         await fetch(`${crsBase}/admin/claude-accounts/${crs.id}/reset-status`, { method: 'POST', headers: H }).catch(


### PR DESCRIPTION
## Summary
- preserve existing CRS account routing fields when token feed updates OAuth tokens
- keep existing `schedulable` state on token propagation so capped accounts are not reopened
- treat weekly utilization breaches as hard-off in the conservative priority floor

## Why
The token feed only sent `claudeAiOauth` to the CRS account update endpoint. If the admin API defaulted omitted fields, capped accounts could become schedulable again after every feed tick. The conservative priority floor also treated 7-day caps as soft, allowing weekly-capped accounts to be rescued to satisfy the floor.

## Verification
- `node --check scripts/account-rotation/crs-token-feed.mjs`
- `node --check scripts/account-rotation/crs-priority-daemon.mjs`
- `npm run lint`
- `npm test`
- `npm run type-check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect CRS routing and schedulable state on every token feed tick and pool prioritization; incorrect behavior could mis-route traffic or keep overloaded accounts in rotation.
> 
> **Overview**
> **Token feed** no longer sends OAuth alone on CRS account PUTs. It now re-sends existing `proxy`, `maxConcurrency`, and `schedulable` from the current account record when those fields are present, so periodic propagation cannot accidentally reopen capped accounts if the admin API treats omitted fields as defaults.
> 
> **Priority daemon (conservative policy)** splits utilization off-thresholds: **7-day** (and 7-day Opus) breaches are **hard** deprioritizations (`soft = false`), so the minimum-pool **FLOOR** logic cannot re-enable weekly-capped accounts. **5-hour** breaches stay **soft**, so the floor can still rescue accounts disabled only for short-window utilization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5f82a9add4f269806e366ab4628871f1eeb4550. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account disablement behavior so weekly usage breaches are handled more strictly, while shorter-term threshold breaches remain soft when appropriate.
  * Account updates now preserve more settings during synchronization, including connection and scheduling-related fields when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->