### PR TITLE
fix(hermes): install the native plugin without a skills path

### DIFF
--- a/claude-ops/hermes-plugin/RUNTIME.md
+++ b/claude-ops/hermes-plugin/RUNTIME.md
@@ -9,7 +9,7 @@ Grok loads the same Claude plugin (`skills/` + `.claude-plugin/`) — there is n
 | `AskUserQuestion` | Numbered options in chat, then wait. Telegram/gateway: two turns — full draft as its own message, then the Send / Edit / Skip card. Never put the draft only in a clipped preview. Max 4 options per card. |
 | `Workflow` | `delegate_task` for parallel read-only work. If that tool is missing, run the same scanners sequentially in the main session. |
 | `TeamCreate` / `Agent` teams | `delegate_task`. No Claude agent-team steering. |
-| `TaskCreate` / `TaskUpdate` / `TaskList` | Hermes Kanban, or skip. Do not require Paperclip. |
+| `TaskCreate` / `TaskUpdate` / `TaskList` | Hermes Kanban. If that is missing too, say tracking is unavailable and ask what to do instead. Never drop the item silently. Do not require Paperclip. |
 | `CronCreate` / `CronList` | `hermes cron`. |
 | `mcp__linear__*` | Linear CLI / GraphQL. Resolve the real tool names at runtime. |
 | `mcp__whatsapp__*` | Resolve the live server name (Rule 8). Hermes may also have native `whatsapp_*` plugin tools — same Rule 6 send gate. |

--- a/claude-ops/tests/test-hermes-plugin.sh
+++ b/claude-ops/tests/test-hermes-plugin.sh
@@ -42,7 +42,8 @@ else
   err "missing __init__.py or RUNTIME.md"
 fi
 
-if python3 -m py_compile "$HP/__init__.py"; then
+# Redirect the bytecode cache so py_compile does not drop __pycache__ in the tree.
+if PYTHONPYCACHEPREFIX="$(mktemp -d)" python3 -m py_compile "$HP/__init__.py"; then
   ok "__init__.py compiles"
 else
   err "__init__.py failed to compile"

--- a/installer/src/dispatch.mjs
+++ b/installer/src/dispatch.mjs
@@ -55,26 +55,29 @@ export function planAll({
       plan.agents[name] = { skipped: true, reason: "not detected" };
       continue;
     }
-    if (!a.skillsPath) {
-      plan.agents[name] = { skipped: true, reason: "no skillsPath" };
-      continue;
+    // A native plugin path stands on its own: an agent can take the plugin
+    // without mirroring skills, so this must not sit behind the skillsPath gate.
+    let entry;
+    if (a.skillsPath) {
+      entry = planMirror({
+        srcDir,
+        targetDir: a.skillsPath,
+        skillNames,
+        force,
+        dryRun,
+      });
+      if (entry.errors.length) plan.errors.push(...entry.errors);
+    } else {
+      entry = { skipped: true, reason: "no skillsPath" };
     }
-    const mirror = planMirror({
-      srcDir,
-      targetDir: a.skillsPath,
-      skillNames,
-      force,
-      dryRun,
-    });
-    plan.agents[name] = mirror;
-    if (mirror.errors.length) plan.errors.push(...mirror.errors);
+    plan.agents[name] = entry;
     if (a.pluginPath) {
       const pluginPlan = planNativePlugin({
         srcDir,
         pluginPath: a.pluginPath,
         force,
       });
-      plan.agents[name].plugin = pluginPlan;
+      entry.plugin = pluginPlan;
       if (pluginPlan.errors) plan.errors.push(...pluginPlan.errors);
     }
   }
@@ -184,11 +187,12 @@ function applyPluginLink(pluginPlan, { dryRun, onApply }) {
 function applyAll({ plan, dryRun, cfg }) {
   let manifest = loadManifest();
   for (const [name, mirror] of Object.entries(plan.agents)) {
-    if (mirror.skipped) continue;
-    applyActions(mirror.actions, {
-      dryRun,
-      onApply: (to, from) => addSymlink(manifest, to, from),
-    });
+    if (!mirror.skipped) {
+      applyActions(mirror.actions, {
+        dryRun,
+        onApply: (to, from) => addSymlink(manifest, to, from),
+      });
+    }
     if (mirror.plugin) {
       applyPluginLink(mirror.plugin, {
         dryRun,
@@ -196,7 +200,7 @@ function applyAll({ plan, dryRun, cfg }) {
       });
     }
     // Record every applied symlink in the manifest.
-    if (!dryRun) {
+    if (!dryRun && mirror.actions) {
       for (const a of mirror.actions) {
         if (a.status === "applied") {
           try {

--- a/installer/test/smoke.mjs
+++ b/installer/test/smoke.mjs
@@ -139,6 +139,28 @@ try {
     "undetected agent target directory is not created",
   );
 
+  // A plugin path must still be planned when the agent mirrors no skills.
+  const pluginOnlyTo = path.join(scratch, "plugin-only", "ops");
+  const pluginOnlyPlan = planAll({
+    cfg: { bin: null },
+    srcDir: SRC,
+    agents: {
+      hermes: { installed: true, pluginPath: pluginOnlyTo },
+    },
+    force: false,
+    dryRun: true,
+    skipUndetected: true,
+  });
+  assert(
+    pluginOnlyPlan.agents.hermes?.skipped &&
+      pluginOnlyPlan.agents.hermes.reason === "no skillsPath",
+    "agent without skillsPath is still reported as skipped for skills",
+  );
+  assert(
+    pluginOnlyPlan.agents.hermes?.plugin?.action?.op === "symlink",
+    "native plugin is planned even when skillsPath is absent",
+  );
+
   const pluginTo = path.join(scratch, "hermes-plugins", "ops");
   const pluginPlan = planNativePlugin({
     srcDir: SRC,
@@ -146,7 +168,7 @@ try {
     force: false,
   });
   assert(
-    pluginPlan && !pluginPlan.skipped && pluginPlan.action?.op === "symlink",
+    !pluginPlan.skipped && pluginPlan.action?.op === "symlink",
     "hermes native plugin symlink is planned",
   );
   assert(


### PR DESCRIPTION
Review fixes for the Hermes native plugin. The feature commit itself already landed on `main`, so this carries only the corrections — see #861, which this replaces.

**Plugin install was gated behind the skills path (HIGH).** `planAll` returned early on `!a.skillsPath`, so an agent configured with only a `pluginPath` never reached the plugin block, and `applyAll` also skipped the plugin link for any skipped mirror. Both now handle the plugin independently of the skills mirror. The manifest loop is guarded, because a skipped entry has no `actions`.

Covered by a smoke assertion that fails without the fix (verified by reverting).

Also:
- Dropped an always-true `pluginPlan &&` guard CodeQL flagged in `installer/test/smoke.mjs`.
- `py_compile` in `tests/test-hermes-plugin.sh` now runs under `PYTHONPYCACHEPREFIX`, so no `__pycache__` lands in the plugin tree.
- `hermes-plugin/RUNTIME.md` no longer says "or skip" for task tracking; it states the capability is unavailable and asks, per the never-silently-skip rule.

Not changed: the `fs.rmSync(..., { recursive: true, force: true })` in `applyPluginLink`. It is reached only after `planNativePlugin` classifies the target, which refuses a real file or directory unless `--force` was passed. Reasoning is in the #861 thread.

Tests: `installer/test/smoke.mjs` all green, `tests/test-hermes-plugin.sh` 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)