### PR TITLE
fix(ops-inbox): Paperclip SSOT scan + mandatory WA archive API

### DIFF
--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -564,6 +564,16 @@ All channel credentials come from env vars or CLI auth — no hardcoded secrets.
 
 **The success metric of `/ops:ops-inbox` is an EMPTY inbox on EVERY channel — not "surfaced the NEEDS_REPLY".** Every conversation that no longer needs the user's eyes, action, or reaction MUST be archived in the same run. This is mandatory, not a nicety:
 
+> **Paperclip SSOT + WA archive API (Sam 2026-07-19 — hard):**
+> 1. **When Paperclip is on the box**, before KEEP-classifying or drafting money/legal/hire/product: scan open issues + pending `issue_thread_interactions` for that counterparty/thread id (examples: Betaalronde → AUR-880; Centurion → AUR-696 / AUR-1004; Ian comp → AUR-920; Brittany YT → SFB-172). Prefer the board gate + staged draft over a new Telegram `AskUserQuestion` when the same decision is already wired. Never re-ask a locked Q or contradict answered options.
+> 2. **WhatsApp archive is mandatory every pass** — not “demote only.” After classify, call the bridge archive endpoint on **every non-actionable chat and every chat you just replied to** (phone `@s.whatsapp.net` **and** every `@lid` / `alt_jids`):
+>    ```bash
+>    curl -s -X POST http://127.0.0.1:8080/api/archive \
+>      -H 'Content-Type: application/json' \
+>      -d '{"chat_jid":"<jid>","archive":true}'
+>    ```
+>    MCP equivalent: `mcp__whatsapp__archive_chat {chat_jid, archive: true}`. Report archived count. Leave only true NEEDS_REPLY / creative-hold / crisis-surface chats unarchived. Demote-without-archive is a defect (phone inbox still noisy).
+
 > **🚫 HARD GUARDRAIL — NEVER ARCHIVE A TODO/ACTION-LABELED EMAIL UNTIL VERIFIED DONE (overrides every archive rule below).**
 > An email carrying ANY of the user's todo/action labels is an open task the user is tracking — it MUST stay in the inbox until the task is verified complete, regardless of how it looks to the classifier (even if the subject reads like spam, a newsletter, or an automated notification, and even if it lands in WAITING/FYI). Treat the label as the user's explicit intent and obey it over your own classification.
 > - **Protected labels** (case-insensitive, match by name): `To Respond`, `Respond`, `Reply`, `Reply Later`, `Action`, `Needs Action`, `Follow up`, `Awaiting Reply`, `To-do` / `Todo`, `Tasklet`, `Timed Actions`, and any label whose name contains `to-do`/`todo`/`task`/`action`/`respond`/`follow up`/`reply later`/`needs action`/`awaiting reply` — **except** completion labels like `Actioned` or any name containing `actioned` (those signal verified done, not open todos). (Skip Gmail system labels `INBOX/SENT/DRAFT/UNREAD/IMPORTANT/STARRED/CATEGORY_*` — those are not todo markers.)


### PR DESCRIPTION
## Summary
- Require Paperclip issue + `issue_thread_interactions` scan when Paperclip is present before money/legal KEEP drafts
- Prefer board gates over duplicate Telegram clarifies when already wired (e.g. AUR-880 Betaalronde, AUR-1004 Centurion)
- Make WhatsApp bridge `POST /api/archive` mandatory for every non-actionable / just-replied chat (phone + @lid), not demote-only

## Test plan
- [x] Skill-only change on clean branch from origin/main
- [ ] After merge: ops-release patch + ops-update on box

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an agent skill; no runtime code paths. Operational impact depends on agents following the new procedures after ops-release on the box.
> 
> **Overview**
> Extends **`ops-inbox`** under **INBOX ZERO** with a new **Paperclip SSOT + WA archive** block (Sam 2026-07-19).
> 
> **Paperclip:** When Paperclip is on the host, agents must scan open issues and pending `issue_thread_interactions` for the counterparty/thread **before** KEEP-classifying or drafting sensitive threads (money/legal/hire/product). Use existing board gates and staged drafts instead of duplicate Telegram clarifications; do not re-ask locked questions or contradict answered options (examples cite AUR-880, AUR-696, etc.).
> 
> **WhatsApp:** Archive is **required every pass**, not demote-only. After classification, call `POST /api/archive` (or `mcp__whatsapp__archive_chat`) on every non-actionable chat and every just-replied chat, including phone JIDs and all `@lid` / `alt_jids`; report archived count and treat demote-without-archive as a defect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a07c3d0bddd3827bccf96e6aee94789e3494eb50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to consult Paperclip records before classifying or responding to sensitive business conversations.
  * Made WhatsApp archiving mandatory for non-actionable chats and conversations that have received a reply.
  * Added instructions for archiving related phone and alternate chat identifiers, including required reporting of archive counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->