### PR TITLE
fix(crs): use managed Node in token feed

### DIFF
--- a/claude-ops/scripts/account-rotation/crs-token-feed.sh
+++ b/claude-ops/scripts/account-rotation/crs-token-feed.sh
@@ -5,4 +5,4 @@ source "$HOME/.claude/scripts/lib/once.sh" 2>/dev/null || true
 if command -v claude_once >/dev/null 2>&1; then
   claude_once crs-token-feed 60 || exit 0
 fi
-exec /usr/bin/node "$HOME/.claude/scripts/account-rotation/crs-token-feed.mjs" "$@"
+exec /usr/local/bin/node "$HOME/.claude/scripts/account-rotation/crs-token-feed.mjs" "$@"


### PR DESCRIPTION
**What**

Run the CRS token feeder with the managed Node runtime instead of Ubuntu's old system Node.

**Why**

The scheduled wrapper used Node 12, which failed before the feeder could parse and left refreshed Claude tokens out of CRS.

**How**

Change only the wrapper executable path. The feeder and its scheduling policy are unchanged.

**Contract impact**

None.

**Test plan**

```text
npm run lint
All matched files use Prettier code style!

npm run type-check
node --check bin/*.mjs lib/*.mjs telegram-server/index.js

npm test
Results: 25 passed, 0 failed

bash -n scripts/account-rotation/crs-token-feed.sh
git diff --check
```

**Risk & rollback**

Low. The path is already used by live CRS services. Revert this commit to restore the system Node path.

**Evidence**

The live feeder completed after installation and a fresh Claude request returned `CLAUDE_CRS_OK`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single executable path change in a wrapper script; rollback is reverting the line. PR notes the managed Node path is already used by live CRS services.
> 
> **Overview**
> The CRS token feed shell wrapper now **`exec`s `/usr/local/bin/node`** instead of **`/usr/bin/node`**, so the scheduled feeder runs on the managed Node runtime rather than Ubuntu’s older system Node (Node 12).
> 
> That one-line path change fixes failures where the feeder could not parse/run and Claude tokens were not refreshed into CRS. Single-flight wrapping via `claude_once` and the feeder script path are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b9aa574cfbd7a484752e2a109fcd240f4a10b45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->