### PR TITLE
fix(account-rotation): keep CRS harness for agents TUI

### DIFF
--- a/claude-ops/scripts/account-rotation/launch-claude.mjs
+++ b/claude-ops/scripts/account-rotation/launch-claude.mjs
@@ -196,8 +196,7 @@ if (needsCrsHarness) {
   }
   Object.assign(baseEnv, harnessEnv);
   // Keep API_KEY=cr_ (derived from harness). Stripping it left BASE→CRS with no key.
-  baseEnv.ANTHROPIC_API_KEY =
-    baseEnv.ANTHROPIC_API_KEY || baseEnv.CRS_API_KEY || baseEnv.ANTHROPIC_AUTH_TOKEN;
+  baseEnv.ANTHROPIC_API_KEY = baseEnv.ANTHROPIC_API_KEY || baseEnv.CRS_API_KEY || baseEnv.ANTHROPIC_AUTH_TOKEN;
   // Agent-hub TUI: stay on CRS relay; do not per-account OAuth rewrite.
   if (launchCmd === 'agents') {
     baseEnv.CLAUDE_SESSION_ROUTING = '0';

--- a/claude-ops/scripts/account-rotation/launch-claude.mjs
+++ b/claude-ops/scripts/account-rotation/launch-claude.mjs
@@ -149,6 +149,14 @@ function withBypassPermissions(args) {
 
 const args = withBypassPermissions(rawArgs);
 const isModelLaunch = shouldBypassPermissions(rawArgs);
+// `agents` is a control subcommand (no tool-permission bypass) but it is the
+// agent-hub interactive surface and MUST keep CRS harness pairing. Stripping
+// CRS keys here forces session-router onto raw OAuth + direct-oauth.settings
+// and surfaces "login required / 401 Invalid bearer token" when vault tokens
+// are stale. Pure path: agent-hub-claude-crs; this keeps the launch-efficient
+// / ls-attach path on CRS too.
+const launchCmd = firstCommand(rawArgs);
+const needsCrsHarness = isModelLaunch || launchCmd === 'agents';
 const settingsEnv = (() => {
   try {
     return JSON.parse(readFileSync(CLAUDE_SETTINGS_PATH, 'utf8'))?.env || {};
@@ -178,7 +186,7 @@ for (const key of [
 delete baseEnv.CLAUDE_CODE_USE_BEDROCK;
 delete baseEnv.ANTHROPIC_MODEL;
 
-if (isModelLaunch) {
+if (needsCrsHarness) {
   let harnessEnv;
   try {
     harnessEnv = loadClaudeHarnessEnv({ home });
@@ -188,7 +196,12 @@ if (isModelLaunch) {
   }
   Object.assign(baseEnv, harnessEnv);
   // Keep API_KEY=cr_ (derived from harness). Stripping it left BASE→CRS with no key.
-  baseEnv.ANTHROPIC_API_KEY = baseEnv.ANTHROPIC_API_KEY || baseEnv.CRS_API_KEY || baseEnv.ANTHROPIC_AUTH_TOKEN;
+  baseEnv.ANTHROPIC_API_KEY =
+    baseEnv.ANTHROPIC_API_KEY || baseEnv.CRS_API_KEY || baseEnv.ANTHROPIC_AUTH_TOKEN;
+  // Agent-hub TUI: stay on CRS relay; do not per-account OAuth rewrite.
+  if (launchCmd === 'agents') {
+    baseEnv.CLAUDE_SESSION_ROUTING = '0';
+  }
 } else {
   for (const key of [
     'ANTHROPIC_BASE_URL',


### PR DESCRIPTION
## Summary
- `launch-claude.mjs` treated `agents` as a control command and stripped CRS harness keys.
- Session-router then injected vault OAuth + direct-oauth settings, causing `401 Invalid bearer token` / login walls on the agent-hub TUI.
- Keep CRS harness for `agents` and set `CLAUDE_SESSION_ROUTING=0` so the agents surface stays on the local relay.

## Test plan
- [ ] Launch `claude-launch-efficient.sh agents` (or hub path) and confirm env has `ANTHROPIC_BASE_URL=…3005/api` and `cr_*` tokens
- [ ] Confirm no `--settings …/direct-oauth.settings.json` on the agents process
- [ ] Confirm agents TUI does not show login required / 401 Invalid bearer token

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file launcher change scoped to the `agents` subcommand; no auth or routing changes for other control commands or default model launches.
> 
> **Overview**
> **Fixes agent-hub auth** when launching via `claude agents` (or equivalent launch-efficient / ls-attach paths). Previously `agents` was treated like other control subcommands, so CRS harness env (`ANTHROPIC_BASE_URL`, `cr_*` keys) was stripped and **session-router** could push vault OAuth plus `direct-oauth.settings`, leading to **login required** / **401 Invalid bearer token** when vault tokens were stale.
> 
> `launch-claude.mjs` now sets **`needsCrsHarness`** for model launches **or** when the first subcommand is **`agents`**, so harness env is loaded the same way as interactive model runs. For **`agents` only**, it sets **`CLAUDE_SESSION_ROUTING=0`** so the TUI stays on the **CRS relay** without per-account OAuth rewrite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ea566d564f33ced25cad2dad6bba9bcd5792257. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent management command handling when using the Claude harness environment.
  * Preserved the correct session routing and authentication configuration for agent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->