### PR TITLE
release: v3.9.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 64 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "3.9.1",
+      "version": "3.9.2",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-3.9.1-blue)
+![Version](https://img.shields.io/badge/version-3.9.2-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-64-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "Business operations command center for Claude Code — 64 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -70,6 +70,12 @@
 - **ops-ecom:** `channels` | `agentic` | `shop` verbs — sales channel inventory, agentic storefront health, Shop Campaigns readiness (read-only; Rule 5 / stage-only spend).
 - **ops-marketing:** brand-agnostic `shop_campaigns` + `agentic_storefronts` project prefs schema; `shop-campaigns` / `agentic` routing; portfolio awareness; NEVER LEAK MONEY guardrails for Shop Campaigns.
 
+## [3.9.2] - 2026-08-24
+
+### Fixed
+- `/flow` now resolves its lifecycle reference on macOS (renamed the skill's internal map file to avoid a case-insensitive filename collision).
+
+
 ## [3.9.1] - 2026-08-24
 
 ### Fixed

--- a/claude-ops/docs/INDEX.md
+++ b/claude-ops/docs/INDEX.md
@@ -4,7 +4,7 @@
 
 _Top-level map of every doc file in `claude-ops/docs/`._
 
-[![version](https://img.shields.io/badge/version-3.9.1-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.9.2-blue)](../CHANGELOG.md)
 
 </div>
 

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-3.9.1-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.9.2-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 64 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-3.9.1-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.9.2-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-64-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/hermes-plugin/plugin.yaml
+++ b/claude-ops/hermes-plugin/plugin.yaml
@@ -1,4 +1,4 @@
 name: ops
-version: "3.9.1"
+version: "3.9.2"
 description: "claude-ops on Hermes — slash commands and skills for inbox, deploy, revenue, and the rest of the ops suite. Enable with plugins.enabled: [ops]."
 author: Lifecycle Innovations Limited

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/installer/README.md
+++ b/installer/README.md
@@ -56,7 +56,7 @@ version: 1
 source:
   type: git
   url: https://github.com/Lifecycle-Innovations-Limited/claude-ops.git
-  ref: v3.9.1
+  ref: v3.9.2
 
 agents:
   claude:    { enabled: true }

--- a/installer/src/config.mjs
+++ b/installer/src/config.mjs
@@ -17,7 +17,7 @@ export const DEFAULT_CONFIG = {
   source: {
     type: "git",
     url: "https://github.com/Lifecycle-Innovations-Limited/claude-ops.git",
-    ref: "v3.9.1",
+    ref: "v3.9.2",
   },
   agents: {
     claude: { enabled: true, type: "marketplace" },


### PR DESCRIPTION
Release **v3.9.2** (was 3.9.1).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

### Fixed
- `/flow` now resolves its lifecycle reference on macOS (renamed the skill's internal map file to avoid a case-insensitive filename collision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)