### PR TITLE
fix(whatsapp): stop assuming the MCP server is named `whatsapp`, fix Fix Q duplicate route

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- fix(whatsapp): `apply-patches.py` Fix Q no longer appends a duplicate `/api/app_state_status` route. The sentinel gated on the comment text, which Fix Y later rewrote to `Fix Q/Y`, so on any tree that had taken Fix Y the check missed and a second `http.HandleFunc` for the same path was added. Go panics at startup on a duplicate pattern, so the bridge died on the next `go build`. The sentinel is now the handler registration itself, which is stable across variants.
+- docs(whatsapp): stop assuming the MCP server is named `whatsapp`. Multi-account installs run one bridge and one server per account (`whatsapp-<label>`) and have no plain `mcp__whatsapp__*`, so every hardcoded reference failed with an unknown tool. Adds CLAUDE.md Rule 8 (resolve the name at runtime, pick the account deliberately, never send from the wrong number, Rule 6 applies to every variant) and points ops-inbox, ops-comms, comms-scanner, and `scripts/whatsapp/ENDPOINTS.md` at it. Also warns that `allowed-tools` entries are exact strings and that host send-gate hook matchers pinned to the literal `mcp__whatsapp__send_message` silently stop firing when an account is renamed or added.
 - Security: replace direct/unattended Claude browser reauthentication with short-lived HMAC-approved, single-use staged enrollment and atomic rollback activation; legacy reauth wrappers now fail closed.
 - ops-accounts-gateway skeleton (:3005 health/auth/grok hop; CLI gateway subcommand)
 - feat(crs-priority-daemon): dual-mode `backend=crs|local` file seat-state without CRS Docker

--- a/claude-ops/CLAUDE.md
+++ b/claude-ops/CLAUDE.md
@@ -165,6 +165,40 @@ That's the bar. If a skill can't compress to that shape, it's too verbose for mo
 - Detect via `[[ -n "$SSH_CONNECTION$SSH_CLIENT$SSH_TTY" || "$OPS_MOBILE" == "1" ]]` and switch to a compact code path.
 - For URL opening, source `lib/opener.sh` and call `ops_open_url` — never call `open`/`xdg-open` directly.
 
+## Rule 8 — Never assume the WhatsApp MCP server is called `whatsapp`
+
+Docs and skills in this plugin write WhatsApp tools as `mcp__whatsapp__list_chats`,
+`mcp__whatsapp__send_message`, and so on. That is the name of a **single-account** install. It is a
+default, not a guarantee.
+
+An install with more than one WhatsApp account runs one bridge and one MCP server per account, each
+registered under its own name. The usual convention is `whatsapp-<label>`, where the label is the
+account (`whatsapp-personal`, `whatsapp-work`, or a country code). On those machines `mcp__whatsapp__*`
+does not exist at all, and a skill that calls it fails with an unknown tool.
+
+**What every skill must do:**
+
+1. **Resolve the name, do not assume it.** Read the available tool list and use whatever matches
+   `mcp__whatsapp*__`. Treat `mcp__whatsapp__*` in this repo as shorthand for "the WhatsApp server that
+   is actually registered here".
+2. **With two or more accounts, pick deliberately.** Each account has its own contacts and its own
+   history, and the stores do not overlap. Choose by where the conversation already lives. If that is
+   unclear, ask the user which account to use. Never guess, and never fall back to the first one.
+3. **Never send from an account the thread is not on.** A reply that arrives from the wrong number is
+   worse than no reply, because the recipient sees a number they do not recognise.
+4. **Rule 6 applies to every variant.** `mcp__whatsapp-work__send_message` needs the same per-message
+   approval as `mcp__whatsapp__send_message`. A different server name is not a different gate.
+
+**For `allowed-tools` frontmatter:** entries are exact tool names, so a skill listing only
+`mcp__whatsapp__list_chats` will not grant `mcp__whatsapp-work__list_chats`. Multi-account users must
+add their own per-account entries. Keep the single-account names in this repo as the default and say so
+in a comment next to them.
+
+**For host-level send gates:** a hook matcher pinned to the literal string `mcp__whatsapp__send_message`
+silently stops firing the moment an account is renamed or added, which turns an approval gate off
+without any error. Match on a pattern such as `mcp__whatsapp[a-z-]*__send_(message|audio_message|file)`
+so every present and future account stays gated.
+
 ## Appendix: CLI Reference (EXACT SYNTAX — never guess)
 
 ### gog (v0.12.0+)

--- a/claude-ops/agents/comms-scanner.md
+++ b/claude-ops/agents/comms-scanner.md
@@ -25,6 +25,10 @@ Run all channel scans in parallel:
 
 ```bash
 # WhatsApp — ALL non-archived chats (not just unread)
+# SERVER NAME: mcp__whatsapp__* is the single-account default. One bridge per account means one
+# server per account (whatsapp-personal, whatsapp-work, ...) and no plain mcp__whatsapp__*.
+# Resolve the real name from the available tools, scan every account, and label each result with
+# the account it came from. Pair each with its own WHATSAPP_BRIDGE_DB below. See CLAUDE.md Rule 8.
 # Step 1: list chats — the response includes last_is_from_me (int 0/1) and last_message_time (RFC3339+TZ string)
 mcp__whatsapp__list_chats sort_by=last_active
 

--- a/claude-ops/scripts/whatsapp/ENDPOINTS.md
+++ b/claude-ops/scripts/whatsapp/ENDPOINTS.md
@@ -74,6 +74,13 @@ There is **no** delete/mark-read/group-admin endpoint. There is no `/api/health`
 Source: `whatsapp-mcp-server/main.py`. Load with
 `ToolSearch select:mcp__whatsapp__list_chats,mcp__whatsapp__list_messages,...` (retry 3× at 5s if both ports are up).
 
+**Server name.** `whatsapp` is the single-account default. Each extra account needs its own bridge (its
+own port and its own `store/`) and its own MCP server entry, named `whatsapp-<label>` by convention.
+Point each entry at its account with `WHATSAPP_BRIDGE_DB`, `WHATSAPP_DEVICE_DB`, and
+`WHATSAPP_API_BASE_URL`; without those the second server silently reads the first account's database.
+The proxy path follows the entry name, so the endpoint is `/servers/<name>/mcp`. Tool names follow it
+too: `mcp__whatsapp-work__list_chats`. See CLAUDE.md Rule 8.
+
 | Tool                                                                                                                        | Backed by                            | Notes                                                                                                       |
 | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
 | `list_chats {sort_by,limit}`                                                                                                | messages.db read                     | chat list + last-message metadata                                                                           |

--- a/claude-ops/scripts/whatsapp/apply-patches.py
+++ b/claude-ops/scripts/whatsapp/apply-patches.py
@@ -2137,7 +2137,14 @@ FIXQ_STATUS_REPLACEMENT = """\t// claude-ops Fix Q: GET /api/app_state_status â€
 \t\t}
 \t}()
 }"""
-FIXQ_STATUS_SENTINEL = "claude-ops Fix Q: GET /api/app_state_status"
+# Gate on the route registration, NOT on the comment above it. Fix Y later rewrote that
+# comment to "claude-ops Fix Q/Y: GET /api/app_state_status", so a comment-based sentinel
+# stopped matching on any tree that had taken Fix Y, and this patch re-appended a second
+# http.HandleFunc for the same path. Go panics at startup on a duplicate pattern
+# ("http: multiple registrations for /api/app_state_status"), so the bridge died on the
+# next `go build`. The handler line is stable across every variant and is exactly the
+# thing that must not appear twice.
+FIXQ_STATUS_SENTINEL = 'http.HandleFunc("/api/app_state_status"'
 
 # Q2: kick the full regular_low sync on Connected and flip readiness when done.
 # Anchors on the closing two lines of the auto-backfill goroutine

--- a/claude-ops/skills/ops-comms/SKILL.md
+++ b/claude-ops/skills/ops-comms/SKILL.md
@@ -68,6 +68,11 @@ If not running: `launchctl kickstart -k gui/$(id -u)/com.${USER}.whatsapp-bridge
 | `mcp__whatsapp__get_chat`            | `{chat_jid}`               | Chat metadata                                                 |
 | `mcp__whatsapp__get_message_context` | `{chat_jid, message_id}`   | Message context window                                        |
 
+`whatsapp` above is the single-account server name. With one bridge per account the servers are named
+`whatsapp-personal`, `whatsapp-work`, and so on, and plain `mcp__whatsapp__*` does not exist. Resolve
+the real name from the available tools first, and send from the account the thread is already on. See
+CLAUDE.md Rule 8.
+
 ### gog CLI (Gmail/Calendar)
 
 | Command                                                                            | Usage                             | Output                |

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -37,6 +37,10 @@ allowed-tools:
   - mcp__claude_ai_Notion__notion-create-comment
   - mcp__claude_ai_Notion__notion-update-page
   - mcp__claude_ai_Notion__notion-create-pages
+  # WhatsApp — these are the SINGLE-ACCOUNT server names (see CLAUDE.md Rule 8).
+  # allowed-tools entries are exact strings, so if you run one bridge per account
+  # (`whatsapp-personal`, `whatsapp-work`, ...) these will NOT grant access to yours.
+  # Add your own per-account entries alongside these, e.g. mcp__whatsapp-work__list_chats.
   - mcp__whatsapp__list_chats
   - mcp__whatsapp__list_messages
   - mcp__whatsapp__search_contacts
@@ -58,6 +62,12 @@ maxTurns: 60
 ## ⚠️ WHATSAPP TRANSPORT — MCP ONLY, NEVER `wacli`
 
 For **all** WhatsApp operations in this skill (list chats, read messages, search contacts, send replies, archive chats), use the `mcp__whatsapp__*` tool family backed by the whatsmeow (Go) whatsapp-bridge — upstream `lharries/whatsapp-mcp`. (Earlier docs misnamed this as "Baileys" — Baileys is the Node.js WhatsApp library; this bridge uses `go.mau.fi/whatsmeow`.)
+
+> **Server name.** `mcp__whatsapp__*` is the single-account default. Installs with more than one account
+> register one server per account (`whatsapp-personal`, `whatsapp-work`, ...) and have no plain
+> `mcp__whatsapp__*` at all. Resolve the real name from the available tools before the first call, and
+> when several accounts exist, scan each one separately and keep the results labelled by account. See
+> CLAUDE.md Rule 8.
 
 **NEVER call the legacy `wacli` CLI** (`wacli chats list`, `wacli messages list`, `wacli send`, `wacli doctor`, `wacli history backfill`, etc). The wacli store and keepalive daemon are deprecated for this skill.
 


### PR DESCRIPTION
Found while restoring a multi-account WhatsApp install. Two separate problems.

## 1. `apply-patches.py` Fix Q appended a duplicate route

The Fix Q idempotency sentinel matched the **comment** above the handler:

```python
FIXQ_STATUS_SENTINEL = "claude-ops Fix Q: GET /api/app_state_status"
```

Fix Y later rewrote that comment to `claude-ops Fix Q/Y: GET /api/app_state_status`. On any tree that had taken Fix Y the sentinel no longer matched, so Fix Q re-ran and appended a second `http.HandleFunc("/api/app_state_status", ...)`.

Go panics at startup on a duplicate pattern:

```
http: multiple registrations for /api/app_state_status
```

So the bridge would die on the next `go build`. It fails at run time, not patch time, which is why it went unnoticed.

The sentinel is now the handler registration itself, which is byte-stable across every variant and is exactly the thing that must not appear twice.

**Verified** against an install that reproduced it: before the fix the patcher mutated `main.go` (+8 lines, duplicate route); after the fix it reports `[skip] Fix Q: GET /api/app_state_status endpoint: already applied` and `main.go` is left byte-identical.

## 2. The plugin assumed the MCP server is named `whatsapp`

`mcp__whatsapp__*` appears in ~100 places. That is the **single-account** name.

An install with more than one account runs one bridge and one MCP server per account, registered as `whatsapp-<label>`. On those machines plain `mcp__whatsapp__*` does not exist, so every one of those references fails with an unknown tool. ops-inbox alone had 62.

Adds **CLAUDE.md Rule 8**:

- resolve the server name from the available tools, do not assume it
- with several accounts, pick by where the thread already lives, and ask if unclear
- never reply from an account the thread is not on, since the recipient sees a number they do not recognise
- Rule 6 per-message approval applies to every variant, not just the bare name

`ops-inbox`, `ops-comms`, `comms-scanner` and `scripts/whatsapp/ENDPOINTS.md` now point at that rule instead of repeating the assumption.

### Two silent-failure traps called out explicitly

**`allowed-tools` entries are exact strings.** A skill listing `mcp__whatsapp__list_chats` does not grant `mcp__whatsapp-work__list_chats`. There is no wildcard precedent anywhere in this repo, so multi-account users must add their own entries. Noted in a comment next to the existing block.

**Host send-gate hook matchers pinned to the literal tool name stop firing.** A `PreToolUse` matcher on `mcp__whatsapp__send_message` silently stops matching the moment an account is renamed or added. That turns an outbound approval gate off with no error, which is the worst way for a gate to fail. Recommends `mcp__whatsapp[a-z-]*__send_(message|audio_message|file)`, which covers present and future accounts and still leaves reads like `list_chats` ungated.

## Scope

Docs plus one sentinel string. No behaviour change for single-account installs; `mcp__whatsapp__*` stays the documented default. `tests/test-no-secrets.sh`: 25 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate WhatsApp status routes that could cause startup failures when applying patches.

* **Documentation**
  * Added guidance for multi-account WhatsApp setups, including account-specific server names, databases, ports, and tool selection.
  * Clarified safeguards for sending messages from the correct account and resolving available tools before use.
  * Updated communications and inbox workflows to scan and label results by account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->