### PR TITLE
chore(rotate): parity-diff sweep between local and public account-rotation scripts

### DIFF
--- a/claude-ops/scripts/account-rotation/claude-stack.mjs
+++ b/claude-ops/scripts/account-rotation/claude-stack.mjs
@@ -99,7 +99,8 @@ function accountRotationStatus() {
 
 function status() {
   const route = routeStatus();
-  const crsHealthUrl = route.state.crs?.healthUrl || 'http://127.0.0.1:3000/health';
+  const crsHealthUrl =
+    route.state.crs?.healthUrl || process.env.CRS_HEALTH_URL || 'http://127.0.0.1:3005/health';
   return {
     ok: !route.settings.mixedProvider,
     route,
@@ -139,6 +140,12 @@ function doctor() {
     });
   if (s.route.state.mode === 'crs-oauth' && !s.crs.healthy)
     findings.push({ severity: 'error', code: 'crs_unhealthy', detail: `${s.crs.healthUrl} is not healthy` });
+  if (s.route.state.mode === 'crs-oauth' && s.route.settings.tokenKind !== 'crs-relay')
+    findings.push({
+      severity: 'error',
+      code: 'crs_auth_token_missing',
+      detail: 'CRS token variable is not a relay token (set ANTHROPIC_AUTH_TOKEN or CLAUDE_CODE_OAUTH_TOKEN)',
+    });
   if (s.route.state.mode === 'bedrock-confirmed' && !s.route.bedrockConfirmationActive)
     findings.push({
       severity: 'error',

--- a/claude-ops/scripts/account-rotation/daemon.mjs
+++ b/claude-ops/scripts/account-rotation/daemon.mjs
@@ -1691,7 +1691,12 @@ async function mainLoop() {
       // Deferred bg-session respawn sweep (every 2 min): sessions that were
       // busy at rotation time get respawned once they go idle, or force-
       // respawned after 90 min so they never wedge on an expired token.
-      if (Date.now() - lastRespawnSweep > 120_000) {
+      // Opt-in (default OFF): bg-session respawn sweep assumes daemon-hosted
+      // `claude --bg` sessions and per-session leases exist. On a fresh install
+      // neither does, so this stays a no-op until explicitly enabled — set
+      // CLAUDE_ENABLE_BG_RESPAWN=1 to turn it on. Mirrors the opt-in gate in
+      // session-router.mjs / bg-respawn.mjs.
+      if (process.env.CLAUDE_ENABLE_BG_RESPAWN === '1' && Date.now() - lastRespawnSweep > 120_000) {
         lastRespawnSweep = Date.now();
         try {
           const handled = sweepDeferredRespawns((m) => log(m));
@@ -1793,7 +1798,11 @@ async function mainLoop() {
         await doRotation(reason);
         lastRotatedAt = Date.now();
         await sleep(RATE_LIMIT_COOLDOWN);
-      } else {
+      } else if (process.env.CLAUDE_ENABLE_BG_SESSION_ROUTER === '1') {
+        // Opt-in (default OFF): per-session account leasing only makes sense
+        // once CLAUDE_SESSION_ROUTING is in use (see session-router.mjs). Keep
+        // it disabled by default so a fresh install never starts reassigning
+        // leases/respawning sessions on its own.
         await checkSessionLeaseRotations(config, state);
       }
     } catch (err) {

--- a/claude-ops/scripts/account-rotation/rotation-policy.mjs
+++ b/claude-ops/scripts/account-rotation/rotation-policy.mjs
@@ -30,3 +30,25 @@ export function liveUtilMax(u) {
   if (!isLiveUtilOk(u)) return null;
   return Math.max(u.pct5h, u.pct7d);
 }
+
+/**
+ * Return max(5h, 7d) from a persisted utilization snapshot.
+ *
+ * New snapshots store `pct`/`reset` for 5h and `pct7`/`reset7` for 7d.
+ * Older daemon snapshots stored the already-combined max in `pct`, so the
+ * missing weekly field remains backward compatible.
+ */
+export function cachedUtilizationMax(cached, now = Date.now()) {
+  if (!cached || typeof cached !== 'object') return null;
+
+  const windowValue = (pctField, resetField) => {
+    const pct = Number(cached[pctField]);
+    if (!Number.isFinite(pct)) return null;
+    const reset = Number(cached[resetField]);
+    if (Number.isFinite(reset) && reset > 0 && reset * 1000 <= now) return 0;
+    return pct;
+  };
+
+  const values = [windowValue('pct', 'reset'), windowValue('pct7', 'reset7')].filter((value) => value !== null);
+  return values.length ? Math.max(...values) : null;
+}


### PR DESCRIPTION
## Summary
- Small parity fixes found while auditing local vs public account-rotation scripts for further upstreaming (see PR for the reconciler trio and priority-daemon parity for the bigger pieces).
- daemon.mjs: two bg-fleet sweeps now opt-in (env-flag gated) instead of running unconditionally on every fresh install.
- claude-stack.mjs: CRS health URL now configurable via env, plus a new doctor() finding for a missing relay-token auth kind.
- rotation-policy.mjs: added a small helper for reading max(5h,7d) off either the legacy or newer utilization-snapshot shape.

## Test plan
- [ ] `node --check` passes on all three files (verified locally)
- [ ] Fresh install with autoRotate:true no longer touches session-leases.json until CLAUDE_ENABLE_BG_RESPAWN/CLAUDE_ENABLE_BG_SESSION_ROUTER are set

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change is mostly safer defaults (opt-in bg routing); CRS default port and doctor check may surface config issues on existing setups but do not touch auth or rotation core paths.
> 
> **Overview**
> Parity tweaks for account-rotation so **fresh installs** with `autoRotate` no longer run background-session fleet logic until you opt in.
> 
> **`daemon.mjs`** gates the deferred bg-session respawn sweep behind `CLAUDE_ENABLE_BG_RESPAWN=1` and per-session lease rotation behind `CLAUDE_ENABLE_BG_SESSION_ROUTER=1` (default off). Core account rotation, drift detection, and Bedrock watchdog behavior are unchanged.
> 
> **`claude-stack.mjs`** resolves CRS health from `CRS_HEALTH_URL` when route state does not set one, with default `http://127.0.0.1:3005/health` (was 3000). In `crs-oauth` mode, **doctor** now errors when `tokenKind` is not `crs-relay` (`crs_auth_token_missing`).
> 
> **`rotation-policy.mjs`** adds `cachedUtilizationMax()` to compute max(5h, 7d) from persisted snapshots, including legacy single-`pct` records and reset-aware weekly fields—aligned with how session routing reads utilization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd4820dd3e06f095af36942a0a6871a9db6e6fa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->