### PR TITLE
fix(ops-post-update-migrate): remove dangling symlink before refreshing current/

### DIFF
--- a/claude-ops/bin/ops-post-update-migrate
+++ b/claude-ops/bin/ops-post-update-migrate
@@ -43,6 +43,18 @@ refresh_current_directory() {
   cache_parent="$(dirname "$PLUGIN_ROOT")"
   current_dir="$cache_parent/current"
   installed_json="$PLUGINS_DIR/installed_plugins.json"
+
+  # current/ must be a real rsynced directory, not a symlink. A legacy or
+  # dangling symlink (e.g. left pointing at a version pruned by ops-update
+  # step 5 before this migration runs) makes rsync's directory-destination
+  # write fail silently, leaving current/ broken for every consumer that
+  # resolves the plugin through it. Clear it so rsync always (re)creates a
+  # real directory below.
+  if [[ -L "$current_dir" ]]; then
+    rm -f "$current_dir"
+    log "  info: removed symlink at $current_dir (current/ must be a real directory)"
+  fi
+
   root_real="$(cd "$PLUGIN_ROOT" 2>/dev/null && pwd -P || echo "$PLUGIN_ROOT")"
   current_real="$(cd "$current_dir" 2>/dev/null && pwd -P || echo "$current_dir")"
 


### PR DESCRIPTION
## Summary
- `current/` under the plugin cache must be a real rsynced directory, never a symlink, so a mid-session GC of an old versioned cache dir never breaks plugin resolution.
- `ops-update` step 5 (prune old cache versions) runs before step 7 (post-update migrations, which refreshes `current/`). If `current/` was a legacy or dangling symlink pointing at the version step 5 just deleted, `rsync -a --delete` against that dangling symlink destination fails silently, and `current/` never gets repaired.
- Fix: strip any symlink at `current_dir` before the rsync/cp refresh logic runs in `refresh_current_directory()`, so `current/` always ends up as a real directory afterward.

Found and verified on the box while completing the "keep this plugin current across all CLIs" standing task — `ops/current` had gone dangling after a real `ops-update` run pruned the version it pointed at. Verified the fix in an isolated sandbox: simulated a dangling `current -> <deleted-version>` symlink, ran the migrated script against it, confirmed `current/` comes back as a real directory containing the new version's `plugin.json`.

## Test plan
- [x] `bash -n bin/ops-post-update-migrate` — syntax OK
- [x] Isolated sandbox repro: dangling symlink at `current/` → run script → `current/` becomes a real directory with correct `plugin.json` contents
- [x] Manually verified the box's real `ops/current` (previously repaired by hand for this same bug) still resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, idempotent guard in post-update migration with no auth or data-model changes; only affects cache layout repair during updates.
> 
> **Overview**
> **`refresh_current_directory()`** now deletes any symlink at the plugin cache’s `current/` path before the existing rsync or `cp` refresh runs.
> 
> That matters because `current/` must be a real directory: if `ops-update` prunes an old versioned cache dir while `current/` still symlinks to it, `rsync -a --delete` to `current/` can fail quietly and leave plugin resolution broken for anything using `installPath` / `CLAUDE_PLUGIN_ROOT` through `current/`. After removal, the refresh path can recreate `current/` as a normal directory again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f95f67c6d16b9b7d2175ed10f7e3e65fb4a7123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->