### PR TITLE
fix: stop ops-post-update-migrate self-rsync load storm on SessionStart

### DIFF
--- a/claude-ops/bin/ops-post-update-migrate
+++ b/claude-ops/bin/ops-post-update-migrate
@@ -34,15 +34,34 @@ refresh_current_directory() {
   current_dir="$cache_parent/current"
   installed_json="$PLUGINS_DIR/installed_plugins.json"
 
-  if command -v rsync >/dev/null 2>&1; then
-    rsync -a --delete "$PLUGIN_ROOT/" "$current_dir/" 2>/dev/null \
-      && log "  ok: refreshed $current_dir via rsync" \
-      || log "  warn: rsync to current/ failed (non-fatal)"
+  # Guard: when the plugin already runs FROM current/, PLUGIN_ROOT == current_dir.
+  # rsync/cp of a directory onto itself is pointless and, with --delete under
+  # concurrent SessionStart hooks, storms the disk (fseventsd) and spikes load.
+  local root_real cur_real
+  root_real="$(cd "$PLUGIN_ROOT" 2>/dev/null && pwd -P || echo "$PLUGIN_ROOT")"
+  cur_real="$(cd "$current_dir" 2>/dev/null && pwd -P || echo "$current_dir")"
+  if [[ "$root_real" == "$cur_real" ]]; then
+    log "  skip: PLUGIN_ROOT already == current/ ($cur_real) — no self-rsync"
   else
-    mkdir -p "$current_dir"
-    cp -rp "$PLUGIN_ROOT/." "$current_dir/" 2>/dev/null \
-      && log "  ok: refreshed $current_dir via cp" \
-      || log "  warn: cp to current/ failed (non-fatal)"
+    # Single-flight lock so concurrent sessions can't stack rsyncs on current/.
+    local lock="$DATA_DIR/.refresh-current.lock"
+    [[ -d "$lock" ]] && [[ -n "$(find "$lock" -maxdepth 0 -mmin +2 2>/dev/null)" ]] \
+      && rmdir "$lock" 2>/dev/null || true   # clear stale lock from a killed run
+    if mkdir "$lock" 2>/dev/null; then
+      trap 'rmdir "'"$lock"'" 2>/dev/null || true' RETURN
+      if command -v rsync >/dev/null 2>&1; then
+        rsync -a --delete "$PLUGIN_ROOT/" "$current_dir/" 2>/dev/null \
+          && log "  ok: refreshed $current_dir via rsync" \
+          || log "  warn: rsync to current/ failed (non-fatal)"
+      else
+        mkdir -p "$current_dir"
+        cp -rp "$PLUGIN_ROOT/." "$current_dir/" 2>/dev/null \
+          && log "  ok: refreshed $current_dir via cp" \
+          || log "  warn: cp to current/ failed (non-fatal)"
+      fi
+    else
+      log "  skip: refresh-current lock held by another process"
+    fi
   fi
 
   if [[ -f "$installed_json" ]]; then
@@ -131,7 +150,12 @@ run_migrations() {
     cache_parent="$(dirname "$PLUGIN_ROOT")"
     current_dir="$cache_parent/current"
 
-    if command -v rsync >/dev/null 2>&1; then
+    local b_root_real b_cur_real
+    b_root_real="$(cd "$PLUGIN_ROOT" 2>/dev/null && pwd -P || echo "$PLUGIN_ROOT")"
+    b_cur_real="$(cd "$current_dir" 2>/dev/null && pwd -P || echo "$current_dir")"
+    if [[ "$b_root_real" == "$b_cur_real" ]]; then
+      log "  skip: PLUGIN_ROOT already == current/ ($b_cur_real) — no self-rsync"
+    elif command -v rsync >/dev/null 2>&1; then
       rsync -a --delete "$PLUGIN_ROOT/" "$current_dir/" 2>/dev/null \
         && log "  ok: refreshed $current_dir via rsync" \
         || log "  warn: rsync to current/ failed (non-fatal)"


### PR DESCRIPTION
## Problem

Host load spiked to **130+** on a 16-core Mac. Root cause traced to a **self-referential rsync storm** from this plugin's `bin/ops-post-update-migrate`.

`refresh_current_directory()` runs **unconditionally on every SessionStart** (line 68, before the sentinel check). It computes `current_dir = dirname(PLUGIN_ROOT)/current`. But the SessionStart hook invokes the script *from* `.../ops/current/`, so `PLUGIN_ROOT` **is** `current/` → the command becomes:

```
rsync -a --delete .../ops/current/  .../ops/current/    # SRC == DST
```

Copying a directory onto itself with `--delete`. With ~10 background Claude sessions each firing SessionStart (plus `ops-daemon-manager.sh ensure-current` also spawning it), the self-rsyncs **stack and never converge**. The 60s watchdog only wraps `run_migrations`, **not** `refresh_current_directory`, so each ran unbounded — observed **14–17 minutes alive** — hammering the disk and pinning `fseventsd` at ~55%, cascading into `secd`/`trustd`/`cloudd`.

Observed live: 8+ concurrent `rsync -a --delete .../current/ .../current/` pairs.

## Fix

- **Same-path guard:** skip the rsync/cp entirely when `realpath(PLUGIN_ROOT) == realpath(current_dir)` — the common case, where you already *are* `current/` and there is nothing to copy.
- **Single-flight lock:** `mkdir`-based lock so concurrent sessions can't stack refreshes, with a 2-minute stale-lock sweep for killed runs.
- Same guard applied to the duplicate rsync block inside `run_migrations` (#4).

## Verification

- `bash -n` clean.
- Running the script exactly as the SessionStart hook does (`CLAUDE_PLUGIN_ROOT=.../ops/current`) now logs `skip: PLUGIN_ROOT already == current/ — no self-rsync` and spawns **zero** rsyncs.
- Live host load recovered from 130+ → downtrend (1-min < 15-min) after killing the storm and hot-patching the cached copy; this PR lands the same fix in canonical so it survives plugin updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted guard and locking around an existing refresh path; behavior when plugin root differs from `current/` is unchanged aside from serialized refreshes.
> 
> **Overview**
> Fixes a **host load spike** caused by `refresh_current_directory()` running on every SessionStart while the hook’s `PLUGIN_ROOT` is already `.../ops/current/`, so `rsync -a --delete` copied that directory onto itself and stacked across many sessions.
> 
> **`refresh_current_directory()`** now compares canonical paths (`pwd -P`) and **skips** rsync/cp when source and destination are the same. When a real refresh is needed, a **`mkdir`-based single-flight lock** (with a 2-minute stale lock cleanup) ensures only one rsync runs at a time; other processes log and skip.
> 
> The duplicate **migration step #4** `current/` sync gets the **same-path skip** only (no lock in that block), so the common “already on `current/`” case no longer spawns rsync there either.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8b8623c29df9fd50f7db1de2fa2cacf12e6247a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unnecessary refresh operations when the active plugin directory already matches the target directory.
  * Reduced duplicate refresh activity by avoiding overlapping update steps when multiple hooks run at the same time.
  * Kept existing update behavior intact, including fallback copy handling and post-refresh plugin metadata updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->