### PR TITLE
fix(ops-accounts): route gateway/seats through shell before Node CLI

### DIFF
--- a/claude-ops/bin/ops-accounts
+++ b/claude-ops/bin/ops-accounts
@@ -28,12 +28,21 @@ ROOT="$(resolve_root)"
 export CLAUDE_PLUGIN_ROOT="$ROOT"
 CLI="$ROOT/scripts/ops-accounts/cli.mjs"
 
+# Shell-owned commands (dual-backend + gateway + seats). Node CLI only covers
+# multi-provider status/reauth/switch/refresh — do not exec it for these.
+cmd="${1:-status}"
+SHELL_CMDS="util setup crs crs-tick seats gateway grok-proxy help -h --help"
 if [[ -f "$CLI" ]]; then
-  exec node "$CLI" "$@"
+  case " $SHELL_CMDS " in
+    *" $cmd "*) ;;
+    *)
+      # status|list|reauth|switch|refresh|providers → Node when present
+      exec node "$CLI" "$@"
+      ;;
+  esac
 fi
 
-# --- fallback shell (phase-0 pre-Node) ---
-cmd="${1:-status}"
+# --- shell path (dual-backend + gateway + seats + util) ---
 shift || true
 have() { command -v "$1" >/dev/null 2>&1; }
 
@@ -237,6 +246,22 @@ case "$cmd" in
     fi
     ;;
 
+  grok-proxy)
+    sub="${1:-status}"
+    case "$sub" in
+      status|accounts|"")
+        if curl -fsS -m 2 http://127.0.0.1:31845/accounts 2>/dev/null; then
+          echo
+        else
+          echo "grok-cli-auth-proxy not listening on :31845"
+          exit 1
+        fi
+        ;;
+      *)
+        echo "usage: ops-accounts grok-proxy status"; exit 2 ;;
+    esac
+    ;;
+
   gateway)
     sub="${1:-status}"
     GW="${ROT}/ops-accounts-gateway.mjs"
@@ -291,7 +316,9 @@ ops-accounts — multi-provider seats (canonical; /ops:rotate is alias)
   reauth claude <email> | reauth grok <email>
   setup [claude|grok]
   crs | crs-tick
-  seats [status|list|set|toggle|import-claude-config]
+  seats [status|list|set|toggle|import-claude-config|tick]
+  gateway status|start|path|self-test|config
+  grok-proxy status   # SuperGrok OAuth proxy :31845
 H
     ;;
   *)


### PR DESCRIPTION
## What
`bin/ops-accounts` always `exec`d the Node CLI when present, so shell-only commands from #736/#737 (`gateway`, `seats`, `crs`, `util`, `grok-proxy`) never ran.

## Fix
Route those commands through the shell half first. Keep `status` / `reauth` / `switch` / `refresh` / `providers` on the Node CLI.

## Verify
```
CLAUDE_PLUGIN_ROOT=$PWD/claude-ops bash claude-ops/bin/ops-accounts gateway self-test
CLAUDE_PLUGIN_ROOT=$PWD/claude-ops bash claude-ops/bin/ops-accounts help
node claude-ops/scripts/account-rotation/__tests__/ops-accounts-backend.test.mjs
node claude-ops/scripts/account-rotation/__tests__/ops-accounts-gateway.test.mjs
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routing and help/grok-proxy additions only; no auth or data-path changes.
> 
> **Overview**
> **Fixes command routing** when `scripts/ops-accounts/cli.mjs` exists: the wrapper no longer always `exec`s Node first, which had blocked shell-only handlers for `gateway`, `seats`, `crs`, `util`, `grok-proxy`, and related commands.
> 
> A **shell-owned allowlist** runs those subcommands in bash; **`status`**, **`list`**, **`reauth`**, **`switch`**, **`refresh`**, and **`providers`** still go to the Node CLI when the file is present.
> 
> Also adds a **`grok-proxy status`** subcommand (SuperGrok OAuth proxy on `:31845`) and expands **`help`** to document **`gateway`** and **`seats tick`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e091e48aaebd44b907143845f9cc8b7fcdc20edc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->