### PR TITLE
fix: PostToolUse hook output schema

### DIFF
--- a/claude-ops/bin/ops-deploy-fix-build-trigger
+++ b/claude-ops/bin/ops-deploy-fix-build-trigger
@@ -49,7 +49,6 @@ if [ "$(config auto_rerun_transients true)" = "true" ] && is_transient "$last_li
   notify "Build transient" "Detected transient ($cmd) — recommend retry"
   cat <<JSON
 {
-  "suppressOutput": true,
   "hookSpecificOutput": {
     "hookEventName": "PostToolUse",
     "additionalContext": "[ops-deploy-fix] '${cmd:0:60}' failed with a transient signature (network/registry/runner blip). No fixer dispatched — retry the build."
@@ -85,7 +84,6 @@ case $dispatch_status in
   0)
     cat <<JSON
 {
-  "suppressOutput": true,
   "hookSpecificOutput": {
     "hookEventName": "PostToolUse",
     "additionalContext": "[ops-deploy-fix] Build failure detected in '${cmd:0:60}'. Haiku build-fixer dispatched (logs: $fix_log). Will open fix PR or report transient."


### PR DESCRIPTION
Opened as part of fleet PR sweep (branch was ahead of main with no PR). Auto-driving to green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-line JSON schema tweak in a PostToolUse hook; no change to failure detection, dispatch, or security paths.
> 
> **Overview**
> **PostToolUse hook output** for the npm build failure trigger no longer sets `"suppressOutput": true` on the JSON emitted when a failure is classified as **transient** or when a **Haiku build-fixer** is successfully dispatched.
> 
> Those paths still return `hookSpecificOutput` with `additionalContext` explaining retry vs. fixer dispatch; only the suppression flag is dropped so the hook message follows the intended **PostToolUse output schema** and can surface to the session normally. Dispatch, dedup, and notify behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36fc79e48bbf354f52ff63f3257dda07a9234ae4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment status output by ensuring transient build failures and successful fixer dispatches are displayed normally.
  * Existing deployment and deduplication behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->