### PR TITLE
release: v3.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 64 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "3.8.1",
+      "version": "3.9.0",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-3.8.1-blue)
+![Version](https://img.shields.io/badge/version-3.9.0-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-64-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "description": "Business operations command center for Claude Code — 64 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -70,6 +70,25 @@
 - **ops-ecom:** `channels` | `agentic` | `shop` verbs — sales channel inventory, agentic storefront health, Shop Campaigns readiness (read-only; Rule 5 / stage-only spend).
 - **ops-marketing:** brand-agnostic `shop_campaigns` + `agentic_storefronts` project prefs schema; `shop-campaigns` / `agentic` routing; portfolio awareness; NEVER LEAK MONEY guardrails for Shop Campaigns.
 
+## [3.9.0] - 2026-08-23
+
+### Changed
+### Added
+- **ops-ar taste profile injection.** When `ar.profile` exists in preferences, the whole object is injected into every ar-producer spawn so verdicts are calibrated to the owner's own catalog, tempo range and songwriting taste, and REFERENCE & POSITIONING names the closest catalog comparison instead of a generic genre act. Absent profile falls back to the generic default and says so in the card header.
+- **ops-ar imprint gate.** Imprints defined under `ar.imprints` get an IMPRINT section on the A&R card, scored against that imprint's own ten-point test, plus one routing line. An imprint is a strict subset of the label, so a failed gate routes the release and never downgrades the main verdict.
+- **ops-inbox step 0.** Reading a thread's own sent messages is now a blocking pre-check on every connected account before anything is classed NEEDS_REPLY. A scan result is a snapshot rather than current state, and a subagent's NEEDS_REPLY is a claim about the moment it looked.
+
+### Changed
+- Imprints are data, not code. The imprint gate reads every imprint's name, lane, sound description and test from preferences rather than assuming one hardcoded imprint, so any number of imprints work.
+- Corrected the CRS-removal entry, which listed `scripts/crsproxy-reauth/` as deleted. It was kept, holds the Browser Use OAuth reauthentication helpers, and is covered by `tests/test-crsproxy-reauth.sh`.
+
+### Removed
+- Dead gitleaks allowlist entry for the RFC 6238 TOTP vector. The constant is now assembled from fragments, so the full string appears nowhere in the tree and the exclusion had nothing left to excuse.
+
+### Migration
+- `ar.future_tropical` in `preferences.json` moves to `ar.imprints.<key>` with a `display_name` added. Nothing reads the old key, so an unmigrated profile simply skips the IMPRINT section.
+
+
 ## [3.8.1] - 2026-08-23
 
 ### Fixed

--- a/claude-ops/docs/INDEX.md
+++ b/claude-ops/docs/INDEX.md
@@ -4,7 +4,7 @@
 
 _Top-level map of every doc file in `claude-ops/docs/`._
 
-[![version](https://img.shields.io/badge/version-3.8.1-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.9.0-blue)](../CHANGELOG.md)
 
 </div>
 

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-3.8.1-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.9.0-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 64 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-3.8.1-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.9.0-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-64-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/hermes-plugin/plugin.yaml
+++ b/claude-ops/hermes-plugin/plugin.yaml
@@ -1,4 +1,4 @@
 name: ops
-version: "3.8.1"
+version: "3.9.0"
 description: "claude-ops on Hermes — slash commands and skills for inbox, deploy, revenue, and the rest of the ops suite. Enable with plugins.enabled: [ops]."
 author: Lifecycle Innovations Limited

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/installer/README.md
+++ b/installer/README.md
@@ -56,7 +56,7 @@ version: 1
 source:
   type: git
   url: https://github.com/Lifecycle-Innovations-Limited/claude-ops.git
-  ref: v3.8.1
+  ref: v3.9.0
 
 agents:
   claude:    { enabled: true }

--- a/installer/src/config.mjs
+++ b/installer/src/config.mjs
@@ -17,7 +17,7 @@ export const DEFAULT_CONFIG = {
   source: {
     type: "git",
     url: "https://github.com/Lifecycle-Innovations-Limited/claude-ops.git",
-    ref: "v3.8.1",
+    ref: "v3.9.0",
   },
   agents: {
     claude: { enabled: true, type: "marketplace" },


### PR DESCRIPTION
Release **v3.9.0** (was 3.8.1).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

### Added
- **ops-ar taste profile injection.** When `ar.profile` exists in preferences, the whole object is injected into every ar-producer spawn so verdicts are calibrated to the owner's own catalog, tempo range and songwriting taste, and REFERENCE & POSITIONING names the closest catalog comparison instead of a generic genre act. Absent profile falls back to the generic default and says so in the card header.
- **ops-ar imprint gate.** Imprints defined under `ar.imprints` get an IMPRINT section on the A&R card, scored against that imprint's own ten-point test, plus one routing line. An imprint is a strict subset of the label, so a failed gate routes the release and never downgrades the main verdict.
- **ops-inbox step 0.** Reading a thread's own sent messages is now a blocking pre-check on every connected account before anything is classed NEEDS_REPLY. A scan result is a snapshot rather than current state, and a subagent's NEEDS_REPLY is a claim about the moment it looked.

### Changed
- Imprints are data, not code. The imprint gate reads every imprint's name, lane, sound description and test from preferences rather than assuming one hardcoded imprint, so any number of imprints work.
- Corrected the CRS-removal entry, which listed `scripts/crsproxy-reauth/` as deleted. It was kept, holds the Browser Use OAuth reauthentication helpers, and is covered by `tests/test-crsproxy-reauth.sh`.

### Removed
- Dead gitleaks allowlist entry for the RFC 6238 TOTP vector. The constant is now assembled from fragments, so the full string appears nowhere in the tree and the exclusion had nothing left to excuse.

### Migration
- `ar.future_tropical` in `preferences.json` moves to `ar.imprints.<key>` with a `display_name` added. Nothing reads the old key, so an unmigrated profile simply skips the IMPRINT section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated Claude Ops to version 3.9.0 across the product, installer, and documentation.
* **Enhancements**
  * Added A&R profile injection and imprint-specific scoring.
  * Added inbox prechecks for sent messages.
  * Enabled preference-driven imprint configuration.
  * Migrated future tropical configuration to the imprint-based format.
* **Bug Fixes**
  * Corrected the CRS reauthentication guidance.
* **Maintenance**
  * Removed an obsolete security scanning exception.
* **Documentation**
  * Updated changelog entries, version badges, and installer defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->