### PR TITLE
fix(hooks): stop Grok skipping WhatsApp PreToolUse

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+- fix(hooks): PreToolUse WhatsApp bridge health no longer interpolates `$TOOL_INPUT`.
+  Grok treats `$VAR` in a hook command as a required env var and skips the hook
+  when it is unset (`hook not executed: required env var(s) not set: ${TOOL_INPUT}`).
+  Claude Code still sends the event JSON on stdin, so the script now reads stdin
+  (argv kept for old callers). Do not put `$TOOL_INPUT` / `$TOOL_RESULT` /
+  `$USER_PROMPT` in `hooks.json` command strings.
+
 - fix(whatsapp): `ops-wa-accounts` resolves client-of-remote-bridge accounts from
   `$PREFS_PATH` `.channels.whatsapp` (written by `/ops:setup` step 3b) and
   `$OPS_DATA_DIR/registry.json` `.whatsapp`, with legacy

--- a/claude-ops/bin/ops-pretool-whatsapp-bridge-health
+++ b/claude-ops/bin/ops-pretool-whatsapp-bridge-health
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 # PreToolUse hook: fast whatsapp-bridge health check (backgrounded to avoid blocking)
+# Event JSON arrives on stdin (Claude + Grok). Optional argv kept for old callers.
 set -e
-INPUT="${1:-}"
+if [[ -n "${1:-}" ]]; then
+  INPUT="$1"
+else
+  INPUT=$(cat)
+fi
 echo "$INPUT" | grep -q "whatsapp" || exit 0
 
 # Background the slow checks (lsof, launchctl) so this hook returns instantly.

--- a/claude-ops/hooks/hooks.json
+++ b/claude-ops/hooks/hooks.json
@@ -54,7 +54,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-pretool-whatsapp-bridge-health \"$TOOL_INPUT\" 2>/dev/null || true",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-pretool-whatsapp-bridge-health 2>/dev/null || true",
             "async": true
           }
         ]

--- a/claude-ops/tests/test-hooks.sh
+++ b/claude-ops/tests/test-hooks.sh
@@ -119,6 +119,40 @@ if command -v jq &>/dev/null; then
   done <<< "$events"
 fi
 
+# 6. Command strings must not interpolate Claude-only payload vars.
+# Grok expands $VAR from the environment and skips the hook if the var is unset:
+#   hook not executed: required env var(s) not set: ${TOOL_INPUT}
+# Claude Code substitutes those tokens before exec; Grok does not. Hooks must
+# read the event JSON from stdin instead.
+echo ""
+echo "Checking command interpolations..."
+if command -v jq &>/dev/null; then
+  bad=$(printf '%s\n' "$commands" | grep -E '\$\{?(TOOL_INPUT|TOOL_RESULT|USER_PROMPT)\}?' || true)
+  if [[ -n "$bad" ]]; then
+    err "command interpolates Claude-only payload var (Grok skips the hook): $bad"
+  else
+    ok "no Claude-only payload interpolations in hook commands"
+  fi
+fi
+
+# 7. WhatsApp PreToolUse hook reads stdin (the event JSON), not argv.
+echo ""
+echo "Checking ops-pretool-whatsapp-bridge-health stdin..."
+HEALTH="$PLUGIN_ROOT/bin/ops-pretool-whatsapp-bridge-health"
+if [[ ! -x "$HEALTH" ]]; then
+  err "bin/ops-pretool-whatsapp-bridge-health missing or not executable"
+else
+  payload='{"toolName":"Bash","toolInput":{"command":"wacli whatsapp send"}}'
+  trace=$(printf '%s' "$payload" | bash -x "$HEALTH" 2>&1 || true)
+  # Payload-only token: the script greps for "whatsapp", so that word appears in
+  # the trace even when stdin is ignored. "wacli" is only in the event JSON.
+  if printf '%s' "$trace" | grep -q 'wacli'; then
+    ok "whatsapp-bridge-health inspects stdin payload"
+  else
+    err "whatsapp-bridge-health ignores stdin; Grok/Claude send the event on stdin, not argv"
+  fi
+fi
+
 echo ""
 echo "---"
 echo "Results: $pass passed, $fail failed"

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -216,7 +216,7 @@ Hooks are declared in `claude-ops/claude-ops/hooks/hooks.json`. Three event type
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-pretool-wacli-health \"$TOOL_INPUT\" 2>/dev/null || true"
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-pretool-whatsapp-bridge-health 2>/dev/null || true"
           }
         ]
       }
@@ -238,7 +238,7 @@ Hooks are declared in `claude-ops/claude-ops/hooks/hooks.json`. Three event type
 | Event          | Matcher | Current use                                                  |
 | -------------- | ------- | ------------------------------------------------------------ |
 | `SessionStart` | (all)   | Run `ops-welcome` banner + surface any setup health failures |
-| `PreToolUse`   | `Bash`  | Check wacli health before any Bash call                      |
+| `PreToolUse`   | `Bash`  | Check WhatsApp bridge health. Read the event from stdin; never interpolate `$TOOL_INPUT`. |
 | `Stop`         | (all)   | Post-session cleanup                                         |
 
 Hook commands must always exit `0` (note the `|| true` suffix). A failing hook causes Claude Code to surface an error — never let hooks fail loudly.


### PR DESCRIPTION
Grok fails `plugin/ops/hooks:pre_tool_use[0]` with `required env var(s) not set: ${TOOL_INPUT}`.

Grok expands `$VAR` in hook commands from the environment and skips the hook if the var is unset. `$TOOL_INPUT` is a Claude Code substitution, not an env var. Both CLIs already send the event JSON on stdin.

- Drop `$TOOL_INPUT` from the WhatsApp PreToolUse command
- Read stdin in `ops-pretool-whatsapp-bridge-health` (argv still works)
- Test that hook commands never interpolate `$TOOL_INPUT` / `$TOOL_RESULT` / `$USER_PROMPT`

Local Grok install patched the same way so the next session stops failing before this lands.