### PR TITLE
fix(desktop-act): valid Claude plugin.json (drop path arrays)

### DIFF
--- a/desktop-act/.claude-plugin/plugin.json
+++ b/desktop-act/.claude-plugin/plugin.json
@@ -19,12 +19,6 @@
     "vnc",
     "screenshot"
   ],
-  "skills": [
-    "skills/desktop-act"
-  ],
-  "commands": [
-    "commands/act.md"
-  ],
   "mcpServers": {
     "desktop-act": {
       "type": "stdio",


### PR DESCRIPTION
## Summary
Post-#724: `claude plugin install desktop-act@ops-marketplace` fails with `commands: Invalid input, skills: Invalid input` because Claude Code does not accept path arrays for those fields.

## Change
Remove `skills` / `commands` path arrays from vendored `desktop-act/.claude-plugin/plugin.json`. Directories remain for auto-discovery.

## Evidence
Local strip of the same arrays made install succeed: `desktop-act@ops-marketplace` 0.2.0 at user scope.

Upstream: Lifecycle-Innovations-Limited/desktop-act#15

## Test plan
- [ ] CI green
- [ ] `claude plugin marketplace update ops-marketplace && claude plugin install desktop-act@ops-marketplace`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change to plugin packaging; no runtime or MCP server logic is modified.
> 
> **Overview**
> Fixes **`claude plugin install desktop-act@ops-marketplace`** failing with `commands: Invalid input` / `skills: Invalid input` by removing the **`skills`** and **`commands`** path-array fields from vendored **`desktop-act/.claude-plugin/plugin.json`**.
> 
> Claude Code rejects those path lists in this schema; **`mcpServers`** and the existing **`skills/`** / **`commands/`** directories are unchanged so discovery can still work without explicit entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ed9c81d96fcaec3efb2f79325a6d2d9a345b1ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->