### PR TITLE
Fix the rm -rf guard, which blocked nothing on stock macOS

### DIFF
--- a/claude-ops/bin/ops-no-rm-rf-anchor
+++ b/claude-ops/bin/ops-no-rm-rf-anchor
@@ -83,24 +83,35 @@ DANGER=$(set -f; while IFS= read -r seg; do
   rest=$(echo "$seg" | sed -E 's/^.*[[:space:]]?rm([[:space:]]+|$)//')
   # Tokenize on spaces (best-effort — won't perfectly handle quoted-with-spaces but covers the patterns specified).
   for tok in $rest; do
+    # NOTE: no `case` inside this block. This whole loop runs inside a
+    # DANGER=$( ... ) command substitution, and under bash 3.2 a case pattern's
+    # unbalanced `)` closes that substitution early. The file then fails to
+    # parse, the hook emits nothing, and a missing deny reads as allow — so the
+    # guard silently stopped blocking anything. bash 3.2 is Apple's /bin/bash,
+    # so that was every stock macOS install. Keep these as plain string tests.
+
     # Skip flags.
-    case "$tok" in
-      -*) continue ;;
-    esac
+    if [ "${tok#-}" != "$tok" ]; then
+      continue
+    fi
     # Strip surrounding quotes for comparison.
     bare="${tok%\"}"; bare="${bare#\"}"
     bare="${bare%\'}"; bare="${bare#\'}"
 
-    case "$bare" in
-      "" | "/" | "/*" | "/." | \
-      "~" | "~/" | "~/*" | \
-      '$HOME' | '$HOME/' | '$HOME/*' | \
-      ".." | "../" | "../*" | \
-      ".")
-        DANGER="$bare"
+    # Literal anchors, matching the original quoted case patterns exactly:
+    # a quoted pattern in `case` is literal, so "/*" meant the two characters
+    # `/` and `*`, never a glob over everything under root.
+    is_danger=0
+    for anchor in '' '/' '/*' '/.' '~' '~/' '~/*' '$HOME' '$HOME/' '$HOME/*' '..' '../' '../*' '.'; do
+      if [ "$bare" = "$anchor" ]; then
+        is_danger=1
         break
-        ;;
-    esac
+      fi
+    done
+    if [ "$is_danger" -eq 1 ]; then
+      DANGER="$bare"
+      break
+    fi
     # Also catch quoted $HOME variants where the shell hasn't expanded them.
     if [[ "$tok" == '"$HOME"' || "$tok" == '"$HOME"/' || "$tok" == '"$HOME"/*' ]]; then
       DANGER="$tok"; break


### PR DESCRIPTION
`bin/ops-no-rm-rf-anchor` has not been blocking anything on stock macOS. It fails
to parse under bash 3.2, and a PreToolUse hook that cannot parse emits no deny
decision — which reads as allow. `rm -rf /` went straight through.

bash 3.2 is Apple's `/bin/bash`. The shebang is `#!/usr/bin/env bash`, so the
guard works on machines that have a newer bash earlier in PATH (homebrew) and
silently does nothing on those that don't. That is why it survived review.

## Proof, before the fix

```
$ /bin/bash --version
GNU bash, version 3.2.57(1)-release

$ TOOL_INPUT='{"command":"rm -rf /"}' /bin/bash claude-ops/bin/ops-no-rm-rf-anchor
ops-no-rm-rf-anchor: line 88: syntax error near unexpected token `;;'
# exit 0, no output  ->  no deny  ->  ALLOWED

$ TOOL_INPUT='{"command":"rm -rf /"}' /opt/homebrew/bin/bash claude-ops/bin/ops-no-rm-rf-anchor
{"hookSpecificOutput": {... "permissionDecision": "deny" ...}}
```

## Cause

The target-scanning loop runs inside `DANGER=$( ... )`. Under bash 3.2 a `case`
pattern's unbalanced `)` closes that command substitution early, so the file
stops parsing at the first `;;`. The reported line 88 is where it surfaces, not
where it originates — bisecting shows the last clean prefix is line 61, the line
that opens the substitution.

## Fix

No `case` inside that substitution. Flag-skipping becomes a prefix test, and the
anchor list becomes a loop of plain string comparisons.

Behaviour is unchanged, including the subtle part: the original patterns were
quoted, and a quoted pattern in `case` is literal. `"/*"` always meant the two
characters `/` and `*`, never a glob over everything under root. The replacement
compares the same literals, so no target changes classification.

## Verification

Both shells, executing no `rm` — the guard only evaluates a payload string.

| check | bash 3.2.57 | bash 5.3.15 |
|---|---|---|
| file parses | yes | yes |
| `rm -rf /` | deny | deny |
| `rm -rf ~` | deny | deny |
| `rm -rf $HOME` | deny | deny |
| `rm -rf ..` / `.` | deny | deny |
| `sudo rm -rf /` | deny | deny |
| `rm -fr /` (reversed flags) | deny | deny |
| `rm -rf ./node_modules` | allow | allow |
| `rm -rf /tmp/foo` | allow | allow |
| `ls -la /` | allow | allow |
| `rm -r /` (no `-f`) | allow | allow |

22/22, no false positives on legitimate deletes.

Repo suites:
- `tests/test-safety-hooks.sh` — **49 passed, 0 failed**. On `origin/main` the
  same suite gives **26 passed, 23 failed**, so this closes a pre-existing
  baseline failure rather than hiding one.
- `tests/test-no-secrets.sh` — 27 passed, 0 failed.

One file changed, no behaviour flags, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for dangerous-command detection on older Bash versions.
  * Preserved existing flag handling, quote processing, anchor detection, and blocking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->