### PR TITLE
docs(ops-projects): describe the real GSD scan roots

### DIFF
--- a/claude-ops/scripts/daemon-services.default.json
+++ b/claude-ops/scripts/daemon-services.default.json
@@ -57,7 +57,7 @@
       "enabled": true,
       "command": "${CLAUDE_PLUGIN_ROOT}/scripts/ops-gsd-registry-sync.sh",
       "cron": "0 6,18 * * *",
-      "_note": "Scans ~/Projects and ~/gsd-workspaces for GSD .planning/ dirs, updates central registry and projects_health cache. Runs at 6am and 6pm daily."
+      "_note": "Discovers GSD .planning/ dirs anywhere under $HOME (extra roots via OPS_GSD_SCAN_ROOTS), updates central registry and projects_health cache. Runs at 6am and 6pm daily."
     },
     "inbox-digest": {
       "enabled": false,

--- a/claude-ops/skills/ops-projects/SKILL.md
+++ b/claude-ops/skills/ops-projects/SKILL.md
@@ -45,15 +45,16 @@ cat ${OPS_DATA_DIR}/cache/projects_health.json
 ## Data flow
 
 ```
-~/Projects/              ~/gsd-workspaces/
-    │                          │
-    ▼                          ▼
- [project]/.planning/    [project]/.planning/
-    │                          │
-    ├── HANDOFF.json           ├── HANDOFF.json     ← active-phase projects
-    ├── STATE.md               ├── MILESTONES.md
-    ├── ROADMAP.md             └── STATE.md
-    └── MILESTONES.md
+$HOME  (walked recursively, depth <= OPS_GSD_SCAN_DEPTH, default 5)
+   + any extra roots listed in OPS_GSD_SCAN_ROOTS (colon-separated)
+              │
+              ▼
+      <any-dir>/.planning/
+              │
+              ├── HANDOFF.json     ← active-phase projects
+              ├── STATE.md
+              ├── ROADMAP.md
+              └── MILESTONES.md
               │
               ▼  ops-gsd-registry-sync.sh (daemon: 6am + 6pm)
                     │
@@ -65,6 +66,20 @@ cat ${OPS_DATA_DIR}/cache/projects_health.json
                               │
                               ▼  ops-projects skill reads this
 ```
+
+### Discovery
+
+`ops-gsd-registry-sync.sh` does not assume a fixed workspace directory. It walks
+`$HOME` and records every `.planning/` directory it finds, so any layout works.
+
+- `OPS_GSD_SCAN_ROOTS` — colon-separated extra roots to walk besides `$HOME`
+  (use this for projects that live outside the home directory)
+- `OPS_GSD_SCAN_DEPTH` — how deep to walk (default 5)
+- `OPS_GSD_SCAN_EXCLUDE` — colon-separated extra directory names to skip
+- `OPS_GSD_INCLUDE_WORKTREES=1` — also scan `.worktrees/` (skipped by default,
+  since worktrees duplicate an existing project)
+
+Build noise (`node_modules`, `.git`, `.venv`, `dist`, caches) is always skipped.
 
 ---
 
@@ -120,7 +135,7 @@ If `$ARGUMENTS` contains a project alias, find it in the registry and show:
 ╔══════════════════════════════════════════════════════════════╗
 ║  PROJECT — [alias]                                           ║
 ╠══════════════════════════════════════════════════════════════╣
-║  Path:      ~/Projects/[alias]/                              ║
+║  Path:      [path from registry]                             ║
 ║  Phase:     [phase]  Status: [status]                       ║
 ║  Milestone: [milestone name]                                ║
 ║  Branch:    [branch]   Dirty: [N]  Unpushed: [N]            ║

--- a/claude-ops/skills/ops/references/capabilities.json
+++ b/claude-ops/skills/ops/references/capabilities.json
@@ -152,7 +152,7 @@
     },
     {
       "name": "ops-projects",
-      "summary": "This skill should be used when the user asks to \"portfolio dashboard\", \"gsd projects\", or \"/ops:ops-projects\". Portfolio dashboard for all GSD-tracked projects. Scans ~/Projects and ~/gsd-workspaces for .planning/ directories, shows phase status, git state, blockers, and next actions for every project. Run /ops projects to see the full portfolio."
+      "summary": "This skill should be used when the user asks to \"portfolio dashboard\", \"gsd projects\", or \"/ops:ops-projects\". Portfolio dashboard for all GSD-tracked projects. Discovers GSD .planning/ directories anywhere under $HOME (plus any extra roots set in OPS_GSD_SCAN_ROOTS), shows phase status, git state, blockers, and next actions for every project. Run /ops projects to see the full portfolio."
     },
     {
       "name": "ops-recap",


### PR DESCRIPTION
## What

`skills/ops-projects/SKILL.md`, `skills/ops/references/capabilities.json`, and `scripts/daemon-services.default.json` all claimed the GSD sync "scans `~/Projects` and `~/gsd-workspaces`".

`scripts/ops-gsd-registry-sync.sh` has not done that for a while. It walks `$HOME` recursively for `.planning/` directories and adds any roots listed in `OPS_GSD_SCAN_ROOTS`. On an install where neither directory exists, the docs described a scan that never runs.

## Why it matters

The capability index feeds skill discovery. A description naming two directories that do not exist tells the router the skill is irrelevant on most machines.

## Changes

Docs only, no behaviour change.

- Data-flow diagram now shows the `$HOME` walk plus `OPS_GSD_SCAN_ROOTS`.
- New **Discovery** section documenting `OPS_GSD_SCAN_ROOTS`, `OPS_GSD_SCAN_DEPTH`, `OPS_GSD_SCAN_EXCLUDE`, `OPS_GSD_INCLUDE_WORKTREES`.
- Deep-dive card no longer hardcodes `~/Projects/[alias]/`; it shows the path from the registry.
- Capability summary and daemon service note reworded to match.

`~/Projects` is left alone everywhere it is a genuine configurable default (`repo_search_roots`, `prompts/deploy-fix.md`), a registry example, or a changelog entry.

## Validation

- `jq . capabilities.json` and `jq . daemon-services.default.json` — valid
- `tests/test-skills-lint.sh` — 767 passed, 0 failed
- `tests/test-plugin-validate.sh` — 7 passed, 0 failed
- `tests/test-compact-discovery.sh` — pass (63 skills, 21 agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)