### PR TITLE
fix(ops-inbox): recheck the live thread tail immediately before every send

### DIFF
--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -794,7 +794,14 @@ Only after steps 1–7 come up empty may you draft; only after step 8 is satisfi
 **The call, exactly:**
 
 - **Single-select**, options limited to `[Send]` `[Edit]` `[Skip]` (3 options — well under the Rule-1 cap of 4). Do not add extra options like "Read full thread" or "Archive" to this specific question — the full-thread read is already mandatory *before* the draft is staged (FULL-THREAD AWARENESS GATE + fact-verified redraft gate above), and archive is a separate, subsequent step once the draft is sent or skipped.
-- One draft → full draft printed inline in chat → one `AskUserQuestion` (short `preview`) → one decision (`Send`/`Edit`/`Skip`) → (if `Send`) one send → archive → **then and only then** move to the next draft's own inline text + `AskUserQuestion`.
+- One draft → full draft printed inline in chat → one `AskUserQuestion` (short `preview`) → one decision (`Send`/`Edit`/`Skip`) → (if `Send`) **LIVE TAIL RECHECK** → one send → archive → **then and only then** move to the next draft's own inline text + `AskUserQuestion`.
+
+**LIVE TAIL RECHECK (BLOCKING — immediately before every send, owner 2026-08-15).** Approval is not a license to fire a stale draft. After `Send`/`ok`/`set` and before the actual send tool/API call, re-read the live thread tail on the real channel (WhatsApp store or MCP thread, `gog gmail thread get`, Slack `conversations.history` + every nonzero `reply_count` thread, iMessage `chat_messages`). Check for:
+
+1. **New inbound** after the draft was staged (the ask may have changed or closed).
+2. **Already-sent replies** from this session, another Hermes session, the phone, or any other client (`is_from_me` / `SENT` / Sam's Slack user id).
+
+If either exists: do **not** send. Rebuild or drop the draft. Never double-respond. Never answer a last-message that is no longer last. A scan from earlier in the same run is not current state.
 
 **Forbidden patterns (same spirit as Rule 6's forbidden-output list):**
 


### PR DESCRIPTION
Salvaged from an uncommitted edit sitting in the local marketplace clone (`~/.claude/plugins/marketplaces/ops-marketplace`). That directory is managed by the plugin updater, so this would have been destroyed the next time the cache was pruned. It was blocking a `git pull` there, which is how it surfaced.

## What it does

Approval is not a license to fire a stale draft. Between staging a draft and actually calling the send tool, two things can change:

1. **New inbound arrives** after the draft was staged, so the ask has moved or closed.
2. **A reply already went out** from another session, the phone, or a different client.

Either way the send is wrong, and the double reply is the worse of the two failure modes.

This adds a blocking recheck between the approval and the send call: re-read the live thread tail on the real channel (WhatsApp store or MCP thread, `gog gmail thread get`, Slack `conversations.history` including every nonzero `reply_count` thread, iMessage `chat_messages`) and check for both conditions. If either holds, rebuild or drop the draft instead of sending.

The key line is that a scan from earlier in the same run does not count as current state. That is precisely the gap that lets a stale draft through.

## Scope

One file, 8 insertions. Documentation for the send loop in `ops-inbox`. No code, no behaviour change outside the skill's own instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a mandatory final review of the latest conversation activity before sending approved drafts.
  * Sending is now canceled when new inbound messages or prior replies are detected, preventing outdated or duplicate responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->