### PR TITLE
release: v3.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 62 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-3.3.0-blue)
+![Version](https://img.shields.io/badge/version-3.3.1-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-62-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Business operations command center for Claude Code — 62 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -42,6 +42,17 @@
 - **ops-ecom:** `channels` | `agentic` | `shop` verbs — sales channel inventory, agentic storefront health, Shop Campaigns readiness (read-only; Rule 5 / stage-only spend).
 - **ops-marketing:** brand-agnostic `shop_campaigns` + `agentic_storefronts` project prefs schema; `shop-campaigns` / `agentic` routing; portfolio awareness; NEVER LEAK MONEY guardrails for Shop Campaigns.
 
+## [3.3.1] - 2026-08-15
+
+### Changed
+
+- The outbound guard now refuses to send from a Gmail send-as alias whose SMTP relay is broken. Such a send fails silently: Gmail stamps the message SENT and drops the delivery failure into Trash, so the sender believes it arrived and the recipient never gets it. The check runs ahead of every path that would otherwise allow the send, including a held approval and the approved-recipient bypass, because a broken relay bounces the mail whoever it was addressed to.
+- When a service account can impersonate the alias, the block message names the command that works. Sending as the mailbox over the API skips the send-as relay entirely and needs no app password, so a "broken" alias is often already reachable.
+- New `refresh_broken_aliases.py` builds the alias list from Gmail's own bounce threads, reading the failed alias off the SENT message's `From` header rather than matching addresses in the bounce body. `--clear <address>` drops an alias after a repair, and an absent or empty list blocks nothing.
+- New `gog-sa-token` mints a narrow-scope impersonated token. `gog` requests its whole scope bundle in one call, so a Workspace that delegated only `gmail.send` and `gmail.readonly` refuses the entire request, and a mailbox that can in fact send looks unreachable.
+- New `tests/outbound-guard/test-broken-alias.py` covers the alias path against a throwaway `HOME`, and clears the shared approval store afterwards so the other guard suites stay order-independent.
+
+
 ## [3.3.0] - 2026-08-15
 
 ### Added

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-3.3.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.3.1-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 62 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-3.3.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.3.1-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-62-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",


### PR DESCRIPTION
Release **v3.3.1** (was 3.1.5).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated


- The outbound guard now refuses to send from a Gmail send-as alias whose SMTP relay is broken. Such a send fails silently: Gmail stamps the message SENT and drops the delivery failure into Trash, so the sender believes it arrived and the recipient never gets it. The check runs ahead of every path that would otherwise allow the send, including a held approval and the approved-recipient bypass, because a broken relay bounces the mail whoever it was addressed to.
- When a service account can impersonate the alias, the block message names the command that works. Sending as the mailbox over the API skips the send-as relay entirely and needs no app password, so a "broken" alias is often already reachable.
- New `refresh_broken_aliases.py` builds the alias list from Gmail's own bounce threads, reading the failed alias off the SENT message's `From` header rather than matching addresses in the bounce body. `--clear <address>` drops an alias after a repair, and an absent or empty list blocks nothing.
- New `gog-sa-token` mints a narrow-scope impersonated token. `gog` requests its whole scope bundle in one call, so a Workspace that delegated only `gmail.send` and `gmail.readonly` refuses the entire request, and a mailbox that can in fact send looks unreachable.
- New `tests/outbound-guard/test-broken-alias.py` covers the alias path against a throwaway `HOME`, and clears the shared approval store afterwards so the other guard suites stay order-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)