### PR TITLE
feat(windsor): reusable data-sanity check for silent all-zero data after plan expiry

### DIFF
--- a/claude-ops/scripts/windsor-data-sanity.sh
+++ b/claude-ops/scripts/windsor-data-sanity.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# windsor-data-sanity.sh — detect the Windsor.ai "all-zero" pattern (expired plan / blocked reads).
+#
+# When a Windsor.ai subscription lapses (`get_current_user` → `is_paid: false`),
+# reads keep "working" but silently return only zeros / empty rows. Dashboards and
+# blended-ROAS math then report zeros as if they were real data. This script sums
+# a set of numeric fields from a Windsor JSON payload (REST response or cache
+# file) and warns when they are ALL exactly zero.
+#
+# Usage:
+#   windsor-data-sanity.sh [FILE] [PATHS]
+#
+#   FILE   JSON file to inspect (a Windsor cache or REST response).
+#          Use "-" or omit to read from stdin.
+#   PATHS  Comma-separated jq paths to sum. Default recursively sums every
+#          `spend`, `impressions`, and `reach` field, which covers the
+#          facebook (Meta) + google_ads spend/impressions and instagram reach
+#          signals used for expired-plan detection.
+#
+# Output / exit codes:
+#   ok                                              exit 0  (real signal present)
+#   warn: windsor all-zero pattern (plan expired?)  exit 1  (all-zero or empty)
+#   error: ...                                      exit 2  (bad input / usage)
+#
+# Examples:
+#   windsor-data-sanity.sh ~/.claude/cache/windsor-30d.json
+#   curl -s "$WINDSOR_URL" | windsor-data-sanity.sh
+#   windsor-data-sanity.sh cache.json '.data[].spend,.data[].impressions'
+#
+# See docs/integrations/windsor-ai.md → "Data sanity / expired-plan detection".
+set -euo pipefail
+
+FILE="${1:--}"
+PATHS="${2:-..|.spend?,..|.impressions?,..|.reach?}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required" >&2
+  exit 2
+fi
+
+if [ "$FILE" != "-" ] && [ ! -r "$FILE" ]; then
+  echo "error: cannot read file: $FILE" >&2
+  exit 2
+fi
+
+# Build a jq filter that collects every value at every requested path, coerces
+# numeric strings, ignores non-numbers, and sums the result.
+FILTER="["
+first=1
+old_ifs="$IFS"
+IFS=','
+for p in $PATHS; do
+  # Trim surrounding whitespace.
+  p="${p#"${p%%[![:space:]]*}"}"
+  p="${p%"${p##*[![:space:]]}"}"
+  [ -n "$p" ] || continue
+  if [ "$first" -eq 1 ]; then
+    first=0
+  else
+    FILTER="$FILTER,"
+  fi
+  FILTER="${FILTER}[${p}]"
+done
+IFS="$old_ifs"
+FILTER="$FILTER] | flatten
+  | map(if type == \"string\" then (tonumber? // 0)
+        elif type == \"number\" then .
+        else 0 end)
+  | add // 0"
+
+if [ "$first" -eq 1 ]; then
+  echo "error: no jq paths given" >&2
+  exit 2
+fi
+
+if [ "$FILE" = "-" ]; then
+  total="$(jq "$FILTER" 2>/dev/null)" || { echo "error: invalid JSON on stdin" >&2; exit 2; }
+else
+  total="$(jq "$FILTER" "$FILE" 2>/dev/null)" || { echo "error: invalid JSON in $FILE" >&2; exit 2; }
+fi
+
+# Non-zero (positive or negative) anywhere → real signal.
+if awk -v t="$total" 'BEGIN { exit (t + 0 != 0 ? 0 : 1) }'; then
+  echo "ok"
+  exit 0
+fi
+
+echo "warn: windsor all-zero pattern (plan expired?)"
+exit 1

--- a/claude-ops/skills/ops-dash/SKILL.md
+++ b/claude-ops/skills/ops-dash/SKILL.md
@@ -415,3 +415,7 @@ Map accounts per project via `registry.json` → `.projects[].windsor`. Prefer *
 ROAS** (store/analytics revenue ÷ total ad spend) over platform-reported ROAS. See
 [docs/integrations/windsor-ai.md](../../../docs/integrations/windsor-ai.md) for the full playbook (REST + MCP modes,
 registry mapping, analysis mandate, and caveats).
+Data sanity: if Windsor returns only zeros across sources (Meta + Google spend/impressions and
+Instagram reach all exactly 0 over 30d while accounts are connected), treat the data as unavailable —
+the plan may be expired (check `get_current_user` → `is_paid`) — warn the user, and never present
+zeros as real metrics. `scripts/windsor-data-sanity.sh` automates the check.

--- a/claude-ops/skills/ops-ecom/SKILL.md
+++ b/claude-ops/skills/ops-ecom/SKILL.md
@@ -611,3 +611,7 @@ Map accounts per project via `registry.json` → `.projects[].windsor`. Prefer *
 ROAS** (store/analytics revenue ÷ total ad spend) over platform-reported ROAS. See
 [docs/integrations/windsor-ai.md](../../../docs/integrations/windsor-ai.md) for the full playbook (REST + MCP modes,
 registry mapping, analysis mandate, and caveats).
+Data sanity: if Windsor returns only zeros across sources (Meta + Google spend/impressions and
+Instagram reach all exactly 0 over 30d while accounts are connected), treat the data as unavailable —
+the plan may be expired (check `get_current_user` → `is_paid`) — warn the user, and never present
+zeros as real metrics. `scripts/windsor-data-sanity.sh` automates the check.

--- a/claude-ops/skills/ops-marketing/SKILL.md
+++ b/claude-ops/skills/ops-marketing/SKILL.md
@@ -2811,3 +2811,7 @@ Map accounts per project via `registry.json` → `.projects[].windsor`. Prefer *
 ROAS** (store/analytics revenue ÷ total ad spend) over platform-reported ROAS. See
 [docs/integrations/windsor-ai.md](../../../docs/integrations/windsor-ai.md) for the full playbook (REST + MCP modes,
 registry mapping, analysis mandate, and caveats).
+Data sanity: if Windsor returns only zeros across sources (Meta + Google spend/impressions and
+Instagram reach all exactly 0 over 30d while accounts are connected), treat the data as unavailable —
+the plan may be expired (check `get_current_user` → `is_paid`) — warn the user, and never present
+zeros as real metrics. `scripts/windsor-data-sanity.sh` automates the check.

--- a/claude-ops/skills/ops-socials/SKILL.md
+++ b/claude-ops/skills/ops-socials/SKILL.md
@@ -298,3 +298,7 @@ Map accounts per project via `registry.json` → `.projects[].windsor`. Prefer *
 ROAS** (store/analytics revenue ÷ total ad spend) over platform-reported ROAS. See
 [docs/integrations/windsor-ai.md](../../../docs/integrations/windsor-ai.md) for the full playbook (REST + MCP modes,
 registry mapping, analysis mandate, and caveats).
+Data sanity: if Windsor returns only zeros across sources (Meta + Google spend/impressions and
+Instagram reach all exactly 0 over 30d while accounts are connected), treat the data as unavailable —
+the plan may be expired (check `get_current_user` → `is_paid`) — warn the user, and never present
+zeros as real metrics. `scripts/windsor-data-sanity.sh` automates the check.

--- a/claude-ops/tests/fixtures/windsor-all-zero.json
+++ b/claude-ops/tests/fixtures/windsor-all-zero.json
@@ -1,0 +1,10 @@
+{
+  "data": [
+    { "source": "facebook", "account_id": "act_000000000000000", "date": "2026-06-19", "spend": 0, "impressions": 0 },
+    { "source": "facebook", "account_id": "act_000000000000000", "date": "2026-07-18", "spend": 0, "impressions": 0 },
+    { "source": "google_ads", "account_id": "000-000-0000", "date": "2026-06-19", "spend": 0, "impressions": 0 },
+    { "source": "google_ads", "account_id": "000-000-0000", "date": "2026-07-18", "spend": 0, "impressions": 0 },
+    { "source": "instagram", "account_id": "17800000000000000", "date": "2026-06-19", "reach": 0 },
+    { "source": "instagram", "account_id": "17800000000000000", "date": "2026-07-18", "reach": 0 }
+  ]
+}

--- a/claude-ops/tests/fixtures/windsor-healthy.json
+++ b/claude-ops/tests/fixtures/windsor-healthy.json
@@ -1,0 +1,10 @@
+{
+  "data": [
+    { "source": "facebook", "account_id": "act_000000000000000", "date": "2026-06-19", "spend": "12.34", "impressions": 4521 },
+    { "source": "facebook", "account_id": "act_000000000000000", "date": "2026-07-18", "spend": 8.9, "impressions": 3877 },
+    { "source": "google_ads", "account_id": "000-000-0000", "date": "2026-06-19", "spend": 0, "impressions": 0 },
+    { "source": "google_ads", "account_id": "000-000-0000", "date": "2026-07-18", "spend": 5.5, "impressions": 1204 },
+    { "source": "instagram", "account_id": "17800000000000000", "date": "2026-06-19", "reach": 980 },
+    { "source": "instagram", "account_id": "17800000000000000", "date": "2026-07-18", "reach": 1103 }
+  ]
+}

--- a/claude-ops/tests/test-windsor-data-sanity.sh
+++ b/claude-ops/tests/test-windsor-data-sanity.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# test-windsor-data-sanity.sh — smoke tests for scripts/windsor-data-sanity.sh
+#
+# Hermetic: runs entirely against local fixtures, no network.
+# Asserts:
+#   - all-zero fixture → "warn: windsor all-zero pattern (plan expired?)" + exit 1
+#   - healthy fixture (incl. string-typed spend) → "ok" + exit 0
+#   - stdin mode works
+#   - custom jq paths work
+#   - invalid JSON → exit 2
+set -uo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPT="$PLUGIN_ROOT/scripts/windsor-data-sanity.sh"
+FIXTURES="$PLUGIN_ROOT/tests/fixtures"
+
+pass=0; fail=0
+ok()  { echo "  PASS: $1"; pass=$((pass+1)); }
+err() { echo "  FAIL: $1 — $2"; fail=$((fail+1)); }
+
+echo "Testing $SCRIPT"
+echo ""
+
+if [ -x "$SCRIPT" ]; then
+  ok "script exists and is executable"
+else
+  err "script missing or not executable" "$SCRIPT"
+fi
+
+# 1) all-zero fixture → warn + exit 1
+out="$(bash "$SCRIPT" "$FIXTURES/windsor-all-zero.json")"; rc=$?
+if [ "$rc" -eq 1 ] && [ "$out" = "warn: windsor all-zero pattern (plan expired?)" ]; then
+  ok "all-zero fixture warns with exit 1"
+else
+  err "all-zero fixture" "rc=$rc out=$out"
+fi
+
+# 2) healthy fixture → ok + exit 0
+out="$(bash "$SCRIPT" "$FIXTURES/windsor-healthy.json")"; rc=$?
+if [ "$rc" -eq 0 ] && [ "$out" = "ok" ]; then
+  ok "healthy fixture passes with exit 0"
+else
+  err "healthy fixture" "rc=$rc out=$out"
+fi
+
+# 3) stdin mode
+out="$(bash "$SCRIPT" < "$FIXTURES/windsor-healthy.json")"; rc=$?
+if [ "$rc" -eq 0 ] && [ "$out" = "ok" ]; then
+  ok "stdin mode works"
+else
+  err "stdin mode" "rc=$rc out=$out"
+fi
+
+# 4) custom jq paths
+out="$(bash "$SCRIPT" "$FIXTURES/windsor-all-zero.json" '.data[].spend,.data[].impressions')"; rc=$?
+if [ "$rc" -eq 1 ]; then
+  ok "custom jq paths detect all-zero"
+else
+  err "custom jq paths" "rc=$rc out=$out"
+fi
+
+out="$(bash "$SCRIPT" "$FIXTURES/windsor-healthy.json" '.data[].spend')"; rc=$?
+if [ "$rc" -eq 0 ] && [ "$out" = "ok" ]; then
+  ok "custom jq paths pass on healthy data"
+else
+  err "custom jq paths healthy" "rc=$rc out=$out"
+fi
+
+# 5) invalid JSON → exit 2
+out="$(printf 'not json' | bash "$SCRIPT" 2>/dev/null)"; rc=$?
+if [ "$rc" -eq 2 ]; then
+  ok "invalid JSON exits 2"
+else
+  err "invalid JSON" "rc=$rc out=$out"
+fi
+
+echo ""
+echo "windsor-data-sanity: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/docs/integrations/windsor-ai.md
+++ b/docs/integrations/windsor-ai.md
@@ -107,6 +107,45 @@ dump:
 - **Trial plan limits.** Free/trial Windsor plans cap the number of data sources;
   adding a new connector may require freeing a slot or upgrading.
 
+## Data sanity / expired-plan detection
+
+**When a Windsor.ai subscription lapses, reads do not fail — they silently
+return only zeros / empty rows.** Every downstream consumer (dashboards,
+blended-ROAS math, AI insight layers, cron caches) then reports zeros as if
+they were real data, potentially for weeks, with no error anywhere.
+
+Detection pattern that works in practice:
+
+- If **spend + impressions for `facebook` (Meta) AND `google_ads`, and
+  `instagram` reach, are ALL exactly 0 over a 30-day window** while the
+  accounts are connected, it is almost certainly an expired plan or blocked
+  reads — not a real quiet month.
+- Confirm via the Windsor MCP `get_current_user` where available: `is_paid:
+  false` (and `plan_name`) is the smoking gun. Offer `get_subscription_url`
+  so the user can renew.
+
+What to do on an all-zero result:
+
+1. **Warn the user explicitly** — e.g. *"Windsor returns all zeros — plan
+   likely expired, data unreliable"* — instead of reporting the zeros.
+2. **Never present the zeros as real metrics** in any dashboard, analysis, or
+   recommendation. Treat the source as unavailable and fall back to direct
+   platform APIs or cached last-known-good data, clearly labeled as such.
+3. Offer `get_subscription_url` (MCP) or the Windsor dashboard to restore the
+   plan, then re-verify with a fresh pull.
+
+The reusable check lives in
+[`claude-ops/scripts/windsor-data-sanity.sh`](../../claude-ops/scripts/windsor-data-sanity.sh):
+it reads a Windsor JSON payload (file or stdin), sums a configurable list of
+jq paths (default: every `spend`, `impressions`, and `reach` field), and
+prints `ok` (exit 0) or `warn: windsor all-zero pattern (plan expired?)`
+(exit 1). Wire it into any cron pull or cache refresh so stale-plan zeros are
+flagged before they reach a dashboard:
+
+```sh
+curl -s "$WINDSOR_URL" | claude-ops/scripts/windsor-data-sanity.sh || echo "flag cache as unreliable"
+```
+
 ## Adding the integration
 
 Run `/ops:integrate windsor.ai` (auth type `api-key`, base


### PR DESCRIPTION
## Problem

When a Windsor.ai subscription lapses (`get_current_user` → `is_paid: false`), reads do **not** fail — every connector keeps returning HTTP 200 with only zeros / empty rows. In a real incident (July 2026), dashboards, blended-ROAS calculations, and the AI-insights layer silently reported zeros as real metrics for weeks, with no error anywhere in the stack.

Detection pattern that works in practice: if spend + impressions for `facebook` (Meta) **and** `google_ads`, and `instagram` reach, are ALL exactly 0 over a 30-day window while the accounts are connected, it is almost certainly an expired plan or blocked reads — not a real quiet month. Confirmable via the Windsor MCP `get_current_user` (`is_paid` / `plan_name`).

## What this PR adds

- **`docs/integrations/windsor-ai.md`** (existing doc): new prominent "Data sanity / expired-plan detection" section — the detection pattern, confirmation via `get_current_user`, and the mandate: warn the user explicitly ("Windsor returns all zeros — plan likely expired, data unreliable") instead of reporting zeros, and offer `get_subscription_url`.
- **`claude-ops/scripts/windsor-data-sanity.sh`**: small reusable, shellcheck-clean bash check. Reads a Windsor JSON payload (file arg or stdin), sums a comma-separated list of jq paths (default recursively covers all `spend` / `impressions` / `reach` fields, i.e. the Meta + Google + Instagram signals), prints `ok` (exit 0) or `warn: windsor all-zero pattern (plan expired?)` (exit 1); exit 2 on bad input. Designed to be wired into cron pulls / cache refreshes so stale-plan zeros are flagged before they reach a dashboard.
- **Skill updates** (`ops-marketing`, `ops-dash`, `ops-ecom`, `ops-socials` SKILL.md): 3-line data-sanity note appended to each existing "Windsor.ai (optional live data)" section — treat all-zero Windsor data as unavailable, check `is_paid`, warn the user, never present zeros as real metrics.
- **Tests**: hermetic `claude-ops/tests/test-windsor-data-sanity.sh` + two fixtures (`windsor-all-zero.json`, `windsor-healthy.json` — the healthy one includes a string-typed `"spend"` to cover Windsor's mixed typing).

## How tested

- `bash claude-ops/tests/test-windsor-data-sanity.sh` → 7/7 PASS (all-zero fixture warns with exit 1; healthy fixture ok with exit 0; stdin mode; custom jq paths; invalid JSON exits 2).
- `shellcheck` clean on both new scripts.
- `bash claude-ops/tests/test-skills-lint.sh` → 480 passed, 0 failed (skill edits keep frontmatter/fence conventions intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)