### PR TITLE
Skip the ops-speedup suite when python3 is unavailable

### DIFF
--- a/claude-ops/tests/test-ops-speedup.sh
+++ b/claude-ops/tests/test-ops-speedup.sh
@@ -34,6 +34,18 @@ export HOME="$tmpdir"
 export NO_COLOR=1
 export TERM=dumb
 
+# python3 parses ops-speedup's JSON contract below. The README lists only Claude
+# Code and gh as requirements and CI never installs Python, so an unguarded call
+# would abort this file under `set -e` and be reported as a speedup regression
+# rather than a missing interpreter. Skip the way the sibling suites do.
+PY="$(command -v python3 || true)"
+if [ -z "$PY" ]; then
+  echo "== ops-speedup runtime health tests =="
+  echo "  SKIP: python3 unavailable"
+  echo "test-ops-speedup.sh: 0 passed, 0 failed (skipped)"
+  exit 0
+fi
+
 echo "== ops-speedup runtime health tests =="
 assert_true "bash syntax" bash -n "$BIN"
 assert_true "no auto-aggressive default" bash -c "! grep -q 'MODE_CLEAN=true; MODE_DEEP=true; MODE_AGGRESSIVE=true' '$BIN'"


### PR DESCRIPTION
## Why

Closes the outstanding CodeRabbit thread on #827 (`claude-ops/tests/test-ops-speedup.sh`, python3 prerequisite). The finding is valid.

`test-ops-speedup.sh` calls `python3` six times (lines 47, 91, 110, 123, 137, 175) to parse `ops-speedup`'s JSON contract, with no guard, under `set -euo pipefail`. Meanwhile:

- `claude-ops/README.md` "Requirements" lists only Claude Code 1.0+ and `gh`, then says "Everything else is optional."
- the repository CI workflow never installs Python and never probes for it.
- sibling suites already guard it: `test-ops-pocket-notify.sh` and `test-pocket-env-broker.sh` both resolve `PY="$(command -v python3 || true)"` and skip; `test-hooks.sh`, `test-template.sh`, and `test-ops-daemon-manager.sh` all branch on `command -v python3`.

So on a host matching the documented requirements, this one file aborts partway through and surfaces as an `ops-speedup` regression rather than a missing interpreter. That is a misleading failure, not a real one.

## How

Resolve `python3` once before the first call and take the established skip path when it is absent: print a visible `SKIP` line, report `0 passed, 0 failed (skipped)`, exit 0. Matches the sibling suites exactly, so `run-all.sh` aggregation is unchanged.

No test assertion is weakened, removed, or made conditional. When `python3` is present, every check runs exactly as before.

## How tested

Both branches exercised locally:

| Case | Command | Result |
|---|---|---|
| syntax | `bash -n tests/test-ops-speedup.sh` | ok |
| python3 present | `bash tests/test-ops-speedup.sh` | `Results: 18 passed, 0 failed`, exit 0 |
| python3 absent | `env -i PATH=<shim without python3> bash tests/test-ops-speedup.sh` | `SKIP: python3 unavailable`, `0 passed, 0 failed (skipped)`, exit 0 |

The absent case used a PATH shim containing the suite's other utilities but deliberately no `python3`, which is what proves the guard actually fires rather than being dead code.

## Files changed

| File | +/- | Change |
|---|---|---|
| `claude-ops/tests/test-ops-speedup.sh` | +12/-0 | resolve `python3` once, skip cleanly when absent |

## Scope

Test-harness only. No plugin behaviour, hook, daemon, script, or `ops-speedup` logic is touched. No personal data, paths, or secrets added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test execution on systems without Python 3 by reporting an appropriate skip instead of failing.
  * Existing JSON contract tests continue to run normally when Python 3 is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->