### PR TITLE
fix(watchdog): expand ${VAR} in config headers before probing

### DIFF
--- a/claude-ops/scripts/ops-mcp-watchdog.py
+++ b/claude-ops/scripts/ops-mcp-watchdog.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -87,14 +88,48 @@ def get_api_key_for(name: str) -> str | None:
     return None
 
 
+def _secrets_env() -> dict:
+    """KEY=value pairs from ~/.mcp-secrets.env, as a fallback for ${VAR}
+    references in config headers when the daemon env lacks them (the daemon
+    is not a login shell, so ~/.bashrc exports never reach it)."""
+    out: dict = {}
+    try:
+        for line in (HOME / ".mcp-secrets.env").read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if line.startswith("export "):
+                line = line[len("export "):]
+            k, sep, v = line.partition("=")
+            if sep:
+                out[k.strip()] = v.strip().strip('"').strip("'")
+    except Exception:
+        pass
+    return out
+
+
 def config_headers(name: str) -> dict:
     """Static headers from ~/.claude.json mcpServers[name].headers (e.g. a
-    local gateway MCP configured with a Bearer token in its config entry)."""
+    local gateway MCP configured with a Bearer token in its config entry).
+    Expands ${VAR} references the way Claude Code does at session start,
+    from os.environ first, then ~/.mcp-secrets.env."""
     try:
         d = json.loads((HOME / ".claude.json").read_text())
-        return dict(((d.get("mcpServers") or {}).get(name) or {}).get("headers") or {})
+        raw = dict(((d.get("mcpServers") or {}).get(name) or {}).get("headers") or {})
     except Exception:
         return {}
+    if not any(isinstance(v, str) and "${" in v for v in raw.values()):
+        return raw
+    env = {**_secrets_env(), **os.environ}
+
+    def expand(v: str) -> str:
+        return re.sub(
+            r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}",
+            lambda m: env.get(m.group(1), m.group(0)),
+            v,
+        )
+
+    return {k: (expand(v) if isinstance(v, str) else v) for k, v in raw.items()}
 
 
 def keychain_oauth_token(name: str) -> str | None:


### PR DESCRIPTION
## What changed

`config_headers()` in `scripts/ops-mcp-watchdog.py` reads header values straight from `mcpServers[name].headers` in `~/.claude.json`. It now expands `${VAR}` references in those values before the probe uses them, checking `os.environ` first and falling back to `~/.mcp-secrets.env` (the watchdog daemon isn't a login shell, so `~/.bashrc` exports never reach it). Values with no `${` are returned untouched; a `${VAR}` that can't be resolved is left as-is rather than raising.

## Why

Claude Code expands `${VAR}` header references at session start, but the watchdog probe runs outside that session, so it sent the literal unexpanded string. A header like `Authorization: Bearer ${MEM0_API_KEY}` went out as-is, the server answered 401, and the watchdog classified a healthy API-key MCP as `needs_bootstrap` — then tried an OAuth reauth flow that server doesn't support. Hit in production on 2026-07-28 with the mem0 MCP.

## Behaviour before / after

- Before: probe sends the literal string `${MEM0_API_KEY}` as the Bearer token → 401 → misclassified `needs_bootstrap` → wrong OAuth reauth attempt.
- After: probe resolves `${MEM0_API_KEY}` from the environment or `~/.mcp-secrets.env` before sending → 200 → correctly classified `healthy`.

## Test plan

- [x] `python3 -m py_compile scripts/ops-mcp-watchdog.py`
- [x] `tests/test-no-secrets.sh` (25 passed, 0 failed)
- [x] Manually verified: with `MEM0_API_KEY` absent from the environment, the patched watchdog probes mem0 as healthy (200) via the `~/.mcp-secrets.env` fallback; unpatched it reports `needs_bootstrap` / `invalid_token`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-script operational fix for header expansion during probes; no changes to OAuth, notifications, or broader auth flows.
> 
> **Overview**
> The MCP watchdog’s HTTP probes now resolve **`${VAR}` placeholders** in `mcpServers[name].headers` from `~/.claude.json` the same way Claude Code does at session start, instead of sending the literal string and getting false **401 / `needs_bootstrap`** (e.g. mem0 with `Bearer ${MEM0_API_KEY}`).
> 
> A new **`_secrets_env()`** helper loads `~/.mcp-secrets.env` because the cron/daemon process is not a login shell and often lacks exports from `~/.bashrc`. **`config_headers()`** merges that file with `os.environ` (env wins), expands only when a value contains `${`, and leaves unresolved placeholders unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a00ce5d654430c7468eeb10142a8433b4acddd25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP connection headers can now use `${VAR}` placeholders.
  * Values are resolved from environment variables or a local secrets file, including common `export VAR=value` formats.
  * Existing static header configurations continue to work unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->