### PR TITLE
fix(auth): release reauth lock after runs

### DIFF
--- a/claude-ops/scripts/account-rotation/magic-link-autoloop.sh
+++ b/claude-ops/scripts/account-rotation/magic-link-autoloop.sh
@@ -54,4 +54,4 @@ if [[ -f "$LOG" ]]; then
   fi
 fi
 
-exec "$NODE" "$SCRIPT_DIR/magic-link-autoloop.mjs" "$@" >>"$LOG" 2>&1
+"$NODE" "$SCRIPT_DIR/magic-link-autoloop.mjs" "$@" >>"$LOG" 2>&1

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -2599,9 +2599,8 @@ async function runAuthFlow(driver, account) {
           .innerText()
           .catch(() => '')) ||
         '';
-      const displayedCode = /use verification code to continue/i.test(displayText)
-        ? displayText.match(/\b(\d{6})\b/)?.[1]
-        : null;
+      const displayUrl = await driver.currentUrl().catch(() => '');
+      const displayedCode = displayUrl.includes('/magic-link') ? displayText.match(/\b(\d{6})\b/)?.[1] : null;
       if (displayedCode && driver._authUrl) {
         log('[magic-link] Captured displayed verification code — returning to sign-in');
         await driver.goto(driver._authUrl).catch(() => {});
@@ -2705,7 +2704,8 @@ async function runAuthFlow(driver, account) {
   async function finishDisplayedClaudeVerificationCode() {
     if (!driver.readPageText || !driver._authUrl) return false;
     const text = await driver.readPageText().catch(() => '');
-    if (!/use verification code to continue/i.test(text)) return false;
+    const url = await driver.currentUrl().catch(() => '');
+    if (!url.includes('/magic-link')) return false;
     const code = text.match(/\b(\d{6})\b/)?.[1];
     if (!code) return false;
     log('[magic-link] Captured displayed verification code — returning to sign-in');


### PR DESCRIPTION
## What
Release the serial reauth lock after every run and detect Claude's displayed verification code without depending on the page language.

## Why
The wrapper used `exec`, which replaced the shell that owned its EXIT cleanup trap. Each run left the lock directory behind and blocked the ten-minute scheduler for an hour. Claude may also localize the code-display heading, so an English-only detector missed valid codes.

## How
- Keep the wrapper shell alive while Node runs so the EXIT trap removes the lock and records the throttle timestamp.
- Detect a six-digit code on the `/magic-link` page instead of matching English copy.
- Keep the existing serial account limit and two-minute completed-run throttle.

## Contract impact
No public API or data-shape change. This changes only OAuth recovery scheduling and browser-page detection.

## Test plan
```text
bash -n scripts/account-rotation/magic-link-autoloop.sh
npm run type-check
npm run lint
All matched files use Prettier code style!
npm test
Results: 25 passed, 0 failed
```

## Risk & rollback
The URL gate limits displayed-code extraction to Claude's magic-link page. The existing one-account serial limit remains. Revert this commit to restore the prior lock and English-only behavior.

## Evidence
The stale `.once.crs-magic-link-autoloop.lock` survived completed and terminated runs. After removing `exec`, a stopped systemd run removed the lock through the existing trap. A live localized display page showed a six-digit code on `/magic-link` with no input fields.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow changes to wrapper process lifetime and magic-link page heuristics; no auth token or API contract changes.
> 
> **Overview**
> Fixes **serial reauth scheduling** by running `magic-link-autoloop.mjs` without `exec` in `magic-link-autoloop.sh`, so the wrapper shell survives until Node exits and its **EXIT trap** can remove the single-flight lock and record the completed-run throttle. Previously `exec` replaced the shell and left stale lock dirs that blocked the ~10-minute scheduler for up to an hour.
> 
> In `rotate.mjs`, **displayed six-digit verification codes** on Claude’s magic-link page are detected when the current URL is on `/magic-link` and body text matches `\b(\d{6})\b`, instead of requiring the English heading *“use verification code to continue”*. Localized UIs can still surface a code on that route without tripping the old English-only gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc7c8d27ba3dc028ab5c003ce54a6238a8773ca6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->