### PR TITLE
fix(ops-update): cursor-agent marketplace update is a no-op

### DIFF
--- a/claude-ops/scripts/sync-companion-clis.sh
+++ b/claude-ops/scripts/sync-companion-clis.sh
@@ -10,12 +10,15 @@
 #   - Grok:   has a native `grok plugin update <name>` that updates the
 #             installed plugin directory in place. We just call it.
 #   - Cursor: has NO native command to refresh a plugin's materialized content
-#             cache (only `cursor-agent plugin marketplace add/remove/update`,
-#             which only re-indexes the catalogue clone, confirmed via
-#             `cursor-agent plugin --help`). So we re-index the catalogue,
-#             then rsync the resolved commit's plugin dir from the catalogue
-#             clone into Cursor's content cache ourselves, and prune any other
-#             commit-hash directories left over from prior versions.
+#             cache (only `cursor-agent plugin marketplace add/remove/update`).
+#             `marketplace update` reports success but does NOT actually
+#             re-fetch the underlying git clone — confirmed by testing: after
+#             a new commit landed on origin/main, `update` left the clone
+#             pinned to the old commit hash, while `remove` + `add` fetched
+#             the new one immediately. So we always remove+add (never rely on
+#             `update`), then rsync the resolved commit's plugin dir from the
+#             catalogue clone into Cursor's content cache ourselves, and prune
+#             any other commit-hash directories left over from prior versions.
 #   - Codex:  needs nothing here. Its ops-* skills are symlinks straight into
 #             Claude Code's own cache/.../ops/current/ directory, which
 #             ops-post-update-migrate already keeps current.
@@ -87,23 +90,20 @@ sync_cursor() {
 	}
 
 	if [[ "$DRY" -eq 1 ]]; then
-		say "${c_dim}[dry-run] cursor-agent plugin marketplace update ops-marketplace${c_rst}"
+		say "${c_dim}[dry-run] cursor-agent plugin marketplace remove/add ops-marketplace (update is a no-op, proven stale)${c_rst}"
 		say "${c_dim}[dry-run] rsync resolved commit dir -> $cache_root/<hash>, prune old hashes${c_rst}"
 		return 0
 	fi
 
+	# `marketplace update` is a proven no-op against the underlying clone —
+	# always force a fresh fetch via remove+add instead.
+	cursor-agent plugin marketplace remove ops-marketplace >/dev/null 2>&1 || true
 	local out
-	if out="$(cursor-agent plugin marketplace update ops-marketplace 2>&1)"; then
-		ok "cursor: catalogue re-indexed ($out)"
-	else
-		warn "cursor: catalogue update failed, retrying via remove+add: $out"
-		cursor-agent plugin marketplace remove ops-marketplace >/dev/null 2>&1 || true
-		if ! out="$(cursor-agent plugin marketplace add "$MARKETPLACE_GIT_URL" 2>&1)"; then
-			warn "cursor: remove+add also failed (non-fatal): $out"
-			return 0
-		fi
-		ok "cursor: catalogue re-added ($out)"
+	if ! out="$(cursor-agent plugin marketplace add "$MARKETPLACE_GIT_URL" 2>&1)"; then
+		warn "cursor: marketplace re-add failed (non-fatal): $out"
+		return 0
 	fi
+	ok "cursor: catalogue re-added ($out)"
 
 	[[ -d "$mp_clone_root" ]] || {
 		warn "cursor: no catalogue clone at $mp_clone_root (non-fatal)"


### PR DESCRIPTION
## Summary
- Live-tested the just-merged companion-CLI sync step against a real new release (v2.47.3): `cursor-agent plugin marketplace update ops-marketplace` reports success but leaves the catalogue clone pinned to the previous commit — it does not re-fetch.
- `remove` then `add` does force a fresh fetch (verified: clone resolved to the new origin/main commit immediately, `.claude-plugin/plugin.json` inside Cursor's synced cache read the correct new version).
- Removes the `update`-then-fallback path; always does remove+add for Cursor now.

## Test plan
- [x] `bash -n` + `shellcheck -x` clean
- [x] Ran the script live end-to-end: Cursor cache now resolves to the actual latest commit and old stale cache dir was pruned; verified synced `plugin.json` version matches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single maintenance script change with best-effort, non-fatal behavior; no auth, data, or Claude Code upgrade path changes beyond fixing stale Cursor catalogue sync.
> 
> **Overview**
> **Cursor companion sync** no longer calls `cursor-agent plugin marketplace update` before rsyncing the ops plugin into Cursor’s content cache. Live testing showed that command succeeds but leaves the catalogue git clone on the old commit; **remove then add** on `ops-marketplace` is what actually fetches the latest `origin/main`.
> 
> The script now always does marketplace remove + add (with remove errors ignored), then continues with the existing rsync and old commit-hash cache pruning. Dry-run messaging and header comments were updated to document that `update` must not be relied on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74bdadea51acf89d6552443c94f0497e5be5d047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->