### PR TITLE
fix(hermes): let ops slash commands enter the agent loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Turn Claude Code into a complete business operating system — infrastructure he
 
 | | |
 |---|---|
-| Native Hermes plugin | `hermes-plugin/` → `~/.hermes/plugins/ops`. Slash commands + `skill_view("ops:*")`. |
+| Hermes | Installer mirrors skills into `~/.hermes/skills` for working slash commands and links `hermes-plugin/` for `skill_view("ops:*")`. |
 | Grok | Loads the Claude plugin as-is. No `.grok-plugin`. |
 | Skills | Third-person trigger descriptions, shared preamble, `ops-rules` (plugin-root `CLAUDE.md` is a pointer). Oversized skills split into `references/`. |
 | Versions | `plugin.json` = Hermes `plugin.yaml` = installer pin. `ops-release` keeps them together. |

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+- fix(hermes): stop the native plugin registering duplicate `/ops-*` handlers.
+  Hermes displays a plugin command handler's return value as the final reply,
+  so those handlers echoed an instruction to load the skill and ended the turn
+  before the agent ran anything. The cross-CLI installer already mirrors every
+  claude-ops skill into Hermes' normal skills directory; those native skill
+  slash commands now remain unshadowed and enter the agent loop as intended.
+
 - fix(deploy-fix): `scripts/ops-deploy-monitor.sh` no longer calls `gh run watch`.
   That call blocks, polls every 2-5s with no tick cap, and is the exact pattern
   `hooks/gh-watch-guard.sh` denies for every other caller. The monitor is spawned

--- a/claude-ops/hermes-plugin/README.md
+++ b/claude-ops/hermes-plugin/README.md
@@ -27,15 +27,16 @@ plugins:
     - ops
 ```
 
-Restart the gateway / CLI. Slash commands (`/ops-inbox`, `/ops-go`, `/ops`)
-and `skill_view("ops:ops-inbox")` become available.
+Restart the gateway / CLI. The installer-mirrored skills provide working slash
+commands (`/ops-inbox`, `/ops-go`, `/ops`), while the native plugin provides
+explicit namespaced loads such as `skill_view("ops:ops-inbox")`.
 
 ## Layout
 
 | Path | Role |
 |---|---|
 | `plugin.yaml` | Hermes manifest (`name: ops`) |
-| `__init__.py` | Registers skills + slash commands |
+| `__init__.py` | Registers namespaced read-only skills |
 | `RUNTIME.md` | Claude Code → Hermes primitive map |
 | `../skills/` | Canonical SKILL.md tree (unchanged) |
 

--- a/claude-ops/hermes-plugin/__init__.py
+++ b/claude-ops/hermes-plugin/__init__.py
@@ -1,8 +1,10 @@
 """Hermes native plugin for claude-ops.
 
-Registers every skill as ``ops:<name>`` and a slash command ``/<name>``.
-Skills stay in the sibling ``skills/`` tree (the Claude Code plugin). This
-package does not import Hermes internals.
+Registers every skill as ``ops:<name>``. The cross-CLI installer mirrors the
+same skill tree into Hermes' normal skills directory, where Hermes creates the
+working ``/<name>`` slash commands itself. Do not register duplicate plugin
+commands here: plugin command return values are displayed as final text, so
+they shadow the real skill command and stop before the agent can run it.
 """
 
 from __future__ import annotations
@@ -44,45 +46,6 @@ def _description(md: Path) -> str:
     return desc[:200] if desc else md.parent.name
 
 
-def _handler(name: str):
-    def handle(raw_args: str = "") -> str:
-        args = (raw_args or "").strip()
-        return (
-            f"Run the claude-ops skill `{name}` now.\n"
-            f"Load it with skill_view(\"ops:{name}\") if that tool exists; "
-            f"otherwise open `{SKILLS_DIR / name / 'SKILL.md'}`.\n"
-            f"Arguments: {args or '(none)'}\n\n"
-            "This session is Hermes, not Claude Code. Use the degrade table in "
-            "ops:hermes-runtime (AskUserQuestion → numbered options / two-turn "
-            "Telegram card; Workflow → delegate_task; never gh --admin). "
-            "Rule 6 still applies: one draft, one approval, one send."
-        )
-
-    handle.__name__ = f"ops_cmd_{name.replace('-', '_')}"
-    return handle
-
-
-def _handle_ops(raw_args: str = "") -> str:
-    token = (raw_args or "").strip().split(None, 1)
-    names = [name for name, _ in _iter_skills()]
-    if token:
-        want = token[0].lstrip("/").replace("_", "-")
-        rest = token[1] if len(token) > 1 else ""
-        if want in names:
-            return _handler(want)(rest)
-        aliased = want if want.startswith("ops-") else f"ops-{want}"
-        if aliased in names:
-            return _handler(aliased)(rest)
-    listed = ", ".join(f"/{n}" for n in names[:12])
-    more = f" (+{len(names) - 12} more)" if len(names) > 12 else ""
-    return (
-        "claude-ops on Hermes. Enable this plugin in plugins.enabled, then "
-        f"use a slash command.\nExamples: {listed}{more}\n"
-        "Or: /ops inbox   /ops go   /ops fires\n"
-        'Skills also load as skill_view("ops:<name>").'
-    )
-
-
 def register(ctx) -> None:
     if RUNTIME_MD.is_file():
         ctx.register_skill(
@@ -90,18 +53,6 @@ def register(ctx) -> None:
             RUNTIME_MD,
             "Claude Code → Hermes primitive map for ops skills",
         )
-    ctx.register_command(
-        "ops",
-        handler=_handle_ops,
-        description="claude-ops router (inbox, go, fires, …)",
-        args_hint="[skill] [args]",
-    )
     for name, md in _iter_skills():
         desc = _description(md)
         ctx.register_skill(name, md, desc)
-        ctx.register_command(
-            name,
-            handler=_handler(name),
-            description=desc,
-            args_hint="[args]",
-        )

--- a/claude-ops/tests/test-hermes-plugin.sh
+++ b/claude-ops/tests/test-hermes-plugin.sh
@@ -49,6 +49,45 @@ else
   err "__init__.py failed to compile"
 fi
 
+# Plugin slash command handlers are terminal responses, not agent turns. The
+# installer-mirrored skills own /ops-*; registering the same names here shadows
+# them and only echoes the handler string back to the user.
+registration_json="$(PYTHONPYCACHEPREFIX="$(mktemp -d)" python3 - "$HP/__init__.py" <<'PY'
+import importlib.util
+import json
+import sys
+
+spec = importlib.util.spec_from_file_location("claude_ops_hermes_plugin", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+class Context:
+    def __init__(self):
+        self.skills = []
+        self.commands = []
+
+    def register_skill(self, name, path, description=""):
+        self.skills.append(name)
+
+    def register_command(self, name, **kwargs):
+        self.commands.append(name)
+
+ctx = Context()
+module.register(ctx)
+print(json.dumps({"skills": ctx.skills, "commands": ctx.commands}))
+PY
+)"
+if python3 -c 'import json,sys; d=json.loads(sys.argv[1]); raise SystemExit(0 if "ops-inbox" in d["skills"] and "ops" in d["skills"] else 1)' "$registration_json"; then
+  ok "Hermes plugin registers ops + ops-inbox as namespaced skills"
+else
+  err "Hermes plugin did not register expected namespaced skills"
+fi
+if python3 -c 'import json,sys; d=json.loads(sys.argv[1]); raise SystemExit(0 if d["commands"] == [] else 1)' "$registration_json"; then
+  ok "Hermes plugin does not shadow skill slash commands"
+else
+  err "Hermes plugin still registers shadowing slash commands: $registration_json"
+fi
+
 skill_count=$(find "$PLUGIN_ROOT/skills" -mindepth 2 -maxdepth 2 -name SKILL.md | wc -l | tr -d ' ')
 if ((skill_count >= 50)); then
   ok "sibling skills/ has $skill_count SKILL.md files"


### PR DESCRIPTION
## Summary
- stop the native Hermes plugin registering duplicate slash handlers that echo instructions and end the turn
- leave slash commands to the installer-mirrored Hermes skills
- keep namespaced skill_view("ops:*") registration in the plugin
- add a regression test proving no shadowing commands register

## Verification
- npm test: 27/27
- npm run lint: clean
- tests/run-all.sh: 39/39 suites
- test-hermes-plugin.sh: 10/10