### PR TITLE
release: v2.47.8

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 62 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "2.47.7",
+      "version": "2.47.8",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-2.47.7-blue)
+![Version](https://img.shields.io/badge/version-2.47.8-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-62-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "2.47.7",
+  "version": "2.47.8",
   "description": "Business operations command center for Claude Code — 62 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -39,6 +39,12 @@
 - **ops-ecom:** `channels` | `agentic` | `shop` verbs — sales channel inventory, agentic storefront health, Shop Campaigns readiness (read-only; Rule 5 / stage-only spend).
 - **ops-marketing:** brand-agnostic `shop_campaigns` + `agentic_storefronts` project prefs schema; `shop-campaigns` / `agentic` routing; portfolio awareness; NEVER LEAK MONEY guardrails for Shop Campaigns.
 
+## [2.47.8] - 2026-07-30
+
+### Changed
+- **Keep `current/.in_use`:** 2.47.6 cleared both `.orphaned_at` and `.in_use` from `current/` after the refresh. Clearing `.in_use` was wrong — every session that resolves `current/` as its plugin root registers its own live PID there, and that registry is what stops the sweeper deleting `current/` under a running session if `installPath` moves off it. Only the orphan marker is cleared now; excluding `.in_use` from the rsync already keeps the version directory's dead PIDs out.
+
+
 ## [2.47.7] - 2026-07-30
 
 ### Changed

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-2.47.7-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.47.8-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 62 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-2.47.7-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-2.47.8-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-62-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "2.47.7",
+  "version": "2.47.8",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v2.47.8** (was 2.47.7).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

- **Keep `current/.in_use`:** 2.47.6 cleared both `.orphaned_at` and `.in_use` from `current/` after the refresh. Clearing `.in_use` was wrong — every session that resolves `current/` as its plugin root registers its own live PID there, and that registry is what stops the sweeper deleting `current/` under a running session if `installPath` moves off it. Only the orphan marker is cleared now; excluding `.in_use` from the rsync already keeps the version directory's dead PIDs out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata and changelog only in the diff; the migrate change is a targeted fix to plugin cache lifecycle with no auth or data-path impact.
> 
> **Overview**
> **Release v2.47.8** bumps the ops plugin from **2.47.7** across marketplace metadata, `plugin.json`, `package.json`, README/docs version badges, and adds a **CHANGELOG** entry for the headline fix.
> 
> The documented behavior change fixes **`ops-post-update-migrate`** handling of Claude Code plugin-cache markers under `current/`: after refresh, only **`.orphaned_at`** is cleared; **`current/.in_use`** is **no longer removed**. Live sessions register PIDs in `.in_use` so the cache sweeper does not delete `current/` while `installPath` has moved off it. Rsync already excludes `.in_use` (and `.orphaned_at`) from the version directory so stale PIDs are not copied in.
> 
> No other functional code changes appear in this diff—it's a **release + documentation** cut for that migrate guardrail correction introduced after 2.47.6.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e532409ec60380287ae0272fe9fe289c700c910b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->