### PR TITLE
fix(paths): stop resolving four helpers through ~/Projects, which exists on no install

### DIFF
--- a/claude-ops/bin/ops-post-session-cleanup
+++ b/claude-ops/bin/ops-post-session-cleanup
@@ -8,9 +8,22 @@ rm -f /tmp/wacli-sync-probe-*.log /tmp/wacli-bootstrap-*.log 2>/dev/null || true
 # Clean stale agent worktrees older than 2 hours.
 # Check every known checkout root — a hardcoded ~/Projects path silently
 # cleans nothing on installs that live elsewhere.
+#
+# Do not infer staleness from the worktree ROOT mtime: an active session can
+# keep writing files below the root while the directory inode stays old, and
+# `find -type d -mmin +120` on the root would then rm -rf an in-use checkout.
+# Require BOTH: the worktree HEAD is older than 2h AND no file inside has
+# been touched in 2h. `find -print -quit` is GNU-only, so we stop after the
+# first match with a subshell break instead.
 for _root in "$HOME/Developer/repos/claude-ops" "$HOME/Developer/active/claude-ops" "$HOME/Projects/claude-ops"; do
   [ -d "$_root/.worktrees" ] || continue
-  find "$_root/.worktrees" -maxdepth 1 -mindepth 1 -type d -mmin +120 -exec rm -rf {} \; 2>/dev/null || true
+  find "$_root/.worktrees" -maxdepth 1 -mindepth 1 -type d | while IFS= read -r _wt; do
+    _head_mtime=$(find "$_wt/.git" -maxdepth 1 -name HEAD -mmin +120 2>/dev/null | head -1)
+    [ -n "$_head_mtime" ] || continue
+    _recent=$(find "$_wt" -type f -mmin -120 2>/dev/null | head -1)
+    [ -z "$_recent" ] || continue
+    rm -rf "$_wt"
+  done
 done
 
 exit 0

--- a/claude-ops/bin/ops-post-session-cleanup
+++ b/claude-ops/bin/ops-post-session-cleanup
@@ -5,7 +5,12 @@ set -euo pipefail
 # Clean temp bridge files (formerly wacli temp files)
 rm -f /tmp/wacli-sync-probe-*.log /tmp/wacli-bootstrap-*.log 2>/dev/null || true
 
-# Clean stale agent worktrees older than 2 hours
-find "$HOME/Projects/claude-ops/.worktrees" -maxdepth 1 -type d -mmin +120 -exec rm -rf {} \; 2>/dev/null || true
+# Clean stale agent worktrees older than 2 hours.
+# Check every known checkout root — a hardcoded ~/Projects path silently
+# cleans nothing on installs that live elsewhere.
+for _root in "$HOME/Developer/repos/claude-ops" "$HOME/Developer/active/claude-ops" "$HOME/Projects/claude-ops"; do
+  [ -d "$_root/.worktrees" ] || continue
+  find "$_root/.worktrees" -maxdepth 1 -mindepth 1 -type d -mmin +120 -exec rm -rf {} \; 2>/dev/null || true
+done
 
 exit 0

--- a/claude-ops/bin/ops-post-session-cleanup
+++ b/claude-ops/bin/ops-post-session-cleanup
@@ -18,8 +18,12 @@ rm -f /tmp/wacli-sync-probe-*.log /tmp/wacli-bootstrap-*.log 2>/dev/null || true
 for _root in "$HOME/Developer/repos/claude-ops" "$HOME/Developer/active/claude-ops" "$HOME/Projects/claude-ops"; do
   [ -d "$_root/.worktrees" ] || continue
   find "$_root/.worktrees" -maxdepth 1 -mindepth 1 -type d | while IFS= read -r _wt; do
-    _head_mtime=$(find "$_wt/.git" -maxdepth 1 -name HEAD -mmin +120 2>/dev/null | head -1)
-    [ -n "$_head_mtime" ] || continue
+    # Linked worktrees store $_wt/.git as a gitfile, not a directory, so
+    # `find $_wt/.git -name HEAD` never matches. Resolve HEAD through git.
+    _head=$(git -C "$_wt" rev-parse --git-path HEAD 2>/dev/null) || continue
+    [ -f "$_head" ] || continue
+    _head_old=$(find "$_head" -maxdepth 0 -mmin +120 2>/dev/null | head -1)
+    [ -n "$_head_old" ] || continue
     _recent=$(find "$_wt" -type f -mmin -120 2>/dev/null | head -1)
     [ -z "$_recent" ] || continue
     rm -rf "$_wt"

--- a/claude-ops/bin/ops-update
+++ b/claude-ops/bin/ops-update
@@ -238,7 +238,7 @@ if [[ "$LOCALSYNC" -eq 0 ]]; then
   say "  ${c_dim}(skipped: --no-localsync)${c_rst}"
 else
   localrepo=""
-  for d in "$HOME"/Projects/claude-ops-marketplace "$HOME"/Projects/claude-ops "$HOME"/Projects/*/claude-ops "$HOME"/Projects/claude-ops/claude-ops; do
+  for d in "$HOME"/Developer/repos/claude-ops/claude-ops "$HOME"/external-skills/claude-ops "$HOME"/Projects/claude-ops-marketplace "$HOME"/Projects/claude-ops "$HOME"/Projects/*/claude-ops "$HOME"/Projects/claude-ops/claude-ops; do
     case "$d" in *"/.worktrees/"*) continue ;; esac
     [[ -f "$d/.claude-plugin/marketplace.json" ]] || continue
     git -C "$d" rev-parse --git-dir >/dev/null 2>&1 || continue

--- a/claude-ops/scripts/agent-dash/control.mjs
+++ b/claude-ops/scripts/agent-dash/control.mjs
@@ -5,7 +5,7 @@
 
 import { spawnSync, execFileSync } from 'node:child_process';
 import { homedir } from 'node:os';
-import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { appendFileSync, existsSync, mkdirSync, readFileSync, statSync } from 'node:fs';
 import { join, dirname, resolve as pathResolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -35,17 +35,22 @@ function resolveOpsBg() {
   if (process.env.OPS_BG_BIN) return process.env.OPS_BG_BIN;
   // Sibling of this file is the authoritative answer: control.mjs ships at
   // <root>/scripts/agent-dash/control.mjs, so ops-bg is <root>/bin/ops-bg.
-  const sibling = pathResolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'bin', 'ops-bg');
-  if (existsSync(sibling)) return sibling;
-  for (const c of [
+  const candidates = [
+    pathResolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'bin', 'ops-bg'),
     `${HOME}/Developer/repos/claude-ops/claude-ops/bin/ops-bg`,
     `${HOME}/external-skills/claude-ops/bin/ops-bg`,
     `${HOME}/.claude/plugins/marketplaces/ops-marketplace/claude-ops/bin/ops-bg`,
     `${HOME}/Projects/claude-ops/claude-ops/bin/ops-bg`,
-  ]) {
-    if (existsSync(c)) return c;
+  ];
+  for (const c of candidates) {
+    try {
+      const st = statSync(c);
+      if (st.isFile() && (st.mode & 0o111)) return c;
+    } catch {
+      // missing path — keep looking
+    }
   }
-  return sibling;
+  return candidates[0];
 }
 const OPS_BG = resolveOpsBg();
 

--- a/claude-ops/scripts/agent-dash/control.mjs
+++ b/claude-ops/scripts/agent-dash/control.mjs
@@ -45,7 +45,7 @@ function resolveOpsBg() {
   for (const c of candidates) {
     try {
       const st = statSync(c);
-      if (st.isFile() && (st.mode & 0o111)) return c;
+      if (st.isFile() && st.mode & 0o111) return c;
     } catch {
       // missing path — keep looking
     }

--- a/claude-ops/scripts/agent-dash/control.mjs
+++ b/claude-ops/scripts/agent-dash/control.mjs
@@ -6,7 +6,8 @@
 import { spawnSync, execFileSync } from 'node:child_process';
 import { homedir } from 'node:os';
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, resolve as pathResolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const HOME = homedir();
 const ARCHIVE_LOG = join(HOME, '.claude', 'state', 'agent-archive.jsonl');
@@ -30,7 +31,23 @@ function fraSshHost() {
   }
   return FRA_HOSTS[0];
 }
-const OPS_BG = process.env.OPS_BG_BIN || `${HOME}/Projects/claude-ops/claude-ops/bin/ops-bg`;
+function resolveOpsBg() {
+  if (process.env.OPS_BG_BIN) return process.env.OPS_BG_BIN;
+  // Sibling of this file is the authoritative answer: control.mjs ships at
+  // <root>/scripts/agent-dash/control.mjs, so ops-bg is <root>/bin/ops-bg.
+  const sibling = pathResolve(dirname(fileURLToPath(import.meta.url)), '..', '..', 'bin', 'ops-bg');
+  if (existsSync(sibling)) return sibling;
+  for (const c of [
+    `${HOME}/Developer/repos/claude-ops/claude-ops/bin/ops-bg`,
+    `${HOME}/external-skills/claude-ops/bin/ops-bg`,
+    `${HOME}/.claude/plugins/marketplaces/ops-marketplace/claude-ops/bin/ops-bg`,
+    `${HOME}/Projects/claude-ops/claude-ops/bin/ops-bg`,
+  ]) {
+    if (existsSync(c)) return c;
+  }
+  return sibling;
+}
+const OPS_BG = resolveOpsBg();
 
 export function findAgent(snapshot, idOrName) {
   const q = String(idOrName);

--- a/claude-ops/skills/ops-release/SKILL.md
+++ b/claude-ops/skills/ops-release/SKILL.md
@@ -36,7 +36,7 @@ Resolve it first:
 
 ```bash
 RELEASE=""
-for d in ~/Projects/claude-ops-workspace/claude-ops ~/Projects/claude-ops/claude-ops "$HOME"/Projects/*/claude-ops; do
+for d in ~/Developer/repos/claude-ops ~/Projects/claude-ops-workspace/claude-ops ~/Projects/claude-ops/claude-ops "$HOME"/Projects/*/claude-ops; do
   if [ -f "$d/.claude-plugin/marketplace.json" ] && [ -x "$d/claude-ops/bin/ops-release" ]; then
     RELEASE="$d/claude-ops/bin/ops-release"; REPO="$d"; break
   fi

--- a/claude-ops/skills/ops-ship/SKILL.md
+++ b/claude-ops/skills/ops-ship/SKILL.md
@@ -44,7 +44,7 @@ Run the copy inside a git checkout of the repo:
 
 ```bash
 SHIP=""
-for d in ~/Projects/claude-ops-workspace/claude-ops ~/Projects/claude-ops/claude-ops "$HOME"/Projects/*/claude-ops; do
+for d in ~/Developer/repos/claude-ops ~/Projects/claude-ops-workspace/claude-ops ~/Projects/claude-ops/claude-ops "$HOME"/Projects/*/claude-ops; do
   if [ -f "$d/.claude-plugin/marketplace.json" ] && [ -x "$d/claude-ops/bin/ops-ship" ]; then
     SHIP="$d/claude-ops/bin/ops-ship"; break
   fi


### PR DESCRIPTION
#877 fixed the `/flow` router hardcoding `$HOME/Projects/claude-ops`. Auditing for the same pattern found the dead root is load-bearing in four more places. Every one of them **fails silently** rather than erroring, which is why they survived.

| File | What silently breaks |
|---|---|
| `bin/ops-update` (step 8/11) | probes only `~/Projects/*`, so it prints `no linked local source checkout found (skipped)` and never syncs the local checkout |
| `bin/ops-post-session-cleanup` | `find` on a nonexistent `.worktrees` path matches nothing, so stale agent worktrees are never reaped |
| `scripts/agent-dash/control.mjs` | `OPS_BG` points at a path that does not exist, so every attach/steer/revive/kill breaks unless `OPS_BG_BIN` is set |
| `skills/ops-ship`, `skills/ops-release` | resolver loops leave `$SHIP` empty and the skill exits |

Fixes:

- Probe the real checkout roots (`~/Developer/repos/claude-ops`, `~/external-skills/claude-ops`) ahead of the legacy `~/Projects` entries, which are kept for anyone who does have them.
- `control.mjs` now resolves from **its own location first** — it ships at `<root>/scripts/agent-dash/control.mjs`, so `ops-bg` is `<root>/bin/ops-bg`. That is correct for every install including forks and renames, with the known roots as fallback. `OPS_BG_BIN` still overrides.
- The cleanup loop gained `-mindepth 1` so it can never `rm -rf` the `.worktrees` root itself.

Verified on both macOS and Linux: `bash -n` and `node --check` clean, `ops-post-session-cleanup` exits 0, `control.mjs` imports, and the ops-ship resolver loop now yields a real binary instead of an empty string.

Follows #877, #879.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of stale worktrees across supported checkout locations.
  * Prevented recently active worktrees from being removed during cleanup.
  * Enhanced local source checkout discovery for update, release, and shipping workflows.
  * Improved background process resolution across repository-local and installed locations, including configurable overrides.

* **Documentation**
  * Updated operational guidance to recognize additional checkout locations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->