### PR TITLE
release: v2.41.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 60 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.40.0",
+      "version": "2.41.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-2.40.0-blue)
+![Version](https://img.shields.io/badge/version-2.41.0-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-60-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.40.0",
+  "version": "2.41.0",
   "description": "Business operations command center for Claude Code — 60 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [2.41.0] - 2026-07-19
+
+### Added
+- Direct channel wiring: a free direct-API fallback for Windsor.ai, with a new organic-metrics aggregator that pulls marketing metrics straight from channel APIs when Windsor is unavailable or over quota
+- Marketing setup guide and integration docs covering direct channel wiring and when the fallback engages
+- Test coverage for the organic-metrics aggregator and Windsor quota-message handling
+
+### Changed
+- Windsor.ai data-sanity check now detects quota/plan-limit text rows returned inside HTTP 200 responses, so exhausted plans are flagged instead of treated as valid data
+- ops-dash, ops-ecom, ops-marketing, ops-socials, and ops-settings skills updated to surface the direct-channel fallback
+
+
 ## [2.40.0] - 2026-07-19
 
 ### Added

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-2.40.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.41.0-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 60 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-2.40.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.41.0-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-60-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.40.0",
+  "version": "2.41.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.41.0** (was 2.40.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

### Added
- Direct channel wiring: a free direct-API fallback for Windsor.ai, with a new organic-metrics aggregator that pulls marketing metrics straight from channel APIs when Windsor is unavailable or over quota
- Marketing setup guide and integration docs covering direct channel wiring and when the fallback engages
- Test coverage for the organic-metrics aggregator and Windsor quota-message handling

### Changed
- Windsor.ai data-sanity check now detects quota/plan-limit text rows returned inside HTTP 200 responses, so exhausted plans are flagged instead of treated as valid data
- ops-dash, ops-ecom, ops-marketing, ops-socials, and ops-settings skills updated to surface the direct-channel fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how marketing metrics are sourced and validated; mis-routing could show stale or partial data, but improves resilience when Windsor fails and avoids presenting quota errors as real metrics.
> 
> **Overview**
> **Release v2.41.0** bumps plugin and package versions from **2.40.0** to **2.41.0** across the marketplace registry, `plugin.json`, `package.json`, README/docs badges, and documents the release in **CHANGELOG**.
> 
> The release adds **direct channel wiring** as a free fallback when Windsor.ai is down or over quota: a new **organic-metrics aggregator** pulls marketing metrics from channel APIs (Graph, YouTube, Search Console, Merchant, etc.), with docs/tests and skill guidance on **ops-dash**, **ops-ecom**, **ops-marketing**, **ops-socials**, and **ops-settings** to use `ad-spend-aggregator`, `ga4-data-api`, and organic libs instead of treating dead Windsor data as real.
> 
> **Windsor data-sanity** is extended to flag **quota/plan-limit text rows** inside HTTP 200 responses (not only the all-zero pattern), so exhausted plans are surfaced before metrics are shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e1af725e8386262a973e6e406257e39e6aea82e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->