### PR TITLE
Fix the staged-enrollment suite: ps state flags broke the stopped-child probe

### DIFF
--- a/claude-ops/scripts/account-rotation/__tests__/staged-enrollment.test.mjs
+++ b/claude-ops/scripts/account-rotation/__tests__/staged-enrollment.test.mjs
@@ -124,8 +124,19 @@ const waitFor = async (predicate, label, timeoutMs = 5000) => {
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
 };
+/**
+ * Leading state letter from `ps -o state=`, with the flag characters dropped.
+ *
+ * BSD ps appends flags to the state field: `+` foreground process group, `s`
+ * session leader, `N` reduced priority, `<` raised priority. A stopped child on
+ * macOS therefore reads `TN` or `T+`, never a bare `T`, so comparing the whole
+ * field to 'T' could never match and every waitForStoppedChild call timed out
+ * after 5s. Linux CI reports a bare `T`, which is why this only failed locally.
+ */
 const childProcessState = (child) =>
-  spawnSync('ps', ['-o', 'state=', '-p', String(child.pid)], { encoding: 'utf8' }).stdout.trim();
+  spawnSync('ps', ['-o', 'state=', '-p', String(child.pid)], { encoding: 'utf8' })
+    .stdout.trim()
+    .charAt(0);
 const waitForStoppedChild = (child, label) => waitFor(() => childProcessState(child) === 'T', label);
 const signalChild = (child, signal) => {
   try {


### PR DESCRIPTION
`test-staged-enrollment.sh` has been red on `main`, failing with
`timed out waiting for replacement-lock fault stop`. The fault injection it
tests was working fine. The probe watching for it was wrong.

## Cause

`childProcessState` compared the entire `ps -o state=` field to `'T'`:

```js
const childProcessState = (child) =>
  spawnSync('ps', ['-o', 'state=', '-p', String(child.pid)], {encoding: 'utf8'}).stdout.trim();
const waitForStoppedChild = (child, label) => waitFor(() => childProcessState(child) === 'T', label);
```

BSD `ps` appends flag characters to the state field: `+` foreground process
group, `s` session leader, `N` reduced priority, `<` raised priority. A stopped
child on macOS reads `TN` or `T+`, never a bare `T`, so the equality could never
hold and every `waitForStoppedChild` call burned its full 5s timeout before
asserting.

Linux `ps` reports a bare `T`. That is why CI stayed green while local runs
failed, and why the bug survived.

## Measured, not assumed

Spawning a child and stopping it on this machine:

```
running state : "SN"
stopped state : "TN"
strict === 'T' : false
startsWith('T'): true
```

## Fix

Take the leading state letter and drop the flags. One helper, so all four
`waitForStoppedChild` call sites are covered — line 608 was simply the first to
run, which is why only it appeared in the failure output.

## Verification

`test-staged-enrollment.sh` exits 0 on this branch off `main`, and also on the
CRS-removal branch (#830). That takes the repo from 27/28 suites to **28/28**.

Worth noting why this matters beyond one suite: a suite that fails permanently
teaches everyone to skim past failures, which is how the `rm -rf` guard defect
in #826 sat unnoticed inside the *other* red suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of stopped child processes across macOS and Linux.
  - Process-state handling now ignores additional platform-specific status flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->