### PR TITLE
feat(windsor): detect quota/plan-limit text rows in HTTP 200 responses

### DIFF
--- a/claude-ops/scripts/windsor-data-sanity.sh
+++ b/claude-ops/scripts/windsor-data-sanity.sh
@@ -17,10 +17,17 @@
 #          facebook (Meta) + google_ads spend/impressions and instagram reach
 #          signals used for expired-plan detection.
 #
+# Besides the all-zero sum, it also detects Windsor's quota/plan-limit text
+# pattern: when the plan is expired/over limit, the API can return HTTP 200
+# with a text row inside the data, e.g.
+#   {"data":[{"source":"Uh-oh! You've reached your plan limit... Upgrade here..."}]}
+# so `has("data")` checks "succeed" while the payload is garbage.
+#
 # Output / exit codes:
-#   ok                                              exit 0  (real signal present)
-#   warn: windsor all-zero pattern (plan expired?)  exit 1  (all-zero or empty)
-#   error: ...                                      exit 2  (bad input / usage)
+#   ok                                                             exit 0  (real signal present)
+#   warn: windsor quota/plan-limit message detected (plan expired?) exit 1  (quota text row)
+#   warn: windsor all-zero pattern (plan expired?)                 exit 1  (all-zero or empty)
+#   error: ...                                                     exit 2  (bad input / usage)
 #
 # Examples:
 #   windsor-data-sanity.sh ~/.claude/cache/windsor-30d.json
@@ -73,11 +80,31 @@ if [ "$first" -eq 1 ]; then
   exit 2
 fi
 
+# Buffer the input so we can run multiple jq passes (stdin is read once).
 if [ "$FILE" = "-" ]; then
-  total="$(jq "$FILTER" 2>/dev/null)" || { echo "error: invalid JSON on stdin" >&2; exit 2; }
+  INPUT="$(cat)"
+  SRC_DESC="on stdin"
 else
-  total="$(jq "$FILTER" "$FILE" 2>/dev/null)" || { echo "error: invalid JSON in $FILE" >&2; exit 2; }
+  INPUT="$(cat "$FILE")"
+  SRC_DESC="in $FILE"
 fi
+
+if ! printf '%s' "$INPUT" | jq -e . >/dev/null 2>&1; then
+  echo "error: invalid JSON $SRC_DESC" >&2
+  exit 2
+fi
+
+# Quota/plan-limit text pattern: an expired/over-limit plan can return HTTP 200
+# with a marketing text row inside the data instead of metrics. Case-insensitive
+# match on known phrases in any string value of the payload.
+QUOTA_FILTER='[.. | strings] | any(test("upgrade here|plan limit|free plan|uh-oh"; "i"))'
+if printf '%s' "$INPUT" | jq -e "$QUOTA_FILTER" >/dev/null 2>&1; then
+  echo "warn: windsor quota/plan-limit message detected (plan expired?)"
+  exit 1
+fi
+
+total="$(printf '%s' "$INPUT" | jq "$FILTER" 2>/dev/null)" \
+  || { echo "error: invalid JSON $SRC_DESC" >&2; exit 2; }
 
 # Non-zero (positive or negative) anywhere → real signal.
 if awk -v t="$total" 'BEGIN { exit (t + 0 != 0 ? 0 : 1) }'; then

--- a/claude-ops/tests/fixtures/windsor-quota-message.json
+++ b/claude-ops/tests/fixtures/windsor-quota-message.json
@@ -1,0 +1,12 @@
+{
+  "data": [
+    {
+      "source": "Uh-oh! You've reached your plan limit for this month. Upgrade here: https://windsor.ai/pricing to keep your data flowing. You are currently on the Free plan.",
+      "date": "2026-07-19",
+      "campaign": "",
+      "spend": "",
+      "impressions": "",
+      "reach": ""
+    }
+  ]
+}

--- a/claude-ops/tests/test-windsor-data-sanity.sh
+++ b/claude-ops/tests/test-windsor-data-sanity.sh
@@ -4,6 +4,7 @@
 # Hermetic: runs entirely against local fixtures, no network.
 # Asserts:
 #   - all-zero fixture → "warn: windsor all-zero pattern (plan expired?)" + exit 1
+#   - quota-message fixture → "warn: windsor quota/plan-limit message detected (plan expired?)" + exit 1
 #   - healthy fixture (incl. string-typed spend) → "ok" + exit 0
 #   - stdin mode works
 #   - custom jq paths work
@@ -41,6 +42,22 @@ if [ "$rc" -eq 0 ] && [ "$out" = "ok" ]; then
   ok "healthy fixture passes with exit 0"
 else
   err "healthy fixture" "rc=$rc out=$out"
+fi
+
+# 2b) quota/plan-limit message fixture → warn + exit 1
+out="$(bash "$SCRIPT" "$FIXTURES/windsor-quota-message.json")"; rc=$?
+if [ "$rc" -eq 1 ] && [ "$out" = "warn: windsor quota/plan-limit message detected (plan expired?)" ]; then
+  ok "quota-message fixture warns with exit 1"
+else
+  err "quota-message fixture" "rc=$rc out=$out"
+fi
+
+# 2c) healthy fixture still passes the quota text check → ok + exit 0
+out="$(bash "$SCRIPT" "$FIXTURES/windsor-healthy.json")"; rc=$?
+if [ "$rc" -eq 0 ] && [ "$out" = "ok" ]; then
+  ok "healthy fixture unaffected by quota text check"
+else
+  err "healthy fixture vs quota check" "rc=$rc out=$out"
 fi
 
 # 3) stdin mode

--- a/docs/integrations/windsor-ai.md
+++ b/docs/integrations/windsor-ai.md
@@ -124,6 +124,19 @@ Detection pattern that works in practice:
   false` (and `plan_name`) is the smoking gun. Offer `get_subscription_url`
   so the user can renew.
 
+There is a second failure mode: **an expired/over-limit plan can also return
+HTTP 200 with a marketing text row inside the data instead of metrics**, so a
+naive `has("data")` check "succeeds" while the payload is garbage. Example
+payload seen in production:
+
+```json
+{"data":[{"source":"Uh-oh! You've reached your plan limit... Upgrade here... Free plan..."}]}
+```
+
+The sanity script detects this with a case-insensitive match on "upgrade
+here", "plan limit", "free plan", or "uh-oh" in any string value and prints
+`warn: windsor quota/plan-limit message detected (plan expired?)` (exit 1).
+
 What to do on an all-zero result:
 
 1. **Warn the user explicitly** — e.g. *"Windsor returns all zeros — plan
@@ -138,9 +151,10 @@ The reusable check lives in
 [`claude-ops/scripts/windsor-data-sanity.sh`](../../claude-ops/scripts/windsor-data-sanity.sh):
 it reads a Windsor JSON payload (file or stdin), sums a configurable list of
 jq paths (default: every `spend`, `impressions`, and `reach` field), and
-prints `ok` (exit 0) or `warn: windsor all-zero pattern (plan expired?)`
-(exit 1). Wire it into any cron pull or cache refresh so stale-plan zeros are
-flagged before they reach a dashboard:
+prints `ok` (exit 0), `warn: windsor quota/plan-limit message detected (plan
+expired?)` (exit 1, text-row pattern), or `warn: windsor all-zero pattern
+(plan expired?)` (exit 1). Wire it into any cron pull or cache refresh so
+stale-plan garbage is flagged before it reaches a dashboard:
 
 ```sh
 curl -s "$WINDSOR_URL" | claude-ops/scripts/windsor-data-sanity.sh || echo "flag cache as unreliable"


### PR DESCRIPTION
Follow-up to #676 (merged earlier today while this amendment was being pushed).

## Production finding (Jul 19)

When the Windsor.ai plan is expired/over limit, the API can return **HTTP 200 with a marketing text row inside the data** instead of metrics:

```json
{"data":[{"source":"Uh-oh! You've reached your plan limit... Upgrade here... Free plan..."}]}
```

Any `has("data")` check "succeeds" while the payload is garbage. #676 only detected the all-zero pattern; this adds the second pattern.

## Changes

- `claude-ops/scripts/windsor-data-sanity.sh`: buffer input once, then run a case-insensitive text-pattern check ("upgrade here", "plan limit", "free plan", "uh-oh") over all string values before the all-zero sum. On match: `warn: windsor quota/plan-limit message detected (plan expired?)`, exit 1. Interface and existing outputs unchanged; shellcheck-clean.
- `claude-ops/tests/fixtures/windsor-quota-message.json`: realistic 200-response fixture with a quota text row.
- `claude-ops/tests/test-windsor-data-sanity.sh`: 2 new cases (quota fixture warns/exit 1; healthy fixture unaffected). 9/9 passing locally.
- `docs/integrations/windsor-ai.md`: documents the second pattern with example payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects quota and plan-limit messages in Windsor data, including responses that return successfully but contain non-metric content.
  * Supports validating input provided through standard input or files.

* **Bug Fixes**
  * Invalid JSON is now reported clearly with an appropriate failure status.
  * Improves handling of buffered input and numeric metric validation.

* **Documentation**
  * Added guidance and examples for identifying expired-plan and quota-limit responses.

* **Tests**
  * Added coverage for healthy, zero-value, quota-message, standard-input, custom-path, and invalid JSON scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->