### PR TITLE
fix(competitor-intel): claude CLI has no --system flag — use --system-prompt

### DIFF
--- a/claude-ops/scripts/ops-cron-competitor-intel.sh
+++ b/claude-ops/scripts/ops-cron-competitor-intel.sh
@@ -310,7 +310,7 @@ Output format (STRICT):
 EOF
 
   SYNTHESIS=$(claude_invoke --model claude-sonnet-4-6 --no-session-persistence \
-    --system "$SYSTEM_PROMPT" -p < "$PROMPT_FILE" 2>>"$LOG" || echo "")
+    --system-prompt "$SYSTEM_PROMPT" -p < "$PROMPT_FILE" 2>>"$LOG" || echo "")
   rm -f "$PROMPT_FILE"
 else
   log "WARN: claude-invoke.sh not found at $PLUGIN_ROOT — using Tavily-only fallback"


### PR DESCRIPTION
Stage 5 (LLM synthesis) of `ops-cron-competitor-intel.sh` invokes `claude_invoke --system "$SYSTEM_PROMPT"`, but the claude CLI has no `--system` option — it exits instantly with `error: unknown option '--system'` (visible in the cron log, swallowed from the pipeline). As a result competitor extraction always returns empty, state persists 0 competitors, and the weekly report falls back to raw Tavily dumps.

One-line fix: use `--system-prompt`, which is the supported flag.

Verified on a live run: synthesis now completes and the competitor list is extracted and persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)