### PR TITLE
release: v2.46.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 61 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.45.0",
+      "version": "2.46.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-2.45.0-blue)
+![Version](https://img.shields.io/badge/version-2.46.0-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-61-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.45.0",
+  "version": "2.46.0",
   "description": "Business operations command center for Claude Code — 61 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -10,6 +10,17 @@
 - **ops-ecom:** `channels` | `agentic` | `shop` verbs — sales channel inventory, agentic storefront health, Shop Campaigns readiness (read-only; Rule 5 / stage-only spend).
 - **ops-marketing:** brand-agnostic `shop_campaigns` + `agentic_storefronts` project prefs schema; `shop-campaigns` / `agentic` routing; portfolio awareness; NEVER LEAK MONEY guardrails for Shop Campaigns.
 
+## [2.46.0] - 2026-07-24
+
+### Changed
+- fix(rotation): remove duplicate API_KEY/AUTH_TOKEN/OAUTH_TOKEN unset in bg-respawn atomic fallback (#698)
+- fix(hooks): detach ops-inbox-autosync and raise bedrock UPS timeout (#697)
+- fix: serialize post-update migrations (#696)
+- fix(crs): apply prettier formatting
+- fix(ops): report AWS Usage burn, not credit-masked net (#695)
+- feat(crs): live quota poller + multi-port health + richer proxy config
+
+
 ## [2.45.0] - 2026-07-22
 
 ### Changed

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-2.45.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.46.0-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 61 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-2.45.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.46.0-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-61-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.45.0",
+  "version": "2.46.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.46.0** (was 2.45.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

- fix(rotation): remove duplicate API_KEY/AUTH_TOKEN/OAUTH_TOKEN unset in bg-respawn atomic fallback (#698)
- fix(hooks): detach ops-inbox-autosync and raise bedrock UPS timeout (#697)
- fix: serialize post-update migrations (#696)
- fix(crs): apply prettier formatting
- fix(ops): report AWS Usage burn, not credit-masked net (#695)
- feat(crs): live quota poller + multi-port health + richer proxy config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only version strings and changelog/docs badges change; no runtime code in this PR.
> 
> **Overview**
> **Release v2.46.0** — bumps the plugin from **2.45.0** to **2.46.0** across `marketplace.json`, `claude-ops/.claude-plugin/plugin.json`, `claude-ops/package.json`, README/docs version badges, and adds a **`[2.46.0]`** section to `CHANGELOG.md`.
> 
> This diff is **metadata-only**; it tags work already landed on `main`. The changelog calls out: rotation **bg-respawn** cleanup (duplicate credential unsets), **ops-inbox-autosync** hook detachment + higher Bedrock UPS timeout, **serialized post-update migrations**, CRS **prettier** formatting, **AWS Usage burn** reporting (not credit-masked net) in ops revenue, and CRS **live quota poller**, **multi-port health**, and **richer proxy config**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00ae25d27f180d536dfc263341e2d66c9fe6a5da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live quota monitoring with multi-port health checks.
  * Expanded proxy configuration options.
* **Bug Fixes**
  * Improved token cleanup during background recovery.
  * Fixed inbox hook detachment and increased Bedrock UPS timeout.
  * Serialized post-update migrations for more reliable upgrades.
  * Corrected AWS reporting to display burn accurately.
* **Documentation**
  * Updated release documentation and version references to 2.46.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->