### PR TITLE
release: v2.47.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 62 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.47.5",
+      "version": "2.47.6",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-2.47.5-blue)
+![Version](https://img.shields.io/badge/version-2.47.6-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-62-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.47.5",
+  "version": "2.47.6",
   "description": "Business operations command center for Claude Code — 62 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -39,6 +39,13 @@
 - **ops-ecom:** `channels` | `agentic` | `shop` verbs — sales channel inventory, agentic storefront health, Shop Campaigns readiness (read-only; Rule 5 / stage-only spend).
 - **ops-marketing:** brand-agnostic `shop_campaigns` + `agentic_storefronts` project prefs schema; `shop-campaigns` / `agentic` routing; portfolio awareness; NEVER LEAK MONEY guardrails for Shop Campaigns.
 
+## [2.47.6] - 2026-07-30
+
+### Changed
+- **Plugin cache markers:** `ops-post-update-migrate` no longer copies Claude Code's cache-GC bookkeeping (`.orphaned_at`, `.in_use`) from the version directory into `current/`. A copied marker is already past its grace period, so once `installPath` moved off `current/` the CLI would delete it on the next sweep while live sessions still resolved `CLAUDE_PLUGIN_ROOT` through it — the stale-plugin-root failure `current/` exists to prevent.
+- **Atomic installed_plugins.json write:** the file is now written through a temp file and renamed instead of truncated in place. Every installed plugin resolves through it, so a crash or a concurrent reader mid-write broke all of them, not just ops. The rename preserves the original 0600 mode.
+
+
 ## [2.47.5] - 2026-07-30
 
 ### Changed

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-2.47.5-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.47.6-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 62 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-2.47.5-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.47.6-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-62-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.47.5",
+  "version": "2.47.6",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.47.6** (was 2.47.5).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

- **Plugin cache markers:** `ops-post-update-migrate` no longer copies Claude Code's cache-GC bookkeeping (`.orphaned_at`, `.in_use`) from the version directory into `current/`. A copied marker is already past its grace period, so once `installPath` moved off `current/` the CLI would delete it on the next sweep while live sessions still resolved `CLAUDE_PLUGIN_ROOT` through it — the stale-plugin-root failure `current/` exists to prevent.
- **Atomic installed_plugins.json write:** the file is now written through a temp file and renamed instead of truncated in place. Every installed plugin resolves through it, so a crash or a concurrent reader mid-write broke all of them, not just ops. The rename preserves the original 0600 mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the global `installed_plugins.json` is written and how `current/` is synced—high impact if wrong, but the atomic write and GC-marker handling are targeted reliability fixes.
> 
> **Overview**
> **Release v2.47.6** bumps the ops plugin and marketplace registry from **2.47.5** across `plugin.json`, `marketplace.json`, `package.json`, README/docs badges, and **CHANGELOG**.
> 
> The release ships two **plugin install-path stability** fixes in `ops-post-update-migrate` (documented in CHANGELOG; behavior at HEAD):
> 
> - **`current/` rsync** now **excludes** Claude Code cache GC markers **`.orphaned_at`** and **`.in_use`**, and explicitly removes any that slip through after `cp`. Stale markers copied into `current/` could let the CLI delete `current/` while sessions still resolve `CLAUDE_PLUGIN_ROOT` through it.
> - **`installed_plugins.json`** updates use **write temp → fsync → atomic `replace`**, preserving **0600** mode, instead of truncating the live file—so a crash or concurrent read no longer corrupts install metadata for **all** installed plugins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e52b0fbae14171c9ab3fd565a7bb318ef125971. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->