### PR TITLE
fix(ops-speedup): stop reporting a perfect score from no data on bash 3.2

### DIFF
--- a/claude-ops/bin/ops-speedup
+++ b/claude-ops/bin/ops-speedup
@@ -459,37 +459,37 @@ run_parallel_scan() {
   # Load disk vars — key must be alphanumeric+underscore to prevent injection
   while IFS='=' read -r k v; do
     [[ "$k" =~ ^[a-zA-Z0-9_]+$ ]] || continue
-    declare -g "DISK_${k}=${v}"
+    eval "DISK_${k}=\$v"
   done < "$tmp/disk" 2>/dev/null || true
 
   # Load memory vars
   while IFS='=' read -r k v; do
     [[ "$k" =~ ^[a-zA-Z0-9_]+$ ]] || continue
-    declare -g "MEM_${k}=${v}"
+    eval "MEM_${k}=\$v"
   done < "$tmp/mem" 2>/dev/null || true
 
   # Load network vars
   while IFS='=' read -r k v; do
     [[ "$k" =~ ^[a-zA-Z0-9_]+$ ]] || continue
-    declare -g "NET_${k}=${v}"
+    eval "NET_${k}=\$v"
   done < "$tmp/net" 2>/dev/null || true
 
   # Load startup vars
   while IFS='=' read -r k v; do
     [[ "$k" =~ ^[a-zA-Z0-9_]+$ ]] || continue
-    declare -g "STARTUP_${k}=${v}"
+    eval "STARTUP_${k}=\$v"
   done < "$tmp/startup" 2>/dev/null || true
 
   # Load runtime vars
   while IFS='=' read -r k v; do
     [[ "$k" =~ ^[a-zA-Z0-9_]+$ ]] || continue
-    declare -g "RUNTIME_${k}=${v}"
+    eval "RUNTIME_${k}=\$v"
   done < "$tmp/runtime" 2>/dev/null || true
 
   # Load GPU vars
   while IFS='=' read -r k v; do
     [[ "$k" =~ ^[a-zA-Z0-9_]+$ ]] || continue
-    declare -g "GPU_${k}=${v}"
+    eval "GPU_${k}=\$v"
   done < "$tmp/gpu" 2>/dev/null || true
 
   # Persist scan data; update file vars to the persistent copy so action

--- a/claude-ops/tests/test-ops-speedup.sh
+++ b/claude-ops/tests/test-ops-speedup.sh
@@ -95,6 +95,42 @@ print("json-contract-ok")
 PY
 )"
 
+# Portability: macOS ships bash 3.2 as /bin/bash, and `#!/usr/bin/env bash`
+# resolves to it whenever /usr/bin precedes a newer bash on PATH — which is the
+# default for login shells, launchd, and cron. `declare -g` does not exist in
+# 3.2, so using it to publish probe results silently left every RUNTIME_/MEM_/
+# NET_/DISK_/STARTUP_/GPU_ variable unset and scored a perfect 100 from no data.
+# Keep the assignments portable; the loops below redirect stderr, so a 4-only
+# builtin fails invisibly rather than erroring out.
+assert_true "no bash-4-only declare -g" bash -c "! grep -q 'declare -g' '$BIN'"
+
+# The probe read-back must actually populate globals. Process count is the
+# cheapest environment-independent witness: any live host has processes, so a
+# zero here means the probe variables never made it back into scope.
+assert_eq "probe vars reach global scope" "populated" "$(python3 - "$json_out" <<'PY'
+import json, sys
+data = json.loads(sys.argv[1])
+procs = int(data["runtime"].get("processes") or 0)
+print("populated" if procs > 0 else f"empty:processes={procs}")
+PY
+)"
+
+# Run the same contract under the host's /bin/bash when that is a 3.x build.
+# Without this the suite only ever exercises the newer bash on PATH and cannot
+# catch a 4-only builtin regressing the macOS default interpreter.
+legacy_bash_version=$(/bin/bash -c 'echo "${BASH_VERSINFO[0]}"' 2>/dev/null || echo "")
+if [ "$legacy_bash_version" = "3" ]; then
+  assert_eq "populates probe vars under /bin/bash 3.x" "populated" "$(python3 - "$(/bin/bash "$BIN" --json)" <<'PY'
+import json, sys
+data = json.loads(sys.argv[1])
+procs = int(data["runtime"].get("processes") or 0)
+print("populated" if procs > 0 else f"empty:processes={procs}")
+PY
+)"
+else
+  pass "populates probe vars under /bin/bash 3.x (skipped: /bin/bash is ${legacy_bash_version:-unknown}.x)"
+fi
+
 # Score contract: disk reclaimable size must not lower health, and launch-agent
 # count must not either. Inject a synthetic runtime that is healthy except for
 # large reclaimable numbers and many launch agents.


### PR DESCRIPTION
## What was wrong

`run_parallel_scan` published every probe result with `declare -g`, a builtin that does not exist in bash 3.2. macOS ships 3.2 as `/bin/bash`, and the `#!/usr/bin/env bash` shebang resolves to it whenever `/usr/bin` precedes a newer bash on `PATH` — the default for login shells, launchd, and cron.

The read-back loops end with `done < "$tmp/runtime" 2>/dev/null || true`. That redirect swallowed `declare: -g: invalid option` on every line, so the failure was completely silent and each `RUNTIME_` / `MEM_` / `NET_` / `DISK_` / `STARTUP_` / `GPU_` variable stayed unset.

The health model reads those variables with empty defaults. Absent data applied no penalties, so the score defaulted to 100. **Every scan on a stock macOS host reported perfect health regardless of the machine's real state**, which also silently neuters any scheduled monitoring built on it.

Same binary, same moment, only the interpreter changed:

| interpreter | score | cpu_idle | processes | memory |
|---|---|---|---|---|
| `/usr/bin/env bash` → 3.2 | **100** | 0 | 0 | `?` |
| bash 5 | **70** | 40.1 | 1677 | 93% free |

Under bash 5 it correctly flagged `cpu-idle-under-60`, `runqueue-over-2x-cores`, `zombie-accumulation`, `gpu-over-75`, `dns-over-100ms`.

## The fix

Assign with `eval "PREFIX_${k}=\$v"`. A plain assignment inside a function is already global in every bash, so no 4-only builtin is needed. `\$v` defers expansion so values are assigned rather than re-parsed, and the existing `^[a-zA-Z0-9_]+$` check on the key still blocks injection.

`declare -g` was the only bash-4-ism in the file — checked for `declare -A`, `mapfile`/`readarray`, `${x^^}`/`${x,,}`, `coproc`, `|&`, and `wait -n`, none present. So this needs no version guard and no dependency on a newer bash being installed.

## Why the tests missed it

The suite built `RUNTIME_*` variables by hand and tested only the scoring function, bypassing `run_parallel_scan`. It also invoked the binary as `bash "$BIN"`, which picks the newer bash on `PATH`, so the macOS default interpreter was never exercised.

Three checks added:
1. lint against `declare -g` returning
2. assert the probe read-back yields a non-zero process count (any live host has processes, so zero means the variables never reached scope)
3. repeat that assertion under `/bin/bash` when it is a 3.x build, skipping cleanly elsewhere

All three fail on the previous binary. The process-count check reports `empty:processes=0`, the exact signature of the bug. Check 2 passes on the buggy binary when run via PATH's bash 5 — which is precisely why check 3 exists.

## Verification

- `tests/test-ops-speedup.sh` — 18 passed, 0 failed under **both** bash 3.2 and bash 5
- `tests/test-no-secrets.sh` — 27 passed, 0 failed
- `tests/test-bin-scripts.sh` — 265 passed, 0 failed
- `shellcheck -S error` — clean
- `bash -n` — clean under both shells

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with older Bash versions, including Bash 3.2.
  * Probe results now populate system performance data reliably across supported environments.

* **Tests**
  * Added portability checks for older Bash releases.
  * Added validation that disk, memory, network, startup, runtime, and GPU probe results are captured correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->