### PR TITLE
chore(ci): concurrency cancel-in-progress + merge gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches: [dev]
 
+
+concurrency:
+  # Auto-cancel superseded runs for same workflow+ref/PR (Sam 2026-07-14)
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   lint-and-check:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,11 @@ on:
   pull_request_review:
     types: [submitted]
 
+
+concurrency:
+  # Auto-cancel superseded runs for same workflow+ref/PR (Sam 2026-07-14)
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 jobs:
   claude:
     if: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - "v*"
 
+
+concurrency:
+  # Auto-cancel superseded runs for same workflow+ref/PR (Sam 2026-07-14)
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: write
   pull-requests: write

--- a/claude-ops/scripts/account-rotation/crs-health-watch.mjs
+++ b/claude-ops/scripts/account-rotation/crs-health-watch.mjs
@@ -102,7 +102,9 @@ function probe() {
     }).trim();
     // Phase 1b: also fail probe on CRS-reported degraded (inference smoke is the separate hard check for "inference=false")
     let body = '';
-    try { body = execFileSync('curl', ['-sS', '--max-time', '2', HEALTH_URL], { encoding: 'utf8', timeout: 3000 }).trim(); } catch {}
+    try {
+      body = execFileSync('curl', ['-sS', '--max-time', '2', HEALTH_URL], { encoding: 'utf8', timeout: 3000 }).trim();
+    } catch {}
     if (body && /"status"\s*:\s*"(degraded|unhealthy)"/i.test(body)) return false;
     return code === '200';
   } catch {

--- a/docs/MERGE_GATES.md
+++ b/docs/MERGE_GATES.md
@@ -1,0 +1,39 @@
+# Merge gates
+
+**Agents:** admin-merge when the **required** status context is green. Do not wait for optional bots or long smokes unless they are named as required.
+
+## Required
+
+| Typical required context | Notes |
+|--------------------------|--------|
+| **`CI Summary`** (if present) | Only required context on many Healify `dev` branches |
+| Else: branch-protection required checks | `gh api repos/.../branches/<branch>/protection` |
+
+When required green + no conflicts:
+
+```bash
+gh pr merge <N> --admin --squash --delete-branch
+```
+
+Do **not** ask Sam for merge approval.
+
+## Not required
+
+- Names containing **NOT required for merge**
+- Seer · CodeRabbit · Cursor · Vercel Agent · Graphite mergeability
+- Device Farm / long simulator smokes (unless explicitly required)
+- Vercel “Canceled by Ignored Build Step”
+
+## Concurrency
+
+Every workflow must cancel superseded runs:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+```
+
+## Doctrine
+
+`~/.claude/memory/admin-merge-ci-gates.md`


### PR DESCRIPTION
## Summary
- Add/force `concurrency.cancel-in-progress: true` so new commits cancel old runs of the same workflow.
- Document merge gates (`MERGE_GATES.md`): wait for **CI Summary** / required checks only; ignore optional bots/smokes.
- Tag optional smoke-style workflows as **NOT required for merge** where applicable.

## Agent rule
Admin-merge when required check is green. Do not poll device-farm/bots as merge gates.
Doctrine: `~/.claude/memory/admin-merge-ci-gates.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are workflow concurrency, documentation, and cosmetic formatting with no runtime product or security logic changes.
> 
> **Overview**
> Adds **GitHub Actions concurrency** with `cancel-in-progress: true` to **`ci.yml`**, **`claude.yml`**, and **`release.yml`**, keyed by workflow plus PR number or ref so newer pushes cancel stale runs of the same workflow.
> 
> Introduces **`docs/MERGE_GATES.md`** documenting agent merge policy: admin-merge when required checks (e.g. **CI Summary** or branch-protection contexts) are green, ignore optional bots/smokes/Vercel cancels, and require the concurrency pattern on every workflow.
> 
> Includes a **format-only** change in **`crs-health-watch.mjs`** (multi-line `try`/`catch` around the health body fetch); behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 603052cf7f4dd9d3919f45b707431ee5cf24fe23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for admin-merge behavior, including how required CI/status contexts are selected, notable exceptions, and the relevant merge command.
  - Documented workflow concurrency behavior to avoid stale merge-gate evaluations.

- **Chores**
  - Updated CI, release, and related workflows to automatically cancel in-progress runs for the same workflow and PR/ref when newer updates arrive.
  - Minor robustness/readability improvement to health probing logic (no user-facing behavior change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->