### PR TITLE
feat(ops-ecom,ops-marketing): agentic storefronts + Shop Campaigns health

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **ops-ecom:** `channels` | `agentic` | `shop` verbs — sales channel inventory, agentic storefront health, Shop Campaigns readiness (read-only; Rule 5 / stage-only spend).
+- **ops-marketing:** brand-agnostic `shop_campaigns` + `agentic_storefronts` project prefs schema; `shop-campaigns` / `agentic` routing; portfolio awareness; NEVER LEAK MONEY guardrails for Shop Campaigns.
+
 ## [2.41.0] - 2026-07-19
 
 ### Added

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -240,11 +240,14 @@ flowchart LR
 
 ### `/ops:ecom` · `skills/ops-ecom/SKILL.md`
 
-Shopify store command center. Orders, inventory, fulfillment, analytics, and store health via Shopify Admin API.
+Shopify store command center. Orders, inventory, fulfillment, analytics, store health, sales channels, agentic storefronts, and Shop readiness via Shopify Admin API.
 
 - `/ops:ecom orders` — recent orders + fulfillment status
 - `/ops:ecom inventory` — low stock alerts
 - `/ops:ecom analytics` — revenue, AOV, conversion
+- `/ops:ecom channels` — sales channel / publication inventory
+- `/ops:ecom agentic` — agentic storefront health (ChatGPT, Gemini, Copilot, …)
+- `/ops:ecom shop` — Shop channel + Shop Campaigns readiness (stage-only spend)
 - `/ops:ecom setup` — configure Shopify API credentials
 
 ### `/ops:marketing` · `skills/ops-marketing/SKILL.md`
@@ -261,6 +264,8 @@ Marketing analytics dashboard. Email campaigns (Klaviyo), paid ads (Meta Ads, Go
 - `/ops:marketing google-ads campaigns` — Campaign management — list, create, pause, enable, adjust budget
 - `/ops:marketing google-ads keywords` — Keyword Planner — discover keywords with volume and bid data
 - `/ops:marketing google-ads ad-groups` — Ad group management — list, create, add/remove keywords, adjust bids
+- `/ops:marketing shop-campaigns` — Shop Campaigns prefs status (stage-only; no auto-spend)
+- `/ops:marketing agentic` — agentic storefront prefs status (live probe via /ops-ecom agentic)
 
 ### `/ops:voice` · `skills/ops-voice/SKILL.md`
 

--- a/claude-ops/skills/ops-ecom/SKILL.md
+++ b/claude-ops/skills/ops-ecom/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ops-ecom
-description: Shopify store command center. Orders, inventory, fulfillment, analytics, and store health. Works with any Shopify store via Admin API.
-argument-hint: '[orders|inventory|fulfillment|health|products|customers|analytics|setup]'
+description: Shopify store command center. Orders, inventory, fulfillment, analytics, store health, sales channels, agentic storefronts, and Shop readiness. Works with any Shopify store via Admin API.
+argument-hint: '[orders|inventory|fulfillment|health|products|customers|analytics|channels|agentic|shop|setup]'
 allowed-tools:
   - Bash
   - Read
@@ -27,6 +27,8 @@ Before executing, load available context:
 1. **Preferences**: Read `${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json`
    - `timezone` — display all timestamps correctly
    - `shopify_store_url`, `shopify_admin_token` — check userConfig keys before env vars
+   - `ecom.shopify.sales_channels` — optional last probe cache (publications + agentic/Shop gaps)
+   - `ecom.shopify.agentic_storefronts` — optional operator-declared enablement map (channel → status)
 
 2. **Daemon health**: Read `${CLAUDE_PLUGIN_DATA_DIR}/daemon-health.json`
    - If `action_needed` is not null → surface it before running any store operations
@@ -127,6 +129,9 @@ SHOPIFY_AUTH="X-Shopify-Access-Token: ${SHOPIFY_TOKEN}"
 | products, product, catalog              | Products manager    |
 | customers, customer, crm                | Customer stats      |
 | analytics, revenue, stats, metrics      | Analytics dashboard |
+| channels, publications, sales-channels  | Sales channel inventory (publications + gaps) |
+| agentic, agentic-storefronts, ai-channels | Agentic storefront health |
+| shop, shop-channel, shop-campaigns      | Shop channel + Shop Campaigns readiness |
 | setup, configure, init, token           | Setup flow          |
 
 ---
@@ -470,6 +475,140 @@ Use `AskUserQuestion` for action selection.
 
 ---
 
+
+---
+
+## CHANNELS
+
+List publications / sales channels from Shopify Admin GraphQL. Prefer live API; fall back to `ecom.shopify.sales_channels` cache if API fails.
+
+```bash
+# GraphQL publications (use store's configured API version when set; default 2024-10+)
+curl -s -X POST -H "$SHOPIFY_AUTH" -H "Content-Type: application/json" \
+  "$SHOPIFY_GQL" \
+  -d '{"query":"{ publications(first: 50) { nodes { id name autoPublish app { title handle } } } channels(first: 50) { nodes { name handle app { title handle } } } }"}' | \
+  jq '{
+    publications: [.data.publications.nodes[]? | {id, name, autoPublish, app: .app.title}],
+    channels: [.data.channels.nodes[]? | {name, handle, app: .app.title}]
+  }'
+```
+
+Also merge operator prefs when present:
+
+```bash
+jq -r '.ecom.shopify.sales_channels // empty' "$PREFS_PATH" 2>/dev/null
+```
+
+**Render:**
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► ECOM ► CHANNELS — [store] — [timestamp]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PUBLICATIONS / CHANNELS (live)
+  [name]  handle=[…]  app=[…]  autoPublish=[true|false]
+  ...
+
+KNOWN GAPS (prefs / docs — not always in API list)
+  Agentic Storefronts app     [present|missing|unknown]
+  ChatGPT / OpenAI channel    [present|missing|unknown]
+  Google AI Mode / Gemini     [present|missing|unknown]
+  Shop channel                [present|missing|unknown]
+  Microsoft Copilot           [present|missing|unknown]
+
+──────────────────────────────────────────────────────
+ Actions:
+ a) Re-probe GraphQL publications
+ b) Open agentic health  (/ops:ecom agentic)
+ c) Open Shop readiness  (/ops:ecom shop)
+──────────────────────────────────────────────────────
+```
+
+**Guardrails:** publication names vary by locale; match case-insensitively. Do not invent channels. Unknown → `unknown`. Write-back of probe cache only with operator OK.
+
+---
+
+## AGENTIC
+
+Agentic storefront health: which AI commerce surfaces are enabled and whether products are published to them.
+
+```bash
+# Reuse CHANNELS probe; optional prefs:
+jq -r '.ecom.shopify.agentic_storefronts // empty' "$PREFS_PATH" 2>/dev/null
+jq -r '.marketing.projects // {} | to_entries[]? | select(.value.agentic_storefronts != null) | {project: .key, agentic: .value.agentic_storefronts}' "$PREFS_PATH" 2>/dev/null
+```
+
+**Render:**
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► ECOM ► AGENTIC — [store] — [timestamp]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+AI / AGENTIC SURFACES
+  Microsoft Copilot     [on|off|unknown]  channel=[name|—]
+  ChatGPT / OpenAI      [on|off|unknown]
+  Google AI Mode        [on|off|unknown]
+  (other detected)      ...
+
+PRODUCT COVERAGE
+  Sampled: [N] products  published_to_agentic: [M]  unknown: [K]
+
+DOCS
+  https://help.shopify.com/en/manual/online-sales-channels/agentic-storefronts
+
+──────────────────────────────────────────────────────
+ Actions:
+ a) Re-probe publications
+ b) List channels  (/ops:ecom channels)
+ c) Shop readiness (/ops:ecom shop)
+──────────────────────────────────────────────────────
+```
+
+**Guardrails:** Read-only. Never install apps or publish products without explicit operator confirmation (Rule 5). If API cannot list agentic apps, say so — do not claim disabled.
+
+---
+
+## SHOP
+
+Shop sales channel + Shop Campaigns readiness (pay-per-sale on Shop and expanded surfaces).
+
+```bash
+# Detect Shop from publications/channels (name/handle contains shop; avoid false positives)
+jq -r '
+  .ecom.shopify.shop // empty,
+  (.marketing.projects // {} | to_entries[]? | select(.value.shop_campaigns != null) | {project: .key, shop_campaigns: .value.shop_campaigns})
+' "$PREFS_PATH" 2>/dev/null
+```
+
+**Render:**
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ OPS ► ECOM ► SHOP — [store] — [timestamp]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+SHOP CHANNEL
+  Publication:  [present|missing|unknown]
+  Products:     [sample published count or unknown]
+
+SHOP CAMPAIGNS (prefs + admin)
+  Configured in prefs:  [yes|no]
+  Status:               [not_configured|stage_only|active|unknown]
+  Budget approval:      [required|granted|n/a]
+
+DOCS
+  https://help.shopify.com/en/manual/online-sales-channels/shop/shop-campaigns
+  https://www.shopify.com/shop-campaigns
+
+──────────────────────────────────────────────────────
+ NEVER LEAK MONEY: never create or raise Shop Campaigns
+ budgets without explicit owner approval (Rule 5).
+──────────────────────────────────────────────────────
+```
+
+
 ## SETUP FLOW
 
 **Before asking the user for anything**, auto-discover store URLs and tokens. Run ALL of these scans in a single batch:
@@ -599,6 +738,9 @@ FULFILLMENT   [N] unfulfilled orders pending
  /ops:ops-ecom customers  — customer stats
  /ops:ops-ecom analytics  — revenue dashboard
  /ops:ops-ecom health     — store health check
+ /ops:ops-ecom channels   — sales channel inventory
+ /ops:ops-ecom agentic    — agentic storefront health
+ /ops:ops-ecom shop       — Shop channel + Shop Campaigns readiness
  /ops:ops-ecom setup      — configure credentials
 ──────────────────────────────────────────────────────
 ```

--- a/claude-ops/skills/ops-marketing/SKILL.md
+++ b/claude-ops/skills/ops-marketing/SKILL.md
@@ -355,6 +355,58 @@ To enable a daemon service, set `enabled: true` in `daemon-services.default.json
 
 ---
 
+
+## Shopify surfaces (Shop Campaigns + Agentic storefronts)
+
+Brand-agnostic project prefs for Shopify AI commerce and Shop pay-per-sale ads. **No plaintext secrets** — only cred-refs. Defaults are off / stage-only (Rule 5 / NEVER LEAK MONEY).
+
+```jsonc
+{
+  "marketing": {
+    "projects": {
+      "myapp": {
+        "shopify": {
+          "store_url": "example.myshopify.com",
+          "admin_token_ref": "env:SHOPIFY_ACCESS_TOKEN"
+        },
+        "shop_campaigns": {
+          "enabled": false,
+          "status": "not_configured", // not_configured | stage_only | active | paused
+          "eligibility": "unknown", // unknown | eligible | ineligible | pending_review
+          "budget": {
+            "daily_cap_usd": null, // null = no auto-spend
+            "currency": "USD",
+            "approval": "required" // required | granted
+          },
+          "surfaces": {
+            "shop_app": "unknown",
+            "chatgpt": "unknown",
+            "pinterest": "unknown",
+            "microsoft_monetize": "unknown"
+          },
+          "notes": "",
+          "last_probed_at": null
+        },
+        "agentic_storefronts": {
+          "enabled": false,
+          "channels": {
+            "copilot": "unknown",
+            "chatgpt": "unknown",
+            "google_ai_mode": "unknown"
+          },
+          "last_probed_at": null
+        }
+      }
+    }
+  }
+}
+```
+
+**Rules:** (1) no plaintext tokens in prefs; (2) presence of the object does not authorize spend; (3) any future mutate path requires `budget.approval == "granted"` **and** `daily_cap_usd > 0` **and** `status == "active"`; (4) live channel inventory lives in `/ops-ecom channels|agentic|shop`.
+
+Docs: [Agentic storefronts](https://help.shopify.com/en/manual/online-sales-channels/agentic-storefronts) · [Shop Campaigns](https://help.shopify.com/en/manual/online-sales-channels/shop/shop-campaigns)
+
+
 ## Sub-command Routing
 
 **Argument parsing:** `$ARGUMENTS` is split as `<first-token> [rest...]`.
@@ -364,7 +416,7 @@ Route `$ARGUMENTS` to the correct section below:
 
 | Input                                                                                                     | Action                                                                                                                                                                                                                                                                                        |
 | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| (empty), dashboard, portfolio                                                                             | Visual portfolio dashboard — all projects × all configured channels (Meta, Google Ads, GA4, GSC, Resend, SNS, IG, ShipBob, autopilot state). See ## dashboard section.                                                                                                                        |
+| (empty), dashboard, portfolio                                                                             | Visual portfolio dashboard — all projects × all configured channels (Meta, Google Ads, GA4, GSC, Resend, SNS, IG, ShipBob, Shop Campaigns, agentic storefronts, autopilot state). See ## dashboard section.                                                                                                                        |
 | portfolio --json                                                                                          | Machine-readable portfolio JSON (one row per project, full channel config)                                                                                                                                                                                                                    |
 | portfolio --project `<name>`                                                                              | Full single-project config dump (every channel block)                                                                                                                                                                                                                                         |
 | `<project>`                                                                                               | If `marketing.projects.<project>.autopilot.enabled == true` → run live autopilot pass for that project. Otherwise → run `bin/ops-marketing-provision provision-all --project <project>` then `bin/ops-marketing-autopilot --project <project> --dry-run` (see ## project entry-point section) |
@@ -378,6 +430,8 @@ Route `$ARGUMENTS` to the correct section below:
 | social                                                                                                    | Social media aggregator                                                                                                                                                                                                                                                                       |
 | instagram, instagram post, instagram reel, instagram story, instagram insights, instagram demographics    | Instagram publishing + insights (see ## instagram section)                                                                                                                                                                                                                                    |
 | campaigns                                                                                                 | Cross-channel campaign overview (all platforms)                                                                                                                                                                                                                                               |
+| shop-campaigns, shop_campaigns                                                                            | Per-project Shop Campaigns status (prefs + optional live ecom probe) — see ## shop-campaigns                                                                                                                                  |
+| agentic-storefronts, agentic                                                                              | Per-project agentic storefront prefs status (live publication probe via /ops-ecom agentic)                                                                                                                                     |
 | optimize                                                                                                  | Cross-platform ad optimization agent                                                                                                                                                                                                                                                          |
 | `provision <project>`                                                                                     | Idempotent full sweep — provisions GA4, GSC, Instagram, Google Ads in order. Each step is no-op if already configured. Aliases: `provision-all <project>`                                                                                                                                     |
 | `provision-instagram <project>`                                                                           | Auto-resolves `instagram.account_id` from Meta token (uses `appsecret_proof` when `meta.app_secret` configured).                                                                                                                                                                              |
@@ -395,6 +449,8 @@ Route `$ARGUMENTS` to the correct section below:
 | `portfolio --kpis`                                                                                        | Just the KPI section, no config-state table                                                                                                                                                                                                                                                   |
 | `portfolio --prewarm-status`                                                                              | Show what marketing creds exist in Doppler that aren't yet linked                                                                                                                                                                                                                             |
 | `<project> creative --brand=X --product=Y --audience=Z --goal=W [--num-shots=N --env=prd\|dev]`           | Higgsfield brand asset generator. Drafts shot list, generates N images via Higgsfield API, uploads to S3, opens campaign-brief PR on my-project-operating-dashboard. See ## creative (Higgsfield) section.                                                                                    |
+**Shopify Shop Campaigns:** treat `shop_campaigns` as stage-only unless `status=active` and `budget.approval=granted` and a positive daily cap. Never auto-create Shop Campaigns budgets from autopilot in this version.
+
 
 ---
 


### PR DESCRIPTION
## Summary

Brand-agnostic CloudOps surface for **Shopify Agentic storefronts** and **Shop Campaigns**.

### `/ops-ecom`
- `channels` — publications + sales channels inventory
- `agentic` — AI commerce surfaces health
- `shop` — Shop channel + Shop Campaigns readiness

### `/ops-marketing`
- Prefs: `shopify`, `shop_campaigns`, `agentic_storefronts` (cred-refs only)
- Routing + portfolio + stage-only spend guardrails

## Safety
Read-only probes; NEVER LEAK MONEY; no brand secrets.

## Refs
- https://help.shopify.com/en/manual/online-sales-channels/agentic-storefronts
- https://help.shopify.com/en/manual/online-sales-channels/shop/shop-campaigns