### PR TITLE
fix(crs): pass admin env to feed priority tick

### DIFF
--- a/claude-ops/scripts/account-rotation/crs-token-feed.mjs
+++ b/claude-ops/scripts/account-rotation/crs-token-feed.mjs
@@ -105,6 +105,7 @@ async function crsLogin(crsBase, crsContainer, adminUser = 'cradmin') {
       .trim();
   } catch {}
   if (!pw) return null;
+  if (!process.env.CRS_ADMIN_PASSWORD) process.env.CRS_ADMIN_PASSWORD = pw;
   try {
     const r = await fetch(`${crsBase}/web/auth/login`, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- propagate the CRS admin password discovered by token feed into the spawned priority tick
- prevents feed-triggered priority from failing when the parent process was launched without an explicit CRS_ADMIN_PASSWORD env var

## Verification
- `npm run lint`
- `npm test`
- `npm run type-check`
- `node --check scripts/account-rotation/crs-token-feed.mjs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line env propagation using the same password already used for CRS login; no new auth paths or data exposure.
> 
> **Overview**
> When `crs-token-feed.mjs` logs into CRS, it already reads **`ADMIN_PASSWORD`** from the relay container via `docker inspect`. **This PR copies that value into `process.env.CRS_ADMIN_PASSWORD`** when the variable was not set at startup.
> 
> That matters because a successful feed run **spawns `crs-priority-daemon.mjs`** and passes `CRS_ADMIN_PASSWORD` from the parent environment. Without this change, a timer or parent started without an explicit admin env could still feed tokens (login used the inspected password) but the **post-feed priority tick could fail** with an empty password.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53636e9b922b1e21bb665c40d629c8c82f8aac59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->