### PR TITLE
feat(ops-accounts): rotate aliases + multi-provider router + Grok egress cascade

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - **ops-accounts multi-provider plan:** every provider (Claude, Grok, OpenAI/Codex, Factory, Cursor) gets Anthropic-shaped OAuth, reauth, util, switch/LB under `/ops:accounts`.
 - **CRS cherry-pick path:** absorb gateway + Claude seat policy + Grok OAuth proxy into ops-accounts so default installs need no claude-relay-service; external CRS stays advanced-only. See `docs/ops/OPS-ACCOUNTS-VISION.md`.
+- **ops-accounts seat policy (local):** `seat-policy-tick.mjs` applies conservative 5h/7d schedulable thresholds to local seat-state without CRS; `ops-accounts seats tick`.
 - **ops-accounts local seat-state:** `seat-state.mjs` file-backed multi-provider seat store (schedulable/util) for no-CRS policy backend; `ops-accounts seats` command.
 - **ops-accounts skill merge:** `/ops:accounts` is canonical multi-provider entry; `/ops:rotate` and `/ops:rotate-setup` are aliases. Expanded `bin/ops-accounts` (status/util/switch/refresh/reauth/setup/crs). Added `grok-reauth-egress.sh` residential cascade (EFG SOCKS → Bright Data tiers) for Grok device OAuth.
 

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -6,11 +6,8 @@
 
 - **ops-accounts multi-provider plan:** every provider (Claude, Grok, OpenAI/Codex, Factory, Cursor) gets Anthropic-shaped OAuth, reauth, util, switch/LB under `/ops:accounts`.
 - **CRS cherry-pick path:** absorb gateway + Claude seat policy + Grok OAuth proxy into ops-accounts so default installs need no claude-relay-service; external CRS stays advanced-only. See `docs/ops/OPS-ACCOUNTS-VISION.md`.
-
-
-## Unreleased
-
-### Changed
+- **ops-accounts local seat-state:** `seat-state.mjs` file-backed multi-provider seat store (schedulable/util) for no-CRS policy backend; `ops-accounts seats` command.
+- **ops-accounts skill merge:** `/ops:accounts` is canonical multi-provider entry; `/ops:rotate` and `/ops:rotate-setup` are aliases. Expanded `bin/ops-accounts` (status/util/switch/refresh/reauth/setup/crs). Added `grok-reauth-egress.sh` residential cascade (EFG SOCKS → Bright Data tiers) for Grok device OAuth.
 
 - **Required companion co-install:** companions essential to ops commands are no longer optional setup prompts. `plugin-dependencies.json` marks `desktop-act`, `gsd`, `gstack` (skills clone), `superpowers`, and `feature-dev` as `required: true` with `updateWithOps: always` and `essentialFor` command lists. `scripts/install-companions.sh` always installs missing required companions (even under `--update-only`), and `--status` exits 1 when any required companion is missing. `/ops:setup` Step 2b runs the SSOT script without Skip for required deps. `/ops:update` step 9 co-installs the full required set (still skippable only via `--no-companions` / `OPS_SKIP_COMPANIONS=1`). Adds `scripts/install-gstack-companion.sh` (env-templated `GSTACK_REPO`/`GSTACK_DIR`/`GSTACK_BRANCH`).
 

--- a/claude-ops/bin/ops-accounts
+++ b/claude-ops/bin/ops-accounts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # ops-accounts — multi-provider account status / switch / refresh / reauth router.
 # Prefers Node CLI (scripts/ops-accounts/cli.mjs) when present; else thin shell fallback.
+# Claude rotate/setup, Grok seats/proxy, Codex when present. No secrets printed.
 set -euo pipefail
 
 resolve_root() {
@@ -36,36 +37,213 @@ cmd="${1:-status}"
 shift || true
 have() { command -v "$1" >/dev/null 2>&1; }
 
+plugin_root() {
+  if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" && -d "$CLAUDE_PLUGIN_ROOT" ]]; then
+    printf '%s' "$CLAUDE_PLUGIN_ROOT"
+    return
+  fi
+  local c
+  c="$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1 || true)"
+  printf '%s' "${c%/}"
+}
+
+ROOT="$(plugin_root)"
+ROT="${ROOT}/scripts/account-rotation"
+
 print_claude() {
   echo "=== Claude ==="
-  local rot="$ROOT/scripts/account-rotation"
-  if [[ -f "$rot/rotate.mjs" ]]; then
-    node "$rot/rotate.mjs" --status 2>/dev/null | head -40 || echo "(rotate.mjs --status failed)"
+  if [[ -f "$ROT/rotate.mjs" ]]; then
+    node "$ROT/rotate.mjs" --status 2>/dev/null | head -50 || echo "(rotate.mjs --status failed)"
   else
-    echo "plugin rotate.mjs not found"
+    echo "plugin rotate.mjs not found (ROOT=$ROOT)"
   fi
 }
 print_grok() {
-  echo "=== Grok ==="
-  have grok-rotate && grok-rotate status 2>/dev/null || echo "grok-rotate not on PATH"
+  echo "=== Grok (SuperGrok OAuth seats + proxy) ==="
+  if have grok-rotate; then
+    grok-rotate status 2>/dev/null || true
+  else
+    echo "grok-rotate not on PATH"
+  fi
+  if curl -fsS -m 2 http://127.0.0.1:31845/accounts >/tmp/ops-accounts-grok-proxy.json 2>/dev/null; then
+    python3 - <<'PY'
+import json
+from pathlib import Path
+d=json.loads(Path("/tmp/ops-accounts-grok-proxy.json").read_text())
+print("proxy load_balance:", d.get("load_balance"))
+print("proxy last_used:", d.get("current") or d.get("last_used"))
+print("proxy request_counts:", d.get("request_counts"))
+ex=d.get("exhausted_seconds_remaining") or {}
+if ex:
+  print("proxy exhausted_seconds:", {k:int(v) for k,v in ex.items()})
+PY
+  else
+    echo "grok-cli-auth-proxy :31845 not reachable (optional)"
+  fi
+  if curl -fsS -m 2 -o /dev/null -w "crs_grok_hop HTTP %{http_code}\n" http://127.0.0.1:3005/grok/v1/models 2>/dev/null; then
+    :
+  else
+    echo "crs_grok_hop: not reachable (optional thin hop)"
+  fi
 }
 print_codex() {
   echo "=== Codex / OpenAI ==="
   have codex-rotate && codex-rotate status 2>/dev/null | head -30 || echo "codex-rotate optional"
 }
 
+print_factory() {
+  echo "=== Factory ==="
+  echo "(adapter planned — see docs/ops/OPS-ACCOUNTS-VISION.md)"
+}
+
+print_cursor() {
+  echo "=== Cursor ==="
+  echo "(adapter planned — see docs/ops/OPS-ACCOUNTS-VISION.md)"
+}
+
 case "$cmd" in
-  status|list|"") print_claude; echo; print_grok; echo; print_codex ;;
+  status|list|"")
+    print_claude; echo
+    print_grok; echo
+    print_codex; echo
+    print_factory; echo
+    print_cursor
+    ;;
+  util)
+    provider="${1:-all}"
+    case "$provider" in
+      claude)
+        [[ -f "$ROT/rotate.mjs" ]] && node "$ROT/rotate.mjs" --utilization 2>/dev/null | head -60
+        ;;
+      grok)
+        curl -fsS -m 3 http://127.0.0.1:31845/accounts 2>/dev/null | python3 -c 'import json,sys;d=json.load(sys.stdin);print(json.dumps({k:d.get(k) for k in ("request_counts","exhausted_seconds_remaining","load_balance","current")}, indent=2))' || echo "proxy util unavailable"
+        ;;
+      all|"")
+        echo "--- Claude util ---"
+        [[ -f "$ROT/rotate.mjs" ]] && node "$ROT/rotate.mjs" --utilization 2>/dev/null | head -40 || true
+        echo "--- Grok proxy ---"
+        curl -fsS -m 3 http://127.0.0.1:31845/accounts 2>/dev/null | python3 -c 'import json,sys;d=json.load(sys.stdin);print("counts",d.get("request_counts"));print("exhausted",d.get("exhausted_seconds_remaining"))' || true
+        ;;
+      *)
+        echo "usage: ops-accounts util [all|claude|grok]"; exit 2 ;;
+    esac
+    ;;
+  switch|rotate-now)
+    provider="${1:-}"
+    if [[ "$cmd" == "rotate-now" ]]; then
+      provider="claude"
+    fi
+    case "$provider" in
+      grok|xai)
+        have grok-rotate || { echo "grok-rotate missing"; exit 1; }
+        grok-rotate switch
+        grok-rotate status
+        ;;
+      claude|"")
+        if [[ -x "$ROT/force-rotate.sh" ]]; then
+          bash "$ROT/force-rotate.sh" "${2:-}"
+        elif [[ -f "$ROT/rotate.mjs" ]]; then
+          node "$ROT/rotate.mjs" --rotate ${2:+--to "$2"}
+        else
+          echo "Claude rotate scripts missing under $ROT"; exit 1
+        fi
+        ;;
+      *)
+        echo "usage: ops-accounts switch grok|claude [email]"; exit 2 ;;
+    esac
+    ;;
+  refresh)
+    provider="${1:-all}"
+    case "$provider" in
+      grok)
+        if have host-token-keepalive; then host-token-keepalive --force --grok-only
+        elif have grok-rotate; then grok-rotate refresh
+        else echo "no grok refresh tool"; exit 1
+        fi
+        ;;
+      claude)
+        have host-token-keepalive && host-token-keepalive --force --claude-only || true
+        [[ -f "$ROT/rotate.mjs" ]] && node "$ROT/rotate.mjs" --refresh 2>/dev/null || true
+        ;;
+      all|"")
+        have host-token-keepalive && host-token-keepalive --force || true
+        ;;
+      *)
+        echo "usage: ops-accounts refresh [all|claude|grok]"; exit 2 ;;
+    esac
+    ;;
   reauth)
     provider="${1:-}"; email="${2:-}"
     case "$provider" in
-      grok|xai) [[ -n "$email" ]] || { echo "usage: ops-accounts reauth grok <email>"; exit 2; }
-        grok-oauth-reauth --email "$email" ;;
-      claude) [[ -n "$email" ]] || { echo "usage: ops-accounts reauth claude <email>"; exit 2; }
-        node "$ROOT/scripts/account-rotation/rotate-magic.mjs" --to "$email" --force ;;
-      *) echo "usage: ops-accounts reauth grok|claude <email>"; exit 2 ;;
-    esac ;;
+      grok|xai)
+        [[ -n "$email" ]] || { echo "usage: ops-accounts reauth grok <email>"; exit 2; }
+        export DISPLAY="${DISPLAY:-${CLAUDE_DESKTOP_DISPLAY:-:1}}"
+        EGRESS="$ROT/grok-reauth-egress.sh"
+        if [[ -x "$EGRESS" ]]; then
+          # shellcheck disable=SC1090
+          source "$EGRESS" || true
+        fi
+        if have grok-oauth-reauth; then
+          grok-oauth-reauth --email "$email"
+        else
+          echo "grok-oauth-reauth not on PATH (port into plugin next)"
+          exit 1
+        fi
+        ;;
+      claude)
+        [[ -n "$email" ]] || { echo "usage: ops-accounts reauth claude <email>"; exit 2; }
+        if [[ -f "$ROT/rotate-magic.mjs" ]]; then
+          node "$ROT/rotate-magic.mjs" --to "$email" --force
+        else
+          node "$ROT/rotate.mjs" --magic-link --to "$email"
+        fi
+        ;;
+      *)
+        echo "usage: ops-accounts reauth grok|claude <email>"; exit 2 ;;
+    esac
+    ;;
+  setup)
+    provider="${1:-claude}"
+    echo "Interactive setup: invoke skill ops-accounts / ops-rotate-setup for provider=$provider"
+    echo "Claude wizard detail: skills/ops-rotate-setup/SKILL.md"
+    echo "Quick reauth Claude: ops-accounts reauth claude <email>"
+    echo "Quick reauth Grok:   ops-accounts reauth grok <email>"
+    ;;
+  crs)
+    if [[ -x "$ROT/crs-priority-daemon.sh" ]]; then
+      bash "$ROT/crs-priority-daemon.sh" --status 2>&1 | head -40
+    else
+      echo "CRS priority script missing (optional)"
+    fi
+    ;;
+  crs-tick)
+    if [[ -x "$ROT/crs-priority-daemon.sh" ]]; then
+      bash "$ROT/crs-priority-daemon.sh" "$@"
+    else
+      echo "CRS priority script missing"; exit 1
+    fi
+    ;;
+  seats)
+    if [[ -f "$ROT/seat-state.mjs" ]]; then
+      node "$ROT/seat-state.mjs" "${1:-status}" "${@:2}"
+    else
+      echo "seat-state.mjs missing"; exit 1
+    fi
+    ;;
   -h|--help|help)
-    echo "ops-accounts status|reauth|switch|refresh (Node CLI missing — thin shell)" ;;
-  *) echo "unknown: $cmd"; exit 2 ;;
+    cat <<H
+ops-accounts — multi-provider seats (canonical; /ops:rotate is alias)
+
+  status | list
+  util [all|claude|grok]
+  switch claude|grok   |  rotate-now
+  refresh [all|claude|grok]
+  reauth claude <email> | reauth grok <email>
+  setup [claude|grok]
+  crs | crs-tick
+  seats [status|list|set|toggle|import-claude-config]
+H
+    ;;
+  *)
+    echo "unknown command: $cmd (try help)"; exit 2 ;;
 esac

--- a/claude-ops/bin/ops-accounts
+++ b/claude-ops/bin/ops-accounts
@@ -224,8 +224,14 @@ case "$cmd" in
     fi
     ;;
   seats)
+    sub="${1:-status}"
+    if [[ "$sub" == "tick" || "$sub" == "policy-tick" ]]; then
+      shift || true
+      node "$ROT/seat-policy-tick.mjs" "$@"
+      exit $?
+    fi
     if [[ -f "$ROT/seat-state.mjs" ]]; then
-      node "$ROT/seat-state.mjs" "${1:-status}" "${@:2}"
+      node "$ROT/seat-state.mjs" "$sub" "${@:2}"
     else
       echo "seat-state.mjs missing"; exit 1
     fi

--- a/claude-ops/scripts/account-rotation/grok-reauth-egress.sh
+++ b/claude-ops/scripts/account-rotation/grok-reauth-egress.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# grok-reauth-egress.sh — pick residential egress for Grok device OAuth.
+# Order: caller env → EFG SOCKS → Bright Data residential → ISP → mobile → SOCKS fallback.
+# Source before grok-oauth-reauth. Never prints credential values.
+set -euo pipefail
+
+log() { echo "[grok-reauth-egress] $*" >&2; }
+
+if [[ -n "${GROK_REAUTH_HTTP_PROXY:-}" || -n "${GROK_REAUTH_SOCKS:-}" ]]; then
+  log "using caller-provided proxy env"
+  return 0 2>/dev/null || exit 0
+fi
+
+# 1) Local SOCKS (EFG / residential tunnel)
+for port in "${GROK_REAUTH_SOCKS_PORT:-1089}" 1089 1087; do
+  if timeout 1 bash -c "echo >/dev/tcp/127.0.0.1/$port" 2>/dev/null; then
+    code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 8 \
+      --proxy "socks5h://127.0.0.1:${port}" https://accounts.x.ai/ 2>/dev/null || echo 000)"
+    if [[ "$code" != "000" && "$code" != "403" ]]; then
+      export GROK_REAUTH_SOCKS="socks5://127.0.0.1:${port}"
+      log "selected local SOCKS port=${port} (http ${code})"
+      return 0 2>/dev/null || exit 0
+    fi
+    log "local SOCKS port=${port} http=${code}"
+  fi
+done
+
+# 2) Bright Data HTTP proxy tiers via curl --proxy-user (no password in URL literals)
+probe_brd_tier() {
+  local tier="$1" zone="$2"
+  local uid host port sess user code
+  # password material only from env at probe time — never echoed
+  local -a pass_keys
+  case "$tier" in
+    residential) pass_keys=(BRIGHT_DATA_RESIDENTIAL_PROXY_PASSWORD BRIGHT_DATA_PROXY_PASSWORD BRIGHT_DATA_PASS BRIGHT_DATA_TOKEN) ;;
+    isp) pass_keys=(BRIGHT_DATA_ISP_PROXY_PASSWORD BRIGHT_DATA_PROXY_PASSWORD BRIGHT_DATA_PASS BRIGHT_DATA_TOKEN) ;;
+    mobile) pass_keys=(BRIGHT_DATA_MOBILE_PROXY_PASSWORD BRIGHT_DATA_MOBILE_PASSWORD BRIGHT_DATA_PASS BRIGHT_DATA_TOKEN) ;;
+    *) return 1 ;;
+  esac
+  local pass=""
+  local k
+  for k in "${pass_keys[@]}"; do
+    if [[ -n "${!k:-}" ]]; then pass="${!k}"; break; fi
+  done
+  uid="${BRIGHT_DATA_USERID:-${BRIGHT_DATA_CUSTOMER:-${BRIGHT_DATA_USER:-}}}"
+  host="${BRIGHT_DATA_PROXY_HOST:-brd.superproxy.io}"
+  port="${BRIGHT_DATA_PROXY_PORT:-22225}"
+  [[ -n "$uid" && -n "$zone" && -n "$pass" ]] || return 1
+  sess="gr$(date +%s | tail -c 6)${tier:0:1}"
+  user="brd-customer-${uid}-zone-${zone}-country-nl-session-${sess}"
+  code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 \
+    --proxy "http://${host}:${port}" \
+    --proxy-user "${user}:${pass}" \
+    https://accounts.x.ai/ 2>/dev/null || echo 000)"
+  if [[ "$code" == "200" ]]; then
+    # Export for Playwright-style consumers (username/password split preferred)
+    export GROK_REAUTH_HTTP_PROXY_HOST="${host}"
+    export GROK_REAUTH_HTTP_PROXY_PORT="${port}"
+    export GROK_REAUTH_HTTP_PROXY_USER="${user}"
+    export GROK_REAUTH_HTTP_PROXY_PASS="${pass}"
+    # Combined form for tools that only accept one URL (not logged)
+    export GROK_REAUTH_HTTP_PROXY="http://${user}:${pass}@${host}:${port}"
+    log "selected Bright Data tier=${tier} zone=${zone} (http ${code})"
+    return 0
+  fi
+  log "Bright Data tier=${tier} zone=${zone} http=${code}"
+  return 1
+}
+
+Z_RES="${BRIGHT_DATA_RESIDENTIAL_PROXY_ZONE:-${BRIGHT_DATA_RESIDENTIAL_ZONE:-${BRIGHT_DATA_ZONE:-}}}"
+Z_ISP="${BRIGHT_DATA_ISP_PROXY_ZONE:-${BRIGHT_DATA_ISP_ZONE:-}}"
+Z_MOB="${BRIGHT_DATA_MOBILE_PROXY_ZONE:-${BRIGHT_DATA_MOBILE_ZONE:-}}"
+
+if [[ -n "$Z_RES" ]] && probe_brd_tier residential "$Z_RES"; then
+  return 0 2>/dev/null || exit 0
+fi
+if [[ -n "$Z_ISP" ]] && probe_brd_tier isp "$Z_ISP"; then
+  return 0 2>/dev/null || exit 0
+fi
+if [[ -n "$Z_MOB" ]] && probe_brd_tier mobile "$Z_MOB"; then
+  return 0 2>/dev/null || exit 0
+fi
+
+# 3) Last resort SOCKS even if previously 403 (browser may pass CF)
+if timeout 1 bash -c "echo >/dev/tcp/127.0.0.1/1089" 2>/dev/null; then
+  export GROK_REAUTH_SOCKS="socks5://127.0.0.1:1089"
+  log "fallback local SOCKS port=1089 (may hit CF)"
+  return 0 2>/dev/null || exit 0
+fi
+
+log "no egress selected — reauth may use tool defaults"
+return 0 2>/dev/null || exit 0

--- a/claude-ops/scripts/account-rotation/seat-policy-tick.mjs
+++ b/claude-ops/scripts/account-rotation/seat-policy-tick.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * seat-policy-tick.mjs — conservative schedulable policy against local seat-state.
+ * No CRS. Reads optional live util from rotate.mjs --utilization JSON if present.
+ *
+ * Usage:
+ *   node seat-policy-tick.mjs [--dry-run] [--status]
+ *
+ * Env:
+ *   OPS_ACCOUNTS_OFF_5H (default 85)  OPS_ACCOUNTS_ON_5H (default 60)
+ *   OPS_ACCOUNTS_OFF_7D (default 90)  OPS_ACCOUNTS_ON_7D (default 70)
+ *   OPS_ACCOUNTS_FLOOR (default 2)    minimum seats kept schedulable
+ */
+import { spawnSync } from 'child_process';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { homedir } from 'os';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DATA = process.env.CLAUDE_PLUGIN_DATA_DIR || join(homedir(), '.claude', 'plugins', 'data', 'ops-ops-marketplace');
+const STATE_PATH = process.env.OPS_ACCOUNTS_STATE_PATH || join(DATA, 'account-rotation', 'seat-state.json');
+
+const DRY = process.argv.includes('--dry-run');
+const STATUS = process.argv.includes('--status');
+const OFF5 = num(process.env.OPS_ACCOUNTS_OFF_5H, 85);
+const ON5 = num(process.env.OPS_ACCOUNTS_ON_5H, 60);
+const OFF7 = num(process.env.OPS_ACCOUNTS_OFF_7D, 90);
+const ON7 = num(process.env.OPS_ACCOUNTS_ON_7D, 70);
+const FLOOR = num(process.env.OPS_ACCOUNTS_FLOOR, 2);
+
+function num(v, d) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : d;
+}
+
+function load() {
+  if (!existsSync(STATE_PATH)) {
+    return { version: 1, updatedAt: null, providers: { claude: { seats: {} } } };
+  }
+  return JSON.parse(readFileSync(STATE_PATH, 'utf8'));
+}
+
+function save(state) {
+  mkdirSync(dirname(STATE_PATH), { recursive: true });
+  state.updatedAt = new Date().toISOString();
+  const tmp = STATE_PATH + '.tmp';
+  writeFileSync(tmp, JSON.stringify(state, null, 2) + '\n', { mode: 0o600 });
+  renameSync(tmp, STATE_PATH);
+}
+
+function tryLiveUtil() {
+  const rot = join(__dirname, 'rotate.mjs');
+  if (!existsSync(rot)) return {};
+  const r = spawnSync(process.execPath, [rot, '--utilization', '--json'], {
+    encoding: 'utf8',
+    timeout: 60_000,
+  });
+  if (r.status !== 0 || !r.stdout) return {};
+  try {
+    const data = JSON.parse(r.stdout);
+    const map = {};
+    const rows = Array.isArray(data) ? data : data.accounts || data.utilization || [];
+    for (const row of rows) {
+      const email = row.email || row.name || row.id;
+      if (!email) continue;
+      map[email] = {
+        util5h: row.fiveHour ?? row.util5h ?? row['5h'] ?? null,
+        util7d: row.sevenDay ?? row.util7d ?? row['7d'] ?? null,
+      };
+    }
+    return map;
+  } catch {
+    return {};
+  }
+}
+
+const state = load();
+if (!state.providers?.claude) state.providers = { ...state.providers, claude: { seats: {} } };
+const seats = state.providers.claude.seats || {};
+const live = tryLiveUtil();
+
+// merge live util
+for (const [email, u] of Object.entries(live)) {
+  if (!seats[email]) {
+    seats[email] = {
+      schedulable: true,
+      util5h: null,
+      util7d: null,
+      exhaustedUntil: null,
+      lastError: null,
+      updatedAt: null,
+    };
+  }
+  if (u.util5h != null) seats[email].util5h = u.util5h;
+  if (u.util7d != null) seats[email].util7d = u.util7d;
+  seats[email].updatedAt = new Date().toISOString();
+}
+state.providers.claude.seats = seats;
+
+const emails = Object.keys(seats);
+const decisions = [];
+for (const email of emails) {
+  const s = seats[email];
+  const u5 = s.util5h;
+  const u7 = s.util7d;
+  let desired = s.schedulable !== false;
+  let reason = 'hold';
+  if (u5 != null && u5 >= OFF5) {
+    desired = false;
+    reason = `5h=${u5}>=${OFF5}`;
+  } else if (u7 != null && u7 >= OFF7) {
+    desired = false;
+    reason = `7d=${u7}>=${OFF7}`;
+  } else if (s.schedulable === false) {
+    if ((u5 == null || u5 <= ON5) && (u7 == null || u7 <= ON7)) {
+      desired = true;
+      reason = `recover 5h=${u5} 7d=${u7}`;
+    }
+  } else {
+    desired = true;
+    reason = 'ok';
+  }
+  decisions.push({ email, cur: s.schedulable !== false, desired, reason, u5, u7 });
+}
+
+// floor: keep minimum on
+let onCount = decisions.filter((d) => d.desired).length;
+if (onCount < FLOOR) {
+  const softOff = decisions
+    .filter((d) => !d.desired && !String(d.reason).startsWith('7d='))
+    .sort((a, b) => (a.u5 ?? 0) - (b.u5 ?? 0));
+  for (const d of softOff) {
+    if (onCount >= FLOOR) break;
+    d.desired = true;
+    d.reason = `FLOOR(${FLOOR}): ${d.reason}`;
+    onCount++;
+  }
+}
+
+if (STATUS || DRY) {
+  console.log(`seat-policy @ ${STATE_PATH} dry=${DRY}`);
+  for (const d of decisions) {
+    const mark = d.cur === d.desired ? ' ' : d.desired ? '+' : '-';
+    console.log(
+      `  ${mark} ${d.email}  sched ${d.cur}→${d.desired}  5h=${d.u5 ?? '—'} 7d=${d.u7 ?? '—'}  (${d.reason})`,
+    );
+  }
+  if (STATUS && !DRY) process.exit(0);
+}
+
+let changed = 0;
+if (!DRY) {
+  for (const d of decisions) {
+    if (d.cur === d.desired) continue;
+    seats[d.email].schedulable = d.desired;
+    seats[d.email].updatedAt = new Date().toISOString();
+    changed++;
+    console.log(`${d.email}: schedulable ${d.cur}→${d.desired} (${d.reason})`);
+  }
+  state.providers.claude.seats = seats;
+  save(state);
+}
+console.log(`tick: ${changed} change(s), schedulable=${decisions.filter((d) => d.desired).length}/${decisions.length}`);

--- a/claude-ops/scripts/account-rotation/seat-state.mjs
+++ b/claude-ops/scripts/account-rotation/seat-state.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/**
+ * seat-state.mjs — local multi-provider seat state (no CRS required).
+ *
+ * File-backed store used by ops-accounts policy when backend=local.
+ * Schema is provider-agnostic; Claude CRS daemons can dual-write later.
+ *
+ * Usage:
+ *   node seat-state.mjs status
+ *   node seat-state.mjs list [provider]
+ *   node seat-state.mjs set <provider> <email> key=value …
+ *   node seat-state.mjs toggle <provider> <email> schedulable=true|false
+ *   node seat-state.mjs path
+ *
+ * Env:
+ *   OPS_ACCOUNTS_STATE_PATH  override store path
+ *   CLAUDE_PLUGIN_DATA_DIR   default parent for state
+ */
+import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from 'fs';
+import { join, dirname } from 'path';
+import { homedir } from 'os';
+
+const DATA = process.env.CLAUDE_PLUGIN_DATA_DIR || join(homedir(), '.claude', 'plugins', 'data', 'ops-ops-marketplace');
+const STATE_PATH = process.env.OPS_ACCOUNTS_STATE_PATH || join(DATA, 'account-rotation', 'seat-state.json');
+
+function empty() {
+  return {
+    version: 1,
+    updatedAt: null,
+    providers: {
+      // claude: { seats: { [email]: { schedulable, util5h, util7d, lastError, updatedAt } } }
+    },
+  };
+}
+
+function load() {
+  if (!existsSync(STATE_PATH)) return empty();
+  try {
+    return { ...empty(), ...JSON.parse(readFileSync(STATE_PATH, 'utf8')) };
+  } catch {
+    return empty();
+  }
+}
+
+function save(state) {
+  mkdirSync(dirname(STATE_PATH), { recursive: true });
+  state.updatedAt = new Date().toISOString();
+  const tmp = STATE_PATH + '.tmp';
+  writeFileSync(tmp, JSON.stringify(state, null, 2) + '\n', { mode: 0o600 });
+  renameSync(tmp, STATE_PATH);
+}
+
+function ensureSeat(state, provider, email) {
+  if (!state.providers[provider]) state.providers[provider] = { seats: {} };
+  if (!state.providers[provider].seats[email]) {
+    state.providers[provider].seats[email] = {
+      schedulable: true,
+      util5h: null,
+      util7d: null,
+      exhaustedUntil: null,
+      lastError: null,
+      updatedAt: null,
+    };
+  }
+  return state.providers[provider].seats[email];
+}
+
+function printStatus(state) {
+  console.log(`seat-state: ${STATE_PATH}`);
+  console.log(`updatedAt: ${state.updatedAt || '(never)'}`);
+  const providers = Object.keys(state.providers || {});
+  if (!providers.length) {
+    console.log('(no seats — import from provider status or set …)');
+    return;
+  }
+  for (const p of providers) {
+    const seats = state.providers[p].seats || {};
+    const emails = Object.keys(seats);
+    const on = emails.filter((e) => seats[e].schedulable !== false);
+    console.log(`\n=== ${p} ===  schedulable ${on.length}/${emails.length}`);
+    for (const e of emails) {
+      const s = seats[e];
+      const flag = s.schedulable === false ? 'off' : 'on';
+      const u5 = s.util5h == null ? '—' : `${s.util5h}%`;
+      const u7 = s.util7d == null ? '—' : `${s.util7d}%`;
+      console.log(`  [${flag}] ${e}  5h=${u5} 7d=${u7}`);
+    }
+  }
+}
+
+const [cmd, ...args] = process.argv.slice(2);
+const state = load();
+
+switch (cmd) {
+  case 'path':
+    console.log(STATE_PATH);
+    break;
+  case 'status':
+  case undefined:
+  case '':
+    printStatus(state);
+    break;
+  case 'list': {
+    const provider = args[0];
+    if (provider) {
+      console.log(JSON.stringify(state.providers[provider] || { seats: {} }, null, 2));
+    } else {
+      console.log(JSON.stringify(state, null, 2));
+    }
+    break;
+  }
+  case 'set': {
+    const [provider, email, ...kvs] = args;
+    if (!provider || !email || !kvs.length) {
+      console.error('usage: seat-state set <provider> <email> key=value …');
+      process.exit(2);
+    }
+    const seat = ensureSeat(state, provider, email);
+    for (const kv of kvs) {
+      const i = kv.indexOf('=');
+      if (i < 0) continue;
+      const k = kv.slice(0, i);
+      let v = kv.slice(i + 1);
+      if (v === 'true') v = true;
+      else if (v === 'false') v = false;
+      else if (v === 'null') v = null;
+      else if (/^-?\d+(\.\d+)?$/.test(v)) v = Number(v);
+      seat[k] = v;
+    }
+    seat.updatedAt = new Date().toISOString();
+    save(state);
+    console.log(`ok: ${provider} ${email}`);
+    break;
+  }
+  case 'toggle': {
+    const [provider, email, flag] = args;
+    if (!provider || !email) {
+      console.error('usage: seat-state toggle <provider> <email> [true|false]');
+      process.exit(2);
+    }
+    const seat = ensureSeat(state, provider, email);
+    if (flag === 'true' || flag === 'false') seat.schedulable = flag === 'true';
+    else seat.schedulable = !seat.schedulable;
+    seat.updatedAt = new Date().toISOString();
+    save(state);
+    console.log(`ok: ${provider} ${email} schedulable=${seat.schedulable}`);
+    break;
+  }
+  case 'import-claude-config': {
+    // Best-effort: seed emails from rotation config (no tokens)
+    const candidates = [
+      process.env.CRS_CONFIG,
+      join(DATA, 'account-rotation', 'config.json'),
+      join(homedir(), '.claude', 'plugins', 'data', 'ops', 'account-rotation', 'config.json'),
+    ].filter(Boolean);
+    let cfg = null;
+    for (const p of candidates) {
+      if (existsSync(p)) {
+        try {
+          cfg = JSON.parse(readFileSync(p, 'utf8'));
+          break;
+        } catch {
+          /* next */
+        }
+      }
+    }
+    if (!cfg?.accounts?.length) {
+      console.error('no accounts in rotation config');
+      process.exit(1);
+    }
+    for (const a of cfg.accounts) {
+      const email = a.email || a.label;
+      if (!email) continue;
+      ensureSeat(state, 'claude', email);
+      state.providers.claude.seats[email].updatedAt = new Date().toISOString();
+    }
+    save(state);
+    console.log(`ok: imported ${cfg.accounts.length} claude seats`);
+    break;
+  }
+  default:
+    console.error('usage: seat-state status|list|set|toggle|import-claude-config|path');
+    process.exit(2);
+}

--- a/claude-ops/skills/ops-accounts/SKILL.md
+++ b/claude-ops/skills/ops-accounts/SKILL.md
@@ -1,59 +1,108 @@
 ---
 name: ops-accounts
-description: Multi-provider AI account manager (Claude, Grok/xAI, Codex, Factory, Cursor). Status, switch, refresh, and reauth behind one skill. Node adapters under scripts/ops-accounts/; /ops:rotate remains a Claude-focused alias.
-argument-hint: '[status|switch|refresh|reauth|list|providers] [provider] [email]'
+description: Multi-provider AI account manager (Claude, Grok/xAI, OpenAI/Codex, Factory, Cursor). Status, setup, switch, refresh, reauth, util, optional CRS/LB. Canonical replacement for /ops:rotate and /ops:rotate-setup (those remain aliases).
+argument-hint: '[status|list|setup|switch|refresh|reauth|util|rotate-now|crs|crs-tick|help] [provider] [args…]'
 allowed-tools:
   - Bash
   - Read
+  - Write
+  - Edit
   - AskUserQuestion
-effort: low
-maxTurns: 20
+effort: medium
+maxTurns: 40
 ---
 
-# OPS ► ACCOUNTS (phase 0)
+# OPS ► ACCOUNTS
 
-One skill for **all** paid AI seats on the box. Engines stay specialized;
-`scripts/ops-accounts/` is the **router + adapters**.
+**Canonical** multi-provider seat manager. Same layers Anthropic has for Claude —
+for every provider:
 
-| Provider | Adapter | Unattended reauth |
-|----------|---------|-------------------|
-| Claude | `providers/claude.mjs` → rotate / rotate-magic | magic-link + captcha cascade (#727) |
-| Grok | `providers/grok.mjs` → grok-oauth-reauth | xAI device-code + Google (dcli); **EFG SOCKS residential** default `socks5://127.0.0.1:1089` |
-| OpenAI/Codex | `providers/openai.mjs` | status only phase 0 (`codex login` handoff) |
-| Factory | `providers/factory.mjs` | billing restore (402 ≠ reauth) |
-| Cursor | `providers/cursor.mjs` | cloud login; remaining needs session cookie |
+| Layer | Verbs |
+|-------|--------|
+| Status / list | `status`, `list` |
+| Setup / OAuth capture | `setup` |
+| Switch active seat | `switch`, `rotate-now` (Claude) |
+| Refresh tokens | `refresh` |
+| Unattended reauth | `reauth` |
+| Utilization / quota | `util` |
+| Optional Claude LB (CRS or future gateway) | `crs`, `crs-tick` |
 
-CRS is **optional** and Claude-oriented (relay LB). Not required for standalone reauth.
+**Aliases (compat):** `/ops:rotate` → this skill (Claude-focused shortcuts).  
+`/ops:rotate-setup` → `setup` (wizard). `/ops:account` → same as this skill.
 
-## Subcommands (`$ARGUMENTS`)
+## Providers
 
-| Args | Action |
-|------|--------|
-| (none) / `status` / `list` | Cross-provider AccountRows (no secrets) |
-| `providers` | List adapter ids |
-| `switch grok` | SuperGrok next seat |
-| `switch claude` | Handoff to rotate-now |
-| `refresh [all\|claude\|grok\|openai]` | Best-effort token refresh |
-| `reauth claude <email>` | `rotate-magic.mjs` |
-| `reauth grok <email>` | `grok-oauth-reauth` (residential SOCKS) |
+| Provider | Engine | Reauth | Util |
+|----------|--------|--------|------|
+| Claude | `scripts/account-rotation/rotate.mjs` + `rotate-magic.mjs` | magic-link + captcha cascade | 5h/7d |
+| Grok | slots + `grok-cli-auth-proxy` (+ optional CRS hop) | device-code + Google (dcli); residential egress cascade | weekly / 429 |
+| OpenAI / Codex | `codex-rotate` when present | OAuth bridge | usage best-effort |
+| Factory | adapter TBD / quota-feed seeds | native | quota-feed patterns |
+| Cursor | adapter TBD | browser/device OAuth | plan limits if available |
 
-## How to run
+**CRS is optional.** For Grok, CRS is only a thin hop to the SuperGrok OAuth proxy — multi-seat RR lives on the proxy, not a CRS account table. See `docs/ops/OPS-ACCOUNTS-VISION.md` (CRS cherry-pick / no-CRS path).
+
+## Router (`bin/ops-accounts`)
+
+Always prefer:
 
 ```bash
-export CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/ops-marketplace/claude-ops}"
-"${CLAUDE_PLUGIN_ROOT}/bin/ops-accounts" status
-"${CLAUDE_PLUGIN_ROOT}/bin/ops-accounts" reauth grok <email>
-node "${CLAUDE_PLUGIN_ROOT}/scripts/ops-accounts/__tests__/ops-accounts-smoke.mjs"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1)}"
+"$PLUGIN_ROOT/bin/ops-accounts" <cmd> …
 ```
 
-`/ops:rotate *` remains a **Claude-only alias** for one major version.
+| Command | Action |
+|---------|--------|
+| `status` / `list` | All configured providers (no secrets) |
+| `util [claude\|grok\|all]` | Quota / utilization best-effort |
+| `switch claude` / `rotate-now` | Claude keychain rotate (`force-rotate` / `rotate.mjs`) |
+| `switch grok` | Next SuperGrok seat (`grok-rotate switch`) |
+| `refresh [all\|claude\|grok]` | Keepalive / RT refresh |
+| `reauth claude <email>` | `rotate-magic.mjs --to <email>` |
+| `reauth grok <email>` | Device reauth with residential cascade env |
+| `setup` / `setup claude` | Full Claude OAuth wizard (former rotate-setup steps) |
+| `setup grok` | Add/reauth SuperGrok seat |
+| `crs` / `crs-tick` | Optional Claude CRS pool status / one tick |
+| `seats` | Local multi-provider seat-state (no CRS) |
+
+## Claude setup / OAuth
+
+When `$ARGUMENTS` is `setup`, `setup claude`, or this skill is invoked via
+**ops-rotate-setup** alias: follow the full wizard in
+`skills/ops-rotate-setup/SKILL.md` (Steps 1–5, CRS optional 4.4–4.7). That file
+remains the detailed Claude setup procedure; this skill is the entrypoint.
+
+Claude day-2 ops (`status`/`rotate-now`/`list`/`reauth`/`crs`) also match
+`skills/ops-rotate/SKILL.md` — treat that as Claude detail appendix.
+
+## Local seat-state (no CRS)
+
+```bash
+"$PLUGIN_ROOT/bin/ops-accounts" seats status
+"$PLUGIN_ROOT/bin/ops-accounts" seats import-claude-config
+node "$PLUGIN_ROOT/scripts/account-rotation/seat-state.mjs" toggle claude <email> false
+```
+
+File: `$CLAUDE_PLUGIN_DATA_DIR/account-rotation/seat-state.json` (or `OPS_ACCOUNTS_STATE_PATH`).
+
+## Grok notes
+
+1. CLI models often use `base_url` → CRS `/grok/v1` → **host OAuth proxy** → SuperGrok seats.  
+2. `grok-rotate` / `auth.json` is the SuperGrok seat set; keep **auth-slots** in sync after reauth.  
+3. Reauth egress: EFG SOCKS (`GROK_REAUTH_SOCKS`) → Bright Data tiers via  
+   `scripts/account-rotation/grok-reauth-egress.sh` (residential cascade).  
+4. Proxy RR status: `curl -sS http://127.0.0.1:31845/accounts` (no tokens).
 
 ## Rules
 
-1. **Never print tokens, cookies, or full vault dumps.**
-2. Prefer this bin over host paths so cutover retargets one file.
-3. Grok reauth uses residential EFG SOCKS unless `GROK_REAUTH_DIRECT=1`.
-4. Factory 402 / Cursor empty pools: report honestly; do not invent remaining.
-5. Dead Claude RT: `reauth claude <email>` — do not claim CRS fixes OAuth.
+1. Never print tokens, cookies, OTP codes, or vault dumps.  
+2. Never write real emails into committed files.  
+3. Prefer `bin/ops-accounts` over ad-hoc host paths.  
+4. Missing CRS is not a failure.  
+5. Dead RT → `reauth`, not “install CRS.”  
+6. Background long OAuth (Rule 4).  
 
-See `docs/ops/OPS-ACCOUNTS-VISION.md` and plan `2026-07-30T1705Z-ops-accounts-phase0-adapter.md`.
+## Phase map
+
+0 contract + this skill · 1 Claude parity · 2 CRS optional · 3 Grok complete ·  
+4 Codex+Factory · 5 Cursor · 6 companions · 7 host cutover · 8 gateway (no CRS)

--- a/claude-ops/skills/ops-rotate-setup/SKILL.md
+++ b/claude-ops/skills/ops-rotate-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ops-rotate-setup
-description: Interactive OAuth init wizard for the multi-account Claude rotator. Walks through every account in the rotation config and, for any account missing a valid keychain token, delegates to the proven `rotate.mjs` / `rotate-magic.mjs` magic-link flow (browser-driver cascade + Gmail polling), which writes the verified OAuth token to `Claude-Rotation-<key>` (key = account label or email, keychain account `$USER`). CRS is optional (multi-account load balancing only). Re-runnable any time. Standalone alias of the same step inside `/ops:setup`.
+description: Alias of /ops:accounts setup for Claude OAuth init wizard. Prefer /ops:accounts setup. CRS optional multi-account LB only.
 argument-hint: '[--all|--account <email>|--add|--crs|--standalone]'
 allowed-tools:
   - Bash
@@ -9,6 +9,10 @@ allowed-tools:
 effort: medium
 maxTurns: 25
 ---
+> **Alias:** Prefer **`/ops:accounts setup`** (or `/ops:accounts setup claude`).  
+> This file remains the detailed Claude OAuth wizard. Multi-provider entry is ops-accounts.
+
+
 
 ## Purpose
 

--- a/claude-ops/skills/ops-rotate/SKILL.md
+++ b/claude-ops/skills/ops-rotate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ops-rotate
-description: Multi-account Claude Max rotator. Status, manual rotation, account list, add-account wizard, standalone rotate-magic reauth, and optional CRS relay-pool auto-prioritization. CRS is not required. Requires account_rotation_enabled=true in plugin settings for daemon swap; reauth works without it.
+description: Alias of /ops:accounts for Claude Max seats (status, rotate-now, list, reauth, optional CRS). Prefer /ops:accounts for multi-provider. Full Claude procedure still in this file's historical detail via ops-accounts router.
 argument-hint: '[status|rotate-now|list|add-account|reauth|crs|crs-tick]'
 allowed-tools:
   - Bash
@@ -12,215 +12,28 @@ effort: low
 maxTurns: 25
 ---
 
-> **Alias note:** Multi-provider seats live under `/ops:accounts`. This skill stays Claude-focused; prefer `ops-accounts` for Grok/Codex/Factory/Cursor.
+# OPS ► ROTATE (alias → `/ops:accounts`)
 
+This skill is a **compat alias**. Route all work through **ops-accounts**:
 
-# OPS ► ROTATE
+| Old verb | New |
+|----------|-----|
+| (none) / status | `ops-accounts status` (Claude section) |
+| rotate-now | `ops-accounts switch claude` / `ops-accounts rotate-now` |
+| list | `ops-accounts list` |
+| add-account | `ops-accounts setup claude` |
+| reauth | `ops-accounts reauth claude <email>` |
+| crs / crs-tick | `ops-accounts crs` / `ops-accounts crs-tick` |
 
-Manage the optional multi-account Claude Max rotator. Off by default — flip
-`account_rotation_enabled` in plugin settings to use it.
+Load **`skills/ops-accounts/SKILL.md`** first, then for Claude-only depth use the
+bin:
 
-## Subcommands
-
-| `$ARGUMENTS`       | Action                                                                   |
-| ------------------ | ------------------------------------------------------------------------ |
-| (none) or `status` | Show current account, 5h%/7d%, total rotations, daemon health            |
-| `rotate-now`       | Force rotation to the most-cooled candidate (or `--to <email>`)          |
-| `list`             | List every configured account with token state + last util               |
-| `add-account`      | Interactive wizard: collect email, OAuth into rotator vault              |
-| `reauth`           | Standalone rotate-magic for one email (no CRS): magic-link + captcha     |
-| `crs`              | Show the CRS relay-pool schedulable state + priority-daemon health       |
-| `crs-tick`         | Run one CRS priority tick now (append `--dry-run` to preview, no writes) |
-
-## Rotation models (CRS is optional)
-
-This skill manages **complementary** account systems. **CRS is never required.**
-
-- **Standalone rotate-magic** (`reauth`, and setup OAuth) — one account at a time.
-  Magic-link + captcha cascade. Enough for single/few accounts. No CRS install.
-- **Keychain rotator** (`status`/`rotate-now`/`list`/`add-account`) — for **direct-auth**
-  sessions. One active claude.ai OAuth token in the keychain at a time; the daemon swaps
-  to the coolest account when the active one heats up.
-- **CRS priority daemon** (`crs`/`crs-tick`) — **optional** multi-account load balancing
-  / rate-limit spreading via **claude-relay-service**. Toggles each account's
-  `schedulable` flag from live utilization. Off by default; configure only if you
-  run a CRS pool (see **ops-rotate-setup** Step 4.4 detection).
-
-## Pre-flight (every invocation)
-
-1. Read `account_rotation_enabled` from plugin preferences. If false, tell the user how to enable and exit.
-2. Resolve paths:
-   - `ROT_DIR=${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops}/account-rotation`
-   - `ROT_SRC=${CLAUDE_PLUGIN_ROOT}/scripts/account-rotation`
-3. If `$ROT_DIR` doesn't exist yet, mirror the runtime layout:
-   ```
-   mkdir -p "$ROT_DIR"
-   cp "$ROT_SRC/config.example.json" "$ROT_DIR/config.json"  # only if missing
-   ```
-4. Verify Node 20+: `node --version`. If missing, fail fast with install hint.
-
-## status (default)
-
-Run:
-
-```
-node "$ROT_SRC/rotate.mjs" --status
-node "$ROT_SRC/rotate.mjs" --utilization 2>/dev/null | head -40
-launchctl list 2>/dev/null | grep com.claude-ops.account-rotation || echo "daemon: not loaded"
+```bash
+"${CLAUDE_PLUGIN_ROOT}/bin/ops-accounts" status
+"${CLAUDE_PLUGIN_ROOT}/bin/ops-accounts" rotate-now
+"${CLAUDE_PLUGIN_ROOT}/bin/ops-accounts" reauth claude <email>
 ```
 
-Render a compact panel:
+Multi-provider status, Grok, Codex, Factory, Cursor: **`/ops:accounts` only**.
 
-```
-ROTATOR STATUS
-  Active account : <email>
-  5h utilization : 42% (resets in 1h 23m)
-  7d utilization : 18%
-  Total rotations: 14
-  Daemon         : ✓ running (PID 12345)  |  ✗ not loaded
-  Configured     : 4 accounts (3 with valid tokens, 1 expired)
-```
-
-## rotate-now
-
-If user passed an explicit target email (`/ops:rotate rotate-now user@example.com`), pass `--to "<email>"`. Otherwise let `rotate.mjs` pick the most-cooled.
-
-```
-bash "$ROT_SRC/force-rotate.sh" "${TARGET_EMAIL:-}"
-```
-
-Show the trailing status output. Remind the user that running Claude Code sessions hold their own access token until next `/login` or until they exit and re-enter.
-
-## list
-
-```
-node "$ROT_SRC/rotate.mjs" --status 2>/dev/null
-```
-
-Then for each account in `$ROT_DIR/config.json`, render one row:
-
-```
-  [✓] user@example.com           5h 12%   token valid 6.4h  (active)
-  [✓] backup@example.com         5h 87%   token valid 3.1h
-  [✗] expired@example.com        ── ──    token expired 2d ago
-  [○] new@example.com            ── ──    no token captured
-```
-
-If any row is `[○]` or `[✗]`, suggest running `/ops:rotate add-account` for that email.
-
-## add-account (interactive)
-
-This is the only mutating subcommand. Walk the user through:
-
-1. **Collect email.** `AskUserQuestion`: "Email of the Claude Max account to add?" (free text via `Edit` to config — the skill must NOT capture sensitive data through chat options; just ask for the email).
-2. **Optional metadata.** Ask if it's a Workspace account (`AskUserQuestion`: `[Personal]`, `[Workspace]`, `[Skip]`). If Workspace, prompt for `orgName` (free text) — `orgUuid` is auto-discovered later.
-3. **Append to config.** Read `$ROT_DIR/config.json`, append the new account entry to `accounts[]`, write back. Use the schema from `config.example.json._account_schema_example`.
-4. **Capture token.** Two paths via `AskUserQuestion`:
-   - `[Use current Claude Code login]` — runs `node "$ROT_SRC/rotate.mjs" --capture --to <email>` to copy the live `Claude Code-credentials` token into the rotator vault.
-   - `[Run OAuth in browser now]` — runs `node "$ROT_SRC/rotate.mjs" --setup --only=<email>` (background-friendly; opens Chrome).
-   - `[Skip — I'll capture later]`.
-5. **Daemon install (one-time).** If launchd doesn't show `com.claude-ops.account-rotation`, ask `[Install + start daemon]` / `[Skip]`. On install:
-   ```
-   sed "s|\${HOME}|$HOME|g" "${CLAUDE_PLUGIN_ROOT}/templates/com.claude-ops.account-rotation.plist" > ~/Library/LaunchAgents/com.claude-ops.account-rotation.plist
-   launchctl load ~/Library/LaunchAgents/com.claude-ops.account-rotation.plist
-   ```
-   Mirror `daemon.mjs` + friends to `$ROT_DIR` if not already symlinked:
-   ```
-   for f in rotate.mjs daemon.mjs ai-brain.mjs force-rotate.sh; do
-     [ -e "$ROT_DIR/$f" ] || ln -s "$ROT_SRC/$f" "$ROT_DIR/$f"
-   done
-   ```
-6. **Verify.** Run `status` subcommand inline.
-
-## reauth (standalone rotate-magic — no CRS)
-
-Refresh one account's vault token via magic-link + captcha cascade. Does **not**
-need CRS or `crs.enabled`.
-
-```
-EMAIL="<email>"   # required
-node "$ROT_SRC/rotate-magic.mjs" --to "$EMAIL"
-# equivalent:
-# node "$ROT_SRC/rotate.mjs" --magic-link --to "$EMAIL"
-```
-
-Background-friendly; surface the log. Headed display + cascade env:
-`CLAUDE_DESKTOP_DISPLAY`, `CLAUDE_ROT_HEADED=1` (see `CAPTCHA-CASCADE.md`).
-If the user only has one seat, this is the primary recovery path — do not
-push them to install CRS.
-
-## crs (relay-pool status)
-
-**Only if CRS is present.** Detect first (same checks as ops-rotate-setup Step 4.4:
-`command -v crs`, `crs.enabled` in config, `$CRS_BASE_URL/health` or default
-`http://127.0.0.1:3000/health`). If not detected, explain briefly that CRS is
-optional load balancing and suggest `reauth` / `/ops:rotate-setup --standalone`
-instead of failing.
-
-When CRS is available: show the pool's per-account schedulable state + the priority
-daemon's health, plus the three optional reconcilers (429-cooldown, 401-refresher,
-magic-link-autoloop) if enabled. Read-only.
-
-```
-WRAP="$ROT_SRC/crs-priority-daemon.sh"
-bash "$WRAP" --status 2>&1 | head -40   # prints "● name sched=true 5h=NN%  <status>"
-launchctl list 2>/dev/null | grep com.claude-ops.crs-priority || echo "crs-priority daemon: not loaded"
-tail -n 5 "${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/logs/crs-priority.log" 2>/dev/null
-
-# Only if crs.cooldownEnabled / crs.tokenRefreshEnabled / crs.enableMagicLinkRecovery are true in config:
-node "$ROT_SRC/crs-429-cooldown.mjs" --status 2>&1
-launchctl list 2>/dev/null | grep com.claude-ops.crs-429-cooldown || echo "crs-429-cooldown: not loaded"
-node "$ROT_SRC/crs-401-refresher.mjs" --status 2>&1
-launchctl list 2>/dev/null | grep com.claude-ops.crs-401-refresher || echo "crs-401-refresher: not loaded"
-node "$ROT_SRC/magic-link-autoloop.mjs" --status 2>&1
-launchctl list 2>/dev/null | grep com.claude-ops.magic-link-autoloop || echo "magic-link-autoloop: not loaded"
-```
-
-Render a compact panel:
-
-```
-CRS POOL  (http://127.0.0.1:3000)
-  schedulable : 7 / 10
-  off         : canary-sponsors (rate-limited), pool-chairman (warning), pool-foundation (warning)
-  daemon      : ✓ running (every 120s)  |  ✗ not loaded — run /ops:rotate-setup
-  429-cooldown: ✓ running (every 60s)   |  ✗ not loaded  |  – not enabled (crs.cooldownEnabled=false)
-  401-refresher: ✓ running (every 300s) |  ✗ not loaded  |  – not enabled (crs.tokenRefreshEnabled=false)
-  magic-link  : ✓ running (every 600s)  |  ✗ not loaded  |  – not enabled (crs.enableMagicLinkRecovery=false)
-```
-
-If CRS `/health` is unreachable, say so and point to `/ops:rotate-setup` (optional)
-or standalone `reauth`. If the daemon isn't loaded but `crs.enabled` is true, suggest
-`/ops:rotate-setup --crs`. Show reconciler lines only if their config flag is true —
-if false, show `– not enabled` (opt-in, not a failure). If a flag is true but its
-daemon isn't loaded, suggest `/ops:rotate-setup --reconcilers`.
-
-## crs-tick (run one tick now)
-
-Apply (or, with `--dry-run`, preview) one prioritization pass immediately — useful
-right after changing thresholds or to confirm the policy.
-
-```
-bash "$ROT_SRC/crs-priority-daemon.sh" ${ARGS:-}   # ARGS="--dry-run" to preview
-```
-
-This is the same code the launchd timer runs; the daemon only ever toggles
-`schedulable` (fully reversible) and never deletes or mutates account credentials.
-
-## Optional npm dep
-
-`rotate.mjs` uses Playwright only for the browser fallback. It is declared as
-an optional dep in the plugin's `package.json`. If a browser fallback is needed
-and Playwright is missing, the skill should offer:
-
-```
-npm install --prefix "$CLAUDE_PLUGIN_ROOT" --no-save playwright
-npx --prefix "$CLAUDE_PLUGIN_ROOT" playwright install chromium
-```
-
-## Hard rules
-
-- This skill is **read-mostly**. Only `add-account` mutates `config.json`, and only after the user explicitly confirmed the email.
-- Never echo refresh tokens or access tokens to chat output.
-- Never auto-edit `config.json` outside `add-account` — token rotation is the daemon's job, not the skill's.
-- If `account_rotation_enabled` is false, refuse to run subcommands and instead explain the toggle.
-- If multiple OS users share the Mac, surface `CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT` as the override env var.
+Vision: `docs/ops/OPS-ACCOUNTS-VISION.md`.


### PR DESCRIPTION
## Summary

Makes **`/ops:accounts`** the canonical multi-provider account surface (Anthropic-shaped for every provider).

- **`/ops:rotate`** and **`/ops:rotate-setup`** become **aliases** (compat)
- Expanded `bin/ops-accounts`: status, util, switch, rotate-now, refresh, reauth, setup, crs
- **`grok-reauth-egress.sh`**: residential cascade for Grok device OAuth (EFG SOCKS → Bright Data residential → ISP → mobile → SOCKS fallback)
- Claude setup detail remains in ops-rotate-setup body; entry is ops-accounts

Pairs with plan PR #731 (vision / CRS cherry-pick docs).

## Test plan

- [ ] `bin/ops-accounts help` / `status` / `util`
- [ ] PII gate (no real emails in new skill text)
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OAuth reauth routing, Grok egress/proxy selection, and schedulable seat policy for account rotation—important ops paths but mostly new local tooling and shell routing rather than core token/crypto changes.
> 
> **Overview**
> **`/ops:accounts`** becomes the canonical multi-provider seat surface; **`/ops:rotate`** and **`/ops:rotate-setup`** are documented as compat aliases that route through `bin/ops-accounts`.
> 
> The shell fallback router in **`bin/ops-accounts`** is expanded beyond status/reauth to **`util`**, **`switch`/`rotate-now`**, **`refresh`**, **`setup`**, **`crs`/`crs-tick`**, and **`seats`**. Grok status/util now probes the local OAuth proxy (`:31845`) and optional CRS hop; Grok **`reauth`** sources **`grok-reauth-egress.sh`** before device OAuth.
> 
> **No-CRS local scheduling:** new **`seat-state.mjs`** (file-backed `seat-state.json`) and **`seat-policy-tick.mjs`** (5h/7d thresholds, floor, optional live util from `rotate.mjs`) back **`ops-accounts seats`** / **`seats tick`**.
> 
> **`skills/ops-rotate/SKILL.md`** is trimmed to an alias map; Claude depth moves to **`ops-accounts`** + **`ops-rotate-setup`**. Changelog unreleased section is consolidated around the ops-accounts vision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48ce16e34b802dfd3bf697f7b74ff26310151bd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified multi-provider account manager for Claude, Grok/xAI, Codex, Factory, and Cursor.
  * Added commands for status, setup, switching, refreshing, reauthentication, utilities, and seat management.
  * Added local seat tracking with configurable scheduling policies and minimum seat floors.
  * Added automatic proxy and egress selection for Grok reauthentication.

* **Documentation**
  * Updated account-management guidance and clarified compatibility aliases for existing rotation commands.
  * Documented optional CRS support and local seat management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->