### PR TITLE
feat(ops-update): auto-sync Grok and Cursor plugin caches

### DIFF
--- a/claude-ops/bin/ops-update
+++ b/claude-ops/bin/ops-update
@@ -19,7 +19,9 @@
 #   8. Fast-forward a linked local source checkout's main → origin/main (if clean)
 #   9. Companion plugins (plugin-dependencies.json): all required companions;
 #      gsd / superpowers / feature-dev if installed. gstack is not managed.
-#  10. Report old→new + what changed, and how to apply (/reload-plugins or restart)
+#  10. Sync companion CLIs (Grok, Cursor) to the same version, no stale caches
+#      left behind. Codex needs no step — see scripts/sync-companion-clis.sh.
+#  11. Report old→new + what changed, and how to apply (/reload-plugins or restart)
 #
 # Canonical CLI per Claude Code docs:
 #   https://code.claude.com/docs/en/discover-plugins  (marketplace update / plugin update)
@@ -27,7 +29,7 @@
 #
 # Usage:
 #   ops-update [--dry-run] [--force] [--to X.Y.Z] [--no-prune] [--no-patches]
-#              [--no-rewrite] [--no-localsync] [--no-companions]
+#              [--no-rewrite] [--no-localsync] [--no-companions] [--no-clisync]
 #
 #   --dry-run       show everything that would happen; change nothing
 #   --force         force-reinstall even if the CLI says "already at latest" (bug #61954)
@@ -37,6 +39,7 @@
 #   --no-rewrite    skip the stale-version-path rewrite step
 #   --no-localsync  skip fast-forwarding a linked local source checkout's main
 #   --no-companions skip companion install/update
+#   --no-clisync    skip syncing the ops plugin to other CLIs (Grok, Cursor)
 #
 # Public repo: no personal data. All paths derive from $HOME / env. (Rule 0)
 
@@ -52,7 +55,7 @@ INSTALLED="$PLUGINS_DIR/installed_plugins.json"
 DATA_DIR="${CLAUDE_PLUGIN_DATA_DIR:-$PLUGINS_DIR/data/ops-${MARKETPLACE}}"
 THIS_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
-DRY=0; FORCE=0; PRUNE=1; PATCHES=1; REWRITE=1; LOCALSYNC=1; COMPANIONS=1; TARGET=""
+DRY=0; FORCE=0; PRUNE=1; PATCHES=1; REWRITE=1; LOCALSYNC=1; COMPANIONS=1; CLISYNC=1; TARGET=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run) DRY=1; shift ;;
@@ -63,7 +66,8 @@ while [[ $# -gt 0 ]]; do
     --no-rewrite) REWRITE=0; shift ;;
     --no-localsync) LOCALSYNC=0; shift ;;
     --no-companions) COMPANIONS=0; shift ;;
-    -h|--help) sed -n '2,40p' "$0"; exit 0 ;;
+    --no-clisync) CLISYNC=0; shift ;;
+    -h|--help) sed -n '2,42p' "$0"; exit 0 ;;
     *) echo "ops-update: unknown arg '$1'" >&2; exit 2 ;;
   esac
 done
@@ -96,7 +100,7 @@ say "current installed: ${CUR:-<none>}"
 # step 2's target-version resolution needs it to be current to report
 # accurately. The actually destructive/mutating steps (3, 5, 6, 7, 8, 9)
 # stay gated behind $DRY below.
-step "1/10  Refresh marketplace catalogue ($MARKETPLACE)"
+step "1/11  Refresh marketplace catalogue ($MARKETPLACE)"
 if [[ "$DRY" -eq 1 ]]; then
   say "  ${c_dim}[dry-run] (refresh runs for real — read-only catalogue pull, no plugin state changes)${c_rst}"
 fi
@@ -108,7 +112,7 @@ else
 fi
 
 # ── 2. Resolve target version ──────────────────────────────────────────────
-step "2/10  Resolve target version"
+step "2/11  Resolve target version"
 if [[ -n "$TARGET" ]]; then
   NEW="$TARGET"
 else
@@ -121,7 +125,7 @@ if [[ "$CUR" == "$NEW" && "$FORCE" -eq 0 ]]; then
 fi
 
 # ── 3. Update the installed plugin ─────────────────────────────────────────
-step "3/10  Update installed plugin → $NEW"
+step "3/11  Update installed plugin → $NEW"
 if [[ "$DRY" -eq 1 ]]; then
   say "  ${c_dim}[dry-run] claude plugin update $PLUGIN@$MARKETPLACE${c_rst}"
   [[ "$FORCE" -eq 1 ]] && say "  ${c_dim}[dry-run] (force) rm -rf $CACHE_ROOT/$NEW && claude plugin install $PLUGIN@$MARKETPLACE${c_rst}"
@@ -137,7 +141,7 @@ fi
 NEW_CACHE="$CACHE_ROOT/$NEW"
 
 # ── 4. Reapply idempotent local cache patches ──────────────────────────────
-step "4/10  Reapply cache patches"
+step "4/11  Reapply cache patches"
 PATCH_DIR="$THIS_ROOT/scripts/cache-patches"
 if [[ "$PATCHES" -eq 0 ]]; then
   say "  ${c_dim}(skipped: --no-patches)${c_rst}"
@@ -152,7 +156,7 @@ else
 fi
 
 # ── 5. Prune old cache versions everywhere ─────────────────────────────────
-step "5/10  Prune old cache versions"
+step "5/11  Prune old cache versions"
 if [[ "$PRUNE" -eq 0 ]]; then
   say "  ${c_dim}(skipped: --no-prune)${c_rst}"
 else
@@ -171,7 +175,7 @@ fi
 # ── 6. Rewrite stale version-pinned paths in LIVE configs/scripts ──────────
 # Only touch live, editable configs that hardcode cache/<mp>/<plugin>/<OLDVER>/.
 # NEVER rewrite logs, memory notes, session transcripts, the cache, or the clone.
-step "6/10  Rewrite stale version-pinned paths → $NEW"
+step "6/11  Rewrite stale version-pinned paths → $NEW"
 if [[ "$REWRITE" -eq 0 ]]; then
   say "  ${c_dim}(skipped: --no-rewrite)${c_rst}"
 else
@@ -214,7 +218,7 @@ else
 fi
 
 # ── 7. Per-version idempotent migrations ───────────────────────────────────
-step "7/10  Post-update migrations"
+step "7/11  Post-update migrations"
 MIGRATE="$NEW_CACHE/bin/ops-post-update-migrate"
 if [[ "$DRY" -eq 1 ]]; then
   say "  ${c_dim}[dry-run] CLAUDE_PLUGIN_ROOT=$NEW_CACHE $MIGRATE${c_rst}"
@@ -229,7 +233,7 @@ fi
 # up to date with origin/main — but ONLY when it is safely on a clean main, so we
 # never clobber uncommitted WIP or a feature branch. Purely a developer
 # convenience; absence of a checkout is the common case and is a no-op.
-step "8/10  Sync linked local source checkout"
+step "8/11  Sync linked local source checkout"
 if [[ "$LOCALSYNC" -eq 0 ]]; then
   say "  ${c_dim}(skipped: --no-localsync)${c_rst}"
 else
@@ -268,7 +272,7 @@ fi
 # ── 9. Companion plugins (required co-install from plugin-dependencies.json) ─
 # SSOT: plugin-dependencies.json — required companions always install+update
 # (desktop-act, gsd, gstack skills-clone, superpowers, feature-dev).
-step "9/10  Companion plugins"
+step "9/11  Companion plugins"
 if [[ "$COMPANIONS" -eq 0 ]]; then
   say "  ${c_dim}(skipped: --no-companions)${c_rst}"
 else
@@ -290,8 +294,25 @@ else
   fi
 fi
 
-# ── 10. Report ─────────────────────────────────────────────────────────────
-step "10/10  Summary"
+# ── 10. Sync companion CLIs (Grok, Cursor) ─────────────────────────────────
+# Codex needs nothing here — see scripts/sync-companion-clis.sh header.
+step "10/11 Sync companion CLIs"
+CLISYNC_SCRIPT="$NEW_CACHE/scripts/sync-companion-clis.sh"
+[[ -f "$CLISYNC_SCRIPT" ]] || CLISYNC_SCRIPT="$THIS_ROOT/scripts/sync-companion-clis.sh"
+if [[ "$CLISYNC" -eq 0 ]]; then
+  say "  ${c_dim}(skipped: --no-clisync)${c_rst}"
+elif [[ -f "$CLISYNC_SCRIPT" ]]; then
+  if [[ "$DRY" -eq 1 ]]; then
+    bash "$CLISYNC_SCRIPT" --dry-run
+  else
+    bash "$CLISYNC_SCRIPT" || warn "sync-companion-clis.sh non-zero (non-fatal)"
+  fi
+else
+  say "  ${c_dim}no sync-companion-clis.sh in new cache (skipped)${c_rst}"
+fi
+
+# ── 11. Report ─────────────────────────────────────────────────────────────
+step "11/11  Summary"
 say "  plugin:   $PLUGIN@$MARKETPLACE"
 say "  version:  ${CUR:-<none>} → ${c_grn}$NEW${c_rst}"
 say "  cache:    $(ls -1 "$CACHE_ROOT" 2>/dev/null | grep -E '^[0-9]+\.' | tr '\n' ' ')"

--- a/claude-ops/scripts/sync-companion-clis.sh
+++ b/claude-ops/scripts/sync-companion-clis.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# sync-companion-clis.sh — propagate an ops plugin update to other CLIs on this
+# box that support it, so a single `ops-update` run keeps every CLI current
+# with no stale old-version copies left behind.
+#
+# Called as the last step of bin/ops-update, after the Claude Code plugin
+# itself is updated. Safe to also run standalone.
+#
+# Coverage:
+#   - Grok:   has a native `grok plugin update <name>` that updates the
+#             installed plugin directory in place. We just call it.
+#   - Cursor: has NO native command to refresh a plugin's materialized content
+#             cache (only `cursor-agent plugin marketplace add/remove/update`,
+#             which only re-indexes the catalogue clone, confirmed via
+#             `cursor-agent plugin --help`). So we re-index the catalogue,
+#             then rsync the resolved commit's plugin dir from the catalogue
+#             clone into Cursor's content cache ourselves, and prune any other
+#             commit-hash directories left over from prior versions.
+#   - Codex:  needs nothing here. Its ops-* skills are symlinks straight into
+#             Claude Code's own cache/.../ops/current/ directory, which
+#             ops-post-update-migrate already keeps current.
+#
+# Every step below is best-effort and non-fatal: a CLI that isn't installed,
+# or whose update fails, is logged and skipped — this must never block or
+# fail the Claude Code upgrade it's called from.
+#
+# Usage: sync-companion-clis.sh [--dry-run]
+
+set -uo pipefail
+
+DRY=0
+[[ "${1:-}" == "--dry-run" ]] && DRY=1
+
+c_grn=$'\033[1;32m'
+c_ylw=$'\033[1;33m'
+c_dim=$'\033[2m'
+c_rst=$'\033[0m'
+[[ -t 1 ]] || {
+	c_grn=""
+	c_ylw=""
+	c_dim=""
+	c_rst=""
+}
+ok() { printf '  %s✓%s %s\n' "$c_grn" "$c_rst" "$*"; }
+warn() { printf '  %s!%s %s\n' "$c_ylw" "$c_rst" "$*"; }
+say() { printf '  %s\n' "$*"; }
+
+MARKETPLACE_GIT_URL="https://github.com/Lifecycle-Innovations-Limited/claude-ops"
+
+# ── Grok ─────────────────────────────────────────────────────────────────
+sync_grok() {
+	command -v grok >/dev/null 2>&1 || {
+		say "${c_dim}grok CLI not found (skipped)${c_rst}"
+		return 0
+	}
+	compgen -G "$HOME/.grok/installed-plugins/claude-ops-*" >/dev/null 2>&1 ||
+		{
+			say "${c_dim}grok: ops plugin not installed (skipped)${c_rst}"
+			return 0
+		}
+
+	if [[ "$DRY" -eq 1 ]]; then
+		say "${c_dim}[dry-run] grok plugin update ops${c_rst}"
+		return 0
+	fi
+
+	local out
+	if out="$(grok plugin update ops 2>&1)"; then
+		ok "grok: $out"
+	else
+		warn "grok: plugin update failed (non-fatal): $out"
+	fi
+}
+
+# ── Cursor ───────────────────────────────────────────────────────────────
+sync_cursor() {
+	command -v cursor-agent >/dev/null 2>&1 || {
+		say "${c_dim}cursor-agent CLI not found (skipped)${c_rst}"
+		return 0
+	}
+
+	local mp_clone_root="$HOME/.cursor/plugins/marketplaces/github.com/lifecycle-innovations-limited/claude-ops"
+	local cache_root="$HOME/.cursor/plugins/cache/ops-marketplace/ops"
+	[[ -d "$HOME/.cursor/plugins" ]] || {
+		say "${c_dim}cursor: no ~/.cursor/plugins (skipped)${c_rst}"
+		return 0
+	}
+
+	if [[ "$DRY" -eq 1 ]]; then
+		say "${c_dim}[dry-run] cursor-agent plugin marketplace update ops-marketplace${c_rst}"
+		say "${c_dim}[dry-run] rsync resolved commit dir -> $cache_root/<hash>, prune old hashes${c_rst}"
+		return 0
+	fi
+
+	local out
+	if out="$(cursor-agent plugin marketplace update ops-marketplace 2>&1)"; then
+		ok "cursor: catalogue re-indexed ($out)"
+	else
+		warn "cursor: catalogue update failed, retrying via remove+add: $out"
+		cursor-agent plugin marketplace remove ops-marketplace >/dev/null 2>&1 || true
+		if ! out="$(cursor-agent plugin marketplace add "$MARKETPLACE_GIT_URL" 2>&1)"; then
+			warn "cursor: remove+add also failed (non-fatal): $out"
+			return 0
+		fi
+		ok "cursor: catalogue re-added ($out)"
+	fi
+
+	[[ -d "$mp_clone_root" ]] || {
+		warn "cursor: no catalogue clone at $mp_clone_root (non-fatal)"
+		return 0
+	}
+	local clone_dir hash src dst
+	clone_dir="$(find "$mp_clone_root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort | tail -1)"
+	[[ -n "$clone_dir" ]] || {
+		warn "cursor: no commit dir found under $mp_clone_root (non-fatal)"
+		return 0
+	}
+	hash="$(basename "$clone_dir")"
+	src="$clone_dir/claude-ops"
+	[[ -d "$src" ]] || {
+		warn "cursor: expected plugin source $src missing (non-fatal)"
+		return 0
+	}
+
+	mkdir -p "$cache_root"
+	dst="$cache_root/$hash"
+	mkdir -p "$dst"
+	if rsync -a --delete --exclude=".git" "$src/" "$dst/" 2>/dev/null; then
+		ok "cursor: content cache synced -> $hash"
+	else
+		warn "cursor: rsync to $dst failed (non-fatal)"
+		return 0
+	fi
+
+	local pruned=0
+	for d in "$cache_root"/*/; do
+		[[ -d "$d" ]] || continue
+		local v
+		v="$(basename "$d")"
+		[[ "$v" == "$hash" ]] && continue
+		rm -rf "$d"
+		ok "cursor: pruned old cache $v"
+		pruned=$((pruned + 1))
+	done
+	[[ "$pruned" -eq 0 ]] && say "${c_dim}cursor: no old cache versions to prune${c_rst}"
+}
+
+# ── Codex ────────────────────────────────────────────────────────────────
+# No-op by design: ~/.codex/skills/ops* are symlinks into Claude Code's own
+# cache/.../ops/current/, already kept fresh by ops-post-update-migrate.
+report_codex() {
+	local link="$HOME/.codex/skills/ops"
+	if [[ -L "$link" ]]; then
+		say "${c_dim}codex: ops symlinked into Claude Code's current/ (no action needed)${c_rst}"
+	else
+		say "${c_dim}codex: no ops skill symlink found (nothing to do)${c_rst}"
+	fi
+}
+
+sync_grok
+sync_cursor
+report_codex


### PR DESCRIPTION
## Summary
- ops-update only refreshed the Claude Code plugin cache; Grok and Cursor stayed on stale versions until someone manually ran `grok plugin update` / rsynced Cursor's content cache by hand.
- Adds `scripts/sync-companion-clis.sh` as a new, non-fatal pipeline step (10/11): calls `grok plugin update ops` (native command), and for Cursor — which has no content-cache refresh command, only marketplace catalogue re-indexing (confirmed via `cursor-agent plugin --help`) — re-indexes the catalogue then rsyncs the resolved commit dir into Cursor's cache and prunes stale commit-hash dirs.
- Codex needs no action: its `~/.codex/skills/ops*` symlinks point straight into Claude Code's own `current/` dir, already kept fresh by `ops-post-update-migrate`.
- New `--no-clisync` flag to skip the step; behaves like the other companion steps (best-effort, never blocks the core upgrade).

## Test plan
- [x] `bash -n bin/ops-update` — syntax OK
- [x] `shellcheck -x bin/ops-update` and `scripts/sync-companion-clis.sh` — no new warnings introduced
- [x] `bin/ops-update --dry-run` locally — new step prints correctly as `10/11 Sync companion CLIs`, existing steps unaffected
- [ ] Live run on a box with Grok + Cursor installed (will verify post-merge via `ops-release` + `ops-update`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local dev-tool cache sync only; failures are logged and do not block the core Claude upgrade, with no auth or production runtime impact.
> 
> **Overview**
> Extends **`ops-update`** so one upgrade run also refreshes the ops plugin on **Grok** and **Cursor**, not only Claude Code’s cache.
> 
> A new step **10/11** runs **`scripts/sync-companion-clis.sh`** (best-effort, non-fatal): **Grok** via `grok plugin update ops`; **Cursor** by re-indexing the marketplace catalogue, **rsync**ing the resolved commit’s plugin tree into Cursor’s content cache, and pruning older commit-hash dirs (no native content-cache refresh). **Codex** is only reported—skills already symlink Claude’s `current/` via migrate.
> 
> **`--no-clisync`** skips the step; pipeline numbering moves summary to **11/11**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7488c40da9189f3838d9eb3a97fe38ad8e38e101. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->