### PR TITLE
fix(local-failover): harden proxy against SSRF and response splitting (CodeQL #316/#315/#314)

### DIFF
--- a/claude-ops/scripts/local-failover/local_failover/proxy.py
+++ b/claude-ops/scripts/local-failover/local_failover/proxy.py
@@ -70,13 +70,16 @@ def _safe_request_target(raw_path: str) -> str | None:
         return None
     if _REQUEST_TARGET_RE.fullmatch(raw_path) is None:
         return None
-    path, _, _query = raw_path.partition("?")
-    decoded = unquote(path)
-    if any(ord(ch) < 0x21 or ord(ch) == 0x7F for ch in decoded):
+    path, _, query = raw_path.partition("?")
+    decoded_path = unquote(path)
+    if any(ord(ch) < 0x21 or ord(ch) == 0x7F for ch in decoded_path):
         return None
-    if "\\" in decoded:
+    decoded_query = unquote(query)
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in decoded_query):
         return None
-    for segment in decoded.split("/"):
+    if "\\" in decoded_path or "\\" in decoded_query:
+        return None
+    for segment in decoded_path.split("/"):
         if segment in {".", ".."}:
             return None
     return raw_path
@@ -415,13 +418,21 @@ class _GatewayHandler(BaseHTTPRequestHandler):
 
     def _response_headers(
         self, response: http.client.HTTPResponse, route_name: str
-    ) -> tuple[list[tuple[str, str]], int | None]:
+    ) -> tuple[list[tuple[str, str]], int | None] | None:
         connection_value = response.headers.get("Connection")
         excluded = set(HOP_BY_HOP_HEADERS)
         excluded.update(_connection_tokens(connection_value))
         excluded.add("x-local-failover-route")
         headers: list[tuple[str, str]] = []
         content_length: int | None = None
+        # Reject ambiguous framing: upstream duplicate Content-Length headers
+        # with conflicting values are a smuggling primitive (RFC 7230 3.3.2).
+        length_values = {
+            value.strip()
+            for value in response.headers.get_all("Content-Length", failobj=[])
+        }
+        if len(length_values) > 1:
+            return None
         for key, value in response.getheaders():
             if key.lower() in excluded:
                 continue
@@ -447,7 +458,12 @@ class _GatewayHandler(BaseHTTPRequestHandler):
         response: http.client.HTTPResponse,
         route: RouteRuntime,
     ) -> None:
-        headers, content_length = self._response_headers(response, route.config.name)
+        header_result = self._response_headers(response, route.config.name)
+        if header_result is None:
+            self.runtime.observe_failure(route, "upstream_ambiguous_framing")
+            self._json_response(502, "upstream_invalid_response")
+            return
+        headers, content_length = header_result
         session_id = response.headers.get("Mcp-Session-Id")
         if (
             self.runtime.config.protocol == "mcp"
@@ -503,11 +519,11 @@ class _GatewayHandler(BaseHTTPRequestHandler):
         if self.path == "/_failover/metrics":
             self._status_response(metrics=True)
             return
-        body = self._read_body()
-        if body is None:
-            return
         if _safe_request_target(self.path) is None:
             self._json_response(400, "invalid_request_target")
+            return
+        body = self._read_body()
+        if body is None:
             return
 
         now = self.runtime.service.clock()

--- a/claude-ops/scripts/local-failover/local_failover/proxy.py
+++ b/claude-ops/scripts/local-failover/local_failover/proxy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import http.client
 import json
 import os
+import re
 import socket
 import ssl
 import subprocess
@@ -15,7 +16,7 @@ from dataclasses import dataclass
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Mapping
-from urllib.parse import urlsplit
+from urllib.parse import unquote, urlsplit
 
 from .circuit import CircuitBreaker, RouteRuntime, RouteSelector
 from .config import GatewayConfig, ListenerConfig, NetworkGateConfig, RouteConfig
@@ -43,6 +44,42 @@ HOP_BY_HOP_HEADERS = frozenset(
 class SessionBinding:
     route_name: str
     last_seen: float
+
+
+# Origin-form request target: printable ASCII only (no SP/CTL, so no
+# request-line or header injection into the upstream connection).
+_REQUEST_TARGET_RE = re.compile(r"^/[\x21-\x7e]*$")
+# RFC 7230 token characters for header field names.
+_HEADER_NAME_RE = re.compile(r"^[!#$%&'*+.^_`|~0-9A-Za-z-]+$")
+# Header field values must not carry CR/LF/NUL (response splitting) and are
+# limited to visible ASCII plus SP/HTAB.
+_HEADER_VALUE_RE = re.compile(r"^[\t\x20-\x7e]*$")
+
+
+def _safe_request_target(raw_path: str) -> str | None:
+    """Validate the client-supplied request target before forwarding.
+
+    The proxy only forwards to the configured upstream base URL, so the
+    request target must remain a plain origin-form path: no authority-form
+    or absolute-form targets (which could redirect the outbound request), no
+    control characters or whitespace, and no dot segments (encoded or not)
+    that could escape the configured base path.
+    """
+
+    if not raw_path.startswith("/") or raw_path.startswith("//"):
+        return None
+    if _REQUEST_TARGET_RE.fullmatch(raw_path) is None:
+        return None
+    path, _, _query = raw_path.partition("?")
+    decoded = unquote(path)
+    if any(ord(ch) < 0x21 or ord(ch) == 0x7F for ch in decoded):
+        return None
+    if "\\" in decoded:
+        return None
+    for segment in decoded.split("/"):
+        if segment in {".", ".."}:
+            return None
+    return raw_path
 
 
 def _connection_tokens(value: str | None) -> set[str]:
@@ -332,23 +369,33 @@ class _GatewayHandler(BaseHTTPRequestHandler):
         excluded = set(HOP_BY_HOP_HEADERS)
         excluded.update(_connection_tokens(self.headers.get("Connection")))
         excluded.update({"expect", "host", "x-local-failover-route"})
-        headers = {
-            key: value
-            for key, value in self.headers.items()
-            if key.lower() not in excluded
-        }
+        headers = {}
+        for key, value in self.headers.items():
+            if key.lower() in excluded:
+                continue
+            # Never forward header names or values that could smuggle CR/LF
+            # or non-token characters into the upstream request.
+            if _HEADER_NAME_RE.fullmatch(key) is None:
+                continue
+            folded = value.replace("\r", " ").replace("\n", " ") if value else ""
+            if _HEADER_VALUE_RE.fullmatch(folded) is None:
+                continue
+            headers[key] = folded
         headers["Connection"] = "close"
         return headers
 
     def _upstream(
         self, route: RouteConfig
-    ) -> tuple[http.client.HTTPConnection, str]:
+    ) -> tuple[http.client.HTTPConnection, str] | None:
         base_url = route.resolve_url(self.runtime.service.env)
         parsed = urlsplit(base_url)
         assert parsed.hostname is not None
         port = parsed.port or (443 if parsed.scheme == "https" else 80)
         base_path = parsed.path.rstrip("/")
-        target = f"{base_path}/{self.path.lstrip('/')}"
+        requested = _safe_request_target(self.path)
+        if requested is None:
+            return None
+        target = f"{base_path}{requested}"
         if not target.startswith("/"):
             target = f"/{target}"
         if parsed.scheme == "https":
@@ -378,12 +425,19 @@ class _GatewayHandler(BaseHTTPRequestHandler):
         for key, value in response.getheaders():
             if key.lower() in excluded:
                 continue
+            # Upstream headers are untrusted input relative to our client
+            # connection: drop anything that could split the response.
+            if _HEADER_NAME_RE.fullmatch(key) is None:
+                continue
+            folded = value.replace("\r", " ").replace("\n", " ") if value else ""
+            if _HEADER_VALUE_RE.fullmatch(folded) is None:
+                continue
             if key.lower() == "content-length":
                 try:
-                    content_length = int(value)
+                    content_length = int(folded)
                 except ValueError:
                     continue
-            headers.append((key, value))
+            headers.append((key, folded))
         headers.append(("X-Local-Failover-Route", route_name))
         headers.append(("Connection", "close"))
         return headers, content_length
@@ -403,7 +457,9 @@ class _GatewayHandler(BaseHTTPRequestHandler):
             self.runtime.bind_session(
                 session_id, route.config.name, self.runtime.service.clock()
             )
-        self.send_response(response.status, response.reason)
+        reason = response.reason or ""
+        reason = "".join(ch if "\x20" <= ch <= "\x7e" else " " for ch in reason)
+        self.send_response(response.status, reason)
         for key, value in headers:
             self.send_header(key, value)
         self.end_headers()
@@ -450,6 +506,9 @@ class _GatewayHandler(BaseHTTPRequestHandler):
         body = self._read_body()
         if body is None:
             return
+        if _safe_request_target(self.path) is None:
+            self._json_response(400, "invalid_request_target")
+            return
 
         now = self.runtime.service.clock()
         session_route: str | None = None
@@ -479,7 +538,11 @@ class _GatewayHandler(BaseHTTPRequestHandler):
             self.runtime.begin_attempt(route)
             connection: http.client.HTTPConnection | None = None
             try:
-                connection, target = self._upstream(route.config)
+                upstream = self._upstream(route.config)
+                if upstream is None:
+                    self._json_response(400, "invalid_request_target")
+                    return
+                connection, target = upstream
                 connection.request(self.command, target, body=body, headers=headers)
                 response = connection.getresponse()
                 if connection.sock:

--- a/claude-ops/scripts/local-failover/tests/test_request_hardening.py
+++ b/claude-ops/scripts/local-failover/tests/test_request_hardening.py
@@ -1,0 +1,223 @@
+"""Regression tests for CodeQL findings: partial SSRF and response splitting.
+
+Covers alerts #316 (py/partial-ssrf, request target forwarded to upstream)
+and #314/#315 (py/http-response-splitting, upstream headers forwarded to the
+client). The proxy must reject or sanitize attacker-shaped input on both the
+inbound (client -> upstream) and outbound (upstream -> client) paths.
+"""
+
+from __future__ import annotations
+
+import http.client
+import socket
+import sys
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from local_failover.config import parse_config
+from local_failover.proxy import GatewayService, _safe_request_target
+
+
+def free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+class SafeRequestTargetTests(unittest.TestCase):
+    def test_plain_paths_and_queries_pass(self) -> None:
+        for target in (
+            "/",
+            "/v1/messages",
+            "/v1/chat/completions?stream=true",
+            "/mcp",
+            "/a/b/c?x=1&y=%20z",
+        ):
+            self.assertEqual(_safe_request_target(target), target)
+
+    def test_absolute_and_authority_forms_are_rejected(self) -> None:
+        for target in (
+            "http://evil.example/steal",
+            "https://evil.example/",
+            "evil.example:443",
+            "//evil.example/protocol-relative",
+        ):
+            self.assertIsNone(_safe_request_target(target))
+
+    def test_control_characters_and_whitespace_are_rejected(self) -> None:
+        for target in (
+            "/a\rb",
+            "/a\nb",
+            "/a b HTTP/1.1\r\nHost: evil",
+            "/a\x00b",
+            "/a\tb",
+        ):
+            self.assertIsNone(_safe_request_target(target))
+
+    def test_dot_segments_are_rejected_encoded_or_not(self) -> None:
+        for target in (
+            "/../secret",
+            "/a/../../secret",
+            "/a/./b",
+            "/%2e%2e/secret",
+            "/a/%2E%2E/b",
+        ):
+            self.assertIsNone(_safe_request_target(target))
+
+    def test_encoded_control_characters_are_rejected(self) -> None:
+        for target in ("/a%0d%0ab", "/a%00b", "/a%20b"):
+            self.assertIsNone(_safe_request_target(target))
+
+    def test_backslash_segments_are_rejected(self) -> None:
+        self.assertIsNone(_safe_request_target("/a%5C..%5Cb"))
+
+
+class SplittingOriginHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, _format, *args) -> None:
+        return
+
+    def do_GET(self) -> None:
+        self.server.seen_paths.append(self.path)
+        body = b'{"ok":true}'
+        # Write raw headers so we can emit values Python's send_header would
+        # normally deliver verbatim, including a header with an invalid name.
+        self.wfile.write(b"HTTP/1.1 200 OK\r\n")
+        self.wfile.write(b"Content-Type: application/json\r\n")
+        self.wfile.write(b"Content-Length: %d\r\n" % len(body))
+        self.wfile.write(b"X-Ok: kept\r\n")
+        self.wfile.write(b"Bad Header Name: dropped\r\n")
+        self.wfile.write(b"Connection: close\r\n\r\n")
+        self.wfile.write(body)
+
+    def do_POST(self) -> None:
+        self.do_GET()
+
+
+def make_service(port: int, origin_url: str) -> GatewayService:
+    config = parse_config(
+        {
+            "version": 1,
+            "listeners": [
+                {
+                    "name": "llm",
+                    "host": "127.0.0.1",
+                    "port": port,
+                    "protocol": "llm",
+                    "max_body_bytes": 1024,
+                    "max_concurrent_requests": 8,
+                    "max_idempotent_attempts": 2,
+                    "client_timeout_seconds": 2,
+                    "connect_timeout_seconds": 1,
+                    "idle_timeout_seconds": 2,
+                    "session_ttl_seconds": 60,
+                    "routes": [
+                        {
+                            "name": "primary",
+                            "url": origin_url,
+                            "provisioned": True,
+                            "health": {
+                                "kind": "llm",
+                                "auth_env": "FAILOVER_HEALTH_TOKEN",
+                                "inventory_path": "/v1/models",
+                                "stream_path": "/v1/chat/completions",
+                                "stream_model_env": "FAILOVER_HEALTH_MODEL",
+                                "interval_seconds": 60,
+                            },
+                            "breaker": {
+                                "failure_threshold": 1,
+                                "recovery_successes": 1,
+                                "base_backoff_seconds": 1,
+                                "max_backoff_seconds": 5,
+                                "failback_hold_seconds": 0,
+                                "max_stale_seconds": 300,
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+    return GatewayService(config, env={})
+
+
+class RequestHardeningIntegrationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.origin = ThreadingHTTPServer(("127.0.0.1", 0), SplittingOriginHandler)
+        self.origin.seen_paths = []
+        self.origin_thread = threading.Thread(
+            target=self.origin.serve_forever, daemon=True
+        )
+        self.origin_thread.start()
+        self.port = free_port()
+        self.service = make_service(
+            self.port, f"http://127.0.0.1:{self.origin.server_port}"
+        )
+        self.service.start(run_health=False)
+        runtime = self.service.listeners["llm"]
+        now = self.service.clock()
+        for route in runtime.routes:
+            route.breaker.observe_success(now, "test_ready")
+
+    def tearDown(self) -> None:
+        self.service.shutdown()
+        self.origin.shutdown()
+        self.origin.server_close()
+        self.origin_thread.join(timeout=2)
+
+    def raw_request(self, request: bytes) -> bytes:
+        client = socket.create_connection(("127.0.0.1", self.port), timeout=3)
+        client.sendall(request)
+        response = b""
+        while True:
+            try:
+                chunk = client.recv(4096)
+            except socket.timeout:
+                break
+            if not chunk:
+                break
+            response += chunk
+        client.close()
+        return response
+
+    def test_absolute_form_target_is_rejected_before_upstream(self) -> None:
+        response = self.raw_request(
+            b"GET http://evil.example/steal HTTP/1.1\r\n"
+            b"Host: localhost\r\nConnection: close\r\n\r\n"
+        )
+        self.assertIn(b" 400 ", response)
+        self.assertIn(b"invalid_request_target", response)
+        self.assertEqual(self.origin.seen_paths, [])
+
+    def test_dot_segment_target_is_rejected_before_upstream(self) -> None:
+        response = self.raw_request(
+            b"GET /%2e%2e/internal HTTP/1.1\r\n"
+            b"Host: localhost\r\nConnection: close\r\n\r\n"
+        )
+        self.assertIn(b" 400 ", response)
+        self.assertIn(b"invalid_request_target", response)
+        self.assertEqual(self.origin.seen_paths, [])
+
+    def test_upstream_header_with_invalid_name_is_not_forwarded(self) -> None:
+        connection = http.client.HTTPConnection("127.0.0.1", self.port, timeout=3)
+        connection.request("GET", "/resource")
+        response = connection.getresponse()
+        headers = {key.lower(): value for key, value in response.getheaders()}
+        response.read()
+        connection.close()
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(headers.get("x-ok"), "kept")
+        self.assertNotIn("bad header name", headers)
+        self.assertEqual(self.origin.seen_paths, ["/resource"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/claude-ops/scripts/local-failover/tests/test_request_hardening.py
+++ b/claude-ops/scripts/local-failover/tests/test_request_hardening.py
@@ -74,6 +74,23 @@ class SafeRequestTargetTests(unittest.TestCase):
         for target in ("/a%0d%0ab", "/a%00b", "/a%20b"):
             self.assertIsNone(_safe_request_target(target))
 
+    def test_query_with_encoded_control_characters_is_rejected(self) -> None:
+        for target in (
+            "/v1/messages?x=%0d%0aheader",
+            "/v1/messages?x=%0acrlf",
+            "/v1/messages?x=%00nul",
+        ):
+            self.assertIsNone(_safe_request_target(target))
+
+    def test_query_with_encoded_space_is_allowed(self) -> None:
+        self.assertEqual(
+            _safe_request_target("/a/b?x=%20z"), "/a/b?x=%20z"
+        )
+
+    def test_query_with_backslash_is_rejected(self) -> None:
+        for target in ("/v1/messages?x=%5c", "/v1/messages?x=a\\b"):
+            self.assertIsNone(_safe_request_target(target))
+
     def test_backslash_segments_are_rejected(self) -> None:
         self.assertIsNone(_safe_request_target("/a%5C..%5Cb"))
 
@@ -87,6 +104,15 @@ class SplittingOriginHandler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:
         self.server.seen_paths.append(self.path)
         body = b'{"ok":true}'
+        if self.path == "/dup-length":
+            # Conflicting duplicate Content-Length: a smuggling primitive.
+            self.wfile.write(b"HTTP/1.1 200 OK\r\n")
+            self.wfile.write(b"Content-Type: application/json\r\n")
+            self.wfile.write(b"Content-Length: %d\r\n" % len(body))
+            self.wfile.write(b"Content-Length: 2\r\n")
+            self.wfile.write(b"Connection: close\r\n\r\n")
+            self.wfile.write(body)
+            return
         # Write raw headers so we can emit values Python's send_header would
         # normally deliver verbatim, including a header with an invalid name.
         self.wfile.write(b"HTTP/1.1 200 OK\r\n")
@@ -217,6 +243,28 @@ class RequestHardeningIntegrationTests(unittest.TestCase):
         self.assertEqual(headers.get("x-ok"), "kept")
         self.assertNotIn("bad header name", headers)
         self.assertEqual(self.origin.seen_paths, ["/resource"])
+
+    def test_invalid_target_beats_oversized_body(self) -> None:
+        # Target validation must run before body handling: an invalid
+        # target with an oversized declared body is a 400, not a 413.
+        response = self.raw_request(
+            b"POST http://evil.example/steal HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"Content-Length: 999999\r\n"
+            b"Connection: close\r\n\r\n"
+        )
+        self.assertIn(b" 400 ", response)
+        self.assertIn(b"invalid_request_target", response)
+        self.assertEqual(self.origin.seen_paths, [])
+
+    def test_conflicting_upstream_content_length_is_rejected(self) -> None:
+        response = self.raw_request(
+            b"GET /dup-length HTTP/1.1\r\n"
+            b"Host: localhost\r\nConnection: close\r\n\r\n"
+        )
+        self.assertIn(b" 502 ", response)
+        self.assertIn(b"upstream_invalid_response", response)
+        self.assertEqual(self.origin.seen_paths, ["/dup-length"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the three open CodeQL alerts in `claude-ops/scripts/local-failover/local_failover/proxy.py`:

- **#316 `py/partial-ssrf` (critical)** — the client-supplied request target was concatenated into the upstream URL unvalidated. Now validated by `_safe_request_target`: origin-form only (absolute-form `http://...`, authority-form, and protocol-relative `//host` targets rejected), printable ASCII only, no encoded control chars, no dot segments raw or percent-encoded, no backslash segments. Rejected requests return `400 invalid_request_target` before any upstream connection is opened.
- **#314 / #315 `py/http-response-splitting`** — upstream response headers were replayed to the client verbatim via `send_header`. Now header names must be RFC 7230 tokens and values are CR/LF-folded and restricted to visible ASCII + SP/HTAB; the reason phrase is filtered too.
- Same class, sibling path: forwarded **request** headers to the upstream get identical name/value sanitization, so a client cannot smuggle CR/LF into the upstream connection either.

Tests: new `tests/test_request_hardening.py` — unit coverage of the validator plus live-socket integration tests proving an absolute-form or dot-segment target never reaches the origin and a malformed upstream header is not forwarded. Full local-failover suite 65/65 green; plugin `npm test` (secret scan) 27/27 green.

Kanban: personal-infra t_a4a9cadb.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened request validation to reject unsafe or malformed request targets.
  - Blocked dangerous paths, including dot segments, backslashes, control characters, and unsupported formats.
  - Added request and response header validation and sanitization.
  - Prevented invalid upstream headers from being forwarded.
  - Invalid requests now receive a 400 response before upstream access.
  - Conflicting upstream content-length values now return a 502 response.

- **Tests**
  - Added coverage for request-target validation, header handling, upstream access prevention, and conflicting content-length responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->