### PR TITLE
ops-release: survive an unreachable git transport, and fix the badge regex

### DIFF
--- a/claude-ops/bin/ops-release
+++ b/claude-ops/bin/ops-release
@@ -100,6 +100,35 @@ raise SystemExit(result.returncode)
 PY
 }
 
+# GitHub REST call that survives a dead IP stack. Some networks route to
+# github.com over only one of IPv4/IPv6, so try the default first and retry
+# pinned to the other family before giving up.
+gh_api() {
+  local method="$1" path="$2" data="${3:-}"
+  local url="https://api.github.com/repos/${GH_REPO}${path}"
+  local token; token="$(gh auth token 2>/dev/null)" || return 1
+  [ -n "$token" ] || return 1
+  local args=(-fsS -m 30 -X "$method"
+    -H "Authorization: bearer $token"
+    -H "Accept: application/vnd.github+json")
+  [ -n "$data" ] && args+=(-d "$data")
+  curl "${args[@]}" "$url" 2>/dev/null && return 0
+  curl -6 "${args[@]}" "$url" 2>/dev/null && return 0
+  curl -4 "${args[@]}" "$url" 2>/dev/null
+}
+
+# Fallback for `git push origin vX.Y.Z` when the git transport cannot reach
+# GitHub (ssh.github.com timing out on a half-dead route). Creates the annotated
+# tag object, then the ref, over the REST API.
+push_tag_via_api() {
+  local ver="$1" commit="$2" tag_sha
+  tag_sha="$(gh_api POST /git/tags "$(jq -n --arg t "v$ver" --arg m "claude-ops v$ver" --arg o "$commit" \
+    '{tag:$t, message:$m, object:$o, type:"commit"}')" | jq -r '.sha // empty')" || return 1
+  [ -n "$tag_sha" ] || return 1
+  gh_api POST /git/refs "$(jq -n --arg r "refs/tags/v$ver" --arg s "$tag_sha" \
+    '{ref:$r, sha:$s}')" | jq -e '.ref' >/dev/null
+}
+
 wait_for_release_ci() {
   local pr_url="$1"
   local expected_head="$2"
@@ -301,10 +330,29 @@ if [ "$do_merge" -eq 1 ]; then
   gh pr merge "$PR_URL" --repo "$GH_REPO" --squash --delete-branch --match-head-commit "$stable_head"
   echo "ops-release: merged v$NEW to main"
   if [ "$do_tag" -eq 1 ]; then
-    git -C "$REPO_ROOT" fetch origin --quiet
-    git -C "$REPO_ROOT" tag -a "v$NEW" -m "claude-ops v$NEW" origin/main 2>/dev/null || git -C "$REPO_ROOT" tag "v$NEW" origin/main
-    git -C "$REPO_ROOT" push origin "v$NEW"
-    echo "ops-release: tagged v$NEW"
+    # The merge is already done, so a tag failure must never abort the run and
+    # leave main released but untagged. Resolve the commit from the API when the
+    # git transport is unreachable, and push the tag the same way if needed.
+    tag_commit=""
+    if git -C "$REPO_ROOT" fetch origin --quiet 2>/dev/null; then
+      tag_commit="$(git -C "$REPO_ROOT" rev-parse origin/main)"
+    else
+      echo "ops-release: git fetch failed — resolving main over the API"
+      tag_commit="$(gh_api GET /commits/main | jq -r '.sha // empty')"
+    fi
+    if [ -z "$tag_commit" ]; then
+      echo "ops-release: could not resolve main's commit — v$NEW is NOT tagged. Tag it manually." >&2
+    else
+      git -C "$REPO_ROOT" tag -a "v$NEW" -m "claude-ops v$NEW" "$tag_commit" 2>/dev/null \
+        || git -C "$REPO_ROOT" tag "v$NEW" "$tag_commit" 2>/dev/null || true
+      if git -C "$REPO_ROOT" push origin "v$NEW" 2>/dev/null; then
+        echo "ops-release: tagged v$NEW"
+      elif push_tag_via_api "$NEW" "$tag_commit"; then
+        echo "ops-release: tagged v$NEW (pushed over the API — git transport unreachable)"
+      else
+        echo "ops-release: TAG PUSH FAILED — v$NEW is merged to main but NOT tagged. Create refs/tags/v$NEW manually." >&2
+      fi
+    fi
   fi
 
   # ----- wiki: keep the GitHub wiki's counts/version in lockstep + log the release -----
@@ -320,8 +368,8 @@ if [ "$do_merge" -eq 1 ]; then
           -e "s/[0-9]+ skills, [0-9]+ agents/${SK} skills, ${AG} agents/g" \
           -e "s/([Aa]ll )[0-9]+ skills/\1${SK} skills/g" \
           -e "s/([Aa]ll )[0-9]+ agents/\1${AG} agents/g" \
-          -e "s#(badge/skills-)[0-9]+-#\1${SK}-#g" \
-          -e "s#(badge/agents-)[0-9]+-#\1${AG}-#g" \
+          -e "s#(badge/skills-)[0-9]+(%2B|\+)?-#\1${SK}-#g" \
+          -e "s#(badge/agents-)[0-9]+(%2B|\+)?-#\1${AG}-#g" \
           -e "s#(badge/version-)[0-9][0-9.]*-#\1${NEW}-#g" "$page" 2>/dev/null || true
         rm -f "$page.bak"
       done

--- a/claude-ops/bin/ops-sync-docs
+++ b/claude-ops/bin/ops-sync-docs
@@ -58,8 +58,10 @@ apply() {  # apply <file> <sed -e expr ...>
 }
 
 COUNT_E=(-e "s/[0-9]+ skills, [0-9]+ agents/${S} skills, ${A} agents/g")
-BADGE_E=(-e "s#(badge/skills-)[0-9]+-#\1${S}-#g"
-         -e "s#(badge/agents-)[0-9]+-#\1${A}-#g"
+# The count may carry a URL-encoded "+" suffix (skills-33%2B-success). Match it
+# so those badges are not skipped, and drop it — the count is exact, not a floor.
+BADGE_E=(-e "s#(badge/skills-)[0-9]+(%2B|\+)?-#\1${S}-#g"
+         -e "s#(badge/agents-)[0-9]+(%2B|\+)?-#\1${A}-#g"
          -e "s#(badge/version-)[0-9][0-9.]*-#\1${V}-#g")
 HEAD_E=(-e "s/([Aa]ll )[0-9]+ skills/\1${S} skills/g"
         -e "s/([Aa]ll )[0-9]+ agents/\1${A} agents/g")


### PR DESCRIPTION
Two defects the v3.4.0 release exposed.

## Tag step aborted the run after the merge

`git push origin vX.Y.Z` failed with `ssh: connect to host ssh.github.com port 443: Operation timed out`. The script exited there, leaving main released but untagged — and since the release PR had already squash-merged, re-running was not an option. `GIT_SSH_COMMAND="ssh -6"` did not help either; the route is half-dead rather than down.

By the time the tag runs, the irreversible step is already behind us, so a tag failure must never abort:

- `git fetch` failing no longer takes the run down — main's commit is resolved over the REST API instead.
- A failed `git push` falls back to creating the annotated tag object and the ref over the API (`POST /git/tags` then `POST /git/refs`). These are the exact two calls used to tag v3.4.0 by hand after the failure.
- If both paths fail it says so loudly, naming the ref to create, rather than exiting silently mid-release.
- `gh_api` retries pinned to the other IP family, so a host with one dead stack still works.

## Badge regex skipped any count with a "+" suffix

`(badge/skills-)[0-9]+-` requires a `-` immediately after the digits. The wiki's badge is `skills-33%2B-success` — `%` follows the digits, so it never matched and sat frozen at 33 while the tree grew to 63. Now matches an optional `%2B`/`+` and drops it, since the count is exact rather than a floor. Fixed in both `bin/ops-sync-docs` and the copy of the same sed inside `bin/ops-release`'s wiki step.

## Verification

- `bash -n` clean on both scripts.
- Regex checked against all four real badge forms (`33%2B`, `63`, `18`, `21%2B`) — rewrites the stale ones, idempotent on the correct ones.
- `gh_api GET /commits/main` resolves `7c45075` live on the currently-flaky route.
- `ops-sync-docs --dry-run` reports the tree already in sync, so no unintended churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)