### PR TITLE
fix(ci): allowlist the RFC 6238 TOTP test vector

### DIFF
--- a/claude-ops/.gitleaks.toml
+++ b/claude-ops/.gitleaks.toml
@@ -183,4 +183,8 @@ regexes = [
   #   echo "api_secret:ga4.api_secret"  /  marketing.projects.<p>.ga4.property_id
   '''ga4\.api_secret''',
   '''ga4\.property_id''',
+  # RFC 6238 published TOTP test vector: base32 of "12345678901234567890",
+  # which the RFC pairs with the expected code 94287082. A standards-document
+  # constant asserted by scripts/crsproxy-reauth/test_bu_2fa.py, not a secret.
+  '''GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ''',
 ]


### PR DESCRIPTION
`main` is currently red on the secret-scan gate, which blocks every open PR.

43404c6 added `claude-ops/scripts/crsproxy-reauth/test_bu_2fa.py`, which asserts `totp_from_secret()` against the published RFC 6238 SHA1 test vector. gitleaks classifies that base32 string as a `generic-api-key`, so `lint-and-check` fails on main and on each PR's merge commit.

The value is base32 of `12345678901234567890`, which RFC 6238 pairs with the expected code `94287082`. It is a standards-document constant, not a credential.

Allowlisted by literal regex rather than excluding the directory, matching the convention this file already documents ("Narrow regex allowlist preferred over directory exclusion so secret scanning still runs against scripts/"). Real tokens under `scripts/` are still scanned.

Verified locally with the same scan scope CI uses (shallow checkout → working tree):

- main's config: `leaks found: 2`
- this config: `no leaks found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)