### PR TITLE
fix(hooks): remove unsupported PostToolUse suppress output

### DIFF
--- a/claude-ops/bin/ops-deploy-fix-build-trigger
+++ b/claude-ops/bin/ops-deploy-fix-build-trigger
@@ -49,7 +49,6 @@ if [ "$(config auto_rerun_transients true)" = "true" ] && is_transient "$last_li
   notify "Build transient" "Detected transient ($cmd) — recommend retry"
   cat <<JSON
 {
-  "suppressOutput": true,
   "hookSpecificOutput": {
     "hookEventName": "PostToolUse",
     "additionalContext": "[ops-deploy-fix] '${cmd:0:60}' failed with a transient signature (network/registry/runner blip). No fixer dispatched — retry the build."
@@ -85,7 +84,6 @@ case $dispatch_status in
   0)
     cat <<JSON
 {
-  "suppressOutput": true,
   "hookSpecificOutput": {
     "hookEventName": "PostToolUse",
     "additionalContext": "[ops-deploy-fix] Build failure detected in '${cmd:0:60}'. Haiku build-fixer dispatched (logs: $fix_log). Will open fix PR or report transient."


### PR DESCRIPTION
## Summary\n- remove top-level suppressOutput from ops deploy-fix PostToolUse hook responses\n- keep hookSpecificOutput additional context intact for actionable build-fix notices\n\n## Verification\n- npm run type-check\n- npm test\n- bash -n claude-ops/bin/ops-deploy-fix-build-trigger\n- git diff --cached --check before commit\n\nNote: full npm run lint is currently blocked by pre-existing dirty formatting in claude-ops/scripts/account-rotation/crs-pool-config.mjs, which this PR does not touch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Hook JSON shape tweak only; no change to failure detection, dedup, dispatch, or notifications.
> 
> **Overview**
> Removes the top-level `"suppressOutput": true` from both PostToolUse JSON payloads in `ops-deploy-fix-build-trigger` (transient-failure guidance and successful build-fixer dispatch). **`hookSpecificOutput.additionalContext`** messages are unchanged, so users still get the same `[ops-deploy-fix]` notices instead of having hook output incorrectly suppressed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36fc79e48bbf354f52ff63f3257dda07a9234ae4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment hook feedback by ensuring relevant build-trigger responses are displayed instead of being suppressed.
  * Preserved existing safeguards, duplicate prevention, automatic dispatch behavior, and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->