### PR TITLE
fix(flow): pass the project path to flow-state, or PROJECT-MODE never triggers

### DIFF
--- a/claude-ops/bin/flow-state
+++ b/claude-ops/bin/flow-state
@@ -18,11 +18,21 @@ TARGET="$PWD"
 for arg in "$@"; do
   case "$arg" in
     --json) JSON=1 ;;
-    *) [ -d "$arg" ] && TARGET="$arg" ;;
+    *)
+      if [ ! -d "$arg" ]; then
+        echo "flow-state: target '$arg' is not a directory" >&2
+        echo "flow-state: refusing to fall back to \$PWD — MODE would describe the wrong tree" >&2
+        exit 2
+      fi
+      TARGET="$arg"
+      ;;
   esac
 done
 
-cd "$TARGET" 2>/dev/null || true
+if ! cd "$TARGET" 2>/dev/null; then
+  echo "flow-state: cannot enter '$TARGET'" >&2
+  exit 2
+fi
 
 # --- git root + mode ---------------------------------------------------------
 ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"

--- a/claude-ops/skills/flow/SKILL.md
+++ b/claude-ops/skills/flow/SKILL.md
@@ -44,18 +44,31 @@ default), or just route the stage to its single canonical command inline.
 Before routing, compute where the user is on the lifecycle:
 
 ```bash
+# FLOW_TARGET: the project you are actually working on. Default to the shell's
+# cwd, but pass an explicit path when the harness's tool cwd is not the project
+# (see the mode-resolution note below).
+FLOW_TARGET="${FLOW_TARGET:-$PWD}"
 for _d in "${CLAUDE_PLUGIN_ROOT:-}" \
           "$HOME/Developer/repos/claude-ops/claude-ops" \
           "$HOME/external-skills/claude-ops" \
           "$HOME/.claude/plugins/marketplaces/ops-marketplace/claude-ops" \
           "$HOME/Projects/claude-ops/claude-ops"; do
-  [ -n "$_d" ] && [ -x "$_d/bin/flow-state" ] && "$_d/bin/flow-state" && break
+  [ -n "$_d" ] && [ -x "$_d/bin/flow-state" ] && "$_d/bin/flow-state" "$FLOW_TARGET" && break
 done
 ```
 
 Use `${CLAUDE_PLUGIN_ROOT:-}`, not `$CLAUDE_PLUGIN_ROOT`: the bare form aborts
 under `set -u`, and an unguarded `${CLAUDE_PLUGIN_ROOT}/bin/flow-state` expands
 to the absolute path `/bin/flow-state` when the variable is unset.
+
+**Always pass the target path explicitly.** `flow-state` defaults to `$PWD`,
+and on some harnesses the shell tool does NOT run in the directory the user
+launched from — Hermes, for example, runs terminal commands in `$HOME`. A
+bare `flow-state` there inspects the home directory, finds no `.planning/`,
+and reports `MODE=AD-HOC` for every project. PROJECT-MODE then never triggers,
+so the GSD phase state machine is silently unreachable and every request falls
+through to the ad-hoc gstack lifecycle. Resolve the project directory first
+(the repo the user named, or the one under discussion) and pass it.
 
 This prints: mode (PROJECT / AD-HOC), current `.planning/` phase (if any),
 open PRs, and deploy state — the "you are here" marker. Read it first so
@@ -129,9 +142,14 @@ Route `$ARGUMENTS` (first token = intent) using this table:
   `gstack-index` skill lists all 54 names. GSD routes are normal skills and do
   resolve via `skill_view` (`gsd-plan-phase`, `gsd-execute-phase`, ...).
 - **`$REST`** = `$ARGUMENTS` with the leading intent token removed.
-- **Mode resolution**: use the `MODE=` line from `flow-state`. PROJECT when
-  the git root has `.planning/`; AD-HOC otherwise. "multi-project" = the user
-  named >1 repo/project or asked for portfolio-wide work.
+- **Mode resolution**: use the `MODE=` line from `flow-state`, and pass it the
+  PROJECT path (see Runtime Context). PROJECT when the git root has
+  `.planning/`; AD-HOC otherwise. If you did not pass a path and the harness
+  runs shell commands somewhere other than the project (Hermes uses `$HOME`),
+  `MODE` is meaningless — it describes that directory, not the user's work.
+  A universal `AD-HOC` across unrelated projects is the symptom.
+  "multi-project" = the user named >1 repo/project or asked for
+  portfolio-wide work.
 - **Delegation only.** This skill never does the work itself — it invokes the
   canonical command via the `Skill` tool (or prints the route if the target is
   a personal/plugin slash-command the model should call next). After routing,

--- a/claude-ops/skills/flow/SKILL.md
+++ b/claude-ops/skills/flow/SKILL.md
@@ -48,14 +48,22 @@ Before routing, compute where the user is on the lifecycle:
 # cwd, but pass an explicit path when the harness's tool cwd is not the project
 # (see the mode-resolution note below).
 FLOW_TARGET="${FLOW_TARGET:-$PWD}"
+FLOW_STATE=""
 for _d in "${CLAUDE_PLUGIN_ROOT:-}" \
           "$HOME/Developer/repos/claude-ops/claude-ops" \
           "$HOME/external-skills/claude-ops" \
           "$HOME/.claude/plugins/marketplaces/ops-marketplace/claude-ops" \
           "$HOME/Projects/claude-ops/claude-ops"; do
-  [ -n "$_d" ] && [ -x "$_d/bin/flow-state" ] && "$_d/bin/flow-state" "$FLOW_TARGET" && break
+  [ -n "$_d" ] && [ -x "$_d/bin/flow-state" ] && { FLOW_STATE="$_d/bin/flow-state"; break; }
 done
+[ -n "$FLOW_STATE" ] || { echo "flow: no executable bin/flow-state found" >&2; exit 1; }
+"$FLOW_STATE" "$FLOW_TARGET"
 ```
+
+Both failures are **fail-closed on purpose**. If no helper resolves, or the
+target path is not a directory, stop and say so — do not route. `MODE` is what
+decides GSD vs gstack, so routing without it silently picks the wrong half of
+the lifecycle, which is worse than an error.
 
 Use `${CLAUDE_PLUGIN_ROOT:-}`, not `$CLAUDE_PLUGIN_ROOT`: the bare form aborts
 under `set -u`, and an unguarded `${CLAUDE_PLUGIN_ROOT}/bin/flow-state` expands
@@ -161,9 +169,12 @@ Route `$ARGUMENTS` (first token = intent) using this table:
 
 ### Bare `/flow`
 
-If `$ARGUMENTS` is empty: `Read LIFECYCLE-MAP.md`, then run `bin/flow-state`, and
-present the lifecycle map with the current position highlighted. Offer the
-next canonical stage as the suggested action. **Do not auto-advance.**
+If `$ARGUMENTS` is empty: `Read LIFECYCLE-MAP.md`, then reuse the Runtime
+Context result above (the same `"$FLOW_STATE" "$FLOW_TARGET"` invocation — do
+not call `bin/flow-state` bare, it would report on the harness's cwd rather
+than the project), and present the lifecycle map with the current position
+highlighted. Offer the next canonical stage as the suggested action.
+**Do not auto-advance.**
 
 ## CLI/API Reference
 


### PR DESCRIPTION
`flow-state` defaults to `$PWD`. On harnesses whose shell tool does not run in the directory the user launched from, that default is wrong for **every** request. Hermes runs terminal commands in `$HOME`: a bare `flow-state` inspects the home directory, finds no `.planning/`, and reports `MODE=AD-HOC` unconditionally.

The consequence is silent and total. PROJECT-MODE never triggers, so the GSD phase state machine is unreachable and every request — in any repo, however well set up — falls through to the ad-hoc gstack lifecycle. Half the router was dead and nothing errored.

## Reproduction

A repo at `/tmp/flowproj` containing `.planning/`:

```
$ flow-state /tmp/flowproj
MODE=PROJECT
ROOT=/tmp/flowproj
PLANNING=/tmp/flowproj/.planning
NEXT=resume GSD phase → /flow build  (then review · test · ship)
```

The same repo, via `/flow` from a Hermes session standing in that directory:

```
MODE: AD-HOC (no .planning/ at cwd or git root)
Route picked: debug/why -> /investigate
```

The router was working correctly. It was answering a question about the wrong directory.

## Fix

`flow-state` already accepted an optional path argument — the skill just never passed one. Pass `FLOW_TARGET` (defaulting to `$PWD`, so nothing changes for harnesses that already cwd correctly), and document that a universal `AD-HOC` across unrelated projects is the symptom of the unset case.

## Verification

Same request, same repo, after the change:

```
MODE=PROJECT (git root /tmp/flowproj has .planning/, via bin/flow-state with explicit path)
Route: 500 = debug intent -> /investigate, plus gsd-debug (project mode)
```

PROJECT-MODE triggers and the GSD leg fires alongside the gstack tool, which is the documented behaviour in `LIFECYCLE-MAP.md`.

Follows #877, #879, #881.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flow-state mode detection when commands run outside the target project directory.
  * Ensured routing uses the correct target project path, including clearer handling for multi-project setups.
  * Invalid targets now produce an error instead of being silently ignored.
  * Prevented flow-state reports from being generated when the selected project cannot be entered.
  * Bare `/flow` now reuses the validated target-aware result.

* **Documentation**
  * Updated routing guidance and multi-project detection criteria.
  * Clarified that processing should stop when the target is invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->