### PR TITLE
fix(ops-inbox): count a reply sent from another account, and read the live bridge port

### DIFF
--- a/claude-ops/bin/ops-inbox-archive-set
+++ b/claude-ops/bin/ops-inbox-archive-set
@@ -425,15 +425,28 @@ def main():
             except (OSError, subprocess.SubprocessError):
                 pass
     if main_port is None and wa_archive:
-        errors.append(
-            "WhatsApp archive skipped: could not resolve which account these "
-            "chats belong to. Pass --default-bridge-port, or set agent_enabled "
-            "in the ops-wa-accounts policy file.")
+        # A dry run contacts no bridge, so an unresolved port cannot send an
+        # archive to the wrong number. Blocking it there made the preview
+        # machine-dependent: on a box with two agent-enabled accounts the
+        # resolver refuses to pick one, and the dry run reported 0 planned
+        # archives -- a preview that silently disagreed with the real run.
+        # The refusal still stands for a live --apply, which is where a wrong
+        # port is unrecoverable.
+        if not args.dry_run:
+            errors.append(
+                "WhatsApp archive skipped: could not resolve which account these "
+                "chats belong to. Pass --default-bridge-port, or set agent_enabled "
+                "in the ops-wa-accounts policy file.")
+        else:
+            errors.append(
+                "WhatsApp bridge port unresolved: dry run counts the planned "
+                "archives, but a live --apply will refuse until you pass "
+                "--default-bridge-port.")
     result["whatsapp_bridge_port"] = main_port
     result["whatsapp_bridge_port_source"] = port_source
 
     if args.apply:
-        if main_port is None:
+        if main_port is None and not args.dry_run:
             ok, fail = 0, 0
         else:
             ok, fail = archive_whatsapp(wa_archive, main_port, args.dry_run)

--- a/claude-ops/bin/ops-inbox-scan
+++ b/claude-ops/bin/ops-inbox-scan
@@ -38,6 +38,10 @@
 #   --gmail-account ADDR             override Gmail account (default: gog default)
 #   --wa-store DB                    WhatsApp messages.db to scan
 #   --bridge-port N                  bridge REST port for that store
+#   --peer-store DB                  another account's store, read ONLY to see
+#                                    whether a person was already answered there
+#                                    (repeatable; auto-discovered by default)
+#   --no-peer-stores                 disable that auto-discovery
 #   --pretty                         pretty-print JSON
 #
 # WHICH WHATSAPP ACCOUNT: more than one bridge can run here, one per number, and
@@ -57,6 +61,8 @@ EMAIL_QUERY="in:inbox"
 EMAIL_MAX=400
 WA_STORE_OVERRIDE=""
 BRIDGE_PORT_OVERRIDE=""
+PEER_STORES=""
+AUTO_PEERS=1
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -68,6 +74,8 @@ while [ $# -gt 0 ]; do
     --gmail-account) GMAIL_ACCOUNT="${2:-}"; shift ;;
     --wa-store)      WA_STORE_OVERRIDE="${2:-}"; shift ;;
     --bridge-port)   BRIDGE_PORT_OVERRIDE="${2:-}"; shift ;;
+    --peer-store)    PEER_STORES="${PEER_STORES}${PEER_STORES:+:}${2:-}"; shift ;;
+    --no-peer-stores) AUTO_PEERS=0 ;;
     --pretty)        PRETTY=1 ;;
     -h|--help)
       grep '^#' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
@@ -137,6 +145,37 @@ export OIS_WA_MSGDB="$WA_MSGDB" OIS_WA_WADB="$WA_WADB"
 export OIS_GMAIL_ACCOUNT="$GMAIL_ACCOUNT" OIS_PRETTY="$PRETTY"
 export OIS_WA_PHONE="$WA_ACCOUNT_PHONE" OIS_WA_PORT="$BRIDGE_PORT"
 export OIS_WA_ACCOUNT_SOURCE="$WA_ACCOUNT_SOURCE"
+
+# ---------------------------------------------------- peer account stores ----
+# One person, two numbers, two stores. A reply sent from account A lands ONLY in
+# A's messages.db, so B's copy of that same conversation still ends in an
+# inbound message and the scan calls it NEEDS_REPLY -- an already-answered
+# thread, offered up for a second, duplicate reply. (2026-09-06: a contact was
+# answered on the NL number two days earlier; the US store had no idea.)
+# Peer stores are read-only evidence of "already answered", never a scan target.
+if [ "$DO_WA" = 1 ] && [ "$AUTO_PEERS" = 1 ] && [ -z "$PEER_STORES" ]; then
+  _resolver="$(dirname "$0")/ops-wa-accounts"
+  if [ -x "$_resolver" ]; then
+    PEER_STORES="$("$_resolver" 2>/dev/null | python3 -c '
+import json, os, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+mine = os.path.realpath(os.environ.get("OIS_WA_MSGDB", ""))
+out = []
+for a in data.get("accounts", []):
+    st = a.get("store")
+    if not st:
+        continue
+    st = os.path.realpath(st)
+    if st != mine and os.path.exists(st):
+        out.append(st)
+print(":".join(out))
+' 2>/dev/null || true)"
+  fi
+fi
+export OIS_PEER_STORES="$PEER_STORES"
 
 # The bridge dir that owns the store we are actually scanning — not a fixed
 # path, or link_contacts.py would be run out of the wrong account's install.
@@ -237,6 +276,7 @@ PRETTY    = os.environ.get("OIS_PRETTY") == "1"
 GMAIL_F   = os.environ.get("OIS_GMAIL_JSON_FILE", "")
 GMAIL_ERR = os.environ.get("OIS_GMAIL_ERR", "")
 SENDLOG_F = os.environ.get("OIS_SENDLOG_FILE", "")
+PEER_STORES = [p for p in os.environ.get("OIS_PEER_STORES", "").split(":") if p]
 
 now = datetime.now(timezone.utc)
 notes = []
@@ -313,6 +353,56 @@ def ro(path):
     # immutable=1 skips the -wal file and would hide the freshest, uncheckpointed
     # messages. mode=ro respects WAL + locking and never mutates.
     return sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+
+
+def load_peer_outbound():
+    """person-key -> newest epoch WE sent them from ANY other account.
+
+    Keys are both the raw jid and its bare local part (the digits before @), so
+    a peer's `12345@lid` matches this account's `12345@s.whatsapp.net`: the
+    lid<->phone map is per-store, and the same person is routinely filed under a
+    different jid suffix on the other number. Matching on the digits is what
+    makes the cross-account check actually fire.
+    """
+    sent = {}
+    for path in PEER_STORES:
+        if not os.path.exists(path):
+            continue
+        try:
+            con = ro(path)
+            rows = con.execute(
+                "SELECT chat_jid, MAX(timestamp) FROM messages "
+                "WHERE is_from_me=1 GROUP BY chat_jid"
+            ).fetchall()
+            con.close()
+        except sqlite3.Error as exc:                  # noqa: BLE001 - note, never crash
+            notes.append(f"whatsapp: peer store unreadable ({path}): {exc}")
+            continue
+        for jid, ts in rows:
+            ep = ts_epoch(ts)
+            if ep is None or not jid:
+                continue
+            for key in (jid, re.sub(r"@.*$", "", jid)):
+                if key and (key not in sent or ep > sent[key]):
+                    sent[key] = ep
+    return sent
+
+
+PEER_OUTBOUND = load_peer_outbound()
+
+
+def peer_answered_after(jids, inbound_ep):
+    """Newest cross-account send to any of these jids after inbound_ep."""
+    if inbound_ep is None or not PEER_OUTBOUND:
+        return None
+    best = None
+    for j in jids:
+        for key in (j, re.sub(r"@.*$", "", j)):
+            ep = PEER_OUTBOUND.get(key)
+            if ep is not None and ep > inbound_ep + 30 and (best is None or ep > best):
+                best = ep
+    return best
+
 
 def scan_whatsapp():
     out = {"needs_reply": [], "waiting": [], "groups": [], "fyi": []}
@@ -480,7 +570,16 @@ def scan_whatsapp():
                 item["reconciled"] = "answered via send-log (reply sent, not yet in store)"
                 out["waiting"].append(item)
             else:
-                out["needs_reply"].append(item)
+                # Cross-account: same person, other number, answer already sent
+                # there. Without this the second account re-offers a handled
+                # thread and a duplicate reply goes out.
+                peer_ep = peer_answered_after(members, inbound_ep)
+                if peer_ep is not None:
+                    item["last_from_me"] = True
+                    item["reconciled"] = "answered from another WhatsApp account"
+                    out["waiting"].append(item)
+                else:
+                    out["needs_reply"].append(item)
 
     # Group chats — surface recent ones for the skill to scan for @mentions /
     # direct questions. Provisional status from last-message direction only.
@@ -631,6 +730,7 @@ def scan_email():
 result = {
     "generated_at": now.isoformat(),
     "window_days": DAYS,
+    "peer_stores_read": PEER_STORES,
     "notes": notes,
 }
 if DO_WA:

--- a/claude-ops/bin/ops-wa-accounts
+++ b/claude-ops/bin/ops-wa-accounts
@@ -106,6 +106,73 @@ def _sourced_env_files(text):
     return out
 
 
+def _live_ports_by_dir():
+    """Map bridge directory -> port actually LISTENing, read from the OS.
+
+    A launcher script is not the only way a bridge starts. When a bridge is run
+    directly (systemd, a wrapper, a supervisor, by hand) there is no
+    run-bridge.sh to scan, and _scan() falls back to DEFAULT_BRIDGE_PORT. Every
+    account then reports the same port, so callers that trust it hit ONE bridge
+    for both numbers -- reading, archiving and replying on the wrong account.
+    That is the exact failure this whole file exists to prevent, so the port has
+    to come from the same place the phone does: live ground truth.
+
+    /proc/<pid>/cwd is the bridge's own working directory (whatsmeow stores
+    relative to it), which keys the mapping without guessing a binary name.
+    Linux-only by construction; on any other platform this returns {} and the
+    launcher/policy path stays authoritative.
+    """
+    out = {}
+    proc = "/proc"
+    if not os.path.isdir(proc):
+        return out
+    # inode -> port for every listening TCP socket (v4 + v6)
+    port_by_inode = {}
+    for tcp in ("net/tcp", "net/tcp6"):
+        try:
+            with open(os.path.join(proc, tcp)) as fh:
+                next(fh, None)
+                for line in fh:
+                    f = line.split()
+                    if len(f) < 10 or f[3] != "0A":       # 0A = TCP_LISTEN
+                        continue
+                    try:
+                        port_by_inode[f[9]] = int(f[1].rsplit(":", 1)[1], 16)
+                    except (ValueError, IndexError):
+                        continue
+        except OSError:
+            continue
+    if not port_by_inode:
+        return out
+    for pid in os.listdir(proc):
+        if not pid.isdigit():
+            continue
+        try:
+            cwd = os.path.realpath(os.path.join(proc, pid, "cwd"))
+        except OSError:
+            continue
+        fd_dir = os.path.join(proc, pid, "fd")
+        try:
+            fds = os.listdir(fd_dir)
+        except OSError:
+            continue
+        for fd in fds:
+            try:
+                target = os.readlink(os.path.join(fd_dir, fd))
+            except OSError:
+                continue
+            if not target.startswith("socket:["):
+                continue
+            inode = target[8:-1]
+            port = port_by_inode.get(inode)
+            if port is None:
+                continue
+            # lowest listening port wins, deterministic across restarts
+            if cwd not in out or port < out[cwd]:
+                out[cwd] = port
+    return out
+
+
 def _paired_jid(store_dir):
     """The number actually paired in the store — ground truth, unlike config."""
     db = os.path.join(store_dir, "whatsapp.db")
@@ -203,6 +270,7 @@ def discover():
         notes.append(policy_note)
 
     found = []
+    live_ports = _live_ports_by_dir()
     for d in sorted(glob.glob(BRIDGE_GLOB)):
         if not os.path.isdir(d):
             continue
@@ -239,6 +307,16 @@ def discover():
         except ValueError:
             port = DEFAULT_BRIDGE_PORT
 
+        # A LISTENing socket beats a config guess. Without this every bridge
+        # started outside run-bridge.sh reports DEFAULT_BRIDGE_PORT, and two
+        # accounts collapse onto one port.
+        live_port = live_ports.get(os.path.realpath(d))
+        if live_port:
+            port = live_port
+            port_source = "live socket"
+        else:
+            port_source = "launcher/default"
+
         phone_paired = _paired_jid(store)
         phone = phone_paired or phone_cfg
 
@@ -257,6 +335,7 @@ def discover():
             "dir": d,
             "store": msgdb,
             "port": port,
+            "port_source": port_source,
             "api": "http://127.0.0.1:%d" % port,
             "phone": phone,
             "phone_configured": phone_cfg,

--- a/claude-ops/skills/ops-inbox/SKILL.md
+++ b/claude-ops/skills/ops-inbox/SKILL.md
@@ -185,6 +185,23 @@ guess** when that is ambiguous. Its JSON carries a `whatsapp_account` block (`ph
 `store`, `resolved_by`) — that is the account every downstream archive and reply must use, and
 `ops-inbox-archive-set` reads it so the two can never drift onto different numbers.
 
+**THE WORKING SET IS "NOT ARCHIVED", NEVER "UNREAD".** Read/unread says only
+whether a human glanced at a screen; on a phone every thread reads as seen
+within minutes, so an unread filter reports an empty inbox while real asks sit
+there. WhatsApp's working set is `archived=0`, email's is `in:inbox`. Anything
+still in that set is unhandled by definition and stays in scope until it is
+answered, or archived, or both. No recency window hides it either: a question
+from three weeks ago is still a question.
+
+**CROSS-ACCOUNT: a reply on one number counts for the other.** One person often
+exists in both stores under different jids. A reply sent from account A lands
+only in A's database, so B's copy still ends on their inbound line and looks
+unanswered. The scan therefore reads every OTHER account's store as read-only
+evidence and demotes such a thread to `waiting` with
+`reconciled: "answered from another WhatsApp account"`. That discovery is
+automatic; `--peer-store DB` names one explicitly and `--no-peer-stores` turns
+it off. Never draft a reply for a thread carrying a `reconciled` field.
+
 **ARCHIVE/KEEP SPLIT — `bin/ops-inbox-archive-set`.** The scan says what the
 inbox looks like; this turns that into the two lists inbox-zero actually needs,
 deterministically, instead of re-deciding a few hundred rows by eye every run:

--- a/claude-ops/tests/test-ops-inbox-cross-account.sh
+++ b/claude-ops/tests/test-ops-inbox-cross-account.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# test-ops-inbox-cross-account.sh — a thread answered on ANOTHER WhatsApp account
+# must never be offered up for a second reply, and a bridge's port must come
+# from the live socket rather than a launcher default.
+#
+# Both regressions are real:
+#   2026-09-06 — a contact was answered from the NL number two days earlier. The
+#   US store's copy of that same conversation still ended on their inbound line,
+#   so the scan called it NEEDS_REPLY and a duplicate reply was drafted.
+#   Same run — ops-wa-accounts reported both bridges on 8080 (the whatsmeow
+#   default) because neither was started by run-bridge.sh, while they actually
+#   listened on 8082 and 8083. Anything trusting that port hits one account for
+#   both numbers.
+#
+# Mutation-proof: revert either fix and this test goes red.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+SCAN="$ROOT/bin/ops-inbox-scan"
+ACCOUNTS="$ROOT/bin/ops-wa-accounts"
+
+pass=0; fail=0
+ok()   { pass=$((pass+1)); printf '  ok   %s\n' "$1"; }
+bad()  { fail=$((fail+1)); printf '  FAIL %s\n' "$1"; }
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/ops-xacct.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+# --------------------------------------------------------------- fixtures ----
+# Two stores, one person. Their inbound sits in BOTH; our reply exists only in
+# the peer store, which is exactly the shape that produced the duplicate.
+mk_store() {   # mk_store <dir>
+  local d="$1/store"
+  mkdir -p "$d"
+  python3 - "$d/messages.db" <<'PY'
+import sqlite3, sys
+con = sqlite3.connect(sys.argv[1])
+con.execute("CREATE TABLE chats (jid TEXT PRIMARY KEY, name TEXT, "
+            "last_message_time TIMESTAMP, archived INTEGER NOT NULL DEFAULT 0, "
+            "unread_count INTEGER DEFAULT 0)")
+con.execute("CREATE TABLE messages (id TEXT, chat_jid TEXT, sender TEXT, "
+            "content TEXT, timestamp TIMESTAMP, is_from_me BOOLEAN, "
+            "media_type TEXT, filename TEXT, PRIMARY KEY (id, chat_jid))")
+con.execute("CREATE TABLE contacts (jid TEXT PRIMARY KEY, name TEXT, "
+            "phone TEXT, source TEXT, updated_at INTEGER)")
+con.commit(); con.close()
+PY
+  printf '%s' "$d"
+}
+
+MAIN_DIR="$TMP/whatsapp-bridge"
+PEER_DIR="$TMP/whatsapp-bridge-us"
+MAIN_STORE="$(mk_store "$MAIN_DIR")"
+PEER_STORE="$(mk_store "$PEER_DIR")"
+
+# Scanned account: their question is the last line here.
+python3 - "$MAIN_STORE/messages.db" <<'PY'
+import sqlite3, sys
+con = sqlite3.connect(sys.argv[1])
+con.execute("INSERT INTO chats VALUES ('999111@lid','Casey','2026-09-01 11:00:00+00:00',0,0)")
+con.execute("INSERT INTO contacts VALUES ('999111@lid','Casey','999111','test',0)")
+con.execute("INSERT INTO messages VALUES ('m1','999111@lid','999111',"
+            "'How was the trip?','2026-09-01 11:00:00+00:00',0,'','')")
+# An unrelated contact nobody answered anywhere: the control.
+con.execute("INSERT INTO chats VALUES ('999222@lid','Robin','2026-09-01 12:00:00+00:00',0,0)")
+con.execute("INSERT INTO contacts VALUES ('999222@lid','Robin','999222','test',0)")
+con.execute("INSERT INTO messages VALUES ('m2','999222@lid','999222',"
+            "'Still on for Friday?','2026-09-01 12:00:00+00:00',0,'','')")
+con.commit(); con.close()
+PY
+
+# Peer account: the reply to Casey went out HERE, under a different jid suffix.
+python3 - "$PEER_STORE/messages.db" <<'PY'
+import sqlite3, sys
+con = sqlite3.connect(sys.argv[1])
+con.execute("INSERT INTO chats VALUES ('999111@s.whatsapp.net','Casey',"
+            "'2026-09-02 09:00:00+00:00',1,0)")
+con.execute("INSERT INTO messages VALUES ('p1','999111@s.whatsapp.net','me',"
+            "'Trip was great, thanks for asking!','2026-09-02 09:00:00+00:00',1,'','')")
+con.commit(); con.close()
+PY
+
+run_scan() {  # run_scan [extra args...]
+  "$SCAN" --whatsapp-only --pretty \
+    --wa-store "$MAIN_STORE/messages.db" --bridge-port 8099 "$@" 2>/dev/null
+}
+
+bucket_of() {  # bucket_of <json> <name>
+  python3 -c '
+import json, sys
+d = json.loads(sys.stdin.read() or "{}")
+wa = d.get("whatsapp", {})
+for b in ("needs_reply", "waiting", "groups", "fyi"):
+    for row in wa.get(b, []):
+        if row.get("who") == sys.argv[1]:
+            print(b); sys.exit(0)
+print("ABSENT")' "$2" <<<"$1"
+}
+
+echo "cross-account reconciliation"
+OUT="$(run_scan --peer-store "$PEER_STORE/messages.db")"
+
+if [ -z "$OUT" ]; then
+  bad "scan produced no output"
+else
+  b="$(bucket_of "$OUT" Casey)"
+  [ "$b" = "waiting" ] && ok "answered-elsewhere thread demoted out of needs_reply" \
+                       || bad "Casey landed in '$b', expected waiting (duplicate-reply bug)"
+
+  b="$(bucket_of "$OUT" Robin)"
+  [ "$b" = "needs_reply" ] && ok "genuinely unanswered thread still needs_reply" \
+                           || bad "Robin landed in '$b', expected needs_reply (gate too wide)"
+
+  # The reason must be visible, or a human cannot tell why it was skipped.
+  if grep -q "answered from another WhatsApp account" <<<"$OUT"; then
+    ok "demotion carries a stated reason"
+  else
+    bad "no 'reconciled' reason on the demoted thread"
+  fi
+
+  # The peer store must be reported, so a run can prove what it read.
+  if python3 -c '
+import json,sys
+d=json.loads(sys.stdin.read() or "{}")
+sys.exit(0 if d.get("peer_stores_read") else 1)' <<<"$OUT"; then
+    ok "scan reports which peer stores it read"
+  else
+    bad "peer_stores_read missing from scan output"
+  fi
+fi
+
+# Without the peer store the same thread MUST look unanswered: proves the demotion
+# comes from peer evidence and not from some unrelated blanket rule.
+OUT_NOPEER="$(run_scan --no-peer-stores)"
+b="$(bucket_of "$OUT_NOPEER" Casey)"
+[ "$b" = "needs_reply" ] && ok "no peer evidence => thread stays actionable" \
+                         || bad "Casey was '$b' with no peer store; demotion is not evidence-driven"
+
+echo "live port resolution"
+# A bridge with no launcher script, listening on a non-default port.
+PORT_OUT="$(WHATSAPP_BRIDGE_GLOB="$TMP/whatsapp-bridge*" \
+            WHATSAPP_AGENT_POLICY="$TMP/nonexistent-policy.json" \
+            "$ACCOUNTS" 2>/dev/null)"
+if python3 -c '
+import json,sys
+d=json.loads(sys.stdin.read() or "{}")
+accts=d.get("accounts",[])
+sys.exit(0 if accts and all("port_source" in a for a in accts) else 1)' <<<"$PORT_OUT"; then
+  ok "every account states where its port came from"
+else
+  bad "port_source missing: a caller cannot tell a live port from a guess"
+fi
+
+# Real listener on a real port, in a directory shaped like a bridge.
+LIVE_DIR="$TMP/whatsapp-bridge-live"
+mk_store "$LIVE_DIR" >/dev/null
+python3 - "$LIVE_DIR" <<'PY' &
+import os, socket, sys, time
+os.chdir(sys.argv[1])
+s = socket.socket()
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(("127.0.0.1", 0))
+s.listen(1)
+with open("port.txt", "w") as fh:
+    fh.write(str(s.getsockname()[1]))
+time.sleep(20)
+PY
+LISTENER=$!
+for _ in $(seq 1 40); do [ -s "$LIVE_DIR/port.txt" ] && break; sleep 0.1; done
+LIVE_PORT="$(cat "$LIVE_DIR/port.txt" 2>/dev/null || echo)"
+
+if [ -z "$LIVE_PORT" ] || [ ! -d /proc ]; then
+  echo "  skip live-socket check (no /proc or listener failed to start)"
+else
+  LIVE_OUT="$(WHATSAPP_BRIDGE_GLOB="$LIVE_DIR" \
+              WHATSAPP_AGENT_POLICY="$TMP/nonexistent-policy.json" \
+              "$ACCOUNTS" 2>/dev/null)"
+  got="$(python3 -c '
+import json,sys
+d=json.loads(sys.stdin.read() or "{}")
+a=d.get("accounts") or [{}]
+print(a[0].get("port",""))' <<<"$LIVE_OUT")"
+  if [ "$got" = "$LIVE_PORT" ]; then
+    ok "port read from the live socket ($got), not the 8080 default"
+  else
+    bad "reported port $got, listener is on $LIVE_PORT (stale launcher default)"
+  fi
+fi
+kill "$LISTENER" 2>/dev/null || true
+wait "$LISTENER" 2>/dev/null || true
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
fix(ops-inbox): count a reply sent from another account, and read the live bridge port

Three defects, all found in one live inbox-zero run, all with the same shape:
a value was taken from configuration or from one store when the truth lived
somewhere else.

1. Cross-account blind spot. One person exists in both WhatsApp stores under
   different jids. A reply sent from account A lands only in A's messages.db,
   so B's copy of that conversation still ends on their inbound line and the
   scan calls it NEEDS_REPLY. A contact answered from the NL number two days
   earlier was offered up again from the US account, and a duplicate reply was
   drafted before a human caught it. The scan now reads every other account's
   store read-only, keyed on both the raw jid and its bare digits (the
   lid<->phone map is per-store, so the digits are what actually match), and
   demotes such a thread to `waiting` with a stated `reconciled` reason.
   Auto-discovered; `--peer-store` names one, `--no-peer-stores` disables it.

2. Bridge port taken from a launcher that need not exist. ops-wa-accounts
   scanned run-bridge.sh for WA_PORT and fell back to 8080. Both bridges on
   this box are started another way, so both reported 8080 while actually
   listening on 8082 and 8083 -- and anything trusting that port hits one
   account for both numbers, which is the exact failure that file exists to
   prevent. The port now comes from the same place the phone number does: live
   ground truth, by matching each listening socket's inode to the owning
   process's cwd via /proc. Linux-only by construction; elsewhere the previous
   launcher/policy path is unchanged. Every account now also reports
   `port_source` so a caller can tell a live port from a guess.

3. Dry run disagreed with the real run. ops-inbox-archive-set refused to count
   WhatsApp archives when the bridge port was unresolved -- including under
   --dry-run, which contacts no bridge at all. On a box with two agent-enabled
   accounts the resolver correctly declines to pick one, so the preview
   reported zero planned archives while a live run would archive plenty. The
   refusal now applies only to a live --apply, where a wrong port is
   unrecoverable; the dry run counts the plan and says the live run will
   refuse. This also fixes a pre-existing red test unrelated to this work.

Also documents in ops-inbox/SKILL.md what the working set is: `archived=0` for
WhatsApp and `in:inbox` for email, never read/unread. Read state records only
whether a human glanced at a screen -- on a phone every thread reads as seen
within minutes, so an unread filter reports an empty inbox while real asks sit
in it.

tests/test-ops-inbox-cross-account.sh is mutation-proven: removing the
cross-account demotion fails 2 assertions, ignoring the live socket fails 1,
and dropping the bare-digit key match fails 2. It also asserts the negative --
a genuinely unanswered thread stays actionable, and with no peer evidence the
demotion does not fire -- so the fix cannot pass by silencing the bucket.
