### PR TITLE
fix(ops-speedup): stop counting systemctl legend line as a failed unit

### DIFF
--- a/claude-ops/bin/ops-speedup
+++ b/claude-ops/bin/ops-speedup
@@ -492,7 +492,15 @@ probe_startup() {
       echo "launch_agents=$agents"
     elif $IS_LINUX || $IS_WSL; then
       local failed enabled
-      failed=$(systemctl --failed --no-pager 2>/dev/null | grep -c "loaded" || echo 0)
+      # `systemctl --failed --no-pager` prints a trailing legend even when
+      # nothing failed ("0 loaded units listed."), so grep -c "loaded"
+      # returned 1 on a perfectly healthy box and cost 5 health points
+      # forever (verified 2026-08-29: host had 0 failed units in BOTH system
+      # and user scope while the scan reported failed_units=1). Use
+      # --no-legend and count real rows. Note `|| true`, not `|| echo 0`:
+      # grep -c prints 0 AND exits 1 on no match, which would concatenate.
+      failed=$(systemctl --failed --no-legend --no-pager 2>/dev/null | grep -c . || true)
+      failed=${failed:-0}
       enabled=$(systemctl list-unit-files --state=enabled --no-pager --no-legend 2>/dev/null | wc -l | tr -d ' ')
       echo "failed_units=$failed"
       echo "enabled_units=$enabled"


### PR DESCRIPTION
## Problem

`systemctl --failed --no-pager` prints a trailing legend line even when nothing has failed:

```
0 loaded units listed.
```

The startup probe counted failures with `grep -c "loaded"`, which matches that legend. So on a **completely healthy** Linux or WSL box the scan reported `failed_units=1`, which:

- applied a constant `-5` health penalty (`score=$((score - 5))`)
- surfaced a false `failed-startup-units` factor in every single scan

## Evidence

On a host with zero failed units in **both** system and user scope:

```
$ systemctl --failed --no-legend | grep -c .
0
$ systemctl --user --failed --no-legend | grep -c .
0

$ systemctl --failed --no-pager | grep -c "loaded"      # the old code
1
$ systemctl --failed --no-pager | grep -n "loaded"
3:0 loaded units listed.
```

Before/after on the same box, nothing else changed:

```
failed_units: 1 -> 0
factors: [... 'failed-startup-units']  ->  [...]     # factor cleared
```

## Fix

Use `--no-legend` and count real rows.

Note the `|| true` rather than `|| echo 0`: `grep -c` prints `0` **and** exits 1 when there are no matches, so `|| echo 0` would run too and concatenate into `0\n0`, which then fails the later `-gt 0` integer comparison.

## Verification

- `bash -n bin/ops-speedup` clean
- Re-scanned the same host: `failed_units` 1 → 0, `failed-startup-units` factor gone
- macOS path (`launch_agents` count) untouched; this is inside the `elif $IS_LINUX || $IS_WSL` branch
