### PR TITLE
fix(crs): avoid reopening closed accounts during token feed

### DIFF
--- a/claude-ops/scripts/account-rotation/crs-token-feed.mjs
+++ b/claude-ops/scripts/account-rotation/crs-token-feed.mjs
@@ -239,9 +239,11 @@ async function main() {
         body: JSON.stringify(update),
       });
       if (put.ok) {
-        await fetch(`${crsBase}/admin/claude-accounts/${crs.id}/reset-status`, { method: 'POST', headers: H }).catch(
-          () => {},
-        );
+        if (crs.schedulable !== false) {
+          await fetch(`${crsBase}/admin/claude-accounts/${crs.id}/reset-status`, { method: 'POST', headers: H }).catch(
+            () => {},
+          );
+        }
         propagated++;
       } else {
         log(`${key}: CRS PUT ${put.status}`);


### PR DESCRIPTION
## Summary
- skip CRS reset-status after token feed updates for accounts already marked unschedulable
- prevents reset-status from reopening accounts intentionally closed by quota policy

## Verification
- `npm run lint`
- `npm test`
- `npm run type-check`
- `node --check scripts/account-rotation/crs-token-feed.mjs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small conditional around an existing admin API call in the token feeder; no auth or data-model changes.
> 
> **Overview**
> After a successful CRS OAuth **PUT**, `crs-token-feed.mjs` no longer always calls **`reset-status`**. It now posts **`reset-status` only when `crs.schedulable !== false`**, so accounts deliberately marked unschedulable by quota policy are not reopened when tokens are propagated.
> 
> Token refresh and PUT behavior are unchanged; only the post-PUT status reset is gated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 045db6a3854167c2a90668011f9a4f6d024e8639. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->