### PR TITLE
chore: drop dead gitleaks allowlist entry and correct a stale CHANGELOG claim

### DIFF
--- a/claude-ops/.gitleaks.toml
+++ b/claude-ops/.gitleaks.toml
@@ -183,8 +183,4 @@ regexes = [
   #   echo "api_secret:ga4.api_secret"  /  marketing.projects.<p>.ga4.property_id
   '''ga4\.api_secret''',
   '''ga4\.property_id''',
-  # RFC 6238 published TOTP test vector: base32 of "12345678901234567890",
-  # which the RFC pairs with the expected code 94287082. A standards-document
-  # constant asserted by scripts/crsproxy-reauth/test_bu_2fa.py, not a secret.
-  '''GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ''',
 ]

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -11,10 +11,13 @@
   CLIProxyAPI is now the only supported path for multi-account rotation and OAuth
   seat management: it holds one OAuth seat file per account, and `rotate.mjs`
   already writes those files during a rotation.
-  Deleted: the `crs-*` daemons in `scripts/account-rotation/`, all of
-  `scripts/crsproxy-reauth/`, the three `install-crs-*.sh` installers, the five
-  `crs-*` systemd units, the `com.claude-ops.crs-*` plists, and
-  `docs/runbooks/crs-full-tuning-plan.md`.
+  Deleted: the `crs-*` daemons in `scripts/account-rotation/`, the three
+  `install-crs-*.sh` installers, the five `crs-*` systemd units, the
+  `com.claude-ops.crs-*` plists, and `docs/runbooks/crs-full-tuning-plan.md`.
+  Kept: `scripts/crsproxy-reauth/`. An earlier draft of this entry listed it as
+  deleted, but it survived the CRS removal and still carries the Browser Use
+  OAuth reauthentication helpers, which are cliproxy-facing rather than CRS-only.
+  It is covered by `tests/test-crsproxy-reauth.sh`.
   Renamed, same behaviour: `crs-pool-config.mjs` → `rotation-config.mjs`,
   `crs-refresh-lock.mjs` → `refresh-lock.mjs`, `crs-reconciler-state.mjs` →
   `reconciler-state.mjs`.


### PR DESCRIPTION
Two leftovers from the v3.7.0 / v3.8.0 work.

## Dead gitleaks allowlist entry

`.gitleaks.toml` still allowlisted the full RFC 6238 TOTP vector. That entry was only needed while the constant sat in the test as a single literal; #865 changed it to be built by joining eight fragments, so the full string appears nowhere in the tree. The entry has been dead config ever since, and dead allowlist entries are worse than none: they suggest the repo still contains something that needs excusing.

Verified before removing:

- `git grep` for the full literal outside `.gitleaks.toml` itself: **zero occurrences**
- `gitleaks detect --no-git --config claude-ops/.gitleaks.toml`: **no leaks found** with the entry gone (7.77 MB scanned)

## Stale CHANGELOG claim

The CRS-removal entry listed `scripts/crsproxy-reauth/` among the deleted paths. It was not deleted — **17 tracked files are still there**, they hold the Browser Use OAuth reauthentication helpers, and as of #870 they run in CI through `tests/test-crsproxy-reauth.sh`.

I checked every other deletion in that list rather than assuming the whole block was wrong:

| Claimed deleted | Actually gone? |
|---|---|
| `crs-*` daemons in `scripts/account-rotation/` | yes (0 files) |
| `install-crs-*.sh` installers | yes (0 files) |
| `crs-*` systemd units | yes (0 files) |
| `docs/runbooks/crs-full-tuning-plan.md` | yes (0 files) |
| `scripts/crsproxy-reauth/` | **no — 17 files** |

So only that one clause changed, and a short note records that the directory survived the CRS removal because it is cliproxy-facing rather than CRS-only. Historical entries are otherwise left alone.

## Verification

- `test-no-secrets.sh`: 27 passed, 0 failed
- `gitleaks detect --no-git`: no leaks found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the changelog to note that Browser Use OAuth reauthentication helpers remain available, along with their test coverage.
* **Security**
  * Updated secret scanning rules so a previously exempt standards-based test value is now scanned like other repository content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->