### PR TITLE
fix(ops): AWS Usage burn not credit-masked net

### DIFF
--- a/claude-ops/agents/revenue-tracker.md
+++ b/claude-ops/agents/revenue-tracker.md
@@ -138,30 +138,43 @@ Pull from the metrics overview response (`churn_rate` or equivalent field). If n
 
 ---
 
-## Costs — AWS (existing)
+## Costs — AWS (Usage burn only)
 
-### Current month costs by service
+**Doctrine:** Credits mask net UnblendedCost to ≈ $0. Always use
+`RECORD_TYPE=Usage` (or `scripts/aws-usage-cost.sh`). Never report unfiltered
+totals as spend.
+
+### Canonical snapshot
 
 ```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/aws-usage-cost.sh snapshot 2>/dev/null || echo '{}'
+```
+
+### Current month Usage by service
+
+```bash
+USAGE_FILTER='{"Dimensions":{"Key":"RECORD_TYPE","Values":["Usage"]}}'
 aws ce get-cost-and-usage \
   --time-period "Start=$(date +%Y-%m-01),End=$(date +%Y-%m-%d)" \
   --granularity MONTHLY \
   --metrics "UnblendedCost" "UsageQuantity" \
+  --filter "$USAGE_FILTER" \
   --group-by "Type=DIMENSION,Key=SERVICE" \
   --output json 2>/dev/null
 ```
 
-### Last 3 months trend
+### Last 3 months Usage trend
 
 ```bash
+USAGE_FILTER='{"Dimensions":{"Key":"RECORD_TYPE","Values":["Usage"]}}'
 START=$(date -v-3m +%Y-%m-01 2>/dev/null || date -d "-3 months" +%Y-%m-01 2>/dev/null)
 aws ce get-cost-and-usage \
   --time-period "Start=$START,End=$(date +%Y-%m-%d)" \
   --granularity MONTHLY \
   --metrics "UnblendedCost" \
+  --filter "$USAGE_FILTER" \
   --output json 2>/dev/null
 ```
-
 ### End-of-month forecast
 
 ```bash

--- a/claude-ops/agents/yolo-cfo.md
+++ b/claude-ops/agents/yolo-cfo.md
@@ -53,18 +53,28 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/finops-bridge.sh push-event \
 
 ### 1. Actual burn rate vs. what we think it is
 
-Pull real numbers from AWS Cost Explorer. What is the current monthly run rate? What's the forecast for end of month? Is it going up or down?
+**CRITICAL:** Credits mask net CE totals to ≈ $0. Burn = **Usage only**
+(`RECORD_TYPE=Usage`). Prefer the helper; never report unfiltered UnblendedCost
+as spend.
 
 ```bash
+${CLAUDE_PLUGIN_ROOT}/scripts/aws-usage-cost.sh snapshot 2>/dev/null
+# fields: mtd_usage, prev_month_usage, avg_daily_7d, eom_pace, credits_mtd, top_services
+```
+
+Fallback:
+
+```bash
+USAGE_FILTER='{"Dimensions":{"Key":"RECORD_TYPE","Values":["Usage"]}}'
 aws ce get-cost-and-usage \
   --time-period "Start=$(date +%Y-%m-01),End=$(date +%Y-%m-%d)" \
   --granularity MONTHLY \
   --metrics "UnblendedCost" \
+  --filter "$USAGE_FILTER" \
   --group-by "Type=DIMENSION,Key=SERVICE" \
   --output json 2>/dev/null | \
   jq '.ResultsByTime[0].Groups | sort_by(.Metrics.UnblendedCost.Amount | tonumber) | reverse | .[0:10] | map({service: .Keys[0], cost: .Metrics.UnblendedCost.Amount})'
 ```
-
 ### 2. Which AWS services are waste?
 
 For each service over $5/month: is it essential? Can it be right-sized? Any idle resources?
@@ -104,12 +114,15 @@ If AWS credentials are available (`aws sts get-caller-identity`), run a comprehe
 # Cost by account (if multi-account)
 aws organizations list-accounts --output json 2>/dev/null | jq '.Accounts[*].{id:Id,name:Name,status:Status}'
 
-# Last 3 months cost trend
+# Last 3 months Usage burn trend (NOT credit-masked net)
+USAGE_FILTER='{"Dimensions":{"Key":"RECORD_TYPE","Values":["Usage"]}}'
 for i in 3 2 1; do
   START=$(date -v-${i}m +%Y-%m-01 2>/dev/null || date -d "$i months ago" +%Y-%m-01)
   END=$(date -v-$((i-1))m +%Y-%m-01 2>/dev/null || date -d "$((i-1)) months ago" +%Y-%m-01)
-  aws ce get-cost-and-usage --time-period "Start=$START,End=$END" --granularity MONTHLY --metrics UnblendedCost --output json 2>/dev/null
+  aws ce get-cost-and-usage --time-period "Start=$START,End=$END" --granularity MONTHLY --metrics UnblendedCost --filter "$USAGE_FILTER" --output json 2>/dev/null
 done
+# Credit mask (explain why Console net can look near zero)
+${CLAUDE_PLUGIN_ROOT}/scripts/aws-usage-cost.sh record-types 2>/dev/null || true
 
 # Reserved instances utilization
 RES_START=$(date -v-30d +%Y-%m-%d 2>/dev/null || date -d '30 days ago' +%Y-%m-%d)
@@ -143,11 +156,13 @@ Write to `/tmp/yolo-[session]/cfo-analysis.md`:
 
 ## Real Numbers
 
-- Monthly burn (AWS): $[X]
-- MoM change: [+/-X%]
-- EOM forecast: $[X]
+- Monthly Usage burn (AWS, RECORD_TYPE=Usage): $[X]
+- Credits applied MTD (mask, not spend): $[X]
+- MoM change (Usage): [+/-X%]
+- EOM pace (7d Usage avg × days): $[X]
 - Total MRR: $[X]
-- Net burn: $[X/month]
+- Net burn (Usage − MRR): $[X/month]
+- **Do not** use credit-masked net CE total as burn
 
 ## Top Cost Drivers
 

--- a/claude-ops/scripts/aws-usage-cost.sh
+++ b/claude-ops/scripts/aws-usage-cost.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# aws-usage-cost.sh — real AWS burn (RECORD_TYPE=Usage), not credit-masked net.
+#
+# Doctrine (2026-07-22): Startup credits, SPP discounts, and Savings Plan
+# negation make plain UnblendedCost / NetUnblendedCost totals ≈ $0 even when
+# gross usage is hundreds/day. ALWAYS filter RECORD_TYPE=Usage for burn,
+# pace, spikes, and Bedrock. Report credits only as a separate mask line.
+#
+# Usage:
+#   aws-usage-cost.sh snapshot          # JSON: mtd_usage, prev_usage, daily[], top_services[], mask[]
+#   aws-usage-cost.sh daily [N]         # last N days Usage totals (default 7)
+#   aws-usage-cost.sh by-service [mtd|prev]
+#   aws-usage-cost.sh record-types      # Credit / Usage / SP breakdown (mask)
+#   aws-usage-cost.sh all               # human-readable brief for ops dashboards
+#
+# Env:
+#   AWS_REGION / AWS_DEFAULT_REGION (default us-east-1 for CE — global service)
+#   AWS_PROFILE
+set -euo pipefail
+
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-east-1}}"
+USAGE_FILTER='{"Dimensions":{"Key":"RECORD_TYPE","Values":["Usage"]}}'
+
+today() { date +%Y-%m-%d; }
+month_start() { date +%Y-%m-01; }
+# macOS date(1) first; GNU date fallback
+days_ago() {
+  local n="${1:-7}"
+  date -v-"${n}"d +%Y-%m-%d 2>/dev/null || date -d "${n} days ago" +%Y-%m-%d
+}
+prev_month_start() {
+  date -v-1m +%Y-%m-01 2>/dev/null || date -d "$(date +%Y-%m-01) -1 month" +%Y-%m-%d
+}
+prev_month_end() { date +%Y-%m-01; }
+
+ce() {
+  aws ce get-cost-and-usage --region "$REGION" "$@" 2>/dev/null
+}
+
+cmd_daily() {
+  local n="${1:-7}"
+  local start end
+  start=$(days_ago "$n")
+  end=$(today)
+  ce --time-period "Start=${start},End=${end}" \
+    --granularity DAILY --metrics UnblendedCost \
+    --filter "$USAGE_FILTER" --output json \
+    | jq -c '[.ResultsByTime[] | {day: .TimePeriod.Start, usage: (.Total.UnblendedCost.Amount | tonumber)}]'
+}
+
+cmd_by_service() {
+  local which="${1:-mtd}"
+  local start end
+  if [ "$which" = "prev" ]; then
+    start=$(prev_month_start)
+    end=$(prev_month_end)
+  else
+    start=$(month_start)
+    end=$(today)
+  fi
+  ce --time-period "Start=${start},End=${end}" \
+    --granularity MONTHLY --metrics UnblendedCost \
+    --filter "$USAGE_FILTER" \
+    --group-by Type=DIMENSION,Key=SERVICE --output json \
+    | jq -c '[.ResultsByTime[0].Groups[]? | {service: .Keys[0], usage: (.Metrics.UnblendedCost.Amount | tonumber)}] | sort_by(-.usage)'
+}
+
+cmd_total() {
+  local start="$1" end="$2"
+  ce --time-period "Start=${start},End=${end}" \
+    --granularity MONTHLY --metrics UnblendedCost \
+    --filter "$USAGE_FILTER" --output json \
+    | jq -r '.ResultsByTime[0].Total.UnblendedCost.Amount // "0"'
+}
+
+cmd_record_types() {
+  local start end
+  start=$(month_start)
+  end=$(today)
+  ce --time-period "Start=${start},End=${end}" \
+    --granularity MONTHLY --metrics UnblendedCost \
+    --group-by Type=DIMENSION,Key=RECORD_TYPE --output json \
+    | jq -c '[.ResultsByTime[0].Groups[]? | {type: .Keys[0], amount: (.Metrics.UnblendedCost.Amount | tonumber)}]'
+}
+
+cmd_snapshot() {
+  local mtd prev daily top mask avg pace
+  mtd=$(cmd_total "$(month_start)" "$(today)")
+  prev=$(cmd_total "$(prev_month_start)" "$(prev_month_end)")
+  daily=$(cmd_daily 7)
+  top=$(cmd_by_service mtd | jq -c '.[0:10]')
+  mask=$(cmd_record_types)
+  avg=$(echo "$daily" | jq '[.[].usage] | if length>0 then (add/length) else 0 end')
+  # pace: avg daily * days in month
+  local dim
+  dim=$(date -v+1m -v1d -v-1d +%d 2>/dev/null || date -d "$(date +%Y-%m-01) +1 month -1 day" +%d)
+  pace=$(echo "$avg $dim" | awk '{printf "%.2f", $1*$2}')
+
+  local credit_sum spp
+  credit_sum=$(echo "$mask" | jq '[.[] | select(.type|test("Credit";"i")) | .amount] | add // 0')
+  spp=$(echo "$mask" | jq '[.[] | select(.type|test("Solution Provider|Discount";"i")) | .amount] | add // 0')
+
+  jq -n \
+    --argjson mtd_usage "${mtd:-0}" \
+    --argjson prev_usage "${prev:-0}" \
+    --argjson daily "$daily" \
+    --argjson top_services "$top" \
+    --argjson record_types "$mask" \
+    --argjson avg_daily_7d "$avg" \
+    --argjson eom_pace "$pace" \
+    --argjson credits_mtd "$credit_sum" \
+    --argjson discounts_mtd "$spp" \
+    --arg metric "UnblendedCost" \
+    --arg filter "RECORD_TYPE=Usage" \
+    --arg note "Credits mask net totals; burn = Usage only" \
+    --arg generated_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '{
+      generated_at: $generated_at,
+      metric: $metric,
+      filter: $filter,
+      note: $note,
+      mtd_usage: $mtd_usage,
+      prev_month_usage: $prev_usage,
+      avg_daily_7d: $avg_daily_7d,
+      eom_pace: $eom_pace,
+      credits_mtd: $credits_mtd,
+      discounts_mtd: $discounts_mtd,
+      daily: $daily,
+      top_services: $top_services,
+      record_types: $record_types
+    }'
+}
+
+cmd_all() {
+  local snap
+  snap=$(cmd_snapshot) || { echo "AWS Cost Explorer unavailable"; return 1; }
+  echo "$snap" | jq -r '
+    "AWS USAGE BURN (RECORD_TYPE=Usage — not credit-masked net)",
+    "  MTD usage:     $\(.mtd_usage | floor)",
+    "  Prev month:    $\(.prev_month_usage | floor)",
+    "  7d avg/day:    $\(.avg_daily_7d | . * 100 | floor / 100)",
+    "  EOM pace:      $\(.eom_pace | floor)",
+    "  Credits MTD:   $\(.credits_mtd | floor)  (mask — do not treat net $0 as low burn)",
+    "  Top services:",
+    (.top_services[0:5][] | "    \(.service): $\(.usage | floor)")
+  '
+}
+
+main() {
+  local sub="${1:-snapshot}"
+  shift || true
+  case "$sub" in
+    snapshot) cmd_snapshot ;;
+    daily) cmd_daily "${1:-7}" ;;
+    by-service) cmd_by_service "${1:-mtd}" ;;
+    record-types) cmd_record_types ;;
+    all|brief) cmd_all ;;
+    -h|--help|help)
+      sed -n '2,20p' "$0"
+      ;;
+    *)
+      echo "unknown subcommand: $sub" >&2
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/claude-ops/scripts/ops-aws-audit.sh
+++ b/claude-ops/scripts/ops-aws-audit.sh
@@ -260,29 +260,50 @@ audit_security_posture() {
 }
 
 # ===================================================== Cost (per-service Δ) ===
+# Doctrine (2026-07-22): RECORD_TYPE=Usage only. Credits/SPP/SP negation make
+# plain Blended/Unblended totals ≈ $0 while real burn is hundreds/day.
 audit_cost() {
-  sec "Cost Explorer (per-service Δ over ${COST_DAYS}d)"
+  sec "Cost Explorer Usage burn (per-service Δ over ${COST_DAYS}d; RECORD_TYPE=Usage)"
   local e s p
-  e=$(date +%F); s=$(date -d "-${COST_DAYS} days" +%F); p=$(date -d "-$((COST_DAYS*2)) days" +%F)
-  # DAILY granularity (MONTHLY mis-handles sub-month / month-boundary windows),
-  # aggregated per service across the window.
-  AWS ce get-cost-and-usage --time-period Start=$s,End=$e --granularity DAILY --metrics BlendedCost \
+  e=$(date +%F)
+  # macOS date first; GNU date fallback
+  s=$(date -v-"${COST_DAYS}"d +%F 2>/dev/null || date -d "-${COST_DAYS} days" +%F)
+  p=$(date -v-"$((COST_DAYS*2))"d +%F 2>/dev/null || date -d "-$((COST_DAYS*2)) days" +%F)
+  local USAGE_FILTER='{"Dimensions":{"Key":"RECORD_TYPE","Values":["Usage"]}}'
+  # DAILY granularity + Usage filter (credit-masked nets are useless for spikes)
+  AWS ce get-cost-and-usage --time-period Start=$s,End=$e --granularity DAILY --metrics UnblendedCost \
+    --filter "$USAGE_FILTER" \
     --group-by Type=DIMENSION,Key=SERVICE \
-    --query 'ResultsByTime[].Groups[].[Keys[0],Metrics.BlendedCost.Amount]' --output text 2>/dev/null \
+    --query 'ResultsByTime[].Groups[].[Keys[0],Metrics.UnblendedCost.Amount]' --output text 2>/dev/null \
     | awk -F'\t' '{a[$1]+=$2} END{for(k in a) printf "%s\t%.2f\n",k,a[k]}' | sort >"$RAW/cost-current.tsv"
-  AWS ce get-cost-and-usage --time-period Start=$p,End=$s --granularity DAILY --metrics BlendedCost \
+  AWS ce get-cost-and-usage --time-period Start=$p,End=$s --granularity DAILY --metrics UnblendedCost \
+    --filter "$USAGE_FILTER" \
     --group-by Type=DIMENSION,Key=SERVICE \
-    --query 'ResultsByTime[].Groups[].[Keys[0],Metrics.BlendedCost.Amount]' --output text 2>/dev/null \
+    --query 'ResultsByTime[].Groups[].[Keys[0],Metrics.UnblendedCost.Amount]' --output text 2>/dev/null \
     | awk -F'\t' '{a[$1]+=$2} END{for(k in a) printf "%s\t%.2f\n",k,a[k]}' | sort >"$RAW/cost-prev.tsv"
+  # Optional: credit mask snapshot for the report
+  AWS ce get-cost-and-usage --time-period Start=$s,End=$e --granularity MONTHLY --metrics UnblendedCost \
+    --group-by Type=DIMENSION,Key=RECORD_TYPE \
+    --query 'ResultsByTime[0].Groups[].[Keys[0],Metrics.UnblendedCost.Amount]' --output text 2>/dev/null \
+    >"$RAW/cost-record-types.tsv" || true
   if [ -s "$RAW/cost-current.tsv" ]; then
     join -t $'\t' -a1 -e 0 -o '0,1.2,2.2' "$RAW/cost-current.tsv" "$RAW/cost-prev.tsv" 2>/dev/null \
       | awk -F'\t' '{d=$2-$3; printf "%s\t%.2f\t%+.2f\n",$1,$2,d}' \
       | sort -t$'\t' -k2 -nr >"$RAW/cost-delta.tsv"
-    ok "cost delta computed ($(wc -l <"$RAW/cost-delta.tsv") services)"
+    local total_usage
+    total_usage=$(awk -F'\t' '{s+=$2} END{printf "%.2f",s+0}' "$RAW/cost-current.tsv")
+    ok "Usage burn ${COST_DAYS}d total=\$${total_usage}; delta rows=$(wc -l <"$RAW/cost-delta.tsv" | tr -d ' ')"
     # flag any service that jumped >$5 vs previous window
     awk -F'\t' '$3+0>5{print}' "$RAW/cost-delta.tsv" | while IFS=$'\t' read -r svc cur del; do
-      finding MEDIUM Cost global "$svc" "Spend up ${del} vs prior ${COST_DAYS}d (now \$${cur})" "Investigate the cost driver for $svc" 0
+      finding MEDIUM Cost global "$svc" "Usage spend up \$${del} vs prior ${COST_DAYS}d (now \$${cur})" "Investigate the cost driver for $svc (Usage burn, not credit-masked net)" 0
     done
+    # Surface high daily Usage burn so reports don't look "free" under credits
+    avg_daily=$(awk -v d="$COST_DAYS" -v t="$total_usage" 'BEGIN{printf "%.0f", (d>0?t/d:0)}')
+    if [ "${avg_daily:-0}" -gt 50 ] 2>/dev/null; then
+      finding LOW Cost global "account" \
+        "Usage burn avg \$${avg_daily}/day over ${COST_DAYS}d (total \$${total_usage}); credits may mask Console net to ~\$0" \
+        "Track RECORD_TYPE=Usage (scripts/aws-usage-cost.sh), not credit-masked net" 0
+    fi
   else warn "Cost Explorer not available (needs ce:GetCostAndUsage + enablement)"; fi
 }
 

--- a/claude-ops/skills/ops-aws-audit/SKILL.md
+++ b/claude-ops/skills/ops-aws-audit/SKILL.md
@@ -35,8 +35,9 @@ Checks include (2026 baseline):
 - **Lambda** — deprecated/old runtimes.
 - **Security posture** — GuardDuty, Security Hub standards, Cost Anomaly
   Detection monitors, Compute Optimizer enrollment.
-- **Cost** — per-service spend over the last `AUDIT_COST_DAYS` with the Δ vs the
-  prior window (surfaces spend spikes, per ops cost-leak doctrine).
+- **Cost** — per-service **Usage** spend (`RECORD_TYPE=Usage` UnblendedCost) over
+  the last `AUDIT_COST_DAYS` with the Δ vs the prior window. Credits mask net CE
+  totals to ≈ $0 — this audit never uses unfiltered Blended/Unblended nets as burn.
 
 ## Configuration (env, all optional)
 

--- a/claude-ops/skills/ops-go/SKILL.md
+++ b/claude-ops/skills/ops-go/SKILL.md
@@ -119,8 +119,20 @@ When the snapshot has non-zero `services_tracked`, prefer it for the
 burn/runway/anomaly lines. The per-source `Infrastructure` and AWS Cost
 Explorer sections below are the fallback for both empty states above.
 
-### Infrastructure
+**If dashboard `current_month_spend` is ≈ $0**, dual-check with the Usage-only
+helper below — credits often zero the net bill while real burn is hundreds/day.
 
+### AWS Usage burn (RECORD_TYPE=Usage — not credit-masked)
+
+```!
+${CLAUDE_PLUGIN_ROOT}/scripts/aws-usage-cost.sh snapshot 2>/dev/null || echo '{}'
+```
+
+Render in the briefing under a short `AWS BURN` line:
+`MTD usage $X · 7d avg $Y/day · EOM pace $Z · credits mask $W (do not treat net $0 as low spend)`.
+Flag a FIRE if any of the last 7 Usage days is >2× the 7d average.
+
+### Infrastructure
 ```!
 ${CLAUDE_PLUGIN_ROOT}/bin/ops-infra 2>/dev/null || echo '{"clusters":[],"error":"infra check failed"}'
 ```
@@ -222,6 +234,11 @@ Analyze ALL the pre-gathered data above and present it as a morning briefing. Fo
 
 FIRES (fix now)
 [table of production issues, CI failures, broken deploys]
+
+AWS BURN (Usage only — not credit-masked net)
+ MTD usage $[X] · 7d avg $[Y]/day · EOM pace $[Z] · credits mask $[W]
+ Top: [service $a] · [service $b] · [service $c]
+[If any day >2× 7d avg: flag as FIRE. Never report plain CE net ≈$0 as low spend.]
 
 PRs NEEDING ACTION
 [table: repo, PR#, title, status, action needed]

--- a/claude-ops/skills/ops-revenue/SKILL.md
+++ b/claude-ops/skills/ops-revenue/SKILL.md
@@ -37,14 +37,31 @@ Before executing, load available context:
 
 ## CLI/API Reference
 
-### aws CLI (Cost Explorer)
+### AWS burn doctrine (CRITICAL — 2026-07-22)
 
-| Command                                                                                                                                                                             | Usage                        | Output        |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- | ------------- |
-| `aws ce get-cost-and-usage --time-period Start=<YYYY-MM-DD>,End=<YYYY-MM-DD> --granularity MONTHLY --metrics "UnblendedCost" --group-by "Type=DIMENSION,Key=SERVICE" --output json` | Cost by service              | Cost JSON     |
-| `aws ce get-cost-and-usage --time-period Start=<YYYY-MM-DD>,End=<YYYY-MM-DD> --granularity MONTHLY --metrics "UnblendedCost" --output json`                                         | Total cost                   | Cost JSON     |
-| `aws ce get-cost-forecast --time-period Start=<YYYY-MM-DD>,End=<YYYY-MM-DD> --metric "UNBLENDED_COST" --granularity MONTHLY --output json`                                          | End-of-month forecast        | Forecast JSON |
-| `aws ce list-savings-plans-purchase-recommendation --output json`                                                                                                                   | Savings plan recommendations | JSON          |
+**Never report plain `UnblendedCost` / `NetUnblendedCost` totals as "spend".**
+Startup credits, SPP discounts, and Savings Plan negation make those nets ≈ $0
+while real Usage burn is hundreds/day. **Always** use `RECORD_TYPE=Usage` for
+burn, pace, spikes, runway, and Bedrock. Show credits only as a mask line.
+
+Canonical helper (prefer this over raw `aws ce`):
+
+```!
+${CLAUDE_PLUGIN_ROOT}/scripts/aws-usage-cost.sh snapshot 2>/dev/null || echo '{}'
+```
+
+```!
+${CLAUDE_PLUGIN_ROOT}/scripts/aws-usage-cost.sh all 2>/dev/null || true
+```
+
+| Command | Usage | Output |
+| ------- | ----- | ------ |
+| `scripts/aws-usage-cost.sh snapshot` | MTD/prev Usage burn + 7d daily + top services + credit mask | JSON |
+| `scripts/aws-usage-cost.sh daily 7` | Last N days Usage totals | JSON array |
+| `scripts/aws-usage-cost.sh by-service mtd` | MTD Usage by service | JSON array |
+| `scripts/aws-usage-cost.sh record-types` | Credit / Usage / SP breakdown (mask only) | JSON array |
+| `aws ce get-cost-and-usage … --filter '{"Dimensions":{"Key":"RECORD_TYPE","Values":["Usage"]}}'` | Raw Usage-only CE (fallback if helper missing) | Cost JSON |
+| `aws ce list-savings-plans-purchase-recommendation` | Savings plan recommendations | JSON |
 
 ---
 
@@ -58,6 +75,10 @@ and current burn. Per-DBA breakdown comes from the Stripe revenue
 snapshots ingested via `/api/ops/revenue`. Falls open to `{}` if unset —
 the per-source AWS / RevenueCat queries below run as fallback.
 
+**If the dashboard `current_month_spend` is ≈ $0 while Usage burn from
+`aws-usage-cost.sh` is material, trust the helper** (dashboard may still be
+credit-masked or ingest-empty). Always dual-check with the Usage helper.
+
 ```!
 ${CLAUDE_PLUGIN_ROOT}/scripts/finops-bridge.sh snapshot 2>/dev/null || echo "{}"
 ```
@@ -69,28 +90,42 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/finops-bridge.sh revenue project 2>/dev/null || ec
 When the dashboard returns data, render the per-project MRR section from
 `groups[]` rather than from RevenueCat-only data.
 
-### AWS costs (current month)
+### AWS costs — Usage burn (authoritative)
+
+```!
+${CLAUDE_PLUGIN_ROOT}/scripts/aws-usage-cost.sh snapshot 2>/dev/null || echo '{}'
+```
+
+Fallback if helper missing:
 
 ```bash
+USAGE_FILTER='{"Dimensions":{"Key":"RECORD_TYPE","Values":["Usage"]}}'
 aws ce get-cost-and-usage \
   --time-period "Start=$(date +%Y-%m-01),End=$(date +%Y-%m-%d)" \
   --granularity MONTHLY \
   --metrics "UnblendedCost" \
+  --filter "$USAGE_FILTER" \
   --group-by "Type=DIMENSION,Key=SERVICE" \
   --output json 2>/dev/null
 ```
 
-### AWS costs (last 3 months trend)
+### AWS costs (last 3 months Usage trend)
 
 ```bash
+USAGE_FILTER='{"Dimensions":{"Key":"RECORD_TYPE","Values":["Usage"]}}'
 aws ce get-cost-and-usage \
   --time-period "Start=$(date -v-3m +%Y-%m-01 2>/dev/null || date -d '3 months ago' +%Y-%m-01),End=$(date +%Y-%m-%d)" \
   --granularity MONTHLY \
   --metrics "UnblendedCost" \
+  --filter "$USAGE_FILTER" \
   --output json 2>/dev/null
 ```
 
-### AWS credits remaining
+### AWS credits / discount mask (not spend)
+
+```!
+${CLAUDE_PLUGIN_ROOT}/scripts/aws-usage-cost.sh record-types 2>/dev/null || echo '[]'
+```
 
 ```bash
 aws ce list-savings-plans-purchase-recommendation --output json 2>/dev/null || echo '{}'
@@ -99,6 +134,9 @@ aws ce get-credits --output json 2>/dev/null || echo "credits API unavailable"
 
 ### AWS cost forecast (end of month)
 
+Note: CE forecasts are often net-of-credits. Prefer `eom_pace` from
+`aws-usage-cost.sh snapshot` (7d Usage avg × days in month) as the burn forecast.
+
 ```bash
 aws ce get-cost-forecast \
   --time-period "Start=$(date +%Y-%m-%d),End=$(date +%Y-%m-28)" \
@@ -106,7 +144,6 @@ aws ce get-cost-forecast \
   --granularity MONTHLY \
   --output json 2>/dev/null
 ```
-
 ### Project registry (revenue stage)
 
 ```bash
@@ -140,21 +177,25 @@ Include Shopify GMV in the revenue pipeline table with source=shopify.
  OPS ► REVENUE & COSTS — [month]
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-AWS SPEND
- This month to date:  $[X]
- Forecast (EOM):      $[X]
- Last month:          $[X]
+AWS USAGE BURN (RECORD_TYPE=Usage — not credit-masked net)
+ This month usage:    $[X]     ← from aws-usage-cost.sh mtd_usage
+ Forecast (EOM pace): $[X]     ← eom_pace (7d Usage avg × days)
+ Last month usage:    $[X]
  MoM change:          [+/-X%]
+ 7d avg/day:          $[X]
 
- Top services:
- [service]  $[X]  ([%] of total)
+ Top services (Usage):
+ [service]  $[X]  ([%] of usage)
  [service]  $[X]
  ...
 
-CREDITS
- AWS credits remaining:  $[X]
+CREDITS / MASK (do not report as low spend)
+ Credits applied MTD:    $[X]  (record_types Credit)
+ Discounts MTD:          $[X]
+ Net after mask:         ~$0 is EXPECTED when credits cover burn
+ Credits remaining:      $[X] (if API available)
  Expires:                [date]
- Burn rate at current:   [N months remaining]
+ Months cover at pace:   [N]
 
 REVENUE PIPELINE
  PROJECT        SOURCE     STAGE           MRR/GMV    STATUS

--- a/claude-ops/skills/ops-yolo/SKILL.md
+++ b/claude-ops/skills/ops-yolo/SKILL.md
@@ -47,9 +47,12 @@ Before YOLO analysis, load:
 
 ### aws CLI (Cost Explorer)
 
-| Command                                                                                                                                     | Usage               | Output    |
-| ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------- | --------- |
-| `aws ce get-cost-and-usage --time-period Start=<YYYY-MM-DD>,End=<YYYY-MM-DD> --granularity MONTHLY --metrics "UnblendedCost" --output json` | Current month spend | Cost JSON |
+**Doctrine:** burn = `RECORD_TYPE=Usage` only. Plain UnblendedCost totals are credit-masked (~$0) and MUST NOT be used as spend.
+
+| Command | Usage | Output |
+| ------- | ----- | ------ |
+| `${CLAUDE_PLUGIN_ROOT}/scripts/aws-usage-cost.sh snapshot` | MTD Usage burn + 7d daily + top services + credit mask | JSON |
+| `aws ce … --filter '{"Dimensions":{"Key":"RECORD_TYPE","Values":["Usage"]}}'` | Raw Usage-only fallback | Cost JSON |
 
 ### gh CLI (GitHub)
 
@@ -137,9 +140,8 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ops-unread 2>/dev/null || echo '{}'
 ```
 
 ```!
-aws ce get-cost-and-usage --time-period "Start=$(date +%Y-%m-01),End=$(date +%Y-%m-%d)" --granularity MONTHLY --metrics "UnblendedCost" --output json 2>/dev/null || echo '{}'
+${CLAUDE_PLUGIN_ROOT}/scripts/aws-usage-cost.sh snapshot 2>/dev/null || echo '{}'
 ```
-
 ```!
 cat "${CLAUDE_PLUGIN_ROOT}/scripts/registry.json" 2>/dev/null || echo '{}'
 ```


### PR DESCRIPTION
## Summary
- Cost Explorer plain `UnblendedCost` / net totals are ≈ $0 when startup credits offset Usage (~$250–340/day real burn).
- Adds `scripts/aws-usage-cost.sh` — always filters `RECORD_TYPE=Usage`.
- Wires helper into `/ops:revenue`, `/ops:yolo`, `/ops:go`, `yolo-cfo`, `revenue-tracker`, and `ops-aws-audit.sh`.

## Doctrine
Burn = Usage UnblendedCost. Credits shown only as a mask line. Never treat Console net ≈ $0 as low spend.

## Test plan
- [x] `scripts/aws-usage-cost.sh all` → MTD Usage ~$4k, credits −$4k
- [x] Live plugin cache synced for immediate `/ops:*` use
- [ ] CI green on this PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are read-only ops docs, agent prompts, and a CE query helper—no app runtime or auth paths. Main risk is incorrect burn guidance if the Usage filter or script logic is wrong, which would skew financial briefings rather than mutate infrastructure.
> 
> **Overview**
> Fixes **misleading ~$0 AWS spend** when startup credits mask Cost Explorer net totals while real **Usage** burn stays high.
> 
> Adds **`scripts/aws-usage-cost.sh`** as the canonical Cost Explorer helper: always filters `RECORD_TYPE=Usage`, exposes `snapshot` / `daily` / `by-service` / `record-types`, and surfaces credits as a separate mask line (MTD usage, 7d avg, EOM pace, top services).
> 
> **Wires the helper and doctrine** through `revenue-tracker`, `yolo-cfo`, `ops-aws-audit.sh` (Usage-based deltas + high-burn informational finding), and skills **`ops-revenue`**, **`ops-go`**, **`ops-yolo`**, **`ops-aws-audit`** — including dual-check when FinOps dashboard spend ≈ $0 and updated briefing/revenue dashboard copy for Usage burn vs credit mask.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02d151fbc1a838161fef26c2afb4b41ac7894e74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->