### PR TITLE
fix(marketing): isolate dash creds for non-default --project

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+- fix(marketing): `ops-marketing-dash --project` no longer inherits the
+  default brand's env / plugin-config / owner-level Amplitude, AppsFlyer,
+  RevenueCat, Klaviyo, or Instagram credentials. A named project that is not
+  `marketing.default_project` is isolated: missing project keys render as
+  `null`, not another brand's numbers. Owner-brand fallback (no `--project`,
+  or `--project` equal to the default) is unchanged. Guard:
+  `tests/test-ops-marketing-dash-brand-isolation.sh`.
+
 - fix(hooks): PreToolUse WhatsApp bridge health no longer interpolates `$TOOL_INPUT`.
   Grok treats `$VAR` in a hook command as a required env var and skips the hook
   when it is unset (`hook not executed: required env var(s) not set: ${TOOL_INPUT}`).

--- a/claude-ops/bin/ops-marketing-dash
+++ b/claude-ops/bin/ops-marketing-dash
@@ -26,17 +26,28 @@ prefs_get() {
 
 # Project selection: --project <name> arg, OPS_MARKETING_PROJECT env, or
 # marketing.default_project from prefs. Empty if no project context.
-PROJECT=""
+#
+# PROJECT_ISOLATED=1 when the caller named a project that is not the owner
+# default. Env / plugin-config / bare-Doppler / channels.marketing fallbacks
+# belong to the default brand. Using them for another --project paints that
+# brand with the owner's Amplitude, AppsFlyer, RevenueCat, IG, and Klaviyo.
+PROJECT_FROM_ARG=""
 for ((i=1; i<=$#; i++)); do
   if [ "${!i}" = "--project" ]; then
     j=$((i+1))
-    PROJECT="${!j:-}"
+    PROJECT_FROM_ARG="${!j:-}"
     break
   fi
 done
-PROJECT="${PROJECT:-${OPS_MARKETING_PROJECT:-}}"
-if [ -z "$PROJECT" ] && [ -f "$PREFS" ]; then
-  PROJECT="$(jq -r '.marketing.default_project // empty' "$PREFS" 2>/dev/null || true)"
+EXPLICIT_PROJECT="${PROJECT_FROM_ARG:-${OPS_MARKETING_PROJECT:-}}"
+DEFAULT_PROJECT=""
+if [ -f "$PREFS" ]; then
+  DEFAULT_PROJECT="$(jq -r '.marketing.default_project // empty' "$PREFS" 2>/dev/null || true)"
+fi
+PROJECT="${EXPLICIT_PROJECT:-$DEFAULT_PROJECT}"
+PROJECT_ISOLATED=0
+if [ -n "$EXPLICIT_PROJECT" ] && [ "$EXPLICIT_PROJECT" != "${DEFAULT_PROJECT:-}" ]; then
+  PROJECT_ISOLATED=1
 fi
 
 # Read a Doppler-ref from preferences.json channels.marketing.<channel>.<key_field>.
@@ -71,6 +82,9 @@ prefs_marketing_cred() {
 #   4. channels.marketing.<channel>.<key_field> owner-level Doppler-ref (NEW) —
 #      this tier is what lets the morning briefing resolve creds that live in
 #      Doppler under the owner-level schema. Pass it via the 5th/6th args.
+#
+# When PROJECT_ISOLATED=1, stop after tier 1. Missing project keys must
+# surface as unconfigured (null gatherers), not another brand's numbers.
 get_cred() {
   local proj_channel="$1"  # e.g. "klaviyo.private_key"
   local env_var="$2"
@@ -84,6 +98,10 @@ get_cred() {
     local channel="${proj_channel%%.*}"
     local field="${proj_channel#*.}"
     val="$(resolve_cred "$(prefs_get "$PROJECT" "$channel" "$field")")"
+    if [ -n "$val" ] || [ "${PROJECT_ISOLATED:-0}" = "1" ]; then
+      printf '%s' "$val"
+      return 0
+    fi
   fi
   if [ -z "$val" ]; then val="${!env_var:-}"; fi
   if [ -z "$val" ]; then val="$(claude plugin config get "$plugin_key" 2>/dev/null || echo "")"; fi
@@ -102,7 +120,8 @@ get_cred() {
 KLAVIYO_KEY="$(get_cred 'klaviyo.private_key' KLAVIYO_PRIVATE_KEY klaviyo_private_key KLAVIYO_PRIVATE_KEY klaviyo key)"
 META_TOKEN="$(get_cred 'meta.access_token' META_ADS_TOKEN meta_ads_token META_ADS_TOKEN meta system_user_token_key)"
 # meta fallback_env names an env-resident token (META_MY-PROJECT_ACCESS_TOKEN) — try it last.
-if [ -z "$META_TOKEN" ]; then
+# Owner-level only: an isolated --project must not inherit the default brand's token.
+if [ -z "$META_TOKEN" ] && [ "${PROJECT_ISOLATED:-0}" != "1" ]; then
   _meta_fb="$(jq -r '.channels.marketing.meta.fallback_env // empty' "$PREFS" 2>/dev/null)"
   [ -n "$_meta_fb" ] && META_TOKEN="${!_meta_fb:-}"
 fi
@@ -110,7 +129,7 @@ META_ACCOUNT="$(get_cred 'meta.ad_account_id' META_AD_ACCOUNT_ID meta_ad_account
 # GA4 property id: prefer the project-scoped tier, then the owner-level
 # channels.marketing.ga4.property_id (a literal id, not a Doppler ref).
 GA4_PROPERTY="$(get_cred 'ga4.property_id' GA4_PROPERTY_ID ga4_property_id)"
-if [ -z "$GA4_PROPERTY" ] && [ -f "$PREFS" ]; then
+if [ -z "$GA4_PROPERTY" ] && [ -f "$PREFS" ] && [ "${PROJECT_ISOLATED:-0}" != "1" ]; then
   GA4_PROPERTY="$(jq -r '.channels.marketing.ga4.property_id // empty' "$PREFS" 2>/dev/null)"
 fi
 # GA4 read auth uses an SA key file (analytics.readonly). prefs names it under
@@ -133,7 +152,7 @@ INSTAGRAM_ACCOUNT_ID="$(get_cred 'instagram.account_id' INSTAGRAM_ACCOUNT_ID ins
 # prefs stores it under channels.marketing.meta.app_secret_key (Doppler ref);
 # also accept a bare META_MY-PROJECT_APP_SECRET @ claude-ops/prd as a known location.
 META_APP_SECRET="$(get_cred 'meta.app_secret' META_APP_SECRET meta_app_secret META_APP_SECRET meta app_secret_key)"
-if [ -z "$META_APP_SECRET" ]; then
+if [ -z "$META_APP_SECRET" ] && [ "${PROJECT_ISOLATED:-0}" != "1" ]; then
   META_APP_SECRET="$(doppler secrets get META_MY-PROJECT_APP_SECRET --project claude-ops --config prd --plain 2>/dev/null || echo "")"
 fi
 
@@ -163,11 +182,26 @@ APPSFLYER_APP_ID="$(get_cred 'appsflyer.app_id' APPSFLYER_APP_ID appsflyer_app_i
 REVENUECAT_KEY="$(get_cred 'revenuecat.api_key' REVENUECAT_API_KEY revenuecat_api_key REVENUECAT_API_KEY revenuecat api_key_key)"
 REVENUECAT_PROJECT="$(get_cred 'revenuecat.project_id' REVENUECAT_PROJECT_ID revenuecat_project_id)"
 
+# Test hook: presence-only JSON (never values), then exit before any network call.
+# Used by tests/test-ops-marketing-dash-brand-isolation.sh.
+if [ "${OPS_MARKETING_DUMP_CRED_PRESENCE:-}" = "1" ]; then
+  jq -n \
+    --arg project "$PROJECT" \
+    --argjson isolated "$PROJECT_ISOLATED" \
+    --argjson amplitude "$([ -n "${AMPLITUDE_API_KEY:-}" ] && echo true || echo false)" \
+    --argjson appsflyer "$([ -n "${APPSFLYER_TOKEN:-}" ] && [ -n "${APPSFLYER_APP_ID:-}" ] && echo true || echo false)" \
+    --argjson revenuecat "$([ -n "${REVENUECAT_KEY:-}" ] && [ -n "${REVENUECAT_PROJECT:-}" ] && echo true || echo false)" \
+    --argjson klaviyo "$([ -n "${KLAVIYO_KEY:-}" ] && echo true || echo false)" \
+    --argjson instagram "$([ -n "${INSTAGRAM_ACCOUNT_ID:-}" ] && echo true || echo false)" \
+    '{project:$project, isolated:($isolated==1), amplitude:$amplitude, appsflyer:$appsflyer, revenuecat:$revenuecat, klaviyo:$klaviyo, instagram:$instagram}'
+  exit 0
+fi
+
 # Meta ad-account id: prefs carries only the Business Manager id (bm_id_key), not
 # an act_ id. If we have a token+secret but no ad account, resolve the first owned
 # ad account via the BM. Leaves META_ACCOUNT empty (meta insights null) on failure
 # — never fabricated.
-if [ -z "$META_ACCOUNT" ] && [ -n "$META_TOKEN" ] && [ -n "$META_APP_SECRET" ] && [ -f "$PREFS" ]; then
+if [ -z "$META_ACCOUNT" ] && [ -n "$META_TOKEN" ] && [ -n "$META_APP_SECRET" ] && [ -f "$PREFS" ] && [ "${PROJECT_ISOLATED:-0}" != "1" ]; then
   _bm_keyname="$(jq -r '.channels.marketing.meta.bm_id_key // empty' "$PREFS" 2>/dev/null)"
   _bm_id=""
   if [ -n "$_bm_keyname" ]; then

--- a/claude-ops/tests/run-all.sh
+++ b/claude-ops/tests/run-all.sh
@@ -72,6 +72,7 @@ run_suite "$TESTS_DIR/test-deploy-fix-hooks.sh"
 run_suite "$TESTS_DIR/test-deploy-fix-fleet.sh"
 run_suite "$TESTS_DIR/test-cloudflare-dns-lib.sh"
 run_suite "$TESTS_DIR/test-ops-dns-provision.sh"
+run_suite "$TESTS_DIR/test-ops-marketing-dash-brand-isolation.sh"
 run_suite "$TESTS_DIR/../templates/statusline/tests/run-tests.sh"
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/claude-ops/tests/test-ops-marketing-dash-brand-isolation.sh
+++ b/claude-ops/tests/test-ops-marketing-dash-brand-isolation.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# test-ops-marketing-dash-brand-isolation.sh
+# --project other-than-default must not inherit owner env Amplitude/AppsFlyer/RevenueCat.
+# OPS_MARKETING_DUMP_CRED_PRESENCE=1 prints booleans only (no secret values).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BIN="${PLUGIN_ROOT}/bin/ops-marketing-dash"
+
+pass=0
+fail=0
+ok()  { printf '  PASS: %s\n' "$1"; pass=$((pass+1)); }
+err() { printf '  FAIL: %s — %s\n' "$1" "$2"; fail=$((fail+1)); }
+
+FIXTURE_DIR="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+cat > "${FIXTURE_DIR}/preferences.json" <<'EOF'
+{
+  "marketing": {
+    "default_project": "acme",
+    "projects": {
+      "acme": {
+        "domain": "acme.example",
+        "amplitude": {
+          "api_key": "inline-acme-amp",
+          "secret_key": "inline-acme-amp-secret"
+        }
+      },
+      "fresh": {
+        "domain": "fresh.example",
+        "amplitude": {
+          "api_key": "inline-fresh-amp",
+          "secret_key": "inline-fresh-amp-secret"
+        }
+      },
+      "empty": {
+        "domain": "empty.example"
+      }
+    }
+  }
+}
+EOF
+
+export OPS_DATA_DIR="$FIXTURE_DIR"
+export OPS_MARKETING_DUMP_CRED_PRESENCE=1
+unset OPS_MARKETING_PROJECT || true
+
+# Owner-brand env that must not leak onto --project empty / fresh.
+export AMPLITUDE_API_KEY="LEAKED_FROM_ENV"
+export AMPLITUDE_SECRET_KEY="LEAKED_FROM_ENV"
+export APPSFLYER_API_V2_TOKEN="LEAKED_FROM_ENV"
+export APPSFLYER_APP_ID="id0000000000"
+export REVENUECAT_API_KEY="LEAKED_FROM_ENV"
+export REVENUECAT_PROJECT_ID="proj000"
+export KLAVIYO_PRIVATE_KEY="LEAKED_FROM_ENV"
+export INSTAGRAM_ACCOUNT_ID="0000000000"
+
+dump() {
+  "$BIN" "$@"
+}
+
+echo ""
+echo "--- 1. --project empty does not inherit owner env ---"
+out="$(dump --project empty 2>/dev/null || true)"
+if printf '%s' "$out" | jq -e '.isolated == true and .amplitude == false and .appsflyer == false and .revenuecat == false and .klaviyo == false and .instagram == false' >/dev/null; then
+  ok "empty project: all brand trackers absent despite env"
+else
+  err "empty isolation" "$out"
+fi
+
+echo ""
+echo "--- 2. --project fresh uses its own amplitude, not env ---"
+out="$(dump --project fresh 2>/dev/null || true)"
+if printf '%s' "$out" | jq -e '.isolated == true and .amplitude == true and .appsflyer == false and .revenuecat == false' >/dev/null; then
+  ok "fresh: project amplitude present, env appsflyer/revenuecat ignored"
+else
+  err "fresh project keys" "$out"
+fi
+
+echo ""
+echo "--- 3. default project (no --project) may use env for missing channels ---"
+out="$(dump 2>/dev/null || true)"
+if printf '%s' "$out" | jq -e '.isolated == false and .project == "acme" and .amplitude == true and .appsflyer == true and .revenuecat == true' >/dev/null; then
+  ok "default acme: prefs amplitude + env appsflyer/revenuecat"
+else
+  err "default fallback" "$out"
+fi
+
+echo ""
+echo "--- 4. --project acme (same as default) is not isolated ---"
+out="$(dump --project acme 2>/dev/null || true)"
+if printf '%s' "$out" | jq -e '.isolated == false and .amplitude == true' >/dev/null; then
+  ok "--project default-name is not isolated"
+else
+  err "explicit default" "$out"
+fi
+
+echo ""
+echo "--- 5. dump never prints env sentinel ---"
+out="$(dump --project empty 2>/dev/null || true)"
+if printf '%s' "$out" | grep -q 'LEAKED_FROM_ENV'; then
+  err "secret leak" "dump contained env sentinel"
+else
+  ok "dump is presence-only"
+fi
+
+echo ""
+echo "Results: $pass passed, $fail failed"
+if [ "$fail" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Why

`ops-marketing-dash --project <other>` fell through to owner env / plugin-config / `channels.marketing` after a miss in `marketing.projects.<other>`. That painted every named project with the default brand's Amplitude, AppsFlyer, RevenueCat, Klaviyo, and Instagram numbers.

## What

When `--project` (or `OPS_MARKETING_PROJECT`) is not `marketing.default_project`, stop after the project-prefs lookup. Missing keys stay unconfigured (`null`). Owner-brand fallback is unchanged (no `--project`, or `--project` equal to the default).

`OPS_MARKETING_DUMP_CRED_PRESENCE=1` prints booleans only and exits before any network call.

## Test

`tests/test-ops-marketing-dash-brand-isolation.sh` (5 cases), wired into `tests/run-all.sh`.