### PR TITLE
release: v3.10.6

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 66 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "3.10.5",
+      "version": "3.10.6",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-3.10.5-blue)
+![Version](https://img.shields.io/badge/version-3.10.6-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-66-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "3.10.5",
+  "version": "3.10.6",
   "description": "Business operations command center for Claude Code — 66 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -141,6 +141,47 @@
 - **ops-ecom:** `channels` | `agentic` | `shop` verbs — sales channel inventory, agentic storefront health, Shop Campaigns readiness (read-only; Rule 5 / stage-only spend).
 - **ops-marketing:** brand-agnostic `shop_campaigns` + `agentic_storefronts` project prefs schema; `shop-campaigns` / `agentic` routing; portfolio awareness; NEVER LEAK MONEY guardrails for Shop Campaigns.
 
+## [3.10.6] - 2026-09-06
+
+### Changed
+### Fixed — inbox zero was unreachable by construction
+
+Three defects in the inbox toolchain, all found in one live run, all failing the
+same way: a value was read from configuration, or from one store, when the truth
+lived somewhere else.
+
+- **A completed inbox-zero run was diagnosed as flag corruption.** With every
+  chat archived, `ops-inbox-scan` fell back to `handled=0` as its working set.
+  Nothing in the toolchain ever writes `handled`, so that predicate matched 1803
+  of 1806 archived chats and the entire history came back as unanswered asks —
+  171 false NEEDS_REPLY across two accounts, moments after the inbox was
+  genuinely empty. The better a sweep did its job, the louder the next scan
+  disagreed. The corruption fallback now fires only when `handled` is
+  demonstrably in use; genuine corruption still recovers the live thread, and
+  the scan states which verdict it reached and why.
+- **A reply sent from one WhatsApp number did not count on the other.** One
+  person exists in both stores under different jids, and an outgoing message
+  lands only in the store it was sent from — so the second account still saw an
+  unanswered thread and offered a duplicate reply. The scan now reads every
+  other account's store as read-only evidence and demotes those threads with a
+  stated `reconciled` reason. Auto-discovered; `--peer-store` names one
+  explicitly, `--no-peer-stores` disables it. This matters more now that
+  `--all-accounts` scans both numbers in a single pass.
+- **The bridge port came from a launcher script that need not exist.**
+  `ops-wa-accounts` scanned `run-bridge.sh` for `WA_PORT` and fell back to 8080,
+  so two bridges started any other way both reported 8080 while actually
+  listening on 8082 and 8083 — pointing every read, archive and reply at one
+  number. The port is now read from the live listening socket via `/proc`, the
+  same way the phone number is read from the store, and every account reports
+  `port_source` so a caller can tell a live value from a guess.
+
+Also: `ops-inbox-archive-set --dry-run` no longer reports zero planned archives
+on a multi-account box. It refused to count anything when the bridge port was
+unresolved, including under a dry run that contacts no bridge at all, so the
+preview silently disagreed with the real run. The refusal now applies only to a
+live `--apply`, where a wrong port is unrecoverable.
+
+
 ## [3.10.5] - 2026-09-05
 
 ### Changed

--- a/claude-ops/docs/INDEX.md
+++ b/claude-ops/docs/INDEX.md
@@ -4,7 +4,7 @@
 
 _Top-level map of every doc file in `claude-ops/docs/`._
 
-[![version](https://img.shields.io/badge/version-3.10.5-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.10.6-blue)](../CHANGELOG.md)
 
 </div>
 

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-3.10.5-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.10.6-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 66 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-3.10.5-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.10.6-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-66-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/hermes-plugin/plugin.yaml
+++ b/claude-ops/hermes-plugin/plugin.yaml
@@ -1,4 +1,4 @@
 name: ops
-version: "3.10.5"
+version: "3.10.6"
 description: "claude-ops on Hermes — slash commands and skills for inbox, deploy, revenue, and the rest of the ops suite. Enable with plugins.enabled: [ops]."
 author: Lifecycle Innovations Limited

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "3.10.5",
+  "version": "3.10.6",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/installer/README.md
+++ b/installer/README.md
@@ -56,7 +56,7 @@ version: 1
 source:
   type: git
   url: https://github.com/Lifecycle-Innovations-Limited/claude-ops.git
-  ref: v3.10.5
+  ref: v3.10.6
 
 agents:
   claude:    { enabled: true }

--- a/installer/src/config.mjs
+++ b/installer/src/config.mjs
@@ -17,7 +17,7 @@ export const DEFAULT_CONFIG = {
   source: {
     type: "git",
     url: "https://github.com/Lifecycle-Innovations-Limited/claude-ops.git",
-    ref: "v3.10.5",
+    ref: "v3.10.6",
   },
   agents: {
     claude: { enabled: true, type: "marketplace" },


### PR DESCRIPTION
Release **v3.10.6** (was 3.10.5).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

### Fixed — inbox zero was unreachable by construction

Three defects in the inbox toolchain, all found in one live run, all failing the
same way: a value was read from configuration, or from one store, when the truth
lived somewhere else.

- **A completed inbox-zero run was diagnosed as flag corruption.** With every
  chat archived, `ops-inbox-scan` fell back to `handled=0` as its working set.
  Nothing in the toolchain ever writes `handled`, so that predicate matched 1803
  of 1806 archived chats and the entire history came back as unanswered asks —
  171 false NEEDS_REPLY across two accounts, moments after the inbox was
  genuinely empty. The better a sweep did its job, the louder the next scan
  disagreed. The corruption fallback now fires only when `handled` is
  demonstrably in use; genuine corruption still recovers the live thread, and
  the scan states which verdict it reached and why.
- **A reply sent from one WhatsApp number did not count on the other.** One
  person exists in both stores under different jids, and an outgoing message
  lands only in the store it was sent from — so the second account still saw an
  unanswered thread and offered a duplicate reply. The scan now reads every
  other account's store as read-only evidence and demotes those threads with a
  stated `reconciled` reason. Auto-discovered; `--peer-store` names one
  explicitly, `--no-peer-stores` disables it. This matters more now that
  `--all-accounts` scans both numbers in a single pass.
- **The bridge port came from a launcher script that need not exist.**
  `ops-wa-accounts` scanned `run-bridge.sh` for `WA_PORT` and fell back to 8080,
  so two bridges started any other way both reported 8080 while actually
  listening on 8082 and 8083 — pointing every read, archive and reply at one
  number. The port is now read from the live listening socket via `/proc`, the
  same way the phone number is read from the store, and every account reports
  `port_source` so a caller can tell a live value from a guess.

Also: `ops-inbox-archive-set --dry-run` no longer reports zero planned archives
on a multi-account box. It refused to count anything when the bridge port was
unresolved, including under a dry run that contacts no bridge at all, so the
preview silently disagreed with the real run. The refusal now applies only to a
live `--apply`, where a wrong port is unrecoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)