### PR TITLE
fix(post-update-migrate): keep current/.in_use, only clear the orphan marker

### DIFF
--- a/claude-ops/bin/ops-post-update-migrate
+++ b/claude-ops/bin/ops-post-update-migrate
@@ -77,18 +77,25 @@ refresh_current_directory() {
     fi
   fi
 
-  # Never let the cache-GC bookkeeping of a version dir ride into current/.
+  # Never let a version dir's orphan marker ride into current/.
   # Claude Code marks a version dir it no longer recognises with .orphaned_at
   # and deletes it once that marker ages past the grace period, skipping only
-  # dirs still listed as an installPath. If a stale (already-aged) marker is
-  # copied into current/ and installPath later moves off current/ — a plugin
-  # reinstall, or the marketplace remove+add that ops-update performs — the
-  # grace period is already spent, so current/ is deleted on the next sweep
-  # while live sessions still resolve CLAUDE_PLUGIN_ROOT through it. The
-  # copied .in_use PIDs belong to the version dir and are dead, so they do
-  # not hold it open either. cp -rp has no exclude, so clear both here.
+  # dirs still listed as an installPath. A copied marker is already aged, so
+  # if installPath later moves off current/ — a plugin reinstall, or the
+  # marketplace remove+add that ops-update performs — the grace period is
+  # already spent and current/ is deleted on the next sweep while live
+  # sessions still resolve CLAUDE_PLUGIN_ROOT through it. cp -rp has no
+  # exclude, so clear it here too, and clear any earlier leak.
   rm -f "$current_dir/.orphaned_at" 2>/dev/null || true
-  rm -rf "$current_dir/.in_use" 2>/dev/null || true
+
+  # current/.in_use is deliberately left alone. Every session that resolves
+  # current/ as its plugin root registers its own live PID there, and that
+  # registry is what stops the sweeper deleting current/ out from under them
+  # if installPath ever moves off it. Removing it would drop exactly the
+  # protection this function exists to preserve. Excluding it from the rsync
+  # above already stops the version dir's PIDs from replacing the live ones;
+  # under the cp fallback they merely get added, and the sweeper prunes dead
+  # entries itself.
 
   if [[ -f "$installed_json" ]]; then
     if python3 - "$installed_json" "$current_dir" <<'PYEOF' 2>/dev/null

--- a/claude-ops/tests/test-post-update-migrate-current-guard.sh
+++ b/claude-ops/tests/test-post-update-migrate-current-guard.sh
@@ -39,6 +39,12 @@ run_case() {
 	# Pre-existing leak in current/, to prove we clean up as well as prevent.
 	printf '1000000000000\n' >"$current_dir/.orphaned_at"
 
+	# A live session that resolved current/ as its plugin root and registered
+	# itself there. This registry is what stops the sweeper deleting current/
+	# out from under it, so the refresh must not drop it.
+	mkdir -p "$current_dir/.in_use"
+	printf '{"pid":%s}\n' "$$" >"$current_dir/.in_use/$$"
+
 	cat >"$installed" <<JSON
 {
   "plugins": {
@@ -89,8 +95,14 @@ JSON
 	# 2. GC bookkeeping must not be present in current/
 	[[ ! -e "$current_dir/.orphaned_at" ]] ||
 		fail "$label: .orphaned_at leaked into current/ — cache GC would delete the live plugin root"
-	[[ ! -e "$current_dir/.in_use" ]] ||
-		fail "$label: stale .in_use leaked into current/"
+	[[ -f "$current_dir/.in_use/$$" ]] ||
+		fail "$label: dropped the live .in_use registration in current/ — the sweeper could then delete it under a running session"
+	# rsync excludes .in_use outright. cp -rp has no exclude, so it merges the
+	# version dir's dead PIDs in; harmless, the sweeper prunes those itself.
+	if [[ "$mode" == "rsync" ]]; then
+		[[ ! -e "$current_dir/.in_use/999999" ]] ||
+			fail "$label: version dir's stale .in_use PID was copied into current/"
+	fi
 
 	# 3. installPath repointed, other plugins untouched, mode preserved
 	python3 - "$installed" "$current_dir" <<'PY' || fail "$label: installed_plugins.json assertions failed"


### PR DESCRIPTION
## What

Follow-up to #753 / v2.47.6. That change cleared both `.orphaned_at` **and** `.in_use` from `current/` after the copy. Clearing `.in_use` is wrong and I should not have shipped it.

## Why

Every session that resolves `current/` as its plugin root registers its own live PID in `current/.in_use`. The sweeper reads that registry to decide whether it may delete a directory. It is the one thing that stops `current/` being deleted underneath a running session if `installPath` ever moves off it — the exact case #753 set out to protect. Deleting the registry dropped that protection.

The comment in #753 claimed the copied PIDs "belong to the version dir and are dead." That is true of the ones rsync copies, but not of the ones already there. Checked on a live box:

```
$ ls current/.in_use            # 2 entries
$ kill -0 3885901 4070645       # both alive
  LIVE pid 3885901   claude.exe   31:48
  LIVE pid 4070645   claude.exe   21:28
```

Those are running sessions, not stale copies.

## Changes

- Drop the `rm -rf "$current_dir/.in_use"`. Excluding `.in_use` from the rsync already stops the version directory's PIDs replacing the live ones. Under the `cp` fallback they get merged in instead, which is harmless — the sweeper prunes dead entries itself.
- Keep clearing `.orphaned_at`. That one is a genuine landmine: a copied marker arrives with its grace period already spent.
- The check now asserts a live registration in `current/` survives the refresh, rather than asserting the registry is gone. The stale-PID assertion is scoped to the rsync path, since `cp -rp` has no exclude.

## Verification

Red against the released v2.47.6 script:

```
FAIL: rsync-path: dropped the live .in_use registration in current/ — the sweeper could then delete it under a running session
```

Green after:

```
ok: rsync-path
ok: cp-fallback
PASS: current/ stays free of cache-GC markers; installed_plugins.json rewritten atomically
```

- `tests/test-post-update-migrate-lock.sh` still passes (3/3)
- repo `npm` check script — 25 passed, 0 failed
- `bash -n` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets post-update plugin cache refresh and sweeper behavior; wrong handling could delete `current/` under live sessions, but the change restores intended protection rather than altering unrelated logic.
> 
> **Overview**
> Reverts **removing `current/.in_use`** after refreshing the plugin `current/` directory in `ops-post-update-migrate`. v2.47.6 cleared both `.orphaned_at` and `.in_use`; that stripped live session PID registrations that tell the cache sweeper not to delete `current/` under running sessions.
> 
> **Still clears** `.orphaned_at` only (copied or leaked markers can trigger premature GC). **Rsync** already excludes `.in_use` from the version dir; the **cp** fallback may merge dead PIDs, which the sweeper prunes.
> 
> Tests now require a live `.in_use` entry to survive refresh and only assert stale version-dir PIDs are absent on the rsync path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d80a4e08490b795bad2a617faca5e67039c3e0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->