### PR TITLE
ops-release: a failed CI query no longer strands the release PR

### DIFF
--- a/claude-ops/bin/ops-release
+++ b/claude-ops/bin/ops-release
@@ -129,12 +129,51 @@ push_tag_via_api() {
     '{ref:$r, sha:$s}')" | jq -e '.ref' >/dev/null
 }
 
+# The release PR's head SHA. `gh` speaks only to whichever IP family it picks,
+# so fall back to the REST helper, which retries pinned to the other one.
+pr_head_sha() {
+  local pr_ref="$1" timeout="$2" sha
+  sha="$(run_bounded "$timeout" gh pr view "$pr_ref" --repo "$GH_REPO" --json headRefOid --jq .headRefOid 2>/dev/null)" || sha=""
+  if [ -z "$sha" ]; then
+    sha="$(gh_api GET "/pulls/${pr_ref##*/}" | jq -r '.head.sha // empty')" || sha=""
+  fi
+  [ -n "$sha" ] || return 1
+  printf '%s\n' "$sha"
+}
+
+# CI checks in gh's {name,bucket} shape. The REST fallback merges check-runs with
+# classic commit statuses, so a pending legacy status still blocks the merge.
+pr_checks_json() {
+  local pr_ref="$1" sha="$2" timeout="$3" out rc runs statuses
+  set +e
+  out="$(run_bounded "$timeout" gh pr checks "$pr_ref" --repo "$GH_REPO" --json name,state,bucket 2>/dev/null)"
+  rc=$?
+  set -e
+  if { [ "$rc" -eq 0 ] || [ "$rc" -eq 8 ]; } && jq -e 'type == "array"' <<<"$out" >/dev/null 2>&1; then
+    printf '%s\n' "$out"
+    return 0
+  fi
+  runs="$(gh_api GET "/commits/$sha/check-runs?per_page=100")" || return 1
+  statuses="$(gh_api GET "/commits/$sha/status")" || statuses='{"statuses":[]}'
+  jq -n --argjson r "$runs" --argjson s "$statuses" '
+    [ $r.check_runs[]? | {name, bucket:
+        (if .status != "completed" then "pending"
+         elif .conclusion == "success" then "pass"
+         elif .conclusion == "skipped" or .conclusion == "neutral" then "skipping"
+         elif .conclusion == "cancelled" then "cancel"
+         else "fail" end)} ]
+    + [ $s.statuses[]? | {name: .context, bucket:
+        (if .state == "pending" then "pending"
+         elif .state == "success" then "pass"
+         else "fail" end)} ]'
+}
+
 wait_for_release_ci() {
   local pr_url="$1"
   local expected_head="$2"
   local stable_head_file="$3"
   local deadline=$((SECONDS + 900))
-  local checks_json current_head confirmed_head required_seen all_finished request_timeout rc sleep_for
+  local checks_json current_head confirmed_head required_seen all_finished request_timeout sleep_for
   local required_checks='["lint-and-check (ubuntu-latest)","lint-and-check (ubuntu-24.04)","pii-gate","test-suite (ubuntu-latest)","test-suite (ubuntu-24.04)","CodeQL"]'
 
   # Give GitHub Actions time to register the release branch checks.
@@ -143,26 +182,28 @@ wait_for_release_ci() {
     request_timeout=$((deadline - SECONDS))
     ((request_timeout > 25)) && request_timeout=25
 
-    current_head="$(run_bounded "$request_timeout" gh pr view "$pr_url" --repo "$GH_REPO" --json headRefOid --jq .headRefOid)" || {
-      echo "ops-release: unable to query release PR head" >&2
-      return 1
-    }
+    # A query that fails is transient until the deadline says otherwise. Failing
+    # the whole run on one bad request strands an open release PR behind a merge
+    # that never happens.
+    if ! current_head="$(pr_head_sha "$pr_url" "$request_timeout")"; then
+      echo "ops-release: PR head query failed — retrying until the CI deadline" >&2
+      sleep_for=$((deadline - SECONDS))
+      ((sleep_for > 30)) && sleep_for=30
+      ((sleep_for > 0)) && sleep "$sleep_for"
+      continue
+    fi
     if [ "$current_head" != "$expected_head" ]; then
       echo "ops-release: release PR head changed; restarting CI wait for $current_head"
       expected_head="$current_head"
     fi
 
-    set +e
-    checks_json="$(run_bounded "$request_timeout" gh pr checks "$pr_url" --repo "$GH_REPO" --json name,state,bucket)"
-    rc=$?
-    set -e
-    if [ "$rc" -ne 0 ] && [ "$rc" -ne 8 ]; then
-      echo "ops-release: unable to query CI checks" >&2
-      return 1
-    fi
-    if ! jq -e 'type == "array"' <<<"$checks_json" >/dev/null; then
-      echo "ops-release: CI query returned invalid data" >&2
-      return 1
+    if ! checks_json="$(pr_checks_json "$pr_url" "$expected_head" "$request_timeout")" \
+       || ! jq -e 'type == "array"' <<<"$checks_json" >/dev/null 2>&1; then
+      echo "ops-release: CI check query failed — retrying until the CI deadline" >&2
+      sleep_for=$((deadline - SECONDS))
+      ((sleep_for > 30)) && sleep_for=30
+      ((sleep_for > 0)) && sleep "$sleep_for"
+      continue
     fi
     if jq -e 'any(.[]; .bucket == "fail" or .bucket == "cancel")' <<<"$checks_json" >/dev/null; then
       echo "ops-release: CI failed; release PR left open: $pr_url" >&2
@@ -172,10 +213,13 @@ wait_for_release_ci() {
     required_seen="$(jq -r --argjson required "$required_checks" '(($required - [.[].name]) | length) == 0' <<<"$checks_json")"
     all_finished="$(jq -r 'length > 0 and all(.[]; .bucket == "pass" or .bucket == "skipping")' <<<"$checks_json")"
     if [ "$required_seen" = true ] && [ "$all_finished" = true ]; then
-      confirmed_head="$(run_bounded "$request_timeout" gh pr view "$pr_url" --repo "$GH_REPO" --json headRefOid --jq .headRefOid)" || {
-        echo "ops-release: unable to recheck release PR head" >&2
-        return 1
-      }
+      if ! confirmed_head="$(pr_head_sha "$pr_url" "$request_timeout")"; then
+        echo "ops-release: PR head recheck failed — retrying until the CI deadline" >&2
+        sleep_for=$((deadline - SECONDS))
+        ((sleep_for > 30)) && sleep_for=30
+        ((sleep_for > 0)) && sleep "$sleep_for"
+        continue
+      fi
       if [ "$confirmed_head" = "$expected_head" ]; then
         printf '%s\n' "$expected_head" >"$stable_head_file"
         return 0


### PR DESCRIPTION
## What happened

The v3.4.1 release opened PR #818 and then exited:

```
ops-release: opened https://github.com/Lifecycle-Innovations-Limited/claude-ops/pull/818
ops-release: waiting for CI before merge…
ops-release: unable to query release PR head
```

`gh` could not reach api.github.com on a half-dead route. The PR sat open, unmerged and untagged, and the merge / tag / wiki steps never ran — the release had to be finished by hand.

This is the same class of failure as #817, on a code path that fix did not cover. #817 hardened the tag step; the CI wait was still fail-fast.

## Fix

Every query in `wait_for_release_ci` returned 1 on a single bad request and took the release with it. The wait already has a 15-minute deadline, which is the right place to give up — so a failed request is now transient until that deadline says otherwise.

- `pr_head_sha` — `gh pr view`, falling back to `gh_api GET /pulls/<n>` (retries pinned to the other IP family).
- `pr_checks_json` — `gh pr checks`, falling back to `/commits/<sha>/check-runs` **merged with** `/commits/<sha>/status`, so a pending classic commit status still blocks the merge. Emits gh's own `{name,bucket}` shape, so the required-checks gate and the fail/cancel detection are unchanged.
- A query that still fails sleeps and retries rather than returning 1.

The merge gate itself is untouched: same six required checks, same "all finished", same head-stability recheck before merging.

## Verification

- `bash -n` clean, `shellcheck -S warning` clean.
- Exercised against PR #818 with `gh` forced to fail on every call: resolved the head SHA correctly, returned all 16 checks in the right shape, and `required_seen` / `all_finished` both evaluated true — the gate would have fired.
- `tests/run-all.sh` passes in CI on this commit (test-suite on ubuntu-latest and ubuntu-24.04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)