### PR TITLE
release: v2.47.9

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -42,6 +42,12 @@
 ## [2.47.9] - 2026-08-02
 
 ### Changed
+fix(ops-inbox):0.31.0 - enforce live sent-check and auto-heal app-state on archive
+
+
+## [2.47.9] - 2026-08-02
+
+### Changed
 fix(ops-inbox): enforce live sent-check and auto-heal app-state on archive
 
 


### PR DESCRIPTION
Release **v2.47.9** (was 2.47.8).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

fix(ops-inbox):0.31.0 - enforce live sent-check and auto-heal app-state on archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata and changelog only in the shown diff; inbox archive/sent-check behavior ships in the tagged release but is not re-reviewed here.
> 
> **Overview**
> Release **v2.47.9** (from 2.47.8), packaging the **ops-inbox** fix: live sent-check before treating mail as handled and auto-heal of WhatsApp app-state when archiving.
> 
> The PR description also calls for aligned version bumps in `plugin.json`, marketplace registry, and `claude-ops/package.json`; the visible diff only touches **`CHANGELOG.md`**, where the new **2.47.9** section was added **three times** with nearly identical text (one line includes `0.31.0`). That duplication should be collapsed to a single release entry before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d4122e207fc9c50cdc317be64883294b7a4991d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->