### PR TITLE
release: v3.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 62 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "3.1.5",
+      "version": "3.2.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-3.1.5-blue)
+![Version](https://img.shields.io/badge/version-3.2.0-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-62-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "3.1.5",
+  "version": "3.2.0",
   "description": "Business operations command center for Claude Code — 62 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -42,6 +42,27 @@
 - **ops-ecom:** `channels` | `agentic` | `shop` verbs — sales channel inventory, agentic storefront health, Shop Campaigns readiness (read-only; Rule 5 / stage-only spend).
 - **ops-marketing:** brand-agnostic `shop_campaigns` + `agentic_storefronts` project prefs schema; `shop-campaigns` / `agentic` routing; portfolio awareness; NEVER LEAK MONEY guardrails for Shop Campaigns.
 
+## [3.2.0] - 2026-08-15
+
+### Added
+- `ops-inbox-archive-set`: turns a scan into explicit ARCHIVE and KEEP lists instead of leaving the call to eye judgement. Report-only by default, archives nothing without `--apply`, never sends. Mail carrying a todo/action label can't be swept, and anything ambiguous resolves to KEEP.
+- Test suite for the archive split, label guardrail, report-only default, dry-run apply and stale window, run entirely against a fixture so tests can't touch a real inbox.
+- Per-channel archive documentation: email archiving needs thread ids, multi-account WhatsApp installs must resolve the real per-account server name first, and iMessage, Slack and Telegram have no archive at all.
+
+### Changed
+- The scan working set per channel is now "not archived" rather than unread or a recent slice. Email scans all of `in:inbox` up to 400 results; Slack stays unread-and-unreplied because it has no archive.
+- `--days` now only sizes the WhatsApp send-log lookback. Use `--email-query` / `--email-max` to narrow the mail set on purpose.
+- Reply and archive are a single step: send, verify the reply landed on the channel, then archive. An unverified send leaves the thread open.
+- Archive and mark-read no longer sit behind the outbound approval gate. They change local state only and undo cleanly; real external sends stay gated.
+- FYI is a review list, not sweep material. It gets read and summarized, anything money, contract, legal, security or deadline related is promoted out of it, and mass-archiving is only offered after that.
+
+### Fixed
+- The email scan searched a 7-day, 30-result window, so anything older or further down silently stopped being reported as needing a reply.
+- Removed exponential backtracking in the courtesy-reply matcher (CodeQL high severity). Message bodies come straight off WhatsApp, so a crafted message could hang an entire scan.
+- Undescribed media such as a bare `[image]` was read as an empty message and archived as a closing courtesy. Unenriched media now always keeps the thread.
+- A positional `scan` argument overwrote `--scan`, making the tool ignore the scan file it was given and re-scan live.
+
+
 ## [3.1.5] - 2026-08-15
 
 ### Changed

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-3.1.5-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.2.0-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 62 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-3.1.5-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.2.0-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-62-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "3.1.5",
+  "version": "3.2.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v3.2.0** (was 3.1.5).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

### Added
- `ops-inbox-archive-set`: turns a scan into explicit ARCHIVE and KEEP lists instead of leaving the call to eye judgement. Report-only by default, archives nothing without `--apply`, never sends. Mail carrying a todo/action label can't be swept, and anything ambiguous resolves to KEEP.
- Test suite for the archive split, label guardrail, report-only default, dry-run apply and stale window, run entirely against a fixture so tests can't touch a real inbox.
- Per-channel archive documentation: email archiving needs thread ids, multi-account WhatsApp installs must resolve the real per-account server name first, and iMessage, Slack and Telegram have no archive at all.

### Changed
- The scan working set per channel is now "not archived" rather than unread or a recent slice. Email scans all of `in:inbox` up to 400 results; Slack stays unread-and-unreplied because it has no archive.
- `--days` now only sizes the WhatsApp send-log lookback. Use `--email-query` / `--email-max` to narrow the mail set on purpose.
- Reply and archive are a single step: send, verify the reply landed on the channel, then archive. An unverified send leaves the thread open.
- Archive and mark-read no longer sit behind the outbound approval gate. They change local state only and undo cleanly; real external sends stay gated.
- FYI is a review list, not sweep material. It gets read and summarized, anything money, contract, legal, security or deadline related is promoted out of it, and mass-archiving is only offered after that.

### Fixed
- The email scan searched a 7-day, 30-result window, so anything older or further down silently stopped being reported as needing a reply.
- Removed exponential backtracking in the courtesy-reply matcher (CodeQL high severity). Message bodies come straight off WhatsApp, so a crafted message could hang an entire scan.
- Undescribed media such as a bare `[image]` was read as an empty message and archived as a closing courtesy. Unenriched media now always keeps the thread.
- A positional `scan` argument overwrote `--scan`, making the tool ignore the scan file it was given and re-scan live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)