### PR TITLE
release: v2.45.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 61 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.44.0",
+      "version": "2.45.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-2.44.0-blue)
+![Version](https://img.shields.io/badge/version-2.45.0-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-61-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.44.0",
+  "version": "2.45.0",
   "description": "Business operations command center for Claude Code — 61 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -10,6 +10,17 @@
 - **ops-ecom:** `channels` | `agentic` | `shop` verbs — sales channel inventory, agentic storefront health, Shop Campaigns readiness (read-only; Rule 5 / stage-only spend).
 - **ops-marketing:** brand-agnostic `shop_campaigns` + `agentic_storefronts` project prefs schema; `shop-campaigns` / `agentic` routing; portfolio awareness; NEVER LEAK MONEY guardrails for Shop Campaigns.
 
+## [2.45.0] - 2026-07-22
+
+### Changed
+- chore(pii): scrub internal issue keys + a person email from public repo (#692)
+- chore(pii): move owner PII to gitignored local prefs; scrub ops-inbox examples (#690)
+- feat(ops-inbox): scan Slack DMs + group DMs, not just channels; default to parallel fan-out (#691)
+- feat(ops-inbox): one-shot ops-inbox-zero script — WA + Email + Slack + Paperclip + archive (#685)
+- fix(crs): restore accountProxyConfig export in crs-pool-config.mjs (#689)
+- chore(deps): bump the npm_and_yarn group across 1 directory with 3 updates (#688)
+
+
 ## [2.44.0] - 2026-07-21
 
 ### Changed

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-2.44.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.45.0-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 61 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-2.44.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.45.0-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-61-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.44.0",
+  "version": "2.45.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.45.0** (was 2.44.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

- chore(pii): scrub internal issue keys + a person email from public repo (#692)
- chore(pii): move owner PII to gitignored local prefs; scrub ops-inbox examples (#690)
- feat(ops-inbox): scan Slack DMs + group DMs, not just channels; default to parallel fan-out (#691)
- feat(ops-inbox): one-shot ops-inbox-zero script — WA + Email + Slack + Paperclip + archive (#685)
- fix(crs): restore accountProxyConfig export in crs-pool-config.mjs (#689)
- chore(deps): bump the npm_and_yarn group across 1 directory with 3 updates (#688)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes in this PR; functional risk lives in the already-merged commits listed in the changelog.
> 
> **Overview**
> **Release v2.45.0** bumps the plugin and package version from **2.44.0** to **2.45.0** across `marketplace.json`, `plugin.json`, `package.json`, and version badges in the root README and docs references.
> 
> The **CHANGELOG** adds a **[2.45.0] - 2026-07-22** section documenting what ships in this release: **PII scrubbing** in the public repo and gitignored local prefs; **ops-inbox** improvements (Slack DMs/group DMs, parallel fan-out by default, one-shot inbox-zero across WA/Email/Slack/Paperclip/archive); a **CRS** fix restoring `accountProxyConfig` in `crs-pool-config.mjs`; and a **dependency** bump. Unreleased notes for installer, ops-desk, ops-ecom, and ops-marketing remain above the new section and are not part of 2.45.0 in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b31d299ade0f08aaaba65ede9627a48de301434. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->