### PR TITLE
fix(migrate): fail closed when the real home cannot be resolved

### DIFF
--- a/claude-ops/bin/ops-post-update-migrate
+++ b/claude-ops/bin/ops-post-update-migrate
@@ -44,11 +44,21 @@ log() { printf "[%s] %s\n" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "$LOG"; }
 # Guard the whole class: any launchctl mutation is skipped unless $HOME is the
 # invoking user's real home. A sandboxed run still exercises every path that
 # writes files, which is what the tests actually assert on.
-REAL_HOME="$(python3 -c 'import os,pwd; print(pwd.getpwuid(os.getuid()).pw_dir)' 2>/dev/null || echo "$HOME")"
+#
+# FAIL CLOSED. Do not default REAL_HOME to "$HOME" when the lookup fails: that
+# makes the comparison below compare $HOME to itself, which is trivially true
+# for a sandboxed HOME too, and re-enables the exact hazard this guard exists to
+# prevent. An unresolvable real home means we cannot prove we are safe, so we
+# skip the mutation.
+REAL_HOME="$(python3 -c 'import os,pwd; print(pwd.getpwuid(os.getuid()).pw_dir)' 2>/dev/null || true)"
 
 launchctl_guarded() {
   if [[ "${OPS_MIGRATE_NO_LAUNCHCTL:-0}" == "1" ]]; then
     log "  skip: launchctl $* (OPS_MIGRATE_NO_LAUNCHCTL=1)"
+    return 0
+  fi
+  if [[ -z "$REAL_HOME" ]]; then
+    log "  skip: launchctl $* (could not resolve real home — failing closed)"
     return 0
   fi
   if [[ "$HOME" != "$REAL_HOME" ]]; then

--- a/claude-ops/tests/test-migrate-launchctl-domain-isolation.sh
+++ b/claude-ops/tests/test-migrate-launchctl-domain-isolation.sh
@@ -56,8 +56,22 @@ SHIM
 chmod +x "$SHIM_DIR/launchctl"
 export PATH="$SHIM_DIR:$PATH"
 
+# Scenarios below render a plist under the REAL home (with a fake label) and
+# create sandbox roots under $TMPDIR. Clean both up even when the run is
+# interrupted, so a HUP/INT/TERM cannot leave a stray LaunchAgent behind.
+CLEANUP_PATHS=()
+cleanup() {
+  local p
+  for p in "${CLEANUP_PATHS[@]:-}"; do
+    [[ -n "$p" ]] && rm -rf "$p" 2>/dev/null || true
+  done
+  rm -rf "$SHIM_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT HUP INT TERM
+
 setup_sandbox() {
   ROOT=$(mktemp -d)
+  CLEANUP_PATHS+=("$ROOT")
   export HOME="$ROOT/home"
   mkdir -p "$HOME/Library/LaunchAgents"
   PLUGIN_ROOT="$ROOT/plugin"
@@ -114,6 +128,7 @@ FAKE_USER="ops-migrate-guard-test-$$"
 REAL_PLIST="$REAL_HOME_VALUE/Library/LaunchAgents/com.${USER}.whatsapp-bridge.plist"
 REAL_PLIST_SUM_BEFORE="$( [[ -f "$REAL_PLIST" ]] && shasum -a256 "$REAL_PLIST" | awk '{print $1}' || echo absent)"
 TEST_PLIST="$REAL_HOME_VALUE/Library/LaunchAgents/com.${FAKE_USER}.whatsapp-bridge.plist"
+CLEANUP_PATHS+=("$TEST_PLIST")
 
 setup_sandbox
 : > "$CALLS"
@@ -152,6 +167,35 @@ CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
   bash "$SCRIPT" >/dev/null 2>&1 || true
 rm -f "$TEST_PLIST"
 ck "zero launchctl invocations with OPS_MIGRATE_NO_LAUNCHCTL=1" "$(wc -l < "$CALLS" | tr -d ' ')" "0"
+
+echo
+echo "=== real-home lookup FAILS: must fail closed, not fall back to \$HOME ==="
+# The guard resolves the real home with python3. If that lookup ever returns
+# nothing and the code falls back to "$HOME", the comparison becomes $HOME vs
+# $HOME — trivially equal even for a sandboxed HOME — and every launchctl call
+# fires in the real GUI domain again. Force the failure and assert we skip.
+BREAK_DIR=$(mktemp -d)
+CLEANUP_PATHS+=("$BREAK_DIR")
+printf '#!/bin/bash\nexit 1\n' > "$BREAK_DIR/python3"
+chmod +x "$BREAK_DIR/python3"
+
+setup_sandbox
+SANDBOXED_HOME="$HOME"
+: > "$CALLS"
+# HOME is the sandbox here, but with the resolver broken a fallback-to-$HOME
+# implementation would consider it "real" and proceed.
+CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT" \
+  PATH="$BREAK_DIR:$PATH" \
+  HOME="$SANDBOXED_HOME" \
+  USER="$FAKE_USER" \
+  CLAUDE_PLUGIN_DATA_DIR="$CLAUDE_PLUGIN_DATA_DIR" \
+  WHATSAPP_BRIDGE_HOME="$WHATSAPP_BRIDGE_HOME" \
+  bash "$SCRIPT" >/dev/null 2>&1 || true
+ck "zero launchctl invocations when real home is unresolvable" "$(wc -l < "$CALLS" | tr -d ' ')" "0"
+if [[ -s "$CALLS" ]]; then
+  echo "  offending calls:"
+  sed 's/^/    /' "$CALLS"
+fi
 
 rm -rf "$SHIM_DIR"
 echo


### PR DESCRIPTION
## Follow-up to #847 (both findings from that PR's review)

### 1. Fail closed when the real home cannot be resolved (Critical)

`launchctl_guarded()` resolved the real home with `python3` and fell back to `"$HOME"` on failure:

```bash
REAL_HOME="$(python3 -c '...' 2>/dev/null || echo "$HOME")"
```

That fallback makes the safety comparison compare `$HOME` to itself. It is trivially true for a **sandboxed** HOME too, so a broken or missing `python3` silently re-enables the exact hazard the guard exists to prevent: `launchctl` mutations in the real GUI domain from a sandboxed test.

Now resolves to empty on failure, and an empty value skips the mutation.

**Verified by mutation, not by a green run.** A new scenario shims a failing `python3` onto `PATH` and asserts zero `launchctl` invocations. Restoring the old fallback makes it fail with 3 leaked real-domain calls:

```
=== real-home lookup FAILS: must fail closed, not fall back to $HOME ===
  FAIL: zero launchctl invocations when real home is unresolvable (want '0', got '3')
  offending calls:
    unload .../T/tmp.bAlLrrEPxa/home/Library/LaunchAgents/com.<label>.whatsapp-bridge.plist
    load   .../T/tmp.bAlLrrEPxa/home/Library/LaunchAgents/com.<label>.whatsapp-bridge.plist
    unload .../T/tmp.bAlLrrEPxa/home/Library/LaunchAgents/com.claude-ops.wacli-keepalive.plist
```

### 2. Cleanup traps on interruption (Minor)

The "guard is not dead code" scenario needs the real `$HOME` to exercise the guard's condition, so it renders a plist under the operator's real `LaunchAgents` dir with a deliberately fake label. It was removed only on normal completion.

Added `trap cleanup EXIT HUP INT TERM` covering that plist, every `setup_sandbox` root, and the shim dir. Verified by SIGTERMing the suite mid-run: no stray plists remain.

### Regression status

| Check | Result |
|---|---|
| New suite vs fixed script | 7 passed, 0 failed |
| New suite vs **pre-#847** script | still fails (3 leaked calls) |
| New suite vs fallback **mutant** | fails on the new scenario (mutant killed) |
| Live production plist sha256 across all runs | unchanged |
| `npm test` | 27 passed, 0 failed |
