### PR TITLE
fix(daemon): stop health write deadlocking under launchd

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+- fix(daemon): write `daemon-health.json` with builtin `printf` + `mv`, not
+  `cat >file <<EOF`. Under launchd stdin is `/dev/null`, so bash's 16KiB
+  heredoc pipe never drains and the first health write deadlocks — empty
+  health file, no monitor loop. `check_self_upgrade` now picks the newest
+  semver cache dir only, ignoring `current` and `ops-daemon-launcher.sh`.
+
 - fix(hooks): PreToolUse WhatsApp bridge health no longer interpolates `$TOOL_INPUT`.
   Grok treats `$VAR` in a hook command as a required env var and skips the hook
   when it is unset (`hook not executed: required env var(s) not set: ${TOOL_INPUT}`).

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -566,23 +566,26 @@ except: print('')
 " 2>/dev/null || true)
   fi
 
-  cat > "$HEALTH_FILE" <<EOF
-{
-  "timestamp": "$now",
-  "pid": $$,
-  "uptime_seconds": $uptime,
-  "version": "$daemon_version",
-  "services": $services_json,
-  "action_needed": $ACTION_NEEDED,
-  "credential_warnings": $cred_warn_json,
-  "rate_limit_warnings": $rate_warn_json,
-  "brain": {
-    "briefing_cached_at": "$brain_briefing_cached_at",
-    "urgent_count": $brain_urgent_count,
-    "last_memory_extraction": "$brain_last_memory_extraction"
+  # Direct builtin write. `cat >file <<EOF` forks a heredoc pipe and
+  # deadlocks once the payload hits bash's 16KiB pipe buffer (stdin is
+  # /dev/null from launchd, so nothing drains the pipe before exec).
+  local tmp="${HEALTH_FILE}.tmp.$$"
+  builtin printf '%s\n' "{
+  \"timestamp\": \"$now\",
+  \"pid\": $$,
+  \"uptime_seconds\": $uptime,
+  \"version\": \"$daemon_version\",
+  \"services\": $services_json,
+  \"action_needed\": $ACTION_NEEDED,
+  \"credential_warnings\": $cred_warn_json,
+  \"rate_limit_warnings\": $rate_warn_json,
+  \"brain\": {
+    \"briefing_cached_at\": \"$brain_briefing_cached_at\",
+    \"urgent_count\": $brain_urgent_count,
+    \"last_memory_extraction\": \"$brain_last_memory_extraction\"
   }
-}
-EOF
+}" >"$tmp" && mv -f "$tmp" "$HEALTH_FILE"
+  rm -f "$tmp"
 }
 
 # ── Cron service runner ───────────────────────────────────────────────────
@@ -1167,10 +1170,10 @@ check_self_upgrade() {
   local cache_dir="$HOME/.claude/plugins/cache/ops-marketplace/ops"
   [[ -d "$cache_dir" ]] || return 0
 
-  # Resolve newest installed version via lexicographic sort (semver-safe enough
-  # for our 2.x line; major bumps are rare and would trigger anyway).
+  # Only semver dirs. `current` and sibling files (ops-daemon-launcher.sh)
+  # sort after 3.x and would either no-op or reload onto the wrong copy.
   local newest
-  newest=$(ls -1 "$cache_dir" 2>/dev/null | sort -V | tail -1)
+  newest=$(ls -1 "$cache_dir" 2>/dev/null | grep -E '^[0-9]+\.[0-9]+' | sort -V | tail -1)
   [[ -n "$newest" ]] || return 0
 
   local newest_root="$cache_dir/$newest"
@@ -1750,9 +1753,7 @@ ensure_all_services "force"
 
 if ! load_services_config; then
   log "FATAL: no services config — writing empty health and sleeping"
-  cat > "$HEALTH_FILE" <<EOF
-{"timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)", "pid": $$, "uptime_seconds": 0, "services": {}, "action_needed": null}
-EOF
+  builtin printf '%s\n' "{\"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\", \"pid\": $$, \"uptime_seconds\": 0, \"services\": {}, \"action_needed\": null}" >"$HEALTH_FILE"
   # In --run-once mode we exit after writing the health file; otherwise
   # sleep forever until SIGTERM (launchd/systemd simple-mode keeps us alive).
   if [[ $OPS_RUN_ONCE -eq 1 ]]; then exit 0; fi

--- a/claude-ops/tests/test-ops-daemon-manager.sh
+++ b/claude-ops/tests/test-ops-daemon-manager.sh
@@ -218,6 +218,27 @@ MOCK
   rm -rf "$MOCK_DIR"
 fi
 
+# write_daemon_health must not use `cat >file <<EOF` — that deadlocks under
+# launchd (stdin /dev/null, 16KiB heredoc pipe never drains).
+if grep -n 'cat > "$HEALTH_FILE" <<EOF' "$DAEMON_SCRIPT"; then
+  err "ops-daemon.sh still writes health via cat heredoc (launchd deadlock)"
+else
+  ok "write_daemon_health does not use cat heredoc"
+fi
+
+if grep -q 'builtin printf' "$DAEMON_SCRIPT" && grep -q 'HEALTH_FILE}.tmp' "$DAEMON_SCRIPT"; then
+  ok "write_daemon_health uses builtin printf + temp file"
+else
+  err "write_daemon_health missing builtin printf + tmp write"
+fi
+
+# check_self_upgrade must ignore non-semver cache entries (`current`, launcher.sh)
+if grep -q 'newest=.*grep -E' "$DAEMON_SCRIPT"; then
+  ok "check_self_upgrade newest picker is semver-only"
+else
+  err "check_self_upgrade still sorts every cache_dir name (current / launcher.sh)"
+fi
+
 echo ""
 echo "Results: $pass passed, $fail failed"
 [[ "$fail" == "0" ]]


### PR DESCRIPTION
## Why

On macOS launchd, `ops-daemon.sh` stdin is `/dev/null`. `write_daemon_health` used `cat > "$HEALTH_FILE" <<EOF`. Bash forks a heredoc pipe, writes the JSON into it, and waits for `cat` to drain it. Nothing reads the pipe before the write finishes, so once the payload hits the 16KiB pipe buffer `write()` blocks forever.

Observed: new PID, `daemon-health.json` truncated to 0 bytes, writer child stuck in `heredoc_write`, no `LOOP: entering monitor loop`. Restart without this change hits the same hang.

`check_self_upgrade` also did `ls | sort -V | tail -1` on the cache dir, so `current` and `ops-daemon-launcher.sh` could win and reload the daemon onto an unpatched copy.

## What

- Write health with builtin `printf` to a temp file, then `mv`.
- Same for the empty-config fallback.
- Newest-version picker is semver dirs only (`^[0-9]+\.[0-9]+`).
- Guard tests in `tests/test-ops-daemon-manager.sh`.

## Test

`bash tests/test-ops-daemon-manager.sh` — the three new cases pass. Three older cases (bash version guard, usage, `--help`) fail on `main` already; not touched here.

Live on this machine: after the same patch, PID wrote a 2.7KB health file, 14/14 `next_run` future, loop entered.