### PR TITLE
crs: Phase 1b - inference=false hard-fail triggers heal in crs-health-watch

### DIFF
--- a/claude-ops/scripts/account-rotation/crs-health-watch.mjs
+++ b/claude-ops/scripts/account-rotation/crs-health-watch.mjs
@@ -30,6 +30,7 @@ import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { homedir } from 'os';
 import { applyRouteToSettings, readRouteState, setRouteMode } from './route-state.mjs';
+import { healCrsRelay } from './crs-heal-relay.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const args = new Set(process.argv.slice(2));
@@ -63,7 +64,8 @@ const CRS_BASE = process.env.CRS_BASE_URL || ROUTE_CRS.baseUrl || 'http://127.0.
 const HEALTH_URL = process.env.CRS_HEALTH_URL || ROUTE_CRS.healthUrl || CRS_BASE.replace(/\/api\/?$/, '/health');
 const CRS_SMOKE_URL = process.env.CRS_SMOKE_URL || `${CRS_BASE}/v1/messages?beta=true`;
 const CRS_SMOKE_MODEL = process.env.CRS_SMOKE_MODEL || 'claude-sonnet-4-6';
-const CRS_ENABLE_INFERENCE_SMOKE = process.env.CRS_ENABLE_INFERENCE_SMOKE === '1';
+// Phase 1b: default ON (was opt-in ==='1' which caused silent-healthy when inference=false).
+const CRS_ENABLE_INFERENCE_SMOKE = process.env.CRS_ENABLE_INFERENCE_SMOKE !== '0';
 const DOWN_STRIKES = +(process.env.CRS_DOWN_STRIKES || 3); // ~3 min at 60s tick
 const UP_STRIKES = +(process.env.CRS_UP_STRIKES || 1);
 // OS-wedge auto-reboot threshold. Must be >= DOWN_STRIKES so we only reboot AFTER
@@ -341,7 +343,11 @@ function main() {
 
   const healthOk = probe();
   const inferenceOk = CRS_ENABLE_INFERENCE_SMOKE && healthOk ? probeInference() : false;
-  const healthy = healthOk;
+  // Phase 1b: inference=false is hard-fail (triggers heal + affects route fallback) instead of silent healthy.
+  if (CRS_ENABLE_INFERENCE_SMOKE && healthOk && !inferenceOk) {
+    healCrsRelay('inference-false');
+  }
+  const healthy = healthOk && (!CRS_ENABLE_INFERENCE_SMOKE || inferenceOk);
   const st = loadState();
   if (healthy) {
     st.up += 1;

--- a/claude-ops/scripts/account-rotation/crs-health-watch.mjs
+++ b/claude-ops/scripts/account-rotation/crs-health-watch.mjs
@@ -347,9 +347,9 @@ function main() {
   }
 
   const healthOk = probe();
-  const inferenceOk = CRS_ENABLE_INFERENCE_SMOKE && healthOk ? probeInference() : false;
+  const inferenceOk = CRS_ENABLE_INFERENCE_SMOKE ? probeInference() : false;
   // Phase 1b: inference=false is hard-fail (triggers heal + affects route fallback) instead of silent healthy.
-  if (CRS_ENABLE_INFERENCE_SMOKE && healthOk && !inferenceOk) {
+  if (CRS_ENABLE_INFERENCE_SMOKE && !inferenceOk) {
     healCrsRelay('inference-false');
   }
   const healthy = healthOk && (!CRS_ENABLE_INFERENCE_SMOKE || inferenceOk);

--- a/claude-ops/scripts/account-rotation/crs-health-watch.mjs
+++ b/claude-ops/scripts/account-rotation/crs-health-watch.mjs
@@ -100,6 +100,11 @@ function probe() {
       encoding: 'utf8',
       timeout: 5000,
     }).trim();
+    // Phase 1b: also fail probe on CRS-reported inference.capable:false or degraded (in addition to smoke)
+    let body = '';
+    try { body = execFileSync('curl', ['-sS', '--max-time', '2', HEALTH_URL], { encoding: 'utf8', timeout: 3000 }).trim(); } catch {}
+    if (body && /"inference"\s*:\s*\{[^}]*"capable"\s*:\s*false/i.test(body)) return false;
+    if (body && /"status"\s*:\s*"(degraded|unhealthy)"/i.test(body)) return false;
     return code === '200';
   } catch {
     return false;

--- a/claude-ops/scripts/account-rotation/crs-health-watch.mjs
+++ b/claude-ops/scripts/account-rotation/crs-health-watch.mjs
@@ -100,10 +100,9 @@ function probe() {
       encoding: 'utf8',
       timeout: 5000,
     }).trim();
-    // Phase 1b: also fail probe on CRS-reported inference.capable:false or degraded (in addition to smoke)
+    // Phase 1b: also fail probe on CRS-reported degraded (inference smoke is the separate hard check for "inference=false")
     let body = '';
     try { body = execFileSync('curl', ['-sS', '--max-time', '2', HEALTH_URL], { encoding: 'utf8', timeout: 3000 }).trim(); } catch {}
-    if (body && /"inference"\s*:\s*\{[^}]*"capable"\s*:\s*false/i.test(body)) return false;
     if (body && /"status"\s*:\s*"(degraded|unhealthy)"/i.test(body)) return false;
     return code === '200';
   } catch {


### PR DESCRIPTION
Treat inference=false as hard-fail that triggers healCrsRelay (instead of silent healthy when /health returns 200).

Surgical changes to crs-health-watch.mjs (source + live):
* default enable inference smoke
* healthy = healthOk && inferenceOk
* explicitly healCrsRelay on inference failure
* updated comments for Phase 1b

Also: verified+recovered local relay path on :3005 (haproxy primary to local OrbStack CRS @18091 healthy).

Test: node --check passed, --status, curl probes, haproxy stat.

Ready for admin-merge after green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global routing fail-closed behavior in `settings.json` when inference fails even if `/health` is 200; affects every new/respawned session fleet-wide.
> 
> **Overview**
> **Phase 1b** tightens fleet CRS health so a “green” `/health` can’t mask a broken relay.
> 
> Inference smoke is **on by default** (`CRS_ENABLE_INFERENCE_SMOKE` only disables when set to `0`). Each tick runs the smoke independently of HTTP 200, treats failed inference as **unhealthy** (`healthy = healthOk && inferenceOk`), and calls **`healCrsRelay('inference-false')`** when smoke fails.
> 
> The HTTP health probe also **fails closed** when the health JSON reports `degraded` or `unhealthy`, not only on non-200 status codes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83d04dfbe63f534cde224ab4ceaeadafa285d84a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inference smoke checks are now enabled by default for CRS health monitoring.
  * Failed inference checks now trigger an explicit recovery attempt and mark the system unhealthy.

* **Bug Fixes**
  * Improved fail-closed behavior when CRS health appears normal but inference validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->