### PR TITLE
ops-mcp: never start an owner-present OAuth flow from the watchdog

### DIFF
--- a/claude-ops/scripts/ops-mcp-reauth.py
+++ b/claude-ops/scripts/ops-mcp-reauth.py
@@ -42,6 +42,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from urllib.parse import urlparse
 
 LOG_PREFIX = "[ops-mcp-reauth]"
 HOME = Path(os.path.expanduser("~"))
@@ -51,6 +52,8 @@ LOG_FILE = STATE_DIR / "run.log"
 
 HEADLESS = os.environ.get("MCP_REAUTH_HEADLESS", "1") == "1"
 TIMEOUT = int(os.environ.get("MCP_REAUTH_TIMEOUT", "90"))
+
+INTERACTIVE_ONLY_OAUTH_HOSTS = {"mcp.carrier.llc", "mcp.esimmcp.com"}
 
 # Regex for the OAuth authorize URL mcp-remote logs
 AUTH_URL_RE = re.compile(r"(https?://[^\s\"'<>]+/authorize\?[^\s\"'<>]+)")
@@ -278,6 +281,10 @@ def main() -> int:
         return 0
 
     url = sys.argv[1]
+    host = (urlparse(url).hostname or "").lower()
+    if host in INTERACTIVE_ONLY_OAUTH_HOSTS:
+        log(f"{host} requires owner-present OAuth; use `claude mcp login carrier`")
+        return 4
     proc, auth_url = spawn_mcp_remote(url)
     try:
         if auth_url is None:

--- a/claude-ops/scripts/ops-mcp-watchdog.py
+++ b/claude-ops/scripts/ops-mcp-watchdog.py
@@ -64,6 +64,10 @@ REAUTH_SCRIPT = Path(__file__).resolve().parent / "ops-mcp-reauth.py"
 
 UA_HEADER = "ops-mcp-watchdog/0.1 (Mozilla/5.0)"
 
+# These providers require an owner-present browser login. Starting them from a
+# cron tick leaves a browser on a localhost callback after its listener exits.
+INTERACTIVE_ONLY_OAUTH_HOSTS = {"mcp.carrier.llc", "mcp.esimmcp.com"}
+
 # MCPs that use a Bearer API key (not OAuth). The key lives in keychain under
 # the listed `keychain_service` name; we'll inject it as Authorization: Bearer.
 API_KEY_MCPS = {
@@ -535,6 +539,10 @@ def main() -> int:
     if AUTO_REAUTH and REAUTH_SCRIPT.exists():
         for name, info in cur_state.items():
             if info.get("state") != "needs_bootstrap":
+                continue
+            host = (urlparse.urlparse(info["url"]).hostname or "").lower()
+            if host in INTERACTIVE_ONLY_OAUTH_HOSTS:
+                log(f"{name}: interactive OAuth only; skipping background auto-reauth")
                 continue
             log(f"{name}: attempting Playwright auto-reauth")
             try:


### PR DESCRIPTION
## Why

`mcp.carrier.llc` and `mcp.esimmcp.com` authorise only through a browser login the owner completes interactively. When a cron tick starts that flow, the browser lands on a localhost callback whose listener has already exited — the login cannot complete, no token is stored, and the watchdog logs an attempt and moves on. The MCP stays unauthenticated while the logs suggest something was tried.

This matches the machine's standing rule: never launch Carrier OAuth from cron, a watchdog, fixer, daemon, Playwright, or `mcp-remote`. Reauthorising is `claude mcp login carrier` in an owner-present terminal.

## What changes

- `ops-mcp-watchdog.py` — skips `INTERACTIVE_ONLY_OAUTH_HOSTS` before spawning the reauth subprocess, and logs why.
- `ops-mcp-reauth.py` — exits 4 if handed one of those hosts directly, naming `claude mcp login carrier`. Guarding only the caller would leave the script reachable from any other cron path, so both layers refuse.

## Provenance

This was written directly into the installed marketplace clone and existed in **no commit**. It was found because it dirtied that clone, which is what blocks `ops-update` from fast-forwarding — the same failure mode as #821 earlier today. The next successful update would have erased it silently. Committing it is what makes it survive.

## Verification

- `python3 -m py_compile` clean on both scripts; `urlparse` import confirmed present in the watchdog (`from urllib import parse as urlparse`).
- `tests/test-no-secrets.sh`: 27 passed, 0 failed.
- Applied to current main with `git apply --3way`, clean. Content is the original author's; no behaviour invented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)