### PR TITLE
docs(whatsapp): name dual-account MCP servers whatsapp-nl / whatsapp-us

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -6,6 +6,12 @@
   health file, no monitor loop. `check_self_upgrade` now picks the newest
   semver cache dir only, ignoring `current` and `ops-daemon-launcher.sh`.
 
+- docs(whatsapp): dual-account MCP names are `whatsapp-nl` / `whatsapp-us` (or
+  `whatsapp-<label>`). `whatsapp-cos` and a bare `whatsapp` client pointing at
+  `/servers/whatsapp-cos/mcp` are not accounts — sending on them is a
+  wrong-number send. Rule 8, ops-inbox, and `scripts/whatsapp/ENDPOINTS.md`
+  now say so.
+
 - fix(marketing): `ops-marketing-dash --project` no longer inherits the
   default brand's env / plugin-config / owner-level Amplitude, AppsFlyer,
   RevenueCat, Klaviyo, or Instagram credentials. A named project that is not

--- a/claude-ops/scripts/whatsapp/ENDPOINTS.md
+++ b/claude-ops/scripts/whatsapp/ENDPOINTS.md
@@ -75,11 +75,12 @@ Source: `whatsapp-mcp-server/main.py`. Load with
 `ToolSearch select:mcp__whatsapp__list_chats,mcp__whatsapp__list_messages,...` (retry 3× at 5s if both ports are up).
 
 **Server name.** `whatsapp` is the single-account default. Each extra account needs its own bridge (its
-own port and its own `store/`) and its own MCP server entry, named `whatsapp-<label>` by convention.
+own port and its own `store/`) and its own MCP server entry, named `whatsapp-<label>` by convention
+(`whatsapp-nl`, `whatsapp-us`, `whatsapp-work`). `whatsapp-cos` is not an account name.
 Point each entry at its account with `WHATSAPP_BRIDGE_DB`, `WHATSAPP_DEVICE_DB`, and
 `WHATSAPP_API_BASE_URL`; without those the second server silently reads the first account's database.
 The proxy path follows the entry name, so the endpoint is `/servers/<name>/mcp`. Tool names follow it
-too: `mcp__whatsapp-work__list_chats`. See CLAUDE.md Rule 8.
+too: `mcp__whatsapp-nl__list_chats`. See CLAUDE.md / ops-rules Rule 8.
 
 | Tool                                                                                                                        | Backed by                            | Notes                                                                                                       |
 | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------- |

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -68,10 +68,10 @@ Load `ops-rules` before acting. Public repo (no personal data). Outbound: one dr
 For **all** WhatsApp operations in this skill (list chats, read messages, search contacts, send replies, archive chats), use the `mcp__whatsapp__*` tool family backed by the whatsmeow (Go) whatsapp-bridge — upstream `lharries/whatsapp-mcp`. (Earlier docs misnamed this as "Baileys" — Baileys is the Node.js WhatsApp library; this bridge uses `go.mau.fi/whatsmeow`.)
 
 > **Server name.** `mcp__whatsapp__*` is the single-account default. Installs with more than one account
-> register one server per account (`whatsapp-personal`, `whatsapp-work`, ...) and have no plain
-> `mcp__whatsapp__*` at all. Resolve the real name from the available tools before the first call, and
-> when several accounts exist, scan each one separately and keep the results labelled by account. See
-> CLAUDE.md Rule 8.
+> register one server per account (`whatsapp-nl`, `whatsapp-us`, `whatsapp-personal`, `whatsapp-work`, ...)
+> and have no plain `mcp__whatsapp__*` at all. `whatsapp-cos` is not an account — do not send on it.
+> Resolve the real name from the available tools before the first call, and when several accounts exist,
+> scan each one separately and keep the results labelled by account. See CLAUDE.md / ops-rules Rule 8.
 
 **NEVER call the legacy `wacli` CLI** (`wacli chats list`, `wacli messages list`, `wacli send`, `wacli doctor`, `wacli history backfill`, etc). The wacli store and keepalive daemon are deprecated for this skill.
 
@@ -125,9 +125,9 @@ than one is agent-enabled — that is a loop, not a stop.
    unpolicy'd bridges appear with no `api`.
 4. **Reply on the number the thread lives on.** Cross-account replies are never an acceptable fallback.
 5. **Rule 8 applies to the MCP surface too.** With several accounts the servers are named per account
-   (`mcp__whatsapp-personal__*`, `mcp__whatsapp-work__*`) and a bare `mcp__whatsapp__*` may not exist. Match
-   the registered name; do not assume. Hermes `wa status` / `wa thread` / `wa find` is a valid
-   read path on a client box when MCP is down.
+   (`mcp__whatsapp-nl__*`, `mcp__whatsapp-us__*`, or `whatsapp-personal` / `whatsapp-work`) and a bare
+   `mcp__whatsapp__*` / `mcp__whatsapp-cos__*` is not an account. Match the registered name; do not
+   assume. Hermes `wa status` / `wa thread` / `wa find` is a valid read path on a client box when MCP is down.
 
 **Why this section exists:** a full inbox run once followed this skill's hardcoded
 `127.0.0.1:8080` and sent every reply from the wrong number. Guessing a port, or treating a

--- a/claude-ops/skills/ops-rules/SKILL.md
+++ b/claude-ops/skills/ops-rules/SKILL.md
@@ -189,20 +189,26 @@ default, not a guarantee.
 
 An install with more than one WhatsApp account runs one bridge and one MCP server per account, each
 registered under its own name. The usual convention is `whatsapp-<label>`, where the label is the
-account (`whatsapp-personal`, `whatsapp-work`, or a country code). On those machines `mcp__whatsapp__*`
-does not exist at all, and a skill that calls it fails with an unknown tool.
+account (`whatsapp-nl`, `whatsapp-us`, `whatsapp-personal`, `whatsapp-work`). On those machines
+`mcp__whatsapp__*` does not exist at all, and a skill that calls it fails with an unknown tool.
+
+**`whatsapp-cos` is not an account.** It is a leftover CoS/unscoped alias. A mount named
+`whatsapp-cos` (or a client named `whatsapp` that points at `/servers/whatsapp-cos/mcp`) that
+talks to one personal bridge is a defect: sends go out from the wrong number with no error.
+Dual-account installs must register `whatsapp-<label>` per number and must not leave a bare
+`whatsapp` or `whatsapp-cos` as the only send path.
 
 **What every skill must do:**
 
 1. **Resolve the name, do not assume it.** Read the available tool list and use whatever matches
    `mcp__whatsapp*__`. Treat `mcp__whatsapp__*` in this repo as shorthand for "the WhatsApp server that
-   is actually registered here".
+   is actually registered here". Ignore `whatsapp-cos` when labelled accounts exist.
 2. **With two or more accounts, pick deliberately.** Each account has its own contacts and its own
    history, and the stores do not overlap. Choose by where the conversation already lives. If that is
    unclear, ask the user which account to use. Never guess, and never fall back to the first one.
 3. **Never send from an account the thread is not on.** A reply that arrives from the wrong number is
    worse than no reply, because the recipient sees a number they do not recognise.
-4. **Rule 6 applies to every variant.** `mcp__whatsapp-work__send_message` needs the same per-message
+4. **Rule 6 applies to every variant.** `mcp__whatsapp-nl__send_message` needs the same per-message
    approval as `mcp__whatsapp__send_message`. A different server name is not a different gate.
 
 **For `allowed-tools` frontmatter:** entries are exact tool names, so a skill listing only


### PR DESCRIPTION
## Why
A dual-account box had one MCP client named `whatsapp` pointed at `/servers/whatsapp-cos/mcp`. That mount was the US bridge. Inbox skills already say to use `whatsapp-nl` / `whatsapp-us`. Agents followed the live name and would have sent NL threads from the US number.

## What
- Rule 8: `whatsapp-cos` is not an account; dual-account installs register `whatsapp-<label>` per number.
- ops-inbox + ENDPOINTS: same names, do not send on `whatsapp-cos`.
- Machine config (not this PR): mcp-proxy now exposes `whatsapp-nl` (:8483) and `whatsapp-us` (:8482); bare `whatsapp` / `whatsapp-cos` 404.

## Test
`tests/test-no-secrets.sh` 27 passed.