### PR TITLE
fix(auth): schedule only exhausted Claude seats

### DIFF
--- a/claude-ops/scripts/account-rotation/crs-priority-daemon.mjs
+++ b/claude-ops/scripts/account-rotation/crs-priority-daemon.mjs
@@ -305,6 +305,7 @@ async function liveUsage(email) {
     const data = {
       u5: d?.five_hour?.utilization ?? null,
       u7: d?.seven_day?.utilization ?? null,
+      resets5: d?.five_hour?.resets_at ?? null,
       // ISO string when the API supplies it — used by the weekly-cap reconciler
       // below to record/clear an authoritative reset time.
       resets7: d?.seven_day?.resets_at ?? null,
@@ -321,6 +322,21 @@ async function liveUsage(email) {
 function genuineRateLimit(a, now = Date.now()) {
   const flagged = !!a.rateLimitStatus?.isRateLimited || !!a.opusRateLimitStatus?.isRateLimited;
   return flagged && !rateLimitLooksStale(a, now);
+}
+
+function liveQuotaExhaustion(a, now = Date.now()) {
+  const usage = a._liveUsage;
+  if (!usage) return null;
+  const windows = [
+    { name: '5h', utilization: usage.u5, resetsAt: usage.resets5 },
+    { name: '7d', utilization: usage.u7, resetsAt: usage.resets7 },
+  ].filter(({ utilization, resetsAt }) => {
+    const resetMs = resetsAt ? Date.parse(resetsAt) : NaN;
+    return typeof utilization === 'number' && utilization >= 100 && Number.isFinite(resetMs) && resetMs > now;
+  });
+  if (!windows.length) return null;
+  const resetAt = new Date(Math.min(...windows.map(({ resetsAt }) => Date.parse(resetsAt)))).toISOString();
+  return { windows: windows.map(({ name }) => name), resetAt };
 }
 
 function genuineOverload(a, now = Date.now()) {
@@ -459,28 +475,19 @@ function decideMaxOut(accts, nowMs) {
     const u7 = lu?.u7 ?? cu.sevenDay?.utilization;
     const sw = a.sessionWindow?.sessionWindowStatus || null;
     const cur = a.schedulable !== false;
-    const tokenExpiresAt = Number(a.tokenExpiresAt || a.expiresAt || 0);
-    const staleToken =
-      !Number.isFinite(tokenExpiresAt) || tokenExpiresAt <= 0 || tokenExpiresAt <= nowMs + TOKEN_MIN_FRESH_MS;
-    const rl = genuineRateLimit(a, nowMs);
+    const quota = liveQuotaExhaustion(a, nowMs);
+    const rl = Boolean(quota);
     const overloaded = genuineOverload(a, nowMs);
 
     let desired = true;
     let reason = `max-out (5h=${u5 ?? '?'} 7d=${u7 ?? '?'} sw=${sw ?? 'none'})`;
-    if (weeklyCapActive(a, nowMs)) {
+    if (quota) {
       desired = false;
-      reason = `weekly-cap-hold until ${a.weeklyRateLimitEndAt.slice(0, 16)}`;
-    } else if (staleToken) {
-      desired = false;
-      reason = tokenExpiresAt ? `stale-token ${new Date(tokenExpiresAt).toISOString()}` : 'stale-token missing-expiry';
-    } else if (rl) {
-      desired = false;
-      reason = 'rate-limited (live)';
+      reason = `quota exhausted (${quota.windows.join('+')}); auto-reschedule ${quota.resetAt}`;
     } else if (overloaded) {
-      desired = false;
-      reason = 'overloaded(529 live)';
+      reason = 'overloaded(529), staying schedulable';
     }
-    return { a, cur, desired, reason, soft: false, sw, u5: u5 ?? '?', rl, overloaded };
+    return { a, cur, desired, reason, soft: false, sw, u5: u5 ?? '?', u7: u7 ?? '?', rl, overloaded, quota };
   });
 }
 
@@ -488,47 +495,24 @@ function decideConservative(accts, nowMs) {
   const decisions = accts.map((a) => {
     const cu = a.claudeUsage || {};
     const lu = a._liveUsage;
-    const updMs = cu.updatedAt ? Date.parse(cu.updatedAt) : NaN;
-    const fresh = !!lu || (Number.isFinite(updMs) && (nowMs - updMs) / 60000 < FRESH_MIN);
     const u5 = lu?.u5 ?? cu.fiveHour?.utilization;
     const u7 = lu?.u7 ?? cu.sevenDay?.utilization;
-    const u7o = cu.sevenDayOpus?.utilization;
     const sw = a.sessionWindow?.sessionWindowStatus || null;
     const cur = a.schedulable !== false;
-    const rl = genuineRateLimit(a, nowMs);
+    const quota = liveQuotaExhaustion(a, nowMs);
+    const rl = Boolean(quota);
     const overloaded = genuineOverload(a, nowMs);
 
-    const weeklyBreach =
-      fresh && ((typeof u7 === 'number' && u7 >= OFF_7D) || (typeof u7o === 'number' && u7o >= OFF_7D));
-    const utilBreach = fresh && ((u5 ?? 0) >= OFF_5H || weeklyBreach);
-    const utilClear = !fresh || ((u5 ?? 0) < ON_5H && (u7 ?? 0) < ON_7D && (u7o ?? 0) < ON_7D);
-
-    let desired = cur;
-    let reason = 'hold';
+    let desired = true;
+    let reason = 'scheduled unless live quota is exhausted';
     let soft = false;
-    if (weeklyCapActive(a, nowMs)) {
+    if (quota) {
       desired = false;
-      reason = `weekly-cap-hold until ${a.weeklyRateLimitEndAt.slice(0, 16)}`;
-      soft = false;
-    } else if (rl) {
-      desired = false;
-      reason = 'rate-limited';
+      reason = `quota exhausted (${quota.windows.join('+')}); auto-reschedule ${quota.resetAt}`;
     } else if (overloaded) {
-      desired = false;
-      reason = 'overloaded(529)';
-    } else if (sw && WARN_STATUSES.has(sw)) {
-      desired = false;
-      reason = `sessionWindow=${sw}`;
-      soft = true;
-    } else if (utilBreach) {
-      desired = false;
-      reason = `util 5h=${u5} 7d=${u7} 7dOpus=${u7o} ≥ off`;
-      soft = !weeklyBreach;
-    } else if ((sw === 'allowed' || sw === null) && utilClear) {
-      desired = true;
-      reason = `healthy (sw=${sw ?? 'none'}${fresh ? `, 5h=${u5}` : ', usage stale/absent'})`;
+      reason = 'overloaded(529), staying schedulable';
     }
-    return { a, cur, desired, reason, soft, sw, u5: u5 ?? '?', rl, overloaded };
+    return { a, cur, desired, reason, soft, sw, u5: u5 ?? '?', u7: u7 ?? '?', rl, overloaded, quota };
   });
 
   let usable = decisions.filter((d) => d.desired && !d.rl && !d.overloaded).length;
@@ -810,7 +794,7 @@ async function main() {
         const u7 = a._liveUsage?.u7;
         const resets7 = a._liveUsage?.resets7;
         if (typeof u7 !== 'number') continue;
-        if (u7 >= OFF_7D && resets7 && !a.weeklyRateLimitEndAt) {
+        if (u7 >= 100 && resets7 && !a.weeklyRateLimitEndAt) {
           const put = await jfetch(`/admin/claude-accounts/${a.id}`, {
             method: 'PUT',
             headers: auth,


### PR DESCRIPTION
## What
Keep paid Claude seats scheduled unless a live Anthropic usage response reports a quota window at 100% with a future reset time. Return held seats at the first exhausted window reset.

## Why
Transient warnings, stale status, overload, and near-limit usage could remove healthy seats from rotation. That left paid capacity idle and caused avoidable 429 responses.

## How
- Treat only live 5-hour or 7-day utilization at 100% as quota exhaustion.
- Require the same response to include a valid future reset time.
- Use the earliest exhausted-window reset when both windows are full.
- Keep warning, overload, stale telemetry, and partial quota states scheduled.

## Contract impact
No public API shape changes. The internal scheduling contract changes from status-based holds to live quota exhaustion with a reset timestamp.

## Test plan
```text
npm run type-check
> node --check bin/*.mjs lib/*.mjs telegram-server/index.js

npm run lint
> prettier --check '**/*.{js,mjs,json}' --ignore-path .gitignore
All matched files use Prettier code style!

npm test
Results: 25 passed, 0 failed
```

## Risk & rollback
The change can increase traffic to seats that return warnings but still have quota. Live 100% usage still removes those seats. Revert commit `9b434ef` to restore the prior gates.

## Evidence
A live fleet reconcile left 14 of 16 seats scheduled. The two held seats both reported 100% quota use and have exact systemd resume timers at their earliest reset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Scheduling logic is materially looser: seats near quota limits, warnings, and overload may stay in rotation until live 100% exhaustion is observed, which can increase 429s on marginal seats but reduces idle paid capacity.
> 
> **Overview**
> **CRS priority scheduling** now keeps paid Claude seats **schedulable** unless a **live** `/oauth/usage` poll shows a quota window at **100%** with a **future** reset time. The new `liveQuotaExhaustion` helper uses 5h and 7d utilization plus `resets_at` from the live response and picks the **earliest** reset when both windows are full.
> 
> **Removed holds** that previously deprioritized seats on stale OAuth expiry, CRS `rateLimitStatus` flags, weekly-cap timestamps inside `decideMaxOut` / `decideConservative`, high utilization vs `OFF_5H`/`OFF_7D`, and `sessionWindow` warning statuses. **529 overload** no longer turns off schedulability in either policy—it only updates the log reason while the seat stays on.
> 
> **Conservative policy** no longer uses the FLOOR path to re-enable seats held for soft util/session signals (those holds are gone). Weekly-cap reconciliation still records `weeklyRateLimitEndAt` when live 7d is **≥ 100%** (was `OFF_7D`) and clears when 7d drops below `ON_7D`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b434ef14788633a63794ea36251295523788eab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->