### PR TITLE
fix(hooks): begrens de Stop-hook die elke sessie kon ophouden

### DIFF
--- a/claude-ops/hooks/hooks.json
+++ b/claude-ops/hooks/hooks.json
@@ -117,7 +117,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-post-session-cleanup 2>/dev/null || true"
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-post-session-cleanup 2>/dev/null || true",
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
Uit een volledige hook-audit op Sams Mac: 150 hook-registraties uit alle bronnen, elk getimed met de payload die zijn event echt levert.

Van de veertien hooks die deze plugin registreert blokkeerde er nog een zonder grens: `ops-post-session-cleanup` op `Stop`. Die krijgt nu `timeout: 5`.

## Wat er is gemeten

| hook | event | duur | blokkeert |
|---|---|---|---|
| `bedrock-fallback-guard.mjs` | UserPromptSubmit (elke prompt) | 55ms | ja, to=15 |
| `bedrock-billing-guard.mjs` | PreToolUse `*` (elke tool-call) | 55ms | ja, to=5 |
| `ops-rules-context.sh` | SessionStart | 152ms | ja, to=5 |
| `ops-task-reminder` | PostToolUse | 107ms | ja, to=2 |
| `ops-post-session-cleanup` | Stop | 146ms | ja, **geen grens** |
| `ops-post-update-migrate` | SessionStart | 5142ms | nee, async |
| `ops-daemon-manager ensure-current` | SessionStart | 1388-7454ms | nee, async |
| `setup.sh` | SessionStart | 2005ms | nee, async |
| `ops-welcome` | SessionStart | 65ms | nee, async |
| `ops-pretool-whatsapp-bridge-health` | PreToolUse Bash | 89ms | nee, async |

Niets kapot, niets hangend, geen ontbrekende scripts, geen foute exitcodes.

## Wat bewust NIET is aangepast

De trage SessionStart-hooks (5,1s en tot 7,5s) staan op `async: true` en houden de sessiestart dus niet op. Een timeout erbij zou een probleem verzinnen dat er niet is. `ops-pretool-whatsapp-bridge-health` heeft ook geen timeout, maar is async en backgroundt zijn eigen `lsof`.