### PR TITLE
release: v3.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 62 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-3.0.0-blue)
+![Version](https://img.shields.io/badge/version-3.1.0-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-62-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Business operations command center for Claude Code — 62 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -39,6 +39,20 @@
 - **ops-ecom:** `channels` | `agentic` | `shop` verbs — sales channel inventory, agentic storefront health, Shop Campaigns readiness (read-only; Rule 5 / stage-only spend).
 - **ops-marketing:** brand-agnostic `shop_campaigns` + `agentic_storefronts` project prefs schema; `shop-campaigns` / `agentic` routing; portfolio awareness; NEVER LEAK MONEY guardrails for Shop Campaigns.
 
+## [3.1.0] - 2026-08-03
+
+### Changed
+- Added a portable CLIProxyAPI account provider with health, account inventory, and utilization support in `ops-accounts`.
+- Standardized CLIProxyAPI discovery across `CLIPROXYAPI_AUTH_DIR`, `CLIPROXYAPI_HOME`, and `XDG_CONFIG_HOME`, with explicit environment configuration for optional proxy endpoints.
+- Hardened release automation with required CI and CodeQL checks, bounded GitHub queries, stable-head verification, and exact-SHA squash merges without branch-protection bypass.
+- Updated `ip-address` from 10.2.0 to 10.4.0 in the plugin and Telegram server dependency trees.
+- Updated Telegram server `fast-uri` from 3.1.4 to 3.1.5, including the upstream security fix.
+- Preserved existing release notes during first-time and interrupted GitHub wiki synchronization.
+- Fixed gateway execution through symlinked or canonical paths and added a clear 503 response when the optional Grok endpoint is not configured.
+- Removed ShellCheck warnings from the touched account and release commands.
+- Removed deployment-specific browser login, CAPTCHA, reauthentication, and subscription automation from the public plugin.
+
+
 ## [3.0.0] - 2026-08-03
 
 ### Changed

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-3.0.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.1.0-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 62 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-3.0.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.1.0-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-62-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v3.1.0** (was 3.0.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

- Added a portable CLIProxyAPI account provider with health, account inventory, and utilization support in `ops-accounts`.
- Standardized CLIProxyAPI discovery across `CLIPROXYAPI_AUTH_DIR`, `CLIPROXYAPI_HOME`, and `XDG_CONFIG_HOME`, with explicit environment configuration for optional proxy endpoints.
- Hardened release automation with required CI and CodeQL checks, bounded GitHub queries, stable-head verification, and exact-SHA squash merges without branch-protection bypass.
- Updated `ip-address` from 10.2.0 to 10.4.0 in the plugin and Telegram server dependency trees.
- Updated Telegram server `fast-uri` from 3.1.4 to 3.1.5, including the upstream security fix.
- Preserved existing release notes during first-time and interrupted GitHub wiki synchronization.
- Fixed gateway execution through symlinked or canonical paths and added a clear 503 response when the optional Grok endpoint is not configured.
- Removed ShellCheck warnings from the touched account and release commands.
- Removed deployment-specific browser login, CAPTCHA, reauthentication, and subscription automation from the public plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches account routing, release merge automation, and removes internal auth automation from the public tree—behavior changes for operators and publish workflows, with a security-related dependency bump.
> 
> **Overview**
> **Release v3.1.0** bumps the ops plugin and marketplace registry from **3.0.0** across `plugin.json`, `marketplace.json`, `package.json`, README badges, and reference docs, with a new **CHANGELOG** section for the release.
> 
> **`ops-accounts`** gains a portable **CLIProxyAPI** provider: health checks, auth-dir account counts, and `util` inventory keyed off standardized discovery via `CLIPROXYAPI_AUTH_DIR`, `CLIPROXYAPI_HOME`, and `XDG_CONFIG_HOME`, plus optional `CLIPROXYAPI_BASE_URL`.
> 
> **Release automation** is tightened (required CI/CodeQL, bounded GitHub queries, stable-head checks, exact-SHA squash merges). **Dependencies** bump `ip-address` (10.4.0) and Telegram server `fast-uri` (3.1.5, security fix). **Gateway** execution fixes symlink/canonical paths and returns **503** when the optional Grok endpoint is unset.
> 
> The public plugin **strips deployment-specific** browser login, CAPTCHA, reauth, and subscription automation; wiki sync now **preserves** existing release notes on first or interrupted runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 609088ca14024cad5a6e3ba727253d3d0f3d2937. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->