### PR TITLE
fix(ops): memory extractor, proxy auth, and unread-bridge follow-ups

### DIFF
--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -38,6 +38,11 @@ SERVICES_CONFIG="$DATA_DIR/daemon-services.json"
 HEALTH_FILE="$DATA_DIR/daemon-health.json"
 MAX_LOG_SIZE=2097152  # 2MB
 DAEMON_START=$(date +%s)
+# Stderr capture files for the external `gog` calls in prefetch_briefing_cache
+# and prefetch_calendar. These exist so a hard failure from gog lands in the log
+# instead of /dev/null; removed by cleanup() on shutdown.
+TMP_GOG_EMAIL_ERR="$DATA_DIR/cache/.gog_email.err"
+TMP_GOG_CAL_ERR="$DATA_DIR/cache/.gog_calendar.err"
 
 mkdir -p "$LOG_DIR"
 mkdir -p "$DATA_DIR/cache"
@@ -657,11 +662,26 @@ print(json.dumps({'total_chats':len(recent),'count':len(data)}))
   _refresh_pids+=($!)
 
   # Email count
-  (command -v gog &>/dev/null && gog gmail search -j --results-only --no-input --max 10 "in:inbox" 2>/dev/null | python3 -c "
+  # Never swallow gog's stderr. This call used 2>/dev/null, so a hard error
+  # ("missing --account", expired auth) came back as an empty result and got
+  # logged as a quiet inbox — the same failure that kept the memory extractor
+  # looking healthy while it extracted nothing. Capture stderr and surface it.
+  (if command -v gog &>/dev/null; then
+    local _email_raw=""
+    _email_raw=$(gog gmail search -j --results-only --no-input --max 10 "in:inbox" 2>"$TMP_GOG_EMAIL_ERR" || true)
+    if [[ -n "$_email_raw" ]]; then
+      printf '%s' "$_email_raw" | python3 -c "
 import json,sys
 data=json.load(sys.stdin)
 print(json.dumps({'unread_count':len(data)}))
-" > "$tmpdir/email.json" 2>/dev/null) &
+" > "$tmpdir/email.json" 2>>"$TMP_GOG_EMAIL_ERR" || true
+    fi
+    if [[ ! -s "$tmpdir/email.json" ]]; then
+      local _gog_err=""
+      [[ -s "$TMP_GOG_EMAIL_ERR" ]] && _gog_err=$(tr '\n' ' ' < "$TMP_GOG_EMAIL_ERR" | cut -c1-300)
+      log "BRAIN: gog gmail search returned no data${_gog_err:+ -- ${_gog_err}} (skipping email count)"
+    fi
+  fi) &
   _refresh_pids+=($!)
 
   # Open PRs
@@ -884,7 +904,15 @@ prefetch_calendar() {
 
   if command -v gog &>/dev/null; then
     log "BRAIN: refreshing calendar cache"
-    gog calendar events primary --today --json > "$CAL_CACHE" 2>/dev/null || echo '[]' > "$CAL_CACHE"
+    # Never swallow gog's stderr. With 2>/dev/null a hard error fell straight
+    # through to the '[]' fallback and was indistinguishable from "no meetings
+    # today", so a broken calendar fetch could run for weeks unnoticed.
+    if ! gog calendar events primary --today --json > "$CAL_CACHE" 2>"$TMP_GOG_CAL_ERR" || [[ ! -s "$CAL_CACHE" ]]; then
+      echo '[]' > "$CAL_CACHE"
+      local _gog_err=""
+      [[ -s "$TMP_GOG_CAL_ERR" ]] && _gog_err=$(tr '\n' ' ' < "$TMP_GOG_CAL_ERR" | cut -c1-300)
+      log "BRAIN: gog calendar returned no data${_gog_err:+ -- ${_gog_err}} (cached empty)"
+    fi
     date +%s > "$LAST_FETCH"
   fi
 }
@@ -1691,6 +1719,7 @@ cleanup() {
   for name in "${!SERVICE_PIDS[@]}"; do
     stop_service "$name"
   done
+  rm -f "$TMP_GOG_EMAIL_ERR" "$TMP_GOG_CAL_ERR"
   write_daemon_health
   log "SHUTDOWN: all services stopped — exiting"
   exit 0

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -785,7 +785,16 @@ if urgent:
 # avoids spawning a process only for it to exit on the lock.
 trigger_smart_memory_extraction() {
   local MEMORY_TRIGGER="$DATA_DIR/cache/.memory_trigger_ts"
-  local MEM_SCRIPT="${CLAUDE_PLUGIN_ROOT:-$(dirname "$0")}/scripts/ops-memory-extractor.sh"
+  # Prefer the desk wrapper when it is installed. It runs the same extractor,
+  # but with OPS_DATA_DIR pointed at a staging root that holds no contact_*.md,
+  # so no contact list reaches the prompt, and it files the run's person output
+  # in the relationship desk instead of in flat memory. Without this line the
+  # cron path would go through the wrapper (see daemon-services.json) while
+  # this 10-minute trigger kept writing contact_*.md straight into memories/.
+  local MEM_SCRIPT="$DATA_DIR/bin/ops-memory-to-desk.sh"
+  if [[ ! -x "$MEM_SCRIPT" ]]; then
+    MEM_SCRIPT="${CLAUDE_PLUGIN_ROOT:-$(dirname "$0")}/scripts/ops-memory-extractor.sh"
+  fi
   # Minimum seconds between any two extraction runs, whichever trigger starts
   # them. Must stay below the 30-min cron period or it would suppress the
   # scheduled run instead of merely rate-limiting the early one.

--- a/claude-ops/scripts/ops-daemon.sh
+++ b/claude-ops/scripts/ops-daemon.sh
@@ -752,9 +752,44 @@ if urgent:
 }
 
 # Trigger memory extraction early when new high-value messages arrive.
+#
+# This is an "run EARLIER than the next scheduled run", not a second schedule.
+# It used to behave as the latter, for two compounding reasons:
+#
+#   1. It read the wrong key out of memories/.health. The extractor writes
+#      "last_run"; this read "timestamp", which is never present, so last_ts was
+#      always empty and the new-message test fell through to its `data[:5]`
+#      fallback -- a constant 5, permanently above the >3 threshold. Every
+#      10-minute check therefore fired, and the log shows the signature
+#      plainly: 106 consecutive "5 new messages since last extraction" entries
+#      on 2026-08-24, one per check, regardless of actual message activity.
+#
+#   2. Nothing related the trigger to the 30-minute cron entry, so its runs were
+#      purely additive: 106 smart + 36 cron = 142 starts in 18 hours against a
+#      documented schedule of 48/day.
+#
+# Fixes: read "last_run", and refuse to fire unless MIN_EXTRACTION_GAP has
+# elapsed since the extractor last actually ran. That gap is measured from
+# .health, which the extractor writes on every run whatever started it, so the
+# floor applies across BOTH trigger paths rather than only to this one.
+#
+# The gap is 20 min against a 30-min cron period. That lets a genuine burst of
+# messages pull the next extraction forward by up to 10 minutes while making it
+# impossible for this path to add more than one run per cron period. A shorter
+# gap would buy a little more responsiveness for a store that is only re-read
+# every half hour anyway; 20 min is the conservative choice.
+#
+# Overlap itself is no longer this function's problem: ops-memory-extractor.sh
+# now holds its own lock, so cron, this trigger and manual runs cannot collide
+# whatever the timing. The PID check below is kept as a cheap early-out that
+# avoids spawning a process only for it to exit on the lock.
 trigger_smart_memory_extraction() {
   local MEMORY_TRIGGER="$DATA_DIR/cache/.memory_trigger_ts"
   local MEM_SCRIPT="${CLAUDE_PLUGIN_ROOT:-$(dirname "$0")}/scripts/ops-memory-extractor.sh"
+  # Minimum seconds between any two extraction runs, whichever trigger starts
+  # them. Must stay below the 30-min cron period or it would suppress the
+  # scheduled run instead of merely rate-limiting the early one.
+  local MIN_EXTRACTION_GAP=1200
 
   # Only check every 10 min
   if [[ -f "$MEMORY_TRIGGER" ]]; then
@@ -768,14 +803,43 @@ trigger_smart_memory_extraction() {
   # Check if new messages arrived since last extraction
   local last_extraction="$DATA_DIR/memories/.health"
   if [[ -f "$last_extraction" ]]; then
-    local last_ts
+    local last_ts last_epoch
+    # "last_run" is the key the extractor actually writes; "timestamp" is
+    # tolerated so a .health left by an older build still parses.
     last_ts=$(python3 -c "
 import json
 try:
     d=json.load(open('$last_extraction'))
-    print(d.get('timestamp',''))
+    print(d.get('last_run') or d.get('timestamp') or '')
 except: print('')
 " 2>/dev/null)
+
+    # Enforce the floor between runs. If we cannot establish when the extractor
+    # last ran we do NOT fire: cron still covers the store on its own schedule,
+    # so the safe failure mode is to skip the early run, not to add one. This is
+    # what the old `data[:5]` fallback got backwards.
+    if [[ -z "$last_ts" ]]; then
+      log "BRAIN: no readable last_run in .health — leaving extraction to cron"
+      date +%s > "$MEMORY_TRIGGER"
+      return 0
+    fi
+    last_epoch=$(python3 -c "
+import datetime,sys
+try:
+    print(int(datetime.datetime.strptime('$last_ts','%Y-%m-%dT%H:%M:%SZ').replace(tzinfo=datetime.timezone.utc).timestamp()))
+except Exception:
+    print(0)
+" 2>/dev/null || echo 0)
+    if (( last_epoch <= 0 )); then
+      log "BRAIN: could not parse last_run ('$last_ts') — leaving extraction to cron"
+      date +%s > "$MEMORY_TRIGGER"
+      return 0
+    fi
+    local since=$(( $(date +%s) - last_epoch ))
+    if (( since < MIN_EXTRACTION_GAP )); then
+      date +%s > "$MEMORY_TRIGGER"
+      return 0
+    fi
 
     # Read from keepalive cache to check for new messages (no store-lock contention)
     local wacli_chats_cache="$DATA_DIR/cache/wacli_chats.json"
@@ -785,7 +849,7 @@ except: print('')
 import json,datetime
 data=json.load(open('$wacli_chats_cache')).get('data',[]) or []
 last='${last_ts:-}'
-recent=[c for c in data if c.get('LastMessageTS','')>last] if last else data[:5]
+recent=[c for c in data if c.get('LastMessageTS','')>last]
 print(len(recent))
 " 2>/dev/null || echo 0)
 

--- a/claude-ops/scripts/ops-memory-extractor.sh
+++ b/claude-ops/scripts/ops-memory-extractor.sh
@@ -335,14 +335,31 @@ EOF
 
 # ── Read existing memory for context ─────────────────────────────────────────
 read_existing_memory() {
-  local out=""
-  for f in "${MEMORIES_DIR}"/contact_*.md "${MEMORIES_DIR}"/preferences.md \
-            "${MEMORIES_DIR}"/topics_active.md "${MEMORIES_DIR}"/donts.md; do
+  # Bound what goes into the prompt. This whole block is sent to Haiku on every
+  # run, and the store here had grown to ~424KB across 675 files -- roughly 106K
+  # tokens per request, enough that the proxy answered HTTP 504 and the run died
+  # in call_claude. auto_compress, which is what would bring the store back
+  # down, only runs *after* that call, so an oversized store kept itself
+  # oversized. Cap the context instead of the files: nothing on disk is touched,
+  # the newest memories are preferred, and the run completes.
+  local budget="${MAX_CONTEXT_BYTES:-${MAX_TOTAL_BYTES}}"
+  local out="" used=0 skipped=0 f fsize
+  while IFS= read -r f; do
     [[ -f "$f" ]] || continue
+    fsize=$(wc -c < "$f" 2>/dev/null || echo 0)
+    if (( used + fsize > budget )); then
+      skipped=$((skipped + 1))
+      continue
+    fi
+    used=$((used + fsize))
     out+="### $(basename "$f")\n"
     out+=$(cat "$f")
     out+="\n\n"
-  done
+  done < <(ls -t "${MEMORIES_DIR}"/contact_*.md "${MEMORIES_DIR}"/preferences.md \
+                 "${MEMORIES_DIR}"/topics_active.md "${MEMORIES_DIR}"/donts.md 2>/dev/null)
+  if (( skipped > 0 )); then
+    log "Memory context capped at ${budget} bytes (${used} used); ${skipped} older file(s) left out of this run's prompt -- nothing deleted"
+  fi
   printf '%s' "${out}"
 }
 

--- a/claude-ops/scripts/ops-memory-extractor.sh
+++ b/claude-ops/scripts/ops-memory-extractor.sh
@@ -50,6 +50,9 @@ trap cleanup EXIT
 
 # ── Resolve auth (Claude Code OAuth preferred, API key fallback) ──────────────
 # Preference order:
+#   0. Local proxy (CLIProxyAPI) — ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN,
+#      taken from the environment, or read out of ~/.claude/settings.json's
+#      `env` block when the scheduler did not export them. Both are required.
 #   1. Claude Code OAuth token from macOS Keychain — uses your Claude Max/Pro
 #      subscription (no per-token API billing). Works out of the box if you're
 #      signed into Claude Code on this machine. Skipped if the token is expired
@@ -87,6 +90,38 @@ resolve_auth() {
   # api.anthropic.com, which rejects it.
   local _proxy_base="${ANTHROPIC_BASE_URL:-}"
   local _proxy_tok="${ANTHROPIC_AUTH_TOKEN:-}"
+
+  # Claude Code injects settings.json's `env` block into its own sessions, so a
+  # proxy configured only there is visible to anything running INSIDE a Claude
+  # session and invisible to this script, which cron and launchd start with a
+  # bare environment. That asymmetry is nasty to debug: run the script by hand
+  # and it authenticates, leave it to the scheduler and it dies with "No auth
+  # available" every 30 minutes. Read the file directly when the vars are unset.
+  if [[ -z "${_proxy_tok}" || -z "${_proxy_base}" ]]; then
+    local _settings="${HOME}/.claude/settings.json"
+    if [[ -r "${_settings}" ]] && command -v python3 &>/dev/null; then
+      local _from_settings
+      _from_settings=$(python3 - "${_settings}" <<'PYEOF' 2>/dev/null || true
+import json, sys
+try:
+    env = (json.load(open(sys.argv[1])) or {}).get("env") or {}
+except Exception:
+    sys.exit(0)
+base = (env.get("ANTHROPIC_BASE_URL") or "").strip()
+tok = (env.get("ANTHROPIC_AUTH_TOKEN") or "").strip()
+if base and tok:
+    # Tab-separated: neither value may contain one.
+    print(base + "\t" + tok)
+PYEOF
+      )
+      if [[ -n "${_from_settings}" ]]; then
+        _proxy_base="${_from_settings%%$'\t'*}"
+        _proxy_tok="${_from_settings#*$'\t'}"
+        log "Auth: proxy config read from ${_settings} (not in environment)"
+      fi
+    fi
+  fi
+
   if [[ -n "${_proxy_tok}" && -n "${_proxy_base}" ]]; then
     OPS_BASE_URL="${_proxy_base}"
     OPS_AUTH_HEADER="Authorization: Bearer ${_proxy_tok}"
@@ -128,8 +163,14 @@ except Exception:
     # "Claude Code-credentials" items (e.g. an mcpOAuth-only blob under another
     # account), and an unscoped lookup returns whichever matches first — which
     # may lack claudeAiOauth even when a valid token exists under $USER.
+    # ${USER:-}, not $USER: cron and launchd start this script with a bare
+    # environment where USER is unset, and `set -u` turns that into an
+    # "unbound variable" abort before any auth fallback is reached -- an
+    # obscure crash in place of a useful error. id -un is the reliable source.
     token=""
-    for _kc_acct in "$USER" ""; do
+    local _kc_user="${USER:-}"
+    [[ -z "${_kc_user}" ]] && _kc_user=$(id -un 2>/dev/null || true)
+    for _kc_acct in "${_kc_user}" ""; do
       if [[ -n "${_kc_acct}" ]]; then
         blob=$(security find-generic-password -s "Claude Code-credentials" -a "${_kc_acct}" -w 2>/dev/null || true)
       else
@@ -183,7 +224,7 @@ except Exception:
     return 0
   fi
 
-  die "No auth available; tried Claude Code OAuth (keychain), \$ANTHROPIC_API_KEY, keychain ANTHROPIC_API_KEY, and doppler"
+  die "No auth available; tried local proxy (env + ~/.claude/settings.json env block), Claude Code OAuth (keychain), \$ANTHROPIC_API_KEY, keychain ANTHROPIC_API_KEY, and doppler"
 }
 
 # Back-compat alias so older callers / forks still work

--- a/claude-ops/scripts/ops-memory-extractor.sh
+++ b/claude-ops/scripts/ops-memory-extractor.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 # ops-memory-extractor.sh — Extracts user preferences, contact profiles, and behavioral
 # patterns from WhatsApp + email history and writes structured memory files.
-# Runs every 30 min via ops-daemon cron service.
+#
+# Scheduled every 30 min by the ops-daemon cron service. ops-daemon's
+# trigger_smart_memory_extraction can additionally pull a run forward when new
+# high-value messages arrive; it is an "earlier", not a second schedule.
+# Concurrent runs are prevented by the lock below, which every entry point --
+# cron, smart trigger, manual -- goes through.
 set -euo pipefail
 
 # ── Portable shell helpers ────────────────────────────────────────────────────
@@ -16,12 +21,19 @@ _date_days_ago() {
 }
 
 # ── Config ────────────────────────────────────────────────────────────────────
-MEMORIES_DIR="${HOME}/.claude/plugins/data/ops-ops-marketplace/memories"
+DATA_ROOT="${OPS_DATA_DIR:-${HOME}/.claude/plugins/data/ops-ops-marketplace}"
+MEMORIES_DIR="${DATA_ROOT}/memories"
 HEALTH_FILE="${MEMORIES_DIR}/.health"
+# Lock lives under cache/, NOT under memories/: everything in memories/ is real
+# user data and the auto_compress pruner globs that directory.
+LOCK_DIR="${DATA_ROOT}/cache/ops-memory-extractor.lock"
+LOCK_PID_FILE="${LOCK_DIR}/pid"
+LOCK_HELD=0
 TMP_RAW="${TMPDIR:-/tmp}/ops-memory-raw-$$.json"
 TMP_PROMPT="${TMPDIR:-/tmp}/ops-memory-prompt-$$.txt"
 TMP_RESPONSE="${TMPDIR:-/tmp}/ops-memory-response-$$.json"
 TMP_GOG_ERR="${TMPDIR:-/tmp}/ops-memory-gog-$$.err"
+TMP_STREAM_ERR="${TMPDIR:-/tmp}/ops-memory-stream-$$.err"
 MAX_TOTAL_BYTES=51200   # 50KB ceiling across all memory files
 MAX_FILE_BYTES=5120     # 5KB per file before auto-compression
 LOG_PREFIX="[ops-memory-extractor]"
@@ -45,9 +57,92 @@ EOF
 }
 
 cleanup() {
-  rm -f "${TMP_RAW}" "${TMP_PROMPT}" "${TMP_RESPONSE}" "${TMP_GOG_ERR}"
+  rm -f "${TMP_RAW}" "${TMP_PROMPT}" "${TMP_RESPONSE}" "${TMP_GOG_ERR}" "${TMP_STREAM_ERR}"
+  # Only the process that actually took the lock may drop it. A run that exits
+  # because the lock was already held must never delete the holder's lock.
+  if [[ "${LOCK_HELD}" == "1" ]]; then
+    rm -rf "${LOCK_DIR}"
+    LOCK_HELD=0
+  fi
 }
 trap cleanup EXIT
+
+# ── Mutual exclusion ──────────────────────────────────────────────────────────
+# The lock lives HERE, in the extractor, rather than in the callers, because
+# there are two independent trigger paths (the 30-minute ops-daemon cron entry
+# and trigger_smart_memory_extraction) plus manual runs. A guard in one caller
+# cannot see the others: on 2026-08-24 the smart trigger started a run at
+# 18:00:23 and cron started a second at 18:00:54. Duplicate concurrent runs are
+# pure waste -- two copies build the same ~62KB prompt, pay for the same
+# completion, and race each other to write the same files.
+#
+# Note this lock is NOT what fixed the HTTP 504s. Those were measured to occur
+# just as reliably with a single run and no contention; see the streaming
+# comment in call_claude for the actual cause. The lock is still correct: the
+# proxy serialises requests, so overlapping runs inflate each other's latency
+# (measured 15s solo -> 28s with one other in flight) and push a marginal run
+# over the edge.
+#
+# `flock` is not present on macOS, so this is a mkdir-based lock: mkdir is
+# atomic on every filesystem that matters and needs no extra binary. The PID of
+# the holder is recorded inside so a lock left behind by a killed run can be
+# identified and broken instead of blocking every future run forever.
+_SELF_NAME="$(basename "${BASH_SOURCE[0]}")"
+
+_lock_owner_alive() {
+  # Alive AND still running THIS script. Checking the command as well as
+  # liveness matters because PIDs get recycled: a bare `kill -0` on a recycled
+  # PID would make a stale lock look permanently held.
+  #
+  # The name is taken from $0 rather than hardcoded. A hardcoded
+  # "ops-memory-extractor" match silently fails the moment the script is run
+  # through a renamed copy or a symlink -- the holder's own liveness check
+  # stops recognising it, every caller decides the lock is stale, and the
+  # mutual exclusion quietly evaporates while still looking correct in the log.
+  #
+  # `ps -ww` because the default output is truncated to terminal width and the
+  # script path -- the part being matched -- sits at the END of the command
+  # line, so truncation would drop exactly what we test for.
+  local pid="$1"
+  [[ -n "${pid}" ]] || return 1
+  kill -0 "${pid}" 2>/dev/null || return 1
+  ps -ww -p "${pid}" -o command= 2>/dev/null | grep -qF "${_SELF_NAME}"
+}
+
+acquire_lock() {
+  mkdir -p "$(dirname "${LOCK_DIR}")"
+
+  if mkdir "${LOCK_DIR}" 2>/dev/null; then
+    echo "$$" > "${LOCK_PID_FILE}"
+    LOCK_HELD=1
+    return 0
+  fi
+
+  local owner
+  owner=$(cat "${LOCK_PID_FILE}" 2>/dev/null || true)
+
+  # The holder creates the directory and writes its PID as two steps, so a
+  # racing process can observe the directory with the PID file not yet written.
+  # Give it a moment before concluding the lock is stale.
+  if [[ -z "${owner}" ]]; then
+    sleep 1
+    owner=$(cat "${LOCK_PID_FILE}" 2>/dev/null || true)
+  fi
+
+  if _lock_owner_alive "${owner}"; then
+    return 1
+  fi
+
+  log "Breaking stale lock at ${LOCK_DIR} (recorded pid=${owner:-none} is not running)"
+  rm -rf "${LOCK_DIR}"
+  if mkdir "${LOCK_DIR}" 2>/dev/null; then
+    echo "$$" > "${LOCK_PID_FILE}"
+    LOCK_HELD=1
+    return 0
+  fi
+  # Someone else won the race to re-create it; treat as held.
+  return 1
+}
 
 # ── Resolve auth (Claude Code OAuth preferred, API key fallback) ──────────────
 # Preference order:
@@ -443,11 +538,40 @@ data = sys.stdin.read()
 print(json.dumps(data))
 ")
 
+  # "stream": true is load-bearing, not a style choice.
+  #
+  # This call goes through the local CLIProxyAPI/Caddy data plane, which sets
+  # `response_header_timeout 30s` to bound time-to-first-token and detect dead
+  # routes. On a NON-streaming request the upstream sends no response headers
+  # until the entire completion has been generated, so that 30s ceases to be a
+  # TTFT bound and becomes a hard ceiling on total generation time.
+  #
+  # This prompt is ~62KB and its completion measures 37-44s of generation, so it
+  # blew through the header timeout on essentially every run. Measured
+  # 2026-08-24 with the identical captured prompt: non-streaming returns HTTP
+  # 504 at exactly 30.0s, repeatably, WITH NO OTHER EXTRACTOR RUNNING; streaming
+  # returns HTTP 200 in 37-44s. Every one of the 32 gateway 504s in the proxy
+  # log that day has duration 30.0s, and 17 of them had no concurrent run at
+  # all -- so this, not trigger overlap, was the cause of the failures.
+  #
+  # Streaming makes headers and the first SSE event arrive immediately, so the
+  # header timeout is satisfied and the remaining tokens stream in under the
+  # much larger read timeout. Do not "simplify" this back to a plain JSON
+  # response without also raising response_header_timeout in the Caddyfile.
+  #
+  # max_tokens is 8192, up from 4096. The extraction JSON for the current store
+  # measures ~4200 output tokens, so 4096 truncated it mid-object and the result
+  # failed to parse -- silently, because write_memory_files treats a JSON parse
+  # error as a warning and still reports the run healthy. 4096 was adequate when
+  # the store was smaller; it is the store's growth that crossed the boundary.
+  # Measured: max_tokens 4096 -> stop_reason "max_tokens", invalid JSON;
+  # max_tokens 8192 -> stop_reason "end_turn" at 4187 tokens, valid JSON.
   local payload
   payload=$(cat <<EOF
 {
   "model": "claude-haiku-4-5-20251001",
-  "max_tokens": 4096,
+  "max_tokens": 8192,
+  "stream": true,
   "system": $(printf '%s' "${system_prompt}" | python3 -c "import sys, json; print(json.dumps(sys.stdin.read()))"),
   "messages": [
     {"role": "user", "content": ${user_content}}
@@ -456,38 +580,79 @@ print(json.dumps(data))
 EOF
 )
 
-  log "Calling Claude Haiku for extraction (auth: ${OPS_AUTH_MODE:-unknown})..."
+  log "Calling Claude Haiku for extraction (auth: ${OPS_AUTH_MODE:-unknown}, streaming)..."
   local http_status
+  # --max-time bounds a stream that stalls mid-flight. The proxy's own read
+  # timeout is 900s, which is far too long to leave a scheduled job hanging;
+  # 300s is well clear of the 37-44s a healthy run takes.
   http_status=$(curl -s -o "${TMP_RESPONSE}" -w "%{http_code}" \
+    --no-buffer --max-time 300 \
     "${OPS_BASE_URL:-https://api.anthropic.com}/v1/messages" \
     -H "content-type: application/json" \
     -H "${OPS_AUTH_HEADER}" \
     -H "anthropic-version: 2023-06-01" \
+    -H "accept: text/event-stream" \
     "${OPS_AUTH_EXTRA_HEADERS[@]}" \
     -d "${payload}" 2>/dev/null)
 
   if [[ "${http_status}" != "200" ]]; then
     local err
-    err=$(cat "${TMP_RESPONSE}" 2>/dev/null || echo "unknown error")
+    err=$(head -c 400 "${TMP_RESPONSE}" 2>/dev/null || echo "unknown error")
     die "Claude API returned HTTP ${http_status}: ${err}"
   fi
 
-  # Extract text content from response
-  python3 - <<'PYEOF' "${TMP_RESPONSE}"
+  # Reassemble the SSE stream into the assistant's text.
+  local text
+  if ! text=$(python3 - "${TMP_RESPONSE}" 2>"${TMP_STREAM_ERR}" <<'PYEOF'
 import sys, json
 
-resp_file = sys.argv[1]
-with open(resp_file) as f:
-    data = json.load(f)
+parts, err, stop_reason = [], None, None
+with open(sys.argv[1], encoding="utf-8", errors="replace") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue
+        blob = line[5:].strip()
+        if not blob or blob == "[DONE]":
+            continue
+        try:
+            ev = json.loads(blob)
+        except Exception:
+            continue
+        etype = ev.get("type")
+        if etype == "content_block_delta":
+            delta = ev.get("delta") or {}
+            if delta.get("type") == "text_delta":
+                parts.append(delta.get("text", ""))
+        elif etype == "message_delta":
+            stop_reason = (ev.get("delta") or {}).get("stop_reason") or stop_reason
+        elif etype == "error":
+            e = ev.get("error") or {}
+            err = "{}: {}".format(e.get("type", "error"), e.get("message", ""))
 
-content = data.get("content", [])
-for block in content:
-    if block.get("type") == "text":
-        print(block["text"])
-        sys.exit(0)
+if err:
+    sys.stderr.write(err)
+    sys.exit(1)
 
-print("{}")
+text = "".join(parts).strip()
+if not text:
+    # An empty stream is a real failure, not an empty extraction: report it so
+    # the caller does not record a healthy "no new memories" run.
+    sys.stderr.write("stream contained no text content (stop_reason={})".format(stop_reason))
+    sys.exit(1)
+
+# max_tokens truncation yields invalid JSON downstream; surface it clearly.
+if stop_reason == "max_tokens":
+    sys.stderr.write("response truncated at max_tokens")
+    sys.exit(1)
+
+print(text)
 PYEOF
+  ); then
+    die "Claude streaming response unusable: $(head -c 300 "${TMP_STREAM_ERR}" 2>/dev/null)"
+  fi
+
+  printf '%s\n' "${text}"
 }
 
 # ── Write memory files ────────────────────────────────────────────────────────
@@ -696,6 +861,17 @@ PYEOF
 
 # ── Main ──────────────────────────────────────────────────────────────────────
 main() {
+  # Take the lock before announcing a run, so a skipped attempt does not look
+  # like a started one in the log. A held lock is the normal, expected outcome
+  # of two triggers lining up -- it is not an error, so exit 0 and leave the
+  # health file alone (overwriting it would mask the real last run's status).
+  if ! acquire_lock; then
+    local holder
+    holder=$(cat "${LOCK_PID_FILE}" 2>/dev/null || echo "unknown")
+    log "Another extraction is already running (pid=${holder}) — skipping this run"
+    exit 0
+  fi
+
   log "Starting memory extraction run at $(ts)"
   mkdir -p "${MEMORIES_DIR}"
 

--- a/claude-ops/scripts/ops-memory-extractor.sh
+++ b/claude-ops/scripts/ops-memory-extractor.sh
@@ -21,6 +21,7 @@ HEALTH_FILE="${MEMORIES_DIR}/.health"
 TMP_RAW="${TMPDIR:-/tmp}/ops-memory-raw-$$.json"
 TMP_PROMPT="${TMPDIR:-/tmp}/ops-memory-prompt-$$.txt"
 TMP_RESPONSE="${TMPDIR:-/tmp}/ops-memory-response-$$.json"
+TMP_GOG_ERR="${TMPDIR:-/tmp}/ops-memory-gog-$$.err"
 MAX_TOTAL_BYTES=51200   # 50KB ceiling across all memory files
 MAX_FILE_BYTES=5120     # 5KB per file before auto-compression
 LOG_PREFIX="[ops-memory-extractor]"
@@ -44,7 +45,7 @@ EOF
 }
 
 cleanup() {
-  rm -f "${TMP_RAW}" "${TMP_PROMPT}" "${TMP_RESPONSE}"
+  rm -f "${TMP_RAW}" "${TMP_PROMPT}" "${TMP_RESPONSE}" "${TMP_GOG_ERR}"
 }
 trap cleanup EXIT
 
@@ -231,6 +232,44 @@ except Exception:
 resolve_api_key() { resolve_auth; }
 
 # ── Collect raw data ──────────────────────────────────────────────────────────
+# Resolve the mailbox gog should read. gog only picks an account implicitly when
+# exactly one token is stored; there are ~20 here, so it always needs --account.
+# The configured default is an OAuth account whose token lives in gog's file
+# keyring, and that keyring cannot be unlocked without a TTY or
+# GOG_KEYRING_PASSWORD -- so the default resolves by hand and fails under
+# launchd, the same environment asymmetry resolve_auth() deals with above.
+# Service-account tokens carry no such requirement and work headlessly.
+resolve_gog_account() {
+  local _acct="${GOG_ACCOUNT:-}"
+  if [[ -n "${_acct}" ]]; then
+    printf '%s' "${_acct}"
+    return 0
+  fi
+
+  # Then this plugin's own preferences. Deliberately NOT settings.json's `env`
+  # block: Claude Code injects that into every session, so a GOG_ACCOUNT there
+  # would silently redirect interactive gog calls too. Keep the daemon's mailbox
+  # choice scoped to the daemon.
+  local _prefs="${HOME}/.claude/plugins/data/ops-ops-marketplace/preferences.json"
+  if [[ -r "${_prefs}" ]] && command -v python3 &>/dev/null; then
+    _acct=$(python3 - "${_prefs}" <<'PYEOF' 2>/dev/null || true
+import json, sys
+try:
+    prefs = json.load(open(sys.argv[1])) or {}
+except Exception:
+    sys.exit(0)
+print((prefs.get("gog_account") or "").strip())
+PYEOF
+    )
+    if [[ -n "${_acct}" ]]; then
+      printf '%s' "${_acct}"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
 collect_data() {
   local wa_data="" email_data=""
   local yesterday
@@ -258,10 +297,21 @@ collect_data() {
 
   # Email via gog
   if command -v gog &>/dev/null; then
-    log "Collecting recent emails..."
-    email_data=$(gog gmail search -j --results-only --no-input --max 20 "newer_than:1d" 2>/dev/null || true)
-    if [[ -z "${email_data}" ]]; then
-      log "gog returned no data (skipping)"
+    local gog_acct=""
+    gog_acct=$(resolve_gog_account || true)
+    local -a gog_args=(gmail search -j --results-only --no-input --max 20 "newer_than:1d")
+    [[ -n "${gog_acct}" ]] && gog_args+=(--account "${gog_acct}")
+    log "Collecting recent emails${gog_acct:+ for ${gog_acct}}..."
+    email_data=$(gog "${gog_args[@]}" 2>"${TMP_GOG_ERR}" || true)
+    # An empty array is a successful search with no hits; treat it as no data.
+    if [[ -z "${email_data}" || "${email_data}" == "[]" ]]; then
+      email_data=""
+      # Never swallow gog's stderr. This call used 2>/dev/null, so
+      # "missing --account" was logged as "gog returned no data" and read as
+      # "quiet inbox" for weeks while the daemon extracted nothing at all.
+      local _gog_err=""
+      [[ -s "${TMP_GOG_ERR}" ]] && _gog_err=$(tr '\n' ' ' < "${TMP_GOG_ERR}" | cut -c1-300)
+      log "gog returned no data${_gog_err:+ -- ${_gog_err}} (skipping)"
     fi
   else
     log "gog not available (skipping email)"


### PR DESCRIPTION
Continues merged PR #866 (deferred specialist discovery context) with 6 follow-up
fixes cherry-picked from perf/ops-lazy-discovery-router that never made it to main:

- fix(ops): resolve proxy auth from settings.json; guard unset USER
- fix(ops): give the memory extractor a resolvable gog account, and stop hiding gog errors
- fix(ops): cap the memory context sent to Haiku so a large store can't wedge the run
- ops-daemon: stop hiding gog stderr in briefing and calendar prefetch
- fix(ops): stop the memory extractor running 3x its schedule, and fix the 504s
- ops-daemon: route the 10-minute memory trigger through the desk wrapper too

Note: a 7th fix from that branch (`380d284`, "fix(unread): follow the WhatsApp
bridge when it is not local") is NOT included here. It patches the old
direct-Baileys-bridge code path in `claude-ops/bin/ops-unread`, which main has
since replaced with an `ops-wa-accounts`/policy-based resolver. The two are
structurally incompatible, so it needs a manual reimplementation against the
current resolver rather than a cherry-pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)