### PR TITLE
feat(ops-accounts): dual-mode seat policy + plugin Grok proxy (no CRS)

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- **ops-accounts local seat-state:** `seat-state.mjs` file-backed multi-provider seat store (schedulable/util) for no-CRS policy backend; `ops-accounts seats` command.
+
+- **ops-accounts skill merge:** `/ops:accounts` is canonical multi-provider entry; `/ops:rotate` and `/ops:rotate-setup` are aliases. Expanded `bin/ops-accounts` (status/util/switch/refresh/reauth/setup/crs). Added `grok-reauth-egress.sh` residential cascade (EFG SOCKS → Bright Data tiers) for Grok device OAuth.
+
 - **Required companion co-install:** companions essential to ops commands are no longer optional setup prompts. `plugin-dependencies.json` marks `desktop-act`, `gsd`, `gstack` (skills clone), `superpowers`, and `feature-dev` as `required: true` with `updateWithOps: always` and `essentialFor` command lists. `scripts/install-companions.sh` always installs missing required companions (even under `--update-only`), and `--status` exits 1 when any required companion is missing. `/ops:setup` Step 2b runs the SSOT script without Skip for required deps. `/ops:update` step 9 co-installs the full required set (still skippable only via `--no-companions` / `OPS_SKIP_COMPANIONS=1`). Adds `scripts/install-gstack-companion.sh` (env-templated `GSTACK_REPO`/`GSTACK_DIR`/`GSTACK_BRANCH`).
 
 

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- **CRS dual backend (no Docker required):** `crs-priority-daemon` honors `OPS_ACCOUNTS_BACKEND=auto|crs|local`. `auto` tries CRS admin API and falls back to `seat-policy-tick` + `seat-state.json`. CRS ticks dual-write into seat-state (unless `OPS_ACCOUNTS_DUAL_WRITE=0`). `ops-accounts policy` / `policy-tick` aliases. Shared resolver: `ops-accounts-backend.mjs`.
+
+- **Grok proxy in plugin:** `scripts/account-rotation/grok-cli-auth-proxy.py` (sanitized — no host emails) + `ops-accounts grok-proxy status|start|path` so SuperGrok multi-seat RR works without CRS or `~/.local/bin`.
+
 - **ops-accounts seat policy (local):** `seat-policy-tick.mjs` applies conservative 5h/7d schedulable thresholds to local seat-state without CRS; `ops-accounts seats tick`.
 
 - **ops-accounts local seat-state:** `seat-state.mjs` file-backed multi-provider seat store (schedulable/util) for no-CRS policy backend; `ops-accounts seats` command.

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- **CRS dual backend (no Docker required):** `crs-priority-daemon` honors `OPS_ACCOUNTS_BACKEND=auto|crs|local`. `auto` tries CRS admin API and falls back to `seat-policy-tick` + `seat-state.json`. CRS ticks dual-write into seat-state (unless `OPS_ACCOUNTS_DUAL_WRITE=0`). `ops-accounts policy` / `policy-tick` aliases. Shared resolver: `ops-accounts-backend.mjs`.
+- **CRS dual backend (no Docker required):** `crs-priority-daemon` honors `OPS_ACCOUNTS_BACKEND=auto|crs|local`. `auto` tries CRS admin API and falls back to `seat-policy-tick` + `seat-state.json`. CRS ticks dual-write into seat-state (unless `OPS_ACCOUNTS_DUAL_WRITE=0`). `crs-429-cooldown` / `crs-401-refresher` / `crs-token-feed` no-op under `backend=local`. `ops-accounts policy` / `policy-tick` aliases. Shared resolver: `ops-accounts-backend.mjs`. Gateway design: `docs/ops/OPS-ACCOUNTS-GATEWAY.md`.
 
 - **Grok proxy in plugin:** `scripts/account-rotation/grok-cli-auth-proxy.py` (sanitized — no host emails) + `ops-accounts grok-proxy status|start|path` so SuperGrok multi-seat RR works without CRS or `~/.local/bin`.
 

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- **ops-accounts seat policy (local):** `seat-policy-tick.mjs` applies conservative 5h/7d schedulable thresholds to local seat-state without CRS; `ops-accounts seats tick`.
+
 - **ops-accounts local seat-state:** `seat-state.mjs` file-backed multi-provider seat store (schedulable/util) for no-CRS policy backend; `ops-accounts seats` command.
 
 - **ops-accounts skill merge:** `/ops:accounts` is canonical multi-provider entry; `/ops:rotate` and `/ops:rotate-setup` are aliases. Expanded `bin/ops-accounts` (status/util/switch/refresh/reauth/setup/crs). Added `grok-reauth-egress.sh` residential cascade (EFG SOCKS → Bright Data tiers) for Grok device OAuth.

--- a/claude-ops/bin/ops-accounts
+++ b/claude-ops/bin/ops-accounts
@@ -205,8 +205,14 @@ case "$cmd" in
     ;;
 
   seats)
+    sub="${1:-status}"
+    if [[ "$sub" == "tick" || "$sub" == "policy-tick" ]]; then
+      shift || true
+      node "$ROT/seat-policy-tick.mjs" "$@"
+      exit $?
+    fi
     if [[ -f "$ROT/seat-state.mjs" ]]; then
-      node "$ROT/seat-state.mjs" "${1:-status}" "${@:2}"
+      node "$ROT/seat-state.mjs" "$sub" "${@:2}"
     else
       echo "seat-state.mjs missing"; exit 1
     fi

--- a/claude-ops/bin/ops-accounts
+++ b/claude-ops/bin/ops-accounts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# ops-accounts — multi-provider account status / switch / refresh / reauth router.
-# Phase 0 thin shell: delegates to existing engines (Claude rotate, grok-*, codex).
-# No host hardcodes beyond $HOME; no secrets printed.
+# ops-accounts — multi-provider account router (canonical).
+# Claude rotate/setup, Grok seats/proxy, Codex when present.
+# No secrets printed. Paths via CLAUDE_PLUGIN_ROOT or latest cache.
 set -euo pipefail
 
 cmd="${1:-status}"
@@ -9,31 +9,54 @@ shift || true
 
 have() { command -v "$1" >/dev/null 2>&1; }
 
+plugin_root() {
+  if [[ -n "${CLAUDE_PLUGIN_ROOT:-}" && -d "$CLAUDE_PLUGIN_ROOT" ]]; then
+    printf '%s' "$CLAUDE_PLUGIN_ROOT"
+    return
+  fi
+  local c
+  c="$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1 || true)"
+  printf '%s' "${c%/}"
+}
+
+ROOT="$(plugin_root)"
+ROT="${ROOT}/scripts/account-rotation"
+
 print_claude() {
   echo "=== Claude ==="
-  local rot="${CLAUDE_PLUGIN_ROOT:-}/scripts/account-rotation"
-  if [[ -z "${CLAUDE_PLUGIN_ROOT:-}" ]]; then
-    # best-effort cache path
-    local c
-    c="$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1 || true)"
-    rot="${c}scripts/account-rotation"
-  fi
-  if [[ -f "$rot/rotate.mjs" ]]; then
-    node "$rot/rotate.mjs" --status 2>/dev/null | head -40 || echo "(rotate.mjs --status failed)"
+  if [[ -f "$ROT/rotate.mjs" ]]; then
+    node "$ROT/rotate.mjs" --status 2>/dev/null | head -50 || echo "(rotate.mjs --status failed)"
   else
-    echo "plugin rotate.mjs not found (set CLAUDE_PLUGIN_ROOT or install ops plugin)"
+    echo "plugin rotate.mjs not found (ROOT=$ROOT)"
   fi
 }
 
 print_grok() {
-  echo "=== Grok ==="
+  echo "=== Grok (SuperGrok OAuth seats + proxy) ==="
   if have grok-rotate; then
     grok-rotate status 2>/dev/null || true
   else
     echo "grok-rotate not on PATH"
   fi
-  if have host-token-keepalive; then
-    host-token-keepalive --status --grok-only 2>/dev/null | tail -15 || true
+  if curl -fsS -m 2 http://127.0.0.1:31845/accounts >/tmp/ops-accounts-grok-proxy.json 2>/dev/null; then
+    python3 - <<'PY'
+import json
+from pathlib import Path
+d=json.loads(Path("/tmp/ops-accounts-grok-proxy.json").read_text())
+print("proxy load_balance:", d.get("load_balance"))
+print("proxy last_used:", d.get("current") or d.get("last_used"))
+print("proxy request_counts:", d.get("request_counts"))
+ex=d.get("exhausted_seconds_remaining") or {}
+if ex:
+  print("proxy exhausted_seconds:", {k:int(v) for k,v in ex.items()})
+PY
+  else
+    echo "grok-cli-auth-proxy :31845 not reachable (optional)"
+  fi
+  if curl -fsS -m 2 -o /dev/null -w "crs_grok_hop HTTP %{http_code}\n" http://127.0.0.1:3005/grok/v1/models 2>/dev/null; then
+    :
+  else
+    echo "crs_grok_hop: not reachable (optional thin hop)"
   fi
 }
 
@@ -46,52 +69,86 @@ print_codex() {
   fi
 }
 
+print_factory() {
+  echo "=== Factory ==="
+  echo "(adapter planned — see docs/ops/OPS-ACCOUNTS-VISION.md)"
+}
+
+print_cursor() {
+  echo "=== Cursor ==="
+  echo "(adapter planned — see docs/ops/OPS-ACCOUNTS-VISION.md)"
+}
+
 case "$cmd" in
-  status|"")
-    print_claude
-    echo
-    print_grok
-    echo
-    print_codex
+  status|list|"")
+    print_claude; echo
+    print_grok; echo
+    print_codex; echo
+    print_factory; echo
+    print_cursor
     ;;
-  switch)
-    provider="${1:-}"
-    target="${2:-}"
+  util)
+    provider="${1:-all}"
     case "$provider" in
-      grok|xai)
-        if [[ -n "$target" ]]; then
-          # force state to previous index so switch lands on target if ordered — fallback simple switch
-          grok-rotate switch
-        else
-          grok-rotate switch
-        fi
-        grok-rotate status
-        ;;
       claude)
-        echo "use: /ops:rotate rotate-now [--to email] or node rotate.mjs --rotate"
+        [[ -f "$ROT/rotate.mjs" ]] && node "$ROT/rotate.mjs" --utilization 2>/dev/null | head -60
+        ;;
+      grok)
+        curl -fsS -m 3 http://127.0.0.1:31845/accounts 2>/dev/null | python3 -c 'import json,sys;d=json.load(sys.stdin);print(json.dumps({k:d.get(k) for k in ("request_counts","exhausted_seconds_remaining","load_balance","current")}, indent=2))' || echo "proxy util unavailable"
+        ;;
+      all|"")
+        echo "--- Claude util ---"
+        [[ -f "$ROT/rotate.mjs" ]] && node "$ROT/rotate.mjs" --utilization 2>/dev/null | head -40 || true
+        echo "--- Grok proxy ---"
+        curl -fsS -m 3 http://127.0.0.1:31845/accounts 2>/dev/null | python3 -c 'import json,sys;d=json.load(sys.stdin);print("counts",d.get("request_counts"));print("exhausted",d.get("exhausted_seconds_remaining"))' || true
         ;;
       *)
-        echo "usage: ops-accounts switch grok|claude [email]"
-        exit 2
+        echo "usage: ops-accounts util [all|claude|grok]"; exit 2 ;;
+    esac
+    ;;
+  switch|rotate-now)
+    provider="${1:-}"
+    # allow: ops-accounts rotate-now  OR  ops-accounts switch claude
+    if [[ "$cmd" == "rotate-now" ]]; then
+      provider="claude"
+    fi
+    case "$provider" in
+      grok|xai)
+        have grok-rotate || { echo "grok-rotate missing"; exit 1; }
+        grok-rotate switch
+        grok-rotate status
         ;;
+      claude|"")
+        if [[ -x "$ROT/force-rotate.sh" ]]; then
+          bash "$ROT/force-rotate.sh" "${2:-}"
+        elif [[ -f "$ROT/rotate.mjs" ]]; then
+          node "$ROT/rotate.mjs" --rotate ${2:+--to "$2"}
+        else
+          echo "Claude rotate scripts missing under $ROT"; exit 1
+        fi
+        ;;
+      *)
+        echo "usage: ops-accounts switch grok|claude [email]"; exit 2 ;;
     esac
     ;;
   refresh)
     provider="${1:-all}"
     case "$provider" in
       grok)
-        host-token-keepalive --force --grok-only 2>/dev/null || grok-rotate refresh
+        if have host-token-keepalive; then host-token-keepalive --force --grok-only
+        elif have grok-rotate; then grok-rotate refresh
+        else echo "no grok refresh tool"; exit 1
+        fi
         ;;
       claude)
-        host-token-keepalive --force --claude-only 2>/dev/null || true
+        have host-token-keepalive && host-token-keepalive --force --claude-only || true
+        [[ -f "$ROT/rotate.mjs" ]] && node "$ROT/rotate.mjs" --refresh 2>/dev/null || true
         ;;
       all|"")
-        host-token-keepalive --force 2>/dev/null || true
+        have host-token-keepalive && host-token-keepalive --force || true
         ;;
       *)
-        echo "usage: ops-accounts refresh [all|claude|grok]"
-        exit 2
-        ;;
+        echo "usage: ops-accounts refresh [all|claude|grok]"; exit 2 ;;
     esac
     ;;
   reauth)
@@ -100,36 +157,75 @@ case "$cmd" in
     case "$provider" in
       grok|xai)
         [[ -n "$email" ]] || { echo "usage: ops-accounts reauth grok <email>"; exit 2; }
-        export DISPLAY="${DISPLAY:-:1}"
-        grok-oauth-reauth --email "$email"
+        export DISPLAY="${DISPLAY:-${CLAUDE_DESKTOP_DISPLAY:-:1}}"
+        EGRESS="$ROT/grok-reauth-egress.sh"
+        if [[ -x "$EGRESS" ]]; then
+          # shellcheck disable=SC1090
+          source "$EGRESS" || true
+        fi
+        if have grok-oauth-reauth; then
+          grok-oauth-reauth --email "$email"
+        else
+          echo "grok-oauth-reauth not on PATH (port into plugin next)"
+          exit 1
+        fi
         ;;
       claude)
         [[ -n "$email" ]] || { echo "usage: ops-accounts reauth claude <email>"; exit 2; }
-        root="${CLAUDE_PLUGIN_ROOT:-}"
-        if [[ -z "$root" ]]; then
-          root="$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1)"
+        if [[ -f "$ROT/rotate-magic.mjs" ]]; then
+          node "$ROT/rotate-magic.mjs" --to "$email" --force
+        else
+          node "$ROT/rotate.mjs" --magic-link --to "$email"
         fi
-        node "${root}/scripts/account-rotation/rotate-magic.mjs" --to "$email" --force
         ;;
       *)
-        echo "usage: ops-accounts reauth grok|claude <email>"
-        exit 2
-        ;;
+        echo "usage: ops-accounts reauth grok|claude <email>"; exit 2 ;;
     esac
     ;;
+  setup)
+    provider="${1:-claude}"
+    echo "Interactive setup: invoke skill ops-accounts / ops-rotate-setup for provider=$provider"
+    echo "Claude wizard detail: skills/ops-rotate-setup/SKILL.md"
+    echo "Quick reauth Claude: ops-accounts reauth claude <email>"
+    echo "Quick reauth Grok:   ops-accounts reauth grok <email>"
+    ;;
+  crs)
+    if [[ -x "$ROT/crs-priority-daemon.sh" ]]; then
+      bash "$ROT/crs-priority-daemon.sh" --status 2>&1 | head -40
+    else
+      echo "CRS priority script missing (optional)"
+    fi
+    ;;
+  crs-tick)
+    if [[ -x "$ROT/crs-priority-daemon.sh" ]]; then
+      bash "$ROT/crs-priority-daemon.sh" "$@"
+    else
+      echo "CRS priority script missing"; exit 1
+    fi
+    ;;
+
+  seats)
+    if [[ -f "$ROT/seat-state.mjs" ]]; then
+      node "$ROT/seat-state.mjs" "${1:-status}" "${@:2}"
+    else
+      echo "seat-state.mjs missing"; exit 1
+    fi
+    ;;
+
   -h|--help|help)
     cat <<H
-ops-accounts — multi-provider seat router (phase 0)
+ops-accounts — multi-provider seats (canonical; /ops:rotate is alias)
 
-  ops-accounts status
-  ops-accounts switch grok|claude
-  ops-accounts refresh [all|claude|grok]
-  ops-accounts reauth grok <email>
-  ops-accounts reauth claude <email>
+  status | list
+  util [all|claude|grok]
+  switch claude|grok   |  rotate-now
+  refresh [all|claude|grok]
+  reauth claude <email> | reauth grok <email>
+  setup [claude|grok]
+  crs | crs-tick
+  seats [status|list|set|toggle|import-claude-config]
 H
     ;;
   *)
-    echo "unknown command: $cmd (try help)"
-    exit 2
-    ;;
+    echo "unknown command: $cmd (try help)"; exit 2 ;;
 esac

--- a/claude-ops/docs/ops/OPS-ACCOUNTS-GATEWAY.md
+++ b/claude-ops/docs/ops/OPS-ACCOUNTS-GATEWAY.md
@@ -1,0 +1,42 @@
+# ops-accounts-gateway (design — not shipped)
+
+**Goal:** Optional thin OpenAI-compat gateway so fleets that today set
+`base_url=http://127.0.0.1:3005` (CRS) can point at a plugin-owned process
+**without** installing weishaw/claude-relay-service.
+
+## What it must do
+
+| Route / job | Backend |
+|-------------|---------|
+| `/v1/messages` (Anthropic-shaped) or OpenAI `/v1/chat/completions` for Claude | Pick schedulable Claude seat from `seat-state` + vault OAuth; apply cooldown |
+| `/v1/*` Grok | Forward to plugin `grok-cli-auth-proxy` (`:31845`) |
+| API key gate | Personal keys (simpler than multi-tenant CRS `cr_` product) |
+| State | File/SQLite only by default — **no Redis** |
+
+## What it must not do
+
+- Admin SPA, multi-tenant product UI
+- Grafana / Prometheus stack by default
+- Require Docker
+- Re-implement Grok seat table inside Claude account rows
+
+## Migration
+
+```
+CRS_BASE_URL → OPS_ACCOUNTS_GATEWAY_URL
+# harnesses keep OpenAI-compat client shape
+```
+
+External CRS remains **advanced-only** for operators who want the full CRS admin UI.
+
+## Build order
+
+1. Dual backend policy + seat-state (**done** in ops-accounts local-backend PR)
+2. Plugin Grok proxy (**done**)
+3. Gateway skeleton (this doc) — next PR
+4. Harness matrix update (`docs/ops` CLI path matrix)
+
+## License
+
+If any line is copied from CRS (MIT), keep attribution. Prefer rewrite of the
+proxy surface over vendoring the monorepo.

--- a/claude-ops/docs/ops/OPS-ACCOUNTS-VISION.md
+++ b/claude-ops/docs/ops/OPS-ACCOUNTS-VISION.md
@@ -57,8 +57,9 @@ multi-provider later.
 | **0** | **ops-accounts contract** — skill surface, provider adapter interface, unified status/switch/refresh/reauth verbs, wire existing Claude + Grok + Codex tools behind it (thin orchestration first, no big rewrite) | `/ops:accounts status` shows all providers; `switch`/`refresh`/`reauth` work for Claude and Grok without knowing host script names |
 | **1** | Close host / plugin Claude rotate gap | Plugin cascade modules; gap doc; host units still host until proven |
 | **2** | CRS optional wire (Claude only) | Detect CRS; install vs standalone; never required for single seat |
-| **3** | Absorb host Grok/Codex scripts into plugin (portable, env-templated) | No load-bearing `~/.local/bin/grok-*` for happy path; timers under plugin installers |
-| **4** | Optional bundled balancer (rebranded cherry-pick, not CRS dump-fork) | Only if wire-optional CRS still hurts multi-Claude users |
+| **2b** | **Dual backend + local seat-state** | `OPS_ACCOUNTS_BACKEND=auto\|crs\|local`; policy tick without Docker CRS; dual-write seat-state |
+| **3** | Absorb host Grok/Codex scripts into plugin (portable, env-templated) | Plugin `grok-cli-auth-proxy.py` + reauth egress; no load-bearing `~/.local/bin/grok-*` for happy path |
+| **4** | Optional `ops-accounts-gateway` (thin OpenAI-compat multi-provider) | Replaces `:3005` for most fleets; CRS advanced-only |
 
 **This week’s PRs (#726 companions, #727 captcha/CRS-optional) are phase 1–2
 enablers.** They must not re-label phase 0 as “later design only.”

--- a/claude-ops/scripts/account-rotation/__tests__/ops-accounts-backend.test.mjs
+++ b/claude-ops/scripts/account-rotation/__tests__/ops-accounts-backend.test.mjs
@@ -1,0 +1,32 @@
+/**
+ * Unit tests: OPS_ACCOUNTS_BACKEND resolution + seat-state merge (no CRS).
+ */
+import { resolveAccountsBackend, dualWriteEnabled, mergeSeatsIntoState } from '../ops-accounts-backend.mjs';
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'assert failed');
+}
+
+assert(resolveAccountsBackend({ env: {} }) === 'auto', 'default auto');
+assert(resolveAccountsBackend({ env: { OPS_ACCOUNTS_BACKEND: 'local' } }) === 'local', 'local');
+assert(resolveAccountsBackend({ env: { OPS_ACCOUNTS_BACKEND: 'seat-state' } }) === 'local', 'seat-state');
+assert(resolveAccountsBackend({ env: { OPS_ACCOUNTS_BACKEND: 'CRS' } }) === 'crs', 'crs case');
+assert(resolveAccountsBackend({ env: {}, cfgBackend: 'file' }) === 'local', 'cfg file');
+assert(resolveAccountsBackend({ env: { OPS_ACCOUNTS_BACKEND: 'auto' } }) === 'auto', 'explicit auto');
+
+assert(dualWriteEnabled({ env: {} }) === true, 'dual-write default on');
+assert(dualWriteEnabled({ env: { OPS_ACCOUNTS_DUAL_WRITE: '0' } }) === false, 'dual-write off');
+
+const merged = mergeSeatsIntoState(
+  { version: 1, providers: {} },
+  [
+    { email: 'a@example.com', schedulable: true, util5h: 10, util7d: 20 },
+    { email: 'b@example.com', schedulable: false, util5h: 90 },
+  ],
+);
+assert(merged.providers.claude.seats['a@example.com'].schedulable === true, 'a on');
+assert(merged.providers.claude.seats['b@example.com'].schedulable === false, 'b off');
+assert(merged.providers.claude.seats['a@example.com'].util5h === 10, 'util');
+assert(merged.updatedAt, 'timestamp');
+
+console.log('ops-accounts-backend.test.mjs: ok');

--- a/claude-ops/scripts/account-rotation/crs-401-refresher.mjs
+++ b/claude-ops/scripts/account-rotation/crs-401-refresher.mjs
@@ -59,6 +59,7 @@ import { fileURLToPath } from 'url';
 import { homedir } from 'os';
 import { loadJsonState, saveJsonStateAtomic, withOwnStateLock } from './crs-reconciler-state.mjs';
 import { crsBaseUrl, loadRotationConfig, resolveCrsAdminPassword } from './crs-pool-config.mjs';
+import { resolveAccountsBackend } from './ops-accounts-backend.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const args = new Set(process.argv.slice(2));
@@ -359,6 +360,11 @@ async function tick() {
 }
 
 async function main() {
+  const backend = resolveAccountsBackend({ env: process.env, cfgBackend: C.backend });
+  if (backend === 'local') {
+    log('backend=local — CRS 401 refresher no-op (vault refresh is rotate.mjs / keychain keepalive)');
+    return;
+  }
   if (!ENABLED && !STATUS) {
     log('crs.tokenRefreshEnabled is not true (and $CRS_TOKEN_REFRESH_ENABLED!=1) — skipping tick (opt-in required)');
     return;

--- a/claude-ops/scripts/account-rotation/crs-429-cooldown.mjs
+++ b/claude-ops/scripts/account-rotation/crs-429-cooldown.mjs
@@ -61,6 +61,7 @@ import { fileURLToPath } from 'url';
 import { homedir } from 'os';
 import { loadJsonState, saveJsonStateAtomic, withOwnStateLock } from './crs-reconciler-state.mjs';
 import { crsBaseUrl, loadRotationConfig, resolveCrsAdminPassword } from './crs-pool-config.mjs';
+import { resolveAccountsBackend } from './ops-accounts-backend.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const args = new Set(process.argv.slice(2));
@@ -312,6 +313,11 @@ async function tick() {
 }
 
 async function main() {
+  const backend = resolveAccountsBackend({ env: process.env, cfgBackend: C.backend });
+  if (backend === 'local') {
+    log('backend=local — CRS 429 cooldown no-op (use seat-policy-tick / exhaustedUntil on seat-state)');
+    return;
+  }
   if (!ENABLED && !STATUS) {
     log('crs.cooldownEnabled is not true (and $CRS_COOLDOWN_ENABLED!=1) — skipping tick (opt-in required)');
     return;

--- a/claude-ops/scripts/account-rotation/crs-priority-daemon.mjs
+++ b/claude-ops/scripts/account-rotation/crs-priority-daemon.mjs
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 // crs-priority-daemon.mjs — utilization-driven account prioritization for a
-// claude-relay-service (CRS) pool.
+// claude-relay-service (CRS) pool OR local seat-state (no CRS).
+//
+// Backend (OPS_ACCOUNTS_BACKEND | crs.backend):
+//   auto (default) — try CRS admin API; on failure run seat-policy-tick (local)
+//   crs            — CRS only (error if unavailable)
+//   local          — seat-state.json only (no Docker CRS)
+// Dual-write: when CRS path succeeds, mirror schedulable/util into seat-state
+// unless OPS_ACCOUNTS_DUAL_WRITE=0.
 //
 // CRS load-balances Claude requests across many claude.ai accounts at once. Each
 // account carries a `schedulable` flag; CRS only routes to schedulable accounts.
@@ -57,8 +64,8 @@
 // CLI:  (none)=one live tick · --dry-run=log decisions, no writes · --status=print
 //       current schedulable + utilization table and exit · --once (alias for tick).
 
-import { execFileSync } from 'child_process';
-import { readFileSync, existsSync } from 'fs';
+import { execFileSync, spawnSync } from 'child_process';
+import { readFileSync, writeFileSync, mkdirSync, renameSync, existsSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { homedir, platform } from 'os';
@@ -70,6 +77,11 @@ import {
   loadRotationConfig,
   vaultLookupKeysForEmail,
 } from './crs-pool-config.mjs';
+import {
+  resolveAccountsBackend,
+  dualWriteEnabled,
+  mergeSeatsIntoState,
+} from './ops-accounts-backend.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || join(__dirname, '..', '..');
@@ -580,8 +592,66 @@ function decide(accts) {
   return decideConservative(accts, nowMs);
 }
 
+// ── local seat-state backend (no CRS) ────────────────────────────────────────
+const SEAT_STATE_PATH =
+  process.env.OPS_ACCOUNTS_STATE_PATH || join(DATA_DIR, 'account-rotation', 'seat-state.json');
+const BACKEND_WANT = resolveAccountsBackend({ env: process.env, cfgBackend: C.backend });
+
+function runLocalPolicy() {
+  const tick = join(__dirname, 'seat-policy-tick.mjs');
+  if (!existsSync(tick)) {
+    throw new Error(`local backend: missing ${tick}`);
+  }
+  const pass = [];
+  if (DRY) pass.push('--dry-run');
+  if (STATUS) pass.push('--status');
+  log(`backend=local seat-policy-tick ${pass.join(' ') || '(apply)'} @ ${SEAT_STATE_PATH}`);
+  const r = spawnSync(process.execPath, [tick, ...pass], {
+    encoding: 'utf8',
+    stdio: 'inherit',
+    env: process.env,
+  });
+  if (r.status !== 0 && r.status != null) {
+    process.exit(r.status);
+  }
+}
+
+function dualWriteFromCrsDecisions(decisions) {
+  if (!dualWriteEnabled()) return;
+  try {
+    let state = { version: 1, providers: {} };
+    if (existsSync(SEAT_STATE_PATH)) {
+      try {
+        state = JSON.parse(readFileSync(SEAT_STATE_PATH, 'utf8'));
+      } catch {
+        /* keep empty */
+      }
+    }
+    const seats = decisions.map((d) => {
+      const email =
+        d.a?.subscriptionInfo?.email || vaultKeyByCrsName[d.a?.name] || d.a?.name || null;
+      const u5 = d.u5;
+      const u7 = d.a?._liveUsage?.u7;
+      return {
+        email,
+        schedulable: d.desired !== false,
+        util5h: typeof u5 === 'number' ? u5 : null,
+        util7d: typeof u7 === 'number' ? u7 : null,
+      };
+    });
+    const next = mergeSeatsIntoState(state, seats, { provider: 'claude' });
+    mkdirSync(dirname(SEAT_STATE_PATH), { recursive: true });
+    const tmp = SEAT_STATE_PATH + '.tmp';
+    writeFileSync(tmp, JSON.stringify(next, null, 2) + '\n', { mode: 0o600 });
+    renameSync(tmp, SEAT_STATE_PATH);
+    log(`dual-write: mirrored ${seats.filter((s) => s.email).length} seat(s) → ${SEAT_STATE_PATH}`);
+  } catch (e) {
+    log(`dual-write skipped: ${e.message}`);
+  }
+}
+
 // ── main ─────────────────────────────────────────────────────────────────────
-async function main() {
+async function mainCrs() {
   if (C.enabled === false && !STATUS && !DRY) {
     log('crs.enabled=false — skipping tick');
     return;
@@ -687,6 +757,26 @@ async function main() {
   log(
     `tick: ${changed} change(s). live-quota=${liveN}/${decisions.length} schedulable=${on.length} [${on.join(',')}] | off=[${off.join(',')}]`,
   );
+  dualWriteFromCrsDecisions(decisions);
+}
+
+async function main() {
+  log(`backend want=${BACKEND_WANT}`);
+  if (BACKEND_WANT === 'local') {
+    runLocalPolicy();
+    return;
+  }
+  try {
+    await mainCrs();
+  } catch (e) {
+    if (BACKEND_WANT === 'crs') {
+      log(`ERROR: ${e.message}`);
+      process.exit(1);
+    }
+    // auto: fall back to local seat-state so multi-seat works without Docker CRS
+    log(`CRS unavailable (${e.message}) — falling back to local seat-state`);
+    runLocalPolicy();
+  }
 }
 
 main().catch((e) => {

--- a/claude-ops/scripts/account-rotation/crs-token-feed.mjs
+++ b/claude-ops/scripts/account-rotation/crs-token-feed.mjs
@@ -27,6 +27,7 @@ import {
   loadRotationConfig,
   resolveConfigPath,
 } from './crs-pool-config.mjs';
+import { resolveAccountsBackend } from './ops-accounts-backend.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const LOG_PATH = join(__dirname, 'rotation.log');
@@ -120,13 +121,19 @@ async function crsLogin(crsBase, crsContainer, adminUser = 'cradmin') {
 }
 
 async function main() {
+  const earlyCfg = loadRotationConfig();
+  const backend = resolveAccountsBackend({ env: process.env, cfgBackend: earlyCfg.crs?.backend });
+  if (backend === 'local') {
+    log('backend=local — CRS token-feed no-op (CLI seats read vault/keychain directly; no pool to feed)');
+    return;
+  }
   assertCrsInvariant(process.env, 'crs-token-feed:main');
   const configPath = resolveConfigPath();
   if (!configPath) {
     log('no rotation config found — set CRS_CONFIG or install account-rotation config.json');
     process.exit(1);
   }
-  const config = loadRotationConfig();
+  const config = earlyCfg;
   const { nameByVaultKey } = buildCrsNameMaps(config);
   const fileVault = crsFileVaultPath(config);
   const crsBase = crsBaseUrl(config);

--- a/claude-ops/scripts/account-rotation/grok-cli-auth-proxy.py
+++ b/claude-ops/scripts/account-rotation/grok-cli-auth-proxy.py
@@ -1,0 +1,688 @@
+#!/usr/bin/env python3
+"""OpenAI-compatible local proxy backed by SuperGrok CLI OAuth (multi-account).
+
+Ported into claude-ops for no-CRS installs. Host path ~/.local/bin is not required.
+Configure seats via GROK_PREFERRED_EMAILS / GROK_SLOT_FILES / ~/.grok/auth-slots.
+
+Reads OAuth grants from ~/.grok/auth.json plus ~/.grok/auth-slots/*.json, refreshes
+tokens under a lock, and forwards coding traffic to cli-chat-proxy.grok.com so
+callers stay on SuperGrok subscription seats instead of metered api.x.ai credits.
+
+Seats are load-balanced (round-robin) across all non-exhausted SuperGrok OAuth
+accounts. On 429/quota the failing seat is cooled down and the request retries
+on another seat.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime as dt
+import fcntl
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+AUTH_FILE = Path(os.environ.get("GROK_AUTH_FILE", str(Path.home() / ".grok" / "auth.json"))).expanduser()
+LOCK_FILE = Path(os.environ.get("GROK_AUTH_LOCK_FILE", str(AUTH_FILE) + ".lock")).expanduser()
+SLOTS_DIR = Path(os.environ.get("GROK_AUTH_SLOTS_DIR", str(Path.home() / ".grok" / "auth-slots"))).expanduser()
+STATE_FILE = Path(os.environ.get("GROK_ROTATE_STATE_FILE", str(Path.home() / ".grok" / ".proxy-rotate-state.json"))).expanduser()
+UPSTREAM = os.environ.get("GROK_UPSTREAM", "https://cli-chat-proxy.grok.com/v1").rstrip("/")
+UPSTREAM_CODING = os.environ.get("GROK_UPSTREAM_CODING", UPSTREAM).rstrip("/")
+UPSTREAM_IMAGINE = os.environ.get("GROK_UPSTREAM_IMAGINE", "https://api.x.ai/v1").rstrip("/")
+ISSUER = os.environ.get("GROK_OIDC_ISSUER", "https://auth.x.ai").rstrip("/")
+CLIENT_ID = os.environ.get("GROK_OIDC_CLIENT_ID", "b1a00492-073a-47ea-816f-4c329264a828")
+REFRESH_SKEW_SECONDS = int(os.environ.get("GROK_REFRESH_SKEW_SECONDS", str(6 * 3600)))  # proactive: refresh when <6h left
+EXHAUST_COOLDOWN_SECONDS = int(os.environ.get("GROK_EXHAUST_COOLDOWN_SECONDS", "3600"))
+
+# Ordered SuperGrok seats used for rotation (comma-separated emails).
+PREFERRED_GROK_EMAILS = [
+    e.strip().lower()
+    for e in os.environ.get(
+        "GROK_PREFERRED_EMAILS",
+        "",  # operator-supplied; never hardcode personal seats in the public plugin
+    ).split(",")
+    if e.strip()
+]
+
+# Optional explicit slot filename map: email=file,email2=file2
+_SLOT_MAP_ENV = os.environ.get("GROK_SLOT_FILES", "").strip()
+DEFAULT_SLOT_FILES = {}  # optional: GROK_SLOT_FILES=email=file.json,...
+if _SLOT_MAP_ENV:
+    for part in _SLOT_MAP_ENV.split(","):
+        if "=" in part:
+            email, fname = part.split("=", 1)
+            DEFAULT_SLOT_FILES[email.strip().lower()] = fname.strip()
+
+LISTEN_HOST = os.environ.get("GROK_PROXY_HOST", "127.0.0.1")
+LISTEN_PORT = int(os.environ.get("GROK_PROXY_PORT", "31845"))
+HTTP_TIMEOUT = float(os.environ.get("GROK_PROXY_TIMEOUT", "600"))
+
+HOP_BY_HOP = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+    "host",
+}
+
+QUOTA_RE = re.compile(
+    r"quota|rate.?limit|too many requests|limit.?reached|credits?.?exhaust|"
+    r"prepaid.?balance|usage.?cap|throttl|capacity|resource.?exhausted",
+    re.I,
+)
+
+
+def _utc_now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def _parse_iso(value: Any) -> dt.datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip().replace("Z", "+00:00")
+    # Truncate nanoseconds to microseconds for fromisoformat.
+    raw = re.sub(r"\.(\d{1,6})\d*(?=[+-]\d\d:\d\d$)", lambda m: "." + m.group(1), raw)
+    try:
+        out = dt.datetime.fromisoformat(raw)
+        if out.tzinfo is None:
+            out = out.replace(tzinfo=dt.timezone.utc)
+        return out
+    except Exception:
+        return None
+
+
+def _jwt_exp(token: str) -> float | None:
+    try:
+        parts = token.split(".")
+        if len(parts) < 2:
+            return None
+        payload = parts[1] + "=" * (-len(parts[1]) % 4)
+        data = json.loads(base64.urlsafe_b64decode(payload.encode("ascii")))
+        exp = data.get("exp")
+        return float(exp) if isinstance(exp, (int, float)) else None
+    except Exception:
+        return None
+
+
+def _email_of(entry: Dict[str, Any]) -> str:
+    return str(entry.get("email") or "").strip().lower()
+
+
+def _auth_entries(raw: Dict[str, Any]) -> list[tuple[str, Dict[str, Any]]]:
+    out: list[tuple[str, Dict[str, Any]]] = []
+    if not isinstance(raw, dict):
+        return out
+    for key, entry in raw.items():
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("auth_mode") in (None, "oidc", "oauth") and (
+            entry.get("refresh_token") or entry.get("key") or entry.get("access_token")
+        ):
+            out.append((key, entry))
+    return out
+
+
+def _load_state() -> Dict[str, Any]:
+    if not STATE_FILE.exists():
+        return {"exhausted": {}, "active_email": None}
+    try:
+        data = json.loads(STATE_FILE.read_text())
+        if not isinstance(data, dict):
+            return {"exhausted": {}, "active_email": None}
+        data.setdefault("exhausted", {})
+        data.setdefault("active_email", None)
+        return data
+    except Exception:
+        return {"exhausted": {}, "active_email": None}
+
+
+def _save_state(state: Dict[str, Any]) -> None:
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    tmp = STATE_FILE.with_suffix(STATE_FILE.suffix + f".tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(state, indent=2) + "\n")
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, STATE_FILE)
+
+
+def _is_exhausted(state: Dict[str, Any], email: str) -> bool:
+    exp_map = state.get("exhausted") or {}
+    until = exp_map.get(email)
+    if not until:
+        return False
+    try:
+        return float(until) > time.time()
+    except Exception:
+        return False
+
+
+def _mark_exhausted(state: Dict[str, Any], email: str) -> None:
+    state.setdefault("exhausted", {})[email] = time.time() + EXHAUST_COOLDOWN_SECONDS
+    _save_state(state)
+    sys.stderr.write(f"[grok-proxy] marked exhausted: {email} for {EXHAUST_COOLDOWN_SECONDS}s\n")
+
+
+def _slot_path_for_email(email: str) -> Path:
+    fname = DEFAULT_SLOT_FILES.get(email.lower())
+    if not fname:
+        safe = re.sub(r"[^a-z0-9]+", "_", email.lower()).strip("_")
+        fname = f"{safe}.json"
+    return SLOTS_DIR / fname
+
+
+def _discover_slot_files() -> Dict[str, Path]:
+    """email -> path for all known SuperGrok OAuth slot files + active auth."""
+    found: Dict[str, Path] = {}
+    # Preferred slot filenames first.
+    for email in PREFERRED_GROK_EMAILS:
+        path = _slot_path_for_email(email)
+        if path.exists():
+            found[email] = path
+    # Active auth.json
+    if AUTH_FILE.exists():
+        try:
+            raw = json.loads(AUTH_FILE.read_text())
+            for _, entry in _auth_entries(raw):
+                email = _email_of(entry)
+                if email:
+                    found.setdefault(email, AUTH_FILE)
+        except Exception:
+            pass
+    # Any other json in slots dir.
+    if SLOTS_DIR.exists():
+        for path in SLOTS_DIR.glob("*.json"):
+            if ".bak" in path.name:
+                continue
+            try:
+                raw = json.loads(path.read_text())
+            except Exception:
+                continue
+            for _, entry in _auth_entries(raw):
+                email = _email_of(entry)
+                if email:
+                    found.setdefault(email, path)
+    return found
+
+
+def _load_auth_blob(path: Path) -> Dict[str, Any]:
+    raw = json.loads(path.read_text())
+    if not isinstance(raw, dict):
+        raise RuntimeError(f"{path} is not a JSON object")
+    return raw
+
+
+def _pick_entry_from_raw(raw: Dict[str, Any], want_email: Optional[str] = None) -> tuple[str, Dict[str, Any]]:
+    entries = _auth_entries(raw)
+    if not entries:
+        raise RuntimeError("No usable Grok CLI OAuth entry found")
+    by_email = {}
+    for key, entry in entries:
+        email = _email_of(entry)
+        if email:
+            by_email[email] = (key, entry)
+    if want_email and want_email in by_email:
+        return by_email[want_email]
+    for preferred in PREFERRED_GROK_EMAILS:
+        if preferred in by_email:
+            return by_email[preferred]
+    return entries[0]
+
+
+def _ordered_accounts(state: Dict[str, Any]) -> List[str]:
+    slots = _discover_slot_files()
+    ordered: List[str] = []
+    for email in PREFERRED_GROK_EMAILS:
+        if email in slots and not _is_exhausted(state, email):
+            ordered.append(email)
+    # append any other non-preferred available seats last
+    for email in sorted(slots):
+        if email not in ordered and not _is_exhausted(state, email):
+            ordered.append(email)
+    # if all exhausted, allow preferred slots anyway (retry after cooldown may have expired mid-loop)
+    if not ordered:
+        for email in PREFERRED_GROK_EMAILS:
+            if email in slots:
+                ordered.append(email)
+        for email in sorted(slots):
+            if email not in ordered:
+                ordered.append(email)
+    return ordered
+
+
+def _needs_refresh(entry: Dict[str, Any], *, force: bool = False) -> bool:
+    if force:
+        return True
+    token = str(entry.get("key") or entry.get("access_token") or "").strip()
+    exp = _jwt_exp(token)
+    if exp is not None:
+        return exp <= time.time() + REFRESH_SKEW_SECONDS
+    exp_dt = _parse_iso(entry.get("expires_at"))
+    if exp_dt is not None:
+        return exp_dt.timestamp() <= time.time() + REFRESH_SKEW_SECONDS
+    return False
+
+
+def _token_endpoint() -> str:
+    req = urllib.request.Request(
+        f"{ISSUER}/.well-known/openid-configuration",
+        headers={"Accept": "application/json", "User-Agent": "grok-cli-auth-proxy/1.1"},
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = json.loads(resp.read())
+    endpoint = str(data.get("token_endpoint") or "").strip()
+    parsed = urllib.parse.urlparse(endpoint)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme != "https" or (host != "x.ai" and not host.endswith(".x.ai")):
+        raise RuntimeError(f"Refusing unexpected xAI token endpoint: {endpoint!r}")
+    return endpoint
+
+
+def _refresh(entry: Dict[str, Any]) -> Dict[str, Any]:
+    refresh_token = str(entry.get("refresh_token") or "").strip()
+    if not refresh_token:
+        raise RuntimeError("Grok CLI auth entry has no refresh_token")
+    body = urllib.parse.urlencode(
+        {
+            "grant_type": "refresh_token",
+            "client_id": str(entry.get("oidc_client_id") or CLIENT_ID),
+            "refresh_token": refresh_token,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        _token_endpoint(),
+        data=body,
+        method="POST",
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "User-Agent": "grok-cli-auth-proxy/1.1",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:1000]
+        raise RuntimeError(f"xAI refresh failed HTTP {exc.code}: {detail}") from exc
+    access = str(data.get("access_token") or "").strip()
+    if not access:
+        raise RuntimeError(f"xAI refresh response missing access_token: {data!r}")
+    now = _utc_now()
+    expires_in = int(data.get("expires_in") or 3600)
+    updated = dict(entry)
+    updated["key"] = access
+    updated["refresh_token"] = str(data.get("refresh_token") or refresh_token).strip()
+    updated["expires_at"] = (now + dt.timedelta(seconds=expires_in)).isoformat().replace("+00:00", "Z")
+    updated["token_type"] = str(data.get("token_type") or entry.get("token_type") or "Bearer")
+    if data.get("id_token"):
+        updated["id_token"] = str(data.get("id_token"))
+    return updated
+
+
+def _atomic_write_json(path: Path, raw: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(raw, indent=2, sort_keys=False) + "\n")
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, path)
+
+
+def _persist_slot(email: str, raw: Dict[str, Any], source_path: Path) -> None:
+    """Write seat tokens back to its slot file (and optionally mirror last-used auth.json)."""
+    slot = _slot_path_for_email(email)
+    _atomic_write_json(slot, raw)
+    # Keep auth.json as last-used mirror for tools that still read it; not sticky for LB.
+    if os.environ.get("GROK_MIRROR_ACTIVE_AUTH", "1") not in ("0", "false", "no"):
+        _atomic_write_json(AUTH_FILE, raw)
+
+
+def _rr_pick(candidates: List[str], state: Dict[str, Any]) -> List[str]:
+    """Rotate candidate order for round-robin load balancing."""
+    if not candidates:
+        return candidates
+    rr = int(state.get("rr_index") or 0) % len(candidates)
+    return candidates[rr:] + candidates[:rr]
+
+
+def current_token(*, force_refresh: bool = False, prefer_email: Optional[str] = None) -> Tuple[str, str]:
+    """Return (access_token, email) for the next SuperGrok seat (round-robin LB)."""
+    LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with LOCK_FILE.open("a+") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        state = _load_state()
+        state.setdefault("request_counts", {})
+        slots = _discover_slot_files()
+        candidates = _ordered_accounts(state)
+        if prefer_email and prefer_email in candidates:
+            ordered = [prefer_email] + [e for e in candidates if e != prefer_email]
+        else:
+            ordered = _rr_pick(candidates, state)
+
+        last_err: Exception | None = None
+        for email in ordered:
+            path = slots.get(email)
+            if not path or not path.exists():
+                continue
+            try:
+                raw = _load_auth_blob(path)
+                key, entry = _pick_entry_from_raw(raw, want_email=email)
+                if _needs_refresh(entry, force=force_refresh):
+                    try:
+                        entry = _refresh(entry)
+                        raw[key] = entry
+                        _atomic_write_json(path, raw)
+                    except Exception as refresh_exc:
+                        # Keep serving while access JWT is still valid even if RT is dead.
+                        tok_now = str(entry.get("key") or entry.get("access_token") or "").strip()
+                        exp = _jwt_exp(tok_now)
+                        if exp is None or exp <= time.time() + 60:
+                            raise RuntimeError(f"{email}: refresh failed and access expired: {refresh_exc}") from refresh_exc
+                        sys.stderr.write(
+                            f"[grok-proxy] {email}: refresh failed ({refresh_exc}); "
+                            f"using access token until {int(exp - time.time())}s left\n"
+                        )
+                token = str(entry.get("key") or entry.get("access_token") or "").strip()
+                if not token:
+                    raise RuntimeError(f"{email}: no access token")
+                # Reject clearly expired access even if present
+                exp_chk = _jwt_exp(token)
+                if exp_chk is not None and exp_chk <= time.time():
+                    raise RuntimeError(f"{email}: access token expired")
+                _persist_slot(email, raw, path)
+                # Advance RR only on successful pick so failed seats do not burn slots forever.
+                if email in candidates:
+                    idx = candidates.index(email)
+                    state["rr_index"] = (idx + 1) % max(1, len(candidates))
+                state["active_email"] = email  # last-used, not sticky
+                counts = state.setdefault("request_counts", {})
+                counts[email] = int(counts.get(email) or 0) + 1
+                _save_state(state)
+                return token, email
+            except Exception as exc:
+                last_err = exc
+                sys.stderr.write(f"[grok-proxy] skip {email}: {exc}\n")
+                continue
+        raise RuntimeError(f"No usable SuperGrok OAuth seat: {last_err}")
+
+
+def refresh_all_seats(*, force: bool = True) -> Dict[str, Any]:
+    """Force-refresh every known SuperGrok slot. Clears exhaust cooldowns for successes."""
+    LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+    results: Dict[str, Any] = {}
+    with LOCK_FILE.open("a+") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        state = _load_state()
+        slots = _discover_slot_files()
+        for email, path in slots.items():
+            try:
+                raw = _load_auth_blob(path)
+                key, entry = _pick_entry_from_raw(raw, want_email=email)
+                entry = _refresh(entry) if force or _needs_refresh(entry) else entry
+                raw[key] = entry
+                _atomic_write_json(path, raw)
+                # clear exhaust on successful refresh
+                if isinstance(state.get("exhausted"), dict):
+                    state["exhausted"].pop(email, None)
+                results[email] = {
+                    "ok": True,
+                    "expires_at": entry.get("expires_at"),
+                    "path": str(path),
+                }
+            except Exception as exc:
+                results[email] = {"ok": False, "error": str(exc), "path": str(path)}
+        _save_state(state)
+    return results
+
+
+def _looks_like_quota(status: int, body: bytes) -> bool:
+    if status in (429, 402):
+        return True
+    if status == 403 and QUOTA_RE.search(body.decode("utf-8", "replace")[:2000] or ""):
+        return True
+    if status >= 400 and QUOTA_RE.search(body.decode("utf-8", "replace")[:2000] or ""):
+        return True
+    return False
+
+
+class ProxyHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.0"
+    server_version = "grok-cli-auth-proxy/1.2-lb"
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        sys.stderr.write("%s - - [%s] %s\n" % (self.address_string(), self.log_date_time_string(), fmt % args))
+
+    def _send_json(self, status: int, payload: Dict[str, Any]) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _select_upstream(self, body: bytes | None) -> str:
+        path = self.path.lower()
+        if "/images" in path or "/videos" in path or "/image" in path or "/video" in path:
+            return UPSTREAM_IMAGINE
+        if body:
+            try:
+                model = str(json.loads(body).get("model") or "").lower()
+                if model.startswith("grok-imagine") or "imagine" in model:
+                    return UPSTREAM_IMAGINE
+            except Exception:
+                pass
+        return UPSTREAM_CODING
+
+    def _target_url(self, upstream: str) -> str:
+        path = self.path
+        if path.startswith("http://") or path.startswith("https://"):
+            parsed = urllib.parse.urlparse(path)
+            path = urllib.parse.urlunparse(("", "", parsed.path, parsed.params, parsed.query, parsed.fragment))
+        if not path.startswith("/v1"):
+            path = "/v1" + (path if path.startswith("/") else "/" + path)
+        suffix = path[len("/v1") :]
+        return upstream + suffix
+
+    def _build_headers(self, token: str) -> Dict[str, str]:
+        headers: Dict[str, str] = {}
+        for k, v in self.headers.items():
+            lk = k.lower()
+            if lk in HOP_BY_HOP or lk == "authorization" or lk == "content-length":
+                continue
+            headers[k] = v
+        headers["Authorization"] = f"Bearer {token}"
+        headers.setdefault("Accept", "application/json")
+        headers.setdefault("User-Agent", "grok-cli-auth-proxy/1.1")
+        headers.setdefault("x-grok-client-version", "0.2.93")
+        headers.setdefault("x-grok-client-identifier", "grok-cli")
+        return headers
+
+    def _do_upstream(self, upstream: str, body: bytes | None, token: str) -> tuple[int, list[tuple[str, str]], bytes]:
+        headers = self._build_headers(token)
+        req = urllib.request.Request(self._target_url(upstream), data=body, method=self.command, headers=headers)
+        try:
+            resp = urllib.request.urlopen(req, timeout=HTTP_TIMEOUT)
+            with resp:
+                payload = resp.read()
+                hdrs = [(k, v) for k, v in resp.headers.items() if k.lower() not in HOP_BY_HOP and k.lower() != "content-length"]
+                return int(resp.status), hdrs, payload
+        except urllib.error.HTTPError as exc:
+            payload = exc.read()
+            hdrs = [(k, v) for k, v in exc.headers.items() if k.lower() not in HOP_BY_HOP and k.lower() != "content-length"]
+            return int(exc.code), hdrs, payload
+
+    def _forward(self) -> None:
+        length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(length) if length else None
+        upstream = self._select_upstream(body)
+
+        tried: list[str] = []
+        last_status = 503
+        last_headers: list[tuple[str, str]] = []
+        last_body = b'{"error":"no_accounts"}'
+
+        # Try up to N preferred seats on quota/exhaust errors.
+        max_tries = max(1, len(PREFERRED_GROK_EMAILS) or 1)
+        for _ in range(max_tries):
+            try:
+                token, email = current_token()
+            except Exception as exc:
+                self._send_json(503, {"error": f"grok_cli_auth_unavailable: {exc}"})
+                return
+            if email in tried:
+                break
+            tried.append(email)
+            try:
+                status, headers, payload = self._do_upstream(upstream, body, token)
+            except Exception as exc:
+                self._send_json(502, {"error": f"upstream_error: {exc}"})
+                return
+            last_status, last_headers, last_body = status, headers, payload
+            if status < 400:
+                # success
+                self.send_response(status)
+                for k, v in headers:
+                    self.send_header(k, v)
+                self.send_header("X-Grok-Proxy-Account", email)
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+                return
+            if _looks_like_quota(status, payload):
+                state = _load_state()
+                _mark_exhausted(state, email)
+                sys.stderr.write(f"[grok-proxy] quota on {email} status={status}; rotating\n")
+                continue
+            # non-quota error: return as-is
+            self.send_response(status)
+            for k, v in headers:
+                self.send_header(k, v)
+            self.send_header("X-Grok-Proxy-Account", email)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+
+        # all seats exhausted or failed
+        self.send_response(last_status)
+        for k, v in last_headers:
+            self.send_header(k, v)
+        self.send_header("X-Grok-Proxy-Tried", ",".join(tried))
+        self.send_header("Content-Length", str(len(last_body)))
+        self.end_headers()
+        self.wfile.write(last_body)
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urllib.parse.urlparse(self.path)
+        path = parsed.path.rstrip("/") or "/"
+        if path in ("/accounts", "/v1/accounts", "/health", "/v1/health", "/rotate", "/v1/rotate", "/refresh-all", "/v1/refresh-all", "/refresh_all", "/v1/refresh_all"):
+            try:
+                state = _load_state()
+                slots = _discover_slot_files()
+                available = []
+                missing = []
+                for email in PREFERRED_GROK_EMAILS:
+                    if email in slots:
+                        available.append(email)
+                    else:
+                        missing.append(email)
+                for email in slots:
+                    if email not in available:
+                        available.append(email)
+                exhausted = {
+                    e: int(float(until) - time.time())
+                    for e, until in (state.get("exhausted") or {}).items()
+                    if float(until) > time.time()
+                }
+                if path.endswith("refresh-all") or path.endswith("refresh_all"):
+                    results = refresh_all_seats(force=True)
+                    payload = {"refreshed": results, "load_balance": "round_robin"}
+                elif path.endswith("rotate") and self.command == "GET":
+                    # Advance RR without long exhaust (LB mode).
+                    token, email = current_token(force_refresh=False)
+                    payload = {"rotated_to": email, "token_preview": token[:8] + "...", "load_balance": "round_robin"}
+                elif path.endswith("health"):
+                    state = _load_state()
+                    payload = {
+                        "status": "ok",
+                        "service": "grok-cli-auth-proxy",
+                        "load_balance": "round_robin",
+                        "active_accounts": available,
+                        "active": state.get("active_email"),
+                        "last_used": state.get("active_email"),
+                        "rr_index": state.get("rr_index", 0),
+                        "request_counts": state.get("request_counts") or {},
+                        "preferred": PREFERRED_GROK_EMAILS,
+                        "missing_preferred": missing,
+                        "exhausted_seconds_remaining": exhausted,
+                        "slots_dir": str(SLOTS_DIR),
+                    }
+                else:
+                    state = _load_state()
+                    payload = {
+                        "object": "list",
+                        "load_balance": "round_robin",
+                        "active": available,
+                        "current": state.get("active_email"),
+                        "last_used": state.get("active_email"),
+                        "rr_index": state.get("rr_index", 0),
+                        "request_counts": state.get("request_counts") or {},
+                        "preferred": PREFERRED_GROK_EMAILS,
+                        "missing_preferred": missing,
+                        "exhausted_seconds_remaining": exhausted,
+                        "auth_file": str(AUTH_FILE),
+                        "slots_dir": str(SLOTS_DIR),
+                    }
+                body = json.dumps(payload).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            except Exception as exc:
+                body = json.dumps({"error": str(exc)}).encode()
+                self.send_response(500)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            return
+        self._forward()
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._forward()
+
+    def do_OPTIONS(self) -> None:  # noqa: N802
+        self._forward()
+
+
+def main() -> int:
+    # Prefer a live seat at start, but stay up even if all seats are cooling/refresh-broken
+    # so keepalive + re-login can recover without a dead listener.
+    try:
+        token, email = current_token(force_refresh=False)
+        sys.stderr.write(f"grok-cli-auth-proxy active seat={email} token_ok={bool(token)}\n")
+    except Exception as exc:
+        sys.stderr.write(f"grok-cli-auth-proxy starting degraded: {exc}\n")
+    server = ThreadingHTTPServer((LISTEN_HOST, LISTEN_PORT), ProxyHandler)
+    print(
+        f"grok-cli-auth-proxy listening on http://{LISTEN_HOST}:{LISTEN_PORT}/v1 "
+        f"-> {UPSTREAM_CODING} (slots={SLOTS_DIR})",
+        flush=True,
+    )
+    server.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/claude-ops/scripts/account-rotation/grok-reauth-egress.sh
+++ b/claude-ops/scripts/account-rotation/grok-reauth-egress.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# grok-reauth-egress.sh — pick residential egress for Grok device OAuth.
+# Order: caller env → EFG SOCKS → Bright Data residential → ISP → mobile → SOCKS fallback.
+# Source before grok-oauth-reauth. Never prints credential values.
+set -euo pipefail
+
+log() { echo "[grok-reauth-egress] $*" >&2; }
+
+if [[ -n "${GROK_REAUTH_HTTP_PROXY:-}" || -n "${GROK_REAUTH_SOCKS:-}" ]]; then
+  log "using caller-provided proxy env"
+  return 0 2>/dev/null || exit 0
+fi
+
+# 1) Local SOCKS (EFG / residential tunnel)
+for port in "${GROK_REAUTH_SOCKS_PORT:-1089}" 1089 1087; do
+  if timeout 1 bash -c "echo >/dev/tcp/127.0.0.1/$port" 2>/dev/null; then
+    code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 8 \
+      --proxy "socks5h://127.0.0.1:${port}" https://accounts.x.ai/ 2>/dev/null || echo 000)"
+    if [[ "$code" != "000" && "$code" != "403" ]]; then
+      export GROK_REAUTH_SOCKS="socks5://127.0.0.1:${port}"
+      log "selected local SOCKS port=${port} (http ${code})"
+      return 0 2>/dev/null || exit 0
+    fi
+    log "local SOCKS port=${port} http=${code}"
+  fi
+done
+
+# 2) Bright Data HTTP proxy tiers via curl --proxy-user (no password in URL literals)
+probe_brd_tier() {
+  local tier="$1" zone="$2"
+  local uid host port sess user code
+  # password material only from env at probe time — never echoed
+  local -a pass_keys
+  case "$tier" in
+    residential) pass_keys=(BRIGHT_DATA_RESIDENTIAL_PROXY_PASSWORD BRIGHT_DATA_PROXY_PASSWORD BRIGHT_DATA_PASS BRIGHT_DATA_TOKEN) ;;
+    isp) pass_keys=(BRIGHT_DATA_ISP_PROXY_PASSWORD BRIGHT_DATA_PROXY_PASSWORD BRIGHT_DATA_PASS BRIGHT_DATA_TOKEN) ;;
+    mobile) pass_keys=(BRIGHT_DATA_MOBILE_PROXY_PASSWORD BRIGHT_DATA_MOBILE_PASSWORD BRIGHT_DATA_PASS BRIGHT_DATA_TOKEN) ;;
+    *) return 1 ;;
+  esac
+  local pass=""
+  local k
+  for k in "${pass_keys[@]}"; do
+    if [[ -n "${!k:-}" ]]; then pass="${!k}"; break; fi
+  done
+  uid="${BRIGHT_DATA_USERID:-${BRIGHT_DATA_CUSTOMER:-${BRIGHT_DATA_USER:-}}}"
+  host="${BRIGHT_DATA_PROXY_HOST:-brd.superproxy.io}"
+  port="${BRIGHT_DATA_PROXY_PORT:-22225}"
+  [[ -n "$uid" && -n "$zone" && -n "$pass" ]] || return 1
+  sess="gr$(date +%s | tail -c 6)${tier:0:1}"
+  user="brd-customer-${uid}-zone-${zone}-country-nl-session-${sess}"
+  code="$(curl -sS -o /dev/null -w '%{http_code}' --max-time 15 \
+    --proxy "http://${host}:${port}" \
+    --proxy-user "${user}:${pass}" \
+    https://accounts.x.ai/ 2>/dev/null || echo 000)"
+  if [[ "$code" == "200" ]]; then
+    # Export for Playwright-style consumers (username/password split preferred)
+    export GROK_REAUTH_HTTP_PROXY_HOST="${host}"
+    export GROK_REAUTH_HTTP_PROXY_PORT="${port}"
+    export GROK_REAUTH_HTTP_PROXY_USER="${user}"
+    export GROK_REAUTH_HTTP_PROXY_PASS="${pass}"
+    # Combined form for tools that only accept one URL (not logged)
+    export GROK_REAUTH_HTTP_PROXY="http://${user}:${pass}@${host}:${port}"
+    log "selected Bright Data tier=${tier} zone=${zone} (http ${code})"
+    return 0
+  fi
+  log "Bright Data tier=${tier} zone=${zone} http=${code}"
+  return 1
+}
+
+Z_RES="${BRIGHT_DATA_RESIDENTIAL_PROXY_ZONE:-${BRIGHT_DATA_RESIDENTIAL_ZONE:-${BRIGHT_DATA_ZONE:-}}}"
+Z_ISP="${BRIGHT_DATA_ISP_PROXY_ZONE:-${BRIGHT_DATA_ISP_ZONE:-}}"
+Z_MOB="${BRIGHT_DATA_MOBILE_PROXY_ZONE:-${BRIGHT_DATA_MOBILE_ZONE:-}}"
+
+if [[ -n "$Z_RES" ]] && probe_brd_tier residential "$Z_RES"; then
+  return 0 2>/dev/null || exit 0
+fi
+if [[ -n "$Z_ISP" ]] && probe_brd_tier isp "$Z_ISP"; then
+  return 0 2>/dev/null || exit 0
+fi
+if [[ -n "$Z_MOB" ]] && probe_brd_tier mobile "$Z_MOB"; then
+  return 0 2>/dev/null || exit 0
+fi
+
+# 3) Last resort SOCKS even if previously 403 (browser may pass CF)
+if timeout 1 bash -c "echo >/dev/tcp/127.0.0.1/1089" 2>/dev/null; then
+  export GROK_REAUTH_SOCKS="socks5://127.0.0.1:1089"
+  log "fallback local SOCKS port=1089 (may hit CF)"
+  return 0 2>/dev/null || exit 0
+fi
+
+log "no egress selected — reauth may use tool defaults"
+return 0 2>/dev/null || exit 0

--- a/claude-ops/scripts/account-rotation/ops-accounts-backend.mjs
+++ b/claude-ops/scripts/account-rotation/ops-accounts-backend.mjs
@@ -1,0 +1,58 @@
+/**
+ * ops-accounts-backend.mjs — resolve CRS vs local seat-state backend.
+ *
+ * Env / config:
+ *   OPS_ACCOUNTS_BACKEND | crs.backend
+ *     local | seat-state | file  → local seat-state (no CRS)
+ *     crs                        → CRS admin API only
+ *     auto (default)             → try CRS, fall back to local
+ *
+ * Dual-write (CRS path → seat-state.json) is on by default unless
+ * OPS_ACCOUNTS_DUAL_WRITE=0.
+ */
+export function resolveAccountsBackend({ env = process.env, cfgBackend } = {}) {
+  const raw = String(env.OPS_ACCOUNTS_BACKEND || cfgBackend || 'auto')
+    .trim()
+    .toLowerCase()
+    .replace(/_/g, '-');
+  if (raw === 'local' || raw === 'seat-state' || raw === 'file' || raw === 'seatstate') {
+    return 'local';
+  }
+  if (raw === 'crs' || raw === 'relay' || raw === 'claude-relay') {
+    return 'crs';
+  }
+  return 'auto';
+}
+
+export function dualWriteEnabled({ env = process.env } = {}) {
+  return env.OPS_ACCOUNTS_DUAL_WRITE !== '0';
+}
+
+/**
+ * Mirror CRS (or local) decisions into seat-state shape.
+ * @param {Array<{ email: string, schedulable: boolean, util5h?: number|null, util7d?: number|null, lastError?: string|null }>} seats
+ * @param {object} opts
+ */
+export function mergeSeatsIntoState(state, seats, { provider = 'claude' } = {}) {
+  const next = state && typeof state === 'object' ? structuredClone(state) : { version: 1, providers: {} };
+  if (!next.providers) next.providers = {};
+  if (!next.providers[provider]) next.providers[provider] = { seats: {} };
+  if (!next.providers[provider].seats) next.providers[provider].seats = {};
+  const now = new Date().toISOString();
+  for (const s of seats || []) {
+    if (!s?.email) continue;
+    const prev = next.providers[provider].seats[s.email] || {};
+    next.providers[provider].seats[s.email] = {
+      ...prev,
+      schedulable: s.schedulable !== false,
+      util5h: s.util5h ?? prev.util5h ?? null,
+      util7d: s.util7d ?? prev.util7d ?? null,
+      exhaustedUntil: s.exhaustedUntil ?? prev.exhaustedUntil ?? null,
+      lastError: s.lastError ?? prev.lastError ?? null,
+      updatedAt: now,
+    };
+  }
+  next.version = next.version || 1;
+  next.updatedAt = now;
+  return next;
+}

--- a/claude-ops/scripts/account-rotation/seat-policy-tick.mjs
+++ b/claude-ops/scripts/account-rotation/seat-policy-tick.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * seat-policy-tick.mjs — conservative schedulable policy against local seat-state.
+ * No CRS. Reads optional live util from rotate.mjs --utilization JSON if present.
+ *
+ * Usage:
+ *   node seat-policy-tick.mjs [--dry-run] [--status]
+ *
+ * Env:
+ *   OPS_ACCOUNTS_OFF_5H (default 85)  OPS_ACCOUNTS_ON_5H (default 60)
+ *   OPS_ACCOUNTS_OFF_7D (default 90)  OPS_ACCOUNTS_ON_7D (default 70)
+ *   OPS_ACCOUNTS_FLOOR (default 2)    minimum seats kept schedulable
+ */
+import { spawnSync } from 'child_process';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, renameSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { homedir } from 'os';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DATA = process.env.CLAUDE_PLUGIN_DATA_DIR || join(homedir(), '.claude', 'plugins', 'data', 'ops-ops-marketplace');
+const STATE_PATH = process.env.OPS_ACCOUNTS_STATE_PATH || join(DATA, 'account-rotation', 'seat-state.json');
+
+const DRY = process.argv.includes('--dry-run');
+const STATUS = process.argv.includes('--status');
+const OFF5 = num(process.env.OPS_ACCOUNTS_OFF_5H, 85);
+const ON5 = num(process.env.OPS_ACCOUNTS_ON_5H, 60);
+const OFF7 = num(process.env.OPS_ACCOUNTS_OFF_7D, 90);
+const ON7 = num(process.env.OPS_ACCOUNTS_ON_7D, 70);
+const FLOOR = num(process.env.OPS_ACCOUNTS_FLOOR, 2);
+
+function num(v, d) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : d;
+}
+
+function load() {
+  if (!existsSync(STATE_PATH)) {
+    return { version: 1, updatedAt: null, providers: { claude: { seats: {} } } };
+  }
+  return JSON.parse(readFileSync(STATE_PATH, 'utf8'));
+}
+
+function save(state) {
+  mkdirSync(dirname(STATE_PATH), { recursive: true });
+  state.updatedAt = new Date().toISOString();
+  const tmp = STATE_PATH + '.tmp';
+  writeFileSync(tmp, JSON.stringify(state, null, 2) + '\n', { mode: 0o600 });
+  renameSync(tmp, STATE_PATH);
+}
+
+function tryLiveUtil() {
+  const rot = join(__dirname, 'rotate.mjs');
+  if (!existsSync(rot)) return {};
+  const r = spawnSync(process.execPath, [rot, '--utilization', '--json'], {
+    encoding: 'utf8',
+    timeout: 60_000,
+  });
+  if (r.status !== 0 || !r.stdout) return {};
+  try {
+    const data = JSON.parse(r.stdout);
+    const map = {};
+    const rows = Array.isArray(data) ? data : data.accounts || data.utilization || [];
+    for (const row of rows) {
+      const email = row.email || row.name || row.id;
+      if (!email) continue;
+      map[email] = {
+        util5h: row.fiveHour ?? row.util5h ?? row['5h'] ?? null,
+        util7d: row.sevenDay ?? row.util7d ?? row['7d'] ?? null,
+      };
+    }
+    return map;
+  } catch {
+    return {};
+  }
+}
+
+const state = load();
+if (!state.providers?.claude) state.providers = { ...state.providers, claude: { seats: {} } };
+const seats = state.providers.claude.seats || {};
+const live = tryLiveUtil();
+
+// merge live util
+for (const [email, u] of Object.entries(live)) {
+  if (!seats[email]) {
+    seats[email] = {
+      schedulable: true,
+      util5h: null,
+      util7d: null,
+      exhaustedUntil: null,
+      lastError: null,
+      updatedAt: null,
+    };
+  }
+  if (u.util5h != null) seats[email].util5h = u.util5h;
+  if (u.util7d != null) seats[email].util7d = u.util7d;
+  seats[email].updatedAt = new Date().toISOString();
+}
+state.providers.claude.seats = seats;
+
+const emails = Object.keys(seats);
+const decisions = [];
+for (const email of emails) {
+  const s = seats[email];
+  const u5 = s.util5h;
+  const u7 = s.util7d;
+  let desired = s.schedulable !== false;
+  let reason = 'hold';
+  if (u5 != null && u5 >= OFF5) {
+    desired = false;
+    reason = `5h=${u5}>=${OFF5}`;
+  } else if (u7 != null && u7 >= OFF7) {
+    desired = false;
+    reason = `7d=${u7}>=${OFF7}`;
+  } else if (s.schedulable === false) {
+    if ((u5 == null || u5 <= ON5) && (u7 == null || u7 <= ON7)) {
+      desired = true;
+      reason = `recover 5h=${u5} 7d=${u7}`;
+    }
+  } else {
+    desired = true;
+    reason = 'ok';
+  }
+  decisions.push({ email, cur: s.schedulable !== false, desired, reason, u5, u7 });
+}
+
+// floor: keep minimum on
+let onCount = decisions.filter((d) => d.desired).length;
+if (onCount < FLOOR) {
+  const softOff = decisions
+    .filter((d) => !d.desired && !String(d.reason).startsWith('7d='))
+    .sort((a, b) => (a.u5 ?? 0) - (b.u5 ?? 0));
+  for (const d of softOff) {
+    if (onCount >= FLOOR) break;
+    d.desired = true;
+    d.reason = `FLOOR(${FLOOR}): ${d.reason}`;
+    onCount++;
+  }
+}
+
+if (STATUS || DRY) {
+  console.log(`seat-policy @ ${STATE_PATH} dry=${DRY}`);
+  for (const d of decisions) {
+    const mark = d.cur === d.desired ? ' ' : d.desired ? '+' : '-';
+    console.log(
+      `  ${mark} ${d.email}  sched ${d.cur}→${d.desired}  5h=${d.u5 ?? '—'} 7d=${d.u7 ?? '—'}  (${d.reason})`,
+    );
+  }
+  if (STATUS && !DRY) process.exit(0);
+}
+
+let changed = 0;
+if (!DRY) {
+  for (const d of decisions) {
+    if (d.cur === d.desired) continue;
+    seats[d.email].schedulable = d.desired;
+    seats[d.email].updatedAt = new Date().toISOString();
+    changed++;
+    console.log(`${d.email}: schedulable ${d.cur}→${d.desired} (${d.reason})`);
+  }
+  state.providers.claude.seats = seats;
+  save(state);
+}
+console.log(`tick: ${changed} change(s), schedulable=${decisions.filter((d) => d.desired).length}/${decisions.length}`);

--- a/claude-ops/scripts/account-rotation/seat-state.mjs
+++ b/claude-ops/scripts/account-rotation/seat-state.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/**
+ * seat-state.mjs — local multi-provider seat state (no CRS required).
+ *
+ * File-backed store used by ops-accounts policy when backend=local.
+ * Schema is provider-agnostic; Claude CRS daemons can dual-write later.
+ *
+ * Usage:
+ *   node seat-state.mjs status
+ *   node seat-state.mjs list [provider]
+ *   node seat-state.mjs set <provider> <email> key=value …
+ *   node seat-state.mjs toggle <provider> <email> schedulable=true|false
+ *   node seat-state.mjs path
+ *
+ * Env:
+ *   OPS_ACCOUNTS_STATE_PATH  override store path
+ *   CLAUDE_PLUGIN_DATA_DIR   default parent for state
+ */
+import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from 'fs';
+import { join, dirname } from 'path';
+import { homedir } from 'os';
+
+const DATA = process.env.CLAUDE_PLUGIN_DATA_DIR || join(homedir(), '.claude', 'plugins', 'data', 'ops-ops-marketplace');
+const STATE_PATH = process.env.OPS_ACCOUNTS_STATE_PATH || join(DATA, 'account-rotation', 'seat-state.json');
+
+function empty() {
+  return {
+    version: 1,
+    updatedAt: null,
+    providers: {
+      // claude: { seats: { [email]: { schedulable, util5h, util7d, lastError, updatedAt } } }
+    },
+  };
+}
+
+function load() {
+  if (!existsSync(STATE_PATH)) return empty();
+  try {
+    return { ...empty(), ...JSON.parse(readFileSync(STATE_PATH, 'utf8')) };
+  } catch {
+    return empty();
+  }
+}
+
+function save(state) {
+  mkdirSync(dirname(STATE_PATH), { recursive: true });
+  state.updatedAt = new Date().toISOString();
+  const tmp = STATE_PATH + '.tmp';
+  writeFileSync(tmp, JSON.stringify(state, null, 2) + '\n', { mode: 0o600 });
+  renameSync(tmp, STATE_PATH);
+}
+
+function ensureSeat(state, provider, email) {
+  if (!state.providers[provider]) state.providers[provider] = { seats: {} };
+  if (!state.providers[provider].seats[email]) {
+    state.providers[provider].seats[email] = {
+      schedulable: true,
+      util5h: null,
+      util7d: null,
+      exhaustedUntil: null,
+      lastError: null,
+      updatedAt: null,
+    };
+  }
+  return state.providers[provider].seats[email];
+}
+
+function printStatus(state) {
+  console.log(`seat-state: ${STATE_PATH}`);
+  console.log(`updatedAt: ${state.updatedAt || '(never)'}`);
+  const providers = Object.keys(state.providers || {});
+  if (!providers.length) {
+    console.log('(no seats — import from provider status or set …)');
+    return;
+  }
+  for (const p of providers) {
+    const seats = state.providers[p].seats || {};
+    const emails = Object.keys(seats);
+    const on = emails.filter((e) => seats[e].schedulable !== false);
+    console.log(`\n=== ${p} ===  schedulable ${on.length}/${emails.length}`);
+    for (const e of emails) {
+      const s = seats[e];
+      const flag = s.schedulable === false ? 'off' : 'on';
+      const u5 = s.util5h == null ? '—' : `${s.util5h}%`;
+      const u7 = s.util7d == null ? '—' : `${s.util7d}%`;
+      console.log(`  [${flag}] ${e}  5h=${u5} 7d=${u7}`);
+    }
+  }
+}
+
+const [cmd, ...args] = process.argv.slice(2);
+const state = load();
+
+switch (cmd) {
+  case 'path':
+    console.log(STATE_PATH);
+    break;
+  case 'status':
+  case undefined:
+  case '':
+    printStatus(state);
+    break;
+  case 'list': {
+    const provider = args[0];
+    if (provider) {
+      console.log(JSON.stringify(state.providers[provider] || { seats: {} }, null, 2));
+    } else {
+      console.log(JSON.stringify(state, null, 2));
+    }
+    break;
+  }
+  case 'set': {
+    const [provider, email, ...kvs] = args;
+    if (!provider || !email || !kvs.length) {
+      console.error('usage: seat-state set <provider> <email> key=value …');
+      process.exit(2);
+    }
+    const seat = ensureSeat(state, provider, email);
+    for (const kv of kvs) {
+      const i = kv.indexOf('=');
+      if (i < 0) continue;
+      const k = kv.slice(0, i);
+      let v = kv.slice(i + 1);
+      if (v === 'true') v = true;
+      else if (v === 'false') v = false;
+      else if (v === 'null') v = null;
+      else if (/^-?\d+(\.\d+)?$/.test(v)) v = Number(v);
+      seat[k] = v;
+    }
+    seat.updatedAt = new Date().toISOString();
+    save(state);
+    console.log(`ok: ${provider} ${email}`);
+    break;
+  }
+  case 'toggle': {
+    const [provider, email, flag] = args;
+    if (!provider || !email) {
+      console.error('usage: seat-state toggle <provider> <email> [true|false]');
+      process.exit(2);
+    }
+    const seat = ensureSeat(state, provider, email);
+    if (flag === 'true' || flag === 'false') seat.schedulable = flag === 'true';
+    else seat.schedulable = !seat.schedulable;
+    seat.updatedAt = new Date().toISOString();
+    save(state);
+    console.log(`ok: ${provider} ${email} schedulable=${seat.schedulable}`);
+    break;
+  }
+  case 'import-claude-config': {
+    // Best-effort: seed emails from rotation config (no tokens)
+    const candidates = [
+      process.env.CRS_CONFIG,
+      join(DATA, 'account-rotation', 'config.json'),
+      join(homedir(), '.claude', 'plugins', 'data', 'ops', 'account-rotation', 'config.json'),
+    ].filter(Boolean);
+    let cfg = null;
+    for (const p of candidates) {
+      if (existsSync(p)) {
+        try {
+          cfg = JSON.parse(readFileSync(p, 'utf8'));
+          break;
+        } catch {
+          /* next */
+        }
+      }
+    }
+    if (!cfg?.accounts?.length) {
+      console.error('no accounts in rotation config');
+      process.exit(1);
+    }
+    for (const a of cfg.accounts) {
+      const email = a.email || a.label;
+      if (!email) continue;
+      ensureSeat(state, 'claude', email);
+      state.providers.claude.seats[email].updatedAt = new Date().toISOString();
+    }
+    save(state);
+    console.log(`ok: imported ${cfg.accounts.length} claude seats`);
+    break;
+  }
+  default:
+    console.error('usage: seat-state status|list|set|toggle|import-claude-config|path');
+    process.exit(2);
+}

--- a/claude-ops/skills/ops-accounts/SKILL.md
+++ b/claude-ops/skills/ops-accounts/SKILL.md
@@ -1,67 +1,108 @@
 ---
 name: ops-accounts
-description: Multi-provider AI account manager (Claude, Grok/xAI, Codex). Status, switch, refresh, and reauth behind one skill. Phase 0 thin router over existing engines; /ops:rotate remains a Claude-focused alias.
-argument-hint: '[status|switch|refresh|reauth|list] [provider] [email]'
+description: Multi-provider AI account manager (Claude, Grok/xAI, OpenAI/Codex, Factory, Cursor). Status, setup, switch, refresh, reauth, util, optional CRS/LB. Canonical replacement for /ops:rotate and /ops:rotate-setup (those remain aliases).
+argument-hint: '[status|list|setup|switch|refresh|reauth|util|rotate-now|crs|crs-tick|help] [provider] [args…]'
 allowed-tools:
   - Bash
   - Read
+  - Write
+  - Edit
   - AskUserQuestion
-effort: low
-maxTurns: 20
+effort: medium
+maxTurns: 40
 ---
 
-# OPS ► ACCOUNTS (phase 0)
+# OPS ► ACCOUNTS
 
-One skill for **all** paid AI seats on the box. Provider engines stay specialized;
-this skill is the **router** and the product surface for “public plugin only.”
+**Canonical** multi-provider seat manager. Same layers Anthropic has for Claude —
+for every provider:
 
-| Provider | Engine today | Unattended reauth |
-|----------|--------------|-------------------|
-| Claude | `scripts/account-rotation/rotate.mjs` + `rotate-magic.mjs` | magic-link + captcha cascade |
-| Grok | `grok-rotate`, `grok-oauth-reauth`, `grok-cli-auth-proxy` | xAI device-code + Google (dcli) |
-| Codex | `codex-rotate` if present | OpenAI OAuth bridge patterns |
+| Layer | Verbs |
+|-------|--------|
+| Status / list | `status`, `list` |
+| Setup / OAuth capture | `setup` |
+| Switch active seat | `switch`, `rotate-now` (Claude) |
+| Refresh tokens | `refresh` |
+| Unattended reauth | `reauth` |
+| Utilization / quota | `util` |
+| Optional Claude LB (CRS or future gateway) | `crs`, `crs-tick` |
 
-CRS is **optional** and Claude-oriented (relay LB). It is not required for
-standalone reauth on any provider.
+**Aliases (compat):** `/ops:rotate` → this skill (Claude-focused shortcuts).  
+`/ops:rotate-setup` → `setup` (wizard). `/ops:account` → same as this skill.
 
-## Subcommands (`$ARGUMENTS`)
+## Providers
 
-| Args | Action |
-|------|--------|
-| (none) / `status` | Cross-provider status (no secrets) |
-| `list` | Same as status (phase 0) |
-| `switch grok` | Next SuperGrok seat (`grok-rotate switch`) |
-| `switch claude` | Point at `/ops:rotate rotate-now` |
-| `refresh` / `refresh all` | `host-token-keepalive --force` |
-| `refresh grok` / `refresh claude` | Provider-scoped keepalive |
-| `reauth grok <email>` | Device-code reauth (dcli password/TOTP) |
-| `reauth claude <email>` | `rotate-magic.mjs --to <email>` |
+| Provider | Engine | Reauth | Util |
+|----------|--------|--------|------|
+| Claude | `scripts/account-rotation/rotate.mjs` + `rotate-magic.mjs` | magic-link + captcha cascade | 5h/7d |
+| Grok | slots + `grok-cli-auth-proxy` (+ optional CRS hop) | device-code + Google (dcli); residential egress cascade | weekly / 429 |
+| OpenAI / Codex | `codex-rotate` when present | OAuth bridge | usage best-effort |
+| Factory | adapter TBD / quota-feed seeds | native | quota-feed patterns |
+| Cursor | adapter TBD | browser/device OAuth | plan limits if available |
 
-## How to run
+**CRS is optional.** For Grok, CRS is only a thin hop to the SuperGrok OAuth proxy — multi-seat RR lives on the proxy, not a CRS account table. See `docs/ops/OPS-ACCOUNTS-VISION.md` (CRS cherry-pick / no-CRS path).
+
+## Router (`bin/ops-accounts`)
+
+Always prefer:
 
 ```bash
-# preferred: plugin bin
-"${CLAUDE_PLUGIN_ROOT}/bin/ops-accounts" status
-"${CLAUDE_PLUGIN_ROOT}/bin/ops-accounts" reauth grok <email>
-"${CLAUDE_PLUGIN_ROOT}/bin/ops-accounts" switch grok
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(ls -d "$HOME/.claude/plugins/cache/ops-marketplace/ops"/*/ 2>/dev/null | sort -V | tail -1)}"
+"$PLUGIN_ROOT/bin/ops-accounts" <cmd> …
 ```
 
-If `CLAUDE_PLUGIN_ROOT` is unset, resolve the latest
-`~/.claude/plugins/cache/ops-marketplace/ops/*/`.
+| Command | Action |
+|---------|--------|
+| `status` / `list` | All configured providers (no secrets) |
+| `util [claude\|grok\|all]` | Quota / utilization best-effort |
+| `switch claude` / `rotate-now` | Claude keychain rotate (`force-rotate` / `rotate.mjs`) |
+| `switch grok` | Next SuperGrok seat (`grok-rotate switch`) |
+| `refresh [all\|claude\|grok]` | Keepalive / RT refresh |
+| `reauth claude <email>` | `rotate-magic.mjs --to <email>` |
+| `reauth grok <email>` | Device reauth with residential cascade env |
+| `setup` / `setup claude` | Full Claude OAuth wizard (former rotate-setup steps) |
+| `setup grok` | Add/reauth SuperGrok seat |
+| `crs` / `crs-tick` | Optional Claude CRS pool status / one tick |
+| `seats` | Local multi-provider seat-state (no CRS) |
+
+## Claude setup / OAuth
+
+When `$ARGUMENTS` is `setup`, `setup claude`, or this skill is invoked via
+**ops-rotate-setup** alias: follow the full wizard in
+`skills/ops-rotate-setup/SKILL.md` (Steps 1–5, CRS optional 4.4–4.7). That file
+remains the detailed Claude setup procedure; this skill is the entrypoint.
+
+Claude day-2 ops (`status`/`rotate-now`/`list`/`reauth`/`crs`) also match
+`skills/ops-rotate/SKILL.md` — treat that as Claude detail appendix.
+
+## Local seat-state (no CRS)
+
+```bash
+"$PLUGIN_ROOT/bin/ops-accounts" seats status
+"$PLUGIN_ROOT/bin/ops-accounts" seats import-claude-config
+node "$PLUGIN_ROOT/scripts/account-rotation/seat-state.mjs" toggle claude <email> false
+```
+
+File: `$CLAUDE_PLUGIN_DATA_DIR/account-rotation/seat-state.json` (or `OPS_ACCOUNTS_STATE_PATH`).
+
+## Grok notes
+
+1. CLI models often use `base_url` → CRS `/grok/v1` → **host OAuth proxy** → SuperGrok seats.  
+2. `grok-rotate` / `auth.json` is the SuperGrok seat set; keep **auth-slots** in sync after reauth.  
+3. Reauth egress: EFG SOCKS (`GROK_REAUTH_SOCKS`) → Bright Data tiers via  
+   `scripts/account-rotation/grok-reauth-egress.sh` (residential cascade).  
+4. Proxy RR status: `curl -sS http://127.0.0.1:31845/accounts` (no tokens).
 
 ## Rules
 
-1. **Never print tokens, cookies, or full vault dumps.**
-2. Prefer the bin router over ad-hoc host paths so cutover can retarget one file.
-3. On weekly-cap / 429 for Grok interactive TUI: `switch grok` after seats are healthy.
-4. On dead refresh_token: `reauth <provider> <email>` — do not claim CRS will fix OAuth.
-5. `/ops:rotate` stays as Claude alias until one major version after rename.
+1. Never print tokens, cookies, OTP codes, or vault dumps.  
+2. Never write real emails into committed files.  
+3. Prefer `bin/ops-accounts` over ad-hoc host paths.  
+4. Missing CRS is not a failure.  
+5. Dead RT → `reauth`, not “install CRS.”  
+6. Background long OAuth (Rule 4).  
 
 ## Phase map
 
-- **0 (this skill):** unified verbs + docs
-- **1–2:** Claude captcha port + CRS optional (enablers)
-- **3:** absorb host `grok-*` into plugin installers/timers
-- **4:** optional bundled LB (not a full CRS fork)
-
-See `docs/ops/OPS-ACCOUNTS-VISION.md`.
+0 contract + this skill · 1 Claude parity · 2 CRS optional · 3 Grok complete ·  
+4 Codex+Factory · 5 Cursor · 6 companions · 7 host cutover · 8 gateway (no CRS)

--- a/claude-ops/skills/ops-rotate-setup/SKILL.md
+++ b/claude-ops/skills/ops-rotate-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ops-rotate-setup
-description: Interactive OAuth init wizard for the multi-account Claude rotator. Walks through every account in the rotation config and, for any account missing a valid keychain token, delegates to the proven `rotate.mjs` / `rotate-magic.mjs` magic-link flow (browser-driver cascade + Gmail polling), which writes the verified OAuth token to `Claude-Rotation-<key>` (key = account label or email, keychain account `$USER`). CRS is optional (multi-account load balancing only). Re-runnable any time. Standalone alias of the same step inside `/ops:setup`.
+description: Alias of /ops:accounts setup for Claude OAuth init wizard. Prefer /ops:accounts setup. CRS optional multi-account LB only.
 argument-hint: '[--all|--account <email>|--add|--crs|--standalone]'
 allowed-tools:
   - Bash
@@ -9,6 +9,10 @@ allowed-tools:
 effort: medium
 maxTurns: 25
 ---
+> **Alias:** Prefer **`/ops:accounts setup`** (or `/ops:accounts setup claude`).  
+> This file remains the detailed Claude OAuth wizard. Multi-provider entry is ops-accounts.
+
+
 
 ## Purpose
 

--- a/claude-ops/skills/ops-rotate/SKILL.md
+++ b/claude-ops/skills/ops-rotate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ops-rotate
-description: Multi-account Claude Max rotator. Status, manual rotation, account list, add-account wizard, standalone rotate-magic reauth, and optional CRS relay-pool auto-prioritization. CRS is not required. Requires account_rotation_enabled=true in plugin settings for daemon swap; reauth works without it.
+description: Alias of /ops:accounts for Claude Max seats (status, rotate-now, list, reauth, optional CRS). Prefer /ops:accounts for multi-provider. Full Claude procedure still in this file's historical detail via ops-accounts router.
 argument-hint: '[status|rotate-now|list|add-account|reauth|crs|crs-tick]'
 allowed-tools:
   - Bash
@@ -12,212 +12,28 @@ effort: low
 maxTurns: 25
 ---
 
-# OPS ► ROTATE
+# OPS ► ROTATE (alias → `/ops:accounts`)
 
-Manage the optional multi-account Claude Max rotator. Off by default — flip
-`account_rotation_enabled` in plugin settings to use it.
+This skill is a **compat alias**. Route all work through **ops-accounts**:
 
-## Subcommands
+| Old verb | New |
+|----------|-----|
+| (none) / status | `ops-accounts status` (Claude section) |
+| rotate-now | `ops-accounts switch claude` / `ops-accounts rotate-now` |
+| list | `ops-accounts list` |
+| add-account | `ops-accounts setup claude` |
+| reauth | `ops-accounts reauth claude <email>` |
+| crs / crs-tick | `ops-accounts crs` / `ops-accounts crs-tick` |
 
-| `$ARGUMENTS`       | Action                                                                   |
-| ------------------ | ------------------------------------------------------------------------ |
-| (none) or `status` | Show current account, 5h%/7d%, total rotations, daemon health            |
-| `rotate-now`       | Force rotation to the most-cooled candidate (or `--to <email>`)          |
-| `list`             | List every configured account with token state + last util               |
-| `add-account`      | Interactive wizard: collect email, OAuth into rotator vault              |
-| `reauth`           | Standalone rotate-magic for one email (no CRS): magic-link + captcha     |
-| `crs`              | Show the CRS relay-pool schedulable state + priority-daemon health       |
-| `crs-tick`         | Run one CRS priority tick now (append `--dry-run` to preview, no writes) |
+Load **`skills/ops-accounts/SKILL.md`** first, then for Claude-only depth use the
+bin:
 
-## Rotation models (CRS is optional)
-
-This skill manages **complementary** account systems. **CRS is never required.**
-
-- **Standalone rotate-magic** (`reauth`, and setup OAuth) — one account at a time.
-  Magic-link + captcha cascade. Enough for single/few accounts. No CRS install.
-- **Keychain rotator** (`status`/`rotate-now`/`list`/`add-account`) — for **direct-auth**
-  sessions. One active claude.ai OAuth token in the keychain at a time; the daemon swaps
-  to the coolest account when the active one heats up.
-- **CRS priority daemon** (`crs`/`crs-tick`) — **optional** multi-account load balancing
-  / rate-limit spreading via **claude-relay-service**. Toggles each account's
-  `schedulable` flag from live utilization. Off by default; configure only if you
-  run a CRS pool (see **ops-rotate-setup** Step 4.4 detection).
-
-## Pre-flight (every invocation)
-
-1. Read `account_rotation_enabled` from plugin preferences. If false, tell the user how to enable and exit.
-2. Resolve paths:
-   - `ROT_DIR=${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops}/account-rotation`
-   - `ROT_SRC=${CLAUDE_PLUGIN_ROOT}/scripts/account-rotation`
-3. If `$ROT_DIR` doesn't exist yet, mirror the runtime layout:
-   ```
-   mkdir -p "$ROT_DIR"
-   cp "$ROT_SRC/config.example.json" "$ROT_DIR/config.json"  # only if missing
-   ```
-4. Verify Node 20+: `node --version`. If missing, fail fast with install hint.
-
-## status (default)
-
-Run:
-
-```
-node "$ROT_SRC/rotate.mjs" --status
-node "$ROT_SRC/rotate.mjs" --utilization 2>/dev/null | head -40
-launchctl list 2>/dev/null | grep com.claude-ops.account-rotation || echo "daemon: not loaded"
+```bash
+"${CLAUDE_PLUGIN_ROOT}/bin/ops-accounts" status
+"${CLAUDE_PLUGIN_ROOT}/bin/ops-accounts" rotate-now
+"${CLAUDE_PLUGIN_ROOT}/bin/ops-accounts" reauth claude <email>
 ```
 
-Render a compact panel:
+Multi-provider status, Grok, Codex, Factory, Cursor: **`/ops:accounts` only**.
 
-```
-ROTATOR STATUS
-  Active account : <email>
-  5h utilization : 42% (resets in 1h 23m)
-  7d utilization : 18%
-  Total rotations: 14
-  Daemon         : ✓ running (PID 12345)  |  ✗ not loaded
-  Configured     : 4 accounts (3 with valid tokens, 1 expired)
-```
-
-## rotate-now
-
-If user passed an explicit target email (`/ops:rotate rotate-now user@example.com`), pass `--to "<email>"`. Otherwise let `rotate.mjs` pick the most-cooled.
-
-```
-bash "$ROT_SRC/force-rotate.sh" "${TARGET_EMAIL:-}"
-```
-
-Show the trailing status output. Remind the user that running Claude Code sessions hold their own access token until next `/login` or until they exit and re-enter.
-
-## list
-
-```
-node "$ROT_SRC/rotate.mjs" --status 2>/dev/null
-```
-
-Then for each account in `$ROT_DIR/config.json`, render one row:
-
-```
-  [✓] user@example.com           5h 12%   token valid 6.4h  (active)
-  [✓] backup@example.com         5h 87%   token valid 3.1h
-  [✗] expired@example.com        ── ──    token expired 2d ago
-  [○] new@example.com            ── ──    no token captured
-```
-
-If any row is `[○]` or `[✗]`, suggest running `/ops:rotate add-account` for that email.
-
-## add-account (interactive)
-
-This is the only mutating subcommand. Walk the user through:
-
-1. **Collect email.** `AskUserQuestion`: "Email of the Claude Max account to add?" (free text via `Edit` to config — the skill must NOT capture sensitive data through chat options; just ask for the email).
-2. **Optional metadata.** Ask if it's a Workspace account (`AskUserQuestion`: `[Personal]`, `[Workspace]`, `[Skip]`). If Workspace, prompt for `orgName` (free text) — `orgUuid` is auto-discovered later.
-3. **Append to config.** Read `$ROT_DIR/config.json`, append the new account entry to `accounts[]`, write back. Use the schema from `config.example.json._account_schema_example`.
-4. **Capture token.** Two paths via `AskUserQuestion`:
-   - `[Use current Claude Code login]` — runs `node "$ROT_SRC/rotate.mjs" --capture --to <email>` to copy the live `Claude Code-credentials` token into the rotator vault.
-   - `[Run OAuth in browser now]` — runs `node "$ROT_SRC/rotate.mjs" --setup --only=<email>` (background-friendly; opens Chrome).
-   - `[Skip — I'll capture later]`.
-5. **Daemon install (one-time).** If launchd doesn't show `com.claude-ops.account-rotation`, ask `[Install + start daemon]` / `[Skip]`. On install:
-   ```
-   sed "s|\${HOME}|$HOME|g" "${CLAUDE_PLUGIN_ROOT}/templates/com.claude-ops.account-rotation.plist" > ~/Library/LaunchAgents/com.claude-ops.account-rotation.plist
-   launchctl load ~/Library/LaunchAgents/com.claude-ops.account-rotation.plist
-   ```
-   Mirror `daemon.mjs` + friends to `$ROT_DIR` if not already symlinked:
-   ```
-   for f in rotate.mjs daemon.mjs ai-brain.mjs force-rotate.sh; do
-     [ -e "$ROT_DIR/$f" ] || ln -s "$ROT_SRC/$f" "$ROT_DIR/$f"
-   done
-   ```
-6. **Verify.** Run `status` subcommand inline.
-
-## reauth (standalone rotate-magic — no CRS)
-
-Refresh one account's vault token via magic-link + captcha cascade. Does **not**
-need CRS or `crs.enabled`.
-
-```
-EMAIL="<email>"   # required
-node "$ROT_SRC/rotate-magic.mjs" --to "$EMAIL"
-# equivalent:
-# node "$ROT_SRC/rotate.mjs" --magic-link --to "$EMAIL"
-```
-
-Background-friendly; surface the log. Headed display + cascade env:
-`CLAUDE_DESKTOP_DISPLAY`, `CLAUDE_ROT_HEADED=1` (see `CAPTCHA-CASCADE.md`).
-If the user only has one seat, this is the primary recovery path — do not
-push them to install CRS.
-
-## crs (relay-pool status)
-
-**Only if CRS is present.** Detect first (same checks as ops-rotate-setup Step 4.4:
-`command -v crs`, `crs.enabled` in config, `$CRS_BASE_URL/health` or default
-`http://127.0.0.1:3000/health`). If not detected, explain briefly that CRS is
-optional load balancing and suggest `reauth` / `/ops:rotate-setup --standalone`
-instead of failing.
-
-When CRS is available: show the pool's per-account schedulable state + the priority
-daemon's health, plus the three optional reconcilers (429-cooldown, 401-refresher,
-magic-link-autoloop) if enabled. Read-only.
-
-```
-WRAP="$ROT_SRC/crs-priority-daemon.sh"
-bash "$WRAP" --status 2>&1 | head -40   # prints "● name sched=true 5h=NN%  <status>"
-launchctl list 2>/dev/null | grep com.claude-ops.crs-priority || echo "crs-priority daemon: not loaded"
-tail -n 5 "${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/logs/crs-priority.log" 2>/dev/null
-
-# Only if crs.cooldownEnabled / crs.tokenRefreshEnabled / crs.enableMagicLinkRecovery are true in config:
-node "$ROT_SRC/crs-429-cooldown.mjs" --status 2>&1
-launchctl list 2>/dev/null | grep com.claude-ops.crs-429-cooldown || echo "crs-429-cooldown: not loaded"
-node "$ROT_SRC/crs-401-refresher.mjs" --status 2>&1
-launchctl list 2>/dev/null | grep com.claude-ops.crs-401-refresher || echo "crs-401-refresher: not loaded"
-node "$ROT_SRC/magic-link-autoloop.mjs" --status 2>&1
-launchctl list 2>/dev/null | grep com.claude-ops.magic-link-autoloop || echo "magic-link-autoloop: not loaded"
-```
-
-Render a compact panel:
-
-```
-CRS POOL  (http://127.0.0.1:3000)
-  schedulable : 7 / 10
-  off         : canary-sponsors (rate-limited), pool-chairman (warning), pool-foundation (warning)
-  daemon      : ✓ running (every 120s)  |  ✗ not loaded — run /ops:rotate-setup
-  429-cooldown: ✓ running (every 60s)   |  ✗ not loaded  |  – not enabled (crs.cooldownEnabled=false)
-  401-refresher: ✓ running (every 300s) |  ✗ not loaded  |  – not enabled (crs.tokenRefreshEnabled=false)
-  magic-link  : ✓ running (every 600s)  |  ✗ not loaded  |  – not enabled (crs.enableMagicLinkRecovery=false)
-```
-
-If CRS `/health` is unreachable, say so and point to `/ops:rotate-setup` (optional)
-or standalone `reauth`. If the daemon isn't loaded but `crs.enabled` is true, suggest
-`/ops:rotate-setup --crs`. Show reconciler lines only if their config flag is true —
-if false, show `– not enabled` (opt-in, not a failure). If a flag is true but its
-daemon isn't loaded, suggest `/ops:rotate-setup --reconcilers`.
-
-## crs-tick (run one tick now)
-
-Apply (or, with `--dry-run`, preview) one prioritization pass immediately — useful
-right after changing thresholds or to confirm the policy.
-
-```
-bash "$ROT_SRC/crs-priority-daemon.sh" ${ARGS:-}   # ARGS="--dry-run" to preview
-```
-
-This is the same code the launchd timer runs; the daemon only ever toggles
-`schedulable` (fully reversible) and never deletes or mutates account credentials.
-
-## Optional npm dep
-
-`rotate.mjs` uses Playwright only for the browser fallback. It is declared as
-an optional dep in the plugin's `package.json`. If a browser fallback is needed
-and Playwright is missing, the skill should offer:
-
-```
-npm install --prefix "$CLAUDE_PLUGIN_ROOT" --no-save playwright
-npx --prefix "$CLAUDE_PLUGIN_ROOT" playwright install chromium
-```
-
-## Hard rules
-
-- This skill is **read-mostly**. Only `add-account` mutates `config.json`, and only after the user explicitly confirmed the email.
-- Never echo refresh tokens or access tokens to chat output.
-- Never auto-edit `config.json` outside `add-account` — token rotation is the daemon's job, not the skill's.
-- If `account_rotation_enabled` is false, refuse to run subcommands and instead explain the toggle.
-- If multiple OS users share the Mac, surface `CLAUDE_ROTATOR_KEYCHAIN_ACCOUNT` as the override env var.
+Vision: `docs/ops/OPS-ACCOUNTS-VISION.md`.


### PR DESCRIPTION
## Summary

Cherry-pick path so people do **not** need claude-relay-service for multi-seat policy or SuperGrok RR.

- **`OPS_ACCOUNTS_BACKEND=auto|crs|local`** on `crs-priority-daemon` — auto tries CRS, falls back to `seat-policy-tick` + `seat-state.json`
- **Dual-write** CRS decisions into local seat-state (`OPS_ACCOUNTS_DUAL_WRITE=0` to disable)
- **`ops-accounts-backend.mjs`** + unit test
- **Plugin `grok-cli-auth-proxy.py`** (no host emails hardcoded) + `ops-accounts grok-proxy status|start|path`
- Docs: skill cherry-pick map, vision phase 2b/3/4, CHANGELOG

Stacks on **#732** (skill merge + seat-state). Merge order: #731 docs → #732 → **this**.

Not in this PR: full OpenAI-compat `ops-accounts-gateway` (phase 4), dual-mode for 401/429/token-feed daemons.

## Test plan

- [x] `node scripts/account-rotation/__tests__/ops-accounts-backend.test.mjs`
- [x] `OPS_ACCOUNTS_BACKEND=local` priority daemon → seat-policy-tick dry-run
- [x] `python3 -m py_compile` on plugin grok proxy
- [x] PII: no personal emails in proxy/skill
- [ ] CI green
- [ ] After #732 merge: retarget base to `main` if needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes multi-account scheduling and OAuth token refresh/proxy paths for Claude and Grok; scope is large but CRS remains optional and local mode isolates Docker-dependent daemons.
> 
> **Overview**
> Enables **multi-seat Claude policy and SuperGrok round-robin without Docker CRS** by routing account work through a shared backend resolver and a plugin-owned Grok proxy.
> 
> **CRS dual backend:** `crs-priority-daemon` now honors `OPS_ACCOUNTS_BACKEND=auto|crs|local` (via new `ops-accounts-backend.mjs`). `local` runs `seat-policy-tick` against `seat-state.json`; `auto` uses CRS when reachable and falls back to local. Successful CRS ticks **dual-write** schedulable/util fields into seat-state unless `OPS_ACCOUNTS_DUAL_WRITE=0`. `crs-429-cooldown`, `crs-401-refresher`, and `crs-token-feed` **no-op** when backend is `local`.
> 
> **Grok in plugin:** Adds `grok-cli-auth-proxy.py` (env-driven seats, no hardcoded emails) with multi-account RR, quota cooldown, and token refresh—exposed via `ops-accounts grok-proxy status|start|path` so SuperGrok traffic does not depend on CRS or `~/.local/bin`.
> 
> Docs update vision phases (2b local seat-state, 3 plugin Grok, 4 future gateway) and add `OPS-ACCOUNTS-GATEWAY.md` as a **design-only** next step—not shipped here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29fac4711b7d3d0aea850172078db6216615cdc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->