### PR TITLE
release: v2.47.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,9 +9,9 @@
   "plugins": [
     {
       "name": "ops",
-      "description": "Business operations command center for Claude Code \u2014 61 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
+      "description": "Business operations command center for Claude Code — 62 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.46.2",
+      "version": "2.47.0",
       "category": "productivity",
       "keywords": [
         "ops",
@@ -37,7 +37,7 @@
     },
     {
       "name": "desktop-act",
-      "description": "Computer-use MCP companion for /ops:desktop \u2014 screenshot, click, type, multi-desktop pool, autonomous act() loop. Co-installed with the ops plugin.",
+      "description": "Computer-use MCP companion for /ops:desktop — screenshot, click, type, multi-desktop pool, autonomous act() loop. Co-installed with the ops plugin.",
       "source": "./desktop-act",
       "version": "0.2.0",
       "category": "automation",

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-2.46.2-blue)
+![Version](https://img.shields.io/badge/version-2.47.0-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
-![Skills](https://img.shields.io/badge/skills-61-success)
+![Skills](https://img.shields.io/badge/skills-62-success)
 ![Agents](https://img.shields.io/badge/agents-21-informational)
 ![Integrations](https://img.shields.io/badge/integrations-22-orange)
 ![Auto-fix](https://img.shields.io/badge/v2-auto--fix%20subsystem-ef4444)
@@ -113,7 +113,7 @@ claude --plugin-dir ./claude-ops/claude-ops
 
 ## Commands
 
-All 61 skills, grouped by category:
+All 62 skills, grouped by category:
 
 | 🧭 Navigation                    | 📊 Daily Ops                           |
 | -------------------------------- | -------------------------------------- |

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ops",
-  "version": "2.46.2",
-  "description": "Business operations command center for Claude Code \u2014 61 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite \u2014 security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
+  "version": "2.47.0",
+  "description": "Business operations command center for Claude Code — 62 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",
     "url": "https://github.com/Lifecycle-Innovations-Limited"
@@ -66,7 +66,7 @@
     "no_rm_rf_anchor": {
       "type": "boolean",
       "title": "Block rm -rf against root anchors",
-      "description": "PreToolUse hook denies `rm -rf` targeting /, ~, $HOME, .., or . \u2014 protecting against catastrophic filesystem wipes. Specific subpaths (./node_modules, /tmp/foo) are allowed.",
+      "description": "PreToolUse hook denies `rm -rf` targeting /, ~, $HOME, .., or . — protecting against catastrophic filesystem wipes. Specific subpaths (./node_modules, /tmp/foo) are allowed.",
       "default": true
     },
     "warn_mainpush": {
@@ -83,7 +83,7 @@
     },
     "monitor_post_merge": {
       "type": "boolean",
-      "title": "Monitor PR merges \u2192 deploys",
+      "title": "Monitor PR merges → deploys",
       "description": "After `gh pr merge` to dev/main, watch the deploy workflow + audit service health.",
       "default": true
     },
@@ -96,7 +96,7 @@
     "auto_dispatch_fixer": {
       "type": "boolean",
       "title": "Auto-dispatch headless Claude fixer",
-      "description": "When off, failures are logged + notified only \u2014 no agent runs.",
+      "description": "When off, failures are logged + notified only — no agent runs.",
       "default": true
     },
     "allow_dangerous": {
@@ -148,7 +148,7 @@
     "registry_path": {
       "type": "file",
       "title": "Service registry JSON",
-      "description": "Maps owner/repo:base \u2192 health/version URLs. Project .claude/post-merge-services.json overrides.",
+      "description": "Maps owner/repo:base → health/version URLs. Project .claude/post-merge-services.json overrides.",
       "default": "~/.claude/config/post-merge-services.json"
     },
     "repo_search_roots": {
@@ -210,33 +210,33 @@
     "suggest_specialized_agents": {
       "type": "boolean",
       "title": "Suggest specialized subagents",
-      "description": "PreToolUse hook on Agent \u2014 when subagent_type=general-purpose, asks if a domain-specific agent fits better.",
+      "description": "PreToolUse hook on Agent — when subagent_type=general-purpose, asks if a domain-specific agent fits better.",
       "default": true
     },
     "telegram_api_id": {
       "title": "Telegram API ID",
-      "description": "Numeric API ID from https://my.telegram.org/apps. Optional \u2014 run /ops:setup telegram to auto-configure.",
+      "description": "Numeric API ID from https://my.telegram.org/apps. Optional — run /ops:setup telegram to auto-configure.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "telegram_api_hash": {
       "title": "Telegram API Hash",
-      "description": "API hash from https://my.telegram.org/apps. Optional \u2014 run /ops:setup telegram to auto-configure. If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "API hash from https://my.telegram.org/apps. Optional — run /ops:setup telegram to auto-configure. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "telegram_phone": {
       "title": "Telegram Phone Number",
-      "description": "Your phone number in E.164 format. Optional \u2014 run /ops:setup telegram to auto-configure.",
+      "description": "Your phone number in E.164 format. Optional — run /ops:setup telegram to auto-configure.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "telegram_session": {
       "title": "Telegram Session String",
-      "description": "gram.js StringSession. Optional \u2014 run /ops:setup telegram to auto-configure. If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "gram.js StringSession. Optional — run /ops:setup telegram to auto-configure. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -264,14 +264,14 @@
     },
     "klaviyo_private_key": {
       "title": "Klaviyo Private API Key",
-      "description": "Private API key from Klaviyo Settings > API Keys (starts with pk_ or ck_) If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Private API key from Klaviyo Settings > API Keys (starts with pk_ or ck_) If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "meta_ads_token": {
       "title": "Meta Ads Access Token",
-      "description": "Meta Marketing API access token from Facebook Business If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Meta Marketing API access token from Facebook Business If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -307,49 +307,49 @@
     },
     "shopify_admin_token": {
       "title": "Shopify Admin API Token",
-      "description": "Admin API access token from Shopify Partners or custom app If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Admin API access token from Shopify Partners or custom app If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "shipbob_access_token": {
       "title": "ShipBob Access Token",
-      "description": "ShipBob Personal Access Token for fulfillment tracking (optional) If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "ShipBob Personal Access Token for fulfillment tracking (optional) If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "bland_ai_api_key": {
       "title": "Bland AI API Key",
-      "description": "API key from https://app.bland.ai \u2014 used for /ops:ops-voice call If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "API key from https://app.bland.ai — used for /ops:ops-voice call If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "elevenlabs_api_key": {
       "title": "ElevenLabs API Key",
-      "description": "API key from https://elevenlabs.io \u2014 used for /ops:ops-voice tts If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "API key from https://elevenlabs.io — used for /ops:ops-voice tts If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "groq_api_key": {
       "title": "Groq API Key",
-      "description": "API key from https://console.groq.com \u2014 used for /ops:ops-voice transcribe (Whisper) If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "API key from https://console.groq.com — used for /ops:ops-voice transcribe (Whisper) If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "stripe_secret_key": {
       "title": "Stripe Secret Key",
-      "description": "Stripe secret key (sk_live_... or sk_test_...) for revenue tracking. Prefer Doppler reference. If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Stripe secret key (sk_live_... or sk_test_...) for revenue tracking. Prefer Doppler reference. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "revenuecat_api_key": {
       "title": "RevenueCat API Key",
-      "description": "RevenueCat API key for mobile subscription revenue tracking (V2 API). If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "RevenueCat API key for mobile subscription revenue tracking (V2 API). If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -363,21 +363,21 @@
     },
     "datadog_api_key": {
       "title": "Datadog API Key",
-      "description": "From Datadog Organization Settings > API Keys \u2014 used for /ops:monitor If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "From Datadog Organization Settings > API Keys — used for /ops:monitor If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "datadog_app_key": {
       "title": "Datadog Application Key",
-      "description": "From Datadog Organization Settings > Application Keys If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "From Datadog Organization Settings > Application Keys If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "newrelic_api_key": {
       "title": "New Relic API Key",
-      "description": "User API Key from one.newrelic.com/api-keys \u2014 used for /ops:monitor If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "User API Key from one.newrelic.com/api-keys — used for /ops:monitor If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -413,21 +413,21 @@
     },
     "pushover_user_key": {
       "title": "Pushover User Key",
-      "description": "From https://pushover.net/ \u2014 paired with pushover_app_token. If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "From https://pushover.net/ — paired with pushover_app_token. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "pushover_app_token": {
       "title": "Pushover App Token",
-      "description": "App-specific token from https://pushover.net/apps/build If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "App-specific token from https://pushover.net/apps/build If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "telegram_bot_token": {
       "title": "Telegram Bot Token",
-      "description": "Bot token for outbound notifications + channel-mcp DM polling. From @BotFather. If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Bot token for outbound notifications + channel-mcp DM polling. From @BotFather. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -441,28 +441,28 @@
     },
     "discord_bot_token": {
       "title": "Discord Bot Token",
-      "description": "Bot token from Discord Developer Portal \u2014 used for channel reads and DMs. Prefer Doppler reference. If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Bot token from Discord Developer Portal — used for channel reads and DMs. Prefer Doppler reference. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "discord_guild_id": {
       "title": "Discord Guild ID",
-      "description": "Server/guild ID (right-click server in Discord \u2192 Copy ID with Developer Mode enabled)",
+      "description": "Server/guild ID (right-click server in Discord → Copy ID with Developer Mode enabled)",
       "type": "string",
       "sensitive": false,
       "default": ""
     },
     "discord_default_webhook_url": {
       "title": "Discord Default Webhook URL",
-      "description": "Optional default webhook URL (https://discord.com/api/webhooks/\u2026) for /ops:comms discord send. Shared with the ops-fires notification sink (which also reads discord_webhook_url). If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Optional default webhook URL (https://discord.com/api/webhooks/…) for /ops:comms discord send. Shared with the ops-fires notification sink (which also reads discord_webhook_url). If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "doppler_token": {
       "title": "Doppler Token",
-      "description": "Doppler service or personal token for the @dopplerhq/mcp-server MCP integration. Generated by /ops:setup or paste manually. If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Doppler service or personal token for the @dopplerhq/mcp-server MCP integration. Generated by /ops:setup or paste manually. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -483,35 +483,35 @@
     },
     "myparcel_api_key": {
       "title": "MyParcel.nl API Key",
-      "description": "Plain API key from backoffice.myparcel.nl \u2192 Settings \u2192 API. Used by /ops:ops-package. Script base64-encodes it at runtime \u2014 do NOT pre-encode.",
+      "description": "Plain API key from backoffice.myparcel.nl → Settings → API. Used by /ops:ops-package. Script base64-encodes it at runtime — do NOT pre-encode.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "sendcloud_public_key": {
       "title": "Sendcloud Public Key",
-      "description": "Public key from Sendcloud Panel \u2192 Settings \u2192 Integrations \u2192 Sendcloud API. Paired with sendcloud_private_key.",
+      "description": "Public key from Sendcloud Panel → Settings → Integrations → Sendcloud API. Paired with sendcloud_private_key.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "sendcloud_private_key": {
       "title": "Sendcloud Private Key",
-      "description": "Private key from Sendcloud Panel \u2192 Settings \u2192 Integrations \u2192 Sendcloud API. Paired with sendcloud_public_key.",
+      "description": "Private key from Sendcloud Panel → Settings → Integrations → Sendcloud API. Paired with sendcloud_public_key.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "dhl_parcel_user_id": {
       "title": "DHL Parcel NL User ID",
-      "description": "User ID issued in My DHL Parcel \u2192 User settings \u2192 API settings. Paired with dhl_parcel_key.",
+      "description": "User ID issued in My DHL Parcel → User settings → API settings. Paired with dhl_parcel_key.",
       "type": "string",
       "sensitive": true,
       "default": ""
     },
     "dhl_parcel_key": {
       "title": "DHL Parcel NL API Key",
-      "description": "API key from My DHL Parcel \u2192 User settings \u2192 API settings. Paired with dhl_parcel_user_id.",
+      "description": "API key from My DHL Parcel → User settings → API settings. Paired with dhl_parcel_user_id.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -546,7 +546,7 @@
     },
     "dpd_password": {
       "title": "DPD Password",
-      "description": "Password for the DelisID. Exchanged at login for a short-lived token. If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Password for the DelisID. Exchanged at login for a short-lived token. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -560,7 +560,7 @@
     },
     "ups_client_secret": {
       "title": "UPS OAuth Client Secret",
-      "description": "Client secret for the UPS app. Used for OAuth2 client_credentials. If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Client secret for the UPS app. Used for OAuth2 client_credentials. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -581,7 +581,7 @@
     },
     "fedex_client_secret": {
       "title": "FedEx OAuth Client Secret",
-      "description": "Secret Key for the FedEx project. Used for OAuth2 client_credentials. If already configured via /ops:setup or stored in keychain/Doppler, leave blank \u2014 runtime resolves automatically.",
+      "description": "Secret Key for the FedEx project. Used for OAuth2 client_credentials. If already configured via /ops:setup or stored in keychain/Doppler, leave blank — runtime resolves automatically.",
       "type": "string",
       "sensitive": true,
       "default": ""
@@ -596,7 +596,7 @@
     "telegram_enabled": {
       "type": "boolean",
       "title": "Enable Telegram integration",
-      "description": "Use Telegram for inbox + notifications. Requires telegram_api_id/hash/phone/session \u2014 run /ops:setup telegram.",
+      "description": "Use Telegram for inbox + notifications. Requires telegram_api_id/hash/phone/session — run /ops:setup telegram.",
       "default": false
     },
     "discord_enabled": {
@@ -802,7 +802,7 @@
     },
     "ip_whitelist_desc_prefix": {
       "title": "IP-whitelist rule description prefix",
-      "description": "Description prefix for managed rules \u2014 e.g. 'mylaptop'. Defaults to <hostname>-laptop. Rules with this prefix are reaped when older than ip_whitelist_keep_recent.",
+      "description": "Description prefix for managed rules — e.g. 'mylaptop'. Defaults to <hostname>-laptop. Rules with this prefix are reaped when older than ip_whitelist_keep_recent.",
       "type": "string",
       "sensitive": false,
       "default": ""

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -39,6 +39,25 @@
 - **ops-ecom:** `channels` | `agentic` | `shop` verbs — sales channel inventory, agentic storefront health, Shop Campaigns readiness (read-only; Rule 5 / stage-only spend).
 - **ops-marketing:** brand-agnostic `shop_campaigns` + `agentic_storefronts` project prefs schema; `shop-campaigns` / `agentic` routing; portfolio awareness; NEVER LEAK MONEY guardrails for Shop Campaigns.
 
+## [2.47.0] - 2026-07-30
+
+### Changed
+### Added
+- desktop-act companion: virtual desktop control MCP (co-installed with ops)
+- ops-accounts: multi-provider seat/rotation router (Claude/Grok/OpenAI/Factory/Cursor), CRS-optional dual-mode backend
+- account-rotation: captcha-solving cascade for standalone rotation and magic-link reauth flows, portable unattended reauth env
+
+### Fixed
+- security: replaced shell-string execSync calls with execFileSync argument arrays
+- ops-accounts: route gateway/seats/util through shell before Node CLI
+- hea: Paperclip→Linear create-guard + terminal status skip
+- watchdog: expand ${VAR} in config headers before probing
+- account-rotation: keep CRS harness for agents TUI
+
+### Changed
+- deps: bump prettier and playwright
+
+
 ## [2.46.2] - 2026-07-25
 
 ### Changed

--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -142,7 +142,7 @@ The background memory extractor now prefers the Claude Code OAuth token stored i
 
 ### Full Plugin Feature Adoption
 
-- All 61 skills: `effort`, `maxTurns`, `disallowedTools`, `model` annotations
+- All 62 skills: `effort`, `maxTurns`, `disallowedTools`, `model` annotations
 - All 21 agents: `memory` (cross-session learning), `initialPrompt`, `isolation`
 - PreToolUse hooks for WhatsApp health checks and MCP auto-reconnect
 - Runtime Context loading in every skill (preferences, daemon health, memories, secrets)

--- a/claude-ops/docs/INDEX.md
+++ b/claude-ops/docs/INDEX.md
@@ -25,7 +25,7 @@ _Top-level map of every doc file in `claude-ops/docs/`._
 | Doc                                                        | Subject                                                                                        |
 | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | [`agents-reference.md`](agents-reference.md)               | Catalog of all 21 agents (4 v2 specialists + 14 v1 scanners/fixers/C-suite).                   |
-| [`skills-reference.md`](skills-reference.md)               | Catalog of all 61 skills with usage examples.                                                  |
+| [`skills-reference.md`](skills-reference.md)               | Catalog of all 62 skills with usage examples.                                                  |
 | [`daemon-guide.md`](daemon-guide.md)                       | The v1 ops-daemon (briefing pre-warm, whatsapp-bridge-sync, memory-extractor, etc).            |
 | [`docker.md`](docker.md)                                   | Running claude-ops in a container.                                                             |
 | [`marketplace-submissions.md`](marketplace-submissions.md) | Publishing your own plugin to the same marketplace.                                            |

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-2.46.2-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.47.0-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -2,10 +2,10 @@
 
 # Skills Reference
 
-_All 61 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
+_All 62 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-2.46.2-blue)](../CHANGELOG.md)
-[![skills](https://img.shields.io/badge/skills-61-8b5cf6)](.)
+[![version](https://img.shields.io/badge/version-2.47.0-blue)](../CHANGELOG.md)
+[![skills](https://img.shields.io/badge/skills-62-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)
 

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.46.2",
+  "version": "2.47.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.47.0** (was 2.46.2).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

### Added
- desktop-act companion: virtual desktop control MCP (co-installed with ops)
- ops-accounts: multi-provider seat/rotation router (Claude/Grok/OpenAI/Factory/Cursor), CRS-optional dual-mode backend
- account-rotation: captcha-solving cascade for standalone rotation and magic-link reauth flows, portable unattended reauth env

### Fixed
- security: replaced shell-string execSync calls with execFileSync argument arrays
- ops-accounts: route gateway/seats/util through shell before Node CLI
- hea: Paperclip→Linear create-guard + terminal status skip
- watchdog: expand ${VAR} in config headers before probing
- account-rotation: keep CRS harness for agents TUI

### Changed
- deps: bump prettier and playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff is release metadata and changelog only; no runtime logic changes in the shown files. Underlying 2.47.0 features (account rotation, exec hardening) carry their own risk but are not modified in this diff.
> 
> **Overview**
> **Release v2.47.0** — bumps `ops` from 2.46.2 to **2.47.0** across `plugin.json`, `marketplace.json`, and `claude-ops/package.json`, and aligns README/docs badges and copy to **62 skills** (was 61).
> 
> Adds a **CHANGELOG** section for 2.47.0 that records the shipped work: **desktop-act** companion MCP co-install, **ops-accounts** multi-provider rotation router with CRS-optional backend, **account-rotation** captcha cascade and portable reauth env, **security** `execFileSync` hardening, ops-accounts shell routing for gateway/seats/util, HEA Linear guard, watchdog `${VAR}` header expansion, and prettier/playwright dependency bumps.
> 
> `plugin.json` userConfig descriptions are normalized to literal em dashes/arrows (encoding cleanup only; no behavior change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9bb7a30c1997c275bfc37c3dff82480af5dcacb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added desktop companion controls for virtual desktop workflows.
  * Introduced multi-provider account routing across Claude, Grok, OpenAI, Factory, and Cursor.
  * Added account-rotation captcha handling and unattended reauthentication support.
  * Expanded the catalog to 62 skills.

* **Bug Fixes**
  * Improved command safety, configuration handling, deployment routing, and account-rotation reliability.

* **Documentation**
  * Updated release metadata, version references, skill counts, and setup guidance for version 2.47.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->