### PR TITLE
feat(crs): live quota poller, multi-port health, richer proxy config

### DIFF
--- a/claude-ops/hooks/hooks.json
+++ b/claude-ops/hooks/hooks.json
@@ -5,12 +5,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/bedrock-fallback-guard.mjs"
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/bedrock-fallback-guard.mjs",
+            "timeout": 5
           },
           {
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-inbox-autosync 2>/dev/null || true",
-            "timeout": 1,
+            "timeout": 3,
             "async": true
           }
         ]

--- a/claude-ops/scripts/account-rotation/crs-pool-config.mjs
+++ b/claude-ops/scripts/account-rotation/crs-pool-config.mjs
@@ -150,7 +150,12 @@ function accountKey(account) {
 }
 
 function safeSessionSuffix(key) {
-  return String(key || 'account').toLowerCase().replace(/[^a-z0-9]+/g, '').slice(0, 24) || 'account';
+  return (
+    String(key || 'account')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '')
+      .slice(0, 24) || 'account'
+  );
 }
 
 function withBrightDataSession(username, key) {
@@ -169,23 +174,24 @@ function brightDataIps(bright = {}) {
   const raw = Array.isArray(bright.ips)
     ? bright.ips.join(',')
     : String(bright.ips || firstEnvValue(['BRIGHT_DATA_IPS', 'BRIGHT_DATA_PROXY_IPS']) || '');
-  return raw.split(/[\s,]+/).map((x) => x.trim()).filter(Boolean);
+  return raw
+    .split(/[\s,]+/)
+    .map((x) => x.trim())
+    .filter(Boolean);
 }
 
 function brightDataAliasConfig(bright = {}) {
-  const alias = String(
-    bright.alias
-      || firstEnvValue(['BRIGHT_DATA_ACTIVE_PROXY_ALIAS'])
-      || 'isp-proxy',
-  ).trim().toLowerCase();
+  const alias = String(bright.alias || firstEnvValue(['BRIGHT_DATA_ACTIVE_PROXY_ALIAS']) || 'isp-proxy')
+    .trim()
+    .toLowerCase();
   if (alias === 'residential-proxy' || alias === 'residential' || alias === 'isp1') {
     return {
       ...bright,
       zone: bright.residentialZone || firstEnvValue(['BRIGHT_DATA_RESIDENTIAL_PROXY_ZONE']) || 'isp1',
       password:
-        bright.residentialPassword
-        || firstEnvValue(['BRIGHT_DATA_RESIDENTIAL_PROXY_PASSWORD', 'BRIGHT_DATA_RESIDENTIAL_PASSWORD'])
-        || bright.password,
+        bright.residentialPassword ||
+        firstEnvValue(['BRIGHT_DATA_RESIDENTIAL_PROXY_PASSWORD', 'BRIGHT_DATA_RESIDENTIAL_PASSWORD']) ||
+        bright.password,
       ips: [],
     };
   }
@@ -193,9 +199,9 @@ function brightDataAliasConfig(bright = {}) {
     ...bright,
     zone: bright.ispZone || firstEnvValue(['BRIGHT_DATA_ISP_PROXY_ZONE']) || bright.zone,
     password:
-      bright.ispPassword
-      || firstEnvValue(['BRIGHT_DATA_ISP_PROXY_PASSWORD', 'BRIGHT_DATA_PROXY_PASSWORD'])
-      || bright.password,
+      bright.ispPassword ||
+      firstEnvValue(['BRIGHT_DATA_ISP_PROXY_PASSWORD', 'BRIGHT_DATA_PROXY_PASSWORD']) ||
+      bright.password,
     ips: bright.ispIps || bright.ips || firstEnvValue(['BRIGHT_DATA_ISP_PROXY_IPS', 'BRIGHT_DATA_IPS']),
   };
 }
@@ -214,26 +220,31 @@ function brightDataUsernameForAccount(rawUser, bright = {}, key, accountIndex = 
 
 function proxyRoutingEnabled(config) {
   const raw = String(
-    process.env.CLAUDE_ROTATION_PROXY_ENABLED
-      || process.env.CRS_ACCOUNT_PROXY_ENABLED
-      || firstEnvValue(['CLAUDE_ROTATION_PROXY_ENABLED', 'CRS_ACCOUNT_PROXY_ENABLED'])
-      || config.crs?.proxyEnabled
-      || config.crs?.proxy?.enabled
-      || '',
-  ).trim().toLowerCase();
+    process.env.CLAUDE_ROTATION_PROXY_ENABLED ||
+      process.env.CRS_ACCOUNT_PROXY_ENABLED ||
+      firstEnvValue(['CLAUDE_ROTATION_PROXY_ENABLED', 'CRS_ACCOUNT_PROXY_ENABLED']) ||
+      config.crs?.proxyEnabled ||
+      config.crs?.proxy?.enabled ||
+      '',
+  )
+    .trim()
+    .toLowerCase();
   return ['1', 'true', 'yes', 'on'].includes(raw);
 }
 
 function proxyProviderOrder(config) {
   const raw = String(
-    process.env.CLAUDE_ROTATION_PROXY_PROVIDER
-      || process.env.CRS_ACCOUNT_PROXY_PROVIDER
-      || firstEnvValue(['CLAUDE_ROTATION_PROXY_PROVIDER', 'CRS_ACCOUNT_PROXY_PROVIDER'])
-      || config.crs?.proxyProvider
-      || config.crs?.proxy?.provider
-      || '2captcha,brightdata',
+    process.env.CLAUDE_ROTATION_PROXY_PROVIDER ||
+      process.env.CRS_ACCOUNT_PROXY_PROVIDER ||
+      firstEnvValue(['CLAUDE_ROTATION_PROXY_PROVIDER', 'CRS_ACCOUNT_PROXY_PROVIDER']) ||
+      config.crs?.proxyProvider ||
+      config.crs?.proxy?.provider ||
+      '2captcha,brightdata',
   );
-  return raw.split(',').map((x) => x.trim().toLowerCase()).filter(Boolean);
+  return raw
+    .split(',')
+    .map((x) => x.trim().toLowerCase())
+    .filter(Boolean);
 }
 
 function parseProxyUrl(raw) {
@@ -255,34 +266,34 @@ function parseProxyUrl(raw) {
 function twoCaptchaSessionUsername(username, account) {
   const key = accountKey(account);
   const session = safeSessionSuffix(key);
-  return username
-    ? String(username).replace(/-session-[^-]+/, `-session-${session}`)
-    : username;
+  return username ? String(username).replace(/-session-[^-]+/, `-session-${session}`) : username;
 }
 
 function twoCaptchaProxyConfig(twoCaptcha = {}) {
   const preferred = firstEnvValue(['TWOCAPTCHA_PROXY_PREFERRED_TRANSPORT', 'TWO_CAPTCHA_PROXY_PREFERRED_TRANSPORT']);
-  const url = twoCaptcha.url || firstEnvValue(
-    preferred === 'socks5'
-      ? [
-          'TWOCAPTCHA_PROXY_SOCKS5_URL',
-          'TWO_CAPTCHA_PROXY_SOCKS5_URL',
-          'TWOCAPTCHA_PROXY_URL',
-          'TWO_CAPTCHA_PROXY_URL',
-          'CAPTCHA_PROXY_URL',
-          'TWO_CAPTCHA_HTTP_PROXY',
-          'TWOCAPTCHA_HTTP_PROXY',
-        ]
-      : [
-    'TWOCAPTCHA_PROXY_URL',
-    'TWO_CAPTCHA_PROXY_URL',
-    'CAPTCHA_PROXY_URL',
-    'TWO_CAPTCHA_HTTP_PROXY',
-    'TWOCAPTCHA_HTTP_PROXY',
-          'TWOCAPTCHA_PROXY_SOCKS5_URL',
-          'TWO_CAPTCHA_PROXY_SOCKS5_URL',
-        ],
-  );
+  const url =
+    twoCaptcha.url ||
+    firstEnvValue(
+      preferred === 'socks5'
+        ? [
+            'TWOCAPTCHA_PROXY_SOCKS5_URL',
+            'TWO_CAPTCHA_PROXY_SOCKS5_URL',
+            'TWOCAPTCHA_PROXY_URL',
+            'TWO_CAPTCHA_PROXY_URL',
+            'CAPTCHA_PROXY_URL',
+            'TWO_CAPTCHA_HTTP_PROXY',
+            'TWOCAPTCHA_HTTP_PROXY',
+          ]
+        : [
+            'TWOCAPTCHA_PROXY_URL',
+            'TWO_CAPTCHA_PROXY_URL',
+            'CAPTCHA_PROXY_URL',
+            'TWO_CAPTCHA_HTTP_PROXY',
+            'TWOCAPTCHA_HTTP_PROXY',
+            'TWOCAPTCHA_PROXY_SOCKS5_URL',
+            'TWO_CAPTCHA_PROXY_SOCKS5_URL',
+          ],
+    );
   const parsed = parseProxyUrl(url);
   if (parsed?.host && parsed?.port) {
     return {
@@ -291,26 +302,51 @@ function twoCaptchaProxyConfig(twoCaptcha = {}) {
     };
   }
 
-  const host = twoCaptcha.host || firstEnvValue([
-    'TWOCAPTCHA_PROXY_HOST', 'TWO_CAPTCHA_PROXY_HOST', 'CAPTCHA_PROXY_HOST',
-    'TWO_CAPTCHA_HOST', 'TWOCAPTCHA_HOST',
-  ]);
-  const port = twoCaptcha.port || firstEnvValue([
-    'TWOCAPTCHA_PROXY_PORT', 'TWO_CAPTCHA_PROXY_PORT', 'CAPTCHA_PROXY_PORT',
-    'TWO_CAPTCHA_PORT', 'TWOCAPTCHA_PORT',
-  ]);
-  const username = twoCaptcha.username || firstEnvValue([
-    'TWOCAPTCHA_PROXY_USERNAME', 'TWO_CAPTCHA_PROXY_USERNAME', 'CAPTCHA_PROXY_USERNAME',
-    'TWOCAPTCHA_PROXY_USER', 'TWO_CAPTCHA_PROXY_USER', 'CAPTCHA_PROXY_USER',
-  ]);
-  const password = twoCaptcha.password || firstEnvValue([
-    'TWOCAPTCHA_PROXY_PASSWORD', 'TWO_CAPTCHA_PROXY_PASSWORD', 'CAPTCHA_PROXY_PASSWORD',
-    'TWOCAPTCHA_PROXY_PASS', 'TWO_CAPTCHA_PROXY_PASS', 'CAPTCHA_PROXY_PASS',
-  ]);
+  const host =
+    twoCaptcha.host ||
+    firstEnvValue([
+      'TWOCAPTCHA_PROXY_HOST',
+      'TWO_CAPTCHA_PROXY_HOST',
+      'CAPTCHA_PROXY_HOST',
+      'TWO_CAPTCHA_HOST',
+      'TWOCAPTCHA_HOST',
+    ]);
+  const port =
+    twoCaptcha.port ||
+    firstEnvValue([
+      'TWOCAPTCHA_PROXY_PORT',
+      'TWO_CAPTCHA_PROXY_PORT',
+      'CAPTCHA_PROXY_PORT',
+      'TWO_CAPTCHA_PORT',
+      'TWOCAPTCHA_PORT',
+    ]);
+  const username =
+    twoCaptcha.username ||
+    firstEnvValue([
+      'TWOCAPTCHA_PROXY_USERNAME',
+      'TWO_CAPTCHA_PROXY_USERNAME',
+      'CAPTCHA_PROXY_USERNAME',
+      'TWOCAPTCHA_PROXY_USER',
+      'TWO_CAPTCHA_PROXY_USER',
+      'CAPTCHA_PROXY_USER',
+    ]);
+  const password =
+    twoCaptcha.password ||
+    firstEnvValue([
+      'TWOCAPTCHA_PROXY_PASSWORD',
+      'TWO_CAPTCHA_PROXY_PASSWORD',
+      'CAPTCHA_PROXY_PASSWORD',
+      'TWOCAPTCHA_PROXY_PASS',
+      'TWO_CAPTCHA_PROXY_PASS',
+      'CAPTCHA_PROXY_PASS',
+    ]);
   if (!host || !port) return null;
   const scopedUsername = twoCaptchaSessionUsername(username, twoCaptcha.account);
   return {
-    type: twoCaptcha.type || firstEnvValue(['TWOCAPTCHA_PROXY_TYPE', 'TWO_CAPTCHA_PROXY_TYPE', 'CAPTCHA_PROXY_TYPE']) || 'http',
+    type:
+      twoCaptcha.type ||
+      firstEnvValue(['TWOCAPTCHA_PROXY_TYPE', 'TWO_CAPTCHA_PROXY_TYPE', 'CAPTCHA_PROXY_TYPE']) ||
+      'http',
     host,
     port: Number(port),
     username: scopedUsername,
@@ -319,10 +355,7 @@ function twoCaptchaProxyConfig(twoCaptcha = {}) {
 }
 
 function efgProxyConfig(config = {}) {
-  const url =
-    config.url ||
-    firstEnvValue(['EFG_PROXY_URL', 'CRS_EFG_PROXY_URL']) ||
-    'http://100.90.98.93:18088';
+  const url = config.url || firstEnvValue(['EFG_PROXY_URL', 'CRS_EFG_PROXY_URL']) || 'http://100.90.98.93:18088';
   const parsed = parseProxyUrl(url);
   if (parsed?.host && parsed?.port) return parsed;
 
@@ -340,7 +373,8 @@ function efgProxyConfig(config = {}) {
 function brightDataProxyConfig(bright = {}, key, accountIndex = 0) {
   bright = brightDataAliasConfig(bright);
   const user = bright.username || fileEnvValue('BRIGHT_DATA_USERID');
-  const password = bright.password || firstEnvValue(['BRIGHT_DATA_PROXY_PASSWORD', 'BRIGHT_DATA_PASSWORD', 'BRIGHT_DATA_TOKEN']);
+  const password =
+    bright.password || firstEnvValue(['BRIGHT_DATA_PROXY_PASSWORD', 'BRIGHT_DATA_PASSWORD', 'BRIGHT_DATA_TOKEN']);
   if (!user || !password) return null;
   if (process.env.CLAUDE_ROTATION_USE_BRIGHTDATA_PROXY === '0' || bright.enabled === false) return null;
   return {
@@ -351,7 +385,6 @@ function brightDataProxyConfig(bright = {}, key, accountIndex = 0) {
     password,
   };
 }
-
 
 /**
  * Resolve a per-account rotation-proxy descriptor.
@@ -371,9 +404,10 @@ export function accountProxyConfig(config = {}, account, env = process.env) {
     const provider = String(env.CLAUDE_ROTATION_PROXY_PROVIDER || 'brightdata')
       .trim()
       .toLowerCase();
-    const urlKey = provider === 'efg' || provider === 'unifi' || provider === 'home' || provider === 'gateway'
-      ? 'EFG_PROXY_URL'
-      : 'BRIGHTDATA_PROXY_URL';
+    const urlKey =
+      provider === 'efg' || provider === 'unifi' || provider === 'home' || provider === 'gateway'
+        ? 'EFG_PROXY_URL'
+        : 'BRIGHTDATA_PROXY_URL';
     const raw = env[urlKey];
     if (raw && typeof raw === 'string' && raw.trim()) {
       const parsed = parseProxyUrlSimple(raw.trim());
@@ -385,9 +419,12 @@ export function accountProxyConfig(config = {}, account, env = process.env) {
   }
 
   // ── ops-rich path (no public enable flag) ──────────────────────────────
-  const cfg = config && typeof config === 'object' && Object.keys(config).length
-    ? config
-    : (typeof loadRotationConfig === 'function' ? loadRotationConfig() : {});
+  const cfg =
+    config && typeof config === 'object' && Object.keys(config).length
+      ? config
+      : typeof loadRotationConfig === 'function'
+        ? loadRotationConfig()
+        : {};
   const key = accountKey(account);
   const direct = account?.proxy || account?.proxyConfig;
   if (direct) return direct;

--- a/claude-ops/scripts/account-rotation/crs-pool-config.mjs
+++ b/claude-ops/scripts/account-rotation/crs-pool-config.mjs
@@ -114,53 +114,316 @@ export function vaultLookupKeysForEmail(email, accounts = []) {
   return [...keys];
 }
 
-/**
- * Resolve a per-account rotation-proxy descriptor.
- *
- * Returns null when the rotation proxy is disabled (no override, no
- * `CLAUDE_ROTATION_PROXY_ENABLED=1`, or the provider URL is missing). When
- * enabled, parses `EFG_PROXY_URL` / `BRIGHTDATA_PROXY_URL` for the active
- * provider (`CLAUDE_ROTATION_PROXY_PROVIDER`, defaults to `brightdata`) and
- * returns a `{ type, host, port }` object that downstream `oauthFetch` and
- * `curl --proxy` callers consume.
- *
- * Signature: `accountProxyConfig(config, account, env?)`
- *   - `config`: loaded rotation config (from `loadRotationConfig()`)
- *   - `account`: account row (currently unused for routing; kept for future
- *     per-account overrides)
- *   - `env`: optional env-override object (defaults to `process.env`)
- *
- * Provider URL formats accepted:
- *   - `socks5://host:port`
- *   - `socks5h://host:port`
- *   - `http://host:port`            → type=`http`
- *   - `https://host:port`           → type=`http`
- *   - `host:port` (bare)            → type=`http`
- *
- * @param {{accounts?:Array, crs?:object}} _config
- * @param {{email?:string, label?:string}} _account
- * @param {Record<string,string|undefined>} [env]
- * @returns {{type:string, host:string, port:number} | null}
- */
-export function accountProxyConfig(_config, _account, env = process.env) {
-  if (!env || typeof env !== 'object') return null;
-  if (env.CLAUDE_ROTATION_PROXY_ENABLED !== '1') return null;
+function fileEnvValue(name) {
+  if (process.env[name]) return process.env[name];
+  const paths = [
+    join(homedir(), '.mcp-secrets.env'),
+    join(homedir(), '.agent-secrets.env'),
+    join(homedir(), '.config', 'credentials.env'),
+  ];
+  for (const p of paths) {
+    try {
+      if (!existsSync(p)) continue;
+      const lines = readFileSync(p, 'utf8').split(/\r?\n/);
+      for (const line of lines) {
+        const m = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)\s*$/);
+        if (!m || m[1] !== name) continue;
+        let v = m[2].trim();
+        if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) v = v.slice(1, -1);
+        return v;
+      }
+    } catch {}
+  }
+  return '';
+}
 
-  const provider = String(env.CLAUDE_ROTATION_PROXY_PROVIDER || 'brightdata')
-    .trim()
-    .toLowerCase();
+function firstEnvValue(names) {
+  for (const name of names) {
+    const value = fileEnvValue(name);
+    if (value) return value;
+  }
+  return '';
+}
 
-  const urlKey = provider === 'efg' ? 'EFG_PROXY_URL' : 'BRIGHTDATA_PROXY_URL';
-  const raw = env[urlKey];
-  if (!raw || typeof raw !== 'string') return null;
+function accountKey(account) {
+  return account?.label || account?.email || String(account || '');
+}
 
-  const parsed = parseProxyUrl(raw.trim());
-  return parsed;
+function safeSessionSuffix(key) {
+  return String(key || 'account').toLowerCase().replace(/[^a-z0-9]+/g, '').slice(0, 24) || 'account';
+}
+
+function withBrightDataSession(username, key) {
+  const session = safeSessionSuffix(key);
+  if (username.includes('-session-')) return username.replace(/-session-[^-]+/, `-session-${session}`);
+  return `${username}-session-${session}`;
+}
+
+function brightDataUsername(rawUser, bright = {}) {
+  const zone = bright.zone || firstEnvValue(['BRIGHT_DATA_ZONE']) || 'isp1';
+  if (String(rawUser).startsWith('brd-customer-')) return rawUser;
+  return `brd-customer-${rawUser}-zone-${zone}`;
+}
+
+function brightDataIps(bright = {}) {
+  const raw = Array.isArray(bright.ips)
+    ? bright.ips.join(',')
+    : String(bright.ips || firstEnvValue(['BRIGHT_DATA_IPS', 'BRIGHT_DATA_PROXY_IPS']) || '');
+  return raw.split(/[\s,]+/).map((x) => x.trim()).filter(Boolean);
+}
+
+function brightDataAliasConfig(bright = {}) {
+  const alias = String(
+    bright.alias
+      || firstEnvValue(['BRIGHT_DATA_ACTIVE_PROXY_ALIAS'])
+      || 'isp-proxy',
+  ).trim().toLowerCase();
+  if (alias === 'residential-proxy' || alias === 'residential' || alias === 'isp1') {
+    return {
+      ...bright,
+      zone: bright.residentialZone || firstEnvValue(['BRIGHT_DATA_RESIDENTIAL_PROXY_ZONE']) || 'isp1',
+      password:
+        bright.residentialPassword
+        || firstEnvValue(['BRIGHT_DATA_RESIDENTIAL_PROXY_PASSWORD', 'BRIGHT_DATA_RESIDENTIAL_PASSWORD'])
+        || bright.password,
+      ips: [],
+    };
+  }
+  return {
+    ...bright,
+    zone: bright.ispZone || firstEnvValue(['BRIGHT_DATA_ISP_PROXY_ZONE']) || bright.zone,
+    password:
+      bright.ispPassword
+      || firstEnvValue(['BRIGHT_DATA_ISP_PROXY_PASSWORD', 'BRIGHT_DATA_PROXY_PASSWORD'])
+      || bright.password,
+    ips: bright.ispIps || bright.ips || firstEnvValue(['BRIGHT_DATA_ISP_PROXY_IPS', 'BRIGHT_DATA_IPS']),
+  };
+}
+
+function brightDataUsernameForAccount(rawUser, bright = {}, key, accountIndex = 0) {
+  const base = brightDataUsername(rawUser, bright);
+  const ips = brightDataIps(bright);
+  if (ips.length) {
+    const ip = ips[Math.abs(accountIndex) % ips.length];
+    return `${base}-ip-${ip}`;
+  }
+  const country = bright.country || firstEnvValue(['BRIGHT_DATA_COUNTRY']) || 'us';
+  const scoped = `${base}-country-${country}`;
+  return bright.sessionPerAccount === false ? scoped : withBrightDataSession(scoped, key);
+}
+
+function proxyRoutingEnabled(config) {
+  const raw = String(
+    process.env.CLAUDE_ROTATION_PROXY_ENABLED
+      || process.env.CRS_ACCOUNT_PROXY_ENABLED
+      || firstEnvValue(['CLAUDE_ROTATION_PROXY_ENABLED', 'CRS_ACCOUNT_PROXY_ENABLED'])
+      || config.crs?.proxyEnabled
+      || config.crs?.proxy?.enabled
+      || '',
+  ).trim().toLowerCase();
+  return ['1', 'true', 'yes', 'on'].includes(raw);
+}
+
+function proxyProviderOrder(config) {
+  const raw = String(
+    process.env.CLAUDE_ROTATION_PROXY_PROVIDER
+      || process.env.CRS_ACCOUNT_PROXY_PROVIDER
+      || firstEnvValue(['CLAUDE_ROTATION_PROXY_PROVIDER', 'CRS_ACCOUNT_PROXY_PROVIDER'])
+      || config.crs?.proxyProvider
+      || config.crs?.proxy?.provider
+      || '2captcha,brightdata',
+  );
+  return raw.split(',').map((x) => x.trim().toLowerCase()).filter(Boolean);
 }
 
 function parseProxyUrl(raw) {
   if (!raw) return null;
-  // Strip trailing slash, accept bare host:port
+  try {
+    const u = new URL(raw);
+    return {
+      type: u.protocol.replace(':', '') || 'http',
+      host: u.hostname,
+      port: Number(u.port || (u.protocol === 'https:' ? 443 : 80)),
+      username: decodeURIComponent(u.username || ''),
+      password: decodeURIComponent(u.password || ''),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function twoCaptchaSessionUsername(username, account) {
+  const key = accountKey(account);
+  const session = safeSessionSuffix(key);
+  return username
+    ? String(username).replace(/-session-[^-]+/, `-session-${session}`)
+    : username;
+}
+
+function twoCaptchaProxyConfig(twoCaptcha = {}) {
+  const preferred = firstEnvValue(['TWOCAPTCHA_PROXY_PREFERRED_TRANSPORT', 'TWO_CAPTCHA_PROXY_PREFERRED_TRANSPORT']);
+  const url = twoCaptcha.url || firstEnvValue(
+    preferred === 'socks5'
+      ? [
+          'TWOCAPTCHA_PROXY_SOCKS5_URL',
+          'TWO_CAPTCHA_PROXY_SOCKS5_URL',
+          'TWOCAPTCHA_PROXY_URL',
+          'TWO_CAPTCHA_PROXY_URL',
+          'CAPTCHA_PROXY_URL',
+          'TWO_CAPTCHA_HTTP_PROXY',
+          'TWOCAPTCHA_HTTP_PROXY',
+        ]
+      : [
+    'TWOCAPTCHA_PROXY_URL',
+    'TWO_CAPTCHA_PROXY_URL',
+    'CAPTCHA_PROXY_URL',
+    'TWO_CAPTCHA_HTTP_PROXY',
+    'TWOCAPTCHA_HTTP_PROXY',
+          'TWOCAPTCHA_PROXY_SOCKS5_URL',
+          'TWO_CAPTCHA_PROXY_SOCKS5_URL',
+        ],
+  );
+  const parsed = parseProxyUrl(url);
+  if (parsed?.host && parsed?.port) {
+    return {
+      ...parsed,
+      username: twoCaptchaSessionUsername(parsed.username, twoCaptcha.account),
+    };
+  }
+
+  const host = twoCaptcha.host || firstEnvValue([
+    'TWOCAPTCHA_PROXY_HOST', 'TWO_CAPTCHA_PROXY_HOST', 'CAPTCHA_PROXY_HOST',
+    'TWO_CAPTCHA_HOST', 'TWOCAPTCHA_HOST',
+  ]);
+  const port = twoCaptcha.port || firstEnvValue([
+    'TWOCAPTCHA_PROXY_PORT', 'TWO_CAPTCHA_PROXY_PORT', 'CAPTCHA_PROXY_PORT',
+    'TWO_CAPTCHA_PORT', 'TWOCAPTCHA_PORT',
+  ]);
+  const username = twoCaptcha.username || firstEnvValue([
+    'TWOCAPTCHA_PROXY_USERNAME', 'TWO_CAPTCHA_PROXY_USERNAME', 'CAPTCHA_PROXY_USERNAME',
+    'TWOCAPTCHA_PROXY_USER', 'TWO_CAPTCHA_PROXY_USER', 'CAPTCHA_PROXY_USER',
+  ]);
+  const password = twoCaptcha.password || firstEnvValue([
+    'TWOCAPTCHA_PROXY_PASSWORD', 'TWO_CAPTCHA_PROXY_PASSWORD', 'CAPTCHA_PROXY_PASSWORD',
+    'TWOCAPTCHA_PROXY_PASS', 'TWO_CAPTCHA_PROXY_PASS', 'CAPTCHA_PROXY_PASS',
+  ]);
+  if (!host || !port) return null;
+  const scopedUsername = twoCaptchaSessionUsername(username, twoCaptcha.account);
+  return {
+    type: twoCaptcha.type || firstEnvValue(['TWOCAPTCHA_PROXY_TYPE', 'TWO_CAPTCHA_PROXY_TYPE', 'CAPTCHA_PROXY_TYPE']) || 'http',
+    host,
+    port: Number(port),
+    username: scopedUsername,
+    password,
+  };
+}
+
+function efgProxyConfig(config = {}) {
+  const url =
+    config.url ||
+    firstEnvValue(['EFG_PROXY_URL', 'CRS_EFG_PROXY_URL']) ||
+    'http://100.90.98.93:18088';
+  const parsed = parseProxyUrl(url);
+  if (parsed?.host && parsed?.port) return parsed;
+
+  const host = config.host || firstEnvValue(['EFG_PROXY_HOST', 'CRS_EFG_PROXY_HOST']) || '100.90.98.93';
+  const port = config.port || firstEnvValue(['EFG_PROXY_PORT', 'CRS_EFG_PROXY_PORT']) || '18088';
+  return {
+    type: config.type || firstEnvValue(['EFG_PROXY_TYPE', 'CRS_EFG_PROXY_TYPE']) || 'http',
+    host,
+    port: Number(port),
+    username: config.username || firstEnvValue(['EFG_PROXY_USERNAME', 'CRS_EFG_PROXY_USERNAME']),
+    password: config.password || firstEnvValue(['EFG_PROXY_PASSWORD', 'CRS_EFG_PROXY_PASSWORD']),
+  };
+}
+
+function brightDataProxyConfig(bright = {}, key, accountIndex = 0) {
+  bright = brightDataAliasConfig(bright);
+  const user = bright.username || fileEnvValue('BRIGHT_DATA_USERID');
+  const password = bright.password || firstEnvValue(['BRIGHT_DATA_PROXY_PASSWORD', 'BRIGHT_DATA_PASSWORD', 'BRIGHT_DATA_TOKEN']);
+  if (!user || !password) return null;
+  if (process.env.CLAUDE_ROTATION_USE_BRIGHTDATA_PROXY === '0' || bright.enabled === false) return null;
+  return {
+    type: bright.type || process.env.BRIGHT_DATA_PROXY_TYPE || 'http',
+    host: bright.host || process.env.BRIGHT_DATA_HOST || 'brd.superproxy.io',
+    port: Number(bright.port || process.env.BRIGHT_DATA_PORT || 33335),
+    username: brightDataUsernameForAccount(user, bright, key, accountIndex),
+    password,
+  };
+}
+
+
+/**
+ * Resolve a per-account rotation-proxy descriptor.
+ *
+ * Public contract (tests + simple installs):
+ *   accountProxyConfig(config, account, env?)
+ *   Requires env.CLAUDE_ROTATION_PROXY_ENABLED === '1' and a provider URL
+ *   (EFG_PROXY_URL or BRIGHTDATA_PROXY_URL). Returns { type, host, port }.
+ *
+ * Ops fallback (when public env URL path is not used): config-driven Bright
+ * Data / 2captcha / EFG with per-account sessions, reading secrets from env
+ * files only — never hardcodes credentials.
+ */
+export function accountProxyConfig(config = {}, account, env = process.env) {
+  // ── public contract ────────────────────────────────────────────────────
+  if (env && typeof env === 'object' && env.CLAUDE_ROTATION_PROXY_ENABLED === '1') {
+    const provider = String(env.CLAUDE_ROTATION_PROXY_PROVIDER || 'brightdata')
+      .trim()
+      .toLowerCase();
+    const urlKey = provider === 'efg' || provider === 'unifi' || provider === 'home' || provider === 'gateway'
+      ? 'EFG_PROXY_URL'
+      : 'BRIGHTDATA_PROXY_URL';
+    const raw = env[urlKey];
+    if (raw && typeof raw === 'string' && raw.trim()) {
+      const parsed = parseProxyUrlSimple(raw.trim());
+      if (parsed) return parsed;
+    }
+    // Enabled but URL missing/invalid → null (do not fall through to rich path
+    // when the public switch is explicitly on; keeps test contract strict).
+    return null;
+  }
+
+  // ── ops-rich path (no public enable flag) ──────────────────────────────
+  const cfg = config && typeof config === 'object' && Object.keys(config).length
+    ? config
+    : (typeof loadRotationConfig === 'function' ? loadRotationConfig() : {});
+  const key = accountKey(account);
+  const direct = account?.proxy || account?.proxyConfig;
+  if (direct) return direct;
+
+  const byKey = cfg.crs?.proxyByVaultKey || cfg.crs?.proxies;
+  if (byKey && typeof byKey === 'object' && byKey[key]) return byKey[key];
+
+  if (!proxyRoutingEnabled(cfg)) return null;
+
+  const bright = cfg.crs?.brightData || {};
+  const twoCaptcha = cfg.crs?.twoCaptchaProxy || cfg.crs?.captchaProxy || {};
+  const efg = cfg.crs?.efgProxy || cfg.crs?.efg || {};
+  const accountIndex = Math.max(
+    0,
+    (cfg.accounts || []).findIndex((a) => accountKey(a) === key),
+  );
+  for (const provider of proxyProviderOrder(cfg)) {
+    if (provider === 'efg' || provider === 'unifi' || provider === 'home' || provider === 'gateway') {
+      const proxy = efgProxyConfig(efg);
+      if (proxy) return proxy;
+    }
+    if (provider === '2captcha' || provider === 'twocaptcha' || provider === 'captcha') {
+      const proxy = twoCaptchaProxyConfig({ ...twoCaptcha, account });
+      if (proxy) return proxy;
+    }
+    if (provider === 'bright' || provider === 'brightdata' || provider === 'bright-data') {
+      const proxy = brightDataProxyConfig(bright, key, accountIndex);
+      if (proxy) return proxy;
+    }
+  }
+  return null;
+}
+
+/** Simple URL parser for the public contract (type/host/port only). */
+function parseProxyUrlSimple(raw) {
+  if (!raw) return null;
   let s = raw.replace(/\/+$/, '');
   let type = 'http';
   if (s.startsWith('socks5://')) {
@@ -176,19 +439,14 @@ function parseProxyUrl(raw) {
     type = 'http';
     s = s.slice('http://'.length);
   } else {
-    // Reject unsupported schemes (e.g. ftp://, ssh://, file://). Bare
-    // host:port (no scheme, no path/query/fragment) is still allowed.
     if (/[/?#]/.test(s)) return null;
   }
-  // Now s is host[:port] (may have userinfo@host)
   const at = s.lastIndexOf('@');
   if (at >= 0) s = s.slice(at + 1);
   const colon = s.lastIndexOf(':');
   if (colon < 0) return null;
   const host = s.slice(0, colon).trim();
   const portStr = s.slice(colon + 1).trim();
-  // Reject anything that isn't pure decimal digits after the colon — guards
-  // against `host:3128/path`, `host:3128junk`, `host:3128?x=1`, etc.
   if (!host || /[\s/?#]/.test(host) || !/^\d+$/.test(portStr)) return null;
   const port = Number.parseInt(portStr, 10);
   if (!Number.isInteger(port) || port <= 0 || port > 65535) return null;

--- a/claude-ops/scripts/account-rotation/crs-priority-daemon.mjs
+++ b/claude-ops/scripts/account-rotation/crs-priority-daemon.mjs
@@ -18,6 +18,11 @@
 //   sessionWindow.sessionWindowStatus                                  (allowed | allowed_warning | …)
 //   claudeUsage.{fiveHour,sevenDay,sevenDayOpus}.utilization           (fresh secondary only)
 //
+// LIVE QUOTA POLLER (60-120s): hybrid header-derived (CRS rateLimit* from relay
+// upstream headers) + targeted /oauth/usage probe per account (throttled, cached).
+// Clears stale cooldowns on rateLimitResetAt expiry. Feeds live headroom back
+// to CRS scheduler via account PUT for accurate LB/concurrency.
+//
 // POLICY (configurable via crs.policy or $CRS_POLICY):
 //   conservative (default) — deprioritize on fresh high utilization, sessionWindow
 //   warnings, rate limits, and overload; FLOOR keeps minimum pool size; dedup by
@@ -129,12 +134,11 @@ function adminPassword() {
   );
 }
 
-// ── authoritative per-account quota (api.anthropic.com/api/oauth/usage) ────────
-// CRS's cached claudeUsage is often null/stale, so for accurate prioritization we
-// read each account's OAuth token from the credential store and query Anthropic's
-// usage endpoint directly (read-only GET — does NOT rotate the token). Falls back
-// to the cache/sessionWindowStatus when no token / 401 / timeout. Tokens live at
-// `Claude-Rotation-<email>` (rotator schema); CRS account → token by subscription email.
+// ── live per-account quota poller (hybrid header + targeted probe) ──────────────
+// 60-120s friendly: CRS /admin accounts gives header-derived rateLimitStatus etc;
+// we do targeted read-only /oauth/usage probe (via stored OAuth) for u5/u7 headroom.
+// Hybrid: body + response headers. TTL + throttle. Falls back to cache on error.
+// Never drives re-enable from stale; feeds headroom to scheduler after collection.
 const USAGE_TOKEN_SVC = process.env.CRS_USAGE_TOKEN_PREFIX || 'Claude-Rotation-';
 
 function accountVaultKey(a) {
@@ -219,6 +223,10 @@ function rateLimitLooksStale(a, now = Date.now()) {
     return false;
   };
 
+  // Explicit: clear stale cooldowns when rateLimitResetAt (or embedded resetAt) has passed
+  if (resetAtPassed(a.rateLimitStatus, a.rateLimitResetAt, now)) return true;
+  if (resetAtPassed(a.opusRateLimitStatus, a.opusRateLimitStatus?.resetAt, now)) return true;
+
   if (inspect(a.rateLimitStatus, a.rateLimitResetAt)) return true;
   if (inspect(a.opusRateLimitStatus, a.opusRateLimitStatus?.resetAt)) return true;
 
@@ -229,6 +237,13 @@ function rateLimitLooksStale(a, now = Date.now()) {
     if (accountTokenFresh(a, now)) return true;
   }
   return false;
+}
+
+function resetAtPassed(st, fallback, now = Date.now()) {
+  const resetAt = st?.resetAt || fallback;
+  if (!resetAt) return false;
+  const ms = Date.parse(resetAt);
+  return Number.isFinite(ms) && ms <= now;
 }
 async function liveUsage(email) {
   if (!email) return null;
@@ -243,8 +258,16 @@ async function liveUsage(email) {
       signal: AbortSignal.timeout(5000),
     });
     if (!r.ok) return cached?.data ?? null;
+    // Hybrid: body (utilization) + headers (rate reset signals when present)
+    const headers = {};
+    r.headers.forEach((v, k) => { headers[k.toLowerCase()] = v; });
     const d = await r.json();
-    const data = { u5: d?.five_hour?.utilization ?? null, u7: d?.seven_day?.utilization ?? null };
+    const data = {
+      u5: d?.five_hour?.utilization ?? null,
+      u7: d?.seven_day?.utilization ?? null,
+      // capture any reset header for hybrid RL detection if body alone insufficient
+      resetHeader: headers['retry-after'] || headers['anthropic-ratelimit-unified-tokens-reset'] || null,
+    };
     liveUsageCache.set(email, { at: Date.now(), data });
     return data;
   } catch {
@@ -304,15 +327,17 @@ async function clearStaleCooldowns(auth, accts) {
   for (const a of accts) {
     if (!rateLimitLooksStale(a, now)) continue;
     const mins = a.rateLimitStatus?.minutesRemaining ?? '?';
+    const resetPassed = resetAtPassed(a.rateLimitStatus, a.rateLimitResetAt, now) ||
+                        resetAtPassed(a.opusRateLimitStatus, a.opusRateLimitStatus?.resetAt, now);
     if (DRY) {
-      log(`[dry] clear stale RL ${a.name} (mins=${mins})`);
+      log(`[dry] clear stale RL ${a.name} (mins=${mins}${resetPassed ? ', resetAt passed' : ''})`);
       cleared++;
       continue;
     }
     const res = await jfetch(`/admin/claude-accounts/${a.id}/reset-status`, { method: 'POST', headers: auth });
     if (res.status >= 200 && res.status < 300) {
       cleared++;
-      log(`${a.name}: cleared stale RL/error cache (was mins=${mins})`);
+      log(`${a.name}: cleared stale RL/error cache (was mins=${mins}${resetPassed ? ' — rateLimitResetAt passed' : ''})`);
     }
   }
   return cleared;
@@ -342,6 +367,30 @@ async function recoverSchedulableAfterClear(auth, accts) {
     }
   }
   return enabled;
+}
+
+// Feed live headroom (from targeted quota probe) back into CRS account record.
+// This supplies the scheduler with fresh per-account utilization/headroom so
+// load-balancing, concurrency caps, and selection use authoritative 5h/7d numbers
+// instead of stale claudeUsage cache.
+async function feedLiveHeadroom(auth, a, lu) {
+  if (!lu || DRY) return false;
+  const update = {
+    claudeUsage: {
+      fiveHour: { utilization: lu.u5 ?? null, updatedAt: new Date().toISOString() },
+      sevenDay: { utilization: lu.u7 ?? null, updatedAt: new Date().toISOString() },
+    },
+  };
+  try {
+    const r = await jfetch(`/admin/claude-accounts/${a.id}`, {
+      method: 'PUT',
+      headers: auth,
+      body: JSON.stringify(update),
+    });
+    return r.status >= 200 && r.status < 300;
+  } catch {
+    return false;
+  }
 }
 
 // ── policy ───────────────────────────────────────────────────────────────────
@@ -504,14 +553,26 @@ async function main() {
       log(`stale-cooldown: re-enabled ${reenabled} schedulable account(s)`);
     }
   }
-  // Authoritative quota: query Anthropic /oauth/usage directly per account (parallel,
-  // read-only). Falls back to CRS cache + sessionWindowStatus when a token is absent/stale.
-  await Promise.all(
-    accts.map(async (a) => {
-      a._liveUsage = await liveUsage(accountVaultKey(a));
-    }),
-  );
-  const liveN = accts.filter((a) => a._liveUsage).length;
+  // Live per-account quota poller (60-120s cadence): hybrid of CRS-provided
+  // rateLimitStatus / sessionWindow / overload (populated from upstream response
+  // headers in the relay) + targeted /oauth/usage probe for precise u5/u7 headroom.
+  // Throttled sequential probes keep it polite under 60-120s window; feeds headroom
+  // to scheduler after.
+  let liveN = 0;
+  for (const a of accts) {
+    const key = accountVaultKey(a);
+    a._liveUsage = await liveUsage(key);
+    if (a._liveUsage) liveN++;
+    // Throttle ~150ms between probes (fits 60-120s hybrid header+probe cadence for ~13 accts)
+    await new Promise((r) => setTimeout(r, 150));
+  }
+  // Feed fresh headroom/utilization from targeted probes into CRS so scheduler
+  // (unifiedClaudeScheduler etc) sees live quota headroom for selection/LB.
+  let fed = 0;
+  for (const a of accts) {
+    if (a._liveUsage && (await feedLiveHeadroom(auth, a, a._liveUsage))) fed++;
+  }
+  if (fed) log(`headroom feed: updated ${fed} account(s) in CRS for scheduler`);
   const decisions = decide(accts);
 
   if (STATUS) {

--- a/claude-ops/scripts/account-rotation/crs-priority-daemon.mjs
+++ b/claude-ops/scripts/account-rotation/crs-priority-daemon.mjs
@@ -260,7 +260,9 @@ async function liveUsage(email) {
     if (!r.ok) return cached?.data ?? null;
     // Hybrid: body (utilization) + headers (rate reset signals when present)
     const headers = {};
-    r.headers.forEach((v, k) => { headers[k.toLowerCase()] = v; });
+    r.headers.forEach((v, k) => {
+      headers[k.toLowerCase()] = v;
+    });
     const d = await r.json();
     const data = {
       u5: d?.five_hour?.utilization ?? null,
@@ -327,8 +329,9 @@ async function clearStaleCooldowns(auth, accts) {
   for (const a of accts) {
     if (!rateLimitLooksStale(a, now)) continue;
     const mins = a.rateLimitStatus?.minutesRemaining ?? '?';
-    const resetPassed = resetAtPassed(a.rateLimitStatus, a.rateLimitResetAt, now) ||
-                        resetAtPassed(a.opusRateLimitStatus, a.opusRateLimitStatus?.resetAt, now);
+    const resetPassed =
+      resetAtPassed(a.rateLimitStatus, a.rateLimitResetAt, now) ||
+      resetAtPassed(a.opusRateLimitStatus, a.opusRateLimitStatus?.resetAt, now);
     if (DRY) {
       log(`[dry] clear stale RL ${a.name} (mins=${mins}${resetPassed ? ', resetAt passed' : ''})`);
       cleared++;
@@ -337,7 +340,9 @@ async function clearStaleCooldowns(auth, accts) {
     const res = await jfetch(`/admin/claude-accounts/${a.id}/reset-status`, { method: 'POST', headers: auth });
     if (res.status >= 200 && res.status < 300) {
       cleared++;
-      log(`${a.name}: cleared stale RL/error cache (was mins=${mins}${resetPassed ? ' — rateLimitResetAt passed' : ''})`);
+      log(
+        `${a.name}: cleared stale RL/error cache (was mins=${mins}${resetPassed ? ' — rateLimitResetAt passed' : ''})`,
+      );
     }
   }
   return cleared;

--- a/claude-ops/scripts/account-rotation/crs-priority-daemon.sh
+++ b/claude-ops/scripts/account-rotation/crs-priority-daemon.sh
@@ -28,7 +28,10 @@ if [ -z "${CRS_ADMIN_PASSWORD:-}" ]; then
   export CRS_ADMIN_PASSWORD
 fi
 
-curl -sf -o /dev/null --max-time 5 http://127.0.0.1:3005/health || exit 0
+# Probe local CRS (Mac 8091/18091 or dev 3005); tolerate down (priority is advisory)
+for p in ${CRS_HEALTH_PORTS:-8091 18091 3005 13005}; do
+  curl -sf -o /dev/null --max-time 3 "http://127.0.0.1:${p}/health" && break
+done || true
 
 if [ -f "$LOG" ]; then
   LOGSIZE="$(stat -c%s "$LOG" 2>/dev/null || stat -f%z "$LOG" 2>/dev/null || echo 0)"


### PR DESCRIPTION
## Summary

Salvages unfinished CRS ops work left dirty on `fix/posttooluse-hook-output-schema` (already merged as #660/#661) onto a fresh branch from `main`.

1. **Priority daemon live quota poller** — hybrid CRS header-derived rate limits + throttled `/oauth/usage` probes; clear cooldowns when `rateLimitResetAt` has passed; PUT live 5h/7d utilization into CRS accounts for scheduler headroom.
2. **Health wrapper** — accept Mac HAProxy `:8091`, local Docker `:18091`, and legacy `:3005`/`:13005` instead of exiting when only `:3005` is down.
3. **accountProxyConfig** — keeps the public `CLAUDE_ROTATION_PROXY_ENABLED` + URL contract (all existing tests) and adds an ops-rich fallback for Bright Data / 2captcha / EFG with per-account sessions.
4. **hooks.json** — small SessionStart timeout bumps (bedrock guard 5s, autosync 3s).

## Test plan

- [x] `node --test claude-ops/scripts/account-rotation/crs-pool-config.test.mjs` (8/8)
- [ ] Run priority daemon once against local CRS (`crs-priority-daemon.sh`) and confirm headroom feed log line
- [ ] Confirm Mac launchd path sees healthy CRS on 8091/18091

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CRS account scheduling inputs (admin PUTs, cooldown clearing) and expands proxy credential resolution; mistakes could mis-route OAuth traffic or skew pool selection, but public proxy contract remains test-guarded.
> 
> **Overview**
> Extends CRS ops so the priority daemon can drive scheduling from fresher quota signals, while making the wrapper and proxy resolution work better on Mac and in internal installs.
> 
> The **priority daemon** now treats expired `rateLimitResetAt` as stale cooldowns, probes `/oauth/usage` sequentially (with cache/throttle) and captures hybrid header hints, then **PUTs live 5h/7d utilization** into CRS accounts so the scheduler sees current headroom—not only cached `claudeUsage`.
> 
> **`accountProxyConfig`** keeps the public `CLAUDE_ROTATION_PROXY_ENABLED=1` + URL contract (strict, no fallthrough when enabled) and adds an ops path: per-account overrides, config/env-file secrets, and provider-ordered Bright Data / 2captcha / EFG with per-account session usernames.
> 
> The **shell wrapper** probes CRS health on **8091, 18091, 3005, 13005** and no longer exits when only legacy `:3005` is down. **`hooks.json`** adds a **5s** timeout on the bedrock fallback guard and raises ops-inbox autosync from **1s → 3s**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c31239d50991b51628e704c3aed9db8427ac940. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->