### PR TITLE
fix(crs-pool-config): remove hardcoded personal proxy IP default

### DIFF
--- a/claude-ops/scripts/account-rotation/crs-pool-config.mjs
+++ b/claude-ops/scripts/account-rotation/crs-pool-config.mjs
@@ -355,12 +355,20 @@ function twoCaptchaProxyConfig(twoCaptcha = {}) {
 }
 
 function efgProxyConfig(config = {}) {
-  const url = config.url || firstEnvValue(['EFG_PROXY_URL', 'CRS_EFG_PROXY_URL']) || 'http://100.90.98.93:18088';
-  const parsed = parseProxyUrl(url);
-  if (parsed?.host && parsed?.port) return parsed;
+  // No default host/port/URL: an "external gateway forwarder" proxy is always a
+  // specific deployment's own private network address, never a safe generic
+  // default. Require explicit config or env; return null if neither is set so
+  // callers treat it as "no EFG proxy configured" rather than silently pointing
+  // at some other operator's network.
+  const url = config.url || firstEnvValue(['EFG_PROXY_URL', 'CRS_EFG_PROXY_URL']);
+  if (url) {
+    const parsed = parseProxyUrl(url);
+    if (parsed?.host && parsed?.port) return parsed;
+  }
 
-  const host = config.host || firstEnvValue(['EFG_PROXY_HOST', 'CRS_EFG_PROXY_HOST']) || '100.90.98.93';
-  const port = config.port || firstEnvValue(['EFG_PROXY_PORT', 'CRS_EFG_PROXY_PORT']) || '18088';
+  const host = config.host || firstEnvValue(['EFG_PROXY_HOST', 'CRS_EFG_PROXY_HOST']);
+  const port = config.port || firstEnvValue(['EFG_PROXY_PORT', 'CRS_EFG_PROXY_PORT']);
+  if (!host || !port) return null;
   return {
     type: config.type || firstEnvValue(['EFG_PROXY_TYPE', 'CRS_EFG_PROXY_TYPE']) || 'http',
     host,


### PR DESCRIPTION
## Summary
- `efgProxyConfig()` in `crs-pool-config.mjs` fell back to a real private network IP (`100.90.98.93:18088`, Tailscale CGNAT range) when `EFG_PROXY_URL`/`EFG_PROXY_HOST`/`EFG_PROXY_PORT` were unset — one operator's own address shipped as a public-plugin default.
- This was already merged and released (introduced in 21260c8, shipped in v2.45.0/v2.46.0) — flagging separately since a git-history scrub is a judgment call, not something to do unilaterally.
- Fix: returns `null` (already-handled "no EFG proxy configured" case, same as every other optional proxy provider here) unless the operator sets explicit config or env.

## Test plan
- [ ] `node --check` passes (verified locally)
- [ ] Confirm no caller of `efgProxyConfig()` assumes a non-null return (checked: the one caller already iterates provider results and treats null as "try next provider")

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior change in optional proxy resolution; avoids misrouting but may require operators who relied on the old implicit default to set EFG env vars explicitly.
> 
> **Overview**
> **`efgProxyConfig()`** no longer falls back to a hardcoded private gateway (`100.90.98.93:18088`) when EFG env/config is missing. It now returns **`null`** unless `EFG_PROXY_URL` or both host and port are set explicitly, matching other optional proxy providers.
> 
> Callers that walk the proxy provider list already skip a null EFG result and try the next provider, so unset installs no longer silently route traffic toward another operator’s network.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20d33a41c624b848a03bed0c1756eb0870d7e64a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->