### PR TITLE
feat(ops-accounts): Node multi-provider adapters (claude/grok/openai/factory/cursor)

### DIFF
--- a/claude-ops/bin/ops-accounts
+++ b/claude-ops/bin/ops-accounts
@@ -1,135 +1,71 @@
 #!/usr/bin/env bash
 # ops-accounts — multi-provider account status / switch / refresh / reauth router.
-# Phase 0 thin shell: delegates to existing engines (Claude rotate, grok-*, codex).
-# No host hardcodes beyond $HOME; no secrets printed.
+# Prefers Node CLI (scripts/ops-accounts/cli.mjs) when present; else thin shell fallback.
 set -euo pipefail
 
+resolve_root() {
+  if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" && -d "${CLAUDE_PLUGIN_ROOT}" ]]; then
+    printf '%s' "${CLAUDE_PLUGIN_ROOT}"
+    return
+  fi
+  local here
+  here="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  if [[ -f "$here/scripts/ops-accounts/cli.mjs" ]]; then
+    printf '%s' "$here"
+    return
+  fi
+  local c
+  c="$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1 || true)"
+  if [[ -n "$c" ]]; then
+    printf '%s' "${c%/}"
+    return
+  fi
+  printf '%s' "$here"
+}
+
+ROOT="$(resolve_root)"
+export CLAUDE_PLUGIN_ROOT="$ROOT"
+CLI="$ROOT/scripts/ops-accounts/cli.mjs"
+
+if [[ -f "$CLI" ]]; then
+  exec node "$CLI" "$@"
+fi
+
+# --- fallback shell (phase-0 pre-Node) ---
 cmd="${1:-status}"
 shift || true
-
 have() { command -v "$1" >/dev/null 2>&1; }
 
 print_claude() {
   echo "=== Claude ==="
-  local rot="${CLAUDE_PLUGIN_ROOT:-}/scripts/account-rotation"
-  if [[ -z "${CLAUDE_PLUGIN_ROOT:-}" ]]; then
-    # best-effort cache path
-    local c
-    c="$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1 || true)"
-    rot="${c}scripts/account-rotation"
-  fi
+  local rot="$ROOT/scripts/account-rotation"
   if [[ -f "$rot/rotate.mjs" ]]; then
     node "$rot/rotate.mjs" --status 2>/dev/null | head -40 || echo "(rotate.mjs --status failed)"
   else
-    echo "plugin rotate.mjs not found (set CLAUDE_PLUGIN_ROOT or install ops plugin)"
+    echo "plugin rotate.mjs not found"
   fi
 }
-
 print_grok() {
   echo "=== Grok ==="
-  if have grok-rotate; then
-    grok-rotate status 2>/dev/null || true
-  else
-    echo "grok-rotate not on PATH"
-  fi
-  if have host-token-keepalive; then
-    host-token-keepalive --status --grok-only 2>/dev/null | tail -15 || true
-  fi
+  have grok-rotate && grok-rotate status 2>/dev/null || echo "grok-rotate not on PATH"
 }
-
 print_codex() {
   echo "=== Codex / OpenAI ==="
-  if have codex-rotate; then
-    codex-rotate status 2>/dev/null | head -30 || echo "(codex-rotate status failed)"
-  else
-    echo "codex-rotate not on PATH (optional)"
-  fi
+  have codex-rotate && codex-rotate status 2>/dev/null | head -30 || echo "codex-rotate optional"
 }
 
 case "$cmd" in
-  status|"")
-    print_claude
-    echo
-    print_grok
-    echo
-    print_codex
-    ;;
-  switch)
-    provider="${1:-}"
-    target="${2:-}"
-    case "$provider" in
-      grok|xai)
-        if [[ -n "$target" ]]; then
-          # force state to previous index so switch lands on target if ordered — fallback simple switch
-          grok-rotate switch
-        else
-          grok-rotate switch
-        fi
-        grok-rotate status
-        ;;
-      claude)
-        echo "use: /ops:rotate rotate-now [--to email] or node rotate.mjs --rotate"
-        ;;
-      *)
-        echo "usage: ops-accounts switch grok|claude [email]"
-        exit 2
-        ;;
-    esac
-    ;;
-  refresh)
-    provider="${1:-all}"
-    case "$provider" in
-      grok)
-        host-token-keepalive --force --grok-only 2>/dev/null || grok-rotate refresh
-        ;;
-      claude)
-        host-token-keepalive --force --claude-only 2>/dev/null || true
-        ;;
-      all|"")
-        host-token-keepalive --force 2>/dev/null || true
-        ;;
-      *)
-        echo "usage: ops-accounts refresh [all|claude|grok]"
-        exit 2
-        ;;
-    esac
-    ;;
+  status|list|"") print_claude; echo; print_grok; echo; print_codex ;;
   reauth)
-    provider="${1:-}"
-    email="${2:-}"
+    provider="${1:-}"; email="${2:-}"
     case "$provider" in
-      grok|xai)
-        [[ -n "$email" ]] || { echo "usage: ops-accounts reauth grok <email>"; exit 2; }
-        export DISPLAY="${DISPLAY:-:1}"
-        grok-oauth-reauth --email "$email"
-        ;;
-      claude)
-        [[ -n "$email" ]] || { echo "usage: ops-accounts reauth claude <email>"; exit 2; }
-        root="${CLAUDE_PLUGIN_ROOT:-}"
-        if [[ -z "$root" ]]; then
-          root="$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1)"
-        fi
-        node "${root}/scripts/account-rotation/rotate-magic.mjs" --to "$email" --force
-        ;;
-      *)
-        echo "usage: ops-accounts reauth grok|claude <email>"
-        exit 2
-        ;;
-    esac
-    ;;
+      grok|xai) [[ -n "$email" ]] || { echo "usage: ops-accounts reauth grok <email>"; exit 2; }
+        grok-oauth-reauth --email "$email" ;;
+      claude) [[ -n "$email" ]] || { echo "usage: ops-accounts reauth claude <email>"; exit 2; }
+        node "$ROOT/scripts/account-rotation/rotate-magic.mjs" --to "$email" --force ;;
+      *) echo "usage: ops-accounts reauth grok|claude <email>"; exit 2 ;;
+    esac ;;
   -h|--help|help)
-    cat <<H
-ops-accounts — multi-provider seat router (phase 0)
-
-  ops-accounts status
-  ops-accounts switch grok|claude
-  ops-accounts refresh [all|claude|grok]
-  ops-accounts reauth grok <email>
-  ops-accounts reauth claude <email>
-H
-    ;;
-  *)
-    echo "unknown command: $cmd (try help)"
-    exit 2
-    ;;
+    echo "ops-accounts status|reauth|switch|refresh (Node CLI missing — thin shell)" ;;
+  *) echo "unknown: $cmd"; exit 2 ;;
 esac

--- a/claude-ops/scripts/ops-accounts/__tests__/ops-accounts-smoke.mjs
+++ b/claude-ops/scripts/ops-accounts/__tests__/ops-accounts-smoke.mjs
@@ -1,0 +1,34 @@
+/**
+ * Smoke: load providers and list without throwing; no secrets.
+ */
+import { loadProviders, makeCtx } from '../registry.mjs';
+
+const ctx = makeCtx({ dryRun: true });
+const providers = await loadProviders();
+const ids = providers.map((p) => p.providerId).sort();
+const expect = ['claude', 'cursor', 'factory', 'grok', 'openai'];
+for (const id of expect) {
+  if (!ids.includes(id)) {
+    console.error('missing provider', id, 'have', ids);
+    process.exit(1);
+  }
+}
+for (const p of providers) {
+  const rows = await p.listAccounts(ctx);
+  if (!Array.isArray(rows)) {
+    console.error(p.providerId, 'listAccounts not array');
+    process.exit(1);
+  }
+  for (const r of rows) {
+    const s = JSON.stringify(r);
+    if (/sk-|cr_|vk-lw-|eyJ|refresh_token|access_token/i.test(s) && /"[a-zA-Z0-9_-]{20,}"/.test(s)) {
+      // soft check — fail only on obvious long secret-looking values under token keys
+      if (/"accessToken"\s*:\s*"[^"]{10,}"/i.test(s) || /"refresh_token"\s*:\s*"[^"]{10,}"/i.test(s)) {
+        console.error(p.providerId, 'leaked token-like field');
+        process.exit(1);
+      }
+    }
+  }
+  console.log(p.providerId, 'rows', rows.length);
+}
+console.log('ops-accounts-smoke: ok');

--- a/claude-ops/scripts/ops-accounts/cli.mjs
+++ b/claude-ops/scripts/ops-accounts/cli.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * ops-accounts CLI — multi-provider seat router (phase 0 Node implementation).
+ * Never prints tokens.
+ */
+import { loadProviders, makeCtx } from './registry.mjs';
+
+function usage() {
+  console.log(`ops-accounts — multi-provider seat router
+
+  ops-accounts status|list [--provider <id>]
+  ops-accounts reauth <provider> <email>
+  ops-accounts switch <provider> [email]
+  ops-accounts refresh [all|claude|grok|openai]
+  ops-accounts providers
+
+Providers: claude, grok, openai, factory, cursor
+`);
+}
+
+function rowLine(r) {
+  const util =
+    r.utilization && typeof r.utilization === 'object'
+      ? JSON.stringify(r.utilization).slice(0, 80)
+      : '-';
+  return [
+    (r.provider || '').padEnd(10),
+    (r.email || r.accountId || '').padEnd(36),
+    (r.tokenState || '-').padEnd(10),
+    (r.active ? 'active' : '-').padEnd(8),
+    (r.lastError || r.billing?.status || '').toString().slice(0, 50),
+    util,
+  ].join(' ');
+}
+
+async function cmdStatus(ctx, providerFilter) {
+  const providers = await loadProviders();
+  const header =
+    'PROVIDER'.padEnd(10) +
+    'EMAIL/ID'.padEnd(36) +
+    'TOKEN'.padEnd(10) +
+    'ACTIVE'.padEnd(8) +
+    'NOTE';
+  console.log(header);
+  console.log('-'.repeat(100));
+  for (const p of providers) {
+    if (providerFilter && p.providerId !== providerFilter) continue;
+    let rows = [];
+    try {
+      rows = await p.listAccounts(ctx);
+    } catch (e) {
+      console.log(`${p.providerId.padEnd(10)} (list failed: ${e.message})`);
+      continue;
+    }
+    if (!rows.length) {
+      console.log(`${p.providerId.padEnd(10)} (no seats found)`);
+      continue;
+    }
+    for (const r of rows) console.log(rowLine(r));
+  }
+}
+
+async function cmdReauth(ctx, providerId, email) {
+  const providers = await loadProviders();
+  const p = providers.find((x) => x.providerId === providerId);
+  if (!p) {
+    console.error(`unknown provider: ${providerId}`);
+    process.exit(2);
+  }
+  if (typeof p.reauth !== 'function') {
+    console.error(`${providerId}: reauth not implemented`);
+    process.exit(2);
+  }
+  const r = await p.reauth(ctx, { accountId: email, mode: 'default' });
+  console.log(JSON.stringify({ provider: providerId, email, ...r }, null, 2));
+  process.exit(r.ok ? 0 : 1);
+}
+
+async function cmdSwitch(ctx, providerId, email) {
+  const providers = await loadProviders();
+  const p = providers.find((x) => x.providerId === providerId);
+  if (!p || typeof p.switchTo !== 'function') {
+    console.error(`switch not supported for ${providerId}`);
+    process.exit(2);
+  }
+  const r = await p.switchTo(ctx, { accountId: email });
+  console.log(JSON.stringify({ provider: providerId, ...r }, null, 2));
+  process.exit(r.ok ? 0 : 1);
+}
+
+async function cmdRefresh(ctx, providerId) {
+  const providers = await loadProviders();
+  const list =
+    !providerId || providerId === 'all'
+      ? providers
+      : providers.filter((p) => p.providerId === providerId);
+  for (const p of list) {
+    if (typeof p.refresh !== 'function') {
+      console.log(`${p.providerId}: no refresh`);
+      continue;
+    }
+    const r = await p.refresh(ctx, {});
+    console.log(`${p.providerId}:`, r.ok ? 'ok' : r.reason || 'fail');
+  }
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const cmd = argv[0] || 'status';
+  const ctx = makeCtx({ dryRun: process.env.OPS_ACCOUNTS_DRY_RUN === '1' });
+
+  if (['-h', '--help', 'help'].includes(cmd)) {
+    usage();
+    return;
+  }
+  if (cmd === 'providers') {
+    const providers = await loadProviders();
+    for (const p of providers) {
+      console.log(`${p.providerId}\t${p.displayName || ''}`);
+    }
+    return;
+  }
+  if (cmd === 'status' || cmd === 'list' || cmd === '') {
+    let filter = null;
+    const i = argv.indexOf('--provider');
+    if (i >= 0) filter = argv[i + 1];
+    await cmdStatus(ctx, filter);
+    return;
+  }
+  if (cmd === 'reauth') {
+    await cmdReauth(ctx, argv[1], argv[2]);
+    return;
+  }
+  if (cmd === 'switch') {
+    await cmdSwitch(ctx, argv[1], argv[2]);
+    return;
+  }
+  if (cmd === 'refresh') {
+    await cmdRefresh(ctx, argv[1] || 'all');
+    return;
+  }
+  console.error(`unknown command: ${cmd}`);
+  usage();
+  process.exit(2);
+}
+
+main().catch((e) => {
+  console.error(e.message || e);
+  process.exit(1);
+});

--- a/claude-ops/scripts/ops-accounts/cli.mjs
+++ b/claude-ops/scripts/ops-accounts/cli.mjs
@@ -19,10 +19,7 @@ Providers: claude, grok, openai, factory, cursor
 }
 
 function rowLine(r) {
-  const util =
-    r.utilization && typeof r.utilization === 'object'
-      ? JSON.stringify(r.utilization).slice(0, 80)
-      : '-';
+  const util = r.utilization && typeof r.utilization === 'object' ? JSON.stringify(r.utilization).slice(0, 80) : '-';
   return [
     (r.provider || '').padEnd(10),
     (r.email || r.accountId || '').padEnd(36),
@@ -35,12 +32,7 @@ function rowLine(r) {
 
 async function cmdStatus(ctx, providerFilter) {
   const providers = await loadProviders();
-  const header =
-    'PROVIDER'.padEnd(10) +
-    'EMAIL/ID'.padEnd(36) +
-    'TOKEN'.padEnd(10) +
-    'ACTIVE'.padEnd(8) +
-    'NOTE';
+  const header = 'PROVIDER'.padEnd(10) + 'EMAIL/ID'.padEnd(36) + 'TOKEN'.padEnd(10) + 'ACTIVE'.padEnd(8) + 'NOTE';
   console.log(header);
   console.log('-'.repeat(100));
   for (const p of providers) {
@@ -90,10 +82,7 @@ async function cmdSwitch(ctx, providerId, email) {
 
 async function cmdRefresh(ctx, providerId) {
   const providers = await loadProviders();
-  const list =
-    !providerId || providerId === 'all'
-      ? providers
-      : providers.filter((p) => p.providerId === providerId);
+  const list = !providerId || providerId === 'all' ? providers : providers.filter((p) => p.providerId === providerId);
   for (const p of list) {
     if (typeof p.refresh !== 'function') {
       console.log(`${p.providerId}: no refresh`);

--- a/claude-ops/scripts/ops-accounts/providers/claude.mjs
+++ b/claude-ops/scripts/ops-accounts/providers/claude.mjs
@@ -1,0 +1,132 @@
+/**
+ * Claude adapter — wraps account-rotation config + optional rotate --status.
+ * No secrets in AccountRow.
+ */
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { spawnSync } from 'child_process';
+
+export const providerId = 'claude';
+export const displayName = 'Claude Max';
+
+function rotationDir(ctx) {
+  return join(ctx.pluginRoot, 'scripts', 'account-rotation');
+}
+
+function loadConfig(ctx) {
+  const candidates = [
+    join(ctx.home, '.claude/scripts/account-rotation/config.json'),
+    join(rotationDir(ctx), 'config.json'),
+    join(rotationDir(ctx), 'config.example.json'),
+  ];
+  for (const p of candidates) {
+    if (!existsSync(p)) continue;
+    try {
+      return JSON.parse(readFileSync(p, 'utf8'));
+    } catch {
+      /* next */
+    }
+  }
+  return null;
+}
+
+function tokenStateFor(email, vaultPath) {
+  if (!existsSync(vaultPath)) return 'missing';
+  try {
+    const vault = JSON.parse(readFileSync(vaultPath, 'utf8'));
+    const key = `Claude-Rotation-${email}`;
+    const entry = vault[key]?.claudeAiOauth || vault[key];
+    if (!entry?.accessToken && !entry?.refreshToken) return 'missing';
+    const exp = entry.expiresAt || entry.expiry || entry.expires;
+    if (exp && Number(exp) * (String(exp).length < 12 ? 1000 : 1) < Date.now()) {
+      return 'expired';
+    }
+    return 'valid';
+  } catch {
+    return 'missing';
+  }
+}
+
+export async function listAccounts(ctx) {
+  const cfg = loadConfig(ctx);
+  const vault = join(ctx.home, '.claude/.credentials.json');
+  const rows = [];
+  const accounts = cfg?.accounts || [];
+  const nameByVault = cfg?.crs?.nameByVaultKey || {};
+
+  if (Array.isArray(accounts) && accounts.length) {
+    for (const a of accounts) {
+      const email = (a.email || a.id || '').toLowerCase();
+      if (!email) continue;
+      const label = a.label || nameByVault[email] || null;
+      rows.push({
+        provider: providerId,
+        accountId: email,
+        email,
+        label,
+        tokenState: tokenStateFor(a.label || email, vault),
+        active: false,
+        utilization: null,
+        crs: label ? { name: nameByVault[a.label] || nameByVault[email] || null } : null,
+        lastError: null,
+      });
+    }
+  } else {
+    // vault-key map only
+    for (const [vaultKey, crsName] of Object.entries(nameByVault)) {
+      rows.push({
+        provider: providerId,
+        accountId: vaultKey,
+        email: vaultKey.includes('@') ? vaultKey : null,
+        label: crsName,
+        tokenState: tokenStateFor(vaultKey, vault),
+        active: false,
+        utilization: null,
+        crs: { name: crsName },
+        lastError: null,
+      });
+    }
+  }
+  return rows;
+}
+
+export async function reauth(ctx, { accountId }) {
+  const email = accountId;
+  if (!email) return { ok: false, reason: 'email-required' };
+  const magic = join(rotationDir(ctx), 'rotate-magic.mjs');
+  if (!existsSync(magic)) {
+    return { ok: false, reason: 'rotate-magic-missing' };
+  }
+  if (ctx.dryRun) return { ok: true, reason: 'dry-run' };
+  const r = spawnSync(process.execPath, [magic, '--to', email, '--force'], {
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_PLUGIN_ROOT: ctx.pluginRoot },
+    timeout: 120000,
+  });
+  return {
+    ok: r.status === 0,
+    reason: r.status === 0 ? null : (r.stderr || r.stdout || '').slice(-400),
+  };
+}
+
+export async function switchTo(ctx, { accountId }) {
+  return {
+    ok: false,
+    reason: `use rotate.mjs --rotate or /ops:rotate rotate-now --to ${accountId || '<email>'}`,
+  };
+}
+
+export async function refresh(ctx) {
+  const rot = join(rotationDir(ctx), 'rotate.mjs');
+  if (!existsSync(rot)) return { ok: false, reason: 'rotate-missing' };
+  // status only — no thrash
+  const r = spawnSync(process.execPath, [rot, '--status'], {
+    encoding: 'utf8',
+    timeout: 60000,
+  });
+  return { ok: r.status === 0, reason: r.status === 0 ? null : 'status-failed' };
+}
+
+export async function utilization() {
+  return { windows: [], source: 'unavailable', note: 'use crs-live-status / priority daemon' };
+}

--- a/claude-ops/scripts/ops-accounts/providers/cursor.mjs
+++ b/claude-ops/scripts/ops-accounts/providers/cursor.mjs
@@ -1,0 +1,68 @@
+/**
+ * Cursor adapter — identity from last quota probe; remaining needs session cookie.
+ */
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+export const providerId = 'cursor';
+export const displayName = 'Cursor';
+
+export async function listAccounts(ctx) {
+  const snapPath = join(ctx.home, '.claude/crs-keys/quota/cursor-latest.json');
+  let snap = null;
+  if (existsSync(snapPath)) {
+    try {
+      snap = JSON.parse(readFileSync(snapPath, 'utf8'));
+    } catch {
+      snap = null;
+    }
+  }
+  const id = snap?.identity || {};
+  const email = id.userEmail || null;
+  const hasKey = Boolean(process.env.CURSOR_API_KEY);
+  return [
+    {
+      provider: providerId,
+      accountId: email || 'cursor-primary',
+      email,
+      label: id.apiKeyName || 'Cursor',
+      tokenState: hasKey || snap?.v1_me_http === 200 ? 'valid' : 'missing',
+      active: snap?.v1_me_http === 200,
+      utilization: {
+        pools: snap?.pools || [],
+        note: 'Remaining requires WorkosCursorSessionToken (browser) or Enterprise admin',
+      },
+      crs: null,
+      lastError: null,
+      http: { me: snap?.v1_me_http, usage: snap?.usage_http },
+      reauth: {
+        status: 'unavailable',
+        note: 'Cursor cloud login + optional BYOK via gateway; no magic-link cascade in plugin',
+      },
+    },
+  ];
+}
+
+export async function reauth() {
+  return {
+    ok: false,
+    reason: 'cursor-reauth-not-automated',
+    handoff: 'Sign in at cursor.com; for remaining, export session cookie or use Enterprise admin key',
+  };
+}
+
+export async function utilization(ctx) {
+  const snapPath = join(ctx.home, '.claude/crs-keys/quota/cursor-latest.json');
+  if (!existsSync(snapPath)) return { windows: [], source: 'unavailable' };
+  try {
+    const snap = JSON.parse(readFileSync(snapPath, 'utf8'));
+    return {
+      windows: [],
+      source: snap.source || 'cursor-probe',
+      pools: snap.pools || [],
+      http: { me: snap.v1_me_http, usage: snap.usage_http },
+    };
+  } catch {
+    return { windows: [], source: 'unavailable' };
+  }
+}

--- a/claude-ops/scripts/ops-accounts/providers/factory.mjs
+++ b/claude-ops/scripts/ops-accounts/providers/factory.mjs
@@ -20,8 +20,7 @@ export async function listAccounts(ctx) {
   }
   const keyPresent = Boolean(
     process.env.FACTORY_API_KEY ||
-      (existsSync(join(ctx.home, '.factory/auth.v2.file')) &&
-        existsSync(join(ctx.home, '.factory/auth.v2.key'))),
+    (existsSync(join(ctx.home, '.factory/auth.v2.file')) && existsSync(join(ctx.home, '.factory/auth.v2.key'))),
   );
   const blocked = snap?.http?.chat_usage === 402 || snap?.source === 'vendor_402_unpaid';
   return [
@@ -40,9 +39,7 @@ export async function listAccounts(ctx) {
           }
         : null,
       crs: null,
-      lastError: blocked
-        ? snap?.vendor_detail || 'HTTP 402 no active paid subscription'
-        : snap?.error || null,
+      lastError: blocked ? snap?.vendor_detail || 'HTTP 402 no active paid subscription' : snap?.error || null,
       billing: snap?.billing_mail_hint || null,
       http: snap?.http || null,
       note: 'Two orgs in Gmail (GGDXNY Sam Org / DGPBWS Healify); feeder probes one FACTORY_API_KEY',

--- a/claude-ops/scripts/ops-accounts/providers/factory.mjs
+++ b/claude-ops/scripts/ops-accounts/providers/factory.mjs
@@ -1,0 +1,78 @@
+/**
+ * Factory / Droid adapter — reports key presence + last quota snapshot.
+ * Does not invent remaining when vendor returns 402.
+ */
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+export const providerId = 'factory';
+export const displayName = 'Factory / Droid';
+
+export async function listAccounts(ctx) {
+  const snapPath = join(ctx.home, '.claude/crs-keys/quota/factory-droid.json');
+  let snap = null;
+  if (existsSync(snapPath)) {
+    try {
+      snap = JSON.parse(readFileSync(snapPath, 'utf8'));
+    } catch {
+      snap = null;
+    }
+  }
+  const keyPresent = Boolean(
+    process.env.FACTORY_API_KEY ||
+      (existsSync(join(ctx.home, '.factory/auth.v2.file')) &&
+        existsSync(join(ctx.home, '.factory/auth.v2.key'))),
+  );
+  const blocked = snap?.http?.chat_usage === 402 || snap?.source === 'vendor_402_unpaid';
+  return [
+    {
+      provider: providerId,
+      accountId: 'factory-primary',
+      email: null,
+      label: 'box-primary-key',
+      tokenState: keyPresent ? (blocked ? 'expired' : 'valid') : 'missing',
+      active: keyPresent && !blocked,
+      utilization: snap?.remaining
+        ? {
+            standard: snap.remaining.standard,
+            premium: snap.remaining.premium,
+            status: snap.remaining.status,
+          }
+        : null,
+      crs: null,
+      lastError: blocked
+        ? snap?.vendor_detail || 'HTTP 402 no active paid subscription'
+        : snap?.error || null,
+      billing: snap?.billing_mail_hint || null,
+      http: snap?.http || null,
+      note: 'Two orgs in Gmail (GGDXNY Sam Org / DGPBWS Healify); feeder probes one FACTORY_API_KEY',
+      reauth: { status: 'unavailable', note: 'pay invoice / restore Factory billing; no OAuth cascade' },
+    },
+  ];
+}
+
+export async function reauth() {
+  return {
+    ok: false,
+    reason: 'factory-billing-not-reauth',
+    handoff: 'Restore paid subscription in Factory org (402 = unpaid). See Gmail invoices GGDXNY / DGPBWS.',
+  };
+}
+
+export async function utilization(ctx) {
+  const snapPath = join(ctx.home, '.claude/crs-keys/quota/factory-droid.json');
+  if (!existsSync(snapPath)) {
+    return { windows: [], source: 'unavailable' };
+  }
+  try {
+    const snap = JSON.parse(readFileSync(snapPath, 'utf8'));
+    return {
+      windows: [],
+      source: snap.source || 'factory-snapshot',
+      http: snap.http,
+      remaining: snap.remaining,
+    };
+  } catch {
+    return { windows: [], source: 'unavailable' };
+  }
+}

--- a/claude-ops/scripts/ops-accounts/providers/grok.mjs
+++ b/claude-ops/scripts/ops-accounts/providers/grok.mjs
@@ -1,0 +1,102 @@
+/**
+ * Grok / SuperGrok adapter — lists auth-slots; reauth via grok-oauth-reauth (EFG SOCKS default).
+ */
+import { existsSync, readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { spawnSync } from 'child_process';
+
+export const providerId = 'grok';
+export const displayName = 'SuperGrok / xAI';
+
+function slotsDir(ctx) {
+  return process.env.GROK_AUTH_SLOTS_DIR || join(ctx.home, '.grok/auth-slots');
+}
+
+export async function listAccounts(ctx) {
+  const dir = slotsDir(ctx);
+  if (!existsSync(dir)) return [];
+  const rows = [];
+  for (const f of readdirSync(dir).filter((x) => x.endsWith('.json'))) {
+    try {
+      const raw = JSON.parse(readFileSync(join(dir, f), 'utf8'));
+      // slot file: map of key -> { email, refresh_token, ... }
+      for (const [, v] of Object.entries(raw)) {
+        if (!v || typeof v !== 'object') continue;
+        const email = String(v.email || '').toLowerCase();
+        if (!email) continue;
+        const hasRt = Boolean(v.refresh_token);
+        const exp = v.expires_at || v.expiresAt;
+        let tokenState = hasRt ? 'valid' : 'missing';
+        if (exp && Number(exp) * (String(exp).length < 12 ? 1000 : 1) < Date.now()) {
+          tokenState = 'expired';
+        }
+        rows.push({
+          provider: providerId,
+          accountId: email,
+          email,
+          label: f.replace(/\.json$/, ''),
+          tokenState,
+          active: false,
+          utilization: null,
+          crs: { path: 'http://127.0.0.1:31845/v1', note: 'SuperGrok local proxy' },
+          lastError: null,
+          reauth: {
+            engine: 'grok-oauth-reauth',
+            residential: 'EFG SOCKS default socks5://127.0.0.1:1089 (GROK_REAUTH_SOCKS)',
+          },
+        });
+      }
+    } catch {
+      /* skip bad slot */
+    }
+  }
+  return rows;
+}
+
+export async function reauth(ctx, { accountId }) {
+  const email = accountId;
+  if (!email) return { ok: false, reason: 'email-required' };
+  const bin = spawnSync('bash', ['-lc', 'command -v grok-oauth-reauth'], { encoding: 'utf8' });
+  const path = (bin.stdout || '').trim();
+  if (!path) return { ok: false, reason: 'grok-oauth-reauth-not-on-path' };
+  if (ctx.dryRun) return { ok: true, reason: 'dry-run' };
+  // Residential cascade is inside grok-oauth-reauth (EFG SOCKS unless GROK_REAUTH_DIRECT=1)
+  const r = spawnSync(path, ['--email', email], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      DISPLAY: process.env.DISPLAY || ':1',
+      GROK_REAUTH_SOCKS: process.env.GROK_REAUTH_SOCKS || 'socks5://127.0.0.1:1089',
+    },
+    timeout: 600000,
+  });
+  return {
+    ok: r.status === 0,
+    reason: r.status === 0 ? null : (r.stderr || r.stdout || 'reauth-failed').slice(-500),
+  };
+}
+
+export async function switchTo() {
+  const r = spawnSync('bash', ['-lc', 'command -v grok-rotate && grok-rotate switch'], {
+    encoding: 'utf8',
+    timeout: 60000,
+  });
+  return { ok: r.status === 0, reason: r.status === 0 ? null : 'grok-rotate-switch-failed' };
+}
+
+export async function refresh() {
+  const r = spawnSync(
+    'bash',
+    ['-lc', 'command -v host-token-keepalive >/dev/null && host-token-keepalive --force --grok-only || true'],
+    { encoding: 'utf8', timeout: 120000 },
+  );
+  return { ok: true, reason: r.status === 0 ? null : 'keepalive-soft-fail' };
+}
+
+export async function utilization() {
+  return {
+    windows: [],
+    source: 'unavailable',
+    note: 'SuperGrok seat remaining not exposed as public remaining API; use slot tokenState',
+  };
+}

--- a/claude-ops/scripts/ops-accounts/providers/openai.mjs
+++ b/claude-ops/scripts/ops-accounts/providers/openai.mjs
@@ -1,0 +1,71 @@
+/**
+ * OpenAI / Codex adapter — status from ~/.codex + optional codex-rotate.
+ * Reauth not automated in phase 0 (honest unavailable).
+ */
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { spawnSync } from 'child_process';
+
+export const providerId = 'openai';
+export const displayName = 'OpenAI / Codex';
+
+export async function listAccounts(ctx) {
+  const rows = [];
+  const auth = join(ctx.home, '.codex/auth.json');
+  const config = join(ctx.home, '.codex/config.toml');
+  let tokenState = 'missing';
+  let email = null;
+  if (existsSync(auth)) {
+    try {
+      const a = JSON.parse(readFileSync(auth, 'utf8'));
+      // never dump tokens — only presence
+      const has =
+        Boolean(a.OPENAI_API_KEY) ||
+        Boolean(a.tokens?.access_token) ||
+        Boolean(a.access_token) ||
+        Boolean(a.refresh_token);
+      tokenState = has ? 'valid' : 'missing';
+      email = a.account?.email || a.email || null;
+    } catch {
+      tokenState = 'missing';
+    }
+  }
+  rows.push({
+    provider: providerId,
+    accountId: email || 'codex-default',
+    email,
+    label: 'codex',
+    tokenState,
+    active: true,
+    utilization: null,
+    crs: null,
+    lastError: null,
+    configPresent: existsSync(config),
+    reauth: { status: 'unavailable', note: 'use ChatGPT OAuth / codex login; no plugin cascade yet' },
+  });
+  return rows;
+}
+
+export async function reauth() {
+  return {
+    ok: false,
+    reason: 'openai-reauth-not-automated-phase0',
+    handoff: 'Run `codex login` or host codex-rotate if installed',
+  };
+}
+
+export async function refresh() {
+  const r = spawnSync('bash', ['-lc', 'command -v codex-rotate >/dev/null && codex-rotate status || true'], {
+    encoding: 'utf8',
+    timeout: 60000,
+  });
+  return { ok: true, reason: 'status-only' };
+}
+
+export async function utilization() {
+  return {
+    windows: [],
+    source: 'unavailable',
+    note: 'ChatGPT Codex remaining via app usage dashboard or CLI /status (session auth)',
+  };
+}

--- a/claude-ops/scripts/ops-accounts/registry.mjs
+++ b/claude-ops/scripts/ops-accounts/registry.mjs
@@ -31,8 +31,7 @@ export async function loadProviders() {
 
 export function makeCtx({ dryRun = false, log = console.log } = {}) {
   const pluginRoot =
-    process.env.CLAUDE_PLUGIN_ROOT ||
-    dirname(dirname(__dirname)); /* scripts/ops-accounts -> claude-ops root */
+    process.env.CLAUDE_PLUGIN_ROOT || dirname(dirname(__dirname)); /* scripts/ops-accounts -> claude-ops root */
   return {
     pluginRoot,
     dataDir:

--- a/claude-ops/scripts/ops-accounts/registry.mjs
+++ b/claude-ops/scripts/ops-accounts/registry.mjs
@@ -1,0 +1,46 @@
+/**
+ * Provider registry for /ops:accounts.
+ * Loads adapters under ./providers/*.mjs (ESM).
+ */
+import { readdirSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PROVIDERS_DIR = join(__dirname, 'providers');
+
+/** @typedef {{ providerId: string, displayName: string, listAccounts: Function, register?: Function, refresh?: Function, reauth?: Function, switchTo?: Function, utilization?: Function }} Provider */
+
+/**
+ * @returns {Promise<Provider[]>}
+ */
+export async function loadProviders() {
+  const files = readdirSync(PROVIDERS_DIR)
+    .filter((f) => f.endsWith('.mjs') && !f.startsWith('_'))
+    .sort();
+  const out = [];
+  for (const f of files) {
+    const mod = await import(pathToFileURL(join(PROVIDERS_DIR, f)).href);
+    if (!mod.providerId || typeof mod.listAccounts !== 'function') {
+      continue;
+    }
+    out.push(mod);
+  }
+  return out;
+}
+
+export function makeCtx({ dryRun = false, log = console.log } = {}) {
+  const pluginRoot =
+    process.env.CLAUDE_PLUGIN_ROOT ||
+    dirname(dirname(__dirname)); /* scripts/ops-accounts -> claude-ops root */
+  return {
+    pluginRoot,
+    dataDir:
+      process.env.CLAUDE_PLUGIN_DATA_DIR ||
+      join(process.env.HOME || process.env.USERPROFILE || '', '.claude/plugins/data/ops-ops-marketplace'),
+    log,
+    dryRun,
+    env: process.env,
+    home: process.env.HOME || process.env.USERPROFILE || '',
+  };
+}

--- a/claude-ops/skills/ops-accounts/SKILL.md
+++ b/claude-ops/skills/ops-accounts/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ops-accounts
-description: Multi-provider AI account manager (Claude, Grok/xAI, Codex). Status, switch, refresh, and reauth behind one skill. Phase 0 thin router over existing engines; /ops:rotate remains a Claude-focused alias.
-argument-hint: '[status|switch|refresh|reauth|list] [provider] [email]'
+description: Multi-provider AI account manager (Claude, Grok/xAI, Codex, Factory, Cursor). Status, switch, refresh, and reauth behind one skill. Node adapters under scripts/ops-accounts/; /ops:rotate remains a Claude-focused alias.
+argument-hint: '[status|switch|refresh|reauth|list|providers] [provider] [email]'
 allowed-tools:
   - Bash
   - Read
@@ -12,56 +12,48 @@ maxTurns: 20
 
 # OPS ► ACCOUNTS (phase 0)
 
-One skill for **all** paid AI seats on the box. Provider engines stay specialized;
-this skill is the **router** and the product surface for “public plugin only.”
+One skill for **all** paid AI seats on the box. Engines stay specialized;
+`scripts/ops-accounts/` is the **router + adapters**.
 
-| Provider | Engine today | Unattended reauth |
-|----------|--------------|-------------------|
-| Claude | `scripts/account-rotation/rotate.mjs` + `rotate-magic.mjs` | magic-link + captcha cascade |
-| Grok | `grok-rotate`, `grok-oauth-reauth`, `grok-cli-auth-proxy` | xAI device-code + Google (dcli) |
-| Codex | `codex-rotate` if present | OpenAI OAuth bridge patterns |
+| Provider | Adapter | Unattended reauth |
+|----------|---------|-------------------|
+| Claude | `providers/claude.mjs` → rotate / rotate-magic | magic-link + captcha cascade (#727) |
+| Grok | `providers/grok.mjs` → grok-oauth-reauth | xAI device-code + Google (dcli); **EFG SOCKS residential** default `socks5://127.0.0.1:1089` |
+| OpenAI/Codex | `providers/openai.mjs` | status only phase 0 (`codex login` handoff) |
+| Factory | `providers/factory.mjs` | billing restore (402 ≠ reauth) |
+| Cursor | `providers/cursor.mjs` | cloud login; remaining needs session cookie |
 
-CRS is **optional** and Claude-oriented (relay LB). It is not required for
-standalone reauth on any provider.
+CRS is **optional** and Claude-oriented (relay LB). Not required for standalone reauth.
 
 ## Subcommands (`$ARGUMENTS`)
 
 | Args | Action |
 |------|--------|
-| (none) / `status` | Cross-provider status (no secrets) |
-| `list` | Same as status (phase 0) |
-| `switch grok` | Next SuperGrok seat (`grok-rotate switch`) |
-| `switch claude` | Point at `/ops:rotate rotate-now` |
-| `refresh` / `refresh all` | `host-token-keepalive --force` |
-| `refresh grok` / `refresh claude` | Provider-scoped keepalive |
-| `reauth grok <email>` | Device-code reauth (dcli password/TOTP) |
-| `reauth claude <email>` | `rotate-magic.mjs --to <email>` |
+| (none) / `status` / `list` | Cross-provider AccountRows (no secrets) |
+| `providers` | List adapter ids |
+| `switch grok` | SuperGrok next seat |
+| `switch claude` | Handoff to rotate-now |
+| `refresh [all\|claude\|grok\|openai]` | Best-effort token refresh |
+| `reauth claude <email>` | `rotate-magic.mjs` |
+| `reauth grok <email>` | `grok-oauth-reauth` (residential SOCKS) |
 
 ## How to run
 
 ```bash
-# preferred: plugin bin
+export CLAUDE_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/ops-marketplace/claude-ops}"
 "${CLAUDE_PLUGIN_ROOT}/bin/ops-accounts" status
 "${CLAUDE_PLUGIN_ROOT}/bin/ops-accounts" reauth grok <email>
-"${CLAUDE_PLUGIN_ROOT}/bin/ops-accounts" switch grok
+node "${CLAUDE_PLUGIN_ROOT}/scripts/ops-accounts/__tests__/ops-accounts-smoke.mjs"
 ```
 
-If `CLAUDE_PLUGIN_ROOT` is unset, resolve the latest
-`~/.claude/plugins/cache/ops-marketplace/ops/*/`.
+`/ops:rotate *` remains a **Claude-only alias** for one major version.
 
 ## Rules
 
 1. **Never print tokens, cookies, or full vault dumps.**
-2. Prefer the bin router over ad-hoc host paths so cutover can retarget one file.
-3. On weekly-cap / 429 for Grok interactive TUI: `switch grok` after seats are healthy.
-4. On dead refresh_token: `reauth <provider> <email>` — do not claim CRS will fix OAuth.
-5. `/ops:rotate` stays as Claude alias until one major version after rename.
+2. Prefer this bin over host paths so cutover retargets one file.
+3. Grok reauth uses residential EFG SOCKS unless `GROK_REAUTH_DIRECT=1`.
+4. Factory 402 / Cursor empty pools: report honestly; do not invent remaining.
+5. Dead Claude RT: `reauth claude <email>` — do not claim CRS fixes OAuth.
 
-## Phase map
-
-- **0 (this skill):** unified verbs + docs
-- **1–2:** Claude captcha port + CRS optional (enablers)
-- **3:** absorb host `grok-*` into plugin installers/timers
-- **4:** optional bundled LB (not a full CRS fork)
-
-See `docs/ops/OPS-ACCOUNTS-VISION.md`.
+See `docs/ops/OPS-ACCOUNTS-VISION.md` and plan `2026-07-30T1705Z-ops-accounts-phase0-adapter.md`.

--- a/claude-ops/skills/ops-rotate/SKILL.md
+++ b/claude-ops/skills/ops-rotate/SKILL.md
@@ -12,6 +12,9 @@ effort: low
 maxTurns: 25
 ---
 
+> **Alias note:** Multi-provider seats live under `/ops:accounts`. This skill stays Claude-focused; prefer `ops-accounts` for Grok/Codex/Factory/Cursor.
+
+
 # OPS ► ROTATE
 
 Manage the optional multi-account Claude Max rotator. Off by default — flip


### PR DESCRIPTION
## Summary
Phase 0 Node adapters for `/ops:accounts` so multi-provider status does not depend on ad-hoc host scripts.

- `scripts/ops-accounts/cli.mjs` + `registry.mjs` + providers: claude, grok, openai, factory, cursor
- `bin/ops-accounts` prefers the Node CLI
- Grok reauth documents EFG SOCKS residential default
- Factory/Cursor report honest billing/session limits (no invented remaining)
- Smoke test: `scripts/ops-accounts/__tests__/ops-accounts-smoke.mjs`
- `/ops:rotate` remains Claude alias; skill points multi-provider work here

## Test plan
- [x] `node scripts/ops-accounts/__tests__/ops-accounts-smoke.mjs`
- [x] `bin/ops-accounts status` lists five providers
- [ ] CI green
- [ ] Human review (org ruleset)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential-adjacent paths (vault reads, reauth spawning) but phase 0 emphasizes no token output and dry-run support; regression risk is mainly if `bin/ops-accounts` exec path breaks environments missing Node or with wrong `CLAUDE_PLUGIN_ROOT`.
> 
> **Overview**
> **`/ops:accounts` moves to a Node router** with `cli.mjs`, `registry.mjs`, and five provider adapters (Claude, Grok, OpenAI/Codex, Factory, Cursor). `bin/ops-accounts` now **execs the Node CLI** when present and keeps a **minimal shell fallback** (mostly status/list and reauth).
> 
> The CLI adds **`status`/`list`** (optional `--provider`), **`providers`**, **`reauth`**, **`switch`**, and **`refresh`** with tabular output that avoids printing tokens. Adapters read local config/snapshots and delegate to existing tools (`rotate-magic`, `grok-oauth-reauth`, `grok-rotate`, etc.); Factory/Cursor report billing/session limits honestly.
> 
> A **smoke test** loads all providers and checks `listAccounts` shape plus basic secret-leak guards. **`ops-accounts` and `ops-rotate` skills** document the new surface and point multi-provider work at `ops-accounts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b04d1047e4109ddb597ff482c52df42b381dae6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->