### PR TITLE
fix(installer): verify the Hermes native plugin link, not just skills

### DIFF
--- a/claude-ops/scripts/whatsapp/ENDPOINTS.md
+++ b/claude-ops/scripts/whatsapp/ENDPOINTS.md
@@ -139,11 +139,11 @@ it's a typed wrapper. So the MCP can never succeed where the REST endpoint fails
    one-draft → one-approval gate (token at `/tmp/.claude-send-ok`).
 
    **Attachments cross a host boundary.** `send_file` reads `media_path` off the **bridge's own
-   filesystem**, and the bridges run on ai-hub — not on the machine the agent is on. A local path
-   from anywhere else fails with `HTTP 500 - Error reading media file`. There is no server-side
-   fallback and there cannot be one: the MCP server runs on ai-hub too, so it cannot read the
-   agent's disk either. Read the file, base64 it, `upload_media`, then `send_file` with the
-   `media_path` that comes back.
+   filesystem**, and the bridges run on the bridge host — not on the machine the agent is on. A
+   local path from anywhere else fails with `HTTP 500 - Error reading media file`. There is no
+   server-side fallback and there cannot be one: the MCP server runs on that same bridge host, so
+   it cannot read the agent's disk either. Read the file, base64 it, `upload_media`, then
+   `send_file` with the `media_path` that comes back.
 
    `upload_media` is deliberately **not** gated by the outbound guard — staging bytes is not a
    send, and gating it would spend the approval token before the real send. The send still needs

--- a/installer/src/dispatch.mjs
+++ b/installer/src/dispatch.mjs
@@ -7,7 +7,7 @@ import { detectAll, AGENT_DEFS } from "./detect.mjs";
 import { ensureSource, listSourceSkills, listSourceBin } from "./source.mjs";
 import { planMirror, applyActions } from "./mirror.mjs";
 import { planBinLinks, applyBinLinks } from "./bin.mjs";
-import { verifyAgent } from "./verify.mjs";
+import { verifyAgent, verifyNativePlugin } from "./verify.mjs";
 import { runDoctor as runDoctorChecks } from "./doctor.mjs";
 import {
   loadManifest,
@@ -343,6 +343,14 @@ export async function runVerify(flags) {
   const agents = pickAgents(cfg, flags.agents);
   const reports = [];
   for (const [name, a] of Object.entries(agents)) {
+    if (a.pluginPath) {
+      const p = verifyNativePlugin({
+        srcDir: src.dir,
+        agentName: `${name}:plugin`,
+        pluginPath: a.pluginPath,
+      });
+      if (!p.skipped) reports.push(p);
+    }
     if (!a.skillsPath) {
       reports.push({ name, skipped: true });
       continue;

--- a/installer/src/doctor.mjs
+++ b/installer/src/doctor.mjs
@@ -1,7 +1,7 @@
 // doctor.mjs — verify + tool checks + env checks.
 
 import { execSync } from "node:child_process";
-import { verifyAgent } from "./verify.mjs";
+import { verifyAgent, verifyNativePlugin } from "./verify.mjs";
 
 function tryExec(cmd) {
   try {
@@ -17,8 +17,25 @@ function tryExec(cmd) {
 
 export async function runDoctor({ srcDir, agents }) {
   const checks = [];
-  // 1. Each agent's mirror
+  // 1. Each agent's mirror, plus its native plugin link when it has one.
   for (const [name, a] of Object.entries(agents)) {
+    if (a.pluginPath) {
+      const p = verifyNativePlugin({
+        srcDir,
+        agentName: name,
+        pluginPath: a.pluginPath,
+      });
+      if (!p.skipped) {
+        checks.push({
+          name: `${name}:plugin`,
+          ok: p.drifts.length === 0 && p.missing.length === 0,
+          msg:
+            p.drifts.length || p.missing.length
+              ? p.drifts[0]?.reason || "plugin link missing"
+              : a.pluginPath,
+        });
+      }
+    }
     if (!a.skillsPath) {
       checks.push({ name, ok: false, msg: "no skillsPath" });
       continue;

--- a/installer/src/verify.mjs
+++ b/installer/src/verify.mjs
@@ -39,3 +39,51 @@ export function verifyAgent({ srcDir, agentName, targetDir }) {
   }
   return { agent: agentName, targetDir, ok: ok.length, missing, drifts };
 }
+
+// The Hermes native plugin is installed as a symlink at ~/.hermes/plugins/ops
+// pointing at <src>/hermes-plugin. `verify` used to check skills only, so a
+// plugin that had drifted into a real directory — a stale copy pinned at an old
+// version, with its own edits — reported clean. That is the one file the agent
+// actually loads, so a silent copy there means the box runs old plugin code
+// while every skill looks in sync.
+export function verifyNativePlugin({ srcDir, agentName, pluginPath }) {
+  const from = path.join(srcDir, "hermes-plugin");
+  const drifts = [];
+  if (!pluginPath) return { agent: agentName, pluginPath: null, skipped: true };
+  if (!fs.existsSync(path.join(from, "plugin.yaml"))) {
+    return { agent: agentName, pluginPath, skipped: true };
+  }
+  let st = null;
+  try {
+    st = fs.lstatSync(pluginPath);
+  } catch (_e) {}
+  if (!st) {
+    return {
+      agent: agentName,
+      pluginPath,
+      ok: 0,
+      missing: [{ name: "hermes-plugin", from, to: pluginPath }],
+      drifts,
+    };
+  }
+  if (!st.isSymbolicLink()) {
+    drifts.push({
+      name: "hermes-plugin",
+      from,
+      to: pluginPath,
+      reason: "target is not a symlink (stale copy shadows the source tree)",
+    });
+    return { agent: agentName, pluginPath, ok: 0, missing: [], drifts };
+  }
+  const cur = fs.readlinkSync(pluginPath);
+  if (cur !== from && cur !== from + "/") {
+    drifts.push({
+      name: "hermes-plugin",
+      from,
+      to: pluginPath,
+      reason: `symlink points at ${cur}, expected ${from}`,
+    });
+    return { agent: agentName, pluginPath, ok: 0, missing: [], drifts };
+  }
+  return { agent: agentName, pluginPath, ok: 1, missing: [], drifts };
+}

--- a/installer/test/smoke.mjs
+++ b/installer/test/smoke.mjs
@@ -9,6 +9,7 @@ import { listSourceSkills, listSourceBin } from "../src/source.mjs";
 import { planBinLinks, applyBinLinks } from "../src/bin.mjs";
 import { planMirror } from "../src/mirror.mjs";
 import { planAll, planNativePlugin } from "../src/dispatch.mjs";
+import { verifyNativePlugin } from "../src/verify.mjs";
 import {
   loadManifest,
   saveManifest,
@@ -175,6 +176,58 @@ try {
     pluginPlan.action.from.endsWith(`${path.sep}hermes-plugin`) ||
       pluginPlan.action.from.endsWith("/hermes-plugin"),
     "plugin symlink source is hermes-plugin/",
+  );
+
+  // 5. verify must catch a native plugin that drifted into a real directory.
+  // Regression: verify/doctor checked skills only, so a box running a stale
+  // COPY of hermes-plugin (old version, local edits) reported clean while the
+  // agent loaded outdated plugin code. Found live 2026-09-05: one host sat on
+  // plugin 3.10.1 with a hand-edited __init__.py; every skill verified green.
+  const pluginLinked = path.join(scratch, "plugin-linked", "ops");
+  fs.mkdirSync(path.dirname(pluginLinked), { recursive: true });
+  fs.symlinkSync(path.join(SRC, "hermes-plugin"), pluginLinked);
+  const linkedReport = verifyNativePlugin({
+    srcDir: SRC,
+    agentName: "hermes",
+    pluginPath: pluginLinked,
+  });
+  assert(
+    linkedReport.ok === 1 && linkedReport.drifts.length === 0,
+    "verifyNativePlugin passes a correct symlink",
+  );
+
+  const pluginCopied = path.join(scratch, "plugin-copied", "ops");
+  fs.mkdirSync(pluginCopied, { recursive: true });
+  fs.writeFileSync(
+    path.join(pluginCopied, "plugin.yaml"),
+    'version: "0.0.1"\n',
+  );
+  const copiedReport = verifyNativePlugin({
+    srcDir: SRC,
+    agentName: "hermes",
+    pluginPath: pluginCopied,
+  });
+  assert(
+    copiedReport.drifts.length === 1 &&
+      copiedReport.drifts[0].reason.includes("not a symlink"),
+    "verifyNativePlugin flags a stale real-directory copy as drift",
+  );
+
+  const pluginAbsent = path.join(scratch, "plugin-absent", "ops");
+  const absentReport = verifyNativePlugin({
+    srcDir: SRC,
+    agentName: "hermes",
+    pluginPath: pluginAbsent,
+  });
+  assert(
+    absentReport.missing.length === 1,
+    "verifyNativePlugin reports an absent plugin link as missing",
+  );
+
+  assert(
+    verifyNativePlugin({ srcDir: SRC, agentName: "codex", pluginPath: null })
+      .skipped === true,
+    "verifyNativePlugin skips agents with no plugin path",
   );
 } finally {
   fs.rmSync(scratch, { recursive: true, force: true });


### PR DESCRIPTION
## What

`verify` and `doctor` only checked each agent's **skills** mirror. The Hermes native plugin lives at `~/.hermes/plugins/ops` and is supposed to be a symlink into `<src>/hermes-plugin` — nothing checked it.

So a box where that path had drifted into a **real directory** (a stale copy of the plugin, pinned at an old version, with local edits) reported completely clean, while the agent loaded outdated plugin code on every turn. That directory holds the one file the agent actually executes.

## How it was found

Live on 2026-09-05, auditing two hosts for parity. One host ran plugin **3.10.1** with a hand-edited `__init__.py` (hardcoded skills dir, an old `register_command` path) while the repo was on **3.10.4** and every skill verified green. `verify` had no way to see it.

## Changes

- `installer/src/verify.mjs` — new `verifyNativePlugin()`. Reports three failure shapes: link absent, a real directory shadowing the source tree, and a symlink pointing somewhere else.
- `installer/src/dispatch.mjs`, `installer/src/doctor.mjs` — run it for any agent that declares a plugin path. Agents without one are skipped, so nothing changes for Claude Code, Codex, Gemini, OpenClaw, or OpenCode.
- `installer/test/smoke.mjs` — four cases: correct symlink, stale real-directory copy, absent link, and the no-plugin-path skip. The stale-copy case is the regression itself; it fails against `main`'s `verify.mjs`.

Also drops one operator hostname from `claude-ops/scripts/whatsapp/ENDPOINTS.md`. The secret-scan denylist flags it on `main` today (`npm test` → 26 passed, 1 failed), and the sentence keeps its meaning without it.

## Verification

```
installer:  npm run type-check  → clean
installer:  npm run lint        → All matched files use Prettier code style!
installer:  node test/smoke.mjs → all green (21 assertions)
claude-ops: npm test            → Results: 27 passed, 0 failed
```

Behaviour change for existing users: a host whose plugin link has silently drifted now fails `verify`/`doctor` instead of passing. That is the point — the fix is `claude-ops-installer install --force`.