### PR TITLE
fix(post-update-migrate): keep cache-GC markers out of current/

### DIFF
--- a/claude-ops/bin/ops-post-update-migrate
+++ b/claude-ops/bin/ops-post-update-migrate
@@ -61,7 +61,9 @@ refresh_current_directory() {
   if [[ "$root_real" == "$current_real" ]]; then
     log "  skip: PLUGIN_ROOT already == current/ ($current_real) — no self-rsync"
   elif command -v rsync >/dev/null 2>&1; then
-    if rsync -a --delete "$PLUGIN_ROOT/" "$current_dir/" 2>/dev/null; then
+    if rsync -a --delete \
+      --exclude '.orphaned_at' --exclude '.in_use' \
+      "$PLUGIN_ROOT/" "$current_dir/" 2>/dev/null; then
       log "  ok: refreshed $current_dir via rsync"
     else
       log "  warn: rsync to current/ failed (non-fatal)"
@@ -75,9 +77,23 @@ refresh_current_directory() {
     fi
   fi
 
+  # Never let the cache-GC bookkeeping of a version dir ride into current/.
+  # Claude Code marks a version dir it no longer recognises with .orphaned_at
+  # and deletes it once that marker ages past the grace period, skipping only
+  # dirs still listed as an installPath. If a stale (already-aged) marker is
+  # copied into current/ and installPath later moves off current/ — a plugin
+  # reinstall, or the marketplace remove+add that ops-update performs — the
+  # grace period is already spent, so current/ is deleted on the next sweep
+  # while live sessions still resolve CLAUDE_PLUGIN_ROOT through it. The
+  # copied .in_use PIDs belong to the version dir and are dead, so they do
+  # not hold it open either. cp -rp has no exclude, so clear both here.
+  rm -f "$current_dir/.orphaned_at" 2>/dev/null || true
+  rm -rf "$current_dir/.in_use" 2>/dev/null || true
+
   if [[ -f "$installed_json" ]]; then
     if python3 - "$installed_json" "$current_dir" <<'PYEOF' 2>/dev/null
-import json, sys
+import json, os, stat, sys, tempfile
+
 path, current = sys.argv[1], sys.argv[2]
 with open(path) as f:
     d = json.load(f)
@@ -87,8 +103,28 @@ for e in d.get("plugins", {}).get("ops@ops-marketplace", []):
         e["installPath"] = current
         changed = True
 if changed:
-    with open(path, "w") as f:
-        json.dump(d, f, indent=2)
+    # Write via temp + atomic rename. Every installed plugin resolves through
+    # this file, so a truncated write breaks all of them, not just ops. An
+    # in-place open(path, "w") is a visible truncation window for any Claude
+    # process reading concurrently, and leaves the file corrupt if we die
+    # mid-dump. Preserve the original mode — it holds install metadata and
+    # ships 0600, which a default-umask temp file would widen.
+    mode = stat.S_IMODE(os.stat(path).st_mode)
+    d_dir = os.path.dirname(path) or "."
+    fd, tmp = tempfile.mkstemp(dir=d_dir, prefix=".installed_plugins.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(d, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp, mode)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 PYEOF
     then
       log "  ok: patched installed_plugins.json → current"

--- a/claude-ops/tests/test-post-update-migrate-current-guard.sh
+++ b/claude-ops/tests/test-post-update-migrate-current-guard.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Guards refresh_current_directory in bin/ops-post-update-migrate:
+#   1. cache-GC bookkeeping (.orphaned_at, .in_use) never rides into current/
+#   2. installed_plugins.json is rewritten atomically, keeping its mode
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() {
+	printf 'FAIL: %s\n' "$1" >&2
+	exit 1
+}
+
+# $1 = label, $2 = "rsync" | "nossync"
+run_case() {
+	local label="$1" mode="$2"
+	local base="$TMP/$label"
+	local plugin_root="$base/cache/ops-marketplace/ops/2.0.0"
+	local current_dir="$base/cache/ops-marketplace/ops/current"
+	local config_dir="$base/config"
+	local data_dir="$base/data"
+	local installed="$config_dir/plugins/installed_plugins.json"
+
+	mkdir -p "$plugin_root/.claude-plugin" "$plugin_root/bin" "$plugin_root/.in_use" \
+		"$current_dir" "$config_dir/plugins" "$data_dir/.migrated" "$base/home"
+
+	printf '{"version":"test"}\n' >"$plugin_root/.claude-plugin/plugin.json"
+	printf 'payload\n' >"$plugin_root/bin/marker-file"
+	touch "$data_dir/.migrated/vtest"
+
+	# Cache-GC bookkeeping the CLI writes into a version dir it no longer
+	# recognises. Aged marker + a dead PID: exactly the state that makes the
+	# next sweep delete immediately, with nothing holding the dir open.
+	printf '1000000000000\n' >"$plugin_root/.orphaned_at"
+	printf '{"pid":999999}\n' >"$plugin_root/.in_use/999999"
+
+	# Pre-existing leak in current/, to prove we clean up as well as prevent.
+	printf '1000000000000\n' >"$current_dir/.orphaned_at"
+
+	cat >"$installed" <<JSON
+{
+  "plugins": {
+    "ops@ops-marketplace": [
+      {
+        "scope": "user",
+        "installPath": "$plugin_root",
+        "version": "2.0.0"
+      }
+    ],
+    "other@marketplace": [
+      {
+        "scope": "user",
+        "installPath": "/somewhere/else",
+        "version": "1.0.0"
+      }
+    ]
+  }
+}
+JSON
+	chmod 600 "$installed"
+	local inode_before
+	inode_before="$(stat -c %i "$installed")"
+
+	local path_override="$PATH"
+	if [[ "$mode" == "nossync" ]]; then
+		# Force the cp -rp fallback branch.
+		mkdir -p "$base/bin"
+		for exe in bash cp rm mkdir rmdir python3 date dirname find printf \
+			sed cat ls chmod stat tr wc grep; do
+			src="$(command -v "$exe" || true)"
+			[[ -n "$src" ]] && ln -sf "$src" "$base/bin/$exe"
+		done
+		path_override="$base/bin"
+	fi
+
+	HOME="$base/home" \
+		CLAUDE_PLUGIN_ROOT="$plugin_root" \
+		CLAUDE_CONFIG_DIR="$config_dir" \
+		CLAUDE_PLUGIN_DATA_DIR="$data_dir" \
+		PATH="$path_override" \
+		bash "$ROOT/bin/ops-post-update-migrate"
+
+	# 1. real content copied through
+	[[ -f "$current_dir/bin/marker-file" ]] ||
+		fail "$label: current/ missing copied payload"
+
+	# 2. GC bookkeeping must not be present in current/
+	[[ ! -e "$current_dir/.orphaned_at" ]] ||
+		fail "$label: .orphaned_at leaked into current/ — cache GC would delete the live plugin root"
+	[[ ! -e "$current_dir/.in_use" ]] ||
+		fail "$label: stale .in_use leaked into current/"
+
+	# 3. installPath repointed, other plugins untouched, mode preserved
+	python3 - "$installed" "$current_dir" <<'PY' || fail "$label: installed_plugins.json assertions failed"
+import json, os, stat, sys
+path, current = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    d = json.load(f)
+ops = d["plugins"]["ops@ops-marketplace"][0]
+assert ops["installPath"] == current, f"installPath={ops['installPath']!r} want {current!r}"
+assert ops["version"] == "2.0.0", "unrelated ops fields were dropped"
+other = d["plugins"]["other@marketplace"][0]
+assert other["installPath"] == "/somewhere/else", "unrelated plugin was rewritten"
+mode = stat.S_IMODE(os.stat(path).st_mode)
+assert mode == 0o600, f"mode widened to {oct(mode)}"
+PY
+
+	# 4. the rewrite swapped a new file in rather than truncating in place.
+	#    os.replace() always lands a fresh inode; open(path, "w") reuses it.
+	local inode_after
+	inode_after="$(stat -c %i "$installed")"
+	[[ "$inode_before" != "$inode_after" ]] ||
+		fail "$label: installed_plugins.json rewritten in place (inode $inode_after unchanged) — not an atomic replace"
+
+	# 5. no temp file left behind by the atomic rename
+	leftovers="$(find "$config_dir/plugins" -maxdepth 1 -name '.installed_plugins.*.tmp' 2>/dev/null | wc -l | tr -d ' ')"
+	[[ "$leftovers" == "0" ]] || fail "$label: atomic write left $leftovers temp file(s)"
+
+	printf 'ok: %s\n' "$label"
+}
+
+run_case rsync-path rsync
+run_case cp-fallback nossync
+
+printf 'PASS: current/ stays free of cache-GC markers; installed_plugins.json rewritten atomically\n'


### PR DESCRIPTION
## What

`refresh_current_directory` rsynced the version directory into `current/` without excluding Claude Code's cache-GC bookkeeping, so `.orphaned_at` and `.in_use` were copied along with the payload.

## Why it matters

Claude Code marks any plugin version directory that is no longer a registered `installPath` with `.orphaned_at`, then deletes it once that marker passes the grace period. It skips only directories still listed as an `installPath`, and those held open by a live PID in `.in_use`.

A copied `.orphaned_at` is therefore already aged, and the copied `.in_use` PIDs belong to the version directory and are dead. If `installPath` ever moves off `current/` — a plugin reinstall, or the marketplace remove+add that `ops-update` performs (#749) — `current/` becomes an orphan candidate with its grace period already spent. It gets deleted on the next sweep while live sessions are still resolving `CLAUDE_PLUGIN_ROOT` through it.

That is exactly the failure `current/` was introduced to stop: a session whose plugin root is deleted underneath it, and whose SessionStart hooks then fail with `Plugin directory does not exist` on the next compact.

Reproduced directly:

```
$ rsync -a --delete "$T/2.0.0/" "$T/current/"
current/.orphaned_at = 1785449523284
current/.in_use      = PRESENT
```

## Changes

- `rsync --exclude` for `.orphaned_at` and `.in_use`, plus an unconditional clear after the copy — `cp -rp` has no exclude, and any earlier leak needs clearing too.
- Write `installed_plugins.json` via temp file + `os.replace` instead of an in-place `open(path, "w")`. Every installed plugin resolves through that file, so a crash or a concurrent reader during the truncation window breaks all of them, not just ops. The rename preserves the original `0600` mode.
- New `tests/test-post-update-migrate-current-guard.sh` covering both the rsync and `cp` fallback paths.

## Verification

Each assertion proven red against the unfixed script, separately:

```
FAIL: rsync-path: .orphaned_at leaked into current/ — cache GC would delete the live plugin root
FAIL: rsync-path: installed_plugins.json rewritten in place (inode 17440964 unchanged) — not an atomic replace
```

Green after the fix:

```
ok: rsync-path
ok: cp-fallback
PASS: current/ stays free of cache-GC markers; installed_plugins.json rewritten atomically
```

- `tests/test-post-update-migrate-lock.sh` still passes (3/3)
- repo `npm` check script — 25 passed, 0 failed
- `bash -n` clean; embedded Python parses via `ast.parse`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live plugin install metadata and the stable current/ root used by sessions; mistakes could break plugin resolution or trigger premature cache deletion, but changes are narrow and covered by new tests.
> 
> **Overview**
> **`refresh_current_directory`** no longer copies Claude Code’s cache-GC bookkeeping into the stable **`current/`** plugin root, and **`installed_plugins.json`** updates are done safely under concurrency.
> 
> When syncing the version dir into **`current/`**, **`rsync`** now excludes **`.orphaned_at`** and **`.in_use`**, and both are always removed after copy (including the **`cp -rp`** fallback). That stops an already-aged orphan marker from riding into **`current/`** and letting cache GC delete the live install path after **`installPath`** moves away.
> 
> **`installPath`** patching writes JSON via a temp file, **`fsync`**, preserved **`0600`** mode, and **`os.replace`** instead of truncating **`installed_plugins.json`** in place—reducing corrupt reads for every plugin using that file.
> 
> Adds **`tests/test-post-update-migrate-current-guard.sh`** for the rsync and **`cp`** paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94ca036274ef03240b3cbf878a33bd2e99c53d14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->