### PR TITLE
release: v2.42.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 60 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.41.0",
+      "version": "2.42.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-2.41.0-blue)
+![Version](https://img.shields.io/badge/version-2.42.0-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-60-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.41.0",
+  "version": "2.42.0",
   "description": "Business operations command center for Claude Code — 60 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -7,6 +7,14 @@
 - **ops-ecom:** `channels` | `agentic` | `shop` verbs — sales channel inventory, agentic storefront health, Shop Campaigns readiness (read-only; Rule 5 / stage-only spend).
 - **ops-marketing:** brand-agnostic `shop_campaigns` + `agentic_storefronts` project prefs schema; `shop-campaigns` / `agentic` routing; portfolio awareness; NEVER LEAK MONEY guardrails for Shop Campaigns.
 
+## [2.42.0] - 2026-07-19
+
+### Changed
+### Added
+- `/ops-ecom`: new `channels`, `agentic`, and `shop` probes — publications/sales-channel inventory, Shopify Agentic storefronts (AI commerce) health, and Shop channel + Shop Campaigns readiness (read-only)
+- `/ops-marketing`: `shopify`, `shop_campaigns`, and `agentic_storefronts` preferences (cred-refs only) with routing, portfolio awareness, and stage-only spend guardrails — never auto-creates budgets
+
+
 ## [2.41.0] - 2026-07-19
 
 ### Added

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-2.41.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.42.0-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 60 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-2.41.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.42.0-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-60-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.41.0",
+  "version": "2.42.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.42.0** (was 2.41.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

### Added
- `/ops-ecom`: new `channels`, `agentic`, and `shop` probes — publications/sales-channel inventory, Shopify Agentic storefronts (AI commerce) health, and Shop channel + Shop Campaigns readiness (read-only)
- `/ops-marketing`: `shopify`, `shop_campaigns`, and `agentic_storefronts` preferences (cred-refs only) with routing, portfolio awareness, and stage-only spend guardrails — never auto-creates budgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata and documentation-only release bump; no runtime or security-sensitive code changes in the diff.
> 
> **Overview**
> **Release v2.42.0** (from 2.41.0): version strings are aligned in `marketplace.json`, `plugin.json`, `claude-ops/package.json`, README, and skills/agents reference badges.
> 
> `CHANGELOG.md` adds a **[2.42.0]** entry describing product changes shipped in this release: **`/ops-ecom`** gains read-only `channels`, `agentic`, and `shop` probes (publications/sales-channel inventory, Agentic storefront health, Shop + Shop Campaigns readiness), and **`/ops-marketing`** adds cred-ref-only prefs for `shopify`, `shop_campaigns`, and `agentic_storefronts` with routing, portfolio awareness, and stage-only spend guardrails (no auto-created budgets). The **Unreleased** section still lists the same bullets for ongoing work.
> 
> No application code appears in this diff—only packaging and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 167cc3b95d90044360ff53e2caf7006cc2f410e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added e-commerce probes for channels, agentic workflows, and shop activity.
  * Added marketing preferences, improved routing and portfolio awareness, and introduced Shop Campaigns spend guardrails.
* **Documentation**
  * Added release notes for version 2.42.0.
  * Updated displayed version information across product documentation and metadata to 2.42.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->