### PR TITLE
fix(ops-update): refresh marketplace catalogue for real under --dry-run

### DIFF
--- a/claude-ops/bin/ops-update
+++ b/claude-ops/bin/ops-update
@@ -5,6 +5,8 @@
 # with NO stale cache dirs and NO dangling version-pinned paths left behind:
 #
 #   1. Refresh the marketplace catalogue clone     (claude plugin marketplace update)
+#      — runs for real even under --dry-run: it is a read-only pull of the
+#        public catalogue, and step 2 needs it current to report accurately.
 #   2. Resolve the target version from the refreshed marketplace.json
 #   3. Update the installed plugin                 (claude plugin update ops@ops-marketplace)
 #      — with a force-reinstall fallback for the known Claude Code bug where
@@ -89,16 +91,20 @@ say "${c_dim}ops-update — claude-ops local upgrade$([[ $DRY -eq 1 ]] && echo '
 say "current installed: ${CUR:-<none>}"
 
 # ── 1. Refresh marketplace catalogue ───────────────────────────────────────
+# Always runs for real, even under --dry-run: this only pulls the public
+# marketplace catalogue clone (read-only w.r.t. the installed plugin) and
+# step 2's target-version resolution needs it to be current to report
+# accurately. The actually destructive/mutating steps (3, 5, 6, 7, 8, 9)
+# stay gated behind $DRY below.
 step "1/10  Refresh marketplace catalogue ($MARKETPLACE)"
 if [[ "$DRY" -eq 1 ]]; then
-  say "  ${c_dim}[dry-run] claude plugin marketplace update $MARKETPLACE${c_rst}"
+  say "  ${c_dim}[dry-run] (refresh runs for real — read-only catalogue pull, no plugin state changes)${c_rst}"
+fi
+if claude plugin marketplace update "$MARKETPLACE" >/dev/null 2>&1; then
+  ok "marketplace catalogue refreshed via CLI"
 else
-  if claude plugin marketplace update "$MARKETPLACE" >/dev/null 2>&1; then
-    ok "marketplace catalogue refreshed via CLI"
-  else
-    warn "CLI marketplace update failed — falling back to git pull on the clone"
-    git -C "$MKT_CLONE" pull --ff-only >/dev/null 2>&1 && ok "git pull ok" || err "git pull failed (continuing)"
-  fi
+  warn "CLI marketplace update failed — falling back to git pull on the clone"
+  git -C "$MKT_CLONE" pull --ff-only >/dev/null 2>&1 && ok "git pull ok" || err "git pull failed (continuing)"
 fi
 
 # ── 2. Resolve target version ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Step 1 of `ops-update` only printed the marketplace-refresh command in `--dry-run` mode instead of running it, so step 2 resolved the target version from a stale local catalogue clone.
- The refresh is a read-only pull of the public marketplace catalogue and doesn't touch the installed plugin, so it now runs for real in both modes. The mutating steps (install, prune, rewrite, migrate, localsync, companions) stay gated behind `--dry-run` as before.

## Test plan
- [x] `bash -n claude-ops/bin/ops-update` — syntax check
- [x] Ran `ops-update --dry-run` from the fixed checkout — catalogue refreshed for real (`marketplace catalogue refreshed via CLI`), target version resolved correctly without a manual pre-refresh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to dry-run step 1 pulling catalogue metadata; no change to mutating upgrade steps when `--dry-run` is set.
> 
> **Overview**
> **`ops-update --dry-run` now refreshes the marketplace catalogue for real** instead of only printing the command. Previously step 2 could report a stale target version because the local catalogue clone was never updated in dry-run mode.
> 
> The refresh is treated as safe to run always: it only updates the public marketplace clone (CLI or `git pull` fallback) and does not change installed plugin cache or configs. **Install, prune, path rewrites, migrations, localsync, and companions remain dry-run gated** as before.
> 
> Header comments and the dry-run message clarify that step 1 is the exception.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d331f59f03c4aaac1a0c990477936752fcf95e67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->