### PR TITLE
fix(auth): reuse displayed login code

### DIFF
--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -2592,6 +2592,22 @@ async function runAuthFlow(driver, account) {
     } else {
       log(`[magic-link] Navigating to login link`);
       await driver.goto(magicLink);
+      const displayText =
+        (await driver.readPageText?.().catch(() => '')) ||
+        (await driver._page
+          ?.locator('body')
+          .innerText()
+          .catch(() => '')) ||
+        '';
+      const displayedCode = /use verification code to continue/i.test(displayText)
+        ? displayText.match(/\b(\d{6})\b/)?.[1]
+        : null;
+      if (displayedCode && driver._authUrl) {
+        log('[magic-link] Captured displayed verification code — returning to sign-in');
+        await driver.goto(driver._authUrl).catch(() => {});
+        await sleep(2000);
+        return finishMagicLinkLogin(`code:${displayedCode}`);
+      }
     }
     await sleep(4000);
     // After magic link login, session is now valid — re-navigate to authUrl

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -2686,6 +2686,18 @@ async function runAuthFlow(driver, account) {
     }
   }
 
+  async function finishDisplayedClaudeVerificationCode() {
+    if (!driver.readPageText || !driver._authUrl) return false;
+    const text = await driver.readPageText().catch(() => '');
+    if (!/use verification code to continue/i.test(text)) return false;
+    const code = text.match(/\b(\d{6})\b/)?.[1];
+    if (!code) return false;
+    log('[magic-link] Captured displayed verification code — returning to sign-in');
+    await driver.goto(driver._authUrl).catch(() => {});
+    await sleep(2000);
+    return finishMagicLinkLogin(`code:${code}`);
+  }
+
   for (let step = 0; step < 20; step++) {
     await sleep(2500);
     const url = await driver.currentUrl().catch(() => '');
@@ -2721,7 +2733,11 @@ async function runAuthFlow(driver, account) {
         stallCount = 0;
         continue;
       }
-      if (url.includes('/login') && (await isClaudeLoginCodePage())) {
+      if ((url.includes('/login') || url.includes('/magic-link')) && (await isClaudeLoginCodePage())) {
+        if (await finishDisplayedClaudeVerificationCode()) {
+          stallCount = 0;
+          continue;
+        }
         log(`[magic-link] Claude login is waiting for an email verification code; polling Gmail once before aborting`);
         const magicLink = await pollGmailForMagicLink(account.email, 30_000);
         if (await finishMagicLinkLogin(magicLink)) {


### PR DESCRIPTION
## What
Handle Claude's email-link page that displays a six-digit verification code. Return to the original OAuth sign-in page and submit that code through the existing code path.

## Why
The reauth worker treated the display page as an input page. It then polled and archived new login emails on every loop without submitting a code, leaving expired seats unrepaired.

## How
- Detect Claude's "Use verification code to continue" page.
- Read the displayed six-digit code without logging it.
- Return to the captured OAuth URL.
- Reuse the existing verification-code submission path.

## Contract impact
No public API or data-shape change. This changes only the browser OAuth recovery flow.

## Test plan
```text
npm run type-check
> node --check bin/*.mjs lib/*.mjs telegram-server/index.js

npm run lint
All matched files use Prettier code style!

npm test
Results: 25 passed, 0 failed
```

## Risk & rollback
The detector is limited to Claude's exact display-page heading plus a six-digit code. Other magic-link pages keep their existing behavior. Revert the two commits in this PR to restore the prior path.

## Evidence
The failed flow showed the code-display page with no input fields, while the worker repeatedly fetched and archived new codes. The runtime now extracts that displayed code and routes it back to sign-in.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Claude’s specific display-page text plus six-digit extraction; Gmail polling and other magic-link paths stay as fallbacks. Low risk to rotation infrastructure.
> 
> **Overview**
> Fixes **magic-link reauth** when Claude shows a **code-display page** (heading “Use verification code to continue” and a six-digit code) instead of an input form. The worker used to treat that as “waiting for email,” **poll Gmail in a loop**, and never submit a code.
> 
> **Changes in `rotate.mjs` (`runAuthFlow`):**
> - After `goto(magicLink)`, if the page matches that display pattern, read the **six-digit code from page text** (not logged), navigate back to the stored **`driver._authUrl`**, and complete login via the existing **`finishMagicLinkLogin(`code:…`)`** path.
> - Adds **`finishDisplayedClaudeVerificationCode()`** with the same detect → return to OAuth URL → submit code flow.
> - On `/login` or **`/magic-link`** code pages, tries the displayed-code path **before** the one-shot Gmail poll and abort.
> 
> No API or vault contract changes—only browser OAuth recovery behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0ea12e2fe30094185645162ebb48eb78d4d0ee5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->