### PR TITLE
fix(security): capture the OAuth URL under umask 077

### DIFF
--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -3294,12 +3294,19 @@ async function browserOAuthFallback(account) {
   // one step, owner-only: 0o700 already carries the owner exec bit, so the old
   // widening chmod to 0o755 is gone. A leftover from a crashed run is cleared
   // first; if the create still fails, we refuse rather than trust the file.
+  //
+  // The script itself redirects under `umask 077`, because the URL it captures
+  // carries the OAuth state and code challenge and would otherwise land at the
+  // ambient umask — readable by anyone on the box, at a path they can guess.
   try {
     unlinkSync(capScript);
   } catch {
     /* nothing left over */
   }
-  writeFileSync(capScript, `#!/bin/bash\necho "$1" > "${urlFile}"\n`, { flag: 'wx', mode: 0o700 });
+  writeFileSync(capScript, `#!/bin/bash\numask 077\necho "$1" > "${urlFile}"\n`, {
+    flag: 'wx',
+    mode: 0o700,
+  });
 
   const proc = spawn('claude', ['auth', 'login', '--email', account.email], {
     env: { ...process.env, BROWSER: capScript },


### PR DESCRIPTION
## What

The magic-link login path hands `claude auth login` a small generated shell script as `BROWSER`. That script captures the OAuth authorize URL with a plain redirect:

```sh
#!/bin/bash
echo "$1" > "/tmp/claude-auth-url-<pid>.txt"
```

A plain redirect takes the ambient umask, so on a box running the default the captured file came out `0644` — readable by any local user, at a path built from the pid and easy to guess or enumerate. The URL carries the OAuth `state` and `code_challenge`.

This adds `umask 077` inside the generated script, so the file it writes is owner-only.

## Why this was left

#711 fixed the create of the script itself — exclusive `wx`, mode `0o700`, a leftover cleared first, and no widening `chmod` afterwards. What it did not cover was the file the script goes on to produce, which is written by the shell rather than by Node and so sat outside the pattern the CodeQL alerts pointed at.

Found while auditing a separate tree against the same class of weakness. An audit of `main` after this change finds no `/tmp` write left without an owner-only mode, and no other generated shell body redirecting into a file without a umask.

## Test

Verified the sequence out of tree: the script still captures `$1` to the URL file unchanged, the script is `0700`, the file it writes is `0600`, re-running over a leftover from a crashed run with the same pid still works, a planted symlink is removed rather than written through, and an exclusive create refuses a planted file instead of overwriting it.

`node --check` clean. Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavior change in a generated bash snippet for local OAuth capture; no auth logic or API surface changes, only tighter file permissions on `/tmp` output.
> 
> **Overview**
> Hardens the **browser OAuth fallback** path where `claude auth login` runs with a generated `BROWSER` script that writes the authorize URL to a predictable `/tmp` file.
> 
> The generated script now runs **`umask 077`** before redirecting `$1` into that file, so the captured URL is **owner-only** (`0600`) instead of inheriting the process umask (often `0644`). That matters because the URL includes OAuth **`state`** and **`code_challenge`**, and the path is guessable from the PID.
> 
> Comments in `browserOAuthFallback` document why this is separate from the earlier fix that created the hook script itself with `0o700` / exclusive `wx` — the **file the shell writes** was still outside Node’s direct mode control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6437ee8b7feaf69a2033686af2ec5644ad2eddcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified comments and formatting around secure temporary script creation during OAuth fallback.
  * No user-visible behavior or functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->