### PR TITLE
fix(vip): fail loud when the VIP list is not configured

### DIFF
--- a/claude-ops/skills/vip/SKILL.md
+++ b/claude-ops/skills/vip/SKILL.md
@@ -53,6 +53,16 @@ VIP_LIST_PATH="${VIP_LIST_PATH:-$(read_pref vip_list_path)}"
 VIP_LIST_PATH="${VIP_LIST_PATH:-$HOME/.claude-ops/state/vip-list.json}"
 VIP_MAX_TIER="${VIP_MAX_TIER:-$(read_pref vip_max_tier)}"
 VIP_MAX_TIER="${VIP_MAX_TIER:-2}"
+
+# "No VIPs" and "the VIP list was never set up" are DIFFERENT answers and must
+# never look the same. An unconfigured install that silently reports an empty
+# list turns this skill into a no-op: every inbox sweep then treats the most
+# important people as ordinary traffic and nobody finds out. Fail loud.
+if [ ! -f "$VIP_LIST_PATH" ]; then
+  echo "vip: no list at $VIP_LIST_PATH — set userConfig vip_list_path or VIP_LIST_PATH." >&2
+  echo "vip: copy templates/vip-list.example.json there to start one." >&2
+  exit 3
+fi
 ```
 
 The list file lives OUTSIDE the repo tree — it is the operator's identity and


### PR DESCRIPTION
## What

Follow-up audit of the `relations` and `vip` skills added in #902, checked
line by line against the current [Claude Code skills reference](https://code.claude.com/docs/en/skills)
and the [Hermes Agent plugins doc](https://hermes-agent.nousresearch.com/docs/user-guide/features/plugins).

One real defect found and fixed.

## The defect: `vip` could not tell "no VIPs" from "never set up"

The config block resolved `vip_list_path` through userConfig -> env -> a
`$HOME` default, but never checked the file was there. On an install where
the operator had not created the list yet, every read returned nothing and
the skill reported an empty VIP set, which is indistinguishable from a real
no-VIPs answer.

That failure is silent and total. `ops-inbox` step 0 asks `vip` for the tier
order; an empty answer means every sweep ranks the most important people as
ordinary traffic, and nothing anywhere reports a problem. The sibling
`relations` skill already guards exactly this class with its no-ledger-CLI
check, so `vip` was the odd one out.

Now it exits 3 naming the path it looked at, both ways to set it, and the
bundled `templates/vip-list.example.json` to start from.

## Checked, no change needed

- **Frontmatter keys**: every key in both skills (`name`, `description`,
  `argument-hint`, `allowed-tools`) is in the documented allowed set. No
  unknown keys.
- **Description cap**: docs truncate `description` + `when_to_use` at 1,536
  chars in the skill listing. Ours are 106 and 111.
- **`when_to_use`**: optional, and 0 of 66 skills in this repo use it. Trigger
  phrases live in `skills/ops/references/capabilities.json` instead, where
  both skills are indexed. Adding it would duplicate the router and drift.
- **Config placement**: all 12 keys (`relations_*`, `vip_*`) stay in
  `.claude-plugin/plugin.json`; the skill bodies read them via
  userConfig -> env -> `$HOME` default (16 and 11 references).
- **Templatable / no PII**: no real name, phone, email, `/Users/...` path or
  operator-specific tool name in either file.
- **Cross-wiring**: `ops-inbox` (5 refs), `ops-comms` (2), `people` (3).

## Tests

`tests/run-all.sh` 41/41.

Two suites went red once each under parallel load and green on a clean rerun
(`test-skills-lint.sh` claiming `ops-desktop` had no `name` field, which it
does; `test-account-recovery.sh`). Neither touches this change.
