### PR TITLE
fix(deploy-fix): replace gh run watch with bounded REST polling

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## Unreleased
 
+- fix(deploy-fix): `scripts/ops-deploy-monitor.sh` no longer calls `gh run watch`.
+  That call blocks, polls every 2-5s with no tick cap, and is the exact pattern
+  `hooks/gh-watch-guard.sh` denies for every other caller. The monitor is spawned
+  by a PostToolUse hook on any `gh pr merge`, so one merge could arm an uncapped
+  poller. It now polls `gh api repos/{owner}/{repo}/actions/runs/{id}` on a 30s
+  sleep floor, capped at 60 ticks and a 1800s wall-clock deadline. PR and run
+  lookups moved from `gh pr view --json` / `gh run list --json` (GraphQL-backed)
+  to `gh api repos/...` (REST). `gh api rate_limit` — which spends no quota —
+  gates every polling phase and bails out with a log line below 200 remaining.
+  The same banned patterns were removed from `skills/ops-deploy/SKILL.md`,
+  `skills/ops-merge/SKILL.md` and `skills/ops-merge/references/cli.md`, which
+  had been telling agents to run them. `tests/mocks/gh` now serves the REST
+  endpoints and exits 90 if anything invokes `gh run watch`; test case 12 in
+  `tests/test-deploy-fix-hooks.sh` guards the script against regression.
+
 - Slim `ops-inbox` SKILL.md (~6k → ~2k words): runtime, Workflow JS, and Agent Teams moved to `references/`. Rewrite remaining skill descriptions with real NL triggers (Claude / Grok / Hermes share the same `skills/` tree).
 - Sync harness ports: `hermes-plugin/plugin.yaml` version matches `plugin.json`; installer default ref tracks the latest tag; `ops-release` bumps both. Grok still loads the Claude plugin (no `.grok-plugin`). Docs: `.mcp.json` is empty on purpose.
 

--- a/claude-ops/scripts/ops-deploy-monitor.sh
+++ b/claude-ops/scripts/ops-deploy-monitor.sh
@@ -4,6 +4,15 @@
 # Spawned by ops-deploy-fix-merge-trigger after a PR merges. Watches the deploy
 # workflow, audits service health, dispatches Haiku fixer on failure.
 # Single-flight via lock; budget-capped per repo per hour; transient detection.
+#
+# Rate discipline (matches ~/.claude/scripts/gh-pr-watch.sh):
+#   * NO `gh run watch` / `gh pr checks --watch` — those poll every 2-5s with no
+#     cap and are denied by hooks/gh-watch-guard.sh.
+#   * Every GitHub read is one-shot `gh api repos/...` (REST bucket), never
+#     `gh pr view --json` / `gh run list --json` (GraphQL-backed).
+#   * `gh api rate_limit` gates each phase. That endpoint is free — it does not
+#     consume quota — so it is safe to call before every poll phase.
+#   * Bounded polling: hard tick cap + sleep floor + wall-clock deadline.
 set -u
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
@@ -22,6 +31,45 @@ LOG="$LOGS_DIR/monitor-$SLUG-pr$PR.log"
 log() { printf '[%s] %s/#%s %s\n' "$(date '+%H:%M:%S')" "$REPO" "$PR" "$*" >> "$LOG"; }
 fire() { log "❌ $*"; printf '[%s] %s/#%s ❌ %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$REPO" "$PR" "$*" >> "$LOGS_DIR/fires.log"; }
 
+# ── Rate discipline ────────────────────────────────────────────────────────
+# Bounded-poll parameters. Every one is overridable via `config`, but the
+# defaults are deliberate:
+#   POLL_SLEEP=30  — floor, never below the 25s house minimum. A deploy that
+#                    finishes between ticks is still caught on the next tick.
+#   RUN_LOOKUP_TICKS=8 / RUN_LOOKUP_SLEEP=15 — a workflow run is registered by
+#                    GitHub within ~2min of a merge; 8 x 15s = 2min covers it.
+#   TIMEOUT=1800   — unchanged from the old `watcher_timeout_seconds` default,
+#                    so the outward behaviour of a slow deploy is the same.
+#   With a 30s floor, 1800s of wall clock is 60 ticks, so MAX_TICKS=60 and the
+#   deadline bind at the same moment. Whichever trips first, the loop stops:
+#   there is no configuration in which this can spin indefinitely.
+POLL_SLEEP=$(config deploy_poll_sleep_seconds 30)
+[ "$POLL_SLEEP" -lt 25 ] 2>/dev/null && POLL_SLEEP=25
+TIMEOUT=$(config watcher_timeout_seconds 1800)
+MAX_TICKS=$(config deploy_poll_max_ticks 60)
+RUN_LOOKUP_TICKS=$(config deploy_run_lookup_ticks 8)
+RUN_LOOKUP_SLEEP=$(config deploy_run_lookup_sleep_seconds 15)
+RATE_FLOOR=$(config gh_rate_floor 200)
+
+# rate_ok — pre-flight gate. `gh api rate_limit` is itself quota-free, so this
+# costs nothing. Returns 1 when the REST (core) bucket is below the floor.
+rate_ok() {
+  local rem
+  rem=$(gh api rate_limit --jq '.resources.core.remaining' 2>/dev/null)
+  case "$rem" in
+    ''|*[!0-9]*) return 0 ;;   # unreadable → do not block the monitor
+  esac
+  if [ "$rem" -lt "$RATE_FLOOR" ]; then
+    log "rate gate: REST core bucket at $rem (floor $RATE_FLOOR) — bailing out, no polling"
+    return 1
+  fi
+  return 0
+}
+
+# One-shot REST reads. All of these land in the core (REST) bucket.
+api() { gh api -H 'Accept: application/vnd.github+json' "repos/$REPO/$1" 2>/dev/null; }
+
+
 # Single-flight monitor lock
 MONITOR_LOCK="monitor-$SLUG-pr$PR"
 lock_acquire "$MONITOR_LOCK" || { log "monitor already running, exit"; exit 0; }
@@ -29,11 +77,19 @@ trap 'lock_release "$MONITOR_LOCK"' EXIT
 
 log "monitor starting"
 
+rate_ok || exit 0
+
 sleep 5
-PR_INFO=$(gh pr view "$PR" --repo "$REPO" --json baseRefName,mergeCommit,state 2>/dev/null)
-BASE=$(echo "$PR_INFO" | jq -r '.baseRefName // ""')
-SHA=$(echo "$PR_INFO" | jq -r '.mergeCommit.oid // ""')
-STATE=$(echo "$PR_INFO" | jq -r '.state // ""')
+# REST pulls/{n}: base.ref, merge_commit_sha, merged. Same three facts the old
+# `gh pr view --json baseRefName,mergeCommit,state` returned, off the REST bucket.
+PR_INFO=$(api "pulls/$PR")
+BASE=$(echo "$PR_INFO" | jq -r '.base.ref // ""')
+SHA=$(echo "$PR_INFO" | jq -r '.merge_commit_sha // ""')
+if [ "$(echo "$PR_INFO" | jq -r '.merged // false')" = "true" ]; then
+  STATE=MERGED
+else
+  STATE=$(echo "$PR_INFO" | jq -r '(.state // "") | ascii_upcase')
+fi
 
 [ "$STATE" != "MERGED" ] && { log "not merged ($STATE) — exit"; exit 0; }
 [ "$BASE" != "dev" ] && [ "$BASE" != "main" ] && { log "base=$BASE, skip"; exit 0; }
@@ -41,32 +97,50 @@ log "merged to $BASE @ $SHA"
 
 # Find deploy workflow run
 PATTERN=$(config deploy_workflow_pattern "deploy|Deploy|build|Build|ECS|cd|CD")
+RUNS_PATH="actions/runs?branch=$BASE&head_sha=$SHA&per_page=10"
 RUN_ID=""
-for i in $(seq 1 12); do
-  RUN_ID=$(gh run list --repo "$REPO" --branch "$BASE" --limit 5 \
-    --json databaseId,headSha,name --jq \
-    ".[] | select(.headSha==\"$SHA\" and (.name | test(\"$PATTERN\"))) | .databaseId" 2>/dev/null | head -1)
+for _ in $(seq 1 "$RUN_LOOKUP_TICKS"); do
+  rate_ok || exit 0
+  RUN_ID=$(api "$RUNS_PATH" \
+    | jq -r --arg p "$PATTERN" \
+        '(.workflow_runs // [])[] | select((.name // "") | test($p)) | .id' 2>/dev/null | head -1)
   [ -n "$RUN_ID" ] && break
-  sleep 15
+  sleep "$RUN_LOOKUP_SLEEP"
 done
 if [ -z "$RUN_ID" ]; then
-  RUN_ID=$(gh run list --repo "$REPO" --branch "$BASE" --limit 5 \
-    --json databaseId,headSha --jq ".[] | select(.headSha==\"$SHA\") | .databaseId" 2>/dev/null | head -1)
+  # No name match — fall back to any run for this SHA.
+  RUN_ID=$(api "$RUNS_PATH" | jq -r '(.workflow_runs // [])[0].id // ""' 2>/dev/null)
 fi
+[ "$RUN_ID" = "null" ] && RUN_ID=""
 [ -z "$RUN_ID" ] && { log "no run found — exit"; exit 0; }
 log "tracking run #$RUN_ID"
 
-# Wait for completion (configurable timeout)
-TIMEOUT=$(config watcher_timeout_seconds 1800)
-gh run watch "$RUN_ID" --repo "$REPO" --exit-status >> "$LOG" 2>&1 &
-WATCH_PID=$!
-( sleep "$TIMEOUT"; kill -9 $WATCH_PID 2>/dev/null ) &
-TIMEOUT_PID=$!
-wait $WATCH_PID; RC=$?
-kill -9 $TIMEOUT_PID 2>/dev/null
-
-CONCLUSION=$(gh run view "$RUN_ID" --repo "$REPO" --json conclusion --jq .conclusion 2>/dev/null)
-log "conclusion=$CONCLUSION rc=$RC"
+# ── Wait for completion: bounded REST polling ─────────────────────────────
+# Replaces `gh run watch`, which blocks, polls every 2-5s internally, and has no
+# tick cap. Three independent stops: MAX_TICKS, the wall-clock DEADLINE, and the
+# rate gate. RC keeps the old contract (0 = success, 1 = anything else).
+DEADLINE=$(( $(date +%s) + TIMEOUT ))
+CONCLUSION=""
+STATUS=""
+RC=1
+for tick in $(seq 1 "$MAX_TICKS"); do
+  if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+    log "poll deadline reached after ${TIMEOUT}s (tick $tick) — giving up on run #$RUN_ID"
+    break
+  fi
+  rate_ok || break
+  RUN_JSON=$(api "actions/runs/$RUN_ID")
+  STATUS=$(echo "$RUN_JSON" | jq -r '.status // ""')
+  CONCLUSION=$(echo "$RUN_JSON" | jq -r '.conclusion // ""')
+  [ "$CONCLUSION" = "null" ] && CONCLUSION=""
+  log "tick $tick/$MAX_TICKS status=${STATUS:-?} conclusion=${CONCLUSION:-pending}"
+  if [ "$STATUS" = "completed" ] || [ -n "$CONCLUSION" ]; then
+    break
+  fi
+  sleep "$POLL_SLEEP"
+done
+[ "$CONCLUSION" = "success" ] && RC=0
+log "conclusion=${CONCLUSION:-unknown} rc=$RC"
 
 if [ "$CONCLUSION" != "success" ]; then
   failed_log=$(gh run view "$RUN_ID" --repo "$REPO" --log-failed 2>/dev/null | tail -120)

--- a/claude-ops/skills/ops-deploy/SKILL.md
+++ b/claude-ops/skills/ops-deploy/SKILL.md
@@ -65,7 +65,11 @@ Before executing, load available context:
 | --------------------------------------------------------------------------------------------------------- | -------------- | ------------------------------ |
 | `gh run list --repo <owner/repo> --limit 5 --json status,conclusion,name,headBranch,createdAt,databaseId` | CI runs        | JSON array                     |
 | `gh run view <id> --repo <repo> --log-failed`                                                             | Failed CI logs | Log output                     |
-| `gh run watch <run-id> --repo <repo>`                                                                     | Stream CI run  | Live output (use with Monitor) |
+| `gh api repos/<repo>/actions/runs/<run-id> --jq .status,.conclusion`                                      | Poll one CI run | JSON fields (REST bucket)     |
+
+`gh run watch` and `gh pr checks --watch` are banned — they poll every 2-5s with no
+cap. `hooks/gh-watch-guard.sh` denies them. Poll the REST endpoint above on a `sleep
+30` floor with a finite tick count instead.
 
 ---
 
@@ -209,11 +213,15 @@ Trigger deploy for [project]:
 
 ### Monitor — live deploy streaming
 
-When watching a deploy in progress, use `Monitor` to stream logs:
+When watching a deploy in progress, use `Monitor` with a **bounded** REST poll —
+never `gh run watch`, which polls every 2-5s with no cap and is denied by
+`hooks/gh-watch-guard.sh`:
 
 ```
-Monitor(command: "gh run watch <run-id> --repo <repo>")
+Monitor(command: "for i in $(seq 1 60); do s=$(gh api repos/<repo>/actions/runs/<run-id> --jq '.status+\" \"+(.conclusion//\"pending\")'); echo \"$s\"; case \"$s\" in completed*) break;; esac; sleep 30; done")
 ```
+
+Tick cap 60 x 30s = 30 min hard ceiling; `gh api` spends the REST bucket, not GraphQL.
 
 For ECS deploys: `Monitor(command: "aws ecs wait services-stable --cluster <cluster> --services <service>")`
 

--- a/claude-ops/skills/ops-merge/SKILL.md
+++ b/claude-ops/skills/ops-merge/SKILL.md
@@ -430,7 +430,8 @@ For each repo that has separate `dev` and `main` branches:
    ```
 
 3. If confirmed: create sync PR: `gh pr create --repo <repo> --base main --head dev --title "chore: sync dev → main"`
-4. Wait for CI: `gh pr checks <sync-pr-number> --repo <repo> --watch` (background, max 10 min)
+4. Wait for CI with a bounded REST poll (never `--watch`, which is denied by `hooks/gh-watch-guard.sh`):
+   `for i in $(seq 1 20); do gh api repos/<repo>/commits/<sha>/check-runs --jq '[.check_runs[].conclusion]'; sleep 30; done` — 20 ticks x 30s = 10 min ceiling
 5. If CI green: `gh pr merge <sync-pr-number> --repo <repo> --merge` (merge commit, not squash; never `--admin`)
 6. Pull main back into dev: `git -C <path> fetch origin && git -C <path> checkout dev && git -C <path> merge origin/main --no-edit`
 
@@ -560,13 +561,15 @@ the commit, and say which gate it skipped.
 
 ### Monitor — live CI watching
 
-When waiting for CI after a fixer pushes (Phase 3-4), use `Monitor` to stream the GitHub Actions run output instead of polling:
+When waiting for CI after a fixer pushes (Phase 3-4), use `Monitor` with a bounded
+REST poll. `gh run watch` is banned — it polls every 2-5s with no tick cap and
+`hooks/gh-watch-guard.sh` denies it:
 
 ```
-Monitor(command: "gh run watch <run-id> --repo <repo>")
+Monitor(command: "for i in $(seq 1 60); do s=$(gh api repos/<repo>/actions/runs/<run-id> --jq '.status+\" \"+(.conclusion//\"pending\")'); echo \"$s\"; case \"$s\" in completed*) break;; esac; sleep 30; done")
 ```
 
-This avoids sleep loops and gives real-time feedback on CI progress.
+Finite tick count, 30s sleep floor, REST bucket rather than GraphQL.
 
 ### Tasks — progress tracking
 

--- a/claude-ops/skills/ops-merge/references/cli.md
+++ b/claude-ops/skills/ops-merge/references/cli.md
@@ -13,7 +13,7 @@
 | `gh pr create --repo <repo> --title "<t>" --body "<b>" --base dev`                                                        | Create PR            | PR URL                         |
 | `gh run list --repo <repo> --limit 5 --json conclusion,name,headBranch`                                                   | CI runs              | JSON array                     |
 | `gh run view <id> --repo <repo> --log-failed`                                                                             | Failed CI logs       | Log output                     |
-| `gh run watch <run-id> --repo <repo>`                                                                                     | Stream CI run        | Live output (use with Monitor) |
+| `gh api repos/<repo>/actions/runs/<run-id> --jq .status,.conclusion`                                                      | Poll one CI run      | JSON fields (REST bucket)      |
 | `gh api repos/<repo>/pulls/<n>/comments --jq '.[].body'`                                                                  | PR review comments   | Comment text                   |
 
 ---

--- a/claude-ops/tests/mocks/gh
+++ b/claude-ops/tests/mocks/gh
@@ -3,8 +3,15 @@
 #   MOCK_GH_PR_VIEW_JSON   — JSON returned by `gh pr view ... --json ...`
 #   MOCK_GH_RUN_LIST_JSON  — JSON array returned by `gh run list ... --json ...`
 #                            (script will run --jq filter against it)
-#   MOCK_GH_RUN_WATCH_RC   — exit code from `gh run watch` (default 0)
+#   MOCK_GH_RUN_WATCH_RC   — legacy, accepted but unused (gh run watch is banned)
 #   MOCK_GH_RUN_VIEW_CONCLUSION — string conclusion ("success"/"failure"/...)
+#   MOCK_GH_RUN_STATUS     — run status for REST actions/runs/{id} (default "completed")
+#   MOCK_GH_RATE_CORE      — REST core remaining for `gh api rate_limit` (default 5000)
+#   MOCK_GH_RATE_GRAPHQL   — GraphQL remaining for `gh api rate_limit` (default 5000)
+#
+# REST translation: the monitor now reads GitHub over `gh api repos/...`. The
+# MOCK_GH_PR_VIEW_JSON / MOCK_GH_RUN_LIST_JSON fixtures stay in their original
+# (gh --json) shape and are translated here, so existing test cases keep working.
 #   MOCK_GH_RUN_VIEW_LOG_FAILED — stdout for `gh run view ... --log-failed`
 #   MOCK_GH_LOG_FILE       — append every invocation (argv) to this file
 set -u
@@ -17,6 +24,64 @@ shift || true
 sub2="${1:-}"
 
 case "$sub" in
+  api)
+    # Collect the endpoint path (first non-flag arg) and any --jq filter.
+    path=""; api_jq=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --jq|-q) shift; api_jq="${1:-}" ;;
+        -H|--header|-f|-F|--method|-X) shift ;;
+        -*) : ;;
+        *) [ -z "$path" ] && path="$1" ;;
+      esac
+      shift || break
+    done
+
+    emit() {
+      if [ -n "$api_jq" ] && command -v jq >/dev/null 2>&1; then
+        printf '%s' "$1" | jq -r "$api_jq" 2>/dev/null
+      else
+        printf '%s' "$1"
+      fi
+    }
+
+    case "$path" in
+      rate_limit|/rate_limit)
+        emit "{\"resources\":{\"core\":{\"remaining\":${MOCK_GH_RATE_CORE:-5000},\"limit\":5000},\"graphql\":{\"remaining\":${MOCK_GH_RATE_GRAPHQL:-5000},\"limit\":5000}}}"
+        exit 0
+        ;;
+      */pulls/*)
+        # Translate the gh --json PR shape into the REST pulls/{n} shape.
+        _default='{"baseRefName":"dev","mergeCommit":{"oid":"abcdef1234567890"},"state":"MERGED"}'
+        src="${MOCK_GH_PR_VIEW_JSON:-$_default}"
+        emit "$(printf '%s' "$src" | jq -c '{
+          base: {ref: (.baseRefName // "")},
+          merge_commit_sha: (.mergeCommit.oid // ""),
+          merged: ((.state // "") == "MERGED"),
+          state: (if (.state // "") == "MERGED" then "closed" else ((.state // "") | ascii_downcase) end)
+        }' 2>/dev/null)"
+        exit 0
+        ;;
+      */actions/runs/[0-9]*)
+        rid="${path##*/}"; rid="${rid%%\?*}"
+        emit "{\"id\":${rid},\"status\":\"${MOCK_GH_RUN_STATUS:-completed}\",\"conclusion\":\"${MOCK_GH_RUN_VIEW_CONCLUSION:-success}\"}"
+        exit 0
+        ;;
+      */actions/runs*)
+        # Translate the gh --json run-list array into REST {workflow_runs:[...]}.
+        src="${MOCK_GH_RUN_LIST_JSON:-[]}"
+        emit "$(printf '%s' "$src" | jq -c '{workflow_runs: [ .[] | {
+          id: (.databaseId // .id),
+          head_sha: (.headSha // .head_sha // ""),
+          name: (.name // ""),
+          status: "completed"
+        } ]}' 2>/dev/null)"
+        exit 0
+        ;;
+    esac
+    emit "{}"
+    exit 0
+    ;;
   pr)
     case "$sub2" in
       view)
@@ -59,8 +124,10 @@ case "$sub" in
         exit 0
         ;;
       watch)
-        echo "[mock-gh] watching run"
-        exit "${MOCK_GH_RUN_WATCH_RC:-0}"
+        # `gh run watch` is a banned pattern (hooks/gh-watch-guard.sh denies it).
+        # Fail loudly so a regression cannot pass the suite silently.
+        echo "[mock-gh] FORBIDDEN: gh run watch was invoked" >&2
+        exit 90
         ;;
       view)
         # Detect --log-failed

--- a/claude-ops/tests/test-deploy-fix-hooks.sh
+++ b/claude-ops/tests/test-deploy-fix-hooks.sh
@@ -574,6 +574,59 @@ test_monitor_real_failure() {
 test_monitor_real_failure
 
 # ===========================================================================
+# CASE 12 — rate discipline: no banned patterns, quota gate bails out
+# ===========================================================================
+echo ""
+echo "── Case 12: rate discipline ──────────────────────────────────────"
+test_monitor_rate_discipline() {
+  new_isolated_env "case12-rate"
+
+  # 12a — the monitor must not contain any banned polling pattern.
+  # Comment lines are stripped first: the header explains WHY those calls are
+  # banned and naming them there must not trip this guard.
+  monitor_code=$(grep -v '^[[:space:]]*#' "$PLUGIN_ROOT/scripts/ops-deploy-monitor.sh")
+  if printf '%s' "$monitor_code" \
+       | grep -qE 'gh[[:space:]]+run[[:space:]]+watch|gh[[:space:]]+pr[[:space:]]+checks[^|]*--watch'; then
+    fail "12a.no-banned-watch" "ops-deploy-monitor.sh still contains a banned gh watch call"
+  else
+    pass "12a.no-banned-watch"
+  fi
+
+  # 12b — status reads go through `gh api repos/...` (REST), not `--json` (GraphQL).
+  if printf '%s' "$monitor_code" \
+       | grep -qE 'gh[[:space:]]+(pr|run)[[:space:]]+(view|list)[^|]*--json'; then
+    fail "12b.rest-not-graphql" "monitor still uses a GraphQL-backed --json read"
+  else
+    pass "12b.rest-not-graphql"
+  fi
+
+  # 12c — an exhausted REST bucket makes the monitor bail out cleanly (rc 0,
+  #       log line, no fixer dispatched).
+  export MOCK_GH_RATE_CORE=3
+  export MOCK_GH_PR_VIEW_JSON='{"baseRefName":"dev","mergeCommit":{"oid":"abcdef1234567890"},"state":"MERGED"}'
+  export MOCK_GH_RUN_LIST_JSON='[{"databaseId":42,"headSha":"abcdef1234567890","name":"deploy"}]'
+  export MOCK_GH_RUN_VIEW_CONCLUSION="failure"
+  ln -sf /usr/bin/true "$TEST_BIN/sleep" 2>/dev/null || true
+
+  bash "$PLUGIN_ROOT/scripts/ops-deploy-monitor.sh" "owner/repo12" "12" >/dev/null 2>&1
+  rc=$?
+  assert_eq "12c.rate-gate-exit-zero" "0" "$rc"
+  monitor_log="$TEST_LOGS/monitor-owner-repo12-pr12.log"
+  if grep -q "rate gate" "$monitor_log" 2>/dev/null; then
+    pass "12d.rate-gate-logged"
+  else
+    fail "12d.rate-gate-logged" "no rate gate line in $monitor_log"
+  fi
+  if [ ! -s "$TEST_LOGS/claude.log" ]; then
+    pass "12e.no-fixer-when-rate-limited"
+  else
+    fail "12e.no-fixer-when-rate-limited" "claude was invoked while rate-limited"
+  fi
+  unset MOCK_GH_RATE_CORE
+}
+test_monitor_rate_discipline
+
+# ===========================================================================
 # SUMMARY
 # ===========================================================================
 echo ""


### PR DESCRIPTION
## The forbidden pattern

`scripts/ops-deploy-monitor.sh` called **`gh run watch`**. That command blocks and
polls GitHub every 2-5 seconds internally, with no tick cap of its own. The repo
already bans it: `hooks/gh-watch-guard.sh` denies `gh run watch` and
`gh pr checks --watch` for every other caller. This script was the one place that
still shipped it.

It matters because the script is auto-spawned by the PostToolUse hook
`bin/ops-deploy-fix-merge-trigger` on **any** `gh pr merge` from **any** session.
Its log directory is empty, so it has never actually fired — but one merge would
have armed it.

## What replaced it

A bounded poll over `gh api repos/{owner}/{repo}/actions/runs/{id}`:

| Knob | Value | Why |
|---|---|---|
| Sleep floor | **30s** (`deploy_poll_sleep_seconds`, clamped to a hard 25s minimum) | Matches the 25s house floor in `~/.claude/scripts/gh-pr-watch.sh`. A deploy finishing between ticks is caught on the next tick. |
| Tick cap | **60** (`deploy_poll_max_ticks`) | 60 x 30s = 30 min, the same ceiling as the old timeout. Independent of the clock, so it holds even if the sleep is reconfigured. |
| Wall-clock deadline | **1800s** (`watcher_timeout_seconds`) | Unchanged default, so a slow deploy behaves exactly as before. Checked against `date +%s` at the top of every tick. |
| Run-lookup ticks | **8 x 15s** (`deploy_run_lookup_ticks`) | GitHub registers a workflow run within ~2 min of a merge; 2 min covers it. Replaces the old `seq 1 12` x 15s loop, which was itself a `gh` poll loop the repo's own Pattern 2 guard would block. |
| Rate floor | **200 REST remaining** (`gh_rate_floor`) | Leaves headroom for the sibling daemons and the session that share the bucket. |

The tick cap and the deadline bind at the same moment by construction, and either
one alone stops the loop. There is no configuration in which it can spin.

## Which bucket the load moved to

Measured against this repo before the change:

```
gh pr view --json state     →  GraphQL -1,  REST  0
gh run list --json ...      →  GraphQL -2,  REST -1
```

Both are GraphQL-backed. All status reads now go through `gh api repos/...`, which
spends the **REST (core)** bucket only. That is the healthy bucket — the GraphQL
one is what gets exhausted in practice.

`gh api rate_limit` is the pre-flight gate. That endpoint consumes no quota, so it
is safe to call before every polling phase. Below the floor the monitor writes
`rate gate: REST core bucket at N (floor 200) — bailing out, no polling` and exits
0 without dispatching a fixer.

## Interface preserved

Exit codes and output are unchanged, because the PostToolUse hook consumes them:
0 on success / skip / rate-gate bail, 1 on deploy failure or unhealthy service.
`RC` keeps its old meaning (0 = success, anything else = failure), and a poll that
times out lands in the same failure path the old `kill -9` on the watch produced.

## Every forbidden pattern found, and what happened to it

| Location | Pattern | Action |
|---|---|---|
| `scripts/ops-deploy-monitor.sh:61` | `gh run watch` | **Fixed** — bounded REST poll |
| `scripts/ops-deploy-monitor.sh` | `gh pr view --json` (GraphQL) | **Fixed** — `gh api repos/{r}/pulls/{n}` |
| `scripts/ops-deploy-monitor.sh` | `gh run list --json` in a `seq` poll loop | **Fixed** — `gh api repos/{r}/actions/runs?...`, bounded |
| `scripts/ops-deploy-monitor.sh` | `gh run view --json conclusion` | **Fixed** — `gh api repos/{r}/actions/runs/{id}` |
| `skills/ops-deploy/SKILL.md:68` | `gh run watch` in the CLI reference table | **Fixed** — REST row + a note that the watch form is denied |
| `skills/ops-deploy/SKILL.md:215` | `Monitor(command: "gh run watch ...")` | **Fixed** — bounded `seq`/`sleep 30` REST poll |
| `skills/ops-merge/SKILL.md:433` | `gh pr checks <n> --watch` | **Fixed** — 20 x 30s REST `check-runs` poll |
| `skills/ops-merge/SKILL.md:566` | `Monitor(command: "gh run watch ...")` | **Fixed** — bounded REST poll |
| `skills/ops-merge/references/cli.md:16` | `gh run watch` reference row | **Fixed** — REST row |
| `tests/mocks/gh` | mocked `gh run watch` | **Fixed** — now exits 90 so a regression cannot pass silently |
| `hooks/gh-watch-guard.sh` | literal appears in the grep pattern and deny text | Not a violation — this is the guard that blocks it |
| `scripts/gh-orphan-killer.sh` | literal appears in `awk` match patterns | Not a violation — this is the watchdog that kills those orphans |
| `bin/ops-dash:710` | `gh run list` inside `while IFS= read` over repos | Not a poll loop — one pass over a bounded repo list |
| `bin/ops-fleet:325`, `bin/ops-dash:562` | `while true` | No `gh` call inside (TUI render / local-file spinner) |
| `scripts/ops-daemon.sh:1782` | `while true` daemon reaching `gh pr list` | Throttled to one call per 5 min (12/hr). Left alone. |

## Test results

`tests/test-deploy-fix-hooks.sh` — **50 passed, 0 failed** (was 45; case 12 is new).
Cases 9-11 exercise the monitor end to end (happy path, transient → rerun, real
failure → fixer dispatched) and pass unchanged against the rewritten script.

New case 12:
```
── Case 12: rate discipline ──────────────────────────────────────
  PASS: 12a.no-banned-watch
  PASS: 12b.rest-not-graphql
  PASS: 12c.rate-gate-exit-zero
  PASS: 12d.rate-gate-logged
  PASS: 12e.no-fixer-when-rate-limited
```

Other suites:
- `tests/test-no-secrets.sh` — 27 passed, 0 failed
- `tests/test-hooks.sh` — 22 passed, 0 failed
- `tests/test-plugin-validate.sh` — 7 passed, 0 failed
- `shellcheck -S warning` on every changed shell file — clean. The two SC2164
  warnings it reports in `tests/test-deploy-fix-hooks.sh` are on pre-existing
  lines 203 and 307, untouched by this PR.

## Note on the mock

`MOCK_GH_PR_VIEW_JSON` and `MOCK_GH_RUN_LIST_JSON` fixtures keep their original
`gh --json` shape. The mock translates them into the REST response shapes, so no
existing test case needed rewriting — which is also what makes cases 9-11 a real
regression check rather than a rewritten one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
