### PR TITLE
fix(ops-ar): read imprints from preferences instead of hardcoding one

### DIFF
--- a/claude-ops/skills/ops-ar/SKILL.md
+++ b/claude-ops/skills/ops-ar/SKILL.md
@@ -49,9 +49,20 @@ If non-empty, inject the **whole JSON object verbatim** into every ar-producer s
 
 Fields the profile may carry (all optional): `owner`, `label`, `lane`, `tempo_sweet_spot`, `ar_team`, `signing_structure`, `reference_acts`, `catalog_recent`, `signature_classics`, `label_roster_third_party`, `songwriting_taste`, `verdict_calibration`. If the profile is absent, fall back to the generic dance-pop / feel-good house default and say so in the card header.
 
-### Imprint gate (mandatory when `ar.future_tropical` exists)
+### Imprint gate (mandatory when `ar.imprints` is non-empty)
 
-Read `jq '.ar.future_tropical // empty' "$PREFS"`. If non-empty, inject it verbatim into every ar-producer spawn prompt **except `brand_book_corpus`** (the full scraped brand-book text — too large for a spawn prompt; consult it only when a card needs exact brand-book language, via `jq '.ar.future_tropical.brand_book_corpus.pages | keys'` then the specific page). Always inject `sound_description` — it is the imprint's sonic north star and the tiebreaker on points 2, 4 and 5. Add an **IMPRINT** section to the A&R card between VERDICT and WHAT'S WORKING: score the track against `ten_point_test` per `scoring_rule` (one line per point, pass/fail/N-A, with the failing evidence named), then one routing line — `FT-eligible` or `route to parent label`. The imprint is a strict subset of the label: a failed gate never downgrades the main verdict, it only routes the release. Owner's own tracks always get the scorecard; third-party demos get it only when they are in the imprint's lane.
+Imprints are data, not code. Never hardcode an imprint's name, sound, or test — read them:
+
+```bash
+jq -r '.ar.imprints // {} | keys[]' "$PREFS"          # imprint keys
+jq '.ar.imprints["<key>"]' "$PREFS"                   # one imprint
+```
+
+For each imprint whose lane the track falls in, inject that object verbatim into the ar-producer spawn prompt **except `brand_book_corpus`** (the full scraped brand-book text — too large for a spawn prompt; consult it only when a card needs exact brand-book language, via `jq '.ar.imprints["<key>"].brand_book_corpus.pages | keys'` then the specific page). Always inject `sound_description` — it is the imprint's sonic north star and the tiebreaker on the subjective points.
+
+Add an **IMPRINT** section to the A&R card between VERDICT and WHAT'S WORKING: score the track against that imprint's own `ten_point_test` per its `scoring_rule` (one line per point, pass/fail/N-A, with the failing evidence named), then one routing line — eligible for `<imprint display_name>`, or route to parent label. An imprint is a strict subset of the label: a failed gate never downgrades the main verdict, it only routes the release. Owner's own tracks always get the scorecard; third-party demos get it only when they are in that imprint's lane.
+
+Each imprint object may carry: `display_name`, `lane`, `sound_description`, `ten_point_test`, `scoring_rule`, `brand_book_corpus`. If `ar.imprints` is absent or empty, skip the IMPRINT section entirely — do not invent an imprint.
 
 ## Modes
 


### PR DESCRIPTION
You were right that the taste profile belongs in prefs, not code. The profile itself already was — it reads `.ar.profile` from `preferences.json` and hardcodes no owner, label, roster, or tempo. But the **imprint gate keyed off `ar.future_tropical`**, so one imprint's name was baked into the skill and the gate worked for that imprint and no other. That was the one place data had leaked into code.

## Before

```
### Imprint gate (mandatory when `ar.future_tropical` exists)
Read `jq '.ar.future_tropical // empty' "$PREFS"` ... then one routing line — `FT-eligible` or route to parent label.
```

One imprint, named in the skill, with its abbreviation hardcoded in the output format.

## After

The skill enumerates whatever is there:

```bash
jq -r '.ar.imprints // {} | keys[]' "$PREFS"     # imprint keys
jq '.ar.imprints["<key>"]' "$PREFS"              # one imprint
```

Each imprint carries its own `display_name`, `lane`, `sound_description`, `ten_point_test`, `scoring_rule`, and `brand_book_corpus`. The routing line names the imprint from its own `display_name` rather than a hardcoded abbreviation. An absent or empty `ar.imprints` skips the IMPRINT section entirely instead of inventing one.

`git grep future_tropical` now returns **0 hits** across the repo.

## Migration

This renames the preferences key, so the existing `ar.future_tropical` object needs to move under `ar.imprints` with a key of your choosing and a `display_name` added:

```json
{ "ar": { "imprints": { "future_tropical": {
    "display_name": "Future Tropical",
    "lane": "...", "sound_description": "...",
    "ten_point_test": [], "scoring_rule": "...",
    "brand_book_corpus": { "pages": {} }
} } } }
```

`preferences.json` is machine-local and not in this repo, so the move is a local edit — nothing here reads the old key any more.

## Verification

- `git grep future_tropical`: 0 hits
- `compact-plugin-discovery.mjs --check`: 63 skills, 21 agents, index consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring multiple imprints in A&R workflows.
  * A&R cards now include imprint-specific scoring, routing, display names, lanes, sound descriptions, and scoring rules.
  * Producer prompts can use targeted imprint guidance without including large reference content.
  * Imprint sections are omitted when no imprint configuration is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->