### PR TITLE
fix(agent-dash): an unreachable remote reports unknown, not zero agents

### DIFF
--- a/claude-ops/scripts/agent-dash/collect.mjs
+++ b/claude-ops/scripts/agent-dash/collect.mjs
@@ -91,44 +91,63 @@ function probeRemoteHost(sshHost, probeSrc) {
 }
 
 export function collectRemote({ force = false } = {}) {
+  // No remote configured is not the same as a remote that failed to answer.
+  // Report it as its own state so the dashboard never prints a confident 0.
+  if (FRA_HOSTS.length === 0) {
+    return { agents: [], stale: false, source: 'not-configured', cached: false, known: true };
+  }
+
   const cache = readCache();
   if (!force && cache && nowTs() - cache.ts < REMOTE_TTL_MS) {
-    return { agents: cache.agents, stale: false, source: cache.meta?.source || 'cache', cached: true };
+    return { agents: cache.agents, stale: false, source: cache.meta?.source || 'cache', cached: true, known: true };
   }
 
   let probeSrc;
   try {
     probeSrc = readFileSync(PROBE, 'utf8');
   } catch {
-    return { agents: cache?.agents || [], stale: true, source: 'no-probe', cached: !!cache };
+    return { agents: cache?.agents || [], stale: true, source: 'no-probe', cached: !!cache, known: !!cache };
   }
 
   for (const h of FRA_HOSTS) {
     try {
       const agents = probeRemoteHost(h.trim(), probeSrc);
       writeCache(agents, { source: h.trim() });
-      return { agents, stale: false, source: h.trim(), cached: false };
+      return { agents, stale: false, source: h.trim(), cached: false, known: true };
     } catch {
       /* try next host */
     }
   }
 
   // all FRA hosts failed — serve last-known cache, flagged stale
-  if (cache) return { agents: cache.agents, stale: true, source: cache.meta?.source || 'cache', cached: true };
-  return { agents: [], stale: true, source: 'unreachable', cached: false };
+  if (cache) {
+    return { agents: cache.agents, stale: true, source: cache.meta?.source || 'cache', cached: true, known: true };
+  }
+  // Configured, tried, no answer, and nothing cached: the agent count is UNKNOWN,
+  // not zero. `known: false` tells consumers they may not report a number here.
+  return { agents: [], stale: true, source: 'unreachable', cached: false, known: false };
 }
 
 // --- unified ---------------------------------------------------------------
 
 export function collect({ force = false, localOnly = false } = {}) {
   const local = collectLocal();
-  let remote = { agents: [], stale: false, source: 'skipped', cached: false };
+  let remote = { agents: [], stale: false, source: 'skipped', cached: false, known: true };
   if (!localOnly) remote = collectRemote({ force });
   return {
     ts: nowTs(),
     hosts: {
       mac: { count: local.length },
-      fra: { count: remote.agents.length, stale: remote.stale, source: remote.source, cached: remote.cached },
+      // `count` is null — never 0 — when the remote could not be reached and no
+      // cache exists. Zero would read as "no agents there", which is a claim the
+      // probe cannot support. Consumers must render null as unknown.
+      fra: {
+        count: remote.known === false ? null : remote.agents.length,
+        known: remote.known !== false,
+        stale: remote.stale,
+        source: remote.source,
+        cached: remote.cached,
+      },
     },
     agents: [...local, ...remote.agents],
   };

--- a/claude-ops/scripts/agent-dash/render.mjs
+++ b/claude-ops/scripts/agent-dash/render.mjs
@@ -113,17 +113,25 @@ export function renderDashboard(snapshot, { width = 100, selectedIdx = 0, status
   const total = agents.length;
   const needs = agents.filter((a) => a.status === 'needs-sam').length;
   const fra = snapshot.hosts?.fra || {};
-  const fraTag = fra.stale
-    ? `${C.red}stale${C.reset}`
-    : fra.cached
-      ? `${C.gray}cached${C.reset}`
-      : `${C.green}live${C.reset}`;
+  const fraUnknown = fra.known === false || fra.count === null || fra.count === undefined;
+  const fraTag = fraUnknown
+    ? `${C.red}unreachable${C.reset}`
+    : fra.source === 'not-configured'
+      ? `${C.gray}not configured${C.reset}`
+      : fra.stale
+        ? `${C.red}stale${C.reset}`
+        : fra.cached
+          ? `${C.gray}cached${C.reset}`
+          : `${C.green}live${C.reset}`;
+  // "?" not "0": an unreachable host has an unknown agent count, and printing a
+  // number there is indistinguishable from a genuinely idle host.
+  const fraCount = fraUnknown ? '?' : fra.count;
 
   // header
   lines.push(
     `${C.bold}${C.cyan}AGENT-DASH${C.reset}  ${C.bold}${total}${C.reset} agents` +
       `  ${C.dim}·${C.reset} mac ${snapshot.hosts?.mac?.count ?? 0}` +
-      `  ${C.dim}·${C.reset} fra ${fra.count ?? 0} (${fraTag})` +
+      `  ${C.dim}·${C.reset} fra ${fraCount} (${fraTag})` +
       (needs ? `  ${C.brightYellow}${C.bold}◆ ${needs} need you${C.reset}` : '') +
       `  ${C.gray}${new Date(snapshot.ts).toLocaleTimeString()}${C.reset}`,
   );


### PR DESCRIPTION
## The bug

`collect()` set `hosts.fra.count` from `remote.agents.length` unconditionally. When the remote host could not be reached, `agents` was `[]`, so the snapshot said:

```json
"fra": { "count": 0, "stale": true, "source": "unreachable" }
```

and the header rendered `fra 0 (stale)`. That is indistinguishable from a remote that answered and genuinely had no agents running. A supervisor reading the dashboard concludes "nothing running over there" when the honest answer is "unknown".

This is the same silent-partial-data class the plugin already guards against elsewhere: the degraded output looks exactly like correct output, so no consumer can detect it.

## Second bug found while fixing the first

`AGENT_DASH_FRA_HOSTS` is empty by default, so out of the box `FRA_HOSTS` is `[]`, the probe loop body never executes, and control falls straight through to the `unreachable` return. The dashboard reported a probe result for a probe that never ran.

Those are three different states and they now stay separate:

| State | `count` | `known` | `source` | header |
|---|---|---|---|---|
| no remote configured | `0` | `true` | `not-configured` | `fra 0 (not configured)` |
| configured, answered | n | `true` | hostname | `fra n (live)` |
| configured, all hosts failed, no cache | `null` | `false` | `unreachable` | `fra ? (unreachable)` |

Cached and stale-with-cache paths are unchanged.

## Changes

- `collectRemote()` short-circuits to `source: 'not-configured'` before any probe or cache read when no host is configured.
- `collectRemote()` returns `known: false` only when a remote was configured, every host failed, **and** no cache exists.
- `collect()` maps that to `count: null` — never `0` — plus an explicit `known` boolean, so a consumer cannot read a number that isn't there.
- Renderer prints `?` rather than a digit for the unknown case, tagged `unreachable`.

## Verification

Ran with the remote cache moved aside so the cached path could not mask the result:

```
unset            → {'count': 0,    'known': True,  'source': 'not-configured'}
bad host         → {'count': None, 'known': False, 'source': 'unreachable'}
bad host (table) → AGENT-DASH  7 agents  · mac 7  · fra ? (unreachable)
```

`tests/run-all.sh` — 31/31 suites pass. `prettier --write` on both files: unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer FRA host status indicators for live, cached, stale, unconfigured, and unreachable states.
  - Displays `?` when the FRA agent count cannot be determined instead of showing an inaccurate zero.

- **Bug Fixes**
  - Improved handling of remote connection failures while preserving available stale-cache information.
  - Prevented unknown remote agent counts from being reported as zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->