### PR TITLE
docs(ops-release,ops-update): two failure modes that both look like success

### DIFF
--- a/claude-ops/skills/ops-release/SKILL.md
+++ b/claude-ops/skills/ops-release/SKILL.md
@@ -125,6 +125,38 @@ It works inside an **isolated worktree** (`$REPO_ROOT/.worktrees/release/vX.Y.Z`
 branched from `origin/main`), so a dirty main checkout never leaks unrelated WIP
 into the release commit. The worktree is removed on exit.
 
+## The run outlives an agent's foreground timeout — check before re-running
+
+A full release takes longer than a Hermes/agent foreground terminal call allows
+(~7 min hard kill regardless of the requested timeout). When the call dies, the
+script has usually **already** branched, pushed, opened the PR, waited for CI
+and merged — you just never saw the output. Verified 2026-09-05: the timeout
+fired, and a blind retry opened a duplicate release PR (#923) alongside the
+script's own already-merged #922.
+
+Before doing anything after a timeout, read the live state:
+
+```bash
+gh pr list --state merged --limit 5 --json number,title,headRefName
+git fetch --tags origin && git ls-remote --tags origin "v$NEW"
+git show origin/main:claude-ops/.claude-plugin/plugin.json | head -3
+```
+
+Then finish only what is genuinely missing:
+
+- PR merged, version on `origin/main`, **tag absent** → the script died between
+  merge and tag. Tag the merge commit yourself:
+  `git tag -a vX.Y.Z <merge-sha> -m "vX.Y.Z" && git push origin vX.Y.Z`.
+- PR still open → let it finish, do not open a second one.
+- Nothing pushed → re-run the release.
+
+If you did open a duplicate, close it referencing the real one and delete the
+remote branch it shares — both PRs point at the same `release/vX.Y.Z` head, so
+deleting that branch after the real merge is what cleans up.
+
+Better: run the apply step with `background=true, notify=true` instead of a
+foreground call, and let the completion notification carry the output.
+
 ## Mobile / SSH (Rule 7)
 
 The bin auto-detects a non-TTY and drops colour; its output is already

--- a/claude-ops/skills/ops-update/SKILL.md
+++ b/claude-ops/skills/ops-update/SKILL.md
@@ -90,6 +90,30 @@ pruned, which files would be rewritten. If the dry-run shows
 `already on <ver>` and nothing to prune/rewrite, tell the user the box is
 already current and stop (offer `--force` only if they suspect a stale cache).
 
+**"already on <ver>" is a lie when the marketplace clone is stuck.** Step 1
+prints `✓ marketplace catalogue refreshed` even when the underlying git pull
+silently did nothing, so step 2 resolves a stale target and the whole run
+no-ops. `~/.claude/plugins/marketplaces/ops-marketplace` is a real checkout of
+this repo; a dirty worktree (a local edit, stray `.bak` files) blocks the
+fast-forward. Verified 2026-09-05: it sat 28 commits behind on v3.10.3 while
+v3.10.5 was published, and the update reported the box current.
+
+Whenever the target version does not match what you just released, check the
+clone before reaching for `--force`:
+
+```bash
+cd ~/.claude/plugins/marketplaces/ops-marketplace
+git fetch -q origin
+git status -sb                 # ahead/behind AND porcelain lines
+grep -o '"version": *"[^"]*"' .claude-plugin/marketplace.json | head -1
+```
+
+Repair: diff each modified file against `origin/main` first — a local edit that
+is byte-identical to upstream is safe to drop, anything else is real work that
+must be salvaged before you touch it. Then clean the tree,
+`git merge --ff-only origin/main`, and re-run the dry-run. The target version
+should now be the published one.
+
 ### 2. Confirm
 
 Use **AskUserQuestion** before applying:


### PR DESCRIPTION
Both hit for real on 2026-09-05 while cutting v3.10.5.

## ops-release: the run outlives an agent's foreground timeout

A full release takes longer than an agent's foreground terminal call allows (~7min hard kill regardless of the requested timeout). When the call dies, the script has usually **already** branched, pushed, opened the PR, waited for CI and merged — you just never saw the output.

A blind retry opened a duplicate release PR (#923) alongside the script's own already-merged #922.

Adds: the state check to run first (merged PRs, tags, version on `origin/main`), what to finish when only the tag is missing (tag the merge commit by hand), how to clean up a duplicate, and a note to prefer a background call so the completion notification carries the output.

## ops-update: `already on <ver>` is not proof the box is current

Step 1 prints `✓ marketplace catalogue refreshed` even when the underlying git pull silently did nothing, so step 2 resolves a stale target and the whole run no-ops.

`~/.claude/plugins/marketplaces/ops-marketplace` is a real checkout of this repo; a dirty worktree (a local edit plus stray `.bak` files) blocks its fast-forward. It sat **28 commits behind on v3.10.3** while v3.10.5 was published, and `ops-update` reported the box current — so a freshly published release silently never reaches the machine.

Adds the diagnosis (`git status -sb` on the clone plus the version in its own `marketplace.json`) and the repair, including diffing each local edit against `origin/main` before dropping it — a local edit byte-identical to upstream is safe to discard, anything else is real work to salvage first.

Docs only, no behaviour change.

## Verification

```
claude-ops: npm test  → Results: 27 passed, 0 failed
claude-ops: npm run lint → All matched files use Prettier code style!
```