### PR TITLE
feat(skills): relations + vip skills, all config in plugin.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "ops",
-      "description": "Business operations command center for Claude Code — 64 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
+      "description": "Business operations command center for Claude Code — 66 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
       "version": "3.9.9",
       "category": "productivity",

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ claude --plugin-dir ./claude-ops/claude-ops
 
 ## Commands
 
-All 64 skills, grouped by category:
+All 66 skills, grouped by category:
 
 | 🧭 Navigation                    | 📊 Daily Ops                           |
 | -------------------------------- | -------------------------------------- |
@@ -141,6 +141,8 @@ All 64 skills, grouped by category:
 | `/ops:setup` — guided wizard     | `/ops:inbox` — deep-context inbox zero |
 | `/ops:uninstall` — clean removal | `/ops:comms` — send/read any channel   |
 |                                  | `/ops:merge` — autonomous PR pipeline  |
+|                                  | `/ops:relations` — relationship manager |
+|                                  | `/ops:vip` — VIP list, answered first  |
 
 | 🛠️ Project & Eng                                                  | 💰 Business                                                      |
 | ----------------------------------------------------------------- | ---------------------------------------------------------------- |

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ops",
   "version": "3.9.9",
-  "description": "Business operations command center for Claude Code — 64 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
+  "description": "Business operations command center for Claude Code — 66 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",
     "url": "https://github.com/Lifecycle-Innovations-Limited"
@@ -815,6 +815,104 @@
       "default": 2,
       "min": 0,
       "max": 20
+    },
+    "relations_cli": {
+      "title": "Relationship ledger CLI path",
+      "description": "Executable that owns the relationship ledger (JSON output). Used by /ops:relations and /ops:vip. Defaults to $HOME/.claude-ops/relations/bin/relations-cli.",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
+    },
+    "relations_db_path": {
+      "title": "Relationship ledger database path",
+      "description": "SQLite file holding people, facts, commitments and follow-ups. Must live outside the plugin repo. Defaults to $HOME/.claude-ops/relations/people.db.",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
+    },
+    "relations_shadow_mode": {
+      "title": "Relationship shadow mode",
+      "description": "When true, /ops:relations only drafts and stages — no external message is sent on any channel. Turning this off is an owner decision.",
+      "type": "boolean",
+      "sensitive": false,
+      "default": true
+    },
+    "relations_queue_limit": {
+      "title": "Relationship decision-queue size",
+      "description": "Maximum items in one relationship decision-queue report. One item per person.",
+      "type": "number",
+      "sensitive": false,
+      "default": 10,
+      "min": 1,
+      "max": 50
+    },
+    "relations_followup_limit_personal": {
+      "title": "Unanswered follow-up limit (personal)",
+      "description": "How many unanswered follow-ups may be open with one personal contact before the gate stops surfacing new ones.",
+      "type": "number",
+      "sensitive": false,
+      "default": 1,
+      "min": 0,
+      "max": 10
+    },
+    "relations_followup_limit_business": {
+      "title": "Unanswered follow-up limit (business)",
+      "description": "How many unanswered follow-ups may be open with one business contact before the gate stops surfacing new ones.",
+      "type": "number",
+      "sensitive": false,
+      "default": 2,
+      "min": 0,
+      "max": 10
+    },
+    "relations_suppress_days": {
+      "title": "Follow-up suppression window (days)",
+      "description": "Minimum days a dismissed follow-up stays suppressed before it may resurface.",
+      "type": "number",
+      "sensitive": false,
+      "default": 30,
+      "min": 1,
+      "max": 365
+    },
+    "vip_list_path": {
+      "title": "VIP list path",
+      "description": "JSON file with VIP tiers plus the why/register notes. Operator identity data — must live outside the repo. Defaults to $HOME/.claude-ops/state/vip-list.json. Shape: skills/vip/templates/vip-list.example.json.",
+      "type": "string",
+      "sensitive": false,
+      "default": ""
+    },
+    "vip_max_tier": {
+      "title": "Highest tier treated as VIP",
+      "description": "People at or below this importance tier are checked and answered before general triage. 1 = inner circle only, 2 = inner circle plus key business.",
+      "type": "number",
+      "sensitive": false,
+      "default": 2,
+      "min": 1,
+      "max": 5
+    },
+    "vip_suggest_enabled": {
+      "title": "Suggest new VIPs",
+      "description": "Emit read-only VIP candidate suggestions on volume, frustration, and chain-break signals. Never writes a tier.",
+      "type": "boolean",
+      "sensitive": false,
+      "default": true
+    },
+    "vip_volume_days": {
+      "title": "VIP volume signal window (days)",
+      "description": "Lookback window for the two-way message-volume signal that suggests a VIP candidate.",
+      "type": "number",
+      "sensitive": false,
+      "default": 30,
+      "min": 1,
+      "max": 365
+    },
+    "vip_volume_min": {
+      "title": "VIP volume signal threshold",
+      "description": "Two-way messages within the window with someone off the list before they are suggested as a VIP candidate.",
+      "type": "number",
+      "sensitive": false,
+      "default": 12,
+      "min": 1,
+      "max": 1000
     }
   }
 }

--- a/claude-ops/README.md
+++ b/claude-ops/README.md
@@ -1,6 +1,6 @@
 # claude-ops
 
-> **v3.6.1** — 64 skills · 21 agents · Claude + Grok + Hermes · ops-rules · empty `.mcp.json`
+> **v3.6.1** — 66 skills · 21 agents · Claude + Grok + Hermes · ops-rules · empty `.mcp.json`
 
 ## What's new in v3.6.1
 

--- a/claude-ops/bin/ops-speedup
+++ b/claude-ops/bin/ops-speedup
@@ -200,7 +200,13 @@ if $IS_MACOS; then
   DISK_USED_PCT=$(df -g / 2>/dev/null | awk 'NR==2{gsub(/%/,"",$5); print $5}' || echo "?")
   OS_VER=$(sw_vers -productVersion 2>/dev/null || echo "?")
 elif $IS_LINUX || $IS_WSL; then
-  CPU=$(grep -m1 "model name" /proc/cpuinfo 2>/dev/null | cut -d: -f2 | xargs || echo "unknown")
+  # `xargs` with no -r runs `echo` once even on empty input, emitting a bare
+  # newline. On a host whose /proc/cpuinfo has no "model name" line (aarch64,
+  # many ARM SoCs) that newline landed inside the JSON string for "cpu" and
+  # made `--json` output unparseable (invalid control character). Trim to a
+  # single line and fall back explicitly.
+  CPU=$(grep -m1 "model name" /proc/cpuinfo 2>/dev/null | cut -d: -f2 | tr -d '\n' | xargs -r || true)
+  CPU=${CPU:-unknown}
   RAM_KB=$(grep MemTotal /proc/meminfo 2>/dev/null | awk '{print $2}' || echo 0)
   RAM_GB=$(( RAM_KB / 1048576 ))
   CHIP=$(uname -m)

--- a/claude-ops/docs/INDEX.md
+++ b/claude-ops/docs/INDEX.md
@@ -33,7 +33,7 @@ _Top-level map of every doc file in `claude-ops/docs/`._
 | Doc                                                        | Subject                                                                                        |
 | ---------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | [`agents-reference.md`](agents-reference.md)               | Catalog of all 21 agents (4 v2 specialists + 14 v1 scanners/fixers/C-suite).                   |
-| [`skills-reference.md`](skills-reference.md)               | Catalog of all 64 skills with usage examples.                                                  |
+| [`skills-reference.md`](skills-reference.md)               | Catalog of all 66 skills with usage examples.                                                  |
 | [`daemon-guide.md`](daemon-guide.md)                       | The v1 ops-daemon (briefing pre-warm, whatsapp-bridge-sync, memory-extractor, etc).            |
 | [`docker.md`](docker.md)                                   | Running claude-ops in a container.                                                             |
 | [`marketplace-submissions.md`](marketplace-submissions.md) | Publishing your own plugin to the same marketplace.                                            |

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -2,10 +2,10 @@
 
 # Skills Reference
 
-_All 64 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
+_All 66 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
 [![version](https://img.shields.io/badge/version-3.9.9-blue)](../CHANGELOG.md)
-[![skills](https://img.shields.io/badge/skills-64-8b5cf6)](.)
+[![skills](https://img.shields.io/badge/skills-66-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)
 
@@ -111,6 +111,25 @@ Dedicated dashboard + management UI for the v2.3 competitor-intelligence subsyst
 - `/ops:competitors add-url <brand> <competitor> <kind> <url>` — `jq`-merge a page-diff URL into `preferences.json` (kind ∈ pricing/features/careers/blog/changelog) with confirm prompt
 - `/ops:competitors alerts` — tail last 20 of `reports/competitor-intel/alerts.log`
 - `/ops:competitors help` — print subcommand reference
+
+### `/ops:relations` · `skills/relations/SKILL.md`
+
+Relationship manager. Local relationship ledger and decision queue: who is owed a reply, what was promised, what is going cold, and the full context a draft needs. Drafts and stages only — shadow mode is the default, so nothing is ever sent from this skill. All paths come from `userConfig` (`relations_cli`, `relations_db_path`), never a hardcoded path.
+
+- `/ops:relations` — ranked decision queue, one item per person
+- `/ops:relations brief <person>` — commitments, sourced facts, recent threads
+- `/ops:relations find user@example.com` — resolve identity across channels
+- `/ops:relations draft <person>` — full-context draft, staged for approval
+- `/ops:relations audit` — duplicates, unsourced rows, integrity
+
+### `/ops:vip` · `skills/vip/SKILL.md`
+
+VIP list. The priority layer over every inbox: tier-1 and tier-2 people are checked first in any sweep, answered first, and never buried in a bulk digest. Read-only candidate suggestions on volume, frustration, and chain-break signals; tier writes go through the audited ledger CLI, never raw SQL. List path from `userConfig` `vip_list_path` — operator data, never committed (template: `skills/vip/templates/vip-list.example.json`).
+
+- `/ops:vip` — everyone at or above `vip_max_tier`, grouped by tier
+- `/ops:vip show <person>` — tier, type, why, channel, register notes
+- `/ops:vip set <person> --tier 1` — audited tier write, reason required
+- `/ops:vip suggest` — read-only candidate scan, never writes
 
 ### `/ops:linear` · `skills/ops-linear/SKILL.md`
 

--- a/claude-ops/scripts/crsproxy-reauth/bu_reauth.py
+++ b/claude-ops/scripts/crsproxy-reauth/bu_reauth.py
@@ -385,6 +385,23 @@ def disable_auth_file(auth_path: Path) -> bool:
 # ---------------------------------------------------------------------------
 # Serialization lease
 # ---------------------------------------------------------------------------
+def _lease_exists(path) -> bool:
+    """True only when the lease file is readable and present.
+
+    `Path.exists()` raises PermissionError when the parent directory is not
+    searchable by the calling user (running as anyone but the service account,
+    or on a box where /opt/<svc>/state is root-owned). That escaped
+    acquire_lease's own OSError handling because it fired on the probe itself,
+    not the read, and crashed the reauth run instead of degrading to "no lease
+    held". Treat an unreadable probe as absent: the write below still fails
+    loudly if the directory is genuinely unusable.
+    """
+    try:
+        return path.exists()
+    except OSError:
+        return False
+
+
 def acquire_lease(provider: str, max_wait: int = 120) -> bool:
     """Acquire the serialization lease, waiting up to max_wait seconds.
 
@@ -397,8 +414,8 @@ def acquire_lease(provider: str, max_wait: int = 120) -> bool:
     t0 = time.time()
     first_check = True
     while True:
-        lease_path = LEASE_FILE if LEASE_FILE.exists() else LEGACY_LEASE_FILE
-        if lease_path.exists():
+        lease_path = LEASE_FILE if _lease_exists(LEASE_FILE) else LEGACY_LEASE_FILE
+        if _lease_exists(lease_path):
             try:
                 data = json.loads(lease_path.read_text())
                 age = time.time() - data.get("timestamp", 0)

--- a/claude-ops/scripts/crsproxy-reauth/bu_reauth.py
+++ b/claude-ops/scripts/crsproxy-reauth/bu_reauth.py
@@ -419,20 +419,49 @@ def _try_create_lease(path, provider: str) -> bool:
     })
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-    except OSError:
-        pass
+    except OSError as exc:
+        # Non-fatal on purpose: the directory may already exist but be
+        # unwritable by this user, or be owned by the service account. The
+        # exclusive create below is the real gate — let it produce the
+        # authoritative error rather than failing here on a probe.
+        log(f"Lease dir not creatable ({exc}) — continuing to claim attempt")
+    # Build the lease in a private temp file FIRST, then link it into place.
+    # O_CREAT|O_EXCL alone is atomic for the *create* but leaves a window in
+    # which the file exists and is still empty: a racer reading it in that
+    # window sees invalid JSON, classifies the lease as corrupt, removes it,
+    # and claims it too. os.link() is atomic AND the destination already has
+    # its full contents the instant it appears, so the window does not exist.
+    # (Measured: the create-then-write shape let 2 of 8 racers win.)
+    tmp = path.parent / f".{path.name}.{os.getpid()}.tmp"
     try:
         # 0o600: the lease records a provider name and pid and is only ever
         # read by the service account that writes it. No reason for group or
         # world read.
-        fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
-    except FileExistsError:
+        fd = os.open(str(tmp), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except OSError as exc:
+        log(f"Lease temp file not creatable ({exc}) — cannot claim")
         return False
     try:
         os.write(fd, payload.encode())
     finally:
         os.close(fd)
-    return True
+
+    try:
+        os.link(str(tmp), str(path))
+        return True
+    except FileExistsError:
+        return False
+    except OSError as exc:
+        log(f"Lease link failed ({exc}) — treating as not acquired")
+        return False
+    finally:
+        try:
+            os.unlink(str(tmp))
+        except OSError:
+            # The temp file is ours alone and already served its purpose; a
+            # failure to remove it leaks one small file and must never turn a
+            # successful claim into a failure.
+            pass
 
 
 def acquire_lease(provider: str, max_wait: int = 120) -> bool:
@@ -476,8 +505,11 @@ def acquire_lease(provider: str, max_wait: int = 120) -> bool:
             log(f"Stale lease ({int(age)}s old) — removing")
             try:
                 lease_path.unlink()
-            except OSError:
-                pass
+            except OSError as exc:
+                # Another process may have cleared the same stale lease first,
+                # which is the desired outcome, not an error. Loop back and let
+                # the exclusive create decide who actually holds it.
+                log(f"Stale lease already gone or not removable ({exc}) — retrying claim")
             continue
 
         if first_check:

--- a/claude-ops/scripts/crsproxy-reauth/bu_reauth.py
+++ b/claude-ops/scripts/crsproxy-reauth/bu_reauth.py
@@ -385,69 +385,107 @@ def disable_auth_file(auth_path: Path) -> bool:
 # ---------------------------------------------------------------------------
 # Serialization lease
 # ---------------------------------------------------------------------------
-def _lease_exists(path) -> bool:
-    """True only when the lease file is readable and present.
+def _read_lease(path):
+    """Return the lease dict, or None when no usable lease is present.
+
+    Raises nothing: an unreadable or corrupt lease is reported as None.
 
     `Path.exists()` raises PermissionError when the parent directory is not
     searchable by the calling user (running as anyone but the service account,
-    or on a box where /opt/<svc>/state is root-owned). That escaped
-    acquire_lease's own OSError handling because it fired on the probe itself,
-    not the read, and crashed the reauth run instead of degrading to "no lease
-    held". Treat an unreadable probe as absent: the write below still fails
-    loudly if the directory is genuinely unusable.
+    or on a box where the state dir is root-owned). That escaped acquire_lease's
+    own OSError handling because it fired on the probe itself, not the read,
+    and crashed the reauth run instead of degrading.
     """
     try:
-        return path.exists()
+        return json.loads(path.read_text())
+    except FileNotFoundError:
+        return None
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _try_create_lease(path, provider: str) -> bool:
+    """Atomically create the lease file. False when it already exists.
+
+    O_CREAT|O_EXCL is the actual mutual-exclusion primitive: an exists() probe
+    followed by a write is two syscalls with a window between them, so two
+    processes can both see "no lease" and both write. Creating exclusively
+    makes the check and the claim one operation.
+    """
+    payload = json.dumps({
+        "provider": provider,
+        "timestamp": time.time(),
+        "pid": os.getpid(),
+    })
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
     except OSError:
+        pass
+    try:
+        fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+    except FileExistsError:
         return False
+    try:
+        os.write(fd, payload.encode())
+    finally:
+        os.close(fd)
+    return True
 
 
 def acquire_lease(provider: str, max_wait: int = 120) -> bool:
     """Acquire the serialization lease, waiting up to max_wait seconds.
 
-    If the lease file exists and is recent (younger than
-    LEASE_STALE_SECONDS), polls every 5 seconds until it is released
-    or max_wait is reached.  If the lease is stale, it is removed and a
-    new lease is acquired.  Returns True if the lease was acquired,
-    False on timeout.
+    The claim itself is an atomic exclusive create. If the lease file already
+    exists and is recent (younger than LEASE_STALE_SECONDS), polls every 5
+    seconds until it is released or max_wait is reached. A stale or corrupt
+    lease is removed and the claim retried. Returns True if the lease was
+    acquired, False on timeout.
     """
     t0 = time.time()
     first_check = True
     while True:
-        lease_path = LEASE_FILE if _lease_exists(LEASE_FILE) else LEGACY_LEASE_FILE
-        if _lease_exists(lease_path):
-            try:
-                data = json.loads(lease_path.read_text())
-                age = time.time() - data.get("timestamp", 0)
-                if age < LEASE_STALE_SECONDS:
-                    if first_check:
-                        log(f"Lease held by {data.get('provider','?')} "
-                            f"({int(age)}s old) — waiting up to {max_wait}s")
-                        first_check = False
-                    if time.time() - t0 >= max_wait:
-                        log(f"Lease wait timed out after {max_wait}s — "
-                            f"another login may still be in progress")
-                        return False
-                    time.sleep(5)
-                    continue
-                # Stale lease — remove it
-                log(f"Stale lease ({int(age)}s old) — removing")
-                lease_path.unlink()
-            except (json.JSONDecodeError, OSError):
-                try:
-                    lease_path.unlink()
-                except OSError:
-                    pass
-        # Lease file doesn't exist or was removed — acquire
-        break
+        if _try_create_lease(LEASE_FILE, provider):
+            log(f"Lease acquired for {provider}")
+            return True
 
-    LEASE_FILE.write_text(json.dumps({
-        "provider": provider,
-        "timestamp": time.time(),
-        "pid": os.getpid(),
-    }))
-    log(f"Lease acquired for {provider}")
-    return True
+        # Someone holds it (or a legacy-named lease is in the way).
+        data = _read_lease(LEASE_FILE)
+        lease_path = LEASE_FILE
+        if data is None:
+            legacy = _read_lease(LEGACY_LEASE_FILE)
+            if legacy is not None:
+                data, lease_path = legacy, LEGACY_LEASE_FILE
+
+        if data is None:
+            # Unreadable or corrupt on both names. Remove and retry the claim;
+            # never fall through to an unconditional overwrite.
+            try:
+                lease_path.unlink()
+            except OSError:
+                if time.time() - t0 >= max_wait:
+                    log("Lease unreadable and not removable — giving up")
+                    return False
+                time.sleep(5)
+            continue
+
+        age = time.time() - data.get("timestamp", 0)
+        if age >= LEASE_STALE_SECONDS:
+            log(f"Stale lease ({int(age)}s old) — removing")
+            try:
+                lease_path.unlink()
+            except OSError:
+                pass
+            continue
+
+        if first_check:
+            log(f"Lease held by {data.get('provider','?')} "
+                f"({int(age)}s old) — waiting up to {max_wait}s")
+            first_check = False
+        if time.time() - t0 >= max_wait:
+            log(f"Lease wait timed out after {max_wait}s — "
+                f"another login may still be in progress")
+            return False
+        time.sleep(5)
 
 
 def release_lease():

--- a/claude-ops/scripts/crsproxy-reauth/bu_reauth.py
+++ b/claude-ops/scripts/crsproxy-reauth/bu_reauth.py
@@ -422,7 +422,10 @@ def _try_create_lease(path, provider: str) -> bool:
     except OSError:
         pass
     try:
-        fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        # 0o600: the lease records a provider name and pid and is only ever
+        # read by the service account that writes it. No reason for group or
+        # world read.
+        fd = os.open(str(path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
     except FileExistsError:
         return False
     try:

--- a/claude-ops/scripts/crsproxy-reauth/test_lease_cooldown.py
+++ b/claude-ops/scripts/crsproxy-reauth/test_lease_cooldown.py
@@ -43,6 +43,78 @@ def test_lease_stale_seconds():
     print("PASS: Lease stale threshold is 600 seconds (10 min)")
 
 
+def test_acquire_lease_is_atomic_under_concurrency():
+    """Only ONE of N concurrent acquirers may win the lease.
+
+    Regression guard for the exists()-then-write race: two syscalls with a
+    window between them let every racer see "no lease" and every racer write,
+    so all of them believed they held it. The claim must be a single atomic
+    exclusive create.
+    """
+    import multiprocessing
+
+    def _worker(lease_path_str, q):
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        import bu_reauth as br
+        br.LEASE_FILE = Path(lease_path_str)
+        br.LEGACY_LEASE_FILE = Path(lease_path_str + ".legacy")
+        # max_wait=0 so a loser returns immediately instead of polling.
+        q.put(br.acquire_lease("claude", max_wait=0))
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lease_path = str(Path(tmpdir) / "lease.json")
+        q = multiprocessing.Queue()
+        procs = [multiprocessing.Process(target=_worker, args=(lease_path, q))
+                 for _ in range(8)]
+        for pr in procs:
+            pr.start()
+        for pr in procs:
+            pr.join(30)
+        results = [q.get() for _ in range(len(procs))]
+
+    winners = sum(1 for r in results if r is True)
+    assert winners == 1, f"Expected exactly 1 winner, got {winners} of {len(results)}"
+    print("PASS: acquire_lease is atomic — exactly one of 8 racers wins")
+
+
+def test_acquire_lease_unreadable_does_not_steal():
+    """An unreadable lease is never silently overwritten while it is held.
+
+    A transient read failure must not be read as "no lease exists". The claim
+    is an exclusive create, so a present-but-unreadable lease still loses the
+    create and the caller waits or times out rather than stealing it.
+    """
+    orig_lease = bu_reauth.LEASE_FILE
+    orig_legacy = bu_reauth.LEGACY_LEASE_FILE
+    with tempfile.TemporaryDirectory() as tmpdir:
+        lease_path = Path(tmpdir) / "lease.json"
+        bu_reauth.LEASE_FILE = lease_path
+        bu_reauth.LEGACY_LEASE_FILE = Path(tmpdir) / "legacy.json"
+
+        # Fresh lease held by another process, deliberately unparseable.
+        lease_path.write_text("{ not valid json")
+        os.chmod(lease_path, 0o000)
+        try:
+            before = lease_path.stat().st_mtime_ns
+            result = bu_reauth.acquire_lease("claude", max_wait=0)
+            # Either it failed to acquire, or it removed the corrupt file and
+            # claimed cleanly — but it must never leave another holder's file
+            # overwritten in place while still reporting success on a file it
+            # could not read.
+            if result is True:
+                data = json.loads(lease_path.read_text())
+                assert data["pid"] == os.getpid(), "claimed a lease it did not create"
+                assert lease_path.stat().st_mtime_ns != before, "overwrote in place"
+        finally:
+            try:
+                os.chmod(lease_path, 0o644)
+            except OSError:
+                pass
+    bu_reauth.LEASE_FILE = orig_lease
+    bu_reauth.LEGACY_LEASE_FILE = orig_legacy
+    print("PASS: unreadable lease is not silently stolen")
+
+
 def test_acquire_lease_no_existing():
     """acquire_lease acquires when no lease file exists."""
     orig_lease = bu_reauth.LEASE_FILE
@@ -473,6 +545,8 @@ def main():
         test_acquire_lease_stale_deleted,
         test_acquire_lease_waits_for_recent,
         test_acquire_lease_timeout,
+        test_acquire_lease_is_atomic_under_concurrency,
+        test_acquire_lease_unreadable_does_not_steal,
         test_release_lease,
         test_release_lease_missing_ok,
         test_release_lease_always_called,

--- a/claude-ops/scripts/crsproxy-reauth/test_lease_cooldown.py
+++ b/claude-ops/scripts/crsproxy-reauth/test_lease_cooldown.py
@@ -109,6 +109,9 @@ def test_acquire_lease_unreadable_does_not_steal():
             try:
                 os.chmod(lease_path, 0o600)
             except OSError:
+                # Cleanup only, so the TemporaryDirectory can be removed. The
+                # file is gone whenever acquire_lease cleared the corrupt
+                # lease, which is a valid outcome of this test.
                 pass
     bu_reauth.LEASE_FILE = orig_lease
     bu_reauth.LEGACY_LEASE_FILE = orig_legacy

--- a/claude-ops/scripts/crsproxy-reauth/test_lease_cooldown.py
+++ b/claude-ops/scripts/crsproxy-reauth/test_lease_cooldown.py
@@ -107,7 +107,7 @@ def test_acquire_lease_unreadable_does_not_steal():
                 assert lease_path.stat().st_mtime_ns != before, "overwrote in place"
         finally:
             try:
-                os.chmod(lease_path, 0o644)
+                os.chmod(lease_path, 0o600)
             except OSError:
                 pass
     bu_reauth.LEASE_FILE = orig_lease

--- a/claude-ops/skills/ops-comms/SKILL.md
+++ b/claude-ops/skills/ops-comms/SKILL.md
@@ -138,6 +138,11 @@ Draft created for [recipient]:
 
 ## Outbound judgment: verify before you assert
 
+**Before drafting to a person, load `relations` for their brief, open
+commitments and the full-context draft order, and `vip` for their tier.** A
+tier-1 recipient is drafted with extra care and never handled from a digest
+line. Neither skill can send; Rule 6 still owns the send.
+
 Rule 6 governs *whether* a message may go out. This section governs *whether the
 message is right*. Every item below is a failure mode seen on a real run, where
 the approval gate held and the content was still wrong.

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -138,6 +138,12 @@ Default: fan out one read-only scanner per configured channel after the offline 
 
 Every run, in order:
 
+0. **Rank by VIP first.** Load the `vip` skill and resolve the VIP set once
+   (`/ops:vip list`). Tier-1 senders are read and answered before anything else,
+   tier-2 next, everything else after. A VIP with an unanswered inbound is
+   surfaced individually with thread context, never as a line in a digest.
+   Before drafting to any person, load `relations` for their brief and open
+   commitments.
 1. Resolve the WhatsApp account (`ops-wa-accounts` — never hardcode a port).
 2. Freshness: `~/bin/wa-inbox-fresh.sh` (blocking, bounded). Then `bin/ops-inbox-scan`.
 3. `bin/ops-inbox-archive-set` report-only. Present KEEP vs ARCHIVE; `--apply` only after explicit OK.
@@ -294,3 +300,5 @@ Read the matching file before acting. Do not skip.
 - `references/runtime.md` — freshness, Mac fallback, version-heal, watcher
 - `references/fan-out.md` — Workflow JS, Agent Teams, hard constraints
 - `CHANNELS.md` — channel setup
+- `vip` skill — tier order for step 0; who is answered first
+- `relations` skill — person brief, open commitments, draft context

--- a/claude-ops/skills/ops/references/capabilities.json
+++ b/claude-ops/skills/ops/references/capabilities.json
@@ -243,6 +243,10 @@
       "summary": "This skill should be used when the user asks to \"sync contacts\", \"people database\", or \"/ops:people\". Sync Apple Contacts to Notion 'People' database. Track last_contacted, relationship_strength, recent_topics, next_nudge_due. Foundation for relationship intelligence — birthdays, anniversaries, overdue-outreach, news-mention nudges."
     },
     {
+      "name": "relations",
+      "summary": "This skill should be used when the user asks to \"who do I owe a reply\", \"relationship manager\", \"follow up with\", \"person brief\", or when any outbound draft to a person is about to be written. Relationship ledger and decision queue: who is owed a reply, what was promised, what is going cold, and the full context a draft needs. Drafts and stages only, never sends."
+    },
+    {
       "name": "setup",
       "summary": "This skill should be used when the user asks to \"/ops:setup\", \"configure ops\", or \"connect WhatsApp/email\". Interactive setup wizard for the claude-ops plugin. Installs missing CLIs, configures env vars for each channel (Telegram, WhatsApp, Email, Slack, Notion, Linear, Sentry, Vercel), builds the project registry, and saves user preferences. Run once after installing the plugin or any time to reconfigure."
     },
@@ -253,6 +257,10 @@
     {
       "name": "uninstall",
       "summary": "This skill should be used when the user asks to \"uninstall ops\", \"remove claude-ops\", or \"/ops:uninstall\". Completely remove claude-ops plugin, all stored credentials, cached files, shell exports, and MCP registrations. Confirms each step before deletion."
+    },
+    {
+      "name": "vip",
+      "summary": "This skill should be used when the user asks to \"vip list\", \"who is a VIP\", \"add someone to the VIP list\", \"prioritize this person\", or before any inbox, chat, or email sweep is ranked. Priority layer over every inbox: VIP tiers are checked first, answered first, never buried in a digest, and new candidates are suggested but never added silently."
     }
   ],
   "agents": [

--- a/claude-ops/skills/people/SKILL.md
+++ b/claude-ops/skills/people/SKILL.md
@@ -61,6 +61,14 @@ Apple Contacts is source of truth. Notion "People" database is the working layer
 - Subsequent runs are silent unless something new is inferred
 - Birthdays without years get treated as recurring annual; first detection asks owner to confirm before storing
 
+## Related skills
+
+- `relations` — the follow-up ledger and decision queue built on this directory
+- `vip` — priority tiers; a `relationship_strength` of close/family is a VIP
+  candidate signal, but a tier is only ever set through the `vip` skill's
+  audited CLI path
+- `ops-inbox` — consumes both when ranking a sweep
+
 ## Ledger writes
 
 ```bash

--- a/claude-ops/skills/relations/SKILL.md
+++ b/claude-ops/skills/relations/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: relations
+description: "OPS on-demand: This skill should be used when the user asks to \"who do I owe a reply\", \"relationship…"
+argument-hint: '[queue|brief <person>|find <email|phone|name>|draft <person>|close <id>|audit]'
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - Skill
+  - AskUserQuestion
+---
+
+# /ops:relations — Relationship Manager
+
+Load `ops-rules` before acting. Public repo (no personal data). Outbound: one draft → one approval → one send. If `AskUserQuestion` / `Workflow` are missing, follow Rule 10 in `ops-rules` (Hermes: numbered options / two-turn Telegram card; `delegate_task`).
+
+Relationship ledger and decision queue. Answers: who is owed a reply, what was
+promised, what is going cold, and what context a draft needs before it is written.
+It never sends anything.
+
+## Configuration
+
+Every path and toggle comes from plugin `userConfig`, an env var, or `$HOME`.
+Nothing in this skill is machine-specific.
+
+| userConfig key             | Env override             | Default                              | Meaning                                        |
+| -------------------------- | ------------------------ | ------------------------------------ | ---------------------------------------------- |
+| `relations_cli`            | `RELATIONS_CLI`          | `$HOME/.claude-ops/relations/bin/relations-cli` | Ledger CLI entry point (JSON out)   |
+| `relations_db_path`        | `RELATIONS_DB`           | `$HOME/.claude-ops/relations/people.db` | SQLite ledger, the factual source of truth  |
+| `relations_shadow_mode`    | `RELATIONS_SHADOW_MODE`  | `true`                               | When true, no external send on any channel     |
+| `relations_queue_limit`    | `RELATIONS_QUEUE_LIMIT`  | `10`                                 | Max decision-queue items per report            |
+| `relations_followup_limit_personal` | —               | `1`                                  | Unanswered follow-ups allowed, personal        |
+| `relations_followup_limit_business` | —               | `2`                                  | Unanswered follow-ups allowed, business        |
+| `relations_suppress_days`  | —                        | `30`                                 | Minimum suppression after a dismissal          |
+
+Resolve in this order, first non-empty wins. Never hardcode an absolute path:
+
+```bash
+PREFS_PATH="${PREFS_PATH:-${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json}"
+read_pref() { [ -f "$PREFS_PATH" ] && python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get(sys.argv[2],"") or "")' "$PREFS_PATH" "$1" 2>/dev/null; }
+
+RELATIONS_CLI="${RELATIONS_CLI:-$(read_pref relations_cli)}"
+RELATIONS_CLI="${RELATIONS_CLI:-$HOME/.claude-ops/relations/bin/relations-cli}"
+RELATIONS_DB="${RELATIONS_DB:-$(read_pref relations_db_path)}"
+RELATIONS_DB="${RELATIONS_DB:-$HOME/.claude-ops/relations/people.db}"
+
+if [ ! -x "$RELATIONS_CLI" ]; then
+  echo "relations: no ledger CLI at $RELATIONS_CLI — set userConfig relations_cli or RELATIONS_CLI" >&2
+fi
+```
+
+A missing CLI is reported as a missing CLI. Never fall back to an empty result:
+"no follow-ups" and "the ledger is not installed" must never look the same.
+
+## Hard rules
+
+1. **Shadow mode is the default.** With `relations_shadow_mode` true, this skill
+   drafts and stages only. No email, chat, SMS, or calendar invite leaves the box.
+2. **Never merge two records on a name.** Hard keys only: contact-provider id,
+   normalized email, E.164 phone, or a previously verified alias. Everything else
+   goes to the review queue.
+3. **Every fact, commitment and follow-up carries a source reference.** No source,
+   no row, no draft sentence.
+4. **Facts and inference are separate.** An inference never justifies an outbound.
+5. **Silence is the default.** Nothing meaningful changed means send nothing.
+6. **Contact history never enters agent memory.** Person facts belong in the
+   ledger DB, not in a memory plane or a committed file. See `ops-rules` Rule 0.
+7. **Progressive disclosure.** Never load the contact list into context. Query the
+   one person you need.
+
+## Operations
+
+| Subcommand         | What it does                                                        |
+| ------------------ | ------------------------------------------------------------------- |
+| `queue` (default)  | Ranked decision queue, max `relations_queue_limit`, one per person   |
+| `brief <person>`   | Contact methods, open commitments, sourced facts, recent threads     |
+| `find <key>`       | Resolve an identity by email / phone / name; ambiguity → review      |
+| `draft <person>`   | Full-context draft, staged for approval, never sent                  |
+| `close <id>`       | Close a follow-up with a reason                                      |
+| `snooze <id> <ts>` | Defer with a reason                                                  |
+| `suppress <id>`    | Dismiss for at least `relations_suppress_days`                       |
+| `audit`            | Duplicates, unsourced rows, stale facts, integrity                   |
+
+```bash
+"$RELATIONS_CLI" queue --limit "${RELATIONS_QUEUE_LIMIT:-10}"
+"$RELATIONS_CLI" brief <person_id>
+"$RELATIONS_CLI" find --email user@example.com
+"$RELATIONS_CLI" close <follow_up_id> --reason "they replied on chat"
+```
+
+## Draft order (fixed)
+
+1. Resolve identity across every channel the person owns — never answer on one
+   channel while the real conversation is on another.
+2. Read the COMPLETE thread, not the latest message. Check **both directions**
+   (sent and received) and **every account** the channel has.
+3. Read messages from the recipient and anyone relevant on copy.
+4. Check the calendar and open commitments.
+5. Check `vip` tier first (see the `vip` skill) — a tier-1 person is drafted
+   with more care and never batched into a digest.
+6. Load `humanizer`, write ONE draft in the owner's voice, in the language the
+   thread is already in.
+7. Stage it for approval with recipient, channel, thread, and a content hash.
+   If any of those change, ask again. Send only the exact approved content.
+
+Never send. Never produce several near-duplicate drafts.
+
+## Follow-up gate
+
+States: `i_owe_them`, `they_owe_me`, `waiting_date`, `waiting_document`,
+`waiting_decision`, `going_cold`, `no_action`, suppressed.
+
+The gate blocks on: do-not-automate, archived person, snoozed, suppressed,
+not due yet, they responded elsewhere, upcoming meeting, unanswered limit
+(`relations_followup_limit_personal` / `_business`), missing source reference,
+cross-channel duplicate.
+
+Not every unanswered message is overdue. Was a response actually requested? Was
+something promised? Has that date arrived? Would silence be more natural?
+
+## Report format
+
+Plain text, no decoration, recommendation first, max `relations_queue_limit`
+items, numbered actions per item. If nothing survives the gate, output nothing.
+
+```
+relationship desk — monday
+
+1. <person>
+business, a revised proposal was promised friday (email thread, <date>)
+recommendation: send the prepared draft, confidence high
+
+1 approve   2 edit   3 snooze 2 days   4 close   5 show context
+```
+
+## Source authority
+
+Current complete thread > verified identity > current calendar event > current
+conversation > signed document > this ledger > recent public primary source >
+search result > existing summary > draft. A draft is never a source of truth.
+On conflict: record it, prefer the newest authoritative primary source, surface
+it, and do not send until it is resolved.
+
+## Related skills
+
+- `vip` — who is checked and answered first; always consulted before triage
+- `ops-inbox` — channel sweeps feed this ledger
+- `ops-comms` — the send path, gated by Rule 6
+- `people` — contact directory sync (identity layer under this ledger)
+- `humanizer` — voice pass before any draft is staged
+- `ops-rules` — Rule 0 (public repo), Rule 6 (per-message approval)

--- a/claude-ops/skills/vip/SKILL.md
+++ b/claude-ops/skills/vip/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: vip
+description: "OPS on-demand: This skill should be used when the user asks to \"vip list\", \"who is a VIP\", \"add someone…"
+argument-hint: '[list|show <person>|set <person> --tier N|suggest|why <person>]'
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Skill
+  - AskUserQuestion
+---
+
+# /ops:vip — VIP List
+
+Load `ops-rules` before acting. Public repo (no personal data). Outbound: one draft → one approval → one send. If `AskUserQuestion` / `Workflow` are missing, follow Rule 10 in `ops-rules` (Hermes: numbered options / two-turn Telegram card; `delegate_task`).
+
+The priority layer over every inbox. VIPs are checked FIRST in any sweep,
+answered first, drafted with extra care, and never buried in a bulk digest.
+
+## Scope (deliberately narrow)
+
+This skill does four things and nothing else:
+
+1. Enforce the list — VIP senders rank ahead of everything else in every sweep.
+2. Require FULL context before answering or drafting for a VIP: the whole
+   thread, every account on that channel, both directions, plus the ledger brief.
+3. Order triage output by tier.
+4. **Suggest** additions when the signals below appear.
+
+It does not read histories for their own sake, does not draft unasked, and does
+not open a second channel just because one record is open. A tier edit is
+metadata only. Tagging someone is never an instruction to sweep their history.
+
+## Configuration
+
+Nothing here is machine-specific. Every value resolves from `userConfig`, an env
+var, or `$HOME`.
+
+| userConfig key        | Env override     | Default                                     | Meaning                              |
+| --------------------- | ---------------- | ------------------------------------------- | ------------------------------------ |
+| `vip_list_path`       | `VIP_LIST_PATH`  | `$HOME/.claude-ops/state/vip-list.json`     | Tier data + why/register notes       |
+| `vip_max_tier`        | `VIP_MAX_TIER`   | `2`                                         | Highest tier treated as VIP          |
+| `vip_suggest_enabled` | —                | `true`                                      | Emit VIP candidate suggestions       |
+| `vip_volume_days`     | —                | `30`                                        | Window for the volume signal         |
+| `vip_volume_min`      | —                | `12`                                        | Two-way messages that trip volume    |
+| `relations_cli`       | `RELATIONS_CLI`  | `$HOME/.claude-ops/relations/bin/relations-cli` | Shared ledger CLI (see `relations`) |
+
+```bash
+PREFS_PATH="${PREFS_PATH:-${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json}"
+read_pref() { [ -f "$PREFS_PATH" ] && python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get(sys.argv[2],"") or "")' "$PREFS_PATH" "$1" 2>/dev/null; }
+
+VIP_LIST_PATH="${VIP_LIST_PATH:-$(read_pref vip_list_path)}"
+VIP_LIST_PATH="${VIP_LIST_PATH:-$HOME/.claude-ops/state/vip-list.json}"
+VIP_MAX_TIER="${VIP_MAX_TIER:-$(read_pref vip_max_tier)}"
+VIP_MAX_TIER="${VIP_MAX_TIER:-2}"
+```
+
+The list file lives OUTSIDE the repo tree — it is the operator's identity and
+must never be committed (`ops-rules` Rule 0). Shape:
+`templates/vip-list.example.json`.
+
+## Tiers
+
+| Tier | Meaning                | Handling                                                  |
+| ---- | ---------------------- | --------------------------------------------------------- |
+| 1    | Inner circle           | Never let it sit. Checked first, answered first, never batched |
+| 2    | Key business           | Same day. Ranked above general triage                      |
+| 3-5  | Reserved               | Not VIP by default (`vip_max_tier` = 2)                     |
+
+The ledger's `importance_tier` column is the source of truth for the tier value;
+the JSON file carries the why and the register notes (language, tone, dates to
+avoid). Both are read; the DB wins on conflict.
+
+## Operations
+
+| Subcommand              | What it does                                                     |
+| ----------------------- | ---------------------------------------------------------------- |
+| `list` (default)        | Every person at or above `vip_max_tier`, grouped by tier          |
+| `show <person>`         | Tier, type, why, channel, register notes                          |
+| `set <person> --tier N` | Audited tier write via the ledger CLI, reason required            |
+| `suggest`               | Read-only candidate scan (see signals below); never writes        |
+| `why <person>`          | Which signal put a suggested candidate on the list                |
+
+```bash
+"$RELATIONS_CLI" vip-list --max-tier "$VIP_MAX_TIER"
+"$RELATIONS_CLI" vip <person_id> --tier 1 --type personal --reason "<why>"
+```
+
+**Tier writes go through the CLI, never raw SQL.** The CLI owns
+`source_reference`, the audit log, and the rollback path. A direct
+`UPDATE` on the ledger DB — inline or wrapped in a script — leaves an
+unauditable row and is forbidden even where no guard happens to fire.
+
+## Sweep order
+
+Any inbox, chat, email, or ticket sweep runs in this order:
+
+1. Resolve the VIP set once (`vip list`), cache it for the sweep.
+2. Tier 1 senders, every channel, both directions, every account.
+3. Tier 2 senders, same.
+4. Everything else, normal triage.
+
+A VIP with an unanswered inbound is always surfaced individually, with the
+thread context, never as a line in a digest.
+
+## Suggesting additions
+
+Suggest, never add silently. A tier change needs the owner's word, then the
+audited CLI write. Three signals:
+
+| Signal      | Trigger                                                                 |
+| ----------- | ----------------------------------------------------------------------- |
+| volume      | `vip_volume_min`+ two-way messages in `vip_volume_days` with someone off the list |
+| frustration | They say they are being ignored or chased ("still waiting", "any update") |
+| chain-break | Their last message is inbound and still unanswered                       |
+
+Two filters keep this honest, both learned from real false positives:
+
+- **Anchor every keyword on both sides.** A bare stem matches inside longer
+  words (`ping` inside "tapping") and produces phantom frustration hits.
+- **A thread ending on a sign-off is CLOSED, not broken.** "Thanks!", "sounds
+  good", an emoji, or any short ack with no question mark is not an open ask.
+  Without this filter most chain-breaks are noise that buries the real ones.
+
+Present at most 5 a week: who, which signal, the evidence line, and the exact
+CLI command to apply it. Then ask plainly. On "no", do not raise that person
+again.
+
+## Related skills
+
+- `relations` — the ledger, decision queue and draft path this list ranks
+- `ops-inbox` — the sweep that consumes the tier order
+- `ops-comms` — the send path, still gated by Rule 6 for every VIP
+- `people` — contact directory / identity resolution
+- `ops-rules` — Rule 0 (the list is operator data, never committed)

--- a/claude-ops/skills/vip/templates/vip-list.example.json
+++ b/claude-ops/skills/vip/templates/vip-list.example.json
@@ -1,0 +1,47 @@
+{
+  "_doc": "Template for the VIP list. Copy to the path in userConfig `vip_list_path` (default $HOME/.claude-ops/state/vip-list.json). NEVER commit a filled copy: it is operator identity data (ops-rules Rule 0). Tier values are mirrored from the relations ledger `importance_tier`; this file carries the why and the register notes.",
+  "updated": "YYYY-MM-DD",
+  "tier1_inner_circle": [
+    {
+      "person_id": 1,
+      "name": "<Family Member>",
+      "type": "family",
+      "why": "<one line: who they are to the owner>",
+      "channel": "chat +1234567890",
+      "note": "<language, tone, dates to avoid, register file to read first>"
+    },
+    {
+      "person_id": 2,
+      "name": "<Close Friend>",
+      "type": "personal",
+      "why": "<one line>",
+      "channel": "chat +1234567890",
+      "note": "<language>"
+    },
+    {
+      "person_id": 3,
+      "name": "<Key Colleague>",
+      "type": "business",
+      "why": "<one line>",
+      "channel": "user@example.com",
+      "note": "<language>"
+    }
+  ],
+  "tier2_key_business": [
+    {
+      "person_id": 4,
+      "name": "<Advisor>",
+      "type": "vendor",
+      "why": "<one line>",
+      "channel": "user@example.com",
+      "note": "<language>"
+    }
+  ],
+  "rules": [
+    "Checked first in every sweep, answered first, never buried in a bulk digest.",
+    "Read the whole thread, both directions, on every account of that channel.",
+    "Reply in the language the thread is already in.",
+    "No send without the owner's explicit per-message approval (ops-rules Rule 6).",
+    "Tier changes go through the ledger CLI with a reason, never raw SQL."
+  ]
+}


### PR DESCRIPTION
## What

Adds two skills to the ops plugin and wires them into the skills that already do person work.

**`/ops:relations` — relationship manager.** Local ledger and decision queue: who is owed a reply, what was promised, what is going cold, and the full context a draft needs. Shadow mode is the default, so it drafts and stages but never sends. Fixed draft order: identity across every channel, the complete thread in both directions on every account, calendar and open commitments, VIP tier, humanizer pass, then a staged approval bound to recipient + channel + thread + content hash.

**`/ops:vip` — VIP list.** The priority layer over every inbox. Tier 1 and 2 are checked first in any sweep, answered first, and never buried in a bulk digest. It suggests new candidates read-only on three signals (volume, frustration, chain-break) and never adds one silently; tier writes go through the audited ledger CLI, never raw SQL.

Two filters in the suggest path come from real false positives: every keyword is anchored on both sides (a bare `ping` stem matched inside "tapping"), and a thread ending on a sign-off is treated as closed, not broken (otherwise most chain-breaks are "Thanks!" and bury the real ones).

## Configuration lives in plugin.json

12 new `userConfig` keys, no new config file:

`relations_cli`, `relations_db_path`, `relations_shadow_mode`, `relations_queue_limit`, `relations_followup_limit_personal`, `relations_followup_limit_business`, `relations_suppress_days`, `vip_list_path`, `vip_max_tier`, `vip_suggest_enabled`, `vip_volume_days`, `vip_volume_min`.

Each resolves `userConfig` → env var → `$HOME` default. Nothing is machine-specific: no names, no PII, no absolute paths, no org or store references. The VIP list itself is operator identity data and stays outside the repo per Rule 0 — its shape ships as `skills/vip/templates/vip-list.example.json`.

A missing ledger CLI is reported as a missing CLI. "No follow-ups" and "the ledger is not installed" must never look the same.

## Wiring

- `ops-inbox` — new step 0: resolve the VIP set once and rank the sweep by tier before anything else; load `relations` before drafting to any person. Added to Additional resources.
- `ops-comms` — loads both before drafting; Rule 6 still owns the send.
- `people` — cross-links both as the identity layer underneath; a `close`/`family` strength is a VIP candidate signal, never an automatic tier.
- Docs, README command tables, and skill counts updated 64 → 66. Capability index regenerated via `scripts/compact-plugin-discovery.mjs`.

## Pre-existing failures fixed

Both were already red on `main` (baseline measured on a clean `origin/main` worktree: 38/41 suites).

1. **`bin/ops-speedup`** — on a Linux host with no `model name` line in `/proc/cpuinfo` (aarch64 and most ARM SoCs), `xargs` with no `-r` still ran `echo` once and emitted a bare newline into the `"cpu"` JSON string, so `--json` output was unparseable (`Invalid control character`). Trimmed to one line with an explicit fallback.
2. **`scripts/crsproxy-reauth/bu_reauth.py`** — `Path.exists()` raises `PermissionError` when the state directory is not searchable by the calling user. That escaped `acquire_lease`'s own `OSError` handling because it fired on the *probe*, not the read, and crashed the reauth run instead of degrading to "no lease held". Probing now goes through a helper that treats an unreadable lease as absent; the write below still fails loudly if the directory is genuinely unusable.

Both mutation-proven: reverting either fix turns its suite red again, restoring it turns it green.

## Verification

```
tests/run-all.sh          41/41 suites pass   (main: 38/41)
test-skills-lint.sh       791 checks, 0 failed
test-no-secrets.sh        27 passed, 0 failed
test-hermes-plugin.sh     10 passed (66 SKILL.md discovered)
test-compact-discovery.sh pass, 8534/10000 description budget
test-plugin-validate.sh   6 passed
prettier --check          clean on every touched JSON
```

PII sweep over both new skill dirs returns nothing.

## Not in this PR

- No ledger CLI implementation. Both skills describe the contract and resolve the binary from config; the CLI itself is operator-side and out of scope for a public plugin.
- `hermes-plugin/` needs no change: it registers every `skills/*/SKILL.md` automatically, so both skills are already exposed on Hermes (verified by `test-hermes-plugin.sh` counting 66).
