### PR TITLE
fix(ops-speedup): do not count SSH-automation zombies as machine health defects

### DIFF
--- a/claude-ops/bin/ops-speedup
+++ b/claude-ops/bin/ops-speedup
@@ -24,22 +24,36 @@ else
 fi
 
 # Count the latest runnable/zombie states and only call a PID stuck when the
-# same PID remains blocked across all three samples. Kept as one shared helper
-# so regression checks exercise the exact classifier used by the live probe.
+# same PID remains blocked across all three samples. Optional columns 3/4 are
+# PPID and command. A zombie parented by sshd-session is the agent's own SSH
+# connection lifecycle on macOS, not a machine-health defect; ignore only that
+# exact relationship. Kept as one shared helper so regression checks exercise
+# the exact classifier used by the live probe.
 classify_process_state_samples() {
   awk '
     FNR == 1 { sample++ }
     {
       pid=$1; state=$2
       if (!(pid in seen)) { seen[pid]=1; total++ }
-      if (sample == 3 && state ~ /^R/) running++
-      if (sample == 3 && state ~ /^Z/) zombies++
+      if (sample == 3) {
+        latest_state[pid]=state
+        latest_ppid[pid]=$3
+        latest_comm[pid]=$4
+      }
       if (state ~ /^U/) blocked[pid]++
     }
     END {
       if (sample != 3) {
         print "classify_process_state_samples: expected 3 samples, got " sample+0 " (empty or missing ps output?)" > "/dev/stderr"
         exit 1
+      }
+      running=0; zombies=0
+      for (pid in latest_state) {
+        if (latest_state[pid] ~ /^R/) running++
+        if (latest_state[pid] ~ /^Z/) {
+          parent=latest_ppid[pid]
+          if (latest_comm[parent] !~ /^sshd-session/) zombies++
+        }
       }
       persistent=0
       for (pid in blocked) if (blocked[pid] == 3) persistent++
@@ -326,9 +340,9 @@ probe_runtime() {
       states1=$(mktemp "${TMPDIR%/}/ops-speedup-states.XXXXXX")
       states2=$(mktemp "${TMPDIR%/}/ops-speedup-states.XXXXXX")
       states3=$(mktemp "${TMPDIR%/}/ops-speedup-states.XXXXXX")
-      ps -Ao pid=,stat= 2>/dev/null >"$states1"; sleep 1
-      ps -Ao pid=,stat= 2>/dev/null >"$states2"; sleep 1
-      ps -Ao pid=,stat= 2>/dev/null >"$states3"
+      ps -Ao pid=,stat=,ppid=,comm= 2>/dev/null >"$states1"; sleep 1
+      ps -Ao pid=,stat=,ppid=,comm= 2>/dev/null >"$states2"; sleep 1
+      ps -Ao pid=,stat=,ppid=,comm= 2>/dev/null >"$states3"
       process_counts=$(classify_process_state_samples "$states1" "$states2" "$states3")
       rm -f "$states1" "$states2" "$states3"
       tcp_counts=$(netstat -an 2>/dev/null | awk '$6=="CLOSE_WAIT"{cw++} $6=="TIME_WAIT"{tw++} END{printf "%d %d",cw+0,tw+0}')

--- a/claude-ops/tests/test-ops-speedup.sh
+++ b/claude-ops/tests/test-ops-speedup.sh
@@ -82,6 +82,28 @@ state_counts=$(bash "$BIN" --classify-process-states \
   "$tmpdir/states-1" "$tmpdir/states-2" "$tmpdir/states-3")
 assert_eq "transient U is ignored and persistent U is counted" "5 2 1 1" "$state_counts"
 
+# SSH automation on macOS can leave a defunct child under a still-live
+# sshd-session parent. That is the agent's own connection lifecycle, not a
+# machine-health defect. Ignore only that exact parent relationship; an
+# unrelated zombie must still count.
+for n in 1 2; do
+  cat >"$tmpdir/states-sshd-$n" <<'EOF'
+700 S 1 sshd-session
+701 S 700 child
+800 S 1 ordinary-parent
+801 S 800 child
+EOF
+done
+cat >"$tmpdir/states-sshd-3" <<'EOF'
+700 S 1 sshd-session
+701 Z 700 child
+800 S 1 ordinary-parent
+801 Z 800 child
+EOF
+sshd_zombies=$(bash "$BIN" --classify-process-states \
+  "$tmpdir/states-sshd-1" "$tmpdir/states-sshd-2" "$tmpdir/states-sshd-3")
+assert_eq "sshd-session zombie is ignored but unrelated zombie counts" "4 0 0 1" "$sshd_zombies"
+
 cat >"$tmpdir/states-none-1" <<'EOF'
 11 U
 12 S
@@ -107,17 +129,17 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
   cat >"$tmpdir/mock-bin/ps" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ "$*" == "-Ao pid=,stat=" ]]; then
+if [[ "$*" == "-Ao pid=,stat=,ppid=,comm=" ]]; then
   count_file="$OPS_SPEEDUP_PS_COUNT"
   count=0
   [[ -f "$count_file" ]] && count=$(cat "$count_file")
   count=$((count + 1))
   printf '%s\n' "$count" >"$count_file"
   case "${OPS_SPEEDUP_PS_SCENARIO}:${count}" in
-    transient:1) printf '101 U\n202 S\n' ;;
-    transient:2) printf '101 S\n202 U\n' ;;
-    transient:3) printf '101 R\n202 S\n' ;;
-    persistent:*) printf '101 U\n202 S\n' ;;
+    transient:1) printf '101 U 1 worker\n202 S 1 worker\n' ;;
+    transient:2) printf '101 S 1 worker\n202 U 1 worker\n' ;;
+    transient:3) printf '101 R 1 worker\n202 S 1 worker\n' ;;
+    persistent:*) printf '101 U 1 worker\n202 S 1 worker\n' ;;
     *) exit 3 ;;
   esac
 else


### PR DESCRIPTION
Every agent SSH session into a macOS box can leave a defunct child under a still-live `sshd-session` parent. Those are the connection lifecycle of the automation itself and self-clear when the session ends, but the scanner counted them, so a healthy Mac reported phantom zombies on every scan and a genuinely leaked process was buried in that noise.

`classify_process_state_samples` now reads PPID and command alongside state and skips a zombie only when its parent is `sshd-session`. Every other zombie still counts. The ps probes widen to `pid,stat,ppid,comm` to supply those columns.

**Verified on live data:** 5 raw zombies on a Mac, 3 sshd-parented and correctly discounted, 2 real ones surfaced under a busy gateway (which then reaped them).

**Regression test fails without the fix:** two zombies, one sshd-parented and one under an ordinary parent, expects exactly one counted.

Rebased onto #915; both changes verified to coexist (its Linux CPU sampling fix is intact).

Tests: 21/21 focused, all suites pass, 27/27 secret checks.