### PR TITLE
fix(deps): update hono to 4.13.0

### DIFF
--- a/claude-ops/telegram-server/package-lock.json
+++ b/claude-ops/telegram-server/package-lock.json
@@ -842,9 +842,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.31",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"


### PR DESCRIPTION
## Summary

- update the Telegram server's transitive `hono` lock entry from 4.12.31 to 4.13.0
- remediate GHSA-8j4g-w8fx-2239, a CORS middleware ReDoS affecting versions below 4.12.34
- leave direct dependency ranges and all other resolved packages unchanged

## Verification

- `npm ci --ignore-scripts` in `claude-ops/telegram-server`
- `npm audit --omit=dev` reports 0 vulnerabilities
- `npm ls hono --depth=3` resolves one deduplicated `hono@4.13.0`
- root `npm run lint`
- root `npm run type-check`
- root `npm test`
- public sanitizer scan of the changed lockfile
- `git diff --check`

Dependabot alert: https://github.com/Lifecycle-Innovations-Limited/claude-ops/security/dependabot/40
Advisory: https://github.com/advisories/GHSA-8j4g-w8fx-2239

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only lockfile change with no runtime code edits; low regression risk beyond hono’s patch release behavior.
> 
> **Overview**
> Bumps the resolved **`hono`** version in `claude-ops/telegram-server/package-lock.json` from **4.12.31** to **4.13.0**. There are no changes to `package.json` or application source—only the lockfile entry for the transitive dependency pulled in through **`@modelcontextprotocol/sdk`**.
> 
> This addresses **GHSA-8j4g-w8fx-2239** (CORS middleware ReDoS in hono versions below 4.12.34).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca54cc4ad8720b1ff0987d96fc34f5021fbff96c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->