### PR TITLE
fix(pocket): close broker socket readiness race

### DIFF
--- a/claude-ops/scripts/pocket-env-broker.py
+++ b/claude-ops/scripts/pocket-env-broker.py
@@ -373,10 +373,13 @@ def serve() -> int:
     old_umask = os.umask(0o177)
     try:
         srv.bind(str(SOCK_PATH))
+        # Make the socket connectable before post-bind ACL work. The restrictive
+        # umask already keeps the inode owner-only, so this closes the window
+        # where the path exists but clients get ECONNREFUSED without widening access.
+        srv.listen(16)
     finally:
         os.umask(old_umask)
     _harden_socket_perms(want_uid)
-    srv.listen(16)
     with _METRICS_LOCK:
         _METRICS["started_at"] = now_iso()
         _write_health(_health_snapshot_locked())

--- a/claude-ops/tests/test-pocket-env-broker.sh
+++ b/claude-ops/tests/test-pocket-env-broker.sh
@@ -29,7 +29,10 @@ fi
 
 TMP="$(mktemp -d)"
 BROKER_PID=""
+RACE_PID=""
 cleanup() {
+  [[ -n "$RACE_PID" ]] && kill "$RACE_PID" 2>/dev/null
+  [[ -n "$RACE_PID" ]] && wait "$RACE_PID" 2>/dev/null
   [[ -n "$BROKER_PID" ]] && kill "$BROKER_PID" 2>/dev/null
   rm -rf "$TMP"
 }
@@ -105,6 +108,7 @@ else
 fi
 kill "$RACE_PID" 2>/dev/null
 wait "$RACE_PID" 2>/dev/null
+RACE_PID=""
 rm -f "$RACE_SOCK"
 
 # ── Case A: authorized uid (current user) ───────────────────────────────────

--- a/claude-ops/tests/test-pocket-env-broker.sh
+++ b/claude-ops/tests/test-pocket-env-broker.sh
@@ -66,6 +66,47 @@ run_client() { # $1 = var → prints value, sets global RC
   RC=$?
 }
 
+# The socket path must not advertise readiness before listen() is active. Slow
+# the post-bind hardening step and prove a client can connect while it is paused.
+RACE_SOCK="$TMP/readiness.sock"
+RACE_READY="$TMP/hardening-started"
+POCKET_ENV_BROKER_SOCK="$RACE_SOCK" POCKET_ENV_BROKER_POLICY="$POLICY" \
+  POCKET_ENV_BROKER_AUDIT="$TMP/readiness-audit.log" \
+  POCKET_ENV_BROKER_HEALTH="$TMP/readiness-health.json" \
+  POCKET_WORKER_USER="$(id -un)" BROKER_PATH="$BROKER" RACE_READY="$RACE_READY" \
+  "$PY" -c '
+import importlib.util, os, pathlib, sys, time
+spec = importlib.util.spec_from_file_location("pocket_env_broker", os.environ["BROKER_PATH"])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+original = module._harden_socket_perms
+def delayed(uid):
+    pathlib.Path(os.environ["RACE_READY"]).touch()
+    time.sleep(1)
+    original(uid)
+module._harden_socket_perms = delayed
+sys.exit(module.serve())
+' &
+RACE_PID=$!
+for _ in $(seq 1 50); do
+  [[ -S "$RACE_SOCK" && -f "$RACE_READY" ]] && break
+  sleep 0.02
+done
+if POCKET_ENV_BROKER_SOCK="$RACE_SOCK" "$PY" -c '
+import os, socket
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.settimeout(0.2)
+s.connect(os.environ["POCKET_ENV_BROKER_SOCK"])
+s.close()
+'; then
+  ok "socket becomes connectable before post-bind hardening finishes"
+else
+  err "socket readiness" "path existed before listen() accepted connections"
+fi
+kill "$RACE_PID" 2>/dev/null
+wait "$RACE_PID" 2>/dev/null
+rm -f "$RACE_SOCK"
+
 # ── Case A: authorized uid (current user) ───────────────────────────────────
 ME="$(id -un)"
 if start_broker "$ME"; then


### PR DESCRIPTION
Moves listen() directly after bind() under the owner-only umask, before slower ACL hardening. Adds a deterministic regression test that pauses hardening and proves the socket is already connectable. Local proof: regression failed before the fix, then passed 5/5; py_compile, bash -n, shellcheck, and diff check pass.