### PR TITLE
fix(security): stop shelling out with untrusted input (4 CodeQL alerts)

### DIFF
--- a/claude-ops/lib/opener.mjs
+++ b/claude-ops/lib/opener.mjs
@@ -105,6 +105,13 @@ export async function openTarget(target) {
     return { ok: false, command: null, target: '' };
   }
 
+  // `target` reaches here straight from argv when this module is used as a CLI.
+  // A NUL/newline is never valid in a URL or path, so reject those everywhere.
+  if (/[\u0000-\u001F\u007F]/.test(target)) {
+    process.stderr.write('opener: refusing target containing control characters\n');
+    return { ok: false, command: null, target };
+  }
+
   const cmd = resolveOpener();
   if (!cmd) {
     process.stderr.write('opener: no URL opener available on this host\n');
@@ -118,6 +125,15 @@ export async function openTarget(target) {
     const isWindowsStart = cmd === 'cmd.exe /c start' || osId() === 'windows' || process.platform === 'win32';
 
     if (isWindowsStart && cmd.includes('start')) {
+      // Node quotes argv entries, but `cmd.exe /c` then strips the outer quotes and
+      // re-parses the string. A double quote inside `target` escapes that quoting and
+      // everything after it is interpreted by cmd. `&` and friends stay inert while
+      // quoted — which is why only the quote-breakout is rejected here, rather than
+      // stripping characters that appear legitimately in URL query strings.
+      if (target.includes('"')) {
+        process.stderr.write('opener: refusing target containing a double quote on Windows\n');
+        return { ok: false, command: cmd, target };
+      }
       const child = spawn('cmd.exe', ['/c', 'start', '', target], {
         detached: true,
         stdio: 'ignore',

--- a/claude-ops/scripts/account-rotation/crs-token-feed.mjs
+++ b/claude-ops/scripts/account-rotation/crs-token-feed.mjs
@@ -16,7 +16,7 @@
 import { readFileSync, appendFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { execSync, spawnSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 import { foreignActiveKeys } from './account-leases.mjs';
 import { assertCrsInvariant } from './route-state.mjs';
 import { acquireRefreshLock, claimRefreshPace } from './crs-refresh-lock.mjs';
@@ -108,12 +108,20 @@ async function oauthRefresh(refreshToken) {
 async function crsLogin(crsBase, crsContainer, adminUser = 'cradmin') {
   let pw = '';
   try {
-    pw = execSync(
-      `docker inspect ${crsContainer} --format '{{range .Config.Env}}{{println .}}{{end}}' | sed -n 's/^ADMIN_PASSWORD=//p'`,
-      { timeout: 8000 },
-    )
-      .toString()
-      .trim();
+    // The container name came from config/env and used to be interpolated into a shell
+    // pipeline. Run docker directly with argv and do the ADMIN_PASSWORD extraction in JS,
+    // so no part of this can be interpreted as shell syntax.
+    const envDump = execFileSync(
+      'docker',
+      ['inspect', crsContainer, '--format', '{{range .Config.Env}}{{println .}}{{end}}'],
+      { timeout: 8000, encoding: 'utf8' },
+    );
+    for (const line of envDump.split('\n')) {
+      if (line.startsWith('ADMIN_PASSWORD=')) {
+        pw = line.slice('ADMIN_PASSWORD='.length).trim();
+        break;
+      }
+    }
   } catch {}
   if (!pw) return null;
   if (!process.env.CRS_ADMIN_PASSWORD) process.env.CRS_ADMIN_PASSWORD = pw;

--- a/claude-ops/scripts/account-rotation/refresh-tokens.mjs
+++ b/claude-ops/scripts/account-rotation/refresh-tokens.mjs
@@ -19,7 +19,7 @@ import { appendFileSync, existsSync, readFileSync, writeFileSync, renameSync } f
 import { join, dirname } from 'path';
 import { userInfo } from 'os';
 import { fileURLToPath } from 'url';
-import { execFileSync, execSync } from 'child_process';
+import { execFileSync, spawnSync } from 'child_process';
 import { fetchWithProxyFallback } from './proxy-helper.mjs';
 import { acquireRefreshLock, claimRefreshPace } from './crs-refresh-lock.mjs';
 import { readRotationToken, reconcileRemoteRotationVault, writeRotationTokenCoordinated } from './rotation-vault.mjs';
@@ -73,7 +73,14 @@ function tokenService(account) {
 }
 
 function readKeychain(svc = KEYCHAIN_SERVICE, acct = KEYCHAIN_ACCOUNT) {
-  const out = execSync(`security find-generic-password -s "${svc}" -a "${acct}" -g 2>&1`, { timeout: 5000 }).toString();
+  // `security -g` writes the password to stderr, not stdout, which is why this used to
+  // shell out with `2>&1`. spawnSync exposes both streams without a shell, so the
+  // service/account names can no longer be interpreted as shell syntax.
+  const res = spawnSync('security', ['find-generic-password', '-s', svc, '-a', acct, '-g'], {
+    timeout: 5000,
+    encoding: 'utf8',
+  });
+  const out = `${res.stdout || ''}${res.stderr || ''}`;
   const m = out.match(/^password: "?(.*?)"?$/m);
   if (!m) throw new Error(`No keychain entry ${svc}/${acct}`);
   return m[1].replace(/\\"/g, '"');
@@ -110,11 +117,16 @@ function syncStoredTokenToCrs(account) {
   if (process.env.CLAUDE_ROTATION_SKIP_CRS_SYNC === '1') return;
   const key = accountKey(account);
   try {
-    const out = execSync(`node "${join(__dirname, 'sync-crs-account.mjs')}" ${JSON.stringify(key)} 2>&1`, {
+    // JSON.stringify only adds double quotes, and $(...) is still expanded inside shell
+    // double quotes, so the account key must never reach a shell. Pass it as an argv entry.
+    const res = spawnSync('node', [join(__dirname, 'sync-crs-account.mjs'), key], {
       timeout: 45_000,
-    })
-      .toString()
-      .trim();
+      encoding: 'utf8',
+    });
+    if (res.status !== 0) {
+      throw new Error(`${res.stderr || res.stdout || `exit ${res.status}`}`.trim());
+    }
+    const out = `${res.stdout || ''}${res.stderr || ''}`.trim();
     log(out.split('\n').slice(-1)[0] || `${key}: CRS sync complete`);
   } catch (err) {
     log(`${key}: ⚠ CRS sync failed — ${String(err.message || err).slice(0, 180)}`);

--- a/claude-ops/scripts/account-rotation/rotate.mjs
+++ b/claude-ops/scripts/account-rotation/rotate.mjs
@@ -1501,7 +1501,9 @@ function readLatestSMSCode({ maxAgeSec = 300 } = {}) {
     // Apple timestamp = seconds since 2001-01-01, stored as nanoseconds
     const cutoffAppleNs = (Math.floor(Date.now() / 1000) - 978307200 - maxAgeSec) * 1_000_000_000;
     const sql = `SELECT hex(attributedBody), text FROM message WHERE date > ${cutoffAppleNs} AND service IN ('SMS','iMessage') ORDER BY date DESC LIMIT 10;`;
-    const rows = execSync(`sqlite3 "${db}" "${sql}"`, { timeout: 5000 }).toString().split('\n').filter(Boolean);
+    // $HOME feeds `db`, so the old shell string let the environment inject sqlite3 args
+    // or shell syntax. execFileSync passes both as argv entries instead.
+    const rows = execFileSync('sqlite3', [db, sql], { timeout: 5000, encoding: 'utf8' }).split('\n').filter(Boolean);
     for (const row of rows) {
       const [hex, text] = row.split('|');
       // Plain text column (older macOS)


### PR DESCRIPTION
Closes the four open `js/indirect-command-line-injection` alerts in this repo (#179, #158, #37, #36). All four built a shell command by interpolating a value from outside the process, so quoting was the only barrier between untrusted data and the shell.

## Changes

| Alert | Site | Untrusted input | Fix |
|---|---|---|---|
| #179 | `refresh-tokens.mjs:76` | `label \|\| email` via `tokenService()` | `spawnSync` argv |
| #158 | `crs-token-feed.mjs:112` | container name, in a `docker \| sed` pipeline | `execFileSync` argv + parse in JS |
| #37 | `rotate.mjs:1504` | `$HOME` in the sqlite3 path | `execFileSync` argv |
| #36 | `opener.mjs:121` | CLI argv target | reject quote-breakout + control chars |

Also fixed an **unflagged** instance in `refresh-tokens.mjs` (`syncStoredTokenToCrs`). It used `JSON.stringify(key)`, which only adds double quotes — and `$(...)` still expands inside shell double quotes, so the same account key was executable.

## Why opener.mjs is different

It is not a plain argv swap. `spawn` with an argument array is already shell-free, but `cmd.exe /c` strips Node's quoting and re-parses the string, so a `"` in the target escapes it.

Only that breakout is rejected. `&` and similar stay inert while quoted and appear legitimately in URL query strings, so filtering them would break real URLs for no security gain. Control characters are rejected on all platforms.

## Consistency note

`writeKeychain` in `refresh-tokens.mjs` already used `execFileSync` with an argv array. These call sites had simply not been converted yet, so this follows the idiom already present in the file.

## Verification

- `node --check` passes on all four files
- `npm test` — **27 passed, 0 failed**
- prettier clean on `opener.mjs`, `refresh-tokens.mjs`, `crs-token-feed.mjs`
- `rotate.mjs` already fails prettier on `origin/main` (pre-existing). Not reformatted, to avoid an unrelated whole-file diff; the changed line matches prettier's preferred output.
- sqlite3 argv form verified against a fixture DB — identical rows and extracted code
- Injection proof: a hostile value executes under the old shell form and is treated as literal data under the argv form

## Not addressed

`rotate.mjs` has pre-existing prettier violations elsewhere in the file. Worth a separate formatting-only PR rather than mixing it into a security change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection when opening targets by rejecting unsafe control characters and Windows command-line quotes.
  * Preserved valid URL characters, including query-string operators.
  * Improved reliability and error reporting for Docker, keychain, synchronization, and SMS-code operations.
  * Reduced command execution risks by handling arguments safely without shell interpolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->