### PR TITLE
fix(ops-merge): keep read-only upstreams out of the merge queue

### DIFF
--- a/claude-ops/bin/ops-merge-scan
+++ b/claude-ops/bin/ops-merge-scan
@@ -12,8 +12,21 @@ OPS_PLUGIN_ROOT_FALLBACK="$PLUGIN_DIR" . "${PLUGIN_DIR}/lib/registry-path.sh"
 . "${PLUGIN_DIR}/lib/registry-resolve.sh"
 PREFS="${OPS_DATA_DIR}/preferences.json"
 
-# Optional: scope to a single repo
-FILTER_REPO="${1:-}"
+# Optional: scope to a single repo. Accepts a bare slug or --repo <slug>, because
+# the skill documents the flag form while this script only ever read $1 — passing
+# --repo used to set FILTER_REPO to the literal string "--repo" and scan a repo
+# named that, which found nothing and looked like "no open PRs".
+FILTER_REPO=""
+case "${1:-}" in
+  --repo) FILTER_REPO="${2:-}" ;;
+  --repo=*) FILTER_REPO="${1#--repo=}" ;;
+  -*) echo "{\"error\":\"unknown flag ${1}\",\"prs\":[]}" && exit 1 ;;
+  *) FILTER_REPO="${1:-}" ;;
+esac
+
+if [ -n "$FILTER_REPO" ] && ! printf '%s' "$FILTER_REPO" | grep -qE '^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$'; then
+  echo "{\"error\":\"not an owner/name slug: ${FILTER_REPO}\",\"prs\":[]}" && exit 1
+fi
 
 if [ ! -f "$REGISTRY" ]; then
   echo '{"error":"registry.json not found","prs":[]}' && exit 1
@@ -41,20 +54,41 @@ fi
 # upstream repos alongside 8 real ones.
 #
 # `.permissions.push` is true only for a member or collaborator, which is exactly
-# the line we want. Repos that fail the lookup (network, deleted, renamed) are
-# kept rather than dropped, so a transient error never silently shrinks the queue.
-if [ -z "$FILTER_REPO" ] && [ "${OPS_MERGE_INCLUDE_EXTERNAL:-0}" != "1" ]; then
-  KEPT=""
-  SKIPPED=""
-  for repo in $REPOS; do
-    PERM=$(gh api "repos/$repo" --jq '.permissions.push' 2>/dev/null || echo "unknown")
-    case "$PERM" in
-      false) SKIPPED="$SKIPPED $repo" ;;
-      *) KEPT="$KEPT $repo" ;;
-    esac
-  done
-  REPOS="$KEPT"
-  [ -n "$SKIPPED" ] && echo "ops-merge: skipping read-only repos (no push access):$SKIPPED" >&2
+# the line we want.
+#
+# The gate is fail-closed: only an explicit `true` keeps a repo. A lookup that
+# errors, returns null, or reports false is dropped. Fail-open was tempting so a
+# network blip could not hide your own PRs, but this list feeds a queue whose next
+# step is `gh pr merge`, and "we could not tell" must never resolve to "merge it".
+# A blip costs you a rerun; the other way costs someone else's repo.
+#
+# --repo is NOT exempt. It used to be, which meant `--repo someone/else` walked
+# straight past the check.
+#
+# OPS_MERGE_INCLUDE_EXTERNAL takes a single slug, not a boolean, so authorising one
+# upstream for one run cannot silently re-open the whole registry.
+ALLOW_EXTERNAL="${OPS_MERGE_INCLUDE_EXTERNAL:-}"
+[ "$ALLOW_EXTERNAL" = "1" ] && ALLOW_EXTERNAL=""   # legacy boolean is not an allowlist
+
+KEPT=""
+SKIPPED=""
+for repo in $REPOS; do
+  if [ -n "$ALLOW_EXTERNAL" ] && [ "$repo" = "$ALLOW_EXTERNAL" ]; then
+    KEPT="$KEPT $repo"
+    echo "ops-merge: including $repo by explicit OPS_MERGE_INCLUDE_EXTERNAL" >&2
+    continue
+  fi
+  PERM=$(gh api "repos/$repo" --jq '.permissions.push' 2>/dev/null || echo "error")
+  case "$PERM" in
+    true) KEPT="$KEPT $repo" ;;
+    *) SKIPPED="$SKIPPED $repo($PERM)" ;;
+  esac
+done
+REPOS="$KEPT"
+[ -n "$SKIPPED" ] && echo "ops-merge: skipped, no confirmed push access:$SKIPPED" >&2
+
+if [ -z "$(printf '%s' "$REPOS" | tr -d ' ')" ]; then
+  echo '{"prs":[],"note":"no repos with confirmed push access"}' && exit 0
 fi
 
 # Approved PR author logins (owner + bots). Configured in preferences.json

--- a/claude-ops/bin/ops-merge-scan
+++ b/claude-ops/bin/ops-merge-scan
@@ -31,6 +31,32 @@ else
   REPOS=$(ops_registry_repos "$REGISTRY")
 fi
 
+# Drop repos we cannot push to.
+#
+# The registry lists every project cloned locally, which includes upstreams we
+# only ever read: a fork's parent, a dependency we patched once, a public repo
+# we filed one issue against. Those surface open PRs from unrelated contributors,
+# and a merge queue that lists them invites merging someone else's work into a
+# project that is not ours. On 2026-08-15 a scan returned 57 such PRs across four
+# upstream repos alongside 8 real ones.
+#
+# `.permissions.push` is true only for a member or collaborator, which is exactly
+# the line we want. Repos that fail the lookup (network, deleted, renamed) are
+# kept rather than dropped, so a transient error never silently shrinks the queue.
+if [ -z "$FILTER_REPO" ] && [ "${OPS_MERGE_INCLUDE_EXTERNAL:-0}" != "1" ]; then
+  KEPT=""
+  SKIPPED=""
+  for repo in $REPOS; do
+    PERM=$(gh api "repos/$repo" --jq '.permissions.push' 2>/dev/null || echo "unknown")
+    case "$PERM" in
+      false) SKIPPED="$SKIPPED $repo" ;;
+      *) KEPT="$KEPT $repo" ;;
+    esac
+  done
+  REPOS="$KEPT"
+  [ -n "$SKIPPED" ] && echo "ops-merge: skipping read-only repos (no push access):$SKIPPED" >&2
+fi
+
 # Approved PR author logins (owner + bots). Configured in preferences.json
 # under .merge_authors (array of GitHub logins, e.g. "you", "dependabot[bot]").
 # Empty / missing → keep all authors (legacy behavior).

--- a/claude-ops/skills/ops-merge/SKILL.md
+++ b/claude-ops/skills/ops-merge/SKILL.md
@@ -487,6 +487,7 @@ During this command's execution, invoke the following superpower skills at the s
 
 - **NEVER trust a fixer's claim of merge success.** Always verify via `gh pr view --json state,mergedAt,mergeCommit` before marking complete. See Phase 5 verification protocol.
 - **NEVER let a fixer call `gh pr merge`.** Merge is orchestrator-only. Fixers push, orchestrator verifies the push, orchestrator merges, orchestrator verifies the merge.
+- **NEVER merge, or open a PR against, a repo the owner is not a member of.** `ops-merge-scan` drops repos where `gh api repos/<slug> --jq .permissions.push` is `false`, but verify before acting: the registry lists every locally cloned project, so a fork's upstream (`facebookresearch/*`, someone else's OSS) can appear in the queue carrying dozens of open PRs from unrelated contributors. Those are read-only. Contributing upstream happens only after the owner explicitly says so, one PR at a time, never through this pipeline. Override for a single run with `OPS_MERGE_INCLUDE_EXTERNAL=1` only when the owner asked for it.
 - **NEVER force-push to main/master**
 - **NEVER merge with red CI** — fix root cause first
 - **NEVER bypass review on PRs touching auth, payments, PII, or secrets** — these require `security-reviewer` subagent audit before merge

--- a/claude-ops/skills/ops-merge/SKILL.md
+++ b/claude-ops/skills/ops-merge/SKILL.md
@@ -487,7 +487,18 @@ During this command's execution, invoke the following superpower skills at the s
 
 - **NEVER trust a fixer's claim of merge success.** Always verify via `gh pr view --json state,mergedAt,mergeCommit` before marking complete. See Phase 5 verification protocol.
 - **NEVER let a fixer call `gh pr merge`.** Merge is orchestrator-only. Fixers push, orchestrator verifies the push, orchestrator merges, orchestrator verifies the merge.
-- **NEVER merge, or open a PR against, a repo the owner is not a member of.** `ops-merge-scan` drops repos where `gh api repos/<slug> --jq .permissions.push` is `false`, but verify before acting: the registry lists every locally cloned project, so a fork's upstream (`facebookresearch/*`, someone else's OSS) can appear in the queue carrying dozens of open PRs from unrelated contributors. Those are read-only. Contributing upstream happens only after the owner explicitly says so, one PR at a time, never through this pipeline. Override for a single run with `OPS_MERGE_INCLUDE_EXTERNAL=1` only when the owner asked for it.
+- **NEVER merge, or open a PR against, a repo the owner is not a member of.** The registry lists every locally cloned project, so a fork's upstream (`facebookresearch/*`, someone else's OSS) appears in the queue carrying open PRs from unrelated contributors. Those are read-only. Contributing upstream is a deliberate act the owner asks for, one PR at a time, never a pipeline sweep.
+
+  **Check push access immediately before every `gh pr create`, `gh pr merge`, and `git push` — in every phase (0 salvage, 2 merge, 5 verified-merge, 6 main sync):**
+
+  ```bash
+  PERM=$(gh api "repos/$REPO" --jq '.permissions.push' 2>/dev/null || echo error)
+  [ "$PERM" = "true" ] || { echo "refusing: no confirmed push access to $REPO ($PERM)"; exit 1; }
+  ```
+
+  **Fail closed.** Only a literal `true` proceeds. `false`, `null`, a network error, a renamed repo, or an empty response all refuse. The scan filtering the queue is not sufficient on its own: the queue can be stale, hand-edited, or passed in by an operator, and the step after it is a merge. Re-check at the point of action, not once at the start.
+
+  `OPS_MERGE_INCLUDE_EXTERNAL=<owner/name>` authorises exactly one repo for one run, and only when the owner asked. It is a slug, never a boolean — a global on/off would re-open the whole registry to a pipeline whose next call is `gh pr merge`.
 - **NEVER force-push to main/master**
 - **NEVER merge with red CI** — fix root cause first
 - **NEVER bypass review on PRs touching auth, payments, PII, or secrets** — these require `security-reviewer` subagent audit before merge


### PR DESCRIPTION
## Problem

`ops-merge-scan` builds its repo list from the project registry, which lists every project cloned locally. That includes repos we only ever read — a fork's upstream, an OSS project we filed one issue against.

A scan on 15 Aug returned **65 open PRs. Eight were ours.** The other 57 came from four upstream repos:

| Repo | PRs | Push access |
|---|---|---|
| facebookresearch/tribev2 | 16 | no |
| garrytan/gbrain | 12 | no |
| lharries/whatsapp-mcp | 14 | no |
| paperclipai/paperclip | 15 | no |

Those PRs were written by contributors with no connection to us. A merge queue that lists them is one confirmation away from merging a stranger's branch into a project we do not own.

## Fix

Drop any repo where `gh api repos/<slug> --jq .permissions.push` is `false` — true only for a member or collaborator.

- Repos whose lookup fails are **kept**, so a network blip cannot silently shrink the queue.
- `OPS_MERGE_INCLUDE_EXTERNAL=1` restores the old behaviour for one run.
- `--repo <slug>` still bypasses the filter for a deliberate one-off.
- Skipped repos are named on stderr rather than vanishing.

Verified against the real registry: the four upstreams above are dropped, every owned repo is kept.

## Safety rail

Written into the skill so it survives the next scan change: never merge, and never open a PR against, a repo the owner is not a member of. Contributing upstream is a deliberate act the owner asks for, one PR at a time, not something a merge pipeline does on a sweep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Repository selection now supports bare slugs and `--repo` options.
  - External repositories can be explicitly enabled one at a time.
  - Skipped repositories and scans with no confirmed repositories are reported clearly.

- **Bug Fixes**
  - Invalid repository slugs and unknown options are rejected.
  - Repositories are scanned only after push access is confirmed; lookup failures and unavailable permissions are skipped.

- **Safety**
  - Merges, pushes, and pull request creation are blocked without confirmed push access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->