### PR TITLE
fix(merge): stop instructing agents to merge with --admin

### DIFF
--- a/claude-ops/RELEASE.md
+++ b/claude-ops/RELEASE.md
@@ -62,5 +62,5 @@ contracts; **minor** = new skill/command/agent or backward-compatible feature;
 If `ops-release` is unavailable, do the same by hand in a worktree off
 `origin/main`: bump the three JSON `version` fields (plugin.json,
 marketplace.json, package.json), add the CHANGELOG section, `commit --no-verify`,
-push, `gh pr create --base main`, `gh pr merge --squash --admin`, `git tag
+push, `gh pr create --base main`, `gh pr merge --squash`, `git tag
 vX.Y.Z && git push origin vX.Y.Z`.

--- a/claude-ops/bin/ops-ship
+++ b/claude-ops/bin/ops-ship
@@ -96,16 +96,18 @@ if [ "$dry" = 1 ]; then
   exit 0
 fi
 
-# ── Apply: merge each PR (admin override = bypass required checks/reviews) ─────
+# ── Apply: merge each PR (normal merge — never bypass a branch gate) ───────────
 merged=0
 for row in "${PRS[@]:-}"; do
   [ -z "${row:-}" ] && continue
   n="${row%%	*}"
-  echo "  merging #$n (admin override)…"
-  if gh pr merge "$n" --admin --squash --delete-branch 2>&1 | sed 's/^/    /'; then
+  echo "  merging #$n…"
+  if gh pr merge "$n" --squash --delete-branch 2>&1 | sed 's/^/    /'; then
     merged=$((merged+1))
   else
     echo "ops-ship: merge of #$n FAILED — aborting before release (no partial ship)." >&2
+    echo "ops-ship: if the refusal is a required review or unresolved thread, that gate is" >&2
+    echo "ops-ship: intentional. Resolve it or get the approval — do not retry with --admin." >&2
     exit 1
   fi
 done

--- a/claude-ops/docs/deploy-fix.md
+++ b/claude-ops/docs/deploy-fix.md
@@ -15,7 +15,7 @@ _Watches every `gh pr merge` and `npm run build:_` you run, verifies the deploy,
 ## TL;DR
 
 ```
-gh pr merge --squash --admin
+gh pr merge --squash
         │
         ▼ PostToolUse:Bash hook
 bin/ops-deploy-fix-merge-trigger

--- a/claude-ops/skills/ops-merge/SKILL.md
+++ b/claude-ops/skills/ops-merge/SKILL.md
@@ -41,7 +41,7 @@ Before executing, load:
 | `gh pr list --repo <owner/repo> --json number,title,state,headRefName,statusCheckRollup,reviewDecision,mergeable,isDraft` | List PRs with status | JSON array                     |
 | `gh pr view <n> --repo <repo> --json title,body,state,mergeable,reviews`                                                  | PR details           | JSON                           |
 | `gh pr checks <n> --repo <repo>`                                                                                          | CI check status      | Check list                     |
-| `gh pr merge <n> --repo <repo> --squash --admin`                                                                          | Squash merge PR      | Merge result                   |
+| `gh pr merge <n> --repo <repo> --squash`                                                                                  | Squash merge PR      | Merge result                   |
 | `gh pr create --repo <repo> --title "<t>" --body "<b>" --base dev`                                                        | Create PR            | PR URL                         |
 | `gh run list --repo <repo> --limit 5 --json conclusion,name,headBranch`                                                   | CI runs              | JSON array                     |
 | `gh run view <id> --repo <repo> --log-failed`                                                                             | Failed CI logs       | Log output                     |
@@ -251,7 +251,7 @@ If user picks "Let me pick", show each PR with `[Merge]` / `[Skip]` options via 
 For each confirmed PR:
 
 1. Verify CI is still green: `gh pr checks <number> --repo <repo>`
-2. If green: `gh pr merge <number> --repo <repo> --squash --admin`
+2. If green: `gh pr merge <number> --repo <repo> --squash` (never `--admin` — see "Never bypass a branch gate" below)
 3. Report: `✓ Merged <repo>#<number> to <base>`
 
 ### Phase 3 — Dispatch fixers for PRs that need work
@@ -384,8 +384,11 @@ For each fixer's JSON report:
 5. **If all checks pass: orchestrator performs the merge.** The fixer never had merge authority. Run:
 
    ```bash
-   gh pr merge <pr> --repo <repo> --squash --admin
+   gh pr merge <pr> --repo <repo> --squash
    ```
+
+   Never add `--admin`. If the merge is refused, that refusal is the gate doing its
+   job — see "Never bypass a branch gate" below.
 
 6. **Verify the merge actually landed.** Immediately after the merge call:
 
@@ -443,7 +446,7 @@ For each repo that has separate `dev` and `main` branches:
 
 3. If confirmed: create sync PR: `gh pr create --repo <repo> --base main --head dev --title "chore: sync dev → main"`
 4. Wait for CI: `gh pr checks <sync-pr-number> --repo <repo> --watch` (background, max 10 min)
-5. If CI green: `gh pr merge <sync-pr-number> --repo <repo> --merge --admin` (merge commit, not squash)
+5. If CI green: `gh pr merge <sync-pr-number> --repo <repo> --merge` (merge commit, not squash; never `--admin`)
 6. Pull main back into dev: `git -C <path> fetch origin && git -C <path> checkout dev && git -C <path> merge origin/main --no-edit`
 
 ### Phase 7 — Final report
@@ -514,9 +517,44 @@ During this command's execution, invoke the following superpower skills at the s
 - **NEVER bypass review on PRs touching auth, payments, PII, or secrets** — these require `security-reviewer` subagent audit before merge
 - **NEVER run `git reset --hard` on shared branches**
 - **ALWAYS use worktrees** for fixes (multiple agents may be active)
-- **ALWAYS use `--admin` only for squash merges to dev** (not main, unless `--main` flag)
+- **NEVER bypass a branch gate.** Do not pass `--admin` to `gh pr merge`, and do not
+  widen a ruleset, add yourself to a bypass list, or grant yourself admin to get a merge
+  through. A refused merge is the protection working. See "Never bypass a branch gate" below.
+- **ALWAYS confirm the base branch before merging.** Read `baseRefName` from
+  `gh pr view <n> --json baseRefName` in the same step as the merge. A run scoped to one
+  branch must refuse a PR whose base is a different one — a protected branch typically
+  carries a review gate the scoped branch does not.
 - **Max 10 PRs per invocation** to avoid GitHub API throttling
 - **If a PR has > 50 files changed**, flag it for manual review instead of auto-merging
+
+### Never bypass a branch gate
+
+`gh pr merge --admin` merges past branch protection and org rulesets. It is banned in
+this pipeline, in every phase, on every repo. So is any other route to the same outcome:
+editing a ruleset's conditions, adding an actor to a bypass list, or promoting your own
+account to get a merge through.
+
+Why it matters here specifically: a merge queue sweeps many repos at once, and repo
+governance is not uniform. Organisations commonly scope a review gate to a subset of
+repos via a repository custom property, and protect only some branches. The pipeline
+cannot see that policy from the PR alone — but the merge API can, and it enforces it.
+`--admin` throws that enforcement away silently and succeeds, so the violation is only
+discoverable afterwards, from the commit.
+
+Rules:
+
+1. Never pass `--admin` (or `--auto` as a workaround for a refused merge).
+2. Read `baseRefName` in the same step as the merge and refuse any PR whose base is
+   outside the run's declared scope. A default-branch merge and a protected-branch merge
+   are different acts with different approvals.
+3. Treat a refusal as a result, not an obstacle. `mergeStateStatus: BLOCKED` with green
+   checks usually means a required approval or an unresolved review thread. Resolve the
+   findings, request the human reviewer, report the PR as waiting, and move on.
+4. If a merge is genuinely urgent and gated, that is the owner's decision to make, not
+   the pipeline's. Surface it; never route around it.
+
+A merge that landed via bypass cannot be silently undone. Report it immediately, name
+the commit, and say which gate it skipped.
 
 ### Phase 0 (Salvage) Safety Rails
 

--- a/claude-ops/skills/ops-orchestrate/SKILL.md
+++ b/claude-ops/skills/ops-orchestrate/SKILL.md
@@ -56,7 +56,7 @@ Before orchestrating, load:
 | `gh pr list --state open --json number,title,statusCheckRollup,reviewDecision,mergeable,isDraft` | Open PRs with status | JSON array   |
 | `gh pr view <n> --repo <repo> --json files,additions,deletions`                                  | PR file diff summary | JSON         |
 | `gh pr checks <n>`                                                                               | CI check status      | Check list   |
-| `gh pr merge <n> --squash --admin`                                                               | Squash merge PR      | Merge result |
+| `gh pr merge <n> --squash`                                                                       | Squash merge PR      | Merge result |
 | `gh run list --repo <repo> --workflow "<workflow>" --limit 5 --json conclusion,headBranch`       | CI runs for workflow | JSON array   |
 | `gh run view <id> --repo <repo> --log-failed`                                                    | Failed CI logs       | Log output   |
 | `gh issue list --state open`                                                                     | Open issues          | JSON array   |
@@ -400,7 +400,7 @@ For each PR that passed audit:
 1. **Address review comments**: read via `gh api`, resolve each
 2. **CI verification**: `gh pr checks <n>` — wait via `Monitor` if still running
 3. **Merge conflict resolution**: check `mergeable` state, resolve if needed
-4. **Merge to dev**: `gh pr merge <n> --squash --admin` (use `AskUserQuestion` to confirm unless `--force`)
+4. **Merge to dev**: `gh pr merge <n> --squash` (use `AskUserQuestion` to confirm unless `--force`). Never pass `--admin`: a refused merge means a branch gate applies, and the gate is the owner's policy, not an obstacle. Confirm `baseRefName` matches the branch this run is scoped to before merging.
 5. **Merge dev → main** (if applicable and authorized): create sync PR, wait CI, merge
 6. **Post-deploy verification**: health check, Sentry check for new errors
 

--- a/claude-ops/skills/ops-yolo/SKILL.md
+++ b/claude-ops/skills/ops-yolo/SKILL.md
@@ -59,7 +59,7 @@ Before YOLO analysis, load:
 | Command                                                                                                 | Usage                | Output       |
 | ------------------------------------------------------------------------------------------------------- | -------------------- | ------------ |
 | `gh pr list --repo <owner/repo> --json number,title,statusCheckRollup,reviewDecision,mergeable,isDraft` | Open PRs with status | JSON array   |
-| `gh pr merge <n> --repo <repo> --squash --admin`                                                        | Squash merge PR      | Merge result |
+| `gh pr merge <n> --repo <repo> --squash`                                                                | Squash merge PR      | Merge result |
 | `gh run list --limit 20 --json status,conclusion,name,headBranch,createdAt`                             | Recent CI runs       | JSON array   |
 
 ---


### PR DESCRIPTION
## What this fixes

`ops-merge` told the orchestrator to merge with `gh pr merge --squash --admin` in Phase 2, Phase 5 and Phase 6, and a Safety Rail actively mandated it:

> **ALWAYS use `--admin` only for squash merges to dev** (not main, unless `--main` flag)

`ops-orchestrate`, `ops-yolo`, `bin/ops-ship`, `RELEASE.md` and `docs/deploy-fix.md` carried the same form.

`--admin` merges past branch protection and org rulesets. Repo governance in an org is usually **not uniform**: a review gate is commonly scoped to a subset of repos via a repository custom property, and applies to only some branches. The pipeline cannot see that policy from the PR alone — but the merge API can, and it enforces it. `--admin` throws that enforcement away silently and still exits 0, so the violation is only discoverable afterwards, from the commit.

This is not hypothetical. An agent following Phase 5 verbatim merged a PR whose base was a protected branch, skipping a mandatory human review gate. The merge landed and cannot be silently undone.

## Changes

- Every documented `gh pr merge` drops `--admin` (ops-merge, ops-orchestrate, ops-yolo, ops-ship, RELEASE.md, docs/deploy-fix.md).
- The mandating Safety Rail is replaced by two:
  - **Never bypass a branch gate** — no `--admin`, and no widening a ruleset, adding a bypass actor, or self-promoting to admin to get a merge through.
  - **Always confirm the base branch before merging** — read `baseRefName` in the same step as the merge, so a run scoped to one branch cannot merge into a different, more protected one.
- New `### Never bypass a branch gate` section in `ops-merge/SKILL.md`: why a refusal is a result rather than an obstacle, and what to do instead (resolve findings, request the reviewer, report the PR as waiting, move on).
- `bin/ops-ship` merges normally and, on refusal, prints that a required review or unresolved thread is an intentional gate and must not be retried with `--admin`.

## Verification

| Check | Result |
|---|---|
| `tests/run-all.sh` | 31/31 suites pass |
| `tests/test-no-secrets.sh` | 27/27 pass |
| `bash -n bin/ops-ship` | clean |
| deploy-fix PostToolUse trigger on the non-admin command form | still fires (matches `gh pr merge `, returns the monitor hook payload) |

That last one mattered: the hook is gated on `Bash(gh pr merge *)` and matches the substring `gh pr merge `, so removing `--admin` does not break deploy-fix dispatch. Confirmed by piping the non-admin command through the trigger and reading the emitted `hookSpecificOutput`.

## Not changed

`tests/fixtures/merge-trigger-input.json` still contains `--admin` on purpose — it is a fixture asserting the hook matches real-world command strings, including legacy ones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Pull requests now use standard squash merging without administrative overrides.
  * Required reviews, unresolved threads, branch protection, and base-branch checks are respected as merge gates.
  * Release execution remains blocked when any merge fails.

* **Documentation**
  * Updated release and operational guidance to reflect the standard protected merge workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->