### PR TITLE
release: v2.47.9

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -45,6 +45,12 @@
 fix(ops-inbox): enforce live sent-check and auto-heal app-state on archive
 
 
+## [2.47.9] - 2026-08-02
+
+### Changed
+fix(ops-inbox): enforce live sent-check and auto-heal app-state on archive
+
+
 ## [2.47.8] - 2026-07-30
 
 ### Changed


### PR DESCRIPTION
Release **v2.47.9** (was 2.47.8).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

fix(ops-inbox): enforce live sent-check and auto-heal app-state on archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version alignment plus a duplicated changelog section; inbox archive/sent-check changes affect comms workflow but are localized guardrails, not auth or payment paths.
> 
> **Overview**
> Release **v2.47.9** (from 2.47.8): version bumps in `plugin.json`, `package.json`, and marketplace/registry metadata, with a CHANGELOG entry for the shipped **ops-inbox** fix.
> 
> The functional change in this release is **ops-inbox archive behavior**: a **live sent-check** before treating threads as safe to archive, plus **auto-heal of WhatsApp app-state** when archive would otherwise wedge on stale LTHash/sync state.
> 
> **Note:** The diff accidentally **duplicates** the entire `[2.47.9]` CHANGELOG block twice; one copy should be removed before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 176290910d6d9966ef6e51640b5c5792790eb30e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->