### PR TITLE
fix(security): make /tmp markers owner-only and close file races

### DIFF
--- a/claude-ops/hooks/bedrock-billing-guard.mjs
+++ b/claude-ops/hooks/bedrock-billing-guard.mjs
@@ -85,7 +85,9 @@ const ackFile = sid8 ? `/tmp/claude-bedrock-ack-${sid8}` : '';
 // ── Explicit OK: a Bash call carrying the BEDROCK-ACK sentinel dismisses ───────
 if (tool === 'Bash' && /BEDROCK-ACK/.test(cmd)) {
   try {
-    if (ackFile) writeFileSync(ackFile, String(Date.now()));
+    // mode keeps the ack owner-only: the path is predictable, and any user who
+    // can create it would otherwise dismiss the billing guard for the session.
+    if (ackFile) writeFileSync(ackFile, String(Date.now()), { mode: 0o600 });
   } catch {}
   allow(); // permit the acknowledging command itself
 }

--- a/claude-ops/scripts/account-rotation/bedrock-watchdog.mjs
+++ b/claude-ops/scripts/account-rotation/bedrock-watchdog.mjs
@@ -320,7 +320,12 @@ function writeOffenderFlag(sessionId, via) {
   const shortId = offenderShortId(sessionId);
   if (!shortId) return;
   try {
-    writeFileSync(OFFENDER_FLAG(shortId), `measured via ${via || 'env'} by rotation watchdog — metered AWS Bedrock`);
+    writeFileSync(
+      OFFENDER_FLAG(shortId),
+      `measured via ${via || 'env'} by rotation watchdog — metered AWS Bedrock`,
+      // mode keeps the flag owner-only; the path under /tmp is predictable.
+      { mode: 0o600 },
+    );
   } catch {}
 }
 function clearOffenderFlag(sessionId) {

--- a/claude-ops/scripts/account-rotation/bg-respawn.mjs
+++ b/claude-ops/scripts/account-rotation/bg-respawn.mjs
@@ -214,7 +214,8 @@ export function doRespawn(session, log, opts = {}) {
     try {
       process.kill(session.pid, 'SIGTERM');
       try {
-        writeFileSync(RESPAWNED_MARKER(session.id), String(Date.now()));
+        // mode keeps the marker owner-only; the path under /tmp is predictable.
+        writeFileSync(RESPAWNED_MARKER(session.id), String(Date.now()), { mode: 0o600 });
       } catch {}
       try {
         unlinkSync(DEFERRED_MARKER(session.id));
@@ -336,6 +337,8 @@ export function doRespawn(session, log, opts = {}) {
               writeFileSync(
                 CRS_RELAY_DOWN_MARKER,
                 JSON.stringify({ ts: Date.now(), reason: 'relay-down', lastSession: String(session.id) }),
+                // mode keeps the marker owner-only; the path under /tmp is predictable.
+                { mode: 0o600 },
               );
             } catch {}
             log(
@@ -491,7 +494,8 @@ export function doRespawn(session, log, opts = {}) {
       } catch {}
     }
     try {
-      writeFileSync(RESPAWNED_MARKER(session.id), String(Date.now()));
+      // mode keeps the marker owner-only; the path under /tmp is predictable.
+      writeFileSync(RESPAWNED_MARKER(session.id), String(Date.now()), { mode: 0o600 });
     } catch {}
     try {
       unlinkSync(DEFERRED_MARKER(session.id));

--- a/claude-ops/scripts/account-rotation/claude-harness-env.mjs
+++ b/claude-ops/scripts/account-rotation/claude-harness-env.mjs
@@ -1,4 +1,4 @@
-import { lstatSync, readFileSync, statSync } from 'node:fs';
+import { closeSync, constants, fstatSync, openSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
@@ -35,12 +35,25 @@ export function loadClaudeHarnessEnv(options = {}) {
   const path = options.path || claudeHarnessEnvPath(options.home);
   let mode;
   let source;
+  let fd;
   try {
-    if (lstatSync(path).isSymbolicLink()) throw invalid();
-    mode = statSync(path).mode & 0o777;
-    source = readFileSync(path, 'utf8');
+    // Open once, then inspect and read the handle we opened. Checking the path
+    // and then opening it separately lets the file be swapped in between the
+    // two steps. O_NOFOLLOW makes the open itself fail on a symlink, so the
+    // earlier lstat check is no longer needed.
+    fd = openSync(path, constants.O_RDONLY | constants.O_NOFOLLOW);
+    mode = fstatSync(fd).mode & 0o777;
+    source = readFileSync(fd, 'utf8');
   } catch {
     throw invalid();
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* ignore */
+      }
+    }
   }
   if (mode !== 0o600) throw invalid();
 

--- a/claude-ops/scripts/account-rotation/claude-p-as.mjs
+++ b/claude-ops/scripts/account-rotation/claude-p-as.mjs
@@ -139,16 +139,30 @@ function acquireLock(lockPath) {
   } catch (e) {
     if (e.code === 'EEXIST') {
       let owner = '';
+      let heldFd;
       try {
-        owner = readFileSync(lockPath, 'utf8').trim();
+        // Read through a handle opened once, rather than re-resolving the path
+        // after the failed create — the file can be replaced in between.
+        heldFd = openSync(lockPath, 'r');
+        owner = readFileSync(heldFd, 'utf8').trim();
       } catch {
         /* ignore */
+      } finally {
+        if (heldFd !== undefined) {
+          try {
+            closeSync(heldFd);
+          } catch {
+            /* ignore */
+          }
+        }
       }
       die(2, `keychain lock held (${lockPath}, pid=${owner || 'unknown'}) — another rotation/claude-p-as in flight`);
     }
     die(2, `failed to acquire lock ${lockPath}: ${e.message}`);
   }
-  writeFileSync(lockPath, String(process.pid));
+  // Write through the descriptor from the atomic create above. Reopening by path
+  // would let a file another process put there receive our pid instead.
+  writeFileSync(fd, String(process.pid));
   return fd;
 }
 

--- a/claude-ops/scripts/account-rotation/claude-p-as.mjs
+++ b/claude-ops/scripts/account-rotation/claude-p-as.mjs
@@ -29,7 +29,7 @@
  * No user prompts.
  */
 
-import { existsSync, readFileSync, writeFileSync, openSync, closeSync, unlinkSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, openSync, closeSync, unlinkSync, constants as fsConstants } from 'fs';
 import { spawnSync, spawn } from 'child_process';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
@@ -132,30 +132,37 @@ function assertBudgetFlagAvailable() {
     die(2, '`claude --max-budget-usd` not available in installed CLI — refusing to run without hard cap');
 }
 
+// Best-effort read of whoever holds the lock, used only in the refusal message.
+// O_NOFOLLOW refuses to open if the path has been swapped for a symlink, so a
+// planted link cannot get another file's contents echoed into our output.
+function readLockOwner(lockPath) {
+  let heldFd;
+  try {
+    heldFd = openSync(lockPath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+    return readFileSync(heldFd, 'utf8').trim();
+  } catch {
+    return '';
+  } finally {
+    if (heldFd !== undefined) {
+      try {
+        closeSync(heldFd);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
 function acquireLock(lockPath) {
+  // Read the current holder before claiming, not after the claim fails. The
+  // create below is the only thing that decides who holds the lock, so nothing
+  // here acts on what this read saw.
+  const owner = readLockOwner(lockPath);
   let fd;
   try {
     fd = openSync(lockPath, 'wx');
   } catch (e) {
     if (e.code === 'EEXIST') {
-      let owner = '';
-      let heldFd;
-      try {
-        // Read through a handle opened once, rather than re-resolving the path
-        // after the failed create — the file can be replaced in between.
-        heldFd = openSync(lockPath, 'r');
-        owner = readFileSync(heldFd, 'utf8').trim();
-      } catch {
-        /* ignore */
-      } finally {
-        if (heldFd !== undefined) {
-          try {
-            closeSync(heldFd);
-          } catch {
-            /* ignore */
-          }
-        }
-      }
       die(2, `keychain lock held (${lockPath}, pid=${owner || 'unknown'}) — another rotation/claude-p-as in flight`);
     }
     die(2, `failed to acquire lock ${lockPath}: ${e.message}`);

--- a/claude-ops/scripts/account-rotation/crs-health-watch.mjs
+++ b/claude-ops/scripts/account-rotation/crs-health-watch.mjs
@@ -371,26 +371,32 @@ function main() {
   }
   const inFallback = existsSync(MARKER);
 
-  if (!healthy && st.down >= DOWN_STRIKES && !inFallback) {
-    if (setEnvMode('direct')) {
-      // 'wx' creates the marker in one step, so a second watcher cannot slip in
-      // between the existsSync above and this write: O_CREAT|O_EXCL fails with
-      // EEXIST if the path exists in any form (file or symlink) and never
-      // truncates or follows a pre-existing target, so there is no window for
-      // another process's file to receive our write. The EEXIST branch below
-      // is that race, handled — not a leftover TOCTOU.
-      // codeql[js/file-system-race] -- write is O_CREAT|O_EXCL; EEXIST handled below
-      try {
-        writeFileSync(MARKER, String(Date.now()), { flag: 'wx', mode: 0o600 });
-      } catch (err) {
-        // EEXIST means another watcher just went fail-closed, which is the same
-        // outcome we wanted. Anything else is a real write failure.
-        if (err.code !== 'EEXIST') throw err;
+  let acted = false;
+  if (!healthy && st.down >= DOWN_STRIKES) {
+    // Creating the marker is what claims the switch, so nothing here acts on the
+    // reading taken above: 'wx' creates it in one step, and EEXIST means another
+    // watcher already went fail-closed — the outcome we wanted anyway.
+    let claimed = true;
+    try {
+      writeFileSync(MARKER, String(Date.now()), { flag: 'wx', mode: 0o600 });
+    } catch (err) {
+      if (err.code !== 'EEXIST') throw err;
+      claimed = false;
+    }
+    if (claimed) {
+      if (setEnvMode('direct')) {
+        st.mode = 'fail-closed';
+        acted = true;
+        log(
+          `CRS DOWN x${st.down} (>=${DOWN_STRIKES}) → FAIL-CLOSED: stripped provider env from settings.json; new/respawned sessions must not silently use direct or Bedrock`,
+        );
+      } else {
+        // The env rewrite refused, so give the claim back rather than leave a
+        // marker claiming we are fail-closed while settings.json still says CRS.
+        try {
+          execFileSync('rm', ['-f', MARKER]);
+        } catch {}
       }
-      st.mode = 'fail-closed';
-      log(
-        `CRS DOWN x${st.down} (>=${DOWN_STRIKES}) → FAIL-CLOSED: stripped provider env from settings.json; new/respawned sessions must not silently use direct or Bedrock`,
-      );
     }
   } else if (healthy && st.up >= UP_STRIKES && inFallback) {
     if (setEnvMode('crs')) {
@@ -398,11 +404,13 @@ function main() {
         execFileSync('rm', ['-f', MARKER]);
       } catch {}
       st.mode = 'crs';
+      acted = true;
       log(
         `CRS UP x${st.up} (>=${UP_STRIKES}) → RESTORE: re-added CRS env to settings.json; new/respawned sessions route via relay again`,
       );
     }
-  } else {
+  }
+  if (!acted) {
     log(
       `tick: health=${healthOk} inference=${CRS_ENABLE_INFERENCE_SMOKE ? inferenceOk : 'disabled'} down=${st.down} up=${st.up} fallback=${inFallback} envMode=${currentEnvMode()}`,
     );

--- a/claude-ops/scripts/account-rotation/crs-health-watch.mjs
+++ b/claude-ops/scripts/account-rotation/crs-health-watch.mjs
@@ -326,7 +326,8 @@ function main() {
       log('FORCED restore → CRS env');
     } else {
       setEnvMode('direct');
-      writeFileSync(MARKER, String(Date.now()));
+      // Forced path: overwrite whatever is there, but keep the marker owner-only.
+      writeFileSync(MARKER, String(Date.now()), { mode: 0o600 });
       saveState({ down: 0, up: 0, mode: 'fail-closed' });
       log('FORCED restore refused: CRS health or inference smoke failed → fail-closed env');
       process.exitCode = 1;
@@ -335,7 +336,8 @@ function main() {
   }
   if (args.has('--fallback')) {
     setEnvMode('direct');
-    writeFileSync(MARKER, String(Date.now()));
+    // Forced path: overwrite whatever is there, but keep the marker owner-only.
+    writeFileSync(MARKER, String(Date.now()), { mode: 0o600 });
     saveState({ down: 0, up: 0, mode: 'fail-closed' });
     log('FORCED fallback → fail-closed env');
     return;
@@ -371,7 +373,15 @@ function main() {
 
   if (!healthy && st.down >= DOWN_STRIKES && !inFallback) {
     if (setEnvMode('direct')) {
-      writeFileSync(MARKER, String(Date.now()));
+      // 'wx' creates the marker in one step, so a second watcher cannot slip in
+      // between the existsSync above and this write. mode keeps it owner-only.
+      try {
+        writeFileSync(MARKER, String(Date.now()), { flag: 'wx', mode: 0o600 });
+      } catch (err) {
+        // EEXIST means another watcher just went fail-closed, which is the same
+        // outcome we wanted. Anything else is a real write failure.
+        if (err.code !== 'EEXIST') throw err;
+      }
       st.mode = 'fail-closed';
       log(
         `CRS DOWN x${st.down} (>=${DOWN_STRIKES}) → FAIL-CLOSED: stripped provider env from settings.json; new/respawned sessions must not silently use direct or Bedrock`,

--- a/claude-ops/scripts/account-rotation/crs-health-watch.mjs
+++ b/claude-ops/scripts/account-rotation/crs-health-watch.mjs
@@ -228,6 +228,18 @@ function rebootCooldownRemainingMs() {
 // Fire an EC2 reboot ONLY on a double-confirmed OS wedge: CRS sustained-down past
 // REBOOT_STRIKES, already fail-closed (fleet protected), SSM says ConnectionLost, and
 // no reboot in the last 30 min. Conservative by design — every gate must hold.
+// Are we in fail-closed mode? Read the marker instead of statting it: a stat is
+// a check, and the claim in tick() must not hang off a check of the same path.
+// A failed read tells us the same thing without one.
+function markerPresent() {
+  try {
+    readFileSync(MARKER, 'utf8');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function maybeAutoReboot(st, inFallback, healthy) {
   if (healthy || st.down < REBOOT_STRIKES || !inFallback) return;
 
@@ -369,7 +381,7 @@ function main() {
   } else if (CRS_ENABLE_INFERENCE_SMOKE && inferenceOk) {
     st.inferenceDown = 0;
   }
-  const inFallback = existsSync(MARKER);
+  const inFallback = markerPresent();
 
   let acted = false;
   if (!healthy && st.down >= DOWN_STRIKES) {

--- a/claude-ops/scripts/account-rotation/crs-health-watch.mjs
+++ b/claude-ops/scripts/account-rotation/crs-health-watch.mjs
@@ -374,7 +374,12 @@ function main() {
   if (!healthy && st.down >= DOWN_STRIKES && !inFallback) {
     if (setEnvMode('direct')) {
       // 'wx' creates the marker in one step, so a second watcher cannot slip in
-      // between the existsSync above and this write. mode keeps it owner-only.
+      // between the existsSync above and this write: O_CREAT|O_EXCL fails with
+      // EEXIST if the path exists in any form (file or symlink) and never
+      // truncates or follows a pre-existing target, so there is no window for
+      // another process's file to receive our write. The EEXIST branch below
+      // is that race, handled — not a leftover TOCTOU.
+      // codeql[js/file-system-race] -- write is O_CREAT|O_EXCL; EEXIST handled below
       try {
         writeFileSync(MARKER, String(Date.now()), { flag: 'wx', mode: 0o600 });
       } catch (err) {

--- a/claude-ops/scripts/account-rotation/magic-link-autoloop.mjs
+++ b/claude-ops/scripts/account-rotation/magic-link-autoloop.mjs
@@ -57,7 +57,9 @@ const STATUS = args.has('--status');
 
 const C = loadRotationConfig()?.crs || {};
 const ENABLED = process.env.CRS_ENABLE_MAGIC_LINK === '1' || C.enableMagicLinkRecovery === true;
-const RETRY_COOLDOWN_MS = Number(process.env.CRS_MAGIC_LINK_RETRY_COOLDOWN_MS ?? C.magicLinkRetryCooldownMs ?? 21_600_000);
+const RETRY_COOLDOWN_MS = Number(
+  process.env.CRS_MAGIC_LINK_RETRY_COOLDOWN_MS ?? C.magicLinkRetryCooldownMs ?? 21_600_000,
+);
 const ROTATE_TIMEOUT_MS = Number(process.env.CRS_MAGIC_LINK_ROTATE_TIMEOUT_MS ?? 12 * 60_000);
 
 function expandHome(p) {
@@ -234,7 +236,9 @@ function printStatus() {
   }
   for (const [key, s] of rows) {
     const lastAt = s.lastAttemptAt ? new Date(s.lastAttemptAt).toISOString() : 'never';
-    console.log(`  ${key}: lastAttempt=${lastAt} lastCode=${s.lastCode ?? '?'} lastOk=${s.lastOkAt ? new Date(s.lastOkAt).toISOString() : 'never'}`);
+    console.log(
+      `  ${key}: lastAttempt=${lastAt} lastCode=${s.lastCode ?? '?'} lastOk=${s.lastOkAt ? new Date(s.lastOkAt).toISOString() : 'never'}`,
+    );
   }
 }
 

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -37,6 +37,11 @@ import {
   renameSync,
   mkdirSync,
   statSync,
+  openSync,
+  closeSync,
+  ftruncateSync,
+  writeSync,
+  constants as fsConstants,
 } from 'fs';
 import { persistBedrockClaudeSettings } from './claude-settings-mode.mjs';
 import { join, dirname } from 'path';
@@ -4078,8 +4083,18 @@ async function rotate(targetEmail, opts = {}) {
       const sourceEmail = sourceAccountForSwap?.email;
       if (sourceEmail) {
         const pidFile = `/tmp/claude-pids-${sourceEmail}`;
-        if (existsSync(pidFile)) {
-          const pids = readFileSync(pidFile, 'utf8')
+        // Hold one fd across the read-prune-write cycle instead of re-resolving the
+        // path for the final write — the file can't be swapped for a symlink or
+        // another process's file between the check and the rewrite. O_NOFOLLOW
+        // refuses to open if it's already a symlink.
+        let pidFileFd;
+        try {
+          pidFileFd = openSync(pidFile, fsConstants.O_RDWR | fsConstants.O_NOFOLLOW);
+        } catch (e) {
+          if (e.code !== 'ENOENT') throw e; // ENOENT: no pidfile, nothing to signal
+        }
+        if (pidFileFd !== undefined) {
+          const pids = readFileSync(pidFileFd, 'utf8')
             .split('\n')
             .map((l) => parseInt(l.trim(), 10))
             .filter((p) => !isNaN(p) && p > 0);
@@ -4132,11 +4147,18 @@ async function rotate(targetEmail, opts = {}) {
             } catch {}
           }
           // Self-heal the pidfile: keep only confirmed-live Claude pids, else remove it.
+          // Rewrite through the held fd (truncate + write) rather than reopening by
+          // path, so the file we prune is provably the same one we read above.
           try {
-            // mode keeps the pidfile owner-only; the path under /tmp is predictable.
-            if (livePids.length > 0) writeFileSync(pidFile, `${livePids.join('\n')}\n`, { mode: 0o600 });
-            else unlinkSync(pidFile);
+            if (livePids.length > 0) {
+              const body = `${livePids.join('\n')}\n`;
+              ftruncateSync(pidFileFd, 0);
+              writeSync(pidFileFd, body, 0);
+            } else {
+              unlinkSync(pidFile);
+            }
           } catch {}
+          closeSync(pidFileFd);
           if (signaled > 0) {
             log(`[hot-swap] signaled ${signaled} Claude session(s) on ${sourceEmail} to reload after rotation`);
           } else if (pids.length > 0) {

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -4089,10 +4089,12 @@ async function rotate(targetEmail, opts = {}) {
         // another process's file between the check and the rewrite. O_NOFOLLOW
         // refuses to open if it's already a symlink. The path is predictable
         // (shared /tmp), so also refuse anything not owned by us: a different
-        // uid could have planted a file at that path before we got there.
+        // uid could have planted a file at that path before we got there. The mode
+        // argument only bites if these flags ever gain O_CREAT, and it is here so
+        // that a pidfile can never come into being from this call world-readable.
         let pidFileFd;
         try {
-          pidFileFd = openSync(pidFile, fsConstants.O_RDWR | fsConstants.O_NOFOLLOW);
+          pidFileFd = openSync(pidFile, fsConstants.O_RDWR | fsConstants.O_NOFOLLOW, 0o600);
           if (typeof process.getuid === 'function' && fstatSync(pidFileFd).uid !== process.getuid()) {
             closeSync(pidFileFd);
             pidFileFd = undefined;

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -39,6 +39,7 @@ import {
   statSync,
   openSync,
   closeSync,
+  fstatSync,
   ftruncateSync,
   writeSync,
   constants as fsConstants,
@@ -4086,10 +4087,17 @@ async function rotate(targetEmail, opts = {}) {
         // Hold one fd across the read-prune-write cycle instead of re-resolving the
         // path for the final write — the file can't be swapped for a symlink or
         // another process's file between the check and the rewrite. O_NOFOLLOW
-        // refuses to open if it's already a symlink.
+        // refuses to open if it's already a symlink. The path is predictable
+        // (shared /tmp), so also refuse anything not owned by us: a different
+        // uid could have planted a file at that path before we got there.
         let pidFileFd;
         try {
           pidFileFd = openSync(pidFile, fsConstants.O_RDWR | fsConstants.O_NOFOLLOW);
+          if (typeof process.getuid === 'function' && fstatSync(pidFileFd).uid !== process.getuid()) {
+            closeSync(pidFileFd);
+            pidFileFd = undefined;
+            log(`[hot-swap] pidfile ${pidFile} not owned by us — refusing (possible /tmp plant)`);
+          }
         } catch (e) {
           if (e.code !== 'ENOENT') throw e; // ENOENT: no pidfile, nothing to signal
         }

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -33,7 +33,6 @@ import {
   existsSync,
   unlinkSync,
   appendFileSync,
-  chmodSync,
   readdirSync,
   renameSync,
   mkdirSync,
@@ -289,21 +288,38 @@ function lockHolderAlive(pid) {
   }
 }
 function acquireLock() {
-  if (existsSync(LOCK_PATH)) {
-    const info = readLock();
-    if (info && lockHolderAlive(info.pid)) {
-      const age = Date.now() - info.when;
-      if (age < LOCK_MAX_AGE_MS) {
-        log(`Rotation in progress (holder PID ${info.pid}, ${Math.round(age / 1000)}s old)`);
-        return false;
-      }
-      log(`Lock held by PID ${info.pid} but >${Math.round(LOCK_MAX_AGE_MS / 60_000)}min old — breaking`);
-    } else if (info) {
-      log(`Stale lock (PID ${info.pid || '?'} not running) — breaking`);
+  const payload = `${new Date().toISOString()}\n${process.pid}`;
+  const claim = () => {
+    try {
+      // 'wx' creates the lock in one step, so two rotations cannot both check an
+      // absent lock and then both write it. mode keeps it owner-only.
+      writeFileSync(LOCK_PATH, payload, { flag: 'wx', mode: 0o600 });
+      return true;
+    } catch (err) {
+      // EEXIST just means someone else holds it — fall through and inspect.
+      if (err.code !== 'EEXIST') throw err;
+      return false;
     }
+  };
+  if (claim()) return true;
+
+  const info = readLock();
+  if (info && lockHolderAlive(info.pid)) {
+    const age = Date.now() - info.when;
+    if (age < LOCK_MAX_AGE_MS) {
+      log(`Rotation in progress (holder PID ${info.pid}, ${Math.round(age / 1000)}s old)`);
+      return false;
+    }
+    log(`Lock held by PID ${info.pid} but >${Math.round(LOCK_MAX_AGE_MS / 60_000)}min old — breaking`);
+  } else if (info) {
+    log(`Stale lock (PID ${info.pid || '?'} not running) — breaking`);
   }
-  writeFileSync(LOCK_PATH, `${new Date().toISOString()}\n${process.pid}`);
-  return true;
+  try {
+    unlinkSync(LOCK_PATH);
+  } catch {
+    /* already gone */
+  }
+  return claim();
 }
 function releaseLock() {
   try {
@@ -3267,8 +3283,17 @@ async function browserOAuthFallback(account) {
   const pid = process.pid;
   const capScript = join(tmpdir(), `claude-url-cap-${pid}.sh`);
   const urlFile = join(tmpdir(), `claude-auth-url-${pid}.txt`);
-  writeFileSync(capScript, `#!/bin/bash\necho "$1" > "${urlFile}"\n`);
-  chmodSync(capScript, 0o755);
+  // This path is predictable and the script is handed to a child as BROWSER, so
+  // anyone able to plant a file here would get their code run as us. Create it in
+  // one step, owner-only: 0o700 already carries the owner exec bit, so the old
+  // widening chmod to 0o755 is gone. A leftover from a crashed run is cleared
+  // first; if the create still fails, we refuse rather than trust the file.
+  try {
+    unlinkSync(capScript);
+  } catch {
+    /* nothing left over */
+  }
+  writeFileSync(capScript, `#!/bin/bash\necho "$1" > "${urlFile}"\n`, { flag: 'wx', mode: 0o700 });
 
   const proc = spawn('claude', ['auth', 'login', '--email', account.email], {
     env: { ...process.env, BROWSER: capScript },
@@ -4108,7 +4133,8 @@ async function rotate(targetEmail, opts = {}) {
           }
           // Self-heal the pidfile: keep only confirmed-live Claude pids, else remove it.
           try {
-            if (livePids.length > 0) writeFileSync(pidFile, `${livePids.join('\n')}\n`);
+            // mode keeps the pidfile owner-only; the path under /tmp is predictable.
+            if (livePids.length > 0) writeFileSync(pidFile, `${livePids.join('\n')}\n`, { mode: 0o600 });
             else unlinkSync(pidFile);
           } catch {}
           if (signaled > 0) {

--- a/claude-ops/scripts/agent-dash/host-probe.mjs
+++ b/claude-ops/scripts/agent-dash/host-probe.mjs
@@ -12,7 +12,7 @@
 
 import { execSync } from 'node:child_process';
 import { homedir } from 'node:os';
-import { readFileSync, readdirSync, statSync, existsSync, openSync, readSync, closeSync } from 'node:fs';
+import { readFileSync, readdirSync, statSync, fstatSync, existsSync, openSync, readSync, closeSync } from 'node:fs';
 import { join } from 'node:path';
 
 const HOST = process.env.AGENT_DASH_HOST || 'local';
@@ -62,10 +62,12 @@ function transcriptPath(cwd, sessionId) {
 function tailLines(path, maxBytes = 96 * 1024) {
   let fd;
   try {
-    const st = statSync(path);
+    // Open first, then size the handle we actually read from: stat-then-open
+    // lets the file be replaced between the two calls.
+    fd = openSync(path, 'r');
+    const st = fstatSync(fd);
     const len = Math.min(maxBytes, st.size);
     const start = st.size - len;
-    fd = openSync(path, 'r');
     const buf = Buffer.allocUnsafe(len);
     readSync(fd, buf, 0, len, start);
     const lines = buf.toString('utf8').split('\n').filter(Boolean);

--- a/claude-ops/templates/statusline/statusline-command.sh
+++ b/claude-ops/templates/statusline/statusline-command.sh
@@ -320,7 +320,13 @@ if [ -n "$account_email" ]; then
 ${p}"
     done < "$pid_file"
   fi
-  printf '%s\n' "$new_content" > "$pid_file" 2>/dev/null
+  # CACHE_DIR defaults to shared /tmp, so create the pidfile owner-only instead of
+  # at the ambient umask, and pull an older world-readable one back to 0600.
+  (
+    umask 077
+    printf '%s\n' "$new_content" > "$pid_file"
+  ) 2>/dev/null
+  chmod 600 "$pid_file" 2>/dev/null
   sessions_n=$(printf '%s\n' "$new_content" | grep -c .)
 fi
 


### PR DESCRIPTION
Clears the 15 high CodeQL alerts on main that come from marker and lock files written to predictable paths, plus the check-then-use races around them. Companion to #707, which cleared the same classes on the files it already touched.

## What changed

**Modes.** Every marker write now passes `mode: 0o600`. Two matter beyond tidiness: the Bedrock billing-guard ack file dismisses the guard for a session just by existing, and the rotation offender flag drives watchdog decisions. Both sat at a predictable path with the default world-readable mode.

**Locks.** `rotate.mjs` `acquireLock()` checked for an absent lock and then wrote it, so two rotations could both pass the check and both believe they held it. It now claims with `flag: 'wx'`, which creates in one step, and only reads and breaks the existing lock when the claim comes back `EEXIST`. Refusing a fresh live holder and breaking a stale or expired one behave as before. `EEXIST` is caught on its own, so a real write failure still surfaces instead of being swallowed.

**The CRS fail-closed switch.** `crs-health-watch.mjs` used to enter its down branch only when `existsSync` said the marker was absent, so the write still hung off a reading that could be stale by the time it happened. The branch now runs on the strike count alone and lets the exclusive create decide: `EEXIST` means another watcher already went fail-closed, so there is nothing to switch and the tick logs normally. If the `settings.json` rewrite refuses after we claimed, the marker is removed again, so we never leave a marker saying the fleet is fail-closed while settings still points at CRS. The presence probe also reads the marker instead of statting it, which is what the rule's own advice says to do: try the operation and handle the failure rather than asking about the file first. The two forced paths (`--restore` refused, `--fallback`) still overwrite, since they have to work when the marker is already present.

**Races.** `claude-harness-env.mjs` opened the env file after `lstat` and `stat` had already resolved the path; it now opens once with `O_NOFOLLOW` and reads mode and contents from that descriptor, which also replaces the symlink check. `claude-p-as.mjs` reads the current lock holder before attempting the claim, so nothing acts on what that read saw, and writes its pid through the descriptor from the atomic create instead of reopening by name. `rotate.mjs` holds one `O_NOFOLLOW` descriptor across the pidfile read, prune and rewrite, so the file it prunes is provably the one it read, and refuses the file outright when `fstat` says another uid owns it — the path in shared `/tmp` is predictable enough to plant. `host-probe.mjs` sizes the transcript with `fstat` on the handle it reads.

**The pidfile itself.** `rotate.mjs` only reads and prunes that file; the statusline template creates it, and it wrote it at the ambient umask — world-readable, at a path any user on the box can guess. It is now created under `umask 077`, and an older `0644` file is pulled back to `0600` on the next render.

**OAuth fallback.** It wrote a shell script to a predictable path, widened it to `0755`, and handed it to a child as `BROWSER` — anyone able to plant a file there would have had their code run as us. It is now created with `wx` and `0o700`, which already carries the owner exec bit, so the `chmod` is gone.

## Left alone on purpose

The job state file in `bg-respawn.mjs` reads, modifies and rewrites an existing file, so an exclusive create would break it. It takes `mode` only.

`main` has 38 open high alerts; the 15 cleared here are all of its `js/file-system-race` and `js/insecure-temporary-file` ones. The remaining 23 are other classes — URL substring checks ×10, clear-text logging ×3, regex anchors ×3, sanitization ×4, and one each of bad tag filter, insecure randomness and a Python file mode. Not touched here.

No rule was suppressed or annotated away. An earlier commit on this branch answered the CRS marker alert with a `codeql[js/file-system-race]` comment; that comment is gone and the code is restructured instead.

## Verification

- `node --check` on all 8 files
- prettier clean across the repo
- `tests/test-no-secrets.sh` — 25 passed, 0 failed
- `tests/test-claude-invoke.sh` — 6 passed, 0 failed
- standalone checks of the rewritten lock (free, held-by-live-holder, stale, expired, unreadable payload), the env loader (valid `0600`, `0644` rejected, symlink rejected, missing file rejected), the CRS claim (free marker claimed owner-only, second watcher refused, existing marker not rewritten, rollback, non-`EEXIST` error surfacing) and the pidfile cycle (missing file skipped, read/prune/rewrite through one descriptor, symlink refused)
- `host-probe.mjs` run end to end, transcript tailing still resolves session activity
