### PR TITLE
fix(manifest): drop dependencies key that breaks plugin validation

### DIFF
--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -816,45 +816,5 @@
       "min": 0,
       "max": 20
     }
-  },
-  "dependencies": {
-    "plugins": [
-      {
-        "name": "desktop-act",
-        "marketplace": "ops-marketplace",
-        "coInstall": true,
-        "required": true,
-        "reason": "MCP companion for /ops:desktop and unattended captcha cascade"
-      },
-      {
-        "name": "gsd",
-        "marketplace": "gsd-build-get-shit-done",
-        "coInstall": true,
-        "required": true,
-        "reason": "Project roadmap for /ops:flow project mode, /ops:projects, /ops:go"
-      },
-      {
-        "name": "superpowers",
-        "marketplace": "superpowers-marketplace",
-        "coInstall": true,
-        "required": true,
-        "reason": "Guardrails for merge/orchestrate/triage checkpoints"
-      },
-      {
-        "name": "feature-dev",
-        "marketplace": "claude-plugins-official",
-        "coInstall": true,
-        "required": true,
-        "reason": "Structured feature pipeline for /ops:ops-feature-dev"
-      }
-    ],
-    "skillsClones": [
-      {
-        "name": "gstack",
-        "installScript": "scripts/install-gstack-companion.sh",
-        "required": true,
-        "reason": "Ad-hoc /ops:flow lifecycle skills (not a marketplace plugin)"
-      }
-    ]
   }
 }


### PR DESCRIPTION
`/plugin` listed ops under Errors:

```
✘ ops (user)
  Plugin ops has an invalid manifest file at .../ops/2.47.4/.claude-plugin/plugin.json
  Validation errors: dependencies: Invalid input: expected array, received object
```

Claude Code treats `dependencies` in plugin.json as an array of plugins to auto-install. We were storing our own object there (`{plugins: [...], skillsClones: [...]}`), so the whole manifest failed validation.

Nothing read that key. `plugin-dependencies.json` is the SSOT for companions — it's what `scripts/install-companions.sh` and `bin/ops-update` step 9 actually load, and it already declares all five (desktop-act, gsd, gstack, superpowers, feature-dev). The key was duplicated data parked in a reserved field.

Removing it fixes the manifest and changes no companion install behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Manifest-only cleanup with no runtime behavior change; companion install paths were already driven by `plugin-dependencies.json`.
> 
> **Overview**
> Removes the custom **`dependencies`** block from **`plugin.json`** so the ops plugin passes Claude Code manifest validation (`/plugin` was failing with `dependencies: expected array, received object`).
> 
> Claude Code reserves **`dependencies`** for an array of plugins to auto-install; the removed object duplicated companion metadata (`plugins` + `skillsClones`) that nothing consumed from the manifest.
> 
> **Companion co-install is unchanged:** **`plugin-dependencies.json`** remains the source of truth for **`install-companions.sh`** and **`bin/ops-update`** step 9 (desktop-act, gsd, gstack, superpowers, feature-dev).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49faa9bc0a54f6901ba08c4df7cff6c0e7d472aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed marketplace plugin and skill dependency declarations from the plugin configuration.
  * Preserved existing user configuration settings and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->