### PR TITLE
release: v2.47.9

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -42,6 +42,12 @@
 ## [2.47.9] - 2026-08-02
 
 ### Changed
+fix(ops-inbox): enforce live sent-check and auto-heal app-state on archive
+
+
+## [2.47.9] - 2026-08-02
+
+### Changed
 fix(ops-inbox):0.31.0 - enforce live sent-check and auto-heal app-state on archive
 
 


### PR DESCRIPTION
Release **v2.47.9** (was 2.47.8).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

fix(ops-inbox): enforce live sent-check and auto-heal app-state on archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly release metadata; inbox archive behavior changes only matter if the underlying ops-inbox fix is in this release (not visible in the provided diff). Duplicate changelog blocks are documentation noise, not runtime risk.
> 
> **Overview**
> **Release v2.47.9** (from 2.47.8): bumps `plugin.json`, marketplace registry, and `claude-ops/package.json` to **2.47.9** and records the shipped fix in the changelog.
> 
> The noted change is **`fix(ops-inbox)`**: require a **live sent-check** before treating threads as handled, and **auto-heal WhatsApp app-state** when archiving so inbox-zero archive does not wedge on corrupt `regular_low` / stale local store.
> 
> **Changelog hygiene:** this diff **prepends another `## [2.47.9]` block** above several identical 2.47.9 sections (one line even mentions `0.31.0`). Reviewers may want to collapse those duplicates into a single entry before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd73d96f5a963ce8535451eeb30b5c75956966ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->