### PR TITLE
fix(boss): resolve agent-dash from installed plugin, not a phantom path

### DIFF
--- a/claude-ops/skills/boss/SKILL.md
+++ b/claude-ops/skills/boss/SKILL.md
@@ -28,14 +28,23 @@ wins, and a path that does not exist on this machine must never be the only
 candidate:
 
 ```bash
-for candidate in \
-  "${CLAUDE_PLUGIN_ROOT:-}/bin/agent-dash" \
-  "$HOME/.claude/plugins/marketplaces/ops-marketplace/claude-ops/bin/agent-dash" \
-  "$HOME/.claude/plugins/cache/ops-marketplace/ops/current/bin/agent-dash"; do
+candidates=()
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && candidates+=("$CLAUDE_PLUGIN_ROOT/bin/agent-dash")
+candidates+=(
+  "$HOME/.claude/plugins/marketplaces/ops-marketplace/claude-ops/bin/agent-dash"
+  "$HOME/.claude/plugins/cache/ops-marketplace/ops/current/bin/agent-dash"
+)
+AGENT_DASH=""
+for candidate in "${candidates[@]}"; do
   [ -x "$candidate" ] && AGENT_DASH="$candidate" && break
 done
-[ -n "${AGENT_DASH:-}" ] || { echo "agent-dash not found" >&2; exit 1; }
+[ -n "$AGENT_DASH" ] || { echo "agent-dash not found" >&2; exit 1; }
 ```
+
+Build the candidate list conditionally: an unset `CLAUDE_PLUGIN_ROOT` must
+contribute no candidate at all. Interpolating it unguarded would expand to the
+absolute path `/bin/agent-dash`, which is a real system location and would let
+an unrelated executable satisfy the probe.
 
 If none resolve, say so plainly and stop. Never report an empty fleet when the
 snapshot binary was simply missing — those are different facts.

--- a/claude-ops/skills/boss/SKILL.md
+++ b/claude-ops/skills/boss/SKILL.md
@@ -22,8 +22,23 @@ everything to done autonomously and surface to the owner ONLY the decisions and 
 that are genuinely his — as clean A/B/C/D options, each with your recommendation and
 the full context behind it.
 
-`AGENT_DASH="$HOME/Projects/claude-ops/claude-ops/bin/agent-dash"` (or the installed
-plugin path `${CLAUDE_PLUGIN_ROOT}/bin/agent-dash`).
+Resolve `agent-dash` from the installed plugin, falling back to a local
+development checkout. Do NOT hardcode a single absolute path — the first match
+wins, and a path that does not exist on this machine must never be the only
+candidate:
+
+```bash
+for candidate in \
+  "${CLAUDE_PLUGIN_ROOT:-}/bin/agent-dash" \
+  "$HOME/.claude/plugins/marketplaces/ops-marketplace/claude-ops/bin/agent-dash" \
+  "$HOME/.claude/plugins/cache/ops-marketplace/ops/current/bin/agent-dash"; do
+  [ -x "$candidate" ] && AGENT_DASH="$candidate" && break
+done
+[ -n "${AGENT_DASH:-}" ] || { echo "agent-dash not found" >&2; exit 1; }
+```
+
+If none resolve, say so plainly and stop. Never report an empty fleet when the
+snapshot binary was simply missing — those are different facts.
 
 ## STEP 1 — Snapshot the WHOLE fleet (every brand, every host)
 


### PR DESCRIPTION
## What

`skills/boss/SKILL.md` told agents to resolve the fleet snapshot binary from
`$HOME/Projects/claude-ops/claude-ops/bin/agent-dash`. That path does not exist
on a standard install, where the plugin lives under `~/.claude/plugins/`. The
documented alternative, `${CLAUDE_PLUGIN_ROOT}/bin/agent-dash`, is unset outside
Claude Code, so on a normal machine both candidates could miss and the skill had
no resolution path left.

## Why it matters

The failure was silent rather than loud. An agent following the skill invoked a
non-existent binary, got nothing back, and could report "no agents working" —
which is indistinguishable from a genuinely idle fleet. `/boss` exists to tell
the owner what needs them; a version that quietly reports an empty fleet when it
simply cannot find its own snapshot tool is worse than one that errors.

## Change

Replace the hardcoded path with an ordered probe that takes the first executable
match:

1. `${CLAUDE_PLUGIN_ROOT}/bin/agent-dash` (Claude Code)
2. `~/.claude/plugins/marketplaces/ops-marketplace/claude-ops/bin/agent-dash`
3. `~/.claude/plugins/cache/ops-marketplace/ops/current/bin/agent-dash`

Plus an explicit failure branch, so a missing binary is reported as a missing
binary and never rendered as an empty fleet.

## Verification

- Ran the resolver with `CLAUDE_PLUGIN_ROOT` unset: resolves to the marketplace
  path, and `node "$AGENT_DASH" --json` returns a live snapshot.
- `tests/test-no-secrets.sh` — 27 passed, 0 failed.
- `tests/run-all.sh` — 31 suites passed, 0 failed.

Docs-only change to one SKILL.md; no executable code touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command resolution by selecting the first available executable.
  * Added clear errors when no executable is found.
  * Differentiated between a missing snapshot binary and an empty fleet.
  * Removed reliance on a fixed project path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->