### PR TITLE
fix(hooks): stop interpolating $INPUT so Grok runs inbox autosync

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+- fix(hooks): UserPromptSubmit inbox autosync no longer interpolates `$INPUT`.
+  Grok treats `$VAR` in a hook command as a required env var and skips the
+  hook when it is unset. The script already reads the event JSON from stdin.
+  Guard: `tests/test-hooks.sh` now flags `$INPUT` the same way as `$TOOL_INPUT`.
+
 - fix(daemon): write `daemon-health.json` with builtin `printf` + `mv`, not
   `cat >file <<EOF`. Under launchd stdin is `/dev/null`, so bash's 16KiB
   heredoc pipe never drains and the first health write deadlocks — empty

--- a/claude-ops/hooks/hooks.json
+++ b/claude-ops/hooks/hooks.json
@@ -10,7 +10,7 @@
           },
           {
             "type": "command",
-            "command": "INPUT=$(cat); (printf %s \"$INPUT\" | bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-inbox-autosync >/dev/null 2>&1 &); exit 0",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-inbox-autosync >/dev/null 2>&1",
             "timeout": 2,
             "async": true
           }

--- a/claude-ops/tests/test-hooks.sh
+++ b/claude-ops/tests/test-hooks.sh
@@ -127,7 +127,7 @@ fi
 echo ""
 echo "Checking command interpolations..."
 if command -v jq &>/dev/null; then
-  bad=$(printf '%s\n' "$commands" | grep -E '\$\{?(TOOL_INPUT|TOOL_RESULT|USER_PROMPT)\}?' || true)
+  bad=$(printf '%s\n' "$commands" | grep -E '\$\{?(TOOL_INPUT|TOOL_RESULT|USER_PROMPT|INPUT)\}?' || true)
   if [[ -n "$bad" ]]; then
     err "command interpolates Claude-only payload var (Grok skips the hook): $bad"
   else


### PR DESCRIPTION
## Why

Grok expands `$VAR` in hook command strings and skips the hook if the var is unset (`required env var(s) not set`). `$TOOL_INPUT` was already removed (v3.9.8). UserPromptSubmit inbox autosync still interpolated `$INPUT`, so Grok never ran it.

## Change

- Hook command is `bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-inbox-autosync` (still `async`). The script already `cat`s stdin.
- `tests/test-hooks.sh` flags `$INPUT` the same way as `$TOOL_INPUT`.

Live Grok install was patched the same way; reload hooks (`r` in `/hooks`) or start a new session.