### PR TITLE
chore(pii): move owner PII to gitignored local prefs; scrub ops-inbox examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ node_modules/
 
 # Operator PII denylist (out-of-repo, loaded by test-no-secrets.sh / pre-commit)
 .pii-denylist
+
+# Local, owner-specific prefs/overrides — never commit (see docs/LOCAL-PREFS.md)
+ops.local.json
+*.local.json
+.ops-prefs.json

--- a/claude-ops/scripts/whatsapp/apply-patches.py
+++ b/claude-ops/scripts/whatsapp/apply-patches.py
@@ -534,7 +534,7 @@ WHATSAPP_API_BASE_URL = "http://localhost:8080/api"
 
 
 def _resolve_lid_to_pn(jid_or_lid: str) -> str:
-    \"\"\"claude-ops: If jid_or_lid is a LID jid (e.g. ``218030407741450@lid`` or bare
+    \"\"\"claude-ops: If jid_or_lid is a LID jid (e.g. ``100000000000000@lid`` or bare
     digits matching whatsmeow_lid_map.lid), return the phone-number form
     (``<pn>@s.whatsapp.net``). Otherwise return the input unchanged.\"\"\"
     if not jid_or_lid:

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -565,7 +565,7 @@ All channel credentials come from env vars or CLI auth — no hardcoded secrets.
 **The success metric of `/ops:ops-inbox` is an EMPTY inbox on EVERY channel — not "surfaced the NEEDS_REPLY".** Every conversation that no longer needs the user's eyes, action, or reaction MUST be archived in the same run. This is mandatory, not a nicety:
 
 > **Paperclip SSOT + WA archive API (Sam 2026-07-19 — hard):**
-> 1. **When Paperclip is on the box**, before KEEP-classifying or drafting money/legal/hire/product: scan open issues + pending `issue_thread_interactions` for that counterparty/thread id (examples: Betaalronde → AUR-880; Centurion → AUR-696 / AUR-1004; Ian comp → AUR-920; Brittany YT → SFB-172). Prefer the board gate + staged draft over a new Telegram `AskUserQuestion` when the same decision is already wired. Never re-ask a locked Q or contradict answered options.
+> 1. **When Paperclip is on the box**, before KEEP-classifying or drafting money/legal/hire/product: scan open issues + pending `issue_thread_interactions` for that counterparty/thread id (e.g. a payment-round thread → its tracking issue, a card/supplier thread → its issue, a comp/hire thread → its issue). Resolve the concrete counterparty→issue mappings from your local prefs/board, not from this public skill. Prefer the board gate + staged draft over a new Telegram `AskUserQuestion` when the same decision is already wired. Never re-ask a locked Q or contradict answered options.
 > 2. **WhatsApp archive is mandatory every pass** — not “demote only.” After classify, call the bridge archive endpoint on **every non-actionable chat and every chat you just replied to** (phone `@s.whatsapp.net` **and** every `@lid` / `alt_jids`):
 >    ```bash
 >    curl -s -X POST http://127.0.0.1:8080/api/archive \
@@ -700,7 +700,7 @@ Before confirming ANY NEEDS_REPLY or drafting, run steps 1–7:
    - **Search:** `gog gmail search "in:sent newer_than:21d (to:<addr1> OR to:<addr2>)"` plus subject/topic variants for the **same ask** (not just same person).
    - **VERIFY every hit with `gog gmail raw <id>` / `get`:** `labelIds` must contain **`SENT`**. `gog gmail search 'in:sent to:X'` is **polluted** — it often returns thread peers / inbound envelopes that lack `SENT` (session-hardened 2026-07-18). Search alone is never proof of outbound.
    - **`DRAFT` ≠ delivered.** Lindy/Gmail drafts must not be treated as already-replied.
-   - **Same person ≠ same ask.** A pay-pack to Robert on Vinites/Skin does **not** close *Betaalronde Juli II*; calendar invites to JD do **not** close a TF sleep bug; old year Brittany threads do **not** close a new TML opp.
+   - **Same person ≠ same ask.** A payment on one deal does **not** close a different payment-round thread; a calendar invite to someone does **not** close an unrelated bug thread with them; an old thread from a prior year does **not** close a new opportunity. Match on the specific ask, not just the person.
    - **Cross-channel:** also check WA (phone + `@lid`), Slack, Productlane/support@ when the ask is product/support. Demote email NEEDS_REPLY when the same ask was already answered on WA (or vice versa).
    - **Report:** every KEEP / NEEDS_REPLY row must state `already_replied?` = `no` | `yes (where)` | `partial (what remains)`. Never stage a draft that duplicates a verified SENT/WA reply.
 6. **Use the contact registry** (below) to resolve who a sender/number/JID actually is and pull their cross-channel identity + context in one offline lookup, so the steps 2–5 searches are precise across every JID/address/handle the person owns.
@@ -747,7 +747,7 @@ When cleaning up, classify each non-NEEDS_REPLY item one more level:
 - **AWAITING-OTHER, time-sensitive** — the user is waiting on a reply tied to a deadline/deal. → archive (auto-resurfaces) **but** set a nudge reminder if no response by a sensible horizon (default 3 days) so the user can chase.
 - **CONCLUDED** — courtesy close, social tail, fully-answered. → archive, no reminder.
 
-**Scheduling reminders (a safe, non-outbound chore — do autonomously):** use `CronCreate` (one-shot, `recurring:false`) for each USER-OWES / nudge item. The reminder prompt should name the contact, the owed action, and the source thread, e.g. *"Reminder: you told Twan you'd handle Dennis's email tonight — follow up (WhatsApp 31642218102)."* Pick a sensible fire time (same evening for "tonight", +3d for nudges). Reminders fire to the user; they are NOT outbound third-party comms, so no approval gate applies.
+**Scheduling reminders (a safe, non-outbound chore — do autonomously):** use `CronCreate` (one-shot, `recurring:false`) for each USER-OWES / nudge item. The reminder prompt should name the contact, the owed action, and the source thread, e.g. *"Reminder: you told <contact-A> you'd handle <contact-B>'s email tonight — follow up (WhatsApp <number>)."* Pick a sensible fire time (same evening for "tonight", +3d for nudges). Reminders fire to the user; they are NOT outbound third-party comms, so no approval gate applies.
 
 **Meeting-note / assigned-todo capture:** when an email or message contains action items assigned to the user (meeting recaps, "can you…", "actie Sam:"), extract them and schedule reminders so they are never lost — even if the thread itself is then archived. Surface the extracted todos in the run summary.
 

--- a/docs/LOCAL-PREFS.md
+++ b/docs/LOCAL-PREFS.md
@@ -1,0 +1,26 @@
+# Local prefs — keep owner data OUT of this public repo
+
+`claude-ops` is a **public** plugin. No owner-specific data may live in tracked files:
+real personal names, company / business-unit names, contact handles, phone numbers,
+email addresses, chat IDs / JIDs, Slack channel IDs, or personal issue keys.
+
+## Where owner data lives instead
+
+- **`~/.claude/ops-prefs.json`** — central, gitignored prefs (owner, companies, issue
+  prefixes, channel pointers). Read it at runtime when a skill needs a real value.
+- **`~/.claude/memory/ops-inbox-slack-channels.md`** — Slack channel IDs + DM handles
+  (local, not the repo).
+- **`${CLAUDE_PLUGIN_DATA_DIR}/contact-registry.json`** — resolved contact identities.
+- **`~/.mcp-secrets.env` / Doppler** — secrets. Never in the repo.
+
+## Rules for repo content
+
+- Use generic placeholders in skills/docs/examples: `<owner>`, `<company>`, `<contact>`,
+  `<contact-A>`, `<number>`, `<ISSUE-123>`, `<slack-channel-id>`, `100000000000000@lid`.
+- When a skill needs a concrete value, read it from `~/.claude/ops-prefs.json` or the
+  local files above — do not hardcode it.
+- `.gitignore` blocks `ops.local.json`, `*.local.json`, `.ops-prefs.json`.
+
+## Audit
+
+See `docs/PII-AUDIT.md` for the current inventory of remaining PII and the scrub plan.

--- a/docs/PII-AUDIT.md
+++ b/docs/PII-AUDIT.md
@@ -1,0 +1,51 @@
+# PII audit — public claude-ops repo (2026-07-22)
+
+Owner rule: no owner-specific data in this public repo. This tracks what was found, what
+this branch scrubbed, and what remains for a dedicated follow-up pass.
+
+## Scrubbed on this branch (`chore/scrub-pii-to-local-prefs`)
+
+Highest-sensitivity: real people + real phone + a real WhatsApp JID, all in
+`skills/ops-inbox/SKILL.md` example / standing-rule prose (illustrative only — safe to
+genericize, no logic depends on the literals):
+
+- Real contact names in dedup examples (Robert, Brittany, Twan, Dennis, JD) → generic
+  `<contact>` / `<contact-A>` / `<contact-B>`.
+- Real phone number `31642218102` → `<number>`.
+- Real deal/issue references (Betaalronde, Centurion, Ian comp, `AUR-880`, `AUR-696`,
+  `AUR-1004`, `AUR-920`, `SFB-172`) in the Paperclip SSOT example → generic wording
+  ("resolve counterparty→issue mappings from your local prefs/board").
+- LID format example `218030407741450@lid` in `scripts/whatsapp/apply-patches.py`
+  docstring → `100000000000000@lid`.
+
+Mechanism added:
+- `~/.claude/ops-prefs.json` (OUTSIDE the repo, gitignored by location) — central prefs
+  holding the real owner/company/issue-prefix/channel values.
+- `.gitignore` now blocks `ops.local.json`, `*.local.json`, `.ops-prefs.json`.
+- `docs/LOCAL-PREFS.md` documents the pattern.
+
+## Remaining — follow-up pass (NOT done here; needs care/review)
+
+Raw grep counts (many are already example placeholders like `a[at]x[.]com`,
+`123[at]s.whatsapp[.]net`, `<...>` — real count is much lower):
+
+| Category | Raw hits | Real (est.) | Notes |
+|---|---|---|---|
+| `Healify` company name | 149 | ~load-bearing | Integration target across Slack scoping, dashboards, skills. Genericizing to a config-driven company key is a real refactor — do not blind-scrub. |
+| Emails | 155 | ~4 real | `info[at]lifecycleinnovations[.]limited` ×5, `support[at]healify[.]ai` ×3, `deeksha[at]browserstack[.]com` ×1; rest are examples. |
+| WhatsApp JIDs | 79 | ~0 real left | Overwhelmingly format examples. |
+| Issue keys AUR/HEA/SFB/HFT | 15 | ~11 | `HEA-4045/4047/4049/4246`, `SFB-172`, `AUR-*` — traceability comments in credit-rotation code + CHANGELOG. Low-harm, numerous. |
+| Phone E.164 | 7 | 1 (scrubbed) | Rest are `123456…` examples. |
+| `Aurora` | 4 | 0 | All AWS RDS **Aurora**, not the company — false positive. |
+| `Vinites` | 1 | scrubbed | — |
+
+### Recommended follow-up
+1. **Issue keys** (`HEA-####`, `SFB-172`, `AUR-*`) in code comments + CHANGELOG →
+   drop the ticket refs or replace with `<ISSUE>`; mechanical, low-risk, ~11 spots.
+2. **Real emails** (`info[at]lifecycleinnovations[.]limited`, `support[at]healify[.]ai`,
+   `deeksha[at]browserstack[.]com`) → placeholders / read from prefs; ~9 spots.
+3. **`Healify` (×149)** → a real refactor: introduce a company-key indirection
+   (`<company>` in prose; runtime value from `~/.claude/ops-prefs.json`), keeping the
+   Healify-specific Slack/dashboard integration working. Do as its own reviewed PR.
+
+Nothing here is pushed. Branch: `chore/scrub-pii-to-local-prefs`.


### PR DESCRIPTION
Public repo should carry no owner data. This adds the central gitignored prefs mechanism (`~/.claude/ops-prefs.json` — outside the repo), `.gitignore` rules, and `docs/LOCAL-PREFS.md`, and scrubs the highest-sensitivity PII (real names, a real phone number, real issue keys, a real LID) from `ops-inbox/SKILL.md` examples plus an `apply-patches.py` docstring.

Remaining lower-risk items (`Healify` company name x149, ~11 issue-key comments, ~9 real emails) are inventoried in `docs/PII-AUDIT.md` for a dedicated follow-up — not blind-scrubbed here because the company name is load-bearing.

Pre-commit PII guard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example-only text changes plus gitignore entries; no runtime logic or auth/data paths modified.
> 
> **Overview**
> Keeps **owner-specific data out of the public repo** by documenting a gitignored local prefs pattern (`~/.claude/ops-prefs.json`, related local files) and extending **`.gitignore`** for `ops.local.json`, `*.local.json`, and `.ops-prefs.json`.
> 
> **`docs/LOCAL-PREFS.md`** defines the rule: placeholders in tracked skills/docs, real values at runtime from local prefs. **`docs/PII-AUDIT.md`** records what this branch scrubbed and what still needs a follow-up (e.g. load-bearing `Healify` references, remaining emails/issue keys).
> 
> **Scrubbed examples** (no behavior change): **`skills/ops-inbox/SKILL.md`** — real names, phone, and issue/deal examples in Paperclip SSOT, dedup, and reminder prose → generic `<contact>`, `<number>`, and “resolve from local prefs/board”. **`apply-patches.py`** — LID docstring example → `100000000000000@lid`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60ab53f2a915eaef52e288a5dd90987b4091e8ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for managing local preferences and keeping owner-specific or sensitive information out of shared files.
  * Added an audit document summarizing sanitized examples, remaining references, and recommended follow-up cleanup.
  * Updated inbox workflow guidance to use local configuration and generic examples for issue mapping, deduplication, and reminders.

* **Chores**
  * Added ignore rules for local preference and override files.
  * Corrected an example in WhatsApp-related documentation without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->