### PR TITLE
fix(ops-inbox): an archived chat is dealt with, not a recency candidate

### DIFF
--- a/claude-ops/bin/ops-inbox-scan
+++ b/claude-ops/bin/ops-inbox-scan
@@ -692,12 +692,35 @@ def scan_whatsapp():
                 )
     else:
         done_pred = "archived=0"
-    chats = list(con.execute(
-        "SELECT jid, name, last_message_time FROM chats "
-        f"WHERE {done_pred} OR last_message_time >= datetime('now', ?) "
-        "ORDER BY last_message_time DESC",
-        (f"-{DAYS} days",)
-    ))
+    # The recency floor is a corruption net, NOT a second working set. It may
+    # only reopen a chat the flags could be LYING about, and after an
+    # intentional inbox-zero run they are not lying: on 2026-09-06 a US account
+    # with every chat deliberately archived still reported 23 needs_reply, all
+    # 23 already archived, because "active in the last 7 days" outranked the
+    # archive. Archived means dealt with; that is the whole contract of the
+    # sweep. So the net is armed only where corruption is actually plausible --
+    # a store that has never been swept clean.
+    try:
+        n_open_now = con.execute(
+            "SELECT count(*) FROM chats WHERE archived=0").fetchone()[0]
+    except sqlite3.Error:
+        n_open_now = 1
+    if n_open_now:
+        chats = list(con.execute(
+            "SELECT jid, name, last_message_time FROM chats "
+            f"WHERE {done_pred} OR last_message_time >= datetime('now', ?) "
+            "ORDER BY last_message_time DESC",
+            (f"-{DAYS} days",)
+        ))
+    else:
+        notes.append(
+            "whatsapp: inbox is fully archived — recency net disarmed so a "
+            "deliberately archived chat is not reopened as unanswered"
+        )
+        chats = list(con.execute(
+            "SELECT jid, name, last_message_time FROM chats "
+            f"WHERE {done_pred} ORDER BY last_message_time DESC"
+        ))
 
     # Build merged DM groups keyed by canonical jid.
     groups = {}   # canonical_jid -> {member_jids:set, name, latest_ts}

--- a/claude-ops/tests/test-ops-inbox-cross-account.sh
+++ b/claude-ops/tests/test-ops-inbox-cross-account.sh
@@ -256,5 +256,56 @@ b="$(bucket_of "$COUT" Victim)"
 [ "$b" = "needs_reply" ] && ok "real flag corruption still recovers the live thread" \
                          || bad "Victim was '$b'; corruption fallback no longer fires"
 
+
+echo "archived means dealt with"
+# A fully-archived store must report inbox zero. The recency floor is a
+# corruption net; after a deliberate sweep it must not reopen what was archived
+# on purpose (2026-09-06: 23 needs_reply, all 23 already archived).
+SWEPT_DIR="$TMP/whatsapp-bridge-swept"
+SWEPT_STORE="$(mk_store "$SWEPT_DIR")"
+python3 - "$SWEPT_STORE/messages.db" <<'PY'
+import sqlite3, sys, datetime
+con = sqlite3.connect(sys.argv[1])
+# Recent AND archived: yesterday, so any recency window would catch it.
+ts = (datetime.datetime.now(datetime.timezone.utc)
+      - datetime.timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S+00:00")
+con.execute("INSERT INTO chats VALUES ('888111@lid','Swept',?,1,0)", (ts,))
+con.execute("INSERT INTO contacts VALUES ('888111@lid','Swept','888111','test',0)")
+con.execute("INSERT INTO messages VALUES ('s1','888111@lid','888111',"
+            "'Anything left to do?',?,0,'','')", (ts,))
+con.commit(); con.close()
+PY
+
+SWEPT_OUT="$("$SCAN" --whatsapp-only --pretty --no-peer-stores \
+  --wa-store "$SWEPT_STORE/messages.db" --bridge-port 8098 2>/dev/null)"
+b="$(bucket_of "$SWEPT_OUT" Swept)"
+[ "$b" = "ABSENT" ] && ok "archived-but-recent chat stays out of the working set" \
+                    || bad "Swept came back as '$b': archive loses to the recency net"
+
+if grep -q "recency net disarmed" <<<"$SWEPT_OUT"; then
+  ok "scan states that the recency net was disarmed"
+else
+  bad "no note explaining why the recency net was skipped"
+fi
+
+# The net must still exist where corruption is plausible: one open chat means
+# the store was never swept, so a recent archived thread is still surfaced.
+python3 - "$SWEPT_STORE/messages.db" <<'PY'
+import sqlite3, sys, datetime
+con = sqlite3.connect(sys.argv[1])
+ts = (datetime.datetime.now(datetime.timezone.utc)
+      - datetime.timedelta(days=1)).strftime("%Y-%m-%d %H:%M:%S+00:00")
+con.execute("INSERT INTO chats VALUES ('888222@lid','StillOpen',?,0,0)", (ts,))
+con.execute("INSERT INTO contacts VALUES ('888222@lid','StillOpen','888222','test',0)")
+con.execute("INSERT INTO messages VALUES ('s2','888222@lid','888222',"
+            "'And me?',?,0,'','')", (ts,))
+con.commit(); con.close()
+PY
+MIXED_OUT="$("$SCAN" --whatsapp-only --pretty --no-peer-stores \
+  --wa-store "$SWEPT_STORE/messages.db" --bridge-port 8098 2>/dev/null)"
+b="$(bucket_of "$MIXED_OUT" Swept)"
+[ "$b" != "ABSENT" ] && ok "corruption net still armed on a store with open chats" \
+                     || bad "recency net lost entirely: a mass-archived store would go silent"
+
 printf '\n%d passed, %d failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
fix(ops-inbox): an archived chat is dealt with, not a recency candidate

The working set was `archived=0 OR last_message_time >= -7 days`. That second
clause is a corruption net -- it exists because a store was once observed
mass-flagging archived=1 on live threads -- but as written it outranks the
archive for every recent chat, including ones archived seconds earlier on
purpose.

Measured on a live account today: 23 threads reported as needs_reply, all 23
already archived. Inbox zero was unreachable by construction, and every sweep
re-offered handled conversations for a duplicate reply.

The net now arms only where corruption is plausible: a store with at least one
open chat. A fully-swept store is taken at face value and says so in `notes`.

tests: test-ops-inbox-cross-account.sh, 13 assertions. Mutation-proof --
forcing the net always-on turns 2 red; genuine flag corruption on a store with
open chats still recovers the live thread.
