### PR TITLE
release: v2.46.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 61 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.46.1",
+      "version": "2.46.2",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-2.46.1-blue)
+![Version](https://img.shields.io/badge/version-2.46.2-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-61-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.46.1",
+  "version": "2.46.2",
   "description": "Business operations command center for Claude Code — 61 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -10,6 +10,22 @@
 - **ops-ecom:** `channels` | `agentic` | `shop` verbs — sales channel inventory, agentic storefront health, Shop Campaigns readiness (read-only; Rule 5 / stage-only spend).
 - **ops-marketing:** brand-agnostic `shop_campaigns` + `agentic_storefronts` project prefs schema; `shop-campaigns` / `agentic` routing; portfolio awareness; NEVER LEAK MONEY guardrails for Shop Campaigns.
 
+## [2.46.2] - 2026-07-25
+
+### Changed
+- fix(security): capture the OAuth URL under umask 077 (#713)
+- fix(security): drive bg-respawn state load off the read, not a stat (#712)
+- fix(security): make /tmp markers owner-only and close file races (#711)
+- feat(crs): opt-in magic-link autoloop reconciler (#710)
+- fix(rotation): create the deferred-respawn marker atomically (#707)
+- feat(ops-rotate-setup): wire crs-429-cooldown/401-refresher into the setup wizard (#709)
+- fix(crs-token-feed): add missing crs-refresh-lock.mjs (#708)
+- feat(crs-priority-daemon): weekly-cap reconciliation + configurable floor (#706)
+- feat(crs): opt-in 429-cooldown + 401-refresher reconcilers (#705)
+- fix(crs-pool-config): remove hardcoded personal proxy IP default (#703)
+- chore(rotate): reconcile drift between local and public account-rotation scripts (#704)
+
+
 ## [2.46.1] - 2026-07-24
 
 ### Changed

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-2.46.1-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.46.2-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 61 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-2.46.1-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.46.2-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-61-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.46.1",
+  "version": "2.46.2",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.46.2** (was 2.46.1).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

- fix(security): capture the OAuth URL under umask 077 (#713)
- fix(security): drive bg-respawn state load off the read, not a stat (#712)
- fix(security): make /tmp markers owner-only and close file races (#711)
- feat(crs): opt-in magic-link autoloop reconciler (#710)
- fix(rotation): create the deferred-respawn marker atomically (#707)
- feat(ops-rotate-setup): wire crs-429-cooldown/401-refresher into the setup wizard (#709)
- fix(crs-token-feed): add missing crs-refresh-lock.mjs (#708)
- feat(crs-priority-daemon): weekly-cap reconciliation + configurable floor (#706)
- feat(crs): opt-in 429-cooldown + 401-refresher reconcilers (#705)
- fix(crs-pool-config): remove hardcoded personal proxy IP default (#703)
- chore(rotate): reconcile drift between local and public account-rotation scripts (#704)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release bump and changelog; no runtime code changes in this PR.
> 
> **Overview**
> **Release v2.46.2** — version strings move from **2.46.1** to **2.46.2** in the marketplace registry, `plugin.json`, `claude-ops/package.json`, README, and skills/agents reference badges.
> 
> `CHANGELOG.md` gains a **[2.46.2] - 2026-07-25** section that catalogs what this release contains (no application code in this diff): OAuth URL capture under **umask 077**, safer **/tmp** markers and **bg-respawn** state loading, atomic deferred-respawn markers, CRS opt-in reconcilers (magic-link autoloop, **429** cooldown, **401** refresher), **ops-rotate-setup** wiring for those reconcilers, missing **crs-refresh-lock.mjs**, priority-daemon weekly-cap reconciliation, removal of a hardcoded CRS proxy default, and rotation script drift cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd7c8c2558cf7022fb95cf6cf2c0c54d38e48094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in account reconciliation improvements, including cooldown handling, token refresh support, and configurable weekly-cap reconciliation.
  * Enhanced rotation setup with CRS refresh and cooldown support.

* **Bug Fixes**
  * Improved file security, atomic marker creation, OAuth handling, and background state loading.
  * Removed an unintended proxy default and synchronized account-rotation behavior.

* **Documentation**
  * Added release notes for version 2.46.2.

* **Chores**
  * Updated the application and plugin version to 2.46.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->