### PR TITLE
docs: README, INDEX, and harness-ports for v3.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ Turn Claude Code into a complete business operating system — infrastructure he
 
 ---
 
+## What's new in v3.6
+
+**Current: [v3.6.1](https://github.com/Lifecycle-Innovations-Limited/claude-ops/releases/tag/v3.6.1).** One plugin, three harnesses, official skill shape.
+
+| | |
+|---|---|
+| Native Hermes plugin | `hermes-plugin/` → `~/.hermes/plugins/ops`. Slash commands + `skill_view("ops:*")`. |
+| Grok | Loads the Claude plugin as-is. No `.grok-plugin`. |
+| Skills | Third-person trigger descriptions, shared preamble, `ops-rules` (plugin-root `CLAUDE.md` is a pointer). Oversized skills split into `references/`. |
+| Versions | `plugin.json` = Hermes `plugin.yaml` = installer pin. `ops-release` keeps them together. |
+| MCP | Plugin `.mcp.json` is empty. Servers start on demand, not once per session. |
+
+Ports: [`claude-ops/docs/harness-ports.md`](claude-ops/docs/harness-ports.md). Rules: [`skills/ops-rules/SKILL.md`](claude-ops/skills/ops-rules/SKILL.md). Full notes: [`CHANGELOG`](claude-ops/CHANGELOG.md).
+
+---
+
 ## What's new in v2.0
 
 v2 turns claude-ops from a _briefing + comms surface_ into an **autonomy layer for Claude Code itself.** Purely additive — no v1 behaviour changes by default. See [`claude-ops/CHANGELOG.md`](claude-ops/CHANGELOG.md#200--2026-04-26) and [`docs/migrating-from-v1.md`](claude-ops/docs/migrating-from-v1.md).

--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -1,13 +1,13 @@
 # claude-ops
 
-> **v2.11.5** — Autonomy Layer · Deploy Auto-Fix · Safety Hooks · Specialist Agents · Recap Marquee · Multi-Account Rotator · Multi-Workspace Slack · Telegram Bot Push · Linux Headless Browser-Auth · 35 Skills · 18 Agents
+> **v3.6.1** — 64 skills · 21 agents · Claude + Grok + Hermes · ops-rules · empty `.mcp.json`
 
-## What's new in v2.11.5
+## What's new in v3.6.1
 
-- **v2.11.5** — Linux headless browser-auth for the account rotator (Brave Tier-2, Xvnc 1280×800, per-account `gog`, magic-link-only). See [CHANGELOG.md](CHANGELOG.md) for the full list.
-- **v2.11.4** — Account rotator prefers personal accounts over TEAMS/org accounts to avoid org-chooser + Google push-2FA stalls.
-- **v2.11.3** — [`bin/ops-telegram-bot-send`](docs/telegram-bot-send.md): bot-token push to the operator's own Telegram chat. Lower-cost alternative to the user-account MCP path for one-way notifications. Includes the `block-outbound-comms.py` self-channel exception.
-- Older: **v2.2.0** — Audit fixes: plugin validation (install unblocked), deploy-fix test suite (45/45 passing), `set -e` safety, account-rotation stdin handling. See [CHANGELOG.md](CHANGELOG.md) for the full list.
+- **v3.6.1** — Slim `ops-inbox` SKILL.md, real NL skill triggers, Hermes `plugin.yaml` + installer pin locked to `plugin.json`. Grok still loads the Claude plugin. [harness-ports.md](docs/harness-ports.md).
+- **v3.6.0** — Skills match plugin-dev practice: `ops-rules` skill (root `CLAUDE.md` is a pointer), third-person frontmatter, shared preamble, oversized SKILL.md split into `references/`.
+- **v3.5.0** — Native Hermes plugin: slash commands, `skill_view("ops:*")`, Rule 10 harness fallbacks, installer `~/.hermes/plugins/ops`.
+- Older notes: [CHANGELOG.md](CHANGELOG.md).
 
 A Claude Code plugin that turns Claude into a business operating system **and** an autonomy layer. Run `/ops` for the interactive command center — pixel-art dashboard with instant hotkey access to morning briefings, inbox, fires, deploys, revenue, and YOLO mode. Or just keep working — v2's hooks watch every merge, every build, every commit, every push, and every agent dispatch in the background.
 

--- a/claude-ops/bin/ops-sync-docs
+++ b/claude-ops/bin/ops-sync-docs
@@ -77,7 +77,7 @@ apply "$PLUGIN_DIR/README.md" "${COUNT_E[@]}" "${BADGE_E[@]}" "${HEAD_E[@]}"
 # Reference docs + index — badges + headlines.
 apply "$PLUGIN_DIR/docs/skills-reference.md" "${BADGE_E[@]}" "${HEAD_E[@]}"
 apply "$PLUGIN_DIR/docs/agents-reference.md" "${BADGE_E[@]}" "${HEAD_E[@]}"
-apply "$PLUGIN_DIR/docs/INDEX.md"            "${HEAD_E[@]}"
+apply "$PLUGIN_DIR/docs/INDEX.md"            "${BADGE_E[@]}" "${HEAD_E[@]}"
 
 [[ "$changed" -eq 0 ]] && echo "  already in sync — nothing to do"
 echo "ops-sync-docs: done (${changed} file(s) $([[ $DRY -eq 1 ]] && echo 'would change' || echo 'changed'))"

--- a/claude-ops/docs/INDEX.md
+++ b/claude-ops/docs/INDEX.md
@@ -4,11 +4,19 @@
 
 _Top-level map of every doc file in `claude-ops/docs/`._
 
-[![version](https://img.shields.io/badge/version-2.1.0-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.6.1-blue)](../CHANGELOG.md)
 
 </div>
 
 ---
+
+## v3.6 — harnesses and skill shape
+
+| Doc | Subject |
+|---|---|
+| [`harness-ports.md`](harness-ports.md) | Claude / Grok / Hermes: one skill tree, lockstep versions, Rule 10 fallbacks, empty `.mcp.json`. |
+| [`../hermes-plugin/RUNTIME.md`](../hermes-plugin/RUNTIME.md) | Claude Code primitive → Hermes/Grok swap table. |
+| [`../skills/ops-rules/SKILL.md`](../skills/ops-rules/SKILL.md) | Standing rules 0–10. Plugin-root `CLAUDE.md` is a pointer only. |
 
 ## v2.0 — autonomy layer
 
@@ -39,4 +47,4 @@ _Top-level map of every doc file in `claude-ops/docs/`._
 - [Wiki](https://github.com/Lifecycle-Innovations-Limited/claude-ops/wiki) — narrative pages, tutorials, FAQ.
 - [`CHANGELOG.md`](../CHANGELOG.md) — release history.
 - [`README.md`](../README.md) — plugin overview.
-- [`CLAUDE.md`](../CLAUDE.md) — non-negotiable rules for all skills.
+- [`CLAUDE.md`](../CLAUDE.md) — pointer. Rules live in `skills/ops-rules/SKILL.md`.

--- a/claude-ops/docs/harness-ports.md
+++ b/claude-ops/docs/harness-ports.md
@@ -1,0 +1,15 @@
+# Harness ports (Claude, Grok, Hermes)
+
+One skill tree. Three harnesses. Versions stay in lockstep.
+
+| Harness | Loads | Skills |
+|---|---|---|
+| Claude Code | `.claude-plugin/` | `claude-ops/skills/` |
+| Grok | the Claude plugin as-is (no `.grok-plugin`) | same `skills/` |
+| Hermes | `hermes-plugin/` as `~/.hermes/plugins/ops` | same `skills/` |
+
+`ops-release` bumps all of these together: `plugin.json`, marketplace registry, `package.json`, `hermes-plugin/plugin.yaml`, installer `source.ref`.
+
+When a Claude-only primitive is missing (`AskUserQuestion`, `Workflow`, `TeamCreate`), use Rule 10: numbered options, `delegate_task` / sequential work, never `gh --admin`. Table: `hermes-plugin/RUNTIME.md`.
+
+Plugin `.mcp.json` is empty on purpose. MCP servers start on demand (`/ops:setup`, host `~/.claude.json`, `mcp-toggle`), not once per Claude session.


### PR DESCRIPTION
Bring the main docs in line with v3.6.1.

- Root + plugin README: what's new in v3.6 (Hermes, Grok, ops-rules, empty .mcp.json)
- New `docs/harness-ports.md`
- INDEX version badge 3.6.1 + 3.6 section
- ops-sync-docs also rewrites INDEX badges

Wiki already updated: https://github.com/Lifecycle-Innovations-Limited/claude-ops/wiki

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added v3.6.1 release notes covering Hermes plugin support, Grok compatibility, skill structure conventions, synchronized versioning, and on-demand MCP server startup.
  - Updated documentation navigation and version banners.
  - Added guidance on shared skill support across Claude Code, Grok, and Hermes, including fallback behavior and harness integrations.
  - Clarified the role of `CLAUDE.md` as a pointer to the operations rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->