### PR TITLE
feat(ops-accounts): dual-mode seat policy + plugin Grok proxy (no CRS)

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,12 +2,9 @@
 
 - ops-accounts-gateway skeleton (:3005 health/auth/grok hop; CLI gateway subcommand)
 - feat(crs-priority-daemon): dual-mode `backend=crs|local` file seat-state without CRS Docker
+- ops-accounts: dual-write + OPS_ACCOUNTS_BACKEND auto/crs/local; grok-cli-auth-proxy; local no-op reconcilers
 
 # Changelog
-
-## Unreleased
-
-- ops-accounts: dual-write + OPS_ACCOUNTS_BACKEND auto/crs/local; grok-cli-auth-proxy; local no-op reconcilers; gateway design doc
 
 ## Unreleased
 

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 - ops-accounts-gateway skeleton (:3005 health/auth/grok hop; CLI gateway subcommand)
 - feat(crs-priority-daemon): dual-mode `backend=crs|local` file seat-state without CRS Docker
-- ops-accounts: dual-write + OPS_ACCOUNTS_BACKEND auto/crs/local; grok-cli-auth-proxy; local no-op reconcilers
 
 # Changelog
+
+## Unreleased
+
+- ops-accounts: dual-write + OPS_ACCOUNTS_BACKEND auto/crs/local; grok-cli-auth-proxy; local no-op reconcilers; gateway design doc
 
 ## Unreleased
 

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -7,6 +7,10 @@
 
 ## Unreleased
 
+- ops-accounts: dual-write + OPS_ACCOUNTS_BACKEND auto/crs/local; grok-cli-auth-proxy; local no-op reconcilers; gateway design doc
+
+## Unreleased
+
 ### Changed
 
 - **ops-accounts multi-provider plan:** every provider (Claude, Grok, OpenAI/Codex, Factory, Cursor) gets Anthropic-shaped OAuth, reauth, util, switch/LB under `/ops:accounts`.

--- a/claude-ops/scripts/account-rotation/__tests__/ops-accounts-backend.test.mjs
+++ b/claude-ops/scripts/account-rotation/__tests__/ops-accounts-backend.test.mjs
@@ -17,13 +17,10 @@ assert(resolveAccountsBackend({ env: { OPS_ACCOUNTS_BACKEND: 'auto' } }) === 'au
 assert(dualWriteEnabled({ env: {} }) === true, 'dual-write default on');
 assert(dualWriteEnabled({ env: { OPS_ACCOUNTS_DUAL_WRITE: '0' } }) === false, 'dual-write off');
 
-const merged = mergeSeatsIntoState(
-  { version: 1, providers: {} },
-  [
-    { email: 'a@example.com', schedulable: true, util5h: 10, util7d: 20 },
-    { email: 'b@example.com', schedulable: false, util5h: 90 },
-  ],
-);
+const merged = mergeSeatsIntoState({ version: 1, providers: {} }, [
+  { email: 'a@example.com', schedulable: true, util5h: 10, util7d: 20 },
+  { email: 'b@example.com', schedulable: false, util5h: 90 },
+]);
 assert(merged.providers.claude.seats['a@example.com'].schedulable === true, 'a on');
 assert(merged.providers.claude.seats['b@example.com'].schedulable === false, 'b off');
 assert(merged.providers.claude.seats['a@example.com'].util5h === 10, 'util');

--- a/claude-ops/scripts/account-rotation/__tests__/ops-accounts-backend.test.mjs
+++ b/claude-ops/scripts/account-rotation/__tests__/ops-accounts-backend.test.mjs
@@ -1,0 +1,32 @@
+/**
+ * Unit tests: OPS_ACCOUNTS_BACKEND resolution + seat-state merge (no CRS).
+ */
+import { resolveAccountsBackend, dualWriteEnabled, mergeSeatsIntoState } from '../ops-accounts-backend.mjs';
+
+function assert(cond, msg) {
+  if (!cond) throw new Error(msg || 'assert failed');
+}
+
+assert(resolveAccountsBackend({ env: {} }) === 'auto', 'default auto');
+assert(resolveAccountsBackend({ env: { OPS_ACCOUNTS_BACKEND: 'local' } }) === 'local', 'local');
+assert(resolveAccountsBackend({ env: { OPS_ACCOUNTS_BACKEND: 'seat-state' } }) === 'local', 'seat-state');
+assert(resolveAccountsBackend({ env: { OPS_ACCOUNTS_BACKEND: 'CRS' } }) === 'crs', 'crs case');
+assert(resolveAccountsBackend({ env: {}, cfgBackend: 'file' }) === 'local', 'cfg file');
+assert(resolveAccountsBackend({ env: { OPS_ACCOUNTS_BACKEND: 'auto' } }) === 'auto', 'explicit auto');
+
+assert(dualWriteEnabled({ env: {} }) === true, 'dual-write default on');
+assert(dualWriteEnabled({ env: { OPS_ACCOUNTS_DUAL_WRITE: '0' } }) === false, 'dual-write off');
+
+const merged = mergeSeatsIntoState(
+  { version: 1, providers: {} },
+  [
+    { email: 'a@example.com', schedulable: true, util5h: 10, util7d: 20 },
+    { email: 'b@example.com', schedulable: false, util5h: 90 },
+  ],
+);
+assert(merged.providers.claude.seats['a@example.com'].schedulable === true, 'a on');
+assert(merged.providers.claude.seats['b@example.com'].schedulable === false, 'b off');
+assert(merged.providers.claude.seats['a@example.com'].util5h === 10, 'util');
+assert(merged.updatedAt, 'timestamp');
+
+console.log('ops-accounts-backend.test.mjs: ok');

--- a/claude-ops/scripts/account-rotation/__tests__/ops-accounts-gateway.test.mjs
+++ b/claude-ops/scripts/account-rotation/__tests__/ops-accounts-gateway.test.mjs
@@ -1,12 +1,7 @@
 /**
  * Unit tests: ops-accounts-gateway classify / seat pick / auth (no listen).
  */
-import {
-  classifyRoute,
-  pickSchedulableSeat,
-  authorize,
-  extractApiKey,
-} from '../ops-accounts-gateway.mjs';
+import { classifyRoute, pickSchedulableSeat, authorize, extractApiKey } from '../ops-accounts-gateway.mjs';
 
 function assert(cond, msg) {
   if (!cond) throw new Error(msg || 'assert failed');

--- a/claude-ops/scripts/account-rotation/crs-401-refresher.mjs
+++ b/claude-ops/scripts/account-rotation/crs-401-refresher.mjs
@@ -59,6 +59,7 @@ import { fileURLToPath } from 'url';
 import { homedir } from 'os';
 import { loadJsonState, saveJsonStateAtomic, withOwnStateLock } from './crs-reconciler-state.mjs';
 import { crsBaseUrl, loadRotationConfig, resolveCrsAdminPassword } from './crs-pool-config.mjs';
+import { resolveAccountsBackend } from './ops-accounts-backend.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const args = new Set(process.argv.slice(2));
@@ -359,6 +360,11 @@ async function tick() {
 }
 
 async function main() {
+  const backend = resolveAccountsBackend({ env: process.env, cfgBackend: C.backend });
+  if (backend === 'local') {
+    log('backend=local — CRS 401 refresher no-op (vault refresh is rotate.mjs / keychain keepalive)');
+    return;
+  }
   if (!ENABLED && !STATUS) {
     log('crs.tokenRefreshEnabled is not true (and $CRS_TOKEN_REFRESH_ENABLED!=1) — skipping tick (opt-in required)');
     return;

--- a/claude-ops/scripts/account-rotation/crs-429-cooldown.mjs
+++ b/claude-ops/scripts/account-rotation/crs-429-cooldown.mjs
@@ -61,6 +61,7 @@ import { fileURLToPath } from 'url';
 import { homedir } from 'os';
 import { loadJsonState, saveJsonStateAtomic, withOwnStateLock } from './crs-reconciler-state.mjs';
 import { crsBaseUrl, loadRotationConfig, resolveCrsAdminPassword } from './crs-pool-config.mjs';
+import { resolveAccountsBackend } from './ops-accounts-backend.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const args = new Set(process.argv.slice(2));
@@ -312,6 +313,11 @@ async function tick() {
 }
 
 async function main() {
+  const backend = resolveAccountsBackend({ env: process.env, cfgBackend: C.backend });
+  if (backend === 'local') {
+    log('backend=local — CRS 429 cooldown no-op (use seat-policy-tick / exhaustedUntil on seat-state)');
+    return;
+  }
   if (!ENABLED && !STATUS) {
     log('crs.cooldownEnabled is not true (and $CRS_COOLDOWN_ENABLED!=1) — skipping tick (opt-in required)');
     return;

--- a/claude-ops/scripts/account-rotation/crs-priority-daemon.mjs
+++ b/claude-ops/scripts/account-rotation/crs-priority-daemon.mjs
@@ -71,11 +71,7 @@ import {
   loadRotationConfig,
   vaultLookupKeysForEmail,
 } from './crs-pool-config.mjs';
-import {
-  resolveAccountsBackend,
-  dualWriteEnabled,
-  mergeSeatsIntoState,
-} from './ops-accounts-backend.mjs';
+import { resolveAccountsBackend, dualWriteEnabled, mergeSeatsIntoState } from './ops-accounts-backend.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || join(__dirname, '..', '..');
@@ -720,7 +716,6 @@ async function runLocalTick() {
   );
 }
 
-
 /** Mirror CRS decisions into provider-shaped seat-state (ops-accounts dual-write). */
 function dualWriteFromCrsDecisions(decisions) {
   if (!dualWriteEnabled()) return;
@@ -738,8 +733,7 @@ function dualWriteFromCrsDecisions(decisions) {
       }
     }
     const seats = decisions.map((d) => {
-      const email =
-        d.a?.subscriptionInfo?.email || vaultKeyByCrsName[d.a?.name] || d.a?.name || null;
+      const email = d.a?.subscriptionInfo?.email || vaultKeyByCrsName[d.a?.name] || d.a?.name || null;
       const u5 = d.u5;
       const u7 = d.a?._liveUsage?.u7;
       return {
@@ -768,112 +762,112 @@ async function main() {
     return;
   }
   try {
-  if (C.enabled === false && !STATUS && !DRY) {
-    log('crs.enabled=false — skipping tick');
-    return;
-  }
-  const auth = await login();
-  let accts = await getAccounts(auth);
-  if (!accts.length) {
-    log('no active claude accounts');
-    return;
-  }
-  const cleared = await clearStaleCooldowns(auth, accts);
-  if (cleared) {
-    accts = await getAccounts(auth);
-    log(`stale-cooldown: cleared ${cleared} account(s), reloaded pool`);
-    const reenabled = await recoverSchedulableAfterClear(auth, accts);
-    if (reenabled) {
-      accts = await getAccounts(auth);
-      log(`stale-cooldown: re-enabled ${reenabled} schedulable account(s)`);
+    if (C.enabled === false && !STATUS && !DRY) {
+      log('crs.enabled=false — skipping tick');
+      return;
     }
-  }
-  // Live per-account quota poller (60-120s cadence): hybrid of CRS-provided
-  // rateLimitStatus / sessionWindow / overload (populated from upstream response
-  // headers in the relay) + targeted /oauth/usage probe for precise u5/u7 headroom.
-  // Throttled sequential probes keep it polite under 60-120s window; feeds headroom
-  // to scheduler after.
-  let liveN = 0;
-  for (const a of accts) {
-    const key = accountVaultKey(a);
-    a._liveUsage = await liveUsage(key);
-    if (a._liveUsage) liveN++;
-    // Throttle ~150ms between probes (fits 60-120s hybrid header+probe cadence for ~13 accts)
-    await new Promise((r) => setTimeout(r, 150));
-  }
-  // Feed fresh headroom/utilization from targeted probes into CRS so scheduler
-  // (unifiedClaudeScheduler etc) sees live quota headroom for selection/LB.
-  let fed = 0;
-  for (const a of accts) {
-    if (a._liveUsage && (await feedLiveHeadroom(auth, a, a._liveUsage))) fed++;
-  }
-  if (fed) log(`headroom feed: updated ${fed} account(s) in CRS for scheduler`);
-
-  // Weekly-cap reconciliation (see WEEKLY-CAP RECONCILIATION in the header comment).
-  // Safe no-op on any account/deployment that never sets weeklyRateLimitEndAt.
-  if (WEEKLY_RECONCILE && !DRY && !STATUS) {
+    const auth = await login();
+    let accts = await getAccounts(auth);
+    if (!accts.length) {
+      log('no active claude accounts');
+      return;
+    }
+    const cleared = await clearStaleCooldowns(auth, accts);
+    if (cleared) {
+      accts = await getAccounts(auth);
+      log(`stale-cooldown: cleared ${cleared} account(s), reloaded pool`);
+      const reenabled = await recoverSchedulableAfterClear(auth, accts);
+      if (reenabled) {
+        accts = await getAccounts(auth);
+        log(`stale-cooldown: re-enabled ${reenabled} schedulable account(s)`);
+      }
+    }
+    // Live per-account quota poller (60-120s cadence): hybrid of CRS-provided
+    // rateLimitStatus / sessionWindow / overload (populated from upstream response
+    // headers in the relay) + targeted /oauth/usage probe for precise u5/u7 headroom.
+    // Throttled sequential probes keep it polite under 60-120s window; feeds headroom
+    // to scheduler after.
+    let liveN = 0;
     for (const a of accts) {
-      const u7 = a._liveUsage?.u7;
-      const resets7 = a._liveUsage?.resets7;
-      if (typeof u7 !== 'number') continue;
-      if (u7 >= OFF_7D && resets7 && !a.weeklyRateLimitEndAt) {
-        const put = await jfetch(`/admin/claude-accounts/${a.id}`, {
-          method: 'PUT',
-          headers: auth,
-          body: JSON.stringify({ weeklyRateLimitEndAt: resets7 }),
-        }).catch(() => null);
-        if (put && put.status >= 200 && put.status < 300) {
-          a.weeklyRateLimitEndAt = resets7;
-          log(`${a.name}: recorded weekly-cap hold until ${resets7} (live 7d=${u7}%)`);
-        }
-      } else if (u7 < ON_7D && a.weeklyRateLimitEndAt) {
-        const put = await jfetch(`/admin/claude-accounts/${a.id}`, {
-          method: 'PUT',
-          headers: auth,
-          body: JSON.stringify({ weeklyRateLimitEndAt: null }),
-        }).catch(() => null);
-        if (put && put.status >= 200 && put.status < 300) {
-          log(`${a.name}: cleared stale weekly-cap hold (live 7d=${u7}% < ${ON_7D}%)`);
-          a.weeklyRateLimitEndAt = null;
+      const key = accountVaultKey(a);
+      a._liveUsage = await liveUsage(key);
+      if (a._liveUsage) liveN++;
+      // Throttle ~150ms between probes (fits 60-120s hybrid header+probe cadence for ~13 accts)
+      await new Promise((r) => setTimeout(r, 150));
+    }
+    // Feed fresh headroom/utilization from targeted probes into CRS so scheduler
+    // (unifiedClaudeScheduler etc) sees live quota headroom for selection/LB.
+    let fed = 0;
+    for (const a of accts) {
+      if (a._liveUsage && (await feedLiveHeadroom(auth, a, a._liveUsage))) fed++;
+    }
+    if (fed) log(`headroom feed: updated ${fed} account(s) in CRS for scheduler`);
+
+    // Weekly-cap reconciliation (see WEEKLY-CAP RECONCILIATION in the header comment).
+    // Safe no-op on any account/deployment that never sets weeklyRateLimitEndAt.
+    if (WEEKLY_RECONCILE && !DRY && !STATUS) {
+      for (const a of accts) {
+        const u7 = a._liveUsage?.u7;
+        const resets7 = a._liveUsage?.resets7;
+        if (typeof u7 !== 'number') continue;
+        if (u7 >= OFF_7D && resets7 && !a.weeklyRateLimitEndAt) {
+          const put = await jfetch(`/admin/claude-accounts/${a.id}`, {
+            method: 'PUT',
+            headers: auth,
+            body: JSON.stringify({ weeklyRateLimitEndAt: resets7 }),
+          }).catch(() => null);
+          if (put && put.status >= 200 && put.status < 300) {
+            a.weeklyRateLimitEndAt = resets7;
+            log(`${a.name}: recorded weekly-cap hold until ${resets7} (live 7d=${u7}%)`);
+          }
+        } else if (u7 < ON_7D && a.weeklyRateLimitEndAt) {
+          const put = await jfetch(`/admin/claude-accounts/${a.id}`, {
+            method: 'PUT',
+            headers: auth,
+            body: JSON.stringify({ weeklyRateLimitEndAt: null }),
+          }).catch(() => null);
+          if (put && put.status >= 200 && put.status < 300) {
+            log(`${a.name}: cleared stale weekly-cap hold (live 7d=${u7}% < ${ON_7D}%)`);
+            a.weeklyRateLimitEndAt = null;
+          }
         }
       }
     }
-  }
 
-  const decisions = decide(accts);
+    const decisions = decide(accts);
 
-  if (STATUS) {
-    console.log(`CRS pool @ ${BASE} — ${decisions.filter((d) => d.cur).length}/${decisions.length} schedulable`);
-    for (const d of decisions.sort((a, b) => (a.cur === b.cur ? 0 : a.cur ? -1 : 1))) {
-      const flags = [d.rl && 'RL', d.overloaded && 'OVERLOAD', d.sw].filter(Boolean).join(' ');
-      console.log(
-        `  ${d.cur ? '●' : '○'} ${d.a.name.padEnd(26)} sched=${d.cur} 5h=${String(d.u5).padStart(3)}%  ${flags}`,
-      );
+    if (STATUS) {
+      console.log(`CRS pool @ ${BASE} — ${decisions.filter((d) => d.cur).length}/${decisions.length} schedulable`);
+      for (const d of decisions.sort((a, b) => (a.cur === b.cur ? 0 : a.cur ? -1 : 1))) {
+        const flags = [d.rl && 'RL', d.overloaded && 'OVERLOAD', d.sw].filter(Boolean).join(' ');
+        console.log(
+          `  ${d.cur ? '●' : '○'} ${d.a.name.padEnd(26)} sched=${d.cur} 5h=${String(d.u5).padStart(3)}%  ${flags}`,
+        );
+      }
+      return;
     }
-    return;
-  }
 
-  let changed = 0;
-  for (const d of decisions) {
-    if (d.desired === d.cur) continue;
-    changed++;
-    if (DRY) {
-      log(`[dry] ${d.a.name}: ${d.cur}→${d.desired} (${d.reason})`);
-      continue;
+    let changed = 0;
+    for (const d of decisions) {
+      if (d.desired === d.cur) continue;
+      changed++;
+      if (DRY) {
+        log(`[dry] ${d.a.name}: ${d.cur}→${d.desired} (${d.reason})`);
+        continue;
+      }
+      const put = await jfetch(`/admin/claude-accounts/${d.a.id}/toggle-schedulable`, {
+        method: 'PUT',
+        headers: auth,
+        body: JSON.stringify({ schedulable: d.desired }),
+      });
+      log(`${d.a.name}: schedulable ${d.cur}→${d.desired} (${d.reason}) [HTTP ${put.status}]`);
     }
-    const put = await jfetch(`/admin/claude-accounts/${d.a.id}/toggle-schedulable`, {
-      method: 'PUT',
-      headers: auth,
-      body: JSON.stringify({ schedulable: d.desired }),
-    });
-    log(`${d.a.name}: schedulable ${d.cur}→${d.desired} (${d.reason}) [HTTP ${put.status}]`);
-  }
-  const on = decisions.filter((d) => d.desired).map((d) => d.a.name);
-  const off = decisions.filter((d) => !d.desired).map((d) => `${d.a.name}(${d.sw || (d.rl ? 'RL' : '?')})`);
-  log(
-    `tick: ${changed} change(s). live-quota=${liveN}/${decisions.length} schedulable=${on.length} [${on.join(',')}] | off=[${off.join(',')}]`,
-  );
-  dualWriteFromCrsDecisions(decisions);
+    const on = decisions.filter((d) => d.desired).map((d) => d.a.name);
+    const off = decisions.filter((d) => !d.desired).map((d) => `${d.a.name}(${d.sw || (d.rl ? 'RL' : '?')})`);
+    log(
+      `tick: ${changed} change(s). live-quota=${liveN}/${decisions.length} schedulable=${on.length} [${on.join(',')}] | off=[${off.join(',')}]`,
+    );
+    dualWriteFromCrsDecisions(decisions);
   } catch (e) {
     if (BACKEND_WANT === 'crs') {
       log(`ERROR: ${e.message}`);

--- a/claude-ops/scripts/account-rotation/crs-priority-daemon.mjs
+++ b/claude-ops/scripts/account-rotation/crs-priority-daemon.mjs
@@ -59,7 +59,7 @@
 //       current schedulable + utilization table and exit · --once (alias for tick).
 
 import { execFileSync } from 'child_process';
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { readFileSync, writeFileSync, mkdirSync, renameSync, existsSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { homedir, platform } from 'os';
@@ -71,6 +71,11 @@ import {
   loadRotationConfig,
   vaultLookupKeysForEmail,
 } from './crs-pool-config.mjs';
+import {
+  resolveAccountsBackend,
+  dualWriteEnabled,
+  mergeSeatsIntoState,
+} from './ops-accounts-backend.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || join(__dirname, '..', '..');
@@ -89,8 +94,10 @@ function credentialStorePath() {
 const EXEC_QUIET = { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] };
 const DATA_DIR =
   process.env.CLAUDE_PLUGIN_DATA_DIR || join(homedir(), '.claude', 'plugins', 'data', 'ops-ops-marketplace');
-// Dual-mode: backend=crs (default) | backend=local (file seat-state, no Docker)
+// Dual-mode: backend=crs | local | auto (OPS_ACCOUNTS_BACKEND)
 const SEAT_STATE_PATH = process.env.CRS_SEAT_STATE_PATH || join(DATA_DIR, 'seat-state', 'claude-priority.json');
+const OPS_SEAT_STATE_PATH =
+  process.env.OPS_ACCOUNTS_STATE_PATH || join(DATA_DIR, 'account-rotation', 'seat-state.json');
 
 const args = new Set(process.argv.slice(2));
 const DRY = args.has('--dry-run') || process.env.CRS_DRY === '1';
@@ -102,7 +109,12 @@ const log = (m) => console.log(`${ts()} [crs-priority] ${m}`);
 // ── config ───────────────────────────────────────────────────────────────────
 const cfg = loadRotationConfig();
 const C = cfg.crs || {};
-const BACKEND = String(process.env.CRS_PRIORITY_BACKEND || C.backend || 'crs').toLowerCase();
+const BACKEND_WANT = resolveAccountsBackend({
+  env: process.env,
+  cfgBackend: process.env.CRS_PRIORITY_BACKEND || C.backend || 'auto',
+});
+// local|file → local tick; crs → CRS only; auto → CRS with local fallback
+const BACKEND = BACKEND_WANT === 'local' ? 'local' : BACKEND_WANT === 'crs' ? 'crs' : 'auto';
 
 const { vaultKeyByCrsName } = buildCrsNameMaps(cfg);
 const num = (v, d) => (v === undefined || v === null || v === '' || Number.isNaN(+v) ? d : +v);
@@ -708,14 +720,56 @@ async function runLocalTick() {
   );
 }
 
-// ── main ─────────────────────────────────────────────────────────────────────
-async function main() {
-  if (C.enabled === false && !STATUS && !DRY && BACKEND !== 'local' && BACKEND !== 'file') {
-    log('crs.enabled=false — skipping tick');
+
+/** Mirror CRS decisions into provider-shaped seat-state (ops-accounts dual-write). */
+function dualWriteFromCrsDecisions(decisions) {
+  if (!dualWriteEnabled()) return;
+  if (DRY) {
+    log(`[dry] dual-write ${decisions.length} decision(s) → ${OPS_SEAT_STATE_PATH}`);
     return;
   }
-  if (BACKEND === 'local' || BACKEND === 'file') {
+  try {
+    let state = { version: 1, providers: {} };
+    if (existsSync(OPS_SEAT_STATE_PATH)) {
+      try {
+        state = JSON.parse(readFileSync(OPS_SEAT_STATE_PATH, 'utf8'));
+      } catch {
+        /* keep empty */
+      }
+    }
+    const seats = decisions.map((d) => {
+      const email =
+        d.a?.subscriptionInfo?.email || vaultKeyByCrsName[d.a?.name] || d.a?.name || null;
+      const u5 = d.u5;
+      const u7 = d.a?._liveUsage?.u7;
+      return {
+        email,
+        schedulable: d.desired !== false,
+        util5h: typeof u5 === 'number' ? u5 : null,
+        util7d: typeof u7 === 'number' ? u7 : null,
+      };
+    });
+    const next = mergeSeatsIntoState(state, seats, { provider: 'claude' });
+    mkdirSync(dirname(OPS_SEAT_STATE_PATH), { recursive: true });
+    const tmp = OPS_SEAT_STATE_PATH + '.tmp';
+    writeFileSync(tmp, JSON.stringify(next, null, 2) + '\n', { mode: 0o600 });
+    renameSync(tmp, OPS_SEAT_STATE_PATH);
+    log(`dual-write: mirrored ${seats.filter((s) => s.email).length} seat(s) → ${OPS_SEAT_STATE_PATH}`);
+  } catch (e) {
+    log(`dual-write skipped: ${e.message}`);
+  }
+}
+
+// ── main ─────────────────────────────────────────────────────────────────────
+async function main() {
+  log(`backend want=${BACKEND_WANT}`);
+  if (BACKEND_WANT === 'local' || BACKEND === 'local' || BACKEND === 'file') {
     await runLocalTick();
+    return;
+  }
+  try {
+  if (C.enabled === false && !STATUS && !DRY) {
+    log('crs.enabled=false — skipping tick');
     return;
   }
   const auth = await login();
@@ -819,6 +873,15 @@ async function main() {
   log(
     `tick: ${changed} change(s). live-quota=${liveN}/${decisions.length} schedulable=${on.length} [${on.join(',')}] | off=[${off.join(',')}]`,
   );
+  dualWriteFromCrsDecisions(decisions);
+  } catch (e) {
+    if (BACKEND_WANT === 'crs') {
+      log(`ERROR: ${e.message}`);
+      process.exit(1);
+    }
+    log(`CRS unavailable (${e.message}) — falling back to local seat-state`);
+    await runLocalTick();
+  }
 }
 
 main().catch((e) => {

--- a/claude-ops/scripts/account-rotation/crs-token-feed.mjs
+++ b/claude-ops/scripts/account-rotation/crs-token-feed.mjs
@@ -27,6 +27,7 @@ import {
   loadRotationConfig,
   resolveConfigPath,
 } from './crs-pool-config.mjs';
+import { resolveAccountsBackend } from './ops-accounts-backend.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const LOG_PATH = join(__dirname, 'rotation.log');
@@ -120,13 +121,19 @@ async function crsLogin(crsBase, crsContainer, adminUser = 'cradmin') {
 }
 
 async function main() {
+  const earlyCfg = loadRotationConfig();
+  const backend = resolveAccountsBackend({ env: process.env, cfgBackend: earlyCfg.crs?.backend });
+  if (backend === 'local') {
+    log('backend=local — CRS token-feed no-op (CLI seats read vault/keychain directly; no pool to feed)');
+    return;
+  }
   assertCrsInvariant(process.env, 'crs-token-feed:main');
   const configPath = resolveConfigPath();
   if (!configPath) {
     log('no rotation config found — set CRS_CONFIG or install account-rotation config.json');
     process.exit(1);
   }
-  const config = loadRotationConfig();
+  const config = earlyCfg;
   const { nameByVaultKey } = buildCrsNameMaps(config);
   const fileVault = crsFileVaultPath(config);
   const crsBase = crsBaseUrl(config);

--- a/claude-ops/scripts/account-rotation/grok-cli-auth-proxy.py
+++ b/claude-ops/scripts/account-rotation/grok-cli-auth-proxy.py
@@ -486,40 +486,51 @@ class ProxyHandler(BaseHTTPRequestHandler):
     def _target_url(self, upstream: str) -> str:
         """Map client path onto a fixed upstream base (no open proxy / SSRF).
 
-        Client may send absolute-form request lines; we only keep path+query and
-        re-attach them to the configured upstream host allowlist.
+        Scheme + host come ONLY from the preconfigured UPSTREAM_* constants.
+        Client input may only contribute a sanitized path suffix and query.
+        Rebuild with urlunparse so CodeQL cannot treat the full URL as tainted.
         """
+        # Resolve to one of the three constant bases (never client-controlled host).
+        allowed_bases = (UPSTREAM, UPSTREAM_CODING, UPSTREAM_IMAGINE)
+        if upstream not in allowed_bases:
+            raise ValueError("upstream not in allowlist")
+        base = urllib.parse.urlparse(upstream)
+        if base.scheme not in ("https", "http") or not base.netloc:
+            raise ValueError(f"invalid upstream base: {upstream!r}")
+
         raw = self.path or "/"
-        parsed = urllib.parse.urlparse(raw)
-        # Drop scheme/netloc from absolute-form requests; never follow client host.
+        # Absolute-form request lines: drop scheme/netloc entirely.
+        if "://" in raw or raw.startswith("//"):
+            raw = urllib.parse.urlparse(raw).path or "/"
+        parsed = urllib.parse.urlparse(raw if raw.startswith("/") else "/" + raw)
         path = parsed.path or "/"
         query = parsed.query or ""
-        if ".." in path.split("/") or path.startswith("//"):
+
+        # Path may only contain safe URL path characters; no //, .., or schemes.
+        if (
+            ".." in path
+            or "//" in path
+            or not path.startswith("/")
+            or not re.fullmatch(r"/[A-Za-z0-9._~/%+\-]*", path)
+        ):
             raise ValueError(f"rejected path: {path!r}")
+        if query and not re.fullmatch(r"[A-Za-z0-9._~=&%\-+]*", query):
+            raise ValueError(f"rejected query: {query!r}")
+
         if not path.startswith("/v1"):
-            path = "/v1" + (path if path.startswith("/") else "/" + path)
+            path = "/v1" + path
         suffix = path[len("/v1") :] or "/"
         if not suffix.startswith("/"):
             suffix = "/" + suffix
-        # upstream is like https://host/v1 — join keeps host fixed.
-        base = upstream if upstream.endswith("/") else upstream + "/"
-        target = urllib.parse.urljoin(base, suffix.lstrip("/"))
-        if query:
-            target = target + ("&" if "?" in target else "?") + query
-        # Hard allowlist: final URL must stay on a configured upstream origin.
-        allowed = {
-            urllib.parse.urlparse(u).netloc.lower()
-            for u in (UPSTREAM, UPSTREAM_CODING, UPSTREAM_IMAGINE)
-            if u
-        }
-        final = urllib.parse.urlparse(target)
-        if final.scheme not in ("https", "http") or final.netloc.lower() not in allowed:
-            raise ValueError(f"upstream host not allowed: {final.netloc}")
-        if not any(target.startswith(u.rstrip("/") ) or target.startswith(u) for u in (UPSTREAM, UPSTREAM_CODING, UPSTREAM_IMAGINE)):
-            # Prefer prefix match on full upstream base when path depth differs.
-            if final.netloc.lower() not in allowed:
-                raise ValueError(f"upstream URL not allowed: {target}")
-        return target
+
+        # base.path is typically "/v1"; keep it and append validated suffix.
+        origin_path = (base.path or "/v1").rstrip("/") or "/v1"
+        final_path = origin_path + suffix
+
+        # urlunparse with scheme/netloc from constant only — not urljoin.
+        return urllib.parse.urlunparse(
+            (base.scheme, base.netloc, final_path, "", query, "")
+        )
 
     def _build_headers(self, token: str) -> Dict[str, str]:
         headers: Dict[str, str] = {}

--- a/claude-ops/scripts/account-rotation/grok-cli-auth-proxy.py
+++ b/claude-ops/scripts/account-rotation/grok-cli-auth-proxy.py
@@ -37,6 +37,9 @@ STATE_FILE = Path(os.environ.get("GROK_ROTATE_STATE_FILE", str(Path.home() / ".g
 UPSTREAM = os.environ.get("GROK_UPSTREAM", "https://cli-chat-proxy.grok.com/v1").rstrip("/")
 UPSTREAM_CODING = os.environ.get("GROK_UPSTREAM_CODING", UPSTREAM).rstrip("/")
 UPSTREAM_IMAGINE = os.environ.get("GROK_UPSTREAM_IMAGINE", "https://api.x.ai/v1").rstrip("/")
+# Hard-coded host allowlist for CodeQL SSRF; env may only point at these hosts.
+_SAFE_UPSTREAM_HOSTS = frozenset({"cli-chat-proxy.grok.com", "api.x.ai"})
+_SAFE_PATH_RE = re.compile(r"^/v1(?:/[A-Za-z0-9._-]+)*$")
 ISSUER = os.environ.get("GROK_OIDC_ISSUER", "https://auth.x.ai").rstrip("/")
 CLIENT_ID = os.environ.get("GROK_OIDC_CLIENT_ID", "b1a00492-073a-47ea-816f-4c329264a828")
 REFRESH_SKEW_SECONDS = int(os.environ.get("GROK_REFRESH_SKEW_SECONDS", str(6 * 3600)))  # proactive: refresh when <6h left
@@ -486,51 +489,43 @@ class ProxyHandler(BaseHTTPRequestHandler):
     def _target_url(self, upstream: str) -> str:
         """Map client path onto a fixed upstream base (no open proxy / SSRF).
 
-        Scheme + host come ONLY from the preconfigured UPSTREAM_* constants.
-        Client input may only contribute a sanitized path suffix and query.
-        Rebuild with urlunparse so CodeQL cannot treat the full URL as tainted.
+        Host comes only from configured UPSTREAM_* (must be in _SAFE_UPSTREAM_HOSTS).
+        Path is restricted to /v1/... with safe charset; query is re-encoded.
         """
-        # Resolve to one of the three constant bases (never client-controlled host).
-        allowed_bases = (UPSTREAM, UPSTREAM_CODING, UPSTREAM_IMAGINE)
-        if upstream not in allowed_bases:
-            raise ValueError("upstream not in allowlist")
         base = urllib.parse.urlparse(upstream)
-        if base.scheme not in ("https", "http") or not base.netloc:
-            raise ValueError(f"invalid upstream base: {upstream!r}")
+        host = (base.hostname or "").lower()
+        if base.scheme not in ("https", "http") or host not in _SAFE_UPSTREAM_HOSTS:
+            # Fall back to hard-coded coding upstream if env is mis-set.
+            base = urllib.parse.urlparse("https://cli-chat-proxy.grok.com/v1")
+            host = base.hostname or "cli-chat-proxy.grok.com"
 
-        raw = self.path or "/"
-        # Absolute-form request lines: drop scheme/netloc entirely.
-        if "://" in raw or raw.startswith("//"):
-            raw = urllib.parse.urlparse(raw).path or "/"
-        parsed = urllib.parse.urlparse(raw if raw.startswith("/") else "/" + raw)
-        path = parsed.path or "/"
-        query = parsed.query or ""
-
-        # Path may only contain safe URL path characters; no //, .., or schemes.
-        if (
-            ".." in path
-            or "//" in path
-            or not path.startswith("/")
-            or not re.fullmatch(r"/[A-Za-z0-9._~/%+\-]*", path)
-        ):
-            raise ValueError(f"rejected path: {path!r}")
-        if query and not re.fullmatch(r"[A-Za-z0-9._~=&%\-+]*", query):
-            raise ValueError(f"rejected query: {query!r}")
-
+        req = urllib.parse.urlparse(self.path or "/")
+        # Absolute-form request lines: ignore client-supplied scheme/host entirely.
+        path = req.path or "/"
+        if not path.startswith("/"):
+            path = "/" + path
         if not path.startswith("/v1"):
             path = "/v1" + path
-        suffix = path[len("/v1") :] or "/"
-        if not suffix.startswith("/"):
-            suffix = "/" + suffix
+        # Collapse // and reject traversal / non-allowlisted chars.
+        parts = [p for p in path.split("/") if p and p != "."]
+        if any(p == ".." for p in parts):
+            raise ValueError(f"rejected path: {path!r}")
+        safe_path = "/" + "/".join(parts)
+        if not _SAFE_PATH_RE.fullmatch(safe_path):
+            raise ValueError(f"rejected path charset: {safe_path!r}")
 
-        # base.path is typically "/v1"; keep it and append validated suffix.
-        origin_path = (base.path or "/v1").rstrip("/") or "/v1"
-        final_path = origin_path + suffix
-
-        # urlunparse with scheme/netloc from constant only — not urljoin.
-        return urllib.parse.urlunparse(
-            (base.scheme, base.netloc, final_path, "", query, "")
-        )
+        # Rebuild URL from allowlisted host + sanitized path segments only.
+        base_path = (base.path or "/v1").rstrip("/") or "/v1"
+        # client path is /v1/...; strip /v1 and append under base_path
+        suffix_parts = parts[1:]  # drop leading "v1"
+        full_path = base_path + (("/" + "/".join(suffix_parts)) if suffix_parts else "")
+        query = urllib.parse.urlencode(urllib.parse.parse_qsl(req.query, keep_blank_values=True))
+        target = urllib.parse.urlunparse((base.scheme, host, full_path, "", query, ""))
+        # Final belt: host must still be allowlisted.
+        final = urllib.parse.urlparse(target)
+        if (final.hostname or "").lower() not in _SAFE_UPSTREAM_HOSTS:
+            raise ValueError(f"upstream host not allowed: {final.hostname}")
+        return target
 
     def _build_headers(self, token: str) -> Dict[str, str]:
         headers: Dict[str, str] = {}

--- a/claude-ops/scripts/account-rotation/grok-cli-auth-proxy.py
+++ b/claude-ops/scripts/account-rotation/grok-cli-auth-proxy.py
@@ -484,14 +484,42 @@ class ProxyHandler(BaseHTTPRequestHandler):
         return UPSTREAM_CODING
 
     def _target_url(self, upstream: str) -> str:
-        path = self.path
-        if path.startswith("http://") or path.startswith("https://"):
-            parsed = urllib.parse.urlparse(path)
-            path = urllib.parse.urlunparse(("", "", parsed.path, parsed.params, parsed.query, parsed.fragment))
+        """Map client path onto a fixed upstream base (no open proxy / SSRF).
+
+        Client may send absolute-form request lines; we only keep path+query and
+        re-attach them to the configured upstream host allowlist.
+        """
+        raw = self.path or "/"
+        parsed = urllib.parse.urlparse(raw)
+        # Drop scheme/netloc from absolute-form requests; never follow client host.
+        path = parsed.path or "/"
+        query = parsed.query or ""
+        if ".." in path.split("/") or path.startswith("//"):
+            raise ValueError(f"rejected path: {path!r}")
         if not path.startswith("/v1"):
             path = "/v1" + (path if path.startswith("/") else "/" + path)
-        suffix = path[len("/v1") :]
-        return upstream + suffix
+        suffix = path[len("/v1") :] or "/"
+        if not suffix.startswith("/"):
+            suffix = "/" + suffix
+        # upstream is like https://host/v1 — join keeps host fixed.
+        base = upstream if upstream.endswith("/") else upstream + "/"
+        target = urllib.parse.urljoin(base, suffix.lstrip("/"))
+        if query:
+            target = target + ("&" if "?" in target else "?") + query
+        # Hard allowlist: final URL must stay on a configured upstream origin.
+        allowed = {
+            urllib.parse.urlparse(u).netloc.lower()
+            for u in (UPSTREAM, UPSTREAM_CODING, UPSTREAM_IMAGINE)
+            if u
+        }
+        final = urllib.parse.urlparse(target)
+        if final.scheme not in ("https", "http") or final.netloc.lower() not in allowed:
+            raise ValueError(f"upstream host not allowed: {final.netloc}")
+        if not any(target.startswith(u.rstrip("/") ) or target.startswith(u) for u in (UPSTREAM, UPSTREAM_CODING, UPSTREAM_IMAGINE)):
+            # Prefer prefix match on full upstream base when path depth differs.
+            if final.netloc.lower() not in allowed:
+                raise ValueError(f"upstream URL not allowed: {target}")
+        return target
 
     def _build_headers(self, token: str) -> Dict[str, str]:
         headers: Dict[str, str] = {}

--- a/claude-ops/scripts/account-rotation/grok-cli-auth-proxy.py
+++ b/claude-ops/scripts/account-rotation/grok-cli-auth-proxy.py
@@ -1,0 +1,688 @@
+#!/usr/bin/env python3
+"""OpenAI-compatible local proxy backed by SuperGrok CLI OAuth (multi-account).
+
+Ported into claude-ops for no-CRS installs. Host path ~/.local/bin is not required.
+Configure seats via GROK_PREFERRED_EMAILS / GROK_SLOT_FILES / ~/.grok/auth-slots.
+
+Reads OAuth grants from ~/.grok/auth.json plus ~/.grok/auth-slots/*.json, refreshes
+tokens under a lock, and forwards coding traffic to cli-chat-proxy.grok.com so
+callers stay on SuperGrok subscription seats instead of metered api.x.ai credits.
+
+Seats are load-balanced (round-robin) across all non-exhausted SuperGrok OAuth
+accounts. On 429/quota the failing seat is cooled down and the request retries
+on another seat.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime as dt
+import fcntl
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+AUTH_FILE = Path(os.environ.get("GROK_AUTH_FILE", str(Path.home() / ".grok" / "auth.json"))).expanduser()
+LOCK_FILE = Path(os.environ.get("GROK_AUTH_LOCK_FILE", str(AUTH_FILE) + ".lock")).expanduser()
+SLOTS_DIR = Path(os.environ.get("GROK_AUTH_SLOTS_DIR", str(Path.home() / ".grok" / "auth-slots"))).expanduser()
+STATE_FILE = Path(os.environ.get("GROK_ROTATE_STATE_FILE", str(Path.home() / ".grok" / ".proxy-rotate-state.json"))).expanduser()
+UPSTREAM = os.environ.get("GROK_UPSTREAM", "https://cli-chat-proxy.grok.com/v1").rstrip("/")
+UPSTREAM_CODING = os.environ.get("GROK_UPSTREAM_CODING", UPSTREAM).rstrip("/")
+UPSTREAM_IMAGINE = os.environ.get("GROK_UPSTREAM_IMAGINE", "https://api.x.ai/v1").rstrip("/")
+ISSUER = os.environ.get("GROK_OIDC_ISSUER", "https://auth.x.ai").rstrip("/")
+CLIENT_ID = os.environ.get("GROK_OIDC_CLIENT_ID", "b1a00492-073a-47ea-816f-4c329264a828")
+REFRESH_SKEW_SECONDS = int(os.environ.get("GROK_REFRESH_SKEW_SECONDS", str(6 * 3600)))  # proactive: refresh when <6h left
+EXHAUST_COOLDOWN_SECONDS = int(os.environ.get("GROK_EXHAUST_COOLDOWN_SECONDS", "3600"))
+
+# Ordered SuperGrok seats used for rotation (comma-separated emails).
+PREFERRED_GROK_EMAILS = [
+    e.strip().lower()
+    for e in os.environ.get(
+        "GROK_PREFERRED_EMAILS",
+        "",  # operator-supplied; never hardcode personal seats in the public plugin
+    ).split(",")
+    if e.strip()
+]
+
+# Optional explicit slot filename map: email=file,email2=file2
+_SLOT_MAP_ENV = os.environ.get("GROK_SLOT_FILES", "").strip()
+DEFAULT_SLOT_FILES = {}  # optional: GROK_SLOT_FILES=email=file.json,...
+if _SLOT_MAP_ENV:
+    for part in _SLOT_MAP_ENV.split(","):
+        if "=" in part:
+            email, fname = part.split("=", 1)
+            DEFAULT_SLOT_FILES[email.strip().lower()] = fname.strip()
+
+LISTEN_HOST = os.environ.get("GROK_PROXY_HOST", "127.0.0.1")
+LISTEN_PORT = int(os.environ.get("GROK_PROXY_PORT", "31845"))
+HTTP_TIMEOUT = float(os.environ.get("GROK_PROXY_TIMEOUT", "600"))
+
+HOP_BY_HOP = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+    "host",
+}
+
+QUOTA_RE = re.compile(
+    r"quota|rate.?limit|too many requests|limit.?reached|credits?.?exhaust|"
+    r"prepaid.?balance|usage.?cap|throttl|capacity|resource.?exhausted",
+    re.I,
+)
+
+
+def _utc_now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def _parse_iso(value: Any) -> dt.datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip().replace("Z", "+00:00")
+    # Truncate nanoseconds to microseconds for fromisoformat.
+    raw = re.sub(r"\.(\d{1,6})\d*(?=[+-]\d\d:\d\d$)", lambda m: "." + m.group(1), raw)
+    try:
+        out = dt.datetime.fromisoformat(raw)
+        if out.tzinfo is None:
+            out = out.replace(tzinfo=dt.timezone.utc)
+        return out
+    except Exception:
+        return None
+
+
+def _jwt_exp(token: str) -> float | None:
+    try:
+        parts = token.split(".")
+        if len(parts) < 2:
+            return None
+        payload = parts[1] + "=" * (-len(parts[1]) % 4)
+        data = json.loads(base64.urlsafe_b64decode(payload.encode("ascii")))
+        exp = data.get("exp")
+        return float(exp) if isinstance(exp, (int, float)) else None
+    except Exception:
+        return None
+
+
+def _email_of(entry: Dict[str, Any]) -> str:
+    return str(entry.get("email") or "").strip().lower()
+
+
+def _auth_entries(raw: Dict[str, Any]) -> list[tuple[str, Dict[str, Any]]]:
+    out: list[tuple[str, Dict[str, Any]]] = []
+    if not isinstance(raw, dict):
+        return out
+    for key, entry in raw.items():
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("auth_mode") in (None, "oidc", "oauth") and (
+            entry.get("refresh_token") or entry.get("key") or entry.get("access_token")
+        ):
+            out.append((key, entry))
+    return out
+
+
+def _load_state() -> Dict[str, Any]:
+    if not STATE_FILE.exists():
+        return {"exhausted": {}, "active_email": None}
+    try:
+        data = json.loads(STATE_FILE.read_text())
+        if not isinstance(data, dict):
+            return {"exhausted": {}, "active_email": None}
+        data.setdefault("exhausted", {})
+        data.setdefault("active_email", None)
+        return data
+    except Exception:
+        return {"exhausted": {}, "active_email": None}
+
+
+def _save_state(state: Dict[str, Any]) -> None:
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    tmp = STATE_FILE.with_suffix(STATE_FILE.suffix + f".tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(state, indent=2) + "\n")
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, STATE_FILE)
+
+
+def _is_exhausted(state: Dict[str, Any], email: str) -> bool:
+    exp_map = state.get("exhausted") or {}
+    until = exp_map.get(email)
+    if not until:
+        return False
+    try:
+        return float(until) > time.time()
+    except Exception:
+        return False
+
+
+def _mark_exhausted(state: Dict[str, Any], email: str) -> None:
+    state.setdefault("exhausted", {})[email] = time.time() + EXHAUST_COOLDOWN_SECONDS
+    _save_state(state)
+    sys.stderr.write(f"[grok-proxy] marked exhausted: {email} for {EXHAUST_COOLDOWN_SECONDS}s\n")
+
+
+def _slot_path_for_email(email: str) -> Path:
+    fname = DEFAULT_SLOT_FILES.get(email.lower())
+    if not fname:
+        safe = re.sub(r"[^a-z0-9]+", "_", email.lower()).strip("_")
+        fname = f"{safe}.json"
+    return SLOTS_DIR / fname
+
+
+def _discover_slot_files() -> Dict[str, Path]:
+    """email -> path for all known SuperGrok OAuth slot files + active auth."""
+    found: Dict[str, Path] = {}
+    # Preferred slot filenames first.
+    for email in PREFERRED_GROK_EMAILS:
+        path = _slot_path_for_email(email)
+        if path.exists():
+            found[email] = path
+    # Active auth.json
+    if AUTH_FILE.exists():
+        try:
+            raw = json.loads(AUTH_FILE.read_text())
+            for _, entry in _auth_entries(raw):
+                email = _email_of(entry)
+                if email:
+                    found.setdefault(email, AUTH_FILE)
+        except Exception:
+            pass
+    # Any other json in slots dir.
+    if SLOTS_DIR.exists():
+        for path in SLOTS_DIR.glob("*.json"):
+            if ".bak" in path.name:
+                continue
+            try:
+                raw = json.loads(path.read_text())
+            except Exception:
+                continue
+            for _, entry in _auth_entries(raw):
+                email = _email_of(entry)
+                if email:
+                    found.setdefault(email, path)
+    return found
+
+
+def _load_auth_blob(path: Path) -> Dict[str, Any]:
+    raw = json.loads(path.read_text())
+    if not isinstance(raw, dict):
+        raise RuntimeError(f"{path} is not a JSON object")
+    return raw
+
+
+def _pick_entry_from_raw(raw: Dict[str, Any], want_email: Optional[str] = None) -> tuple[str, Dict[str, Any]]:
+    entries = _auth_entries(raw)
+    if not entries:
+        raise RuntimeError("No usable Grok CLI OAuth entry found")
+    by_email = {}
+    for key, entry in entries:
+        email = _email_of(entry)
+        if email:
+            by_email[email] = (key, entry)
+    if want_email and want_email in by_email:
+        return by_email[want_email]
+    for preferred in PREFERRED_GROK_EMAILS:
+        if preferred in by_email:
+            return by_email[preferred]
+    return entries[0]
+
+
+def _ordered_accounts(state: Dict[str, Any]) -> List[str]:
+    slots = _discover_slot_files()
+    ordered: List[str] = []
+    for email in PREFERRED_GROK_EMAILS:
+        if email in slots and not _is_exhausted(state, email):
+            ordered.append(email)
+    # append any other non-preferred available seats last
+    for email in sorted(slots):
+        if email not in ordered and not _is_exhausted(state, email):
+            ordered.append(email)
+    # if all exhausted, allow preferred slots anyway (retry after cooldown may have expired mid-loop)
+    if not ordered:
+        for email in PREFERRED_GROK_EMAILS:
+            if email in slots:
+                ordered.append(email)
+        for email in sorted(slots):
+            if email not in ordered:
+                ordered.append(email)
+    return ordered
+
+
+def _needs_refresh(entry: Dict[str, Any], *, force: bool = False) -> bool:
+    if force:
+        return True
+    token = str(entry.get("key") or entry.get("access_token") or "").strip()
+    exp = _jwt_exp(token)
+    if exp is not None:
+        return exp <= time.time() + REFRESH_SKEW_SECONDS
+    exp_dt = _parse_iso(entry.get("expires_at"))
+    if exp_dt is not None:
+        return exp_dt.timestamp() <= time.time() + REFRESH_SKEW_SECONDS
+    return False
+
+
+def _token_endpoint() -> str:
+    req = urllib.request.Request(
+        f"{ISSUER}/.well-known/openid-configuration",
+        headers={"Accept": "application/json", "User-Agent": "grok-cli-auth-proxy/1.1"},
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = json.loads(resp.read())
+    endpoint = str(data.get("token_endpoint") or "").strip()
+    parsed = urllib.parse.urlparse(endpoint)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme != "https" or (host != "x.ai" and not host.endswith(".x.ai")):
+        raise RuntimeError(f"Refusing unexpected xAI token endpoint: {endpoint!r}")
+    return endpoint
+
+
+def _refresh(entry: Dict[str, Any]) -> Dict[str, Any]:
+    refresh_token = str(entry.get("refresh_token") or "").strip()
+    if not refresh_token:
+        raise RuntimeError("Grok CLI auth entry has no refresh_token")
+    body = urllib.parse.urlencode(
+        {
+            "grant_type": "refresh_token",
+            "client_id": str(entry.get("oidc_client_id") or CLIENT_ID),
+            "refresh_token": refresh_token,
+        }
+    ).encode()
+    req = urllib.request.Request(
+        _token_endpoint(),
+        data=body,
+        method="POST",
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "User-Agent": "grok-cli-auth-proxy/1.1",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", "replace")[:1000]
+        raise RuntimeError(f"xAI refresh failed HTTP {exc.code}: {detail}") from exc
+    access = str(data.get("access_token") or "").strip()
+    if not access:
+        raise RuntimeError(f"xAI refresh response missing access_token: {data!r}")
+    now = _utc_now()
+    expires_in = int(data.get("expires_in") or 3600)
+    updated = dict(entry)
+    updated["key"] = access
+    updated["refresh_token"] = str(data.get("refresh_token") or refresh_token).strip()
+    updated["expires_at"] = (now + dt.timedelta(seconds=expires_in)).isoformat().replace("+00:00", "Z")
+    updated["token_type"] = str(data.get("token_type") or entry.get("token_type") or "Bearer")
+    if data.get("id_token"):
+        updated["id_token"] = str(data.get("id_token"))
+    return updated
+
+
+def _atomic_write_json(path: Path, raw: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + f".tmp.{os.getpid()}")
+    tmp.write_text(json.dumps(raw, indent=2, sort_keys=False) + "\n")
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, path)
+
+
+def _persist_slot(email: str, raw: Dict[str, Any], source_path: Path) -> None:
+    """Write seat tokens back to its slot file (and optionally mirror last-used auth.json)."""
+    slot = _slot_path_for_email(email)
+    _atomic_write_json(slot, raw)
+    # Keep auth.json as last-used mirror for tools that still read it; not sticky for LB.
+    if os.environ.get("GROK_MIRROR_ACTIVE_AUTH", "1") not in ("0", "false", "no"):
+        _atomic_write_json(AUTH_FILE, raw)
+
+
+def _rr_pick(candidates: List[str], state: Dict[str, Any]) -> List[str]:
+    """Rotate candidate order for round-robin load balancing."""
+    if not candidates:
+        return candidates
+    rr = int(state.get("rr_index") or 0) % len(candidates)
+    return candidates[rr:] + candidates[:rr]
+
+
+def current_token(*, force_refresh: bool = False, prefer_email: Optional[str] = None) -> Tuple[str, str]:
+    """Return (access_token, email) for the next SuperGrok seat (round-robin LB)."""
+    LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with LOCK_FILE.open("a+") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        state = _load_state()
+        state.setdefault("request_counts", {})
+        slots = _discover_slot_files()
+        candidates = _ordered_accounts(state)
+        if prefer_email and prefer_email in candidates:
+            ordered = [prefer_email] + [e for e in candidates if e != prefer_email]
+        else:
+            ordered = _rr_pick(candidates, state)
+
+        last_err: Exception | None = None
+        for email in ordered:
+            path = slots.get(email)
+            if not path or not path.exists():
+                continue
+            try:
+                raw = _load_auth_blob(path)
+                key, entry = _pick_entry_from_raw(raw, want_email=email)
+                if _needs_refresh(entry, force=force_refresh):
+                    try:
+                        entry = _refresh(entry)
+                        raw[key] = entry
+                        _atomic_write_json(path, raw)
+                    except Exception as refresh_exc:
+                        # Keep serving while access JWT is still valid even if RT is dead.
+                        tok_now = str(entry.get("key") or entry.get("access_token") or "").strip()
+                        exp = _jwt_exp(tok_now)
+                        if exp is None or exp <= time.time() + 60:
+                            raise RuntimeError(f"{email}: refresh failed and access expired: {refresh_exc}") from refresh_exc
+                        sys.stderr.write(
+                            f"[grok-proxy] {email}: refresh failed ({refresh_exc}); "
+                            f"using access token until {int(exp - time.time())}s left\n"
+                        )
+                token = str(entry.get("key") or entry.get("access_token") or "").strip()
+                if not token:
+                    raise RuntimeError(f"{email}: no access token")
+                # Reject clearly expired access even if present
+                exp_chk = _jwt_exp(token)
+                if exp_chk is not None and exp_chk <= time.time():
+                    raise RuntimeError(f"{email}: access token expired")
+                _persist_slot(email, raw, path)
+                # Advance RR only on successful pick so failed seats do not burn slots forever.
+                if email in candidates:
+                    idx = candidates.index(email)
+                    state["rr_index"] = (idx + 1) % max(1, len(candidates))
+                state["active_email"] = email  # last-used, not sticky
+                counts = state.setdefault("request_counts", {})
+                counts[email] = int(counts.get(email) or 0) + 1
+                _save_state(state)
+                return token, email
+            except Exception as exc:
+                last_err = exc
+                sys.stderr.write(f"[grok-proxy] skip {email}: {exc}\n")
+                continue
+        raise RuntimeError(f"No usable SuperGrok OAuth seat: {last_err}")
+
+
+def refresh_all_seats(*, force: bool = True) -> Dict[str, Any]:
+    """Force-refresh every known SuperGrok slot. Clears exhaust cooldowns for successes."""
+    LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+    results: Dict[str, Any] = {}
+    with LOCK_FILE.open("a+") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        state = _load_state()
+        slots = _discover_slot_files()
+        for email, path in slots.items():
+            try:
+                raw = _load_auth_blob(path)
+                key, entry = _pick_entry_from_raw(raw, want_email=email)
+                entry = _refresh(entry) if force or _needs_refresh(entry) else entry
+                raw[key] = entry
+                _atomic_write_json(path, raw)
+                # clear exhaust on successful refresh
+                if isinstance(state.get("exhausted"), dict):
+                    state["exhausted"].pop(email, None)
+                results[email] = {
+                    "ok": True,
+                    "expires_at": entry.get("expires_at"),
+                    "path": str(path),
+                }
+            except Exception as exc:
+                results[email] = {"ok": False, "error": str(exc), "path": str(path)}
+        _save_state(state)
+    return results
+
+
+def _looks_like_quota(status: int, body: bytes) -> bool:
+    if status in (429, 402):
+        return True
+    if status == 403 and QUOTA_RE.search(body.decode("utf-8", "replace")[:2000] or ""):
+        return True
+    if status >= 400 and QUOTA_RE.search(body.decode("utf-8", "replace")[:2000] or ""):
+        return True
+    return False
+
+
+class ProxyHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.0"
+    server_version = "grok-cli-auth-proxy/1.2-lb"
+
+    def log_message(self, fmt: str, *args: Any) -> None:
+        sys.stderr.write("%s - - [%s] %s\n" % (self.address_string(), self.log_date_time_string(), fmt % args))
+
+    def _send_json(self, status: int, payload: Dict[str, Any]) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _select_upstream(self, body: bytes | None) -> str:
+        path = self.path.lower()
+        if "/images" in path or "/videos" in path or "/image" in path or "/video" in path:
+            return UPSTREAM_IMAGINE
+        if body:
+            try:
+                model = str(json.loads(body).get("model") or "").lower()
+                if model.startswith("grok-imagine") or "imagine" in model:
+                    return UPSTREAM_IMAGINE
+            except Exception:
+                pass
+        return UPSTREAM_CODING
+
+    def _target_url(self, upstream: str) -> str:
+        path = self.path
+        if path.startswith("http://") or path.startswith("https://"):
+            parsed = urllib.parse.urlparse(path)
+            path = urllib.parse.urlunparse(("", "", parsed.path, parsed.params, parsed.query, parsed.fragment))
+        if not path.startswith("/v1"):
+            path = "/v1" + (path if path.startswith("/") else "/" + path)
+        suffix = path[len("/v1") :]
+        return upstream + suffix
+
+    def _build_headers(self, token: str) -> Dict[str, str]:
+        headers: Dict[str, str] = {}
+        for k, v in self.headers.items():
+            lk = k.lower()
+            if lk in HOP_BY_HOP or lk == "authorization" or lk == "content-length":
+                continue
+            headers[k] = v
+        headers["Authorization"] = f"Bearer {token}"
+        headers.setdefault("Accept", "application/json")
+        headers.setdefault("User-Agent", "grok-cli-auth-proxy/1.1")
+        headers.setdefault("x-grok-client-version", "0.2.93")
+        headers.setdefault("x-grok-client-identifier", "grok-cli")
+        return headers
+
+    def _do_upstream(self, upstream: str, body: bytes | None, token: str) -> tuple[int, list[tuple[str, str]], bytes]:
+        headers = self._build_headers(token)
+        req = urllib.request.Request(self._target_url(upstream), data=body, method=self.command, headers=headers)
+        try:
+            resp = urllib.request.urlopen(req, timeout=HTTP_TIMEOUT)
+            with resp:
+                payload = resp.read()
+                hdrs = [(k, v) for k, v in resp.headers.items() if k.lower() not in HOP_BY_HOP and k.lower() != "content-length"]
+                return int(resp.status), hdrs, payload
+        except urllib.error.HTTPError as exc:
+            payload = exc.read()
+            hdrs = [(k, v) for k, v in exc.headers.items() if k.lower() not in HOP_BY_HOP and k.lower() != "content-length"]
+            return int(exc.code), hdrs, payload
+
+    def _forward(self) -> None:
+        length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(length) if length else None
+        upstream = self._select_upstream(body)
+
+        tried: list[str] = []
+        last_status = 503
+        last_headers: list[tuple[str, str]] = []
+        last_body = b'{"error":"no_accounts"}'
+
+        # Try up to N preferred seats on quota/exhaust errors.
+        max_tries = max(1, len(PREFERRED_GROK_EMAILS) or 1)
+        for _ in range(max_tries):
+            try:
+                token, email = current_token()
+            except Exception as exc:
+                self._send_json(503, {"error": f"grok_cli_auth_unavailable: {exc}"})
+                return
+            if email in tried:
+                break
+            tried.append(email)
+            try:
+                status, headers, payload = self._do_upstream(upstream, body, token)
+            except Exception as exc:
+                self._send_json(502, {"error": f"upstream_error: {exc}"})
+                return
+            last_status, last_headers, last_body = status, headers, payload
+            if status < 400:
+                # success
+                self.send_response(status)
+                for k, v in headers:
+                    self.send_header(k, v)
+                self.send_header("X-Grok-Proxy-Account", email)
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+                return
+            if _looks_like_quota(status, payload):
+                state = _load_state()
+                _mark_exhausted(state, email)
+                sys.stderr.write(f"[grok-proxy] quota on {email} status={status}; rotating\n")
+                continue
+            # non-quota error: return as-is
+            self.send_response(status)
+            for k, v in headers:
+                self.send_header(k, v)
+            self.send_header("X-Grok-Proxy-Account", email)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+
+        # all seats exhausted or failed
+        self.send_response(last_status)
+        for k, v in last_headers:
+            self.send_header(k, v)
+        self.send_header("X-Grok-Proxy-Tried", ",".join(tried))
+        self.send_header("Content-Length", str(len(last_body)))
+        self.end_headers()
+        self.wfile.write(last_body)
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urllib.parse.urlparse(self.path)
+        path = parsed.path.rstrip("/") or "/"
+        if path in ("/accounts", "/v1/accounts", "/health", "/v1/health", "/rotate", "/v1/rotate", "/refresh-all", "/v1/refresh-all", "/refresh_all", "/v1/refresh_all"):
+            try:
+                state = _load_state()
+                slots = _discover_slot_files()
+                available = []
+                missing = []
+                for email in PREFERRED_GROK_EMAILS:
+                    if email in slots:
+                        available.append(email)
+                    else:
+                        missing.append(email)
+                for email in slots:
+                    if email not in available:
+                        available.append(email)
+                exhausted = {
+                    e: int(float(until) - time.time())
+                    for e, until in (state.get("exhausted") or {}).items()
+                    if float(until) > time.time()
+                }
+                if path.endswith("refresh-all") or path.endswith("refresh_all"):
+                    results = refresh_all_seats(force=True)
+                    payload = {"refreshed": results, "load_balance": "round_robin"}
+                elif path.endswith("rotate") and self.command == "GET":
+                    # Advance RR without long exhaust (LB mode).
+                    token, email = current_token(force_refresh=False)
+                    payload = {"rotated_to": email, "token_preview": token[:8] + "...", "load_balance": "round_robin"}
+                elif path.endswith("health"):
+                    state = _load_state()
+                    payload = {
+                        "status": "ok",
+                        "service": "grok-cli-auth-proxy",
+                        "load_balance": "round_robin",
+                        "active_accounts": available,
+                        "active": state.get("active_email"),
+                        "last_used": state.get("active_email"),
+                        "rr_index": state.get("rr_index", 0),
+                        "request_counts": state.get("request_counts") or {},
+                        "preferred": PREFERRED_GROK_EMAILS,
+                        "missing_preferred": missing,
+                        "exhausted_seconds_remaining": exhausted,
+                        "slots_dir": str(SLOTS_DIR),
+                    }
+                else:
+                    state = _load_state()
+                    payload = {
+                        "object": "list",
+                        "load_balance": "round_robin",
+                        "active": available,
+                        "current": state.get("active_email"),
+                        "last_used": state.get("active_email"),
+                        "rr_index": state.get("rr_index", 0),
+                        "request_counts": state.get("request_counts") or {},
+                        "preferred": PREFERRED_GROK_EMAILS,
+                        "missing_preferred": missing,
+                        "exhausted_seconds_remaining": exhausted,
+                        "auth_file": str(AUTH_FILE),
+                        "slots_dir": str(SLOTS_DIR),
+                    }
+                body = json.dumps(payload).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            except Exception as exc:
+                body = json.dumps({"error": str(exc)}).encode()
+                self.send_response(500)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+            return
+        self._forward()
+
+    def do_POST(self) -> None:  # noqa: N802
+        self._forward()
+
+    def do_OPTIONS(self) -> None:  # noqa: N802
+        self._forward()
+
+
+def main() -> int:
+    # Prefer a live seat at start, but stay up even if all seats are cooling/refresh-broken
+    # so keepalive + re-login can recover without a dead listener.
+    try:
+        token, email = current_token(force_refresh=False)
+        sys.stderr.write(f"grok-cli-auth-proxy active seat={email} token_ok={bool(token)}\n")
+    except Exception as exc:
+        sys.stderr.write(f"grok-cli-auth-proxy starting degraded: {exc}\n")
+    server = ThreadingHTTPServer((LISTEN_HOST, LISTEN_PORT), ProxyHandler)
+    print(
+        f"grok-cli-auth-proxy listening on http://{LISTEN_HOST}:{LISTEN_PORT}/v1 "
+        f"-> {UPSTREAM_CODING} (slots={SLOTS_DIR})",
+        flush=True,
+    )
+    server.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/claude-ops/scripts/account-rotation/ops-accounts-backend.mjs
+++ b/claude-ops/scripts/account-rotation/ops-accounts-backend.mjs
@@ -1,0 +1,58 @@
+/**
+ * ops-accounts-backend.mjs — resolve CRS vs local seat-state backend.
+ *
+ * Env / config:
+ *   OPS_ACCOUNTS_BACKEND | crs.backend
+ *     local | seat-state | file  → local seat-state (no CRS)
+ *     crs                        → CRS admin API only
+ *     auto (default)             → try CRS, fall back to local
+ *
+ * Dual-write (CRS path → seat-state.json) is on by default unless
+ * OPS_ACCOUNTS_DUAL_WRITE=0.
+ */
+export function resolveAccountsBackend({ env = process.env, cfgBackend } = {}) {
+  const raw = String(env.OPS_ACCOUNTS_BACKEND || cfgBackend || 'auto')
+    .trim()
+    .toLowerCase()
+    .replace(/_/g, '-');
+  if (raw === 'local' || raw === 'seat-state' || raw === 'file' || raw === 'seatstate') {
+    return 'local';
+  }
+  if (raw === 'crs' || raw === 'relay' || raw === 'claude-relay') {
+    return 'crs';
+  }
+  return 'auto';
+}
+
+export function dualWriteEnabled({ env = process.env } = {}) {
+  return env.OPS_ACCOUNTS_DUAL_WRITE !== '0';
+}
+
+/**
+ * Mirror CRS (or local) decisions into seat-state shape.
+ * @param {Array<{ email: string, schedulable: boolean, util5h?: number|null, util7d?: number|null, lastError?: string|null }>} seats
+ * @param {object} opts
+ */
+export function mergeSeatsIntoState(state, seats, { provider = 'claude' } = {}) {
+  const next = state && typeof state === 'object' ? structuredClone(state) : { version: 1, providers: {} };
+  if (!next.providers) next.providers = {};
+  if (!next.providers[provider]) next.providers[provider] = { seats: {} };
+  if (!next.providers[provider].seats) next.providers[provider].seats = {};
+  const now = new Date().toISOString();
+  for (const s of seats || []) {
+    if (!s?.email) continue;
+    const prev = next.providers[provider].seats[s.email] || {};
+    next.providers[provider].seats[s.email] = {
+      ...prev,
+      schedulable: s.schedulable !== false,
+      util5h: s.util5h ?? prev.util5h ?? null,
+      util7d: s.util7d ?? prev.util7d ?? null,
+      exhaustedUntil: s.exhaustedUntil ?? prev.exhaustedUntil ?? null,
+      lastError: s.lastError ?? prev.lastError ?? null,
+      updatedAt: now,
+    };
+  }
+  next.version = next.version || 1;
+  next.updatedAt = now;
+  return next;
+}

--- a/claude-ops/scripts/account-rotation/ops-accounts-gateway.mjs
+++ b/claude-ops/scripts/account-rotation/ops-accounts-gateway.mjs
@@ -35,10 +35,8 @@ const PORT = Number(process.env.OPS_ACCOUNTS_GATEWAY_PORT || '3005');
 const GATEWAY_KEY = process.env.OPS_ACCOUNTS_GATEWAY_KEY || '';
 const GROK_PROXY_URL = (process.env.GROK_PROXY_URL || 'http://127.0.0.1:31845').replace(/\/$/, '');
 const CLAUDE_UPSTREAM_URL = (process.env.CLAUDE_UPSTREAM_URL || '').replace(/\/$/, '');
-const DATA =
-  process.env.CLAUDE_PLUGIN_DATA_DIR || join(homedir(), '.claude', 'plugins', 'data', 'ops-ops-marketplace');
-const STATE_PATH =
-  process.env.OPS_ACCOUNTS_STATE_PATH || join(DATA, 'account-rotation', 'seat-state.json');
+const DATA = process.env.CLAUDE_PLUGIN_DATA_DIR || join(homedir(), '.claude', 'plugins', 'data', 'ops-ops-marketplace');
+const STATE_PATH = process.env.OPS_ACCOUNTS_STATE_PATH || join(DATA, 'account-rotation', 'seat-state.json');
 
 export function loadSeatState(path = STATE_PATH) {
   if (!existsSync(path)) {
@@ -247,8 +245,7 @@ async function handleClaude(req, res, route) {
   if (!picked) {
     sendJson(res, 503, {
       error: {
-        message:
-          'no schedulable Claude seat in seat-state; run ops-accounts seats import-claude-config or seats set',
+        message: 'no schedulable Claude seat in seat-state; run ops-accounts seats import-claude-config or seats set',
         type: 'no_capacity',
       },
     });
@@ -415,8 +412,7 @@ function main(argv = process.argv.slice(2)) {
   });
 }
 
-const isMain =
-  process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
 if (isMain) {
   main();
 }


### PR DESCRIPTION
## What
Cherry-pick path so multi-seat policy and SuperGrok RR do not require claude-relay-service.

- `OPS_ACCOUNTS_BACKEND=auto|crs|local` on priority daemon (auto falls back to seat-state)
- Dual-write CRS decisions into local seat-state
- Plugin `grok-cli-auth-proxy.py` + `ops-accounts grok-proxy`
- CRS reconcilers no-op when backend=local
- Gateway design doc (implementation in #736)

Rebased onto main after #732 merge (replaces closed stack #735).

## Verify
```
node claude-ops/scripts/account-rotation/__tests__/ops-accounts-backend.test.mjs
python3 -m py_compile claude-ops/scripts/account-rotation/grok-cli-auth-proxy.py
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes OAuth token refresh, multi-account rotation, and CRS vs local policy paths—security- and availability-critical. The new Grok proxy handles bearer tokens and upstream forwarding (with host/path allowlists), so misconfiguration or proxy bugs could leak credentials or break seat LB.
> 
> **Overview**
> Adds a **no-CRS default path** for multi-seat Claude policy and SuperGrok traffic by centralizing backend selection and shipping an in-plugin Grok OAuth proxy.
> 
> **Backend resolution** (`ops-accounts-backend.mjs`): `OPS_ACCOUNTS_BACKEND` / `crs.backend` now resolve to `local`, `crs`, or `auto` (try CRS, fall back to file seat-state). Default **dual-write** mirrors CRS schedulable decisions into `seat-state.json` unless `OPS_ACCOUNTS_DUAL_WRITE=0`.
> 
> **CRS daemons**: `crs-priority-daemon` uses the new resolver, logs `backend want=…`, exits CRS-only ticks early on `local`, wraps the CRS tick in try/catch for `auto` fallback, and calls `dualWriteFromCrsDecisions` after a successful CRS tick. `crs-401-refresher`, `crs-429-cooldown`, and `crs-token-feed` **no-op** when backend is `local`.
> 
> **Grok**: New `grok-cli-auth-proxy.py` — OpenAI-compatible local proxy on `:31845` with multi-account OAuth from `~/.grok`, round-robin LB, 429 exhaust cooldowns, token refresh under lock, and SSRF-hardened upstream routing to `cli-chat-proxy.grok.com` / `api.x.ai`.
> 
> Unit tests cover backend resolution and `mergeSeatsIntoState`; gateway changes are mostly formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81c148341b207d383f01df526772c199fb416f15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->