### PR TITLE
test(auth): canonicalize macOS temp fixtures

### DIFF
--- a/claude-ops/scripts/account-rotation/__tests__/credential-file-publication.test.mjs
+++ b/claude-ops/scripts/account-rotation/__tests__/credential-file-publication.test.mjs
@@ -7,6 +7,7 @@ import {
   mkdtempSync,
   readFileSync,
   readlinkSync,
+  realpathSync,
   readdirSync,
   renameSync,
   symlinkSync,
@@ -20,7 +21,9 @@ import { fileURLToPath } from 'node:url';
 import { publishCredentialFileCas, snapshotCredentialFile } from '../credential-file-publication.mjs';
 
 const fixture = () => {
-  const root = mkdtempSync(join(tmpdir(), 'credential-cas-disabled-'));
+  // macOS exposes tmpdir() through /var -> /private/var. Use the physical
+  // path so canonical-destination checks are tested rather than bypassed.
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'credential-cas-disabled-')));
   chmodSync(root, 0o700);
   const path = join(root, 'credentials.json');
   writeFileSync(path, 'old', { mode: 0o600 });

--- a/claude-ops/scripts/account-rotation/__tests__/staged-enrollment.test.mjs
+++ b/claude-ops/scripts/account-rotation/__tests__/staged-enrollment.test.mjs
@@ -8,6 +8,7 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   rmdirSync,
   symlinkSync,
   unlinkSync,
@@ -135,7 +136,9 @@ const signalChild = (child, signal) => {
 };
 
 function fixture(format = JSON.stringify(MANIFEST, null, 2)) {
-  const root = mkdtempSync(join(tmpdir(), 'staged-enrollment-'));
+  // macOS exposes tmpdir() through /var, a system symlink to /private/var.
+  // Resolve the fixture root once so trust-root tests exercise canonical paths.
+  const root = realpathSync(mkdtempSync(join(tmpdir(), 'staged-enrollment-')));
   const names = ['active', 'quarantine', 'quarantine2', 'staging', 'usage', 'rollback', 'locks'];
   const paths = Object.fromEntries(names.map((name) => [name, join(root, name)]));
   for (const path of Object.values(paths)) mkdirSync(path, { mode: 0o700 });


### PR DESCRIPTION
## Summary
- resolve the macOS /var to /private/var alias in security-test fixtures
- exercise canonical trust-root checks with physical paths
- preserve production fail-closed validation behavior

## Verification
- staged enrollment Node test passed
- browser pin recovery passed
- credential publication passed
- shell staged-enrollment suite passed
- public-repo secret and PII scan: 25/25 passed
- Prettier passed
- git diff --check passed