### PR TITLE
feat(account-rotation): trySolveCaptchaWall on public rotate walls

### DIFF
--- a/claude-ops/scripts/account-rotation/README.md
+++ b/claude-ops/scripts/account-rotation/README.md
@@ -207,3 +207,6 @@ Token solvers (env): `TWOCAPTCHA_API_KEY`, `CAPSOLVER_API_KEY`, `ANTICAPTCHA_API
 Bright Data is last-resort cascade for proxy-aligned re-solve (zone/password envs), not a primary token API.
 
 Residual host-only: interactive click helpers (`click-turnstile*.mjs`) and Chrome profile automation — next PR.
+Browser walls on magic-link / OAuth go through `trySolveCaptchaWall` (see
+`CAPTCHA-CASCADE.md`). Solvers need env keys (`TWOCAPTCHA_API_KEY`, etc.) via
+Doppler/`secrets-bootstrap.mjs`. Interactive tile challenges use vision + desktop-act.

--- a/claude-ops/scripts/account-rotation/captcha-optional.mjs
+++ b/claude-ops/scripts/account-rotation/captcha-optional.mjs
@@ -49,7 +49,11 @@ export async function loadCaptchaCascade() {
 }
 
 export function captchaModulesOnDisk() {
-  return ['captcha-helper.mjs', 'visual-captcha-solver.mjs', 'bright-data-cascade.mjs', 'secrets-bootstrap.mjs', 'virtual-display.mjs'].filter(
-    (n) => existsSync(join(__dirname, n)),
-  );
+  return [
+    'captcha-helper.mjs',
+    'visual-captcha-solver.mjs',
+    'bright-data-cascade.mjs',
+    'secrets-bootstrap.mjs',
+    'virtual-display.mjs',
+  ].filter((n) => existsSync(join(__dirname, n)));
 }

--- a/claude-ops/scripts/account-rotation/captcha-optional.mjs
+++ b/claude-ops/scripts/account-rotation/captcha-optional.mjs
@@ -1,0 +1,55 @@
+/**
+ * Soft-load captcha cascade modules when present in this install.
+ * Safe no-ops when modules are missing (public thin rotate path).
+ *
+ * Prefer sibling files in this directory (port targets). Never hard-require host paths.
+ */
+import { existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+async function tryImport(name) {
+  const p = join(__dirname, name);
+  if (!existsSync(p)) return null;
+  try {
+    return await import(pathToFileURL(p).href);
+  } catch {
+    return null;
+  }
+}
+
+let _cache = null;
+
+export async function loadCaptchaCascade() {
+  if (_cache) return _cache;
+  const captcha = await tryImport('captcha-helper.mjs');
+  const visual = await tryImport('visual-captcha-solver.mjs');
+  const bright = await tryImport('bright-data-cascade.mjs');
+  const secrets = await tryImport('secrets-bootstrap.mjs');
+  const vdisplay = await tryImport('virtual-display.mjs');
+  _cache = {
+    present: !!(captcha || visual),
+    captcha,
+    visual,
+    bright,
+    secrets,
+    vdisplay,
+    solveCaptchaOnPage: captcha?.solveCaptchaOnPage || null,
+    captchaSolverAvailable: captcha?.captchaSolverAvailable || (() => false),
+    runAutonomousCaptchaCascade: visual?.runAutonomousCaptchaCascade || null,
+    solveInteractiveCaptchaVisually: visual?.solveInteractiveCaptchaVisually || null,
+    runDesktopActCaptcha: visual?.runDesktopActCaptcha || null,
+    runVncComputerUseCaptcha: visual?.runVncComputerUseCaptcha || null,
+    bootstrapRotatorSecrets: secrets?.bootstrapRotatorSecrets || (() => {}),
+    ensureVirtualDisplay: vdisplay?.ensureVirtualDisplay || (async () => null),
+  };
+  return _cache;
+}
+
+export function captchaModulesOnDisk() {
+  return ['captcha-helper.mjs', 'visual-captcha-solver.mjs', 'bright-data-cascade.mjs', 'secrets-bootstrap.mjs', 'virtual-display.mjs'].filter(
+    (n) => existsSync(join(__dirname, n)),
+  );
+}

--- a/claude-ops/scripts/account-rotation/crs-egress-failover.sh
+++ b/claude-ops/scripts/account-rotation/crs-egress-failover.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -u
+
+DROPIN="$HOME/.config/systemd/user/crs-priority.service.d/40-mac-residential-egress.conf"
+LOCK="${XDG_RUNTIME_DIR:-/tmp}/crs-egress-failover.lock"
+EFG_PROXY='http://127.0.0.1:1088'
+UDM_PROXY='socks5h://127.0.0.1:1087'
+MAC_PROXY='socks5h://127.0.0.1:1086'
+TARGET='https://api.anthropic.com'
+
+mkdir -p "$(dirname "$DROPIN")"
+exec 9>"$LOCK"
+flock -n 9 || exit 0
+
+proxy_healthy() {
+  local proxy="$1" status
+  status=$(curl -ksS --max-time 15 --proxy "$proxy" -o /dev/null -w '%{http_code}' "$TARGET" 2>/dev/null) || return 1
+  case "$status" in
+    2*|3*|4*|5*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+if proxy_healthy "$UDM_PROXY"; then
+  desired='socks5://127.0.0.1:1087'
+elif proxy_healthy "$EFG_PROXY"; then
+  desired='http://127.0.0.1:1088'
+elif proxy_healthy "$MAC_PROXY"; then
+  desired='socks5://127.0.0.1:1086'
+else
+  exit 1
+fi
+
+current=$(python3 - "$DROPIN" <<'PY'
+import pathlib, sys
+p = pathlib.Path(sys.argv[1])
+try:
+    for line in p.read_text().splitlines():
+        if line.startswith('Environment=EFG_PROXY_URL='):
+            print(line.split('=', 2)[2])
+            break
+except FileNotFoundError:
+    pass
+PY
+)
+
+if [ "$current" = "$desired" ]; then
+  exit 0
+fi
+
+tmp="$DROPIN.tmp.$$"
+cat > "$tmp" <<EOF
+[Service]
+# Scoped to live Anthropic quota probes only. Never changes host-wide routing.
+Environment=EFG_PROXY_URL=$desired
+EOF
+chmod 600 "$tmp"
+mv -f "$tmp" "$DROPIN"
+systemctl --user daemon-reload
+systemctl --user restart crs-priority.service
+printf 'switched_proxy=%s\n' "$desired"

--- a/claude-ops/scripts/account-rotation/oauth-keep-alive-policy.mjs
+++ b/claude-ops/scripts/account-rotation/oauth-keep-alive-policy.mjs
@@ -1,0 +1,45 @@
+/**
+ * Shared OAuth token freshness policy — single source of truth for "when is
+ * a Claude account token stale enough to need a proactive refresh" across
+ * refresh-tokens.mjs, crs-token-feed.mjs, and any other refresh call site.
+ */
+
+/** Proactively refresh once remaining TTL drops below this. */
+export const REFRESH_WHEN_BELOW_MS = 6 * 3_600_000; // 6h
+
+/** Below this remaining TTL a token is no longer "healthy" even if unexpired. */
+export const MIN_HEALTHY_TTL_MS = 1 * 3_600_000; // 1h
+
+function parseExpiresAt(tokenJson) {
+  try {
+    const parsed = JSON.parse(tokenJson);
+    const raw = parsed?.claudeAiOauth?.expiresAt;
+    const numeric = Number(raw);
+    return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Ms remaining until expiry; null if the token is missing/unparseable/has no expiry. */
+export function remainingMs(tokenJson, now = Date.now()) {
+  const expiresAt = parseExpiresAt(tokenJson);
+  return expiresAt === null ? null : expiresAt - now;
+}
+
+/** True when this token should be proactively refreshed now. */
+export function needsProactiveRefresh(tokenJson, now = Date.now(), force = false) {
+  if (force) return true;
+  const rem = remainingMs(tokenJson, now);
+  if (rem === null) return true;
+  return rem < REFRESH_WHEN_BELOW_MS;
+}
+
+/** One of FRESH | REFRESH_SOON | EXPIRING | EXPIRED. */
+export function freshnessLabel(tokenJson, now = Date.now()) {
+  const rem = remainingMs(tokenJson, now);
+  if (rem === null || rem <= 0) return 'EXPIRED';
+  if (rem < MIN_HEALTHY_TTL_MS) return 'EXPIRING';
+  if (rem < REFRESH_WHEN_BELOW_MS) return 'REFRESH_SOON';
+  return 'FRESH';
+}

--- a/claude-ops/scripts/account-rotation/proxy-helper.mjs
+++ b/claude-ops/scripts/account-rotation/proxy-helper.mjs
@@ -1,0 +1,55 @@
+let proxyAgent = null;
+
+async function getProxyAgent() {
+  if (proxyAgent) return proxyAgent;
+  const { ProxyAgent } = await import('undici').catch(() => ({ ProxyAgent: null }));
+  if (!ProxyAgent) return null;
+  const proxyUrl = process.env.BRIGHTDATA_PROXY_URL;
+  if (proxyUrl) {
+    proxyAgent = new ProxyAgent(proxyUrl);
+    return proxyAgent;
+  }
+  const user = process.env.BRIGHT_DATA_USERID;
+  const pass = process.env.BRIGHT_DATA_TOKEN;
+  if (user && pass) {
+    proxyAgent = new ProxyAgent(`http://${user}:${pass}@brd.superproxy.io:33335`);
+    return proxyAgent;
+  }
+  return null;
+}
+
+export function reuseProxyAgent() {
+  return proxyAgent;
+}
+
+export function resetProxyAgent() {
+  proxyAgent = null;
+}
+
+export async function fetchWithProxyFallback(url, options = {}) {
+  try {
+    const res = await fetch(url, options);
+    if (res.status !== 429) return res;
+    await res.text().catch(() => '');
+    console.warn(`[proxy] 429 on ${url} — retrying via Bright Data proxy`);
+    return await proxyFetch(url, options);
+  } catch (e) {
+    console.warn(`[proxy] direct error on ${url}: ${e.message} — retrying via proxy`);
+    return await proxyFetch(url, options);
+  }
+}
+
+export async function proxyFetch(url, options = {}) {
+  const agent = await getProxyAgent();
+  if (!agent) {
+    throw new Error(
+      'Bright Data proxy not configured: set BRIGHT_DATA_USERID + BRIGHT_DATA_TOKEN (or BRIGHTDATA_PROXY_URL)',
+    );
+  }
+  try {
+    const { fetch: undiciFetch } = await import('undici');
+    return await undiciFetch(url, { ...options, dispatcher: agent });
+  } catch (e) {
+    throw new Error(`Bright Data proxy: ${e.cause?.message || e.message}`);
+  }
+}

--- a/claude-ops/scripts/account-rotation/refresh-tokens.mjs
+++ b/claude-ops/scripts/account-rotation/refresh-tokens.mjs
@@ -1,0 +1,528 @@
+#!/usr/bin/env node
+/**
+ * Proactive token refresher — uses OAuth refresh_token grant to get fresh
+ * access tokens for all vault accounts before they expire.
+ *
+ * Doctrine: OAuth tokens must never become stale.
+ *   - launchd every 15m (com.sam.crs-rotation-refresh)
+ *   - refresh when remaining TTL < 6h (see oauth-keep-alive-policy.mjs)
+ *   - dead refresh_token → mark needsReauth for magic-link-autoloop
+ *
+ * Usage:
+ *   node refresh-tokens.mjs           # Refresh tokens under keep-alive floor
+ *   node refresh-tokens.mjs --force   # Refresh ALL tokens regardless of expiry
+ *   node refresh-tokens.mjs --status  # Show token expiry times
+ *   node refresh-tokens.mjs --dry-run # Show what would be refreshed without doing it
+ */
+
+import { appendFileSync, existsSync, readFileSync, writeFileSync, renameSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { execFileSync, execSync } from 'child_process';
+import { fetchWithProxyFallback } from './proxy-helper.mjs';
+import { acquireRefreshLock } from './crs-refresh-lock.mjs';
+import { readRotationToken, reconcileRemoteRotationVault, writeRotationToken } from './rotation-vault.mjs';
+import {
+  REFRESH_WHEN_BELOW_MS,
+  MIN_HEALTHY_TTL_MS,
+  needsProactiveRefresh,
+  freshnessLabel,
+  remainingMs,
+} from './oauth-keep-alive-policy.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CONFIG_PATH   = join(__dirname, 'config.json');
+const STATE_PATH    = join(__dirname, 'state.json');
+const LOG_PATH      = join(__dirname, 'rotation.log');
+const NEEDS_REAUTH_PATH = join(__dirname, '.crs-token-refresher-state.json');
+const AUTOLOOP_STATE_PATH = join(__dirname, '.crs-magic-autoloop-state.json');
+const KEYCHAIN_SERVICE = 'Claude Code-credentials';
+const KEYCHAIN_ACCOUNT = process.env.USER || 'samrenders';
+
+const CLIENT_ID       = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const TOKEN_ENDPOINT  = 'https://platform.claude.com/v1/oauth/token';
+/** @deprecated use REFRESH_WHEN_BELOW_MS — kept name for log clarity */
+const REFRESH_BUFFER_MS = REFRESH_WHEN_BELOW_MS;
+const RETRY_DELAY_MS    = 5_000;         // Wait between retries
+const MAX_RETRIES       = 3;
+const INTER_ACCOUNT_DELAY_MS = 1_500;    // Delay between accounts to avoid rate limits
+
+// ── Logging ──────────────────────────────────────────────────────────────────
+
+function log(msg) {
+  const line = `[${new Date().toISOString()}] [refresh] ${msg}`;
+  console.log(line);
+  try { appendFileSync(LOG_PATH, line + '\n'); } catch {}
+}
+
+// ── Keychain helpers ─────────────────────────────────────────────────────────
+
+function accountKey(a) { return a.label || a.email; }
+
+function tokenService(account) {
+  return `Claude-Rotation-${accountKey(account)}`;
+}
+
+function readKeychain(svc = KEYCHAIN_SERVICE, acct = KEYCHAIN_ACCOUNT) {
+  const out = execSync(`security find-generic-password -s "${svc}" -a "${acct}" -g 2>&1`, { timeout: 5000 }).toString();
+  const m = out.match(/^password: "?(.*?)"?$/m);
+  if (!m) throw new Error(`No keychain entry ${svc}/${acct}`);
+  return m[1].replace(/\\"/g, '"');
+}
+
+function writeKeychain(json, svc = KEYCHAIN_SERVICE, acct = KEYCHAIN_ACCOUNT) {
+  try {
+    execFileSync('security', ['add-generic-password', '-U', '-s', svc, '-a', acct, '-w', json], {
+      timeout: 5000,
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+  } catch (error) {
+    const detail = String(error.stderr || error.message || error)
+      .replace(/sk-ant-[A-Za-z0-9_-]+/g, '[REDACTED]')
+      .replace(/-w\s+\{.*$/s, '-w [REDACTED]')
+      .slice(0, 240);
+    throw new Error(`Keychain update failed for ${svc}/${acct}: ${detail}`);
+  }
+}
+
+function readStoredToken(account) {
+  try { return readRotationToken(accountKey(account)); } catch { return null; }
+}
+
+function writeStoredToken(account, json) {
+  writeRotationToken(accountKey(account), json);
+}
+
+function syncStoredTokenToCrs(account) {
+  if (process.env.CLAUDE_ROTATION_SKIP_CRS_SYNC === '1') return;
+  const key = accountKey(account);
+  try {
+    const out = execSync(
+      `node "${join(__dirname, 'sync-crs-account.mjs')}" ${JSON.stringify(key)} 2>&1`,
+      { timeout: 45_000 },
+    ).toString().trim();
+    log(out.split('\n').slice(-1)[0] || `${key}: CRS sync complete`);
+  } catch (err) {
+    log(`${key}: ⚠ CRS sync failed — ${String(err.message || err).slice(0, 180)}`);
+  }
+}
+
+function readState() {
+  try { return JSON.parse(readFileSync(STATE_PATH, 'utf8')); } catch { return {}; }
+}
+
+// ── Token helpers ────────────────────────────────────────────────────────────
+
+function parseToken(tokenJson) {
+  try { return JSON.parse(tokenJson); } catch { return null; }
+}
+
+function getExpiry(tokenJson) {
+  return parseToken(tokenJson)?.claudeAiOauth?.expiresAt || null;
+}
+
+function needsRefresh(tokenJson, force) {
+  return needsProactiveRefresh(tokenJson, Date.now(), force);
+}
+
+/** Mark account for always-on magic-link-autoloop; clear its autoloop cooldown. */
+function markNeedsReauth(key, reason) {
+  try {
+    let state = {};
+    if (existsSync(NEEDS_REAUTH_PATH)) {
+      state = JSON.parse(readFileSync(NEEDS_REAUTH_PATH, 'utf8'));
+    }
+    const id = key.replace(/[^a-zA-Z0-9@._-]/g, '-');
+    state[id] = {
+      name: key,
+      needsReauth: true,
+      lastFailAt: Date.now(),
+      reason: String(reason || 'refresh failed').slice(0, 200),
+    };
+    const tmp = NEEDS_REAUTH_PATH + '.tmp.' + process.pid;
+    writeFileSync(tmp, JSON.stringify(state, null, 2));
+    renameSync(tmp, NEEDS_REAUTH_PATH);
+  } catch (e) {
+    log(`${key}: ⚠ could not write needsReauth state — ${String(e.message || e).slice(0, 80)}`);
+  }
+  // Clear magic-loop cooldown so next tick can pick this account immediately
+  try {
+    if (!existsSync(AUTOLOOP_STATE_PATH)) return;
+    const s = JSON.parse(readFileSync(AUTOLOOP_STATE_PATH, 'utf8'));
+    if (s[key]) {
+      delete s[key].blockedUntil;
+      s[key].dispatchedAt = 0;
+      s[key].reason = 'refresh-http-400';
+      const tmp = AUTOLOOP_STATE_PATH + '.tmp.' + process.pid;
+      writeFileSync(tmp, JSON.stringify(s, null, 2));
+      renameSync(tmp, AUTOLOOP_STATE_PATH);
+    }
+  } catch {}
+}
+
+function clearNeedsReauth(key) {
+  try {
+    if (!existsSync(NEEDS_REAUTH_PATH)) return;
+    const state = JSON.parse(readFileSync(NEEDS_REAUTH_PATH, 'utf8'));
+    let changed = false;
+    for (const [id, entry] of Object.entries(state)) {
+      if (entry?.name === key || id === key) {
+        delete state[id];
+        changed = true;
+      }
+    }
+    if (changed) {
+      const tmp = NEEDS_REAUTH_PATH + '.tmp.' + process.pid;
+      writeFileSync(tmp, JSON.stringify(state, null, 2));
+      renameSync(tmp, NEEDS_REAUTH_PATH);
+    }
+  } catch {}
+}
+
+// ── OAuth token refresh ──────────────────────────────────────────────────────
+
+function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+async function refreshOAuthToken(refreshToken) {
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const res = await fetchWithProxyFallback(TOKEN_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          grant_type: 'refresh_token',
+          refresh_token: refreshToken,
+          client_id: CLIENT_ID,
+        }),
+      });
+
+      const body = await res.json();
+
+      if (res.ok && body.access_token) {
+        return {
+          ok: true,
+          accessToken: body.access_token,
+          refreshToken: body.refresh_token || refreshToken,
+          expiresIn: body.expires_in,
+          expiresAt: body.expires_in
+            ? Date.now() + body.expires_in * 1000
+            : Date.now() + 8 * 3_600_000,
+          subscriptionType: body.subscription_type,
+          rateLimitTier: body.rate_limit_tier,
+        };
+      }
+
+      // patch 048-429: respect Retry-After header on 429s before falling back
+      // to backoff. Anthropic returns seconds-in-Retry-After when present.
+      if (res.status === 429) {
+        const retryAfterHeader = res.headers && (res.headers.get?.('retry-after') || res.headers['retry-after']);
+        const retryAfterMs = retryAfterHeader
+          ? (/\d+/i.test(String(retryAfterHeader))
+              ? Math.min(15 * 60_000, Math.max(2_000, parseInt(String(retryAfterHeader), 10) * 1000 + 2000))
+              : 60_000)
+          : null;
+        const delay = retryAfterMs ?? RETRY_DELAY_MS * attempt;
+        log(`  429 Too Many Requests (attempt ${attempt}/${MAX_RETRIES}) — waiting ${Math.round(delay/1000)}s (Retry-After=${retryAfterHeader ?? 'n/a'})...`);
+        if (attempt < MAX_RETRIES) { await sleep(delay); continue; }
+        return { ok: false, error: `429 after ${MAX_RETRIES} retries (Retry-After=${retryAfterHeader})` };
+      }
+
+      if (body?.error?.type === 'rate_limit_error') {
+        const delay = RETRY_DELAY_MS * attempt;
+        log(`  Rate limited (attempt ${attempt}/${MAX_RETRIES}) — waiting ${delay / 1000}s...`);
+        if (attempt < MAX_RETRIES) { await sleep(delay); continue; }
+        return { ok: false, error: 'Rate limited after all retries' };
+      }
+
+      // Other error — don't retry
+      return { ok: false, error: body?.error?.message || `HTTP ${res.status}` };
+
+    } catch (err) {
+      if (attempt < MAX_RETRIES) {
+        await sleep(RETRY_DELAY_MS * attempt);
+        continue;
+      }
+      return { ok: false, error: err.message };
+    }
+  }
+  return { ok: false, error: 'Max retries exceeded' };
+}
+
+// ── Status command ───────────────────────────────────────────────────────────
+
+function showStatus() {
+  const config = JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
+  const state = readState();
+  const now = Date.now();
+  console.log('\n=== Token Expiry Status (keep-alive) ===\n');
+  console.log(
+    `  policy: refresh when <${(REFRESH_WHEN_BELOW_MS / 3_600_000).toFixed(0)}h left · healthy floor ≥${(MIN_HEALTHY_TTL_MS / 3_600_000).toFixed(0)}h\n`,
+  );
+  let healthy = 0;
+  let unhealthy = 0;
+  for (const a of config.accounts) {
+    const key = accountKey(a);
+    const token = readStoredToken(a);
+    const active = state.activeAccount === key ? ' (ACTIVE)' : '';
+    if (!token) {
+      console.log(`  ${key}: ❌ NO TOKEN${active}`);
+      unhealthy++;
+      continue;
+    }
+    const rem = remainingMs(token, now);
+    const hoursLeft = (rem / 3_600_000).toFixed(1);
+    const label = freshnessLabel(token, now);
+    const icon =
+      label === 'FRESH' ? '✅' : label === 'REFRESH_SOON' ? '🟡' : label === 'EXPIRING' ? '⚠️ ' : '❌';
+    if (label === 'FRESH' || label === 'REFRESH_SOON') healthy++;
+    else unhealthy++;
+    console.log(`  ${key}: ${icon} ${label} (${hoursLeft}h remaining)${active}`);
+  }
+  console.log(`\n  summary: ${healthy} keep-alive-ok · ${unhealthy} need refresh/reauth\n`);
+}
+
+// ── Main refresh logic ──────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+
+try {
+  const reconciled = reconcileRemoteRotationVault();
+  if (!reconciled.skipped && (reconciled.pulled > 0 || reconciled.pushed > 0)) {
+    log(`remote vault reconciled: ${reconciled.pulled} pulled, ${reconciled.pushed} pushed`);
+  }
+} catch (error) {
+  log(`remote vault reconciliation unavailable — ${String(error.message || error).slice(0, 180)}`);
+}
+
+if (args.includes('--status')) {
+  showStatus();
+  process.exit(0);
+}
+
+const force  = args.includes('--force');
+const dryRun = args.includes('--dry-run');
+const config = JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
+const state  = readState();
+const ROTATING_LOCK = join(__dirname, '.rotating');
+const MAGIC_LINK_TIMEOUT_MS = Number(process.env.CLAUDE_ROT_MAGIC_TOTAL_TIMEOUT_MS || 720_000);
+
+function pidAlive(pid) {
+  if (!pid) return false;
+  try { process.kill(pid, 0); return true; } catch { return false; }
+}
+
+/** True when another rotate/reauth already holds the fleet lock. */
+function rotationInProgress() {
+  try {
+    if (!existsSync(ROTATING_LOCK)) return false;
+    const raw = JSON.parse(readFileSync(ROTATING_LOCK, 'utf8'));
+    return pidAlive(Number(raw?.pid || 0));
+  } catch {
+    return false;
+  }
+}
+
+/** Prefer re-authing accounts with headroom; skip 7d-exhausted waste. */
+function magicLinkPriority(account) {
+  const key = accountKey(account);
+  const u = state.accounts?.[key]?.lastUtilization || {};
+  const now = Date.now();
+  const pct7 = Number(u.pct7);
+  const reset7Ms = Number(u.reset7) > 0 ? Number(u.reset7) * 1000 : 0;
+  const weekly =
+    Number.isFinite(pct7) && !(reset7Ms && reset7Ms < now) ? pct7 : 50;
+  // Lower score = better magic-link candidate (headroom first).
+  return weekly;
+}
+
+function shouldSkipMagicLinkForUtil(account) {
+  const key = accountKey(account);
+  const u = state.accounts?.[key]?.lastUtilization || {};
+  const now = Date.now();
+  const pct7 = Number(u.pct7);
+  const reset7Ms = Number(u.reset7) > 0 ? Number(u.reset7) * 1000 : 0;
+  if (Number.isFinite(pct7) && pct7 >= 95 && !(reset7Ms && reset7Ms < now)) {
+    return `7d util ${pct7}% exhausted — re-auth deferred (cannot use until weekly reset)`;
+  }
+  return null;
+}
+
+// Process accounts with freshest tokens first for refresh grant; when picking
+// the single magic-link attempt, prefer headroom (low weekly util) over exhausted.
+const accountsOrdered = [...config.accounts].sort((a, b) => {
+  const ea = getExpiry(readStoredToken(a)) || 0;
+  const eb = getExpiry(readStoredToken(b)) || 0;
+  // Still-fresh first (skip quickly), then expired by magic-link priority.
+  const aFresh = ea > Date.now();
+  const bFresh = eb > Date.now();
+  if (aFresh !== bFresh) return aFresh ? -1 : 1;
+  if (aFresh) return ea - eb; // soonest expiry first among fresh
+  return magicLinkPriority(a) - magicLinkPriority(b);
+});
+
+let refreshed = 0;
+let failed    = 0;
+let skipped   = 0;
+let magicLinkAttempted = false;
+
+for (let i = 0; i < accountsOrdered.length; i++) {
+  const account = accountsOrdered[i];
+  const key = accountKey(account);
+
+  // Skip accounts disabled in config — their token is intentionally not
+  // maintained (e.g. dead refresh token needing manual re-auth). Without this,
+  // a disabled account with a stale token triggers the HTTP-400 → magic-link
+  // browser re-auth path every hour (~180s of doomed browser automation).
+  if (account.disabled === true) {
+    log(`${key}: disabled — skipping`);
+    skipped++;
+    continue;
+  }
+
+  const tokenJson = readStoredToken(account);
+
+  if (!tokenJson) {
+    log(`${key}: no stored token — skipping`);
+    skipped++;
+    continue;
+  }
+
+  if (!needsRefresh(tokenJson, force)) {
+    const exp = getExpiry(tokenJson);
+    const hoursLeft = ((exp - Date.now()) / 3_600_000).toFixed(1);
+    log(`${key}: fresh (${hoursLeft}h remaining) — skipping`);
+    skipped++;
+    continue;
+  }
+
+  const exp = getExpiry(tokenJson);
+  const hoursLeft = exp ? ((exp - Date.now()) / 3_600_000).toFixed(1) : '?';
+  log(`${key}: needs refresh (${hoursLeft}h remaining)${dryRun ? ' [DRY RUN]' : ''}...`);
+
+  if (dryRun) { continue; }
+
+  const releaseRefreshLock = acquireRefreshLock(key);
+  if (!releaseRefreshLock) {
+    log(`${key}: refresh lock held or fleet lock unavailable — skipping`);
+    skipped++;
+    continue;
+  }
+
+  try {
+
+  // Rate limit courtesy: delay between accounts
+  if (i > 0) { await sleep(INTER_ACCOUNT_DELAY_MS); }
+
+  const parsed = parseToken(tokenJson);
+  const oauthData = parsed?.claudeAiOauth;
+  if (!oauthData?.refreshToken) {
+    log(`${key}: no refreshToken in stored token — skipping`);
+    failed++;
+    continue;
+  }
+
+  const result = await refreshOAuthToken(oauthData.refreshToken);
+
+  if (!result.ok) {
+    log(`${key}: ✗ refresh failed — ${result.error}`);
+
+    // HTTP 400 = dead refresh_token. Browser re-auth is owned by the always-on
+    // magic-link-autoloop (com.sam.crs-magic-link-autoloop) — never spawn a
+    // competing headed OAuth from the hourly refresher (2026-07-16 thrash).
+    // Opt-in only: CLAUDE_ROTATION_REFRESH_MAGIC_LINK=1 for emergency one-shots.
+    if (result.error && result.error.includes('400')) {
+      if (account.autoAuthDisabled === true) {
+        log(`${key}: unattended re-auth disabled — leaving token for manual recovery`);
+      } else if (process.env.CLAUDE_ROTATION_REFRESH_MAGIC_LINK === '1' && !magicLinkAttempted) {
+        const utilSkip = shouldSkipMagicLinkForUtil(account);
+        if (utilSkip) {
+          log(`${key}: ${utilSkip}`);
+        } else if (rotationInProgress()) {
+          log(`${key}: rotation lock held — deferring magic-link re-auth`);
+        } else {
+          magicLinkAttempted = true;
+          log(`${key}: refresh token invalid — CLAUDE_ROTATION_REFRESH_MAGIC_LINK=1 → magic-link (timeout ${Math.round(MAGIC_LINK_TIMEOUT_MS / 1000)}s)...`);
+          try {
+            const reAuthResult = execFileSync(
+              process.execPath,
+              [join(__dirname, 'rotate.mjs'), '--to', key, '--magic-link', '--force'],
+              { timeout: MAGIC_LINK_TIMEOUT_MS, encoding: 'utf8' },
+            );
+            log(`${key}: magic link re-auth output: ${reAuthResult.split('\n').slice(-3).join(' | ')}`);
+            const reAuthedToken = readStoredToken(account);
+            if (reAuthedToken) {
+              const reParsed = parseToken(reAuthedToken);
+              if (reParsed?.claudeAiOauth?.accessToken) {
+                log(`${key}: ✓ re-authed via magic link`);
+                refreshed++;
+                continue;
+              }
+            }
+            log(`${key}: magic link re-auth did not produce a valid token`);
+          } catch (err) {
+            log(`${key}: magic link re-auth failed — ${err.message}`);
+          }
+        }
+      } else {
+        log(`${key}: refresh grant failed (HTTP 400) — marking needsReauth for magic-link-autoloop`);
+        markNeedsReauth(key, result.error);
+      }
+    } else if (result.error && /401|invalid|revoked/i.test(result.error)) {
+      markNeedsReauth(key, result.error);
+    }
+
+    failed++;
+    continue;
+  }
+
+  // Build updated token
+  const updated = {
+    claudeAiOauth: {
+      accessToken:      result.accessToken,
+      refreshToken:     result.refreshToken,
+      expiresAt:        result.expiresAt,
+      scopes:           oauthData.scopes || [],
+      subscriptionType: result.subscriptionType || oauthData.subscriptionType,
+      rateLimitTier:    result.rateLimitTier || oauthData.rateLimitTier,
+    },
+    mcpOAuth: {},
+  };
+
+  // Save to vault
+  writeStoredToken(account, JSON.stringify(updated));
+  syncStoredTokenToCrs(account);
+  clearNeedsReauth(key);
+  const newHoursLeft = ((result.expiresAt - Date.now()) / 3_600_000).toFixed(1);
+  log(`${key}: ✓ refreshed (${newHoursLeft}h remaining)`);
+
+  // If this is the currently active account, update the active keychain too
+  if (state.activeAccount === key) {
+    try {
+      const currentActive = readKeychain();
+      const currentParsed = parseToken(currentActive);
+      // Always merge mcpOAuth from the running session — drop the Object.keys>0 guard
+      // which silently skipped preservation when a prior rotation had already zeroed the
+      // field, causing CC to lose all MCP OAuth tokens (giga, Amplitude, higgsfield) on
+      // the next session launch and forcing interactive reauth every session.
+      if (currentParsed?.mcpOAuth) {
+        updated.mcpOAuth = { ...updated.mcpOAuth, ...currentParsed.mcpOAuth };
+      }
+      writeKeychain(JSON.stringify(updated));
+      log(`${key}: ✓ also updated active keychain with mcpOAuth preserved`);
+    } catch (err) {
+      log(`${key}: ⚠ vault updated but active keychain update failed — ${err.message}`);
+    }
+  }
+
+  refreshed++;
+  } finally {
+    releaseRefreshLock();
+  }
+}
+
+log(`Token refresh complete: ${refreshed} refreshed, ${failed} failed, ${skipped} skipped`);
+
+// Show final status if anything was refreshed
+if (refreshed > 0 || failed > 0) {
+  showStatus();
+}

--- a/claude-ops/scripts/account-rotation/refresh-tokens.mjs
+++ b/claude-ops/scripts/account-rotation/refresh-tokens.mjs
@@ -31,33 +31,37 @@ import {
 } from './oauth-keep-alive-policy.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const CONFIG_PATH   = join(__dirname, 'config.json');
-const STATE_PATH    = join(__dirname, 'state.json');
-const LOG_PATH      = join(__dirname, 'rotation.log');
+const CONFIG_PATH = join(__dirname, 'config.json');
+const STATE_PATH = join(__dirname, 'state.json');
+const LOG_PATH = join(__dirname, 'rotation.log');
 const NEEDS_REAUTH_PATH = join(__dirname, '.crs-token-refresher-state.json');
 const AUTOLOOP_STATE_PATH = join(__dirname, '.crs-magic-autoloop-state.json');
 const KEYCHAIN_SERVICE = 'Claude Code-credentials';
 const KEYCHAIN_ACCOUNT = process.env.USER || 'samrenders';
 
-const CLIENT_ID       = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
-const TOKEN_ENDPOINT  = 'https://platform.claude.com/v1/oauth/token';
+const CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const TOKEN_ENDPOINT = 'https://platform.claude.com/v1/oauth/token';
 /** @deprecated use REFRESH_WHEN_BELOW_MS — kept name for log clarity */
 const REFRESH_BUFFER_MS = REFRESH_WHEN_BELOW_MS;
-const RETRY_DELAY_MS    = 5_000;         // Wait between retries
-const MAX_RETRIES       = 3;
-const INTER_ACCOUNT_DELAY_MS = 1_500;    // Delay between accounts to avoid rate limits
+const RETRY_DELAY_MS = 5_000; // Wait between retries
+const MAX_RETRIES = 3;
+const INTER_ACCOUNT_DELAY_MS = 1_500; // Delay between accounts to avoid rate limits
 
 // ── Logging ──────────────────────────────────────────────────────────────────
 
 function log(msg) {
   const line = `[${new Date().toISOString()}] [refresh] ${msg}`;
   console.log(line);
-  try { appendFileSync(LOG_PATH, line + '\n'); } catch {}
+  try {
+    appendFileSync(LOG_PATH, line + '\n');
+  } catch {}
 }
 
 // ── Keychain helpers ─────────────────────────────────────────────────────────
 
-function accountKey(a) { return a.label || a.email; }
+function accountKey(a) {
+  return a.label || a.email;
+}
 
 function tokenService(account) {
   return `Claude-Rotation-${accountKey(account)}`;
@@ -86,7 +90,11 @@ function writeKeychain(json, svc = KEYCHAIN_SERVICE, acct = KEYCHAIN_ACCOUNT) {
 }
 
 function readStoredToken(account) {
-  try { return readRotationToken(accountKey(account)); } catch { return null; }
+  try {
+    return readRotationToken(accountKey(account));
+  } catch {
+    return null;
+  }
 }
 
 function writeStoredToken(account, json) {
@@ -97,10 +105,11 @@ function syncStoredTokenToCrs(account) {
   if (process.env.CLAUDE_ROTATION_SKIP_CRS_SYNC === '1') return;
   const key = accountKey(account);
   try {
-    const out = execSync(
-      `node "${join(__dirname, 'sync-crs-account.mjs')}" ${JSON.stringify(key)} 2>&1`,
-      { timeout: 45_000 },
-    ).toString().trim();
+    const out = execSync(`node "${join(__dirname, 'sync-crs-account.mjs')}" ${JSON.stringify(key)} 2>&1`, {
+      timeout: 45_000,
+    })
+      .toString()
+      .trim();
     log(out.split('\n').slice(-1)[0] || `${key}: CRS sync complete`);
   } catch (err) {
     log(`${key}: ⚠ CRS sync failed — ${String(err.message || err).slice(0, 180)}`);
@@ -108,13 +117,21 @@ function syncStoredTokenToCrs(account) {
 }
 
 function readState() {
-  try { return JSON.parse(readFileSync(STATE_PATH, 'utf8')); } catch { return {}; }
+  try {
+    return JSON.parse(readFileSync(STATE_PATH, 'utf8'));
+  } catch {
+    return {};
+  }
 }
 
 // ── Token helpers ────────────────────────────────────────────────────────────
 
 function parseToken(tokenJson) {
-  try { return JSON.parse(tokenJson); } catch { return null; }
+  try {
+    return JSON.parse(tokenJson);
+  } catch {
+    return null;
+  }
 }
 
 function getExpiry(tokenJson) {
@@ -181,7 +198,9 @@ function clearNeedsReauth(key) {
 
 // ── OAuth token refresh ──────────────────────────────────────────────────────
 
-function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
 
 async function refreshOAuthToken(refreshToken) {
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
@@ -204,9 +223,7 @@ async function refreshOAuthToken(refreshToken) {
           accessToken: body.access_token,
           refreshToken: body.refresh_token || refreshToken,
           expiresIn: body.expires_in,
-          expiresAt: body.expires_in
-            ? Date.now() + body.expires_in * 1000
-            : Date.now() + 8 * 3_600_000,
+          expiresAt: body.expires_in ? Date.now() + body.expires_in * 1000 : Date.now() + 8 * 3_600_000,
           subscriptionType: body.subscription_type,
           rateLimitTier: body.rate_limit_tier,
         };
@@ -217,26 +234,33 @@ async function refreshOAuthToken(refreshToken) {
       if (res.status === 429) {
         const retryAfterHeader = res.headers && (res.headers.get?.('retry-after') || res.headers['retry-after']);
         const retryAfterMs = retryAfterHeader
-          ? (/\d+/i.test(String(retryAfterHeader))
-              ? Math.min(15 * 60_000, Math.max(2_000, parseInt(String(retryAfterHeader), 10) * 1000 + 2000))
-              : 60_000)
+          ? /\d+/i.test(String(retryAfterHeader))
+            ? Math.min(15 * 60_000, Math.max(2_000, parseInt(String(retryAfterHeader), 10) * 1000 + 2000))
+            : 60_000
           : null;
         const delay = retryAfterMs ?? RETRY_DELAY_MS * attempt;
-        log(`  429 Too Many Requests (attempt ${attempt}/${MAX_RETRIES}) — waiting ${Math.round(delay/1000)}s (Retry-After=${retryAfterHeader ?? 'n/a'})...`);
-        if (attempt < MAX_RETRIES) { await sleep(delay); continue; }
+        log(
+          `  429 Too Many Requests (attempt ${attempt}/${MAX_RETRIES}) — waiting ${Math.round(delay / 1000)}s (Retry-After=${retryAfterHeader ?? 'n/a'})...`,
+        );
+        if (attempt < MAX_RETRIES) {
+          await sleep(delay);
+          continue;
+        }
         return { ok: false, error: `429 after ${MAX_RETRIES} retries (Retry-After=${retryAfterHeader})` };
       }
 
       if (body?.error?.type === 'rate_limit_error') {
         const delay = RETRY_DELAY_MS * attempt;
         log(`  Rate limited (attempt ${attempt}/${MAX_RETRIES}) — waiting ${delay / 1000}s...`);
-        if (attempt < MAX_RETRIES) { await sleep(delay); continue; }
+        if (attempt < MAX_RETRIES) {
+          await sleep(delay);
+          continue;
+        }
         return { ok: false, error: 'Rate limited after all retries' };
       }
 
       // Other error — don't retry
       return { ok: false, error: body?.error?.message || `HTTP ${res.status}` };
-
     } catch (err) {
       if (attempt < MAX_RETRIES) {
         await sleep(RETRY_DELAY_MS * attempt);
@@ -272,8 +296,7 @@ function showStatus() {
     const rem = remainingMs(token, now);
     const hoursLeft = (rem / 3_600_000).toFixed(1);
     const label = freshnessLabel(token, now);
-    const icon =
-      label === 'FRESH' ? '✅' : label === 'REFRESH_SOON' ? '🟡' : label === 'EXPIRING' ? '⚠️ ' : '❌';
+    const icon = label === 'FRESH' ? '✅' : label === 'REFRESH_SOON' ? '🟡' : label === 'EXPIRING' ? '⚠️ ' : '❌';
     if (label === 'FRESH' || label === 'REFRESH_SOON') healthy++;
     else unhealthy++;
     console.log(`  ${key}: ${icon} ${label} (${hoursLeft}h remaining)${active}`);
@@ -299,16 +322,21 @@ if (args.includes('--status')) {
   process.exit(0);
 }
 
-const force  = args.includes('--force');
+const force = args.includes('--force');
 const dryRun = args.includes('--dry-run');
 const config = JSON.parse(readFileSync(CONFIG_PATH, 'utf8'));
-const state  = readState();
+const state = readState();
 const ROTATING_LOCK = join(__dirname, '.rotating');
 const MAGIC_LINK_TIMEOUT_MS = Number(process.env.CLAUDE_ROT_MAGIC_TOTAL_TIMEOUT_MS || 720_000);
 
 function pidAlive(pid) {
   if (!pid) return false;
-  try { process.kill(pid, 0); return true; } catch { return false; }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** True when another rotate/reauth already holds the fleet lock. */
@@ -329,8 +357,7 @@ function magicLinkPriority(account) {
   const now = Date.now();
   const pct7 = Number(u.pct7);
   const reset7Ms = Number(u.reset7) > 0 ? Number(u.reset7) * 1000 : 0;
-  const weekly =
-    Number.isFinite(pct7) && !(reset7Ms && reset7Ms < now) ? pct7 : 50;
+  const weekly = Number.isFinite(pct7) && !(reset7Ms && reset7Ms < now) ? pct7 : 50;
   // Lower score = better magic-link candidate (headroom first).
   return weekly;
 }
@@ -361,8 +388,8 @@ const accountsOrdered = [...config.accounts].sort((a, b) => {
 });
 
 let refreshed = 0;
-let failed    = 0;
-let skipped   = 0;
+let failed = 0;
+let skipped = 0;
 let magicLinkAttempted = false;
 
 for (let i = 0; i < accountsOrdered.length; i++) {
@@ -399,7 +426,9 @@ for (let i = 0; i < accountsOrdered.length; i++) {
   const hoursLeft = exp ? ((exp - Date.now()) / 3_600_000).toFixed(1) : '?';
   log(`${key}: needs refresh (${hoursLeft}h remaining)${dryRun ? ' [DRY RUN]' : ''}...`);
 
-  if (dryRun) { continue; }
+  if (dryRun) {
+    continue;
+  }
 
   const releaseRefreshLock = acquireRefreshLock(key);
   if (!releaseRefreshLock) {
@@ -409,112 +438,115 @@ for (let i = 0; i < accountsOrdered.length; i++) {
   }
 
   try {
+    // Rate limit courtesy: delay between accounts
+    if (i > 0) {
+      await sleep(INTER_ACCOUNT_DELAY_MS);
+    }
 
-  // Rate limit courtesy: delay between accounts
-  if (i > 0) { await sleep(INTER_ACCOUNT_DELAY_MS); }
+    const parsed = parseToken(tokenJson);
+    const oauthData = parsed?.claudeAiOauth;
+    if (!oauthData?.refreshToken) {
+      log(`${key}: no refreshToken in stored token — skipping`);
+      failed++;
+      continue;
+    }
 
-  const parsed = parseToken(tokenJson);
-  const oauthData = parsed?.claudeAiOauth;
-  if (!oauthData?.refreshToken) {
-    log(`${key}: no refreshToken in stored token — skipping`);
-    failed++;
-    continue;
-  }
+    const result = await refreshOAuthToken(oauthData.refreshToken);
 
-  const result = await refreshOAuthToken(oauthData.refreshToken);
+    if (!result.ok) {
+      log(`${key}: ✗ refresh failed — ${result.error}`);
 
-  if (!result.ok) {
-    log(`${key}: ✗ refresh failed — ${result.error}`);
-
-    // HTTP 400 = dead refresh_token. Browser re-auth is owned by the always-on
-    // magic-link-autoloop (com.sam.crs-magic-link-autoloop) — never spawn a
-    // competing headed OAuth from the hourly refresher (2026-07-16 thrash).
-    // Opt-in only: CLAUDE_ROTATION_REFRESH_MAGIC_LINK=1 for emergency one-shots.
-    if (result.error && result.error.includes('400')) {
-      if (account.autoAuthDisabled === true) {
-        log(`${key}: unattended re-auth disabled — leaving token for manual recovery`);
-      } else if (process.env.CLAUDE_ROTATION_REFRESH_MAGIC_LINK === '1' && !magicLinkAttempted) {
-        const utilSkip = shouldSkipMagicLinkForUtil(account);
-        if (utilSkip) {
-          log(`${key}: ${utilSkip}`);
-        } else if (rotationInProgress()) {
-          log(`${key}: rotation lock held — deferring magic-link re-auth`);
-        } else {
-          magicLinkAttempted = true;
-          log(`${key}: refresh token invalid — CLAUDE_ROTATION_REFRESH_MAGIC_LINK=1 → magic-link (timeout ${Math.round(MAGIC_LINK_TIMEOUT_MS / 1000)}s)...`);
-          try {
-            const reAuthResult = execFileSync(
-              process.execPath,
-              [join(__dirname, 'rotate.mjs'), '--to', key, '--magic-link', '--force'],
-              { timeout: MAGIC_LINK_TIMEOUT_MS, encoding: 'utf8' },
+      // HTTP 400 = dead refresh_token. Browser re-auth is owned by the always-on
+      // magic-link-autoloop (com.sam.crs-magic-link-autoloop) — never spawn a
+      // competing headed OAuth from the hourly refresher (2026-07-16 thrash).
+      // Opt-in only: CLAUDE_ROTATION_REFRESH_MAGIC_LINK=1 for emergency one-shots.
+      if (result.error && result.error.includes('400')) {
+        if (account.autoAuthDisabled === true) {
+          log(`${key}: unattended re-auth disabled — leaving token for manual recovery`);
+        } else if (process.env.CLAUDE_ROTATION_REFRESH_MAGIC_LINK === '1' && !magicLinkAttempted) {
+          const utilSkip = shouldSkipMagicLinkForUtil(account);
+          if (utilSkip) {
+            log(`${key}: ${utilSkip}`);
+          } else if (rotationInProgress()) {
+            log(`${key}: rotation lock held — deferring magic-link re-auth`);
+          } else {
+            magicLinkAttempted = true;
+            log(
+              `${key}: refresh token invalid — CLAUDE_ROTATION_REFRESH_MAGIC_LINK=1 → magic-link (timeout ${Math.round(MAGIC_LINK_TIMEOUT_MS / 1000)}s)...`,
             );
-            log(`${key}: magic link re-auth output: ${reAuthResult.split('\n').slice(-3).join(' | ')}`);
-            const reAuthedToken = readStoredToken(account);
-            if (reAuthedToken) {
-              const reParsed = parseToken(reAuthedToken);
-              if (reParsed?.claudeAiOauth?.accessToken) {
-                log(`${key}: ✓ re-authed via magic link`);
-                refreshed++;
-                continue;
+            try {
+              const reAuthResult = execFileSync(
+                process.execPath,
+                [join(__dirname, 'rotate.mjs'), '--to', key, '--magic-link', '--force'],
+                { timeout: MAGIC_LINK_TIMEOUT_MS, encoding: 'utf8' },
+              );
+              log(`${key}: magic link re-auth output: ${reAuthResult.split('\n').slice(-3).join(' | ')}`);
+              const reAuthedToken = readStoredToken(account);
+              if (reAuthedToken) {
+                const reParsed = parseToken(reAuthedToken);
+                if (reParsed?.claudeAiOauth?.accessToken) {
+                  log(`${key}: ✓ re-authed via magic link`);
+                  refreshed++;
+                  continue;
+                }
               }
+              log(`${key}: magic link re-auth did not produce a valid token`);
+            } catch (err) {
+              log(`${key}: magic link re-auth failed — ${err.message}`);
             }
-            log(`${key}: magic link re-auth did not produce a valid token`);
-          } catch (err) {
-            log(`${key}: magic link re-auth failed — ${err.message}`);
           }
+        } else {
+          log(`${key}: refresh grant failed (HTTP 400) — marking needsReauth for magic-link-autoloop`);
+          markNeedsReauth(key, result.error);
         }
-      } else {
-        log(`${key}: refresh grant failed (HTTP 400) — marking needsReauth for magic-link-autoloop`);
+      } else if (result.error && /401|invalid|revoked/i.test(result.error)) {
         markNeedsReauth(key, result.error);
       }
-    } else if (result.error && /401|invalid|revoked/i.test(result.error)) {
-      markNeedsReauth(key, result.error);
+
+      failed++;
+      continue;
     }
 
-    failed++;
-    continue;
-  }
+    // Build updated token
+    const updated = {
+      claudeAiOauth: {
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiresAt: result.expiresAt,
+        scopes: oauthData.scopes || [],
+        subscriptionType: result.subscriptionType || oauthData.subscriptionType,
+        rateLimitTier: result.rateLimitTier || oauthData.rateLimitTier,
+      },
+      mcpOAuth: {},
+    };
 
-  // Build updated token
-  const updated = {
-    claudeAiOauth: {
-      accessToken:      result.accessToken,
-      refreshToken:     result.refreshToken,
-      expiresAt:        result.expiresAt,
-      scopes:           oauthData.scopes || [],
-      subscriptionType: result.subscriptionType || oauthData.subscriptionType,
-      rateLimitTier:    result.rateLimitTier || oauthData.rateLimitTier,
-    },
-    mcpOAuth: {},
-  };
+    // Save to vault
+    writeStoredToken(account, JSON.stringify(updated));
+    syncStoredTokenToCrs(account);
+    clearNeedsReauth(key);
+    const newHoursLeft = ((result.expiresAt - Date.now()) / 3_600_000).toFixed(1);
+    log(`${key}: ✓ refreshed (${newHoursLeft}h remaining)`);
 
-  // Save to vault
-  writeStoredToken(account, JSON.stringify(updated));
-  syncStoredTokenToCrs(account);
-  clearNeedsReauth(key);
-  const newHoursLeft = ((result.expiresAt - Date.now()) / 3_600_000).toFixed(1);
-  log(`${key}: ✓ refreshed (${newHoursLeft}h remaining)`);
-
-  // If this is the currently active account, update the active keychain too
-  if (state.activeAccount === key) {
-    try {
-      const currentActive = readKeychain();
-      const currentParsed = parseToken(currentActive);
-      // Always merge mcpOAuth from the running session — drop the Object.keys>0 guard
-      // which silently skipped preservation when a prior rotation had already zeroed the
-      // field, causing CC to lose all MCP OAuth tokens (giga, Amplitude, higgsfield) on
-      // the next session launch and forcing interactive reauth every session.
-      if (currentParsed?.mcpOAuth) {
-        updated.mcpOAuth = { ...updated.mcpOAuth, ...currentParsed.mcpOAuth };
+    // If this is the currently active account, update the active keychain too
+    if (state.activeAccount === key) {
+      try {
+        const currentActive = readKeychain();
+        const currentParsed = parseToken(currentActive);
+        // Always merge mcpOAuth from the running session — drop the Object.keys>0 guard
+        // which silently skipped preservation when a prior rotation had already zeroed the
+        // field, causing CC to lose all MCP OAuth tokens (giga, Amplitude, higgsfield) on
+        // the next session launch and forcing interactive reauth every session.
+        if (currentParsed?.mcpOAuth) {
+          updated.mcpOAuth = { ...updated.mcpOAuth, ...currentParsed.mcpOAuth };
+        }
+        writeKeychain(JSON.stringify(updated));
+        log(`${key}: ✓ also updated active keychain with mcpOAuth preserved`);
+      } catch (err) {
+        log(`${key}: ⚠ vault updated but active keychain update failed — ${err.message}`);
       }
-      writeKeychain(JSON.stringify(updated));
-      log(`${key}: ✓ also updated active keychain with mcpOAuth preserved`);
-    } catch (err) {
-      log(`${key}: ⚠ vault updated but active keychain update failed — ${err.message}`);
     }
-  }
 
-  refreshed++;
+    refreshed++;
   } finally {
     releaseRefreshLock();
   }

--- a/claude-ops/scripts/account-rotation/rotate-captcha-hook.mjs
+++ b/claude-ops/scripts/account-rotation/rotate-captcha-hook.mjs
@@ -13,6 +13,9 @@ import { loadCaptchaCascade } from './captcha-optional.mjs';
  * @returns {Promise<{ok:boolean, layer?:string, reason?:string}>}
  */
 export async function trySolveCaptchaWall(page, log = () => {}, opts = {}) {
+  if (!page) {
+    return { ok: false, reason: 'no-page' };
+  }
   const c = await loadCaptchaCascade();
   if (!c.present) {
     log('[captcha-hook] cascade modules not present');
@@ -25,10 +28,11 @@ export async function trySolveCaptchaWall(page, log = () => {}, opts = {}) {
     if (c.ensureVirtualDisplay) await c.ensureVirtualDisplay(log);
   } catch {}
 
-  if (page && c.solveCaptchaOnPage) {
+  if (c.solveCaptchaOnPage) {
     try {
       const r = await c.solveCaptchaOnPage(page, log, opts);
-      if (r?.ok) return { ok: true, layer: 'token-solver', reason: r.reason };
+      // captcha-helper returns {present, solved, ...}; treat solved as success
+      if (r?.ok || r?.solved) return { ok: true, layer: 'token-solver', reason: r.reason || r.provider };
     } catch (e) {
       log(`[captcha-hook] token solve: ${String(e.message || e).slice(0, 80)}`);
     }

--- a/claude-ops/scripts/account-rotation/rotate-captcha-hook.mjs
+++ b/claude-ops/scripts/account-rotation/rotate-captcha-hook.mjs
@@ -1,0 +1,47 @@
+/**
+ * Soft captcha hook for public rotate.mjs.
+ * Call from browser wall handlers when a page is available:
+ *   const { trySolveCaptchaWall } = await import('./rotate-captcha-hook.mjs');
+ *   await trySolveCaptchaWall(page, log, opts);
+ */
+import { loadCaptchaCascade } from './captcha-optional.mjs';
+
+/**
+ * @param {import('playwright').Page|null} page
+ * @param {(m:string)=>void} [log]
+ * @param {object} [opts]
+ * @returns {Promise<{ok:boolean, layer?:string, reason?:string}>}
+ */
+export async function trySolveCaptchaWall(page, log = () => {}, opts = {}) {
+  const c = await loadCaptchaCascade();
+  if (!c.present) {
+    log('[captcha-hook] cascade modules not present');
+    return { ok: false, reason: 'no-modules' };
+  }
+  try {
+    c.bootstrapRotatorSecrets(log);
+  } catch {}
+  try {
+    if (c.ensureVirtualDisplay) await c.ensureVirtualDisplay(log);
+  } catch {}
+
+  if (page && c.solveCaptchaOnPage) {
+    try {
+      const r = await c.solveCaptchaOnPage(page, log, opts);
+      if (r?.ok) return { ok: true, layer: 'token-solver', reason: r.reason };
+    } catch (e) {
+      log(`[captcha-hook] token solve: ${String(e.message || e).slice(0, 80)}`);
+    }
+  }
+
+  if (c.runAutonomousCaptchaCascade) {
+    try {
+      const r = await c.runAutonomousCaptchaCascade(page, log, opts);
+      if (r?.ok) return { ok: true, layer: r.layer };
+      return { ok: false, reason: 'cascade-exhausted', layer: r?.layer || null };
+    } catch (e) {
+      log(`[captcha-hook] cascade: ${String(e.message || e).slice(0, 80)}`);
+    }
+  }
+  return { ok: false, reason: 'no-solver' };
+}

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -55,15 +55,6 @@ import { destinationUtilHardBlock } from './rotation-policy.mjs';
 import { applyAccountLeases, writeLease } from './account-leases.mjs';
 import { respawnBgSessions } from './bg-respawn.mjs';
 
-// Soft captcha hooks — trySolveCaptchaWall on browser walls (CAPTCHA-CASCADE.md).
-// Helpers live in rotate-captcha-soft.mjs so thin checkouts can omit cascade modules.
-import {
-  trySolveCaptchaWall,
-  maybeClearCaptchaWall,
-  detectCaptchaWall,
-  captchaHardFailed,
-} from './rotate-captcha-soft.mjs';
-
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // Account config lives in the gitignored user data dir (written by
 // setup-account.mjs, Rule 0: no real account data in the committed repo).
@@ -88,6 +79,45 @@ const ACTIVE_KEYCHAIN_ACCOUNT = 'unknown';
 const VAULT_KEYCHAIN_ACCOUNT = process.env.CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT || process.env.USER || 'claude-ops';
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/** Soft captcha wall solve — no-op when cascade modules absent. */
+async function trySolveCaptchaWallSafe(page, log = () => {}, opts = {}) {
+  if (!page) return { ok: false, reason: 'no-page' };
+  try {
+    const mod = await import('./rotate-captcha-hook.mjs');
+    if (typeof mod.trySolveCaptchaWall !== 'function') {
+      return { ok: false, reason: 'no-hook' };
+    }
+    return await mod.trySolveCaptchaWall(page, log, opts);
+  } catch (e) {
+    log(`[captcha-hook] import/run failed: ${String(e.message || e).slice(0, 100)}`);
+    return { ok: false, reason: 'hook-error' };
+  }
+}
+
+async function pageLooksLikeCaptchaWall(page) {
+  if (!page) return false;
+  try {
+    const url = page.url?.() || '';
+    const text = await page.evaluate(() => (document.body?.innerText || '').slice(0, 1200)).catch(() => '');
+    const blob = `${url}\n${text}`.toLowerCase();
+    return (
+      blob.includes('hcaptcha') ||
+      blob.includes('turnstile') ||
+      blob.includes('verify you are human') ||
+      blob.includes('performing security verification') ||
+      blob.includes('security verification') ||
+      blob.includes('cf-challenge') ||
+      blob.includes('just a moment') ||
+      blob.includes('click on each') ||
+      blob.includes('identify the') ||
+      blob.includes('drag the') ||
+      /challenge-large|hcaptcha-box|cf-turnstile/.test(blob)
+    );
+  } catch {
+    return false;
+  }
+}
 
 // ── Bootstrap: verify dependencies ───────────────────────────────────────────
 // Browser driver tiers (Playwright):
@@ -2564,16 +2594,6 @@ async function runAuthFlow(driver, account) {
       await driver.goto(magicLink);
     }
     await sleep(4000);
-    // Post-verify captcha wall (pick/drag hCaptcha / CF) — autonomous cascade when modules present
-    if (driver._page) {
-      await trySolveCaptchaWall(driver._page, 'after-initial-code-verify', log);
-      if (await captchaHardFailed(driver._page)) {
-        log(
-          '[magic-link] aborting: captcha budget exhausted with blocking wall — see CAPTCHA_VNC_HANDOFF marker (autoloop will retry)',
-        );
-        return false;
-      }
-    }
     // After magic link login, session is now valid — re-navigate to authUrl
     // so the OAuth flow can complete (org chooser → authorize → callback)
     if (driver._authUrl) {
@@ -2612,6 +2632,14 @@ async function runAuthFlow(driver, account) {
         await driver.goto(driver._authUrl);
       } catch {}
       await sleep(3000);
+      if (driver._page) {
+        const solved = await trySolveCaptchaWallSafe(
+          driver._page,
+          (m) => log(m),
+          { reason: 'post-magic-link-authUrl', attempt: 0 },
+        );
+        if (solved?.ok) log(`[captcha-hook] post-magic-link wall cleared layer=${solved.layer || 'unknown'}`);
+      }
     }
     return true;
   }
@@ -2632,6 +2660,13 @@ async function runAuthFlow(driver, account) {
     if (!submitted) return false;
     log(`[magic-link] Submitted email — magic link should be sent`);
     await sleep(3000);
+    if (driver._page) {
+      await trySolveCaptchaWallSafe(
+        driver._page,
+        (m) => log(m),
+        { reason: 'post-email-submit', attempt: 0 },
+      );
+    }
 
     const magicLink = await pollGmailForMagicLink(account.email);
     if (await finishMagicLinkLogin(magicLink)) return true;
@@ -2661,31 +2696,21 @@ async function runAuthFlow(driver, account) {
     const url = await driver.currentUrl().catch(() => '');
     log(`Step ${step} [${driver.name}]: ${url.substring(0, 100)}`);
 
-    // Browser walls (post-Verify pick/drag hCaptcha / CF): clear before OTP re-submit
-    // or AI-brain thrash. Soft no-op when cascade modules missing.
-    if (driver._page && /claude\.(ai|com)/i.test(url || '')) {
-      const visualWall = await detectCaptchaWall(driver._page);
-      if (visualWall.blocking) {
-        const cleared = await trySolveCaptchaWall(driver._page, `auth-step-${step}:${visualWall.kind || 'wall'}`, log);
-        if (await captchaHardFailed(driver._page)) {
-          log(
-            `[captcha] aborting: budget exhausted with blocking wall kind=${visualWall.kind} — see CAPTCHA_VNC_HANDOFF (autoloop retries)`,
-          );
-          return false;
-        }
-        if (cleared) {
-          log(`[captcha] step ${step}: wall cleared kind=${visualWall.kind}`);
-          if (driver._authUrl) {
-            try {
-              await driver.goto(driver._authUrl);
-            } catch {}
-            await sleep(2000);
-          }
+    // Browser wall: CF / hCaptcha / interactive tile challenge
+    if (driver._page && url.includes('claude.ai')) {
+      const wallish = await pageLooksLikeCaptchaWall(driver._page);
+      if (wallish || step === 0) {
+        const solved = await trySolveCaptchaWallSafe(
+          driver._page,
+          (m) => log(m),
+          { reason: `magic-link-step-${step}`, attempt: step },
+        );
+        if (solved?.ok) {
+          log(`[captcha-hook] wall cleared layer=${solved.layer || 'unknown'} at step ${step}`);
           stallCount = 0;
+          await sleep(1500);
           continue;
         }
-      } else if (visualWall.kind === 'hcaptcha-challenge-preload') {
-        log('[captcha] preload challenge frame noted (non-blocking)');
       }
     }
 
@@ -3074,14 +3099,6 @@ async function runAuthFlow(driver, account) {
       oauthPath = new URL(url).pathname;
     } catch {}
     if (oauthPath.includes('/oauth/authorize') || (oauthPath.endsWith('/authorize') && url.includes('claude'))) {
-      // Clear captcha wall on authorize (can reappear after session settle).
-      if (driver._page) {
-        await trySolveCaptchaWall(driver._page, 'oauth-authorize', log);
-        if (await captchaHardFailed(driver._page)) {
-          log('[captcha] aborting on /oauth/authorize — budget exhausted');
-          return false;
-        }
-      }
       // Magic-link route: we authenticated via a single-use link delivered to
       // account.email's inbox, so the session on this page is guaranteed to be
       // the right account. Skip the readPageText "verify" dance — it failed to
@@ -3167,7 +3184,19 @@ async function runAuthFlow(driver, account) {
         await sleep(4000);
         continue;
       }
-      log('Authorize button still not clickable after 30s — escalating to ai-brain');
+      log('Authorize button still not clickable after 30s — trying captcha cascade then ai-brain');
+      if (driver._page) {
+        const solved = await trySolveCaptchaWallSafe(
+          driver._page,
+          (m) => log(m),
+          { reason: 'authorize-not-clickable', attempt: 0 },
+        );
+        if (solved?.ok) {
+          log(`[captcha-hook] authorize-path wall cleared layer=${solved.layer || 'unknown'}`);
+          await sleep(2000);
+          continue;
+        }
+      }
       // Fast-path ai-brain escalation: don't wait for stall detector to catch up
       // on the next loop iter. The page is stuck on OAuth authorize — Bedrock
       // vision + optional Context7 / web research picks the next action.
@@ -3240,14 +3269,6 @@ async function runAuthFlow(driver, account) {
               await driver.goto(magicLink);
             }
             await sleep(4000);
-            // Post-verify captcha wall after inline code/link path (mirrors finishMagicLinkLogin)
-            if (driver._page) {
-              await trySolveCaptchaWall(driver._page, 'after-inline-code-verify', log);
-              if (await captchaHardFailed(driver._page)) {
-                log('[magic-link] aborting: captcha budget exhausted after inline verify — see CAPTCHA_VNC_HANDOFF');
-                return false;
-              }
-            }
             // After magic link login, session is now valid — re-navigate to authUrl
             // so the OAuth flow can complete (org chooser → authorize → callback)
             if (driver._authUrl) {

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -2633,11 +2633,10 @@ async function runAuthFlow(driver, account) {
       } catch {}
       await sleep(3000);
       if (driver._page) {
-        const solved = await trySolveCaptchaWallSafe(
-          driver._page,
-          (m) => log(m),
-          { reason: 'post-magic-link-authUrl', attempt: 0 },
-        );
+        const solved = await trySolveCaptchaWallSafe(driver._page, (m) => log(m), {
+          reason: 'post-magic-link-authUrl',
+          attempt: 0,
+        });
         if (solved?.ok) log(`[captcha-hook] post-magic-link wall cleared layer=${solved.layer || 'unknown'}`);
       }
     }
@@ -2661,11 +2660,7 @@ async function runAuthFlow(driver, account) {
     log(`[magic-link] Submitted email — magic link should be sent`);
     await sleep(3000);
     if (driver._page) {
-      await trySolveCaptchaWallSafe(
-        driver._page,
-        (m) => log(m),
-        { reason: 'post-email-submit', attempt: 0 },
-      );
+      await trySolveCaptchaWallSafe(driver._page, (m) => log(m), { reason: 'post-email-submit', attempt: 0 });
     }
 
     const magicLink = await pollGmailForMagicLink(account.email);
@@ -2700,11 +2695,10 @@ async function runAuthFlow(driver, account) {
     if (driver._page && url.includes('claude.ai')) {
       const wallish = await pageLooksLikeCaptchaWall(driver._page);
       if (wallish || step === 0) {
-        const solved = await trySolveCaptchaWallSafe(
-          driver._page,
-          (m) => log(m),
-          { reason: `magic-link-step-${step}`, attempt: step },
-        );
+        const solved = await trySolveCaptchaWallSafe(driver._page, (m) => log(m), {
+          reason: `magic-link-step-${step}`,
+          attempt: step,
+        });
         if (solved?.ok) {
           log(`[captcha-hook] wall cleared layer=${solved.layer || 'unknown'} at step ${step}`);
           stallCount = 0;
@@ -3186,11 +3180,10 @@ async function runAuthFlow(driver, account) {
       }
       log('Authorize button still not clickable after 30s — trying captcha cascade then ai-brain');
       if (driver._page) {
-        const solved = await trySolveCaptchaWallSafe(
-          driver._page,
-          (m) => log(m),
-          { reason: 'authorize-not-clickable', attempt: 0 },
-        );
+        const solved = await trySolveCaptchaWallSafe(driver._page, (m) => log(m), {
+          reason: 'authorize-not-clickable',
+          attempt: 0,
+        });
         if (solved?.ok) {
           log(`[captcha-hook] authorize-path wall cleared layer=${solved.layer || 'unknown'}`);
           await sleep(2000);

--- a/claude-ops/scripts/account-rotation/rotation-vault.mjs
+++ b/claude-ops/scripts/account-rotation/rotation-vault.mjs
@@ -13,7 +13,11 @@ export function rotationService(key) {
 
 function parseToken(value) {
   if (!value) return null;
-  try { return typeof value === 'string' ? JSON.parse(value) : value; } catch { return null; }
+  try {
+    return typeof value === 'string' ? JSON.parse(value) : value;
+  } catch {
+    return null;
+  }
 }
 
 function expiry(value) {
@@ -21,7 +25,11 @@ function expiry(value) {
 }
 
 function readFileStore() {
-  try { return JSON.parse(readFileSync(FILE_PATH, 'utf8')); } catch { return {}; }
+  try {
+    return JSON.parse(readFileSync(FILE_PATH, 'utf8'));
+  } catch {
+    return {};
+  }
 }
 
 function writeFileToken(service, token) {
@@ -52,7 +60,9 @@ function writeKeychainToken(service, token) {
     { timeout: 5000, encoding: 'utf8', stdio: ['ignore', 'ignore', 'pipe'] },
   );
   if (result.status !== 0) {
-    const detail = String(result.stderr || 'security exited non-zero').split('\n')[0].slice(0, 160);
+    const detail = String(result.stderr || 'security exited non-zero')
+      .split('\n')[0]
+      .slice(0, 160);
     throw new Error(`Keychain update failed for ${service}: ${detail}`);
   }
 }
@@ -61,7 +71,7 @@ export function readRotationToken(key, { heal = true } = {}) {
   const service = rotationService(key);
   const fileToken = parseToken(readFileStore()[service]);
   const keychainToken = readKeychainToken(service);
-  const selected = expiry(fileToken) > expiry(keychainToken) ? fileToken : (keychainToken || fileToken);
+  const selected = expiry(fileToken) > expiry(keychainToken) ? fileToken : keychainToken || fileToken;
   if (!selected) return null;
   const serialized = JSON.stringify(selected);
 
@@ -93,7 +103,9 @@ export function reconcileRemoteRotationVault({ host = process.env.CRS_SSH_HOST |
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   if (read.status !== 0) {
-    const detail = String(read.stderr || 'ssh read failed').split('\n')[0].slice(0, 160);
+    const detail = String(read.stderr || 'ssh read failed')
+      .split('\n')[0]
+      .slice(0, 160);
     throw new Error(`Remote rotation vault read failed from ${host}: ${detail}`);
   }
 
@@ -126,7 +138,10 @@ export function reconcileRemoteRotationVault({ host = process.env.CRS_SSH_HOST |
   if (pushed > 0) {
     const write = spawnSync(
       'ssh',
-      [host, 'umask 077; tmp="$HOME/.claude/.credentials.json.tmp.$$"; cat >"$tmp"; mv "$tmp" "$HOME/.claude/.credentials.json"'],
+      [
+        host,
+        'umask 077; tmp="$HOME/.claude/.credentials.json.tmp.$$"; cat >"$tmp"; mv "$tmp" "$HOME/.claude/.credentials.json"',
+      ],
       {
         timeout: 15_000,
         encoding: 'utf8',
@@ -135,7 +150,9 @@ export function reconcileRemoteRotationVault({ host = process.env.CRS_SSH_HOST |
       },
     );
     if (write.status !== 0) {
-      const detail = String(write.stderr || 'ssh write failed').split('\n')[0].slice(0, 160);
+      const detail = String(write.stderr || 'ssh write failed')
+        .split('\n')[0]
+        .slice(0, 160);
       throw new Error(`Remote rotation vault write failed to ${host}: ${detail}`);
     }
   }

--- a/claude-ops/scripts/account-rotation/rotation-vault.mjs
+++ b/claude-ops/scripts/account-rotation/rotation-vault.mjs
@@ -1,0 +1,143 @@
+import { readFileSync, renameSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+import { spawnSync } from 'child_process';
+
+const FILE_PATH = process.env.CLAUDE_ROTATION_FILE_VAULT || join(homedir(), '.claude', '.credentials.json');
+const KEYCHAIN_ACCOUNT = process.env.CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT || process.env.USER || 'claude-ops';
+const LOGIN_KEYCHAIN_PATH = join(homedir(), 'Library', 'Keychains', 'login.keychain-db');
+
+export function rotationService(key) {
+  return `Claude-Rotation-${key}`;
+}
+
+function parseToken(value) {
+  if (!value) return null;
+  try { return typeof value === 'string' ? JSON.parse(value) : value; } catch { return null; }
+}
+
+function expiry(value) {
+  return Number(parseToken(value)?.claudeAiOauth?.expiresAt || 0);
+}
+
+function readFileStore() {
+  try { return JSON.parse(readFileSync(FILE_PATH, 'utf8')); } catch { return {}; }
+}
+
+function writeFileToken(service, token) {
+  const store = readFileStore();
+  store[service] = parseToken(token);
+  const temp = `${FILE_PATH}.tmp.${process.pid}`;
+  writeFileSync(temp, JSON.stringify(store, null, 2), { mode: 0o600 });
+  renameSync(temp, FILE_PATH);
+}
+
+function readKeychainToken(service) {
+  if (process.platform !== 'darwin') return null;
+  const result = spawnSync(
+    'security',
+    ['find-generic-password', '-s', service, '-a', KEYCHAIN_ACCOUNT, '-g', LOGIN_KEYCHAIN_PATH],
+    { timeout: 5000, encoding: 'utf8' },
+  );
+  const output = `${result.stdout || ''}${result.stderr || ''}`;
+  const match = output.match(/^password: "?(.*?)"?$/m);
+  return match ? parseToken(match[1].replace(/\\"/g, '"')) : null;
+}
+
+function writeKeychainToken(service, token) {
+  if (process.platform !== 'darwin') return;
+  const result = spawnSync(
+    'security',
+    ['add-generic-password', '-U', '-s', service, '-a', KEYCHAIN_ACCOUNT, '-w', JSON.stringify(parseToken(token))],
+    { timeout: 5000, encoding: 'utf8', stdio: ['ignore', 'ignore', 'pipe'] },
+  );
+  if (result.status !== 0) {
+    const detail = String(result.stderr || 'security exited non-zero').split('\n')[0].slice(0, 160);
+    throw new Error(`Keychain update failed for ${service}: ${detail}`);
+  }
+}
+
+export function readRotationToken(key, { heal = true } = {}) {
+  const service = rotationService(key);
+  const fileToken = parseToken(readFileStore()[service]);
+  const keychainToken = readKeychainToken(service);
+  const selected = expiry(fileToken) > expiry(keychainToken) ? fileToken : (keychainToken || fileToken);
+  if (!selected) return null;
+  const serialized = JSON.stringify(selected);
+
+  if (heal) {
+    if (JSON.stringify(fileToken) !== serialized) writeFileToken(service, selected);
+    if (process.platform === 'darwin' && JSON.stringify(keychainToken) !== serialized) {
+      writeKeychainToken(service, selected);
+    }
+  }
+  return serialized;
+}
+
+export function writeRotationToken(key, token) {
+  const parsed = parseToken(token);
+  if (!parsed?.claudeAiOauth?.accessToken) throw new Error(`Invalid rotation token for ${key}`);
+  const service = rotationService(key);
+  writeFileToken(service, parsed);
+  writeKeychainToken(service, parsed);
+  return JSON.stringify(parsed);
+}
+
+export function reconcileRemoteRotationVault({ host = process.env.CRS_SSH_HOST || 'dev-us' } = {}) {
+  if (process.platform !== 'darwin' || process.env.CLAUDE_ROTATION_REMOTE_VAULT_SYNC === '0') {
+    return { skipped: true, pulled: 0, pushed: 0 };
+  }
+  const read = spawnSync('ssh', [host, 'cat "$HOME/.claude/.credentials.json"'], {
+    timeout: 15_000,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  if (read.status !== 0) {
+    const detail = String(read.stderr || 'ssh read failed').split('\n')[0].slice(0, 160);
+    throw new Error(`Remote rotation vault read failed from ${host}: ${detail}`);
+  }
+
+  let remote;
+  try {
+    remote = JSON.parse(read.stdout);
+  } catch {
+    throw new Error(`Remote rotation vault from ${host} was not valid JSON`);
+  }
+
+  const local = readFileStore();
+  const services = new Set(
+    [...Object.keys(local), ...Object.keys(remote)].filter((key) => key.startsWith('Claude-Rotation-')),
+  );
+  let pulled = 0;
+  let pushed = 0;
+  for (const service of services) {
+    const key = service.slice('Claude-Rotation-'.length);
+    const localToken = parseToken(readRotationToken(key, { heal: false }));
+    const remoteToken = parseToken(remote[service]);
+    if (expiry(remoteToken) > expiry(localToken)) {
+      writeRotationToken(key, remoteToken);
+      pulled++;
+    } else if (expiry(localToken) > expiry(remoteToken)) {
+      remote[service] = localToken;
+      pushed++;
+    }
+  }
+
+  if (pushed > 0) {
+    const write = spawnSync(
+      'ssh',
+      [host, 'umask 077; tmp="$HOME/.claude/.credentials.json.tmp.$$"; cat >"$tmp"; mv "$tmp" "$HOME/.claude/.credentials.json"'],
+      {
+        timeout: 15_000,
+        encoding: 'utf8',
+        input: `${JSON.stringify(remote, null, 2)}\n`,
+        stdio: ['pipe', 'ignore', 'pipe'],
+      },
+    );
+    if (write.status !== 0) {
+      const detail = String(write.stderr || 'ssh write failed').split('\n')[0].slice(0, 160);
+      throw new Error(`Remote rotation vault write failed to ${host}: ${detail}`);
+    }
+  }
+  return { skipped: false, pulled, pushed };
+}

--- a/claude-ops/scripts/account-rotation/secrets-bootstrap.mjs
+++ b/claude-ops/scripts/account-rotation/secrets-bootstrap.mjs
@@ -123,7 +123,10 @@ function hydrateKeys(keys, log) {
     );
     json = JSON.parse(raw);
   } catch (e) {
-    if (log) log(`secrets-bootstrap: Doppler unavailable (${String(e.message || e).slice(0, 80)}) — ${missing.length} key(s) stay unset`);
+    if (log)
+      log(
+        `secrets-bootstrap: Doppler unavailable (${String(e.message || e).slice(0, 80)}) — ${missing.length} key(s) stay unset`,
+      );
     return { loaded: fileLoaded, source: fileLoaded.length ? 'partial' : 'env' };
   }
 

--- a/claude-ops/scripts/account-rotation/secrets-bootstrap.mjs
+++ b/claude-ops/scripts/account-rotation/secrets-bootstrap.mjs
@@ -1,0 +1,168 @@
+// secrets-bootstrap.mjs
+// Lazily hydrates captcha + proxy secrets into process.env from Doppler
+// (project/config via CLAUDE_ROTATOR_SECRETS_PROJECT / CLAUDE_ROTATOR_SECRETS_CONFIG)
+// when they are not already present.
+//
+// Never throws. Never prints secret values. Runs the Doppler CLI at most once
+// per process, and only if at least one required key is missing.
+import { execFileSync } from 'child_process';
+import { existsSync, readFileSync, statSync } from 'fs';
+import { homedir } from 'os';
+import { join } from 'path';
+
+const DOPPLER_PROJECT = process.env.CLAUDE_ROTATOR_SECRETS_PROJECT || 'claude-ops';
+const DOPPLER_CONFIG = process.env.CLAUDE_ROTATOR_SECRETS_CONFIG || 'prd';
+
+const CAPTCHA_KEYS = [
+  'TWOCAPTCHA_API_KEY',
+  'TWOCAPTCHA_PROXY_URL',
+  'TWOCAPTCHA_PROXY_HOST',
+  'TWOCAPTCHA_PROXY_PORT',
+  'TWOCAPTCHA_PROXY_USER_BASE',
+  'TWOCAPTCHA_PROXY_PASS',
+  'TWOCAPTCHA_PROXY_HTTP_URL',
+  'TWOCAPTCHA_PROXY_SOCKS5_URL',
+  'TWOCAPTCHA_PROXY_SOCKS5_HOST',
+  'TWOCAPTCHA_PROXY_SOCKS5_PORT',
+  'TWOCAPTCHA_PROXY_SOCKS5_TYPE',
+  'TWOCAPTCHA_PROXY_USERNAME',
+  'TWOCAPTCHA_PROXY_PASSWORD',
+  'TWOCAPTCHA_PROXY_TYPE',
+  'TWOCAPTCHA_PROXY_PREFERRED_TRANSPORT',
+  'TWOCAPTCHA_PROXY_API_KEY',
+  'CAPSOLVER_API_KEY',
+  'CAPMONSTER_API_KEY',
+  'CAPMONSTER_CLIENT_KEY',
+  'ANTICAPTCHA_API_KEY',
+  'YESCAPTCHA_CLIENT_KEY',
+  'YESCAPTCHA_API_KEY',
+];
+
+const BRIGHTDATA_KEYS = [
+  'BRIGHT_DATA_USERID',
+  'BRIGHT_DATA_TOKEN',
+  'BRIGHT_DATA_API_TOKEN',
+  'BRIGHTDATA_API_TOKEN',
+  'BRIGHTDATA_API_KEY',
+  'BRIGHTDATA_PROXY_URL',
+  'BRIGHT_DATA_PROXY_HOST',
+  'BRIGHT_DATA_PROXY_PORT',
+  'BRIGHT_DATA_PROXY_USER',
+  'BRIGHT_DATA_PROXY_PASS',
+  'BRIGHT_DATA_PROXY_PASSWORD',
+  'BRIGHT_DATA_CUSTOMER',
+  'BRIGHT_DATA_USER',
+  'BRIGHT_DATA_ZONE',
+  'BRIGHT_DATA_PASS',
+  'BRIGHT_DATA_BROWSER_WSS',
+  'BRIGHT_DATA_SCRAPING_ZONE',
+  'BRIGHT_DATA_SCRAPING_PASS',
+  'BRIGHT_DATA_ISP_PROXY_ZONE',
+  'BRIGHT_DATA_ISP_PROXY_PASSWORD',
+  'BRIGHT_DATA_RESIDENTIAL_PROXY_ZONE',
+  'BRIGHT_DATA_RESIDENTIAL_PROXY_PASSWORD',
+  'BRIGHT_DATA_RESIDENTIAL_ZONE',
+  'BRIGHT_DATA_ISP_ZONE',
+  'BRIGHT_DATA_MOBILE_PROXY_ZONE',
+  'BRIGHT_DATA_MOBILE_ZONE',
+  'BRIGHT_DATA_MOBILE_PROXY_PASSWORD',
+  'BRIGHT_DATA_MOBILE_PASSWORD',
+  'BRIGHT_DATA_WEB_UNLOCKER_ZONE',
+  'BRIGHTDATA_WEB_UNLOCKER_ZONE',
+  'BRIGHT_DATA_UNLOCKER_ZONE',
+  'BRIGHT_DATA_ACTIVE_PROXY_ALIAS',
+];
+
+const BROWSERLESS_KEYS = ['BROWSERLESS_TOKEN', 'BROWSERLESS_WSS', 'BROWSERLESS_REGION'];
+
+let _done = false;
+
+const SECRET_FILES = [
+  process.env.CLAUDE_ROTATOR_SECRETS_FILE,
+  join(homedir(), '.config', 'crs-sync', 'rotator-secrets.env'),
+  join(homedir(), '.mcp-secrets.env'),
+].filter(Boolean);
+
+function hydrateFromSecretFiles(keys, log) {
+  const loaded = [];
+  for (const path of SECRET_FILES) {
+    try {
+      if (!existsSync(path)) continue;
+      if ((statSync(path).mode & 0o077) !== 0) {
+        if (log) log(`secrets-bootstrap: refusing permissive secret file ${path}`);
+        continue;
+      }
+      const allowed = new Set(keys);
+      for (const line of readFileSync(path, 'utf8').split(/\r?\n/)) {
+        const match = line.match(/^\s*(?:export\s+)?([A-Z][A-Z0-9_]*)=(.*)\s*$/);
+        if (!match || !allowed.has(match[1]) || process.env[match[1]]) continue;
+        let value = match[2].trim();
+        if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+          value = value.slice(1, -1);
+        }
+        if (!value) continue;
+        process.env[match[1]] = value;
+        loaded.push(match[1]);
+      }
+    } catch {}
+  }
+  return loaded;
+}
+
+function hydrateKeys(keys, log) {
+  const fileLoaded = hydrateFromSecretFiles(keys, log);
+  const missing = keys.filter((k) => !process.env[k]);
+  if (missing.length === 0) return { loaded: fileLoaded, source: fileLoaded.length ? 'partial' : 'env' };
+
+  let json;
+  try {
+    const raw = execFileSync(
+      'doppler',
+      ['secrets', '--project', DOPPLER_PROJECT, '--config', DOPPLER_CONFIG, '--json'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 20_000 },
+    );
+    json = JSON.parse(raw);
+  } catch (e) {
+    if (log) log(`secrets-bootstrap: Doppler unavailable (${String(e.message || e).slice(0, 80)}) — ${missing.length} key(s) stay unset`);
+    return { loaded: fileLoaded, source: fileLoaded.length ? 'partial' : 'env' };
+  }
+
+  const loaded = [...fileLoaded];
+  let dopplerLoaded = 0;
+  for (const k of missing) {
+    const v = json?.[k]?.computed ?? json?.[k]?.raw;
+    if (typeof v === 'string' && v.length > 0) {
+      process.env[k] = v;
+      loaded.push(k);
+      dopplerLoaded++;
+    }
+  }
+  if (log && loaded.length) {
+    log(`secrets-bootstrap: hydrated ${loaded.length} key(s) from Doppler ${DOPPLER_PROJECT}/${DOPPLER_CONFIG}`);
+  }
+  return { loaded, source: !fileLoaded.length && dopplerLoaded === missing.length ? 'doppler' : 'partial' };
+}
+
+export function bootstrapRotatorSecrets(log) {
+  if (_done) return;
+  _done = true;
+  try {
+    hydrateKeys([...CAPTCHA_KEYS, ...BRIGHTDATA_KEYS, ...BROWSERLESS_KEYS], log);
+  } catch {}
+}
+
+export function captchaKeyPresent() {
+  return !!(
+    process.env.TWOCAPTCHA_API_KEY ||
+    process.env.CAPSOLVER_API_KEY ||
+    process.env.CAPMONSTER_API_KEY ||
+    process.env.CAPMONSTER_CLIENT_KEY ||
+    process.env.ANTICAPTCHA_API_KEY ||
+    process.env.YESCAPTCHA_CLIENT_KEY ||
+    process.env.YESCAPTCHA_API_KEY
+  );
+}
+
+export function captchaKeyNames() {
+  return [...CAPTCHA_KEYS];
+}

--- a/claude-ops/scripts/account-rotation/virtual-display.mjs
+++ b/claude-ops/scripts/account-rotation/virtual-display.mjs
@@ -1,0 +1,101 @@
+/**
+ * Ensure a reachable X display for headed Playwright/Chromium on headless Linux.
+ * Reuses an existing Xvfb (:99+) when present; spawns one if needed.
+ * No-op on macOS/Windows or when DISPLAY already works.
+ */
+
+import { existsSync, readdirSync } from 'fs';
+import { spawn, spawnSync } from 'child_process';
+
+const DISPLAY_RANGE_START = 99;
+const DISPLAY_RANGE_END = 120;
+
+function isDisplayReachable(display) {
+  if (!display) return false;
+  try {
+    const r = spawnSync('xdpyinfo', ['-display', display], {
+      stdio: 'ignore',
+      timeout: 2000,
+    });
+    return r.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+function listUnixDisplays() {
+  const dir = '/tmp/.X11-unix';
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((name) => /^X\d+$/.test(name))
+    .map((name) => `:${name.slice(1)}`)
+    .sort((a, b) => Number(a.slice(1)) - Number(b.slice(1)));
+}
+
+function pickFreeDisplayNum() {
+  for (let n = DISPLAY_RANGE_START; n <= DISPLAY_RANGE_END; n++) {
+    if (!existsSync(`/tmp/.X11-unix/X${n}`) && !isDisplayReachable(`:${n}`)) return n;
+  }
+  return null;
+}
+
+async function waitForDisplay(display, timeoutMs = 4000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (isDisplayReachable(display)) return true;
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  return false;
+}
+
+async function spawnXvfb(displayNum) {
+  const display = `:${displayNum}`;
+  const proc = spawn('Xvfb', [display, '-screen', '0', '1280x800x24', '-ac', '-nolisten', 'tcp'], {
+    stdio: 'ignore',
+    detached: true,
+  });
+  proc.unref();
+  if (!(await waitForDisplay(display))) {
+    try {
+      proc.kill('SIGKILL');
+    } catch {}
+    throw new Error(`Xvfb on ${display} did not become reachable`);
+  }
+  return display;
+}
+
+/**
+ * @param {(msg: string) => void} [log]
+ * @returns {Promise<string|null>} display string set on process.env, or null if unchanged
+ */
+export async function ensureVirtualDisplay(log = () => {}) {
+  if (process.platform !== 'linux') return null;
+
+  if (isDisplayReachable(process.env.DISPLAY)) {
+    log(`[display] Using existing DISPLAY=${process.env.DISPLAY}`);
+    return process.env.DISPLAY;
+  }
+
+  if (process.env.DISPLAY) {
+    log(`[display] DISPLAY=${process.env.DISPLAY} unreachable — probing alternatives`);
+  }
+
+  for (const display of listUnixDisplays()) {
+    if (isDisplayReachable(display)) {
+      process.env.DISPLAY = display;
+      log(`[display] Switched to reachable ${display}`);
+      return display;
+    }
+  }
+
+  const freeNum = pickFreeDisplayNum();
+  if (freeNum == null) {
+    throw new Error('No free display in :99-:120 and no reachable X server found');
+  }
+
+  log(`[display] Starting Xvfb on :${freeNum} for headed browser automation`);
+  const display = await spawnXvfb(freeNum);
+  process.env.DISPLAY = display;
+  log(`[display] Ready DISPLAY=${display}`);
+  return display;
+}

--- a/claude-ops/scripts/systemd/claude-account-rotation.service
+++ b/claude-ops/scripts/systemd/claude-account-rotation.service
@@ -1,15 +1,18 @@
 [Unit]
-Description=Claude account rotation daemon
+Description=Claude account rotation daemon (plugin-first)
 After=network-online.target crs-compose.service
 Wants=network-online.target crs-compose.service
 
 [Service]
 Type=simple
-WorkingDirectory=%h/.claude/scripts/account-rotation
+# Prefer installed plugin tree; override with EnvironmentFile if needed.
+Environment=CLAUDE_PLUGIN_ROOT=%h/.claude/plugins/cache/ops-marketplace/ops/current
 Environment=CLAUDE_ENABLE_FLEET_RECOVERY=0
 Environment=CLAUDE_ENABLE_BG_RESPAWN=0
 Environment=CLAUDE_ENABLE_BG_SESSION_ROUTER=1
-ExecStart=/usr/bin/node %h/.claude/scripts/account-rotation/daemon.mjs
+# Plugin path (marketplace install). Host fork is legacy fallback only.
+WorkingDirectory=%h/.claude/plugins/cache/ops-marketplace/ops/current/scripts/account-rotation
+ExecStart=/usr/bin/node %h/.claude/plugins/cache/ops-marketplace/ops/current/scripts/account-rotation/daemon.mjs
 Restart=always
 RestartSec=30
 StandardOutput=append:%h/.claude/logs/account-rotation.systemd.log


### PR DESCRIPTION
Port captcha cascade into marketplace plugin and wire trySolveCaptchaWall into public rotate.mjs browser walls (email submit, magic-link, step loop, authorize). Soft import when modules absent.

Test: node --check rotate.mjs; live magic-link residual; systemd cutover separate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes OAuth refresh, keychain/vault token writes, and magic-link browser auth behavior—including removal of captcha budget hard-aborts—on security-critical rotation paths.
> 
> **Overview**
> Ports account-rotation infrastructure into the marketplace plugin and rewires **magic-link / OAuth browser walls** to a **soft captcha cascade** (`captcha-optional.mjs` → `rotate-captcha-hook.mjs`) instead of hard-importing `rotate-captcha-soft.mjs`.
> 
> **Captcha / rotate:** `rotate.mjs` now dynamically calls `trySolveCaptchaWallSafe` after email submit, on claude.ai step loops, post-magic-link `authUrl`, and when Authorize is stuck. Heuristic `pageLooksLikeCaptchaWall` replaces the previous `detectCaptchaWall` / `captchaHardFailed` abort paths—failed captcha no longer hard-stops the flow at several sites. README documents Doppler/`secrets-bootstrap.mjs` for solver keys.
> 
> **New operational modules:** `refresh-tokens.mjs` (proactive OAuth refresh via shared `oauth-keep-alive-policy.mjs`, vault I/O through `rotation-vault.mjs`, `needsReauth` handoff to magic-link-autoloop, optional emergency magic-link via env); `proxy-helper.mjs` (Bright Data fallback on 429); `secrets-bootstrap.mjs` and `virtual-display.mjs` for headless Linux; `crs-egress-failover.sh` for scoped CRS proxy failover.
> 
> **Deploy:** `claude-account-rotation.service` points **WorkingDirectory** and **ExecStart** at the installed plugin tree under `ops-marketplace/ops/current`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3e85836d55512977ebde723c91c224a3045c343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->