### PR TITLE
release: v3.6.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 64 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-3.6.0-blue)
+![Version](https://img.shields.io/badge/version-3.6.1-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-64-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Business operations command center for Claude Code — 64 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -67,6 +67,14 @@
 - **ops-ecom:** `channels` | `agentic` | `shop` verbs — sales channel inventory, agentic storefront health, Shop Campaigns readiness (read-only; Rule 5 / stage-only spend).
 - **ops-marketing:** brand-agnostic `shop_campaigns` + `agentic_storefronts` project prefs schema; `shop-campaigns` / `agentic` routing; portfolio awareness; NEVER LEAK MONEY guardrails for Shop Campaigns.
 
+## [3.6.1] - 2026-08-22
+
+### Changed
+- Slim ops-inbox SKILL.md (~6k → ~2k) and rewrite remaining skill descriptions with real NL triggers.
+- Keep Hermes plugin.yaml and the installer pin in lockstep with plugin.json so Claude, Grok, and Hermes ship the same version.
+- Document that plugin .mcp.json is empty on purpose (MCP starts on demand).
+
+
 ## [3.6.0] - 2026-08-22
 
 ### Changed

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-3.6.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.6.1-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 64 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-3.6.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.6.1-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-64-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/hermes-plugin/plugin.yaml
+++ b/claude-ops/hermes-plugin/plugin.yaml
@@ -1,4 +1,4 @@
 name: ops
-version: "3.6.0"
+version: "3.6.1"
 description: "claude-ops on Hermes — slash commands and skills for inbox, deploy, revenue, and the rest of the ops suite. Enable with plugins.enabled: [ops]."
 author: Lifecycle Innovations Limited

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -260,6 +260,17 @@ genuine reasoning, not for reading a database.
 
 **Fan-out for real per-thread volume.** After the cheap scan, deep-read and draft in parallel (`Workflow` default; Agent Teams / Hermes `delegate_task` fallback). Skip only the trivial case (~1–3 candidates). Mechanics, hard constraints, and the canonical Workflow JS: `references/fan-out.md`. Fan-out never sends, archives, or mutates — Rule 6 stays in the main session.
 
+## Agent Teams support
+
+When `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set and `Workflow` is missing, fan out one read-only scanner per available channel:
+
+```
+TeamCreate("inbox-channels")
+Agent(team_name="inbox-channels", name="whatsapp-scanner", ...)
+```
+
+If the flag is NOT set, use `Workflow` or sequential main-session reads. Full script and hard constraints: `references/fan-out.md`.
+
 ### Fallback — Hermes / Grok (`delegate_task`)
 
 When this skill runs on Hermes or Grok (no `Workflow` tool, no `AskUserQuestion`):

--- a/claude-ops/tests/test-agent-teams.sh
+++ b/claude-ops/tests/test-agent-teams.sh
@@ -76,29 +76,38 @@ for skill_file in "${skill_files[@]}"; do
     err "$skill_name: missing 'SendMessage' in allowed-tools"
   fi
 
+  # Progressive disclosure: the section may live in SKILL.md or references/*.md
+  skill_dir="$(dirname "$skill_file")"
+  docs=("$skill_file")
+  if [[ -d "$skill_dir/references" ]]; then
+    while IFS= read -r -d '' rf; do
+      docs+=("$rf")
+    done < <(find "$skill_dir/references" -name '*.md' -print0 2>/dev/null)
+  fi
+
   # 3. Agent Teams support section (accepts "## Agent Teams support" or "## Agent Teams" or subsection variants)
-  if grep -qE "^#{2,3} .*(Agent Teams|Teams support)" "$skill_file" 2>/dev/null; then
+  if grep -qE "^#{2,3} .*(Agent Teams|Teams support)" "${docs[@]}" 2>/dev/null; then
     ok "has Agent Teams documentation section"
   else
     err "$skill_name: missing '## Agent Teams support' section"
   fi
 
   # 4. Feature flag check
-  if grep -q "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" "$skill_file" 2>/dev/null; then
+  if grep -q "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" "${docs[@]}" 2>/dev/null; then
     ok "checks CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS flag"
   else
     err "$skill_name: missing CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS flag check"
   fi
 
   # 5. TeamCreate() call in body
-  if grep -qE "TeamCreate\(" "$skill_file" 2>/dev/null; then
+  if grep -qE "TeamCreate\(" "${docs[@]}" 2>/dev/null; then
     ok "has TeamCreate() usage example"
   else
     err "$skill_name: missing TeamCreate() usage example in body"
   fi
 
   # 6. Fallback to standard subagents when flag is off
-  if grep -qiE "(flag is NOT set|flag is not enabled|not set.*subagent|fallback|fire-and-forget)" "$skill_file" 2>/dev/null; then
+  if grep -qiE "(flag is NOT set|flag is not enabled|not set.*subagent|fallback|fire-and-forget)" "${docs[@]}" 2>/dev/null; then
     ok "documents fallback when flag is off"
   else
     err "$skill_name: missing fallback documentation for when flag is off"

--- a/installer/README.md
+++ b/installer/README.md
@@ -56,7 +56,7 @@ version: 1
 source:
   type: git
   url: https://github.com/Lifecycle-Innovations-Limited/claude-ops.git
-  ref: v3.6.0
+  ref: v3.6.1
 
 agents:
   claude:    { enabled: true }

--- a/installer/src/config.mjs
+++ b/installer/src/config.mjs
@@ -17,7 +17,7 @@ export const DEFAULT_CONFIG = {
   source: {
     type: "git",
     url: "https://github.com/Lifecycle-Innovations-Limited/claude-ops.git",
-    ref: "v3.6.0",
+    ref: "v3.6.1",
   },
   agents: {
     claude: { enabled: true, type: "marketplace" },


### PR DESCRIPTION
Release **v3.6.1** (was 3.6.0).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

- Slim ops-inbox SKILL.md (~6k → ~2k) and rewrite remaining skill descriptions with real NL triggers.
- Keep Hermes plugin.yaml and the installer pin in lockstep with plugin.json so Claude, Grok, and Hermes ship the same version.
- Document that plugin .mcp.json is empty on purpose (MCP starts on demand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)