### PR TITLE
fix(security): eliminate CodeQL critical command-line injection

### DIFF
--- a/claude-ops/bin/ops-telegram-autolink.mjs
+++ b/claude-ops/bin/ops-telegram-autolink.mjs
@@ -36,7 +36,7 @@
  */
 
 import { readFileSync, existsSync, unlinkSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+import { execSync, execFileSync } from 'node:child_process';
 import { parseArgs } from 'node:util';
 import os from 'node:os';
 import { TelegramClient } from 'telegram';
@@ -470,17 +470,30 @@ try {
 
 // Step 2.3: Register MCP server
 try {
-  const pluginRoot =
-    process.env.CLAUDE_PLUGIN_ROOT || execSync('echo $CLAUDE_PLUGIN_ROOT', { encoding: 'utf8' }).trim();
+  // Argv form — never interpolate secrets into a shell string (CodeQL js/command-line-injection).
+  const pluginRoot = (process.env.CLAUDE_PLUGIN_ROOT || '').trim();
   const telegramServerPath = pluginRoot ? `${pluginRoot}/telegram-server/index.js` : null;
   if (telegramServerPath) {
-    execSync(
-      `claude mcp add telegram -s user` +
-        ` -e TELEGRAM_API_ID='${apiId}'` +
-        ` -e TELEGRAM_API_HASH='${apiHash}'` +
-        ` -e TELEGRAM_PHONE='${PHONE}'` +
-        ` -e TELEGRAM_SESSION='${sessionStr.replace(/'/g, "'\\''")}'` +
-        ` -- node "${telegramServerPath}"`,
+    execFileSync(
+      'claude',
+      [
+        'mcp',
+        'add',
+        'telegram',
+        '-s',
+        'user',
+        '-e',
+        `TELEGRAM_API_ID=${apiId}`,
+        '-e',
+        `TELEGRAM_API_HASH=${apiHash}`,
+        '-e',
+        `TELEGRAM_PHONE=${PHONE}`,
+        '-e',
+        `TELEGRAM_SESSION=${sessionStr}`,
+        '--',
+        'node',
+        telegramServerPath,
+      ],
       { timeout: 15000, stdio: 'pipe' },
     );
     emit({

--- a/claude-ops/lib/credential-store.mjs
+++ b/claude-ops/lib/credential-store.mjs
@@ -51,15 +51,7 @@ async function ensureDataDir() {
 function runSync(cmd, args, opts = {}) {
   // Allowlist fixed binary names only. Never pass user-controlled cmd
   // (CodeQL js/command-line-injection on spawnSync first arg).
-  const ALLOWED = new Set([
-    'security',
-    'secret-tool',
-    'which',
-    'cmd.exe',
-    'cmdkey',
-    'powershell',
-    'pwsh',
-  ]);
+  const ALLOWED = new Set(['security', 'secret-tool', 'which', 'cmd.exe', 'cmdkey', 'powershell', 'pwsh']);
   if (!ALLOWED.has(cmd)) {
     throw new Error(`credential-store: refused non-allowlisted command: ${cmd}`);
   }

--- a/claude-ops/lib/credential-store.mjs
+++ b/claude-ops/lib/credential-store.mjs
@@ -49,6 +49,20 @@ async function ensureDataDir() {
 // ─── 1. OS-native backends ───────────────────────────────────────────────────
 
 function runSync(cmd, args, opts = {}) {
+  // Allowlist fixed binary names only. Never pass user-controlled cmd
+  // (CodeQL js/command-line-injection on spawnSync first arg).
+  const ALLOWED = new Set([
+    'security',
+    'secret-tool',
+    'which',
+    'cmd.exe',
+    'cmdkey',
+    'powershell',
+    'pwsh',
+  ]);
+  if (!ALLOWED.has(cmd)) {
+    throw new Error(`credential-store: refused non-allowlisted command: ${cmd}`);
+  }
   return spawnSync(cmd, args, { encoding: 'utf8', ...opts });
 }
 
@@ -70,7 +84,8 @@ function macDelete(service, account) {
 
 // --- Linux libsecret (secret-tool) ---
 function hasSecretTool() {
-  return runSync('sh', ['-c', 'command -v secret-tool']).status === 0;
+  // Fixed argv only — no shell (CodeQL js/command-line-injection).
+  return runSync('secret-tool', ['--version']).status === 0 || runSync('which', ['secret-tool']).status === 0;
 }
 function stSet(service, account, secret) {
   if (!hasSecretTool()) return false;
@@ -95,7 +110,7 @@ function stDelete(service, account) {
 
 // --- Windows Credential Manager (cmdkey — write-only from CLI) ---
 function hasCmd() {
-  return runSync('sh', ['-c', 'command -v cmd.exe || which cmd.exe']).status === 0 || process.platform === 'win32';
+  return process.platform === 'win32' || runSync('which', ['cmd.exe']).status === 0;
 }
 function wincredSet(service, account, secret) {
   if (!hasCmd()) return false;


### PR DESCRIPTION
## Why
Two open **critical** CodeQL findings on public `claude-ops`:
- #13 `js/command-line-injection` in `bin/ops-telegram-autolink.mjs` (shell-string `execSync` with session secrets)
- #12 `js/command-line-injection` in `lib/credential-store.mjs` (dynamic `spawnSync` first arg)

## How
- Telegram MCP registration uses `execFileSync('claude', [...argv])` with env values as separate args (no shell).
- `runSync` allowlists binary names (`security`, `secret-tool`, `which`, Windows tools).
- Dropped `sh -c 'command -v …'` probes.

## How tested
```
cd claude-ops && npm test
# Results: 25 passed, 0 failed
```

## Expected
CodeQL critical alerts #12/#13 close after default-branch analysis of this merge.

## Not validated
- Live CodeQL re-scan until CI/default-branch analysis completes post-merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secure integration registration by preventing sensitive values from appearing in setup commands.
  * Improved compatibility when detecting required system tools across Linux and Windows environments.
  * Added validation to reject unsupported commands, reducing unexpected system operations.
  * Preserved existing registration settings, environment configuration, timeout behavior, and output handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->