### PR TITLE
fix(ops-inbox): query every calendar and mailbox before schedule facts

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -14,6 +14,13 @@
   or `--project` equal to the default) is unchanged. Guard:
   `tests/test-ops-marketing-dash-brand-isolation.sh`.
 
+- fix(ops-inbox): always query every configured calendar, mailbox, and messaging
+  channel before a schedule claim or NEEDS_REPLY draft. Google Calendar primary
+  is not the show/tour SSOT — Notion show-schedule / calendar / appointments
+  databases count when Notion is configured. A miss on one store is not absence.
+  Rule 9, `ops-go`, and `tonight` carry the same gate. Owner-local calendar IDs
+  live in `$PREFS_PATH` `.channels.notion.calendars`, never in this repo.
+
 - fix(hooks): PreToolUse WhatsApp bridge health no longer interpolates `$TOOL_INPUT`.
   Grok treats `$VAR` in a hook command as a required env var and skips the hook
   when it is unset (`hook not executed: required env var(s) not set: ${TOOL_INPUT}`).

--- a/claude-ops/skills/ops-go/SKILL.md
+++ b/claude-ops/skills/ops-go/SKILL.md
@@ -24,6 +24,8 @@ allowed-tools:
   - mcp__claude_ai_Slack__slack_read_channel
   # Notion — comments/mentions surfaced in the briefing.
   - mcp__claude_ai_Notion__notion-search
+  - mcp__claude_ai_Notion__notion-fetch
+  - mcp__claude_ai_Notion__notion-query-data-sources
   - mcp__claude_ai_Notion__notion-get-comments
 effort: medium
 maxTurns: 40
@@ -207,13 +209,17 @@ else
 fi
 ```
 
-### Calendar (today — all calendars)
+### Calendar (today — all stores, not primary Google only)
+
+Google Calendar **and** Notion calendars when Notion is configured. A miss on one store is not absence (Rule 9). Shows, travel, and appointments often live in a Notion show-schedule database and never sync to Google.
 
 ```!
 gog calendar events --all --today --json --sort start 2>/dev/null | head -60 || echo "calendar unavailable"
 ```
 
 Events include a `CalendarID` field (e.g. `work@example.com`, `personal@gmail.com`). When rendering the briefing, attribute each event with a short calendar label in parentheses — derive it from the CalendarID domain or summary (e.g. work account → `(work)`, personal Gmail → `(personal)`). Show total count + top 3 events sorted by start time with format: `HH:MM  Title (calendar)`.
+
+**Notion calendars (required when Notion is configured):** read `$PREFS_PATH` `.channels.notion.calendars` (array of `{name, data_source_url}` — owner-local). If empty, `mcp__claude_ai_Notion__notion-search` for databases titled like "Show Schedule", "Calendar", "Appointments", then `notion-fetch` + `notion-query-data-sources` for today. Merge those rows into the briefing labelled `(notion)`. Do not report "no events today" until both Google `--all` and this Notion query have run.
 
 Fallback: if `gog` is unavailable and `GOOGLE_CALENDAR_IDS` env var is set (comma-separated calendar IDs), fetch each ID individually:
 

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -33,6 +33,7 @@ allowed-tools:
   # Notion: MCP tools (claude.ai integration or self-hosted)
   - mcp__claude_ai_Notion__notion-search
   - mcp__claude_ai_Notion__notion-fetch
+  - mcp__claude_ai_Notion__notion-query-data-sources
   - mcp__claude_ai_Notion__notion-get-comments
   - mcp__claude_ai_Notion__notion-create-comment
   - mcp__claude_ai_Notion__notion-update-page
@@ -146,9 +147,10 @@ Every run, in order:
    commitments.
 1. Resolve the WhatsApp account (`ops-wa-accounts` — never hardcode a port).
 2. Freshness: `~/bin/wa-inbox-fresh.sh` (blocking, bounded). Then `bin/ops-inbox-scan`.
-3. `bin/ops-inbox-archive-set` report-only. Present KEEP vs ARCHIVE; `--apply` only after explicit OK.
-4. Deep-read KEEP / NEEDS_REPLY. Fan out if volume (`references/fan-out.md`).
-5. Stage drafts one at a time (Rule 6). Archive after a verified send.
+3. **All-context sweep** (Rule 9 + `references/details.md` "ALL CONTEXT SOURCES"): query every configured calendar, mailbox, and messaging channel before any schedule claim or NEEDS_REPLY draft. Google Calendar alone is not enough — Notion show/calendar databases count when Notion is configured. A miss on one store is not absence.
+4. `bin/ops-inbox-archive-set` report-only. Present KEEP vs ARCHIVE; `--apply` only after explicit OK.
+5. Deep-read KEEP / NEEDS_REPLY. Fan out if volume (`references/fan-out.md`).
+6. Stage drafts one at a time (Rule 6). Archive after a verified send.
 
 Channel processing, FULL-THREAD AWARENESS GATE, and per-channel recipes: `references/details.md`.
 
@@ -296,8 +298,8 @@ When this skill runs on Hermes or Grok (no `Workflow` tool, no `AskUserQuestion`
 Read the matching file before acting. Do not skip.
 
 - `references/cli.md` — WhatsApp MCP + gog CLI
-- `references/details.md` — inbox-zero rules, gates, per-channel processing
-- `references/runtime.md` — freshness, Mac fallback, version-heal, watcher
+- `references/details.md` — inbox-zero rules, gates, per-channel processing, **ALL CONTEXT SOURCES**
+- `references/runtime.md` — freshness, Mac fallback, version-heal, watcher, all-context sweep
 - `references/fan-out.md` — Workflow JS, Agent Teams, hard constraints
 - `CHANNELS.md` — channel setup
 - `vip` skill — tier order for step 0; who is answered first

--- a/claude-ops/skills/ops-inbox/references/details.md
+++ b/claude-ops/skills/ops-inbox/references/details.md
@@ -222,6 +222,7 @@ The user does NOT remember every thread. For EVERY message you present, you MUST
    - `mcp__whatsapp__list_messages {query: "<topic keywords>", limit: 5}` — related WA messages
    - Summarize: what this topic is about, any deadlines, any pending decisions
 4. **ops-memories** (if available) — check `~/.claude/plugins/data/ops-ops-marketplace/memories/` for any stored context about this contact or topic
+5. **Calendars and every mailbox** — ALL CONTEXT SOURCES above. If the thread names a date, gig, trip, or "are you free", query Google `--all` **and** Notion calendars (when configured) and search every mailbox, not the default one.
 
 **When presenting a NEEDS REPLY item:**
 
@@ -250,6 +251,25 @@ Stage this per the **PER-DRAFT APPROVAL** principle below. On Telegram/Hermes, d
 - **WAITING** — you sent last message, waiting for them (no action needed)
 - **HANDLED** — conversation concluded, can be archived
 - **FYI** — newsletters, notifications, automated messages (bulk archive)
+
+## Core principle: ALL CONTEXT SOURCES — NEVER ONE CALENDAR, NEVER ONE MAILBOX
+
+Rule 9 ("Exhaust before concluding") applies to **schedule and context**, not only to "was this email sent." A draft that states a date, a gig, travel, availability, or "already answered" must be grounded in the **union** of every configured store. One empty search is not absence.
+
+**Do this on every `/ops:ops-inbox` run, before the first schedule claim or NEEDS_REPLY draft:**
+
+1. **Calendars — all of them.**
+   - Google: `gog calendar events --all --from <start> --to <end>` (every calendar the account can see, not primary only).
+   - Notion, when configured: query every calendar / show-schedule / appointments database. Resolve from `$PREFS_PATH` `.channels.notion.calendars` (array of `{name, data_source_url}` — owner-local, never in this repo). If that key is empty, `notion-search` for databases titled like "Show Schedule", "Calendar", "Appointments", then `notion-fetch` + `notion-query-data-sources` for the same date window.
+   - A confirmed row in a Notion show-schedule database that is missing from Google Calendar is still a confirmed event. Google Calendar is **not** the touring/show SSOT.
+
+2. **Mailboxes — all of them.** `gog auth list`. Search each configured mailbox for the contact and the topic. The default account is not the whole estate.
+
+3. **Messaging channels — all of them that are configured.** Every agent-enabled WhatsApp account, every Slack workspace, iMessage, Telegram, Discord. Same person, same ask.
+
+4. **A miss is not a fact.** "Not on Google Calendar" does not mean "not playing tonight." "No email in the default inbox" does not mean "nobody wrote." Label the claim as unverified until the other stores have been queried.
+
+**Forbidden:** drafting "I'm not playing / free / travelling then" after only `gog calendar events` on the primary calendar.
 
 ## Core principle: TONE & LANGUAGE MATCH (every draft, every channel)
 
@@ -290,7 +310,7 @@ Only after steps 1–7 ALL come up empty is a thread a true NEEDS_REPLY candidat
 8. **Fact-verified redraft gate (MANDATORY, before staging ANY draft — owner directive 2026-07-04).** Clearing steps 1–7 makes a thread a genuine NEEDS_REPLY; it does NOT mean the draft you are about to write is safe to stage. Before staging any draft, the drafter MUST additionally:
    - **(a) Deep-read the full target thread, both directions** — not the summary from step 1–7, an actual re-read of every message for the specific facts the draft will state or rely on.
    - **(b) Read RELATED threads** — same contact across other channels, and any other thread about the same topic/deal (a different contact, a group, an earlier email chain) that could bear on what the draft should say.
-   - **(c) Verify every load-bearing factual claim in the draft with a cheap check** before it goes in the draft — a web search for a price/value, a prior email/thread for "who currently holds X", a calendar check for availability, etc. Never state a load-bearing fact in a draft from memory or assumption alone.
+   - **(c) Verify every load-bearing factual claim in the draft with a cheap check** before it goes in the draft — a web search for a price/value, a prior email/thread for "who currently holds X", **every configured calendar** (Google `--all` **and** Notion show/calendar databases when Notion is configured) for availability / gigs / travel, every configured mailbox for the same topic. Never state a load-bearing fact in a draft from memory or from one store alone. See **ALL CONTEXT SOURCES** above.
    - **Failure mode this prevents:** a draft routed a master clearance to the wrong label until the RELATED threads proved Spinnin'/WMG actually held it (checking only the target thread would have missed this); a watch's stated value (€22.600) changed the negotiation advice the draft gave, and stating the wrong figure from memory would have misled the recipient. Both are "the target thread alone looked fine" failures — that is exactly why (b) and (c) are mandatory, not optional enrichment.
 
 Only after steps 1–7 come up empty may you draft; only after step 8 is satisfied may you stage that draft. This is the FULL-THREAD AWARENESS GATE, extended cross-channel, cross-request, and fact-verified. **Surfacing a NEEDS_REPLY without having run the cross-thread, cross-channel, cross-request, and already-sent checks (steps 1–7) is a scan bug — do not present it; do not stage a draft until step 8 is clean.** None of this changes the outbound path: even a genuine, fact-verified NEEDS_REPLY is still drafted and sent only in the main session under the Rule-6 gate, per-draft, per the PER-DRAFT APPROVAL principle below.
@@ -436,7 +456,7 @@ For each channel, detect availability at runtime:
    - 0 workspaces configured → skip Slack with a one-line note: "Slack: no workspaces configured — run /ops:setup slack".
 4. **Telegram**: Only via user-auth MCP (tdlib/MTProto). Check `TELEGRAM_ENABLED` env var. Never use BotFather bots.
 5. **Discord**: Via `${CLAUDE_PLUGIN_ROOT}/bin/ops-discord read <CHANNEL_ID> --limit 20 --json`. Requires `DISCORD_BOT_TOKEN` (v1 is channel-scoped — no DM/gateway support yet). Pre-configured read list lives at `${CLAUDE_PLUGIN_DATA_DIR}/preferences.json` under `discord.inbox_channels` (array of channel IDs). If neither a bot token nor a read list is configured, skip Discord with a one-line note ("Discord not configured — run `/ops:setup discord`") rather than prompting — ops-inbox is not a setup flow. Rule 3 still applies to `/ops:setup`.
-6. **Notion**: Only via MCP tools (`mcp__claude_ai_Notion__*` or self-hosted Notion MCP). Check `NOTION_MCP_ENABLED` env var. Searches workspace for recent comments, mentions, and assigned tasks.
+6. **Notion**: Only via MCP tools (`mcp__claude_ai_Notion__*` or self-hosted Notion MCP). Check `NOTION_MCP_ENABLED` env var. Searches workspace for recent comments, mentions, and assigned tasks. **Also a calendar source:** when Notion is configured, the all-context sweep must query Notion calendar / show-schedule / appointments databases (see **ALL CONTEXT SOURCES**), not only comments.
 7. **iMessage**: Only via the official `imessage` plugin MCP (`mcp__plugin_imessage_imessage__*`). No bridge, no daemon — `chat_messages` reads `~/Library/Messages/chat.db` directly (allowlist-scoped) and `reply` sends via AppleScript to Messages.app. Availability check is a single probe — load the tool schemas:
    - `ToolSearch select:mcp__plugin_imessage_imessage__chat_messages,mcp__plugin_imessage_imessage__reply`. If the tools load, the channel is up. If `chat_messages` returns `(no allowlisted chats — configure via /imessage:access)`, the plugin is wired but no chats are allowlisted yet — surface a one-line note ("iMessage: no allowlisted chats — run `/imessage:access allow <handle>`") and move on; do NOT invoke `/imessage:access` yourself.
    - **MCP flap / reconnect**: the imessage plugin can flap — its bun process holds the `chat.db` handle open and is occasionally reaped (orphan-MCP reaper, TCC re-prompt, or session churn), after which `mcp__plugin_imessage_imessage__*` calls fail until it respawns. Per the MCP auto-reconnect rule: on a failed call wait 5s and retry the same call; if it fails again wait 15s and retry once more (the PreToolUse hook kills the stale process so Claude Code respawns it). Only after 3 total attempts declare iMessage unavailable. The first `chat.db` read after a cold start can also trigger a macOS TCC prompt ("allow Terminal/iTerm/your IDE to control Messages") — if reads return a permission error, surface that the user must click **Allow** on the system prompt.
@@ -1184,6 +1204,7 @@ wrong classification or a wrong draft.
 - **LID and phone mirrors duplicate rows.** The same message can appear once per JID with the same message ID. Deduplicate by message ID before counting toward any minimum-messages rule and before deciding which message is genuinely last.
 - **Same-name searches conflate different people and companies.** Verify the recipient address, domain, and topic before demoting a candidate as already answered.
 - **A meeting on the calendar does not resolve a different open question** from the same person. Match on the specific ask, not on the fact that you have contact with them.
+- **Google Calendar is not the show/tour SSOT.** Confirmed dates often live in a Notion show-schedule or appointments database and never sync to Google. Query every configured calendar store (Google `--all` **and** Notion) before stating "nothing on tonight" / "I'm not playing." A miss on one store is not absence.
 - **An old time, price, or status is context, not proof** of the current fact. Re-verify anything load-bearing against its own source.
 - **An unanswered message is not automatically NEEDS_REPLY.** It may be an action item you owe, a social close that needs nothing, or a request now owned by the other party.
 - **Subagent triage output is a research artifact, not a finished report.** Read the JSON it actually returned before restating its conclusions, and check that it covered every item you gave it. A partial pass that reports confidently will carry its gaps into the user's reply verbatim.

--- a/claude-ops/skills/ops-inbox/references/runtime.md
+++ b/claude-ops/skills/ops-inbox/references/runtime.md
@@ -90,6 +90,13 @@ The whatsmeow bridge can **silently miss inbound messages** when its history/app
    - `topics_active.md` — check for active threads or deadlines related to this contact
    - `donts.md` — never violate these restrictions in drafts
 
-5. **Launch the live inbox watcher (background job, every session)** — right after the steps above, start `bin/ops-inbox-live-watch.sh` via Bash with `run_in_background: true`. It polls the Gmail inbox (via `gog`) every ~4 minutes and exits — with a `NEW INBOX MAIL: <from> | <subject> | <date> | id=<id>` summary line — the instant a genuinely new inbound message lands; it also exits (with a `watcher expired` line) after ~6h if nothing new arrives. **The job's exit IS the new-mail ping** — treat it exactly like a direct orchestrator notification: when it fires, re-scan the affected channel and relaunch the watcher (same command) so live coverage never lapses. Pure bash + python3 + `gog`, no systemd/launchd dependency, cross-platform (Linux + macOS).
+5. **All-context sweep (calendars + mailboxes + channels) — every invocation, before the first draft.** Rule 9 and `details.md` **ALL CONTEXT SOURCES**. Google Calendar primary is not enough:
+   - `gog calendar events --all` for the relevant window (today through the next few days, or the dates named in KEEP threads).
+   - When Notion is configured: `$PREFS_PATH` `.channels.notion.calendars`, else search Notion for "Show Schedule" / "Calendar" / "Appointments" databases and query that window.
+   - `gog auth list` then search every mailbox for the contact and topic of each NEEDS_REPLY candidate.
+   - Every configured messaging channel (each WhatsApp account, each Slack workspace, iMessage, Telegram, Discord).
+   A miss on one store is not absence. Do not draft a schedule fact ("not playing tonight", "free then") until this sweep has run.
+
+6. **Launch the live inbox watcher (background job, every session)** — right after the steps above, start `bin/ops-inbox-live-watch.sh` via Bash with `run_in_background: true`. It polls the Gmail inbox (via `gog`) every ~4 minutes and exits — with a `NEW INBOX MAIL: <from> | <subject> | <date> | id=<id>` summary line — the instant a genuinely new inbound message lands; it also exits (with a `watcher expired` line) after ~6h if nothing new arrives. **The job's exit IS the new-mail ping** — treat it exactly like a direct orchestrator notification: when it fires, re-scan the affected channel and relaunch the watcher (same command) so live coverage never lapses. Pure bash + python3 + `gog`, no systemd/launchd dependency, cross-platform (Linux + macOS).
 
 Channel processing, FULL-THREAD AWARENESS GATE, and per-channel recipes: `details.md`.

--- a/claude-ops/skills/ops-rules/SKILL.md
+++ b/claude-ops/skills/ops-rules/SKILL.md
@@ -227,12 +227,25 @@ not run it, do not write the sentence.
 - "this happened on `<date>`" / "A came after B"
 - "nobody replied" / "it stalled because…"
 - "this needs you" / "that's a human blocker"
+- "that's not on the calendar" / "I'm not playing / meeting / travelling then"
 
 **"It doesn't exist."** Search every configured account, not the default one, and
 page past the first screen. Vary the query at least three ways: by topic keyword,
 by the counterparty's exact address (`to:`/`from:`), and by their domain alone
 plus likely misspellings of the name. A negative from one account, one query, or
 page one is not evidence of absence.
+
+**"That's not on the calendar."** Query every configured calendar store, not
+the primary Google Calendar. That means `gog calendar events --all` for the
+window **and**, when Notion is configured, every Notion calendar / show-schedule
+/ appointments database (resolve IDs from `$PREFS_PATH` `.channels.notion.calendars`,
+or search Notion for databases titled like "Show Schedule", "Calendar",
+"Appointments"). A confirmed date that lives only in Notion is still a date.
+Drafting "nothing on tonight" from Google Calendar alone is a defect.
+
+**Every mailbox, every channel.** `gog auth list` enumerates mailboxes; scan
+each one that is configured. The same for WhatsApp accounts, Slack workspaces,
+iMessage, Telegram, Discord. Context for a draft is the union of those sources.
 
 **"Service X is down."** Enumerate every instance before declaring anything dead:
 all processes, all listening ports, all service labels, all data stores. Probe

--- a/claude-ops/skills/tonight/SKILL.md
+++ b/claude-ops/skills/tonight/SKILL.md
@@ -16,7 +16,9 @@ The "before-bed brief." Counterpart to `/ops:go` (morning).
 ## Output sections
 
 1. **Tomorrow's calendar** — every meeting >=15min with: attendees, prep status (brief
-   exists Y/N), and the suggested 1-line prep ask if no brief exists.
+   exists Y/N), and the suggested 1-line prep ask if no brief exists. Query **every**
+   calendar store (Google `--all` **and** Notion show/calendar/appointments databases
+   when Notion is configured). A miss on Google Calendar is not "nothing tomorrow."
 2. **Birthdays / anniversaries tomorrow** — from Notion People DB. Pre-drafted
    message ready to send.
 3. **Overdue outreach** — anyone whose `next_nudge_due <= tomorrow`. Top 3 only.

--- a/docs/LOCAL-PREFS.md
+++ b/docs/LOCAL-PREFS.md
@@ -8,6 +8,10 @@ email addresses, chat IDs / JIDs, Slack channel IDs, or personal issue keys.
 
 - **`~/.claude/ops-prefs.json`** — central, gitignored prefs (owner, companies, issue
   prefixes, channel pointers). Read it at runtime when a skill needs a real value.
+- **`$PREFS_PATH` `.channels.notion.calendars`** — optional array of
+  `{name, data_source_url}` for Notion show-schedule / calendar / appointments
+  databases. Inbox, `/ops:go`, and `/ops:tonight` query these in addition to
+  Google Calendar. Never put those IDs in the repo.
 - **`~/.claude/memory/ops-inbox-slack-channels.md`** — Slack channel IDs + DM handles
   (local, not the repo).
 - **`${CLAUDE_PLUGIN_DATA_DIR}/contact-registry.json`** — resolved contact identities.


### PR DESCRIPTION
## Why

A real inbox run treated Google Calendar as the show list. A confirmed date that only lived in a Notion show-schedule database was missed, and a draft would have said the owner was not playing that night.

## What

- Rule 9 now treats "not on the calendar" like "it doesn't exist": query every configured calendar store, not primary Google.
- `/ops:inbox` runs an all-context sweep before the first schedule claim or NEEDS_REPLY draft: Google `--all`, Notion show/calendar/appointments databases when Notion is configured, every mailbox, every messaging channel.
- `/ops:go` and `/ops:tonight` use the same gate.
- Owner-local calendar IDs stay in `$PREFS_PATH` `.channels.notion.calendars`. None in this repo.

## Test

`tests/test-no-secrets.sh` — 27 passed.