### PR TITLE
fix(crs): restore accountProxyConfig export in crs-pool-config.mjs

### DIFF
--- a/claude-ops/scripts/account-rotation/crs-pool-config.mjs
+++ b/claude-ops/scripts/account-rotation/crs-pool-config.mjs
@@ -175,6 +175,10 @@ function parseProxyUrl(raw) {
   } else if (s.startsWith('http://')) {
     type = 'http';
     s = s.slice('http://'.length);
+  } else {
+    // Reject unsupported schemes (e.g. ftp://, ssh://, file://). Bare
+    // host:port (no scheme, no path/query/fragment) is still allowed.
+    if (/[/?#]/.test(s)) return null;
   }
   // Now s is host[:port] (may have userinfo@host)
   const at = s.lastIndexOf('@');
@@ -183,7 +187,10 @@ function parseProxyUrl(raw) {
   if (colon < 0) return null;
   const host = s.slice(0, colon).trim();
   const portStr = s.slice(colon + 1).trim();
+  // Reject anything that isn't pure decimal digits after the colon — guards
+  // against `host:3128/path`, `host:3128junk`, `host:3128?x=1`, etc.
+  if (!host || /[\s/?#]/.test(host) || !/^\d+$/.test(portStr)) return null;
   const port = Number.parseInt(portStr, 10);
-  if (!host || !Number.isInteger(port) || port <= 0 || port > 65535) return null;
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return null;
   return { type, host, port };
 }

--- a/claude-ops/scripts/account-rotation/crs-pool-config.mjs
+++ b/claude-ops/scripts/account-rotation/crs-pool-config.mjs
@@ -113,3 +113,77 @@ export function vaultLookupKeysForEmail(email, accounts = []) {
   }
   return [...keys];
 }
+
+/**
+ * Resolve a per-account rotation-proxy descriptor.
+ *
+ * Returns null when the rotation proxy is disabled (no override, no
+ * `CLAUDE_ROTATION_PROXY_ENABLED=1`, or the provider URL is missing). When
+ * enabled, parses `EFG_PROXY_URL` / `BRIGHTDATA_PROXY_URL` for the active
+ * provider (`CLAUDE_ROTATION_PROXY_PROVIDER`, defaults to `brightdata`) and
+ * returns a `{ type, host, port }` object that downstream `oauthFetch` and
+ * `curl --proxy` callers consume.
+ *
+ * Signature: `accountProxyConfig(config, account, env?)`
+ *   - `config`: loaded rotation config (from `loadRotationConfig()`)
+ *   - `account`: account row (currently unused for routing; kept for future
+ *     per-account overrides)
+ *   - `env`: optional env-override object (defaults to `process.env`)
+ *
+ * Provider URL formats accepted:
+ *   - `socks5://host:port`
+ *   - `socks5h://host:port`
+ *   - `http://host:port`            → type=`http`
+ *   - `https://host:port`           → type=`http`
+ *   - `host:port` (bare)            → type=`http`
+ *
+ * @param {{accounts?:Array, crs?:object}} _config
+ * @param {{email?:string, label?:string}} _account
+ * @param {Record<string,string|undefined>} [env]
+ * @returns {{type:string, host:string, port:number} | null}
+ */
+export function accountProxyConfig(_config, _account, env = process.env) {
+  if (!env || typeof env !== 'object') return null;
+  if (env.CLAUDE_ROTATION_PROXY_ENABLED !== '1') return null;
+
+  const provider = String(env.CLAUDE_ROTATION_PROXY_PROVIDER || 'brightdata')
+    .trim()
+    .toLowerCase();
+
+  const urlKey = provider === 'efg' ? 'EFG_PROXY_URL' : 'BRIGHTDATA_PROXY_URL';
+  const raw = env[urlKey];
+  if (!raw || typeof raw !== 'string') return null;
+
+  const parsed = parseProxyUrl(raw.trim());
+  return parsed;
+}
+
+function parseProxyUrl(raw) {
+  if (!raw) return null;
+  // Strip trailing slash, accept bare host:port
+  let s = raw.replace(/\/+$/, '');
+  let type = 'http';
+  if (s.startsWith('socks5://')) {
+    type = 'socks5';
+    s = s.slice('socks5://'.length);
+  } else if (s.startsWith('socks5h://')) {
+    type = 'socks5';
+    s = s.slice('socks5h://'.length);
+  } else if (s.startsWith('https://')) {
+    type = 'http';
+    s = s.slice('https://'.length);
+  } else if (s.startsWith('http://')) {
+    type = 'http';
+    s = s.slice('http://'.length);
+  }
+  // Now s is host[:port] (may have userinfo@host)
+  const at = s.lastIndexOf('@');
+  if (at >= 0) s = s.slice(at + 1);
+  const colon = s.lastIndexOf(':');
+  if (colon < 0) return null;
+  const host = s.slice(0, colon).trim();
+  const portStr = s.slice(colon + 1).trim();
+  const port = Number.parseInt(portStr, 10);
+  if (!host || !Number.isInteger(port) || port <= 0 || port > 65535) return null;
+  return { type, host, port };
+}

--- a/claude-ops/scripts/account-rotation/crs-pool-config.test.mjs
+++ b/claude-ops/scripts/account-rotation/crs-pool-config.test.mjs
@@ -89,9 +89,65 @@ test('accountProxyConfig accepts bare host:port for brightdata', () => {
 });
 
 test('accountProxyConfig returns null on malformed URL', () => {
-  assert.equal(accountProxyConfig({}, {}, { CLAUDE_ROTATION_PROXY_ENABLED: '1', EFG_PROXY_URL: 'not a url' }), null);
   assert.equal(
-    accountProxyConfig({}, {}, { CLAUDE_ROTATION_PROXY_ENABLED: '1', EFG_PROXY_URL: 'socks5://host' }),
+    accountProxyConfig(
+      {},
+      {},
+      {
+        CLAUDE_ROTATION_PROXY_ENABLED: '1',
+        CLAUDE_ROTATION_PROXY_PROVIDER: 'efg',
+        EFG_PROXY_URL: 'not a url',
+      },
+    ),
+    null,
+  );
+  assert.equal(
+    accountProxyConfig(
+      {},
+      {},
+      {
+        CLAUDE_ROTATION_PROXY_ENABLED: '1',
+        CLAUDE_ROTATION_PROXY_PROVIDER: 'efg',
+        EFG_PROXY_URL: 'socks5://host',
+      },
+    ),
+    null,
+  );
+  // Unsupported scheme + path/suffix must also return null.
+  assert.equal(
+    accountProxyConfig(
+      {},
+      {},
+      {
+        CLAUDE_ROTATION_PROXY_ENABLED: '1',
+        CLAUDE_ROTATION_PROXY_PROVIDER: 'efg',
+        EFG_PROXY_URL: 'ftp://proxy.example.com:21',
+      },
+    ),
+    null,
+  );
+  assert.equal(
+    accountProxyConfig(
+      {},
+      {},
+      {
+        CLAUDE_ROTATION_PROXY_ENABLED: '1',
+        CLAUDE_ROTATION_PROXY_PROVIDER: 'efg',
+        EFG_PROXY_URL: 'socks5://127.0.0.1:1087/path',
+      },
+    ),
+    null,
+  );
+  assert.equal(
+    accountProxyConfig(
+      {},
+      {},
+      {
+        CLAUDE_ROTATION_PROXY_ENABLED: '1',
+        CLAUDE_ROTATION_PROXY_PROVIDER: 'efg',
+        EFG_PROXY_URL: 'socks5://127.0.0.1:abc',
+      },
+    ),
     null,
   );
 });

--- a/claude-ops/scripts/account-rotation/crs-pool-config.test.mjs
+++ b/claude-ops/scripts/account-rotation/crs-pool-config.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { buildCrsNameMaps, crsPolicy } from './crs-pool-config.mjs';
+import { buildCrsNameMaps, crsPolicy, accountProxyConfig } from './crs-pool-config.mjs';
 
 test('buildCrsNameMaps uses crsAccountName and nameByVaultKey', () => {
   const config = {
@@ -16,4 +16,82 @@ test('buildCrsNameMaps uses crsAccountName and nameByVaultKey', () => {
 test('crsPolicy defaults to conservative', () => {
   assert.equal(crsPolicy({ crs: {} }), 'conservative');
   assert.equal(crsPolicy({ crs: { policy: 'max-out' } }), 'max-out');
+});
+
+test('accountProxyConfig returns null when proxy is disabled', () => {
+  assert.equal(accountProxyConfig({}, {}, { CLAUDE_ROTATION_PROXY_ENABLED: '0' }), null);
+  assert.equal(accountProxyConfig({}, {}, { CLAUDE_ROTATION_PROXY_PROVIDER: 'efg' }), null);
+  assert.equal(accountProxyConfig({}, {}, {}), null);
+});
+
+test('accountProxyConfig returns null when provider URL is missing', () => {
+  assert.equal(
+    accountProxyConfig({}, {}, { CLAUDE_ROTATION_PROXY_ENABLED: '1', CLAUDE_ROTATION_PROXY_PROVIDER: 'efg' }),
+    null,
+  );
+  assert.equal(
+    accountProxyConfig(
+      {},
+      {},
+      {
+        CLAUDE_ROTATION_PROXY_ENABLED: '1',
+        EFG_PROXY_URL: '',
+      },
+    ),
+    null,
+  );
+});
+
+test('accountProxyConfig parses socks5:// url for efg provider', () => {
+  // Exact contract from crs-parity-regression.test.mjs.
+  assert.deepEqual(
+    accountProxyConfig(
+      {},
+      {},
+      {
+        CLAUDE_ROTATION_PROXY_ENABLED: '1',
+        CLAUDE_ROTATION_PROXY_PROVIDER: 'efg',
+        EFG_PROXY_URL: 'socks5://127.0.0.1:1087',
+        CLAUDE_ROTATION_ENV_FILE: '/nonexistent',
+      },
+    ),
+    { type: 'socks5', host: '127.0.0.1', port: 1087 },
+  );
+});
+
+test('accountProxyConfig defaults to brightdata when no provider env set', () => {
+  assert.deepEqual(
+    accountProxyConfig(
+      {},
+      {},
+      {
+        CLAUDE_ROTATION_PROXY_ENABLED: '1',
+        BRIGHTDATA_PROXY_URL: 'http://proxy.example.com:3128',
+      },
+    ),
+    { type: 'http', host: 'proxy.example.com', port: 3128 },
+  );
+});
+
+test('accountProxyConfig accepts bare host:port for brightdata', () => {
+  assert.deepEqual(
+    accountProxyConfig(
+      {},
+      {},
+      {
+        CLAUDE_ROTATION_PROXY_ENABLED: '1',
+        CLAUDE_ROTATION_PROXY_PROVIDER: 'brightdata',
+        BRIGHTDATA_PROXY_URL: '10.0.0.1:1080',
+      },
+    ),
+    { type: 'http', host: '10.0.0.1', port: 1080 },
+  );
+});
+
+test('accountProxyConfig returns null on malformed URL', () => {
+  assert.equal(accountProxyConfig({}, {}, { CLAUDE_ROTATION_PROXY_ENABLED: '1', EFG_PROXY_URL: 'not a url' }), null);
+  assert.equal(
+    accountProxyConfig({}, {}, { CLAUDE_ROTATION_PROXY_ENABLED: '1', EFG_PROXY_URL: 'socks5://host' }),
+    null,
+  );
 });


### PR DESCRIPTION
## Summary

crs-pool-config.mjs exports `accountProxyConfig` is required by:
- scripts/account-rotation/crs-proxy-health-switch.mjs
- scripts/account-rotation/crs-live-status.mjs
- scripts/account-rotation/crs-parity-regression.test.mjs (asserts the exact contract)

…but the export was missing from the shipped module. Result: every consumer that imports `accountProxyConfig` throws `SyntaxError: The requested module … does not provide an export named 'accountProxyConfig'` on load. Live evidence (journalctl 2026-07-22 07:32:11Z):

```
node[3652198]: file:///…/server.mjs:8
node[3652198]: import { loadRotationConfig, accountProxyConfig } from '…/crs-pool-config.mjs'
node[3652198]:                              ^^^^^^^^^^^^^^^^^^
node[3652198]: SyntaxError: The requested module … does not provide an export named 'accountProxyConfig'
```

## Root cause

The function was never present in this public repo's source — it lived in the Mac/internal-only worktrees that fed into the dev-us install. When the runtime file was synced back into the public plugin source, the export was lost.

## Fix

Add the missing export with the contract already pinned by crs-parity-regression.test.mjs:
- Signature: `accountProxyConfig(config, account, env?) → { type, host, port } | null`
- Reads `CLAUDE_ROTATION_PROXY_ENABLED`, `CLAUDE_ROTATION_PROXY_PROVIDER` (`efg` | `brightdata`), and `EFG_PROXY_URL` / `BRIGHTDATA_PROXY_URL`.
- URL formats accepted: `socks5://`, `socks5h://`, `http(s)://`, bare `host:port`.

## Validation

- `node --check` on the modified file: clean.
- `npm run lint` (Prettier `--check`): clean.
- `node --test scripts/account-rotation/crs-pool-config.test.mjs`: **8/8 pass**.
- `npm test`: **25/25 pass** (includes secret-scan).

## Out of scope / follow-ups

- Live relay smoke must wait for merge → installed-plugin sync → process restart. The orchestrator (`claude --bg` d5c35c03) will run a heartbeat pass and unblock the two parked sessions (10b012ee, 04c5275c) once `accountProxyConfig` is loadable.
- crs-priority-daemon.mjs current live copy no longer imports `accountProxyConfig` (only historical `.bak` did) — no consumer regressions in main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Restores a documented export with env-gated parsing and null-on-invalid behavior; adds tests only in account-rotation config helpers, no auth or data-path changes.
> 
> **Overview**
> Restores the missing **`accountProxyConfig`** export in `crs-pool-config.mjs`, which was causing **module load failures** (`SyntaxError: does not provide an export named 'accountProxyConfig'`) for CRS rotation tooling that already imports it.
> 
> The added **`accountProxyConfig(config, account, env?)`** reads rotation-proxy env (`CLAUDE_ROTATION_PROXY_ENABLED`, `CLAUDE_ROTATION_PROXY_PROVIDER`, `EFG_PROXY_URL` / `BRIGHTDATA_PROXY_URL`) and returns `{ type, host, port }` or **`null`** when disabled or invalid. A private **`parseProxyUrl`** helper accepts `socks5`/`socks5h`, `http(s)://`, and bare `host:port`, and rejects malformed URLs.
> 
> **`crs-pool-config.test.mjs`** gains coverage for disabled/missing URL cases, EFG socks5 and Bright Data HTTP/bare formats, and malformed inputs (aligned with the parity regression contract).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eb472358e24e0f964d9a92e398075c80656edd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring account rotation proxies through environment settings.
  * Supports Bright Data and EFG providers, with HTTP, HTTPS, and SOCKS proxy formats.
  * Valid proxy configurations are automatically parsed into connection details.

* **Bug Fixes**
  * Invalid, incomplete, or disabled proxy configurations are safely ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->