### PR TITLE
fix(security): drive bg-respawn state load off the read, not a stat

### DIFF
--- a/claude-ops/scripts/account-rotation/bg-respawn.mjs
+++ b/claude-ops/scripts/account-rotation/bg-respawn.mjs
@@ -200,14 +200,19 @@ export function doRespawn(session, log, opts = {}) {
   // (resetTty is defined at module scope with process handler)
   const stateFile = join(homedir(), '.claude', 'jobs', String(session.id), 'state.json');
   let state = null;
-  if (existsSync(stateFile)) {
-    try {
-      state = JSON.parse(readFileSync(stateFile, 'utf8'));
-    } catch {
-      state = null;
-    }
+  // Read the file rather than ask whether it exists. The reconciliation further
+  // down rewrites this same path, and a stat here is a check that write would
+  // then hang off. ENOENT says "no saved state" just as well; any other read
+  // failure, or unparseable contents, leaves state null without claiming the
+  // session is a spare — same as the two existsSync calls this replaces.
+  let stateMissing = false;
+  try {
+    state = JSON.parse(readFileSync(stateFile, 'utf8'));
+  } catch (err) {
+    state = null;
+    if (err.code === 'ENOENT') stateMissing = true;
   }
-  if (!existsSync(stateFile)) {
+  if (stateMissing) {
     log(
       `[bg-respawn] session ${session.id} (pid ${session.pid}) has no saved state (spare) — terminating process to refresh`,
     );
@@ -464,7 +469,10 @@ export function doRespawn(session, log, opts = {}) {
         }
         if (mutated) {
           state.respawnFlags = flags;
-          writeFileSync(stateFile, JSON.stringify(state, null, 2));
+          // Rewrite in place, so no exclusive create here. The mode only bites if
+          // the file has gone since we read it, and keeps the replacement from
+          // coming back world-readable when it does.
+          writeFileSync(stateFile, JSON.stringify(state, null, 2), { mode: 0o600 });
         }
       }
     } catch (err) {


### PR DESCRIPTION
Clears the last high `js/file-system-race` alert on main (#171). Follow-up to #711, which cleared the other 14 of that batch: 7 `js/insecure-temporary-file` and 7 `js/file-system-race`.

## What changed

The job state file `~/.claude/jobs/<id>/state.json` was read behind `existsSync`, and a second `existsSync` on the same path decided whether the session counted as a spare. The respawn-flag reconciliation lower in the same function rewrites that file, so the write hung off a reading that could be stale by the time it happened.

The load now reads the file once and sorts the outcomes by error code. `ENOENT` means there is no saved state, which is the spare branch. Anything else — unparseable contents, a permission error, a directory at the path — leaves `state` null without claiming the session is a spare. That is exactly what the pair of stats decided, and it takes both of them out of the flow, which is what the rule asks for: attempt the operation and handle the failure instead of asking about the file first.

The rewrite itself still overwrites an existing file, so an exclusive create would break it. It keeps its plain write and gains `mode: 0o600`, which only applies if the file has gone since we read it.

No rule was suppressed or annotated away.

## Verification

- `node --check` and prettier clean on the changed file
- `tests/test-no-secrets.sh` — 25 passed, 0 failed
- standalone check of the load against the behaviour it replaces, for all five cases: missing file (spare), valid JSON (parsed), unparseable, unreadable, and a directory at the path — all match

## What this leaves

23 open high alerts on main, all other classes: URL substring checks ×10, clear-text logging ×3, regex anchors ×3, sanitization ×4, and one each of bad tag filter, insecure randomness and a Python file mode. Not touched here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to filesystem access in account rotation; behavior is intended to match the prior logic with reduced race surface and tighter file permissions.
> 
> **Overview**
> **`doRespawn`** no longer uses **`existsSync`** on `~/.claude/jobs/<id>/state.json` before loading job state. It **reads once** and branches on the result: **`ENOENT`** still triggers the spare-session terminate path; other failures leave **`state` null** without treating the session as spare, matching the old two-stat behavior while avoiding a check-then-write race with the later **`respawnFlags`** reconciliation on the same file.
> 
> When reconciliation persists **`state.json`**, the in-place **`writeFileSync`** now passes **`{ mode: 0o600 }`** so a recreated file is not world-readable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02a8b2f152daffc5efb63141218d5e07744b98f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session state handling when saved data is missing or cannot be read.
  * Prevented unreadable or invalid state files from being incorrectly treated as spare sessions.
  * Ensured updated session state files remain accessible only to their owner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->