### PR TITLE
release: v3.1.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 62 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-3.1.3-blue)
+![Version](https://img.shields.io/badge/version-3.1.4-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-62-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Business operations command center for Claude Code — 62 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -42,6 +42,12 @@
 - **ops-ecom:** `channels` | `agentic` | `shop` verbs — sales channel inventory, agentic storefront health, Shop Campaigns readiness (read-only; Rule 5 / stage-only spend).
 - **ops-marketing:** brand-agnostic `shop_campaigns` + `agentic_storefronts` project prefs schema; `shop-campaigns` / `agentic` routing; portfolio awareness; NEVER LEAK MONEY guardrails for Shop Campaigns.
 
+## [3.1.4] - 2026-08-15
+
+### Changed
+Fixed: apply-patches.py Fix Q no longer appends a duplicate /api/app_state_status route. The idempotency sentinel matched the comment above the handler, which Fix Y later rewrote, so on any Fix-Y tree the check missed and a second http.HandleFunc for the same path was appended. Go panics at startup on a duplicate pattern, so the bridge died on the next go build. The sentinel is now the handler registration itself. Fixed: the plugin no longer assumes the WhatsApp MCP server is named whatsapp. Multi-account installs run one bridge and one server per account (whatsapp-<label>) and have no plain mcp__whatsapp__*, so every hardcoded reference failed with an unknown tool. Adds CLAUDE.md Rule 8 (resolve the name at runtime, pick the account deliberately, never reply from the wrong number, Rule 6 applies to every variant) and points ops-inbox, ops-comms, comms-scanner and scripts/whatsapp/ENDPOINTS.md at it. Also warns that allowed-tools entries are exact strings and that host send-gate hook matchers pinned to the literal mcp__whatsapp__send_message stop firing silently when an account is renamed or added.
+
+
 ## [3.1.3] - 2026-08-15
 
 ### Changed

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-3.1.3-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.1.4-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 62 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-3.1.3-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.1.4-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-62-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v3.1.4** (was 3.1.2).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

Fixed: apply-patches.py Fix Q no longer appends a duplicate /api/app_state_status route. The idempotency sentinel matched the comment above the handler, which Fix Y later rewrote, so on any Fix-Y tree the check missed and a second http.HandleFunc for the same path was appended. Go panics at startup on a duplicate pattern, so the bridge died on the next go build. The sentinel is now the handler registration itself. Fixed: the plugin no longer assumes the WhatsApp MCP server is named whatsapp. Multi-account installs run one bridge and one server per account (whatsapp-<label>) and have no plain mcp__whatsapp__*, so every hardcoded reference failed with an unknown tool. Adds CLAUDE.md Rule 8 (resolve the name at runtime, pick the account deliberately, never reply from the wrong number, Rule 6 applies to every variant) and points ops-inbox, ops-comms, comms-scanner and scripts/whatsapp/ENDPOINTS.md at it. Also warns that allowed-tools entries are exact strings and that host send-gate hook matchers pinned to the literal mcp__whatsapp__send_message stop firing silently when an account is renamed or added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)