### PR TITLE
feat(ops-rotate-setup): wire crs-429-cooldown/401-refresher into the setup wizard

### DIFF
--- a/claude-ops/scripts/account-rotation/crs-401-refresher.sh
+++ b/claude-ops/scripts/account-rotation/crs-401-refresher.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# crs-401-refresher.sh — single-flight wrapper for crs-401-refresher.mjs.
+# Invoked once-per-tick by launchd/systemd (recommended: every 300s — this
+# reconciler proactively refreshes tokens ahead of a 30-minute expiry window,
+# so a 5-minute cadence has ample margin without hammering CRS).
+set -uo pipefail
+
+source "$HOME/.claude/scripts/lib/once.sh" 2>/dev/null || true
+type claude_once >/dev/null 2>&1 && { claude_once crs-401-refresher 60 || exit 0; }
+
+DIR="$HOME/.claude/scripts/account-rotation"
+LOG="$DIR/crs-401-refresher.log"
+NODE="$(command -v node || echo /opt/homebrew/bin/node)"
+
+export CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/ops-marketplace/claude-ops}"
+
+if [ -f "$LOG" ]; then
+  LOGSIZE="$(stat -c%s "$LOG" 2>/dev/null || stat -f%z "$LOG" 2>/dev/null || echo 0)"
+  [ "$LOGSIZE" -gt 2097152 ] && mv "$LOG" "$LOG.1"
+fi
+
+"$NODE" "$DIR/crs-401-refresher.mjs" >> "$LOG" 2>&1

--- a/claude-ops/scripts/account-rotation/crs-429-cooldown.sh
+++ b/claude-ops/scripts/account-rotation/crs-429-cooldown.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# crs-429-cooldown.sh — single-flight wrapper for crs-429-cooldown.mjs.
+# Invoked once-per-tick by launchd/systemd (recommended: every 60s — this
+# reconciler is meant to react fast to a real rate-limit hit).
+set -uo pipefail
+
+source "$HOME/.claude/scripts/lib/once.sh" 2>/dev/null || true
+type claude_once >/dev/null 2>&1 && { claude_once crs-429-cooldown 20 || exit 0; }
+
+DIR="$HOME/.claude/scripts/account-rotation"
+LOG="$DIR/crs-429-cooldown.log"
+NODE="$(command -v node || echo /opt/homebrew/bin/node)"
+
+export CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/ops-marketplace/claude-ops}"
+
+if [ -f "$LOG" ]; then
+  LOGSIZE="$(stat -c%s "$LOG" 2>/dev/null || stat -f%z "$LOG" 2>/dev/null || echo 0)"
+  [ "$LOGSIZE" -gt 2097152 ] && mv "$LOG" "$LOG.1"
+fi
+
+"$NODE" "$DIR/crs-429-cooldown.mjs" >> "$LOG" 2>&1

--- a/claude-ops/scripts/install-crs-reconcilers-agent.sh
+++ b/claude-ops/scripts/install-crs-reconcilers-agent.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# install-crs-reconcilers-agent.sh — Install the CRS 429-cooldown and/or
+# 401-refresher reconcilers as launchd LaunchAgents (macOS).
+#
+# Reads crs.cooldownEnabled / crs.tokenRefreshEnabled from the rotator config
+# and installs only the ones that are true — this script is safe to re-run
+# any time config changes (idempotent: re-renders + reloads what's enabled,
+# uninstalls what's been turned back off).
+#
+# Pre-req: same CRS admin credentials as install-crs-priority-agent.sh.
+# Config (stateDir, logDir, thresholds) lives in the rotator config.json
+# "crs" block — see config.example.json for the full annotated schema.
+
+set -euo pipefail
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+[[ -d "$PLUGIN_ROOT" ]] || { echo "error: could not resolve CLAUDE_PLUGIN_ROOT" >&2; exit 1; }
+
+USER_CFG="$HOME/.claude/plugins/data/ops-ops-marketplace/account-rotation-config.json"
+REPO_CFG="$PLUGIN_ROOT/scripts/account-rotation/config.json"
+CFG="$([[ -f "$USER_CFG" ]] && echo "$USER_CFG" || echo "$REPO_CFG")"
+DATA_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+LOG_DIR="$DATA_DIR/logs"
+
+command -v node >/dev/null 2>&1 || { echo "error: node not found in PATH (need Node 20+)" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "error: jq not found in PATH" >&2; exit 1; }
+
+COOLDOWN_ENABLED="false"
+TOKEN_REFRESH_ENABLED="false"
+if [[ -f "$CFG" ]]; then
+  COOLDOWN_ENABLED="$(jq -r '.crs.cooldownEnabled // false' "$CFG" 2>/dev/null || echo false)"
+  TOKEN_REFRESH_ENABLED="$(jq -r '.crs.tokenRefreshEnabled // false' "$CFG" 2>/dev/null || echo false)"
+fi
+[[ "${CRS_COOLDOWN_ENABLED:-}" == "1" ]] && COOLDOWN_ENABLED="true"
+[[ "${CRS_TOKEN_REFRESH_ENABLED:-}" == "1" ]] && TOKEN_REFRESH_ENABLED="true"
+
+if [[ "$COOLDOWN_ENABLED" != "true" && "$TOKEN_REFRESH_ENABLED" != "true" ]]; then
+  echo "skip: neither crs.cooldownEnabled nor crs.tokenRefreshEnabled is true in $CFG"
+  echo "      set one (or \$CRS_COOLDOWN_ENABLED=1 / \$CRS_TOKEN_REFRESH_ENABLED=1) and re-run"
+  exit 0
+fi
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "skip: launchd is macOS-only."
+  echo "Linux: install a systemd user timer for each enabled reconciler:"
+  [[ "$COOLDOWN_ENABLED" == "true" ]] && echo "  crs-429-cooldown:   ExecStart=/bin/bash $PLUGIN_ROOT/scripts/account-rotation/crs-429-cooldown.sh   OnUnitActiveSec=60s"
+  [[ "$TOKEN_REFRESH_ENABLED" == "true" ]] && echo "  crs-401-refresher:  ExecStart=/bin/bash $PLUGIN_ROOT/scripts/account-rotation/crs-401-refresher.sh  OnUnitActiveSec=300s"
+  echo "Then: systemctl --user enable --now <unit>.timer"
+  exit 0
+fi
+
+mkdir -p "$LOG_DIR" "$HOME/Library/LaunchAgents"
+
+render_and_install() {
+  local name="$1" wrapper="$2" template="$3"
+  local dest="$HOME/Library/LaunchAgents/com.claude-ops.${name}.plist"
+  chmod +x "$wrapper" 2>/dev/null || true
+  PLIST_TEMPLATE_PATH="$template" WRAPPER_PATH="$wrapper" LOG_DIR_PATH="$LOG_DIR" CRS_HOME="$HOME" \
+    node -e \
+    'const fs=require("fs");const e=(s)=>String(s??"").replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");const t=fs.readFileSync(process.env.PLIST_TEMPLATE_PATH,"utf8");process.stdout.write(t.replace(/__WRAPPER_PATH__/g,e(process.env.WRAPPER_PATH)).replace(/__LOG_DIR__/g,e(process.env.LOG_DIR_PATH)).replace(/__HOME__/g,e(process.env.CRS_HOME)));' \
+    > "$dest"
+  launchctl bootout "gui/$(id -u)/com.claude-ops.${name}" 2>/dev/null || true
+  launchctl bootstrap "gui/$(id -u)" "$dest"
+  echo "ok: ${name} installed ($dest)"
+}
+
+uninstall() {
+  local name="$1" dest="$HOME/Library/LaunchAgents/com.claude-ops.${name}.plist"
+  if [[ -f "$dest" ]]; then
+    launchctl bootout "gui/$(id -u)/com.claude-ops.${name}" 2>/dev/null || true
+    rm -f "$dest"
+    echo "ok: ${name} uninstalled (was enabled, now disabled in config)"
+  fi
+}
+
+if [[ "$COOLDOWN_ENABLED" == "true" ]]; then
+  render_and_install "crs-429-cooldown" \
+    "$PLUGIN_ROOT/scripts/account-rotation/crs-429-cooldown.sh" \
+    "$PLUGIN_ROOT/templates/com.claude-ops.crs-429-cooldown.plist"
+else
+  uninstall "crs-429-cooldown"
+fi
+
+if [[ "$TOKEN_REFRESH_ENABLED" == "true" ]]; then
+  render_and_install "crs-401-refresher" \
+    "$PLUGIN_ROOT/scripts/account-rotation/crs-401-refresher.sh" \
+    "$PLUGIN_ROOT/templates/com.claude-ops.crs-401-refresher.plist"
+else
+  uninstall "crs-401-refresher"
+fi
+
+echo
+echo "verify: node \"$PLUGIN_ROOT/scripts/account-rotation/crs-429-cooldown.mjs\" --status"
+echo "        node \"$PLUGIN_ROOT/scripts/account-rotation/crs-401-refresher.mjs\" --status"
+echo "logs:   $LOG_DIR/crs-429-cooldown.log , $LOG_DIR/crs-401-refresher.log"
+echo "uninstall both: launchctl bootout \"gui/\$(id -u)/com.claude-ops.crs-429-cooldown\" \"gui/\$(id -u)/com.claude-ops.crs-401-refresher\""

--- a/claude-ops/skills/ops-rotate-setup/SKILL.md
+++ b/claude-ops/skills/ops-rotate-setup/SKILL.md
@@ -235,6 +235,67 @@ Tuning (optional, `crs` block): `off5h`/`off7d` (deprioritize thresholds),
 `on5h`/`on7d` (re-enable thresholds, hysteresis), `floor` (min usable accounts),
 `freshMinutes` (max age of utilization data trusted for proactive deprioritize).
 
+Weekly-cap reconciliation (`crs.weeklyReconcile`, default on) is built into the
+priority daemon itself — no separate install step. It clears a stale
+`weeklyRateLimitEndAt` hold once live 7d utilization drops back under `on7d`,
+and is a no-op on any deployment that never sets that field. Set
+`crs.weeklyReconcile=false` (or `$CRS_WEEKLY_RECONCILE=0`) to disable it.
+
+## Step 4.6 — CRS reconciler add-ons (optional)
+
+Only offer this if Step 4.5 configured a CRS pool (`crs.enabled=true`) — these
+reconcilers assume one exists. Two independent, opt-in daemons close gaps the
+priority daemon (Step 4.5) doesn't cover:
+
+- **429-cooldown**: holds an account out of rotation only on a real
+  `rateLimitStatus.isRateLimited=true` from CRS (never a utilization
+  heuristic). Fast cadence (60s) since it reacts to a live rate limit.
+- **401-refresher**: proactively refreshes each account's CRS-pool OAuth
+  token before it expires, so accounts don't silently start 401ing between
+  priority-daemon ticks. Slower cadence (300s) — refreshes ahead of a 30min
+  expiry window.
+
+`AskUserQuestion`:
+
+```
+Enable the optional CRS reconcilers?
+  [Both]              — 429-cooldown + 401-refresher (recommended if you run a busy pool)
+  [429-cooldown only]  — fast rate-limit hold, skip proactive token refresh
+  [401-refresher only] — proactive token refresh, skip rate-limit hold
+  [Skip]               — neither (you can re-run /ops:rotate-setup --crs later)
+```
+
+On anything but `[Skip]`:
+
+1. **Write the config flags.**
+   ```bash
+   CFG="$USER_CFG"
+   jq --argjson cooldown "$COOLDOWN_ENABLED" --argjson tokenRefresh "$TOKEN_REFRESH_ENABLED" \
+      '.crs = ((.crs // {}) + {cooldownEnabled:$cooldown, tokenRefreshEnabled:$tokenRefresh})' \
+      "$CFG" > "$CFG.tmp" && mv "$CFG.tmp" "$CFG"
+   ```
+   (`$COOLDOWN_ENABLED`/`$TOKEN_REFRESH_ENABLED` are `true`/`false` per the
+   selection above.) Optional: also ask for `crs.stateDir`/`crs.logDir` if the
+   user wants non-default paths — see `config.example.json` for the full
+   annotated schema. Both reconcilers default to
+   `<plugin-data-dir>/account-rotation` if left unset.
+
+2. **Smoke-test before installing** (each enabled reconciler, no writes):
+   ```bash
+   [[ "$COOLDOWN_ENABLED" == "true" ]] && node "${CLAUDE_PLUGIN_ROOT}/scripts/account-rotation/crs-429-cooldown.mjs" --status
+   [[ "$TOKEN_REFRESH_ENABLED" == "true" ]] && node "${CLAUDE_PLUGIN_ROOT}/scripts/account-rotation/crs-401-refresher.mjs" --status
+   ```
+   If either errors (login failed / unreachable), surface the message and let
+   the user re-check Step 4.5's CRS creds — do NOT install a broken daemon.
+
+3. **Install** (idempotent — installs whichever flags are true, uninstalls
+   whichever were turned back off):
+   ```bash
+   bash "${CLAUDE_PLUGIN_ROOT}/scripts/install-crs-reconcilers-agent.sh"
+   ```
+   macOS → launchd, 60s / 300s cadence (RunAtLoad fires the first tick).
+   Linux → the installer prints the equivalent systemd-timer snippets.
+
 ## Step 5 — Summary
 
 ```
@@ -249,14 +310,18 @@ Tuning (optional, `crs` block): `off5h`/`off7d` (deprioritize thresholds),
  Config: ~/.claude/plugins/data/ops-ops-marketplace/account-rotation-config.json
  Keychain: Claude-Rotation-<key> (account: $USER)  ·  key = label or email
  CRS priority daemon: ✓ installed (every 120s) | ✗ not configured
+ CRS 429-cooldown:    ✓ installed (every 60s)  | ✗ not enabled
+ CRS 401-refresher:   ✓ installed (every 300s) | ✗ not enabled
 
  To enable automatic rotation, open /plugins → claude-ops → settings and
  toggle "Multi-account Claude rotator" (account_rotation_enabled).
 ──────────────────────────────────────────────────────
 ```
 
-(Show the CRS line only if Step 4.5 ran. The CRS daemon is independent of the
-`account_rotation_enabled` toggle — it is gated by `crs.enabled` in config +
+(Show the CRS priority-daemon line only if Step 4.5 ran; show the two
+reconciler lines only if Step 4.6 ran. All three CRS daemons are independent
+of the `account_rotation_enabled` toggle — each is gated by its own config
+flag (`crs.enabled`, `crs.cooldownEnabled`, `crs.tokenRefreshEnabled`) plus
 whether its launchd/systemd timer is installed.)
 
 Exit. Do NOT auto-enable `account_rotation_enabled` — that decision belongs
@@ -267,7 +332,8 @@ to the user, made explicitly through the plugin settings UI.
 - `--all` (default): full wizard as described above.
 - `--account <email>`: skip Step 2; only init the matching account.
 - `--add`: skip token check; jump straight to Step 2 add loop, then init.
-- `--crs`: jump straight to **Step 4.5** (configure + install the CRS priority daemon), skipping the keychain-account OAuth steps.
+- `--crs`: jump straight to **Step 4.5** (configure + install the CRS priority daemon), then **Step 4.6** (offer the reconciler add-ons), skipping the keychain-account OAuth steps.
+- `--reconcilers`: jump straight to **Step 4.6** (offer/reconfigure the 429-cooldown and 401-refresher reconcilers) — requires Step 4.5 already configured (`crs.enabled=true`); if not, print the same message as `--crs` needing configuration first and exit.
 
 ## Failure modes
 
@@ -280,3 +346,5 @@ to the user, made explicitly through the plugin settings UI.
 | Google SSO / 2FA prompt              | Workspace-domain account needs interactive Google login        | Let the user complete login in the cascade's visible Chrome; do NOT auto-solve 2FA                                        |
 | CRS `--status` "login failed"        | wrong admin user/password or CRS not reachable                 | Re-enter creds (Step 4.5); admin creds are in the CRS container `data/init.json`; verify `curl $CRS_URL/health`           |
 | CRS daemon installed but no effect   | `crs.enabled=false`, or all accounts already correctly flagged | Check `crs.enabled` in config; `tail logs/crs-priority.log`; a steady-state tick logs `0 change(s)`                       |
+| CRS reconciler `--status` errors     | wrong admin creds or CRS unreachable (same creds as priority daemon) | Re-check Step 4.5's CRS creds; `curl $CRS_URL/health`                                                                     |
+| CRS reconciler installed but no effect | `crs.cooldownEnabled`/`crs.tokenRefreshEnabled` false, or no account currently needs it | Check the relevant flag in config; `tail logs/crs-429-cooldown.log` or `crs-401-refresher.log` — both are safe no-ops when nothing needs action |

--- a/claude-ops/skills/ops-rotate/SKILL.md
+++ b/claude-ops/skills/ops-rotate/SKILL.md
@@ -130,13 +130,20 @@ This is the only mutating subcommand. Walk the user through:
 ## crs (relay-pool status)
 
 Show the claude-relay-service pool's per-account schedulable state + the priority
-daemon's health. Read-only.
+daemon's health, plus the two optional reconcilers (429-cooldown, 401-refresher)
+if enabled. Read-only.
 
 ```
 WRAP="$ROT_SRC/crs-priority-daemon.sh"
 bash "$WRAP" --status 2>&1 | head -40   # prints "● name sched=true 5h=NN%  <status>"
 launchctl list 2>/dev/null | grep com.claude-ops.crs-priority || echo "crs-priority daemon: not loaded"
 tail -n 5 "${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/logs/crs-priority.log" 2>/dev/null
+
+# Only if crs.cooldownEnabled / crs.tokenRefreshEnabled are true in config:
+node "$ROT_SRC/crs-429-cooldown.mjs" --status 2>&1
+launchctl list 2>/dev/null | grep com.claude-ops.crs-429-cooldown || echo "crs-429-cooldown: not loaded"
+node "$ROT_SRC/crs-401-refresher.mjs" --status 2>&1
+launchctl list 2>/dev/null | grep com.claude-ops.crs-401-refresher || echo "crs-401-refresher: not loaded"
 ```
 
 Render a compact panel:
@@ -146,10 +153,15 @@ CRS POOL  (http://127.0.0.1:3000)
   schedulable : 7 / 10
   off         : canary-sponsors (rate-limited), pool-chairman (warning), pool-foundation (warning)
   daemon      : ✓ running (every 120s)  |  ✗ not loaded — run /ops:rotate-setup
+  429-cooldown: ✓ running (every 60s)   |  ✗ not loaded  |  – not enabled (crs.cooldownEnabled=false)
+  401-refresher: ✓ running (every 300s) |  ✗ not loaded  |  – not enabled (crs.tokenRefreshEnabled=false)
 ```
 
 If CRS `/health` is unreachable, say so and point to ops-rotate-setup. If the daemon
-isn't loaded but `crs.enabled` is true, suggest `/ops:rotate-setup`.
+isn't loaded but `crs.enabled` is true, suggest `/ops:rotate-setup`. Show the two
+reconciler lines only if their config flag is true — if false, show `– not enabled`
+rather than treating it as a failure (it's an opt-in feature). If a flag is true but
+its daemon isn't loaded, suggest `/ops:rotate-setup --reconcilers`.
 
 ## crs-tick (run one tick now)
 

--- a/claude-ops/templates/com.claude-ops.crs-401-refresher.plist
+++ b/claude-ops/templates/com.claude-ops.crs-401-refresher.plist
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  CRS 401-refresher reconciler (claude-relay-service pool proactive OAuth
+  token refresh).
+
+  Schedule: every 300s. Equivalent systemd: OnUnitActiveSec=300s.
+  The installer (scripts/install-crs-reconcilers-agent.sh) substitutes
+  __WRAPPER_PATH__, __LOG_DIR__, __HOME__ and writes the rendered copy to
+  ~/Library/LaunchAgents/com.claude-ops.crs-401-refresher.plist before:
+    launchctl bootstrap "gui/$(id -u)" <plist>
+
+  To uninstall:
+    launchctl bootout "gui/$(id -u)/com.claude-ops.crs-401-refresher"
+    rm ~/Library/LaunchAgents/com.claude-ops.crs-401-refresher.plist
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.claude-ops.crs-401-refresher</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>__WRAPPER_PATH__</string>
+  </array>
+
+  <key>StartInterval</key>
+  <integer>300</integer>
+
+  <key>ThrottleInterval</key>
+  <integer>60</integer>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>__LOG_DIR__/crs-401-refresher-launchd.log</string>
+  <key>StandardErrorPath</key>
+  <string>__LOG_DIR__/crs-401-refresher-launchd.log</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>HOME</key>
+    <string>__HOME__</string>
+    <key>NODE_NO_WARNINGS</key>
+    <string>1</string>
+  </dict>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>LowPriorityIO</key>
+  <true/>
+</dict>
+</plist>

--- a/claude-ops/templates/com.claude-ops.crs-429-cooldown.plist
+++ b/claude-ops/templates/com.claude-ops.crs-429-cooldown.plist
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  CRS 429-cooldown reconciler (claude-relay-service pool rate-limit hold).
+
+  Schedule: every 60s. Equivalent systemd: OnUnitActiveSec=60s.
+  The installer (scripts/install-crs-reconcilers-agent.sh) substitutes
+  __WRAPPER_PATH__, __LOG_DIR__, __HOME__ and writes the rendered copy to
+  ~/Library/LaunchAgents/com.claude-ops.crs-429-cooldown.plist before:
+    launchctl bootstrap "gui/$(id -u)" <plist>
+
+  To uninstall:
+    launchctl bootout "gui/$(id -u)/com.claude-ops.crs-429-cooldown"
+    rm ~/Library/LaunchAgents/com.claude-ops.crs-429-cooldown.plist
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.claude-ops.crs-429-cooldown</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>__WRAPPER_PATH__</string>
+  </array>
+
+  <key>StartInterval</key>
+  <integer>60</integer>
+
+  <key>ThrottleInterval</key>
+  <integer>20</integer>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>__LOG_DIR__/crs-429-cooldown-launchd.log</string>
+  <key>StandardErrorPath</key>
+  <string>__LOG_DIR__/crs-429-cooldown-launchd.log</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    <key>HOME</key>
+    <string>__HOME__</string>
+    <key>NODE_NO_WARNINGS</key>
+    <string>1</string>
+  </dict>
+
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>LowPriorityIO</key>
+  <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- The reconciler trio (#705) shipped config-driven and opt-in, but had no wizard path or install script — this closes that gap so the capability is actually reachable, per the "fully installable through ops-setup" requirement.
- New Step 4.6 in `ops-rotate-setup/SKILL.md` (+ `--reconcilers` arg), new `install-crs-reconcilers-agent.sh` (idempotent, config-driven), new wrapper scripts + plist templates mirroring the existing `crs-priority-daemon` pattern exactly.
- `ops-rotate/SKILL.md`'s `crs` status panel now shows both reconcilers' health.

## Test plan
- [x] `bash -n` passes on both wrapper scripts and the installer
- [x] Both plist templates are valid XML
- [ ] Manual: run `/ops:rotate-setup --reconcilers` against a real CRS pool end-to-end

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are opt-in installer and skill documentation following the existing CRS priority-daemon pattern; reconcilers still gate on config flags and use the same CRS admin credentials as today.
> 
> **Overview**
> Makes the opt-in **CRS reconciler** daemons installable through the same path as the existing priority daemon, instead of leaving them config-only.
> 
> Adds **`install-crs-reconcilers-agent.sh`**, which reads `crs.cooldownEnabled` / `crs.tokenRefreshEnabled` (plus env overrides), renders **launchd** plists from new templates, bootstraps or **uninstalls** agents idempotently, and prints **systemd** snippets on Linux. **`crs-429-cooldown.sh`** and **`crs-401-refresher.sh`** mirror the priority wrapper: single-flight `claude_once`, log rotation, and invocation of the existing `.mjs` reconcilers.
> 
> **`ops-rotate-setup`** gains **Step 4.6** (wizard prompts, config flags, `--status` smoke tests, then install), extends **`--crs`** to offer reconcilers after Step 4.5, and adds **`--reconcilers`**. The completion summary and failure-mode table cover both daemons; **`crs.weeklyReconcile`** is documented as built into the priority daemon.
> 
> **`ops-rotate` `crs`** status now reports 429-cooldown and 401-refresher health when their flags are enabled, with guidance to **`/ops:rotate-setup --reconcilers`** if a timer is missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48b7d4abd6326e32699ddbab2ddcf64a7fae139b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->