### PR TITLE
fix(ops-fires): pre-gather Sentry, and fix the MCP tool names that never existed

### DIFF
--- a/claude-ops/bin/ops-sentry
+++ b/claude-ops/bin/ops-sentry
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# ops-sentry — Unresolved Sentry issues for the FIRES dashboard → JSON
+#
+# Why this exists: /ops:fires used to declare the Sentry MCP in allowed-tools
+# and hope the model would call it. It never did reliably — the tool name in
+# the frontmatter (mcp__sentry__*) does not match the name the plugin actually
+# registers (mcp__plugin_sentry_sentry__*), so the tool was never available and
+# every run reported Sentry as "unavailable". Pre-gathering it via the REST API
+# puts Sentry on the same footing as infra, CI and external projects: the data
+# is simply in the prompt, with nothing left to remember.
+#
+# Emits {"org":..., "issues":[...], "error":...}. NEVER exits non-zero and
+# never emits anything but valid JSON — the skill inlines this and a bare
+# error string would corrupt the prompt.
+#
+# Token:  env SENTRY_AUTH_TOKEN → env SENTRY_TOKEN → doppler claude-ops/prd
+# Org:    $1 → preferences.json .partner_registry.sentry.org → auto-discover
+# Region: preferences.json .partner_registry.sentry.region_url → us.sentry.io
+#         (Sentry is region-sharded; the org's regionUrl is authoritative and
+#          a wrong region returns an empty list rather than an error.)
+
+set -uo pipefail   # deliberately no -e: a failed probe must degrade, not abort
+
+API_VERSION="0"
+PERIOD="${OPS_SENTRY_PERIOD:-24h}"
+LIMIT="${OPS_SENTRY_LIMIT:-10}"
+CURL_TIMEOUT="${OPS_SENTRY_TIMEOUT:-12}"
+DEFAULT_REGION="https://us.sentry.io"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OPS_PLUGIN_ROOT_FALLBACK="${SCRIPT_DIR}/.." . "${SCRIPT_DIR}/../lib/registry-path.sh" 2>/dev/null || true
+PREFS="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+
+# Bail out with valid JSON and exit 0, always.
+emit_error() {
+  jq -nc --arg e "$1" '{org:null, issues:[], error:$e}'
+  exit 0
+}
+
+command -v jq >/dev/null 2>&1 || { printf '{"org":null,"issues":[],"error":"jq not installed"}\n'; exit 0; }
+command -v curl >/dev/null 2>&1 || emit_error "curl not installed"
+
+pref() {
+  [ -f "$PREFS" ] || return 0
+  jq -r "$1 // empty" "$PREFS" 2>/dev/null || true
+}
+
+# ---- token -----------------------------------------------------------------
+TOKEN="${SENTRY_AUTH_TOKEN:-${SENTRY_TOKEN:-}}"
+if [ -z "$TOKEN" ] && command -v doppler >/dev/null 2>&1; then
+  TOKEN=$(doppler secrets get SENTRY_AUTH_TOKEN --project claude-ops --config prd --plain 2>/dev/null || true)
+fi
+[ -z "$TOKEN" ] && emit_error "no Sentry token (env SENTRY_AUTH_TOKEN / SENTRY_TOKEN / doppler claude-ops/prd)"
+
+REGION_URL="$(pref '.partner_registry.sentry.region_url')"
+[ -z "$REGION_URL" ] && REGION_URL="$DEFAULT_REGION"
+REGION_URL="${REGION_URL%/}"
+
+api() {
+  curl -sS --max-time "$CURL_TIMEOUT" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Accept: application/json" \
+    "$@" 2>/dev/null
+}
+
+# ---- org -------------------------------------------------------------------
+ORG="${1:-}"
+[ -z "$ORG" ] && ORG="$(pref '.partner_registry.sentry.org')"
+if [ -z "$ORG" ]; then
+  # Org listing is not region-sharded; the control silo answers for every org.
+  ORG_RAW=$(api "https://sentry.io/api/${API_VERSION}/organizations/")
+  if printf '%s' "$ORG_RAW" | jq -e 'type=="array"' >/dev/null 2>&1; then
+    ORG=$(printf '%s' "$ORG_RAW" | jq -r '.[0].slug // empty' 2>/dev/null || true)
+  else
+    # An object here means the token was rejected. Say so, rather than blaming
+    # the org — a bad token and a missing org need different fixes.
+    AUTH_DETAIL=$(printf '%s' "$ORG_RAW" | jq -r '.detail // .error // empty' 2>/dev/null || true)
+    [ -n "$AUTH_DETAIL" ] && emit_error "Sentry auth failed: ${AUTH_DETAIL}"
+  fi
+fi
+[ -z "$ORG" ] && emit_error "could not resolve a Sentry org (set .partner_registry.sentry.org in preferences.json)"
+
+# ---- issues ----------------------------------------------------------------
+# statsPeriod bounds the window; query filters to still-open issues.
+RAW=$(api -G "${REGION_URL}/api/${API_VERSION}/organizations/${ORG}/issues/" \
+  --data-urlencode "query=is:unresolved" \
+  --data-urlencode "statsPeriod=${PERIOD}" \
+  --data-urlencode "limit=${LIMIT}" \
+  --data-urlencode "sort=freq")
+
+[ -z "$RAW" ] && emit_error "Sentry API returned no response for org ${ORG} (region ${REGION_URL})"
+
+# An error body is a JSON object; a good body is an array. Distinguish, so an
+# expired token reads as "expired token" and not as "zero issues".
+if ! printf '%s' "$RAW" | jq -e 'type=="array"' >/dev/null 2>&1; then
+  DETAIL=$(printf '%s' "$RAW" | jq -r '.detail // .error // "unrecognised response"' 2>/dev/null || echo "unparseable response")
+  jq -nc --arg o "$ORG" --arg e "Sentry API error: $DETAIL" '{org:$o, issues:[], error:$e}'
+  exit 0
+fi
+
+printf '%s' "$RAW" | jq -c --arg o "$ORG" --arg p "$PERIOD" '{
+  org: $o,
+  period: $p,
+  issues: [ .[] | {
+    short_id:   .shortId,
+    title:      .title,
+    culprit:    .culprit,
+    project:    (.project.slug // null),
+    level:      .level,
+    events:     (.count      // "0"),
+    users:      (.userCount  // 0),
+    first_seen: .firstSeen,
+    last_seen:  .lastSeen,
+    url:        .permalink
+  } ],
+  error: null
+}' 2>/dev/null || emit_error "failed to parse Sentry issue list"

--- a/claude-ops/prompts/build-fix.md
+++ b/claude-ops/prompts/build-fix.md
@@ -11,7 +11,7 @@ You are headless inside Claude Code with full claude-ops tooling:
 | Mobile / Expo / RN / iOS Fastlane  | spawn the `Mobile App Specialist` subagent                                  |
 | TypeScript / type errors           | spawn the `typescript-reviewer` subagent                                    |
 | Cross-repo contract breakage       | spawn the `fullstack-mobile-architect` subagent                             |
-| Sentry context for runtime crashes | `mcp__sentry__search_events`                                                |
+| Sentry context for runtime crashes | `mcp__plugin_sentry_sentry__search_events`                                                |
 | Apple Developer / TestFlight state | `python3 scripts/asc-manage-builds.py` (in your mobile repo)                |
 | Doppler secret resolution          | `doppler secrets get <KEY> --project <your-project> --config <env> --plain` |
 | Library version drift              | `npx expo install --check`, `npm ls <pkg>`, Context7 MCP for docs           |

--- a/claude-ops/prompts/deploy-fix.md
+++ b/claude-ops/prompts/deploy-fix.md
@@ -10,7 +10,7 @@ You are running headless inside a Claude Code session with full claude-ops tooli
 | -------------------------------------------- | ------------------------------------------------------------ |
 | Fetch failed CI logs                         | `gh run view {{RUN_ID}} --repo {{REPO}} --log-failed`        |
 | Inspect ECS / AWS state                      | `/ops:ops-fires`, `/ops:ops-monitor`, raw `aws` CLI          |
-| Sentry context for related errors            | `/ops:ops-triage` or `mcp__sentry__search_events`            |
+| Sentry context for related errors            | `/ops:ops-triage` or `mcp__plugin_sentry_sentry__search_events`            |
 | Find prior fixes for similar failures        | `gh search prs --repo {{REPO}} 'fix(deploy)' --state merged` |
 | My-Project mobile crashes / iOS build issues | spawn the `Mobile App Specialist` subagent                   |
 | My-Project backend / NestJS issues           | spawn the `Health Data Expert` subagent                      |

--- a/claude-ops/skills/ops-fires/SKILL.md
+++ b/claude-ops/skills/ops-fires/SKILL.md
@@ -17,8 +17,9 @@ allowed-tools:
   - Monitor
   - WebFetch
   - WebSearch
-  - mcp__sentry__search_issues
-  - mcp__sentry__get_issue_details
+  - mcp__plugin_sentry_sentry__search_issues
+  - mcp__plugin_sentry_sentry__get_sentry_resource
+  - mcp__plugin_sentry_sentry__find_organizations
 effort: medium
 maxTurns: 30
 ---
@@ -41,7 +42,8 @@ Before executing, load available context:
    - First: check `$AWS_ACCESS_KEY_ID` / `$AWS_PROFILE` env vars
    - Then: `doppler secrets get AWS_ACCESS_KEY_ID --plain` (if `doppler` configured in prefs)
    - Then: use `password_manager_config.query_cmd` from preferences
-   - Sentry token: `$SENTRY_AUTH_TOKEN` → Doppler `SENTRY_AUTH_TOKEN` → vault
+   - Sentry token: `$SENTRY_AUTH_TOKEN` → `$SENTRY_TOKEN` → Doppler `claude-ops/prd/SENTRY_AUTH_TOKEN`. Resolved by `bin/ops-sentry`; no action needed here.
+   - Sentry org and region: `preferences.json` `.partner_registry.sentry.{org,region_url}`. Sentry is region-sharded — issues are served by the org's own region host (e.g. `https://us.sentry.io`), not `sentry.io`, and querying the wrong region returns an empty list rather than an error. Omit `org` and the script discovers the first org the token can see.
 
 3. **Preferences**: Read `${CLAUDE_PLUGIN_DATA_DIR}/preferences.json` for `secrets_manager` config to know which vault to query.
 
@@ -67,7 +69,9 @@ Before executing, load available context:
 | Command                                                                                                                          | Usage                             | Output     |
 | -------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | ---------- |
 | `sentry-cli issues list --project <slug> --status unresolved`                                                                    | Unresolved issues                 | Issue list |
-| `curl -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" "https://sentry.io/api/0/projects/<org>/<proj>/issues/?query=is:unresolved"` | API fallback when MCP unavailable | JSON array |
+| `bin/ops-sentry [org]` | Pre-gather path (already inlined below) | JSON `{org,issues,error}` |
+| `OPS_SENTRY_PERIOD=7d OPS_SENTRY_LIMIT=25 bin/ops-sentry` | Widen the window or cap | JSON |
+| `curl -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" "https://us.sentry.io/api/0/organizations/<org>/issues/?query=is:unresolved"` | Manual probe (note: region host, org-scoped) | JSON array |
 
 ---
 
@@ -111,6 +115,17 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/finops-bridge.sh anomalies high 2>/dev/null || ech
 ${CLAUDE_PLUGIN_ROOT}/bin/ops-ci 2>/dev/null || echo '[]'
 ```
 
+## Sentry — unresolved issues (last 24h)
+
+Pre-gathered so Sentry is never skipped. Sorted by event frequency. An
+`error` field that is not null means the probe itself failed (missing or
+expired token, unreachable API) — report that as a gap, and do NOT read an
+empty `issues` list as "no errors in production".
+
+```!
+${CLAUDE_PLUGIN_ROOT}/bin/ops-sentry 2>/dev/null || echo '{"org":null,"issues":[],"error":"sentry probe failed"}'
+```
+
 ## External projects health
 
 ```!
@@ -132,7 +147,7 @@ fi
 Analyze the pre-gathered data — including external projects. Then run parallel checks:
 
 1. **ECS health** — parse infra data for unhealthy services, stopped tasks, failed deployments.
-2. **Sentry** — if Sentry MCP is connected, query recent unresolved errors. Otherwise note it's unavailable.
+2. **Sentry** — parse the pre-gathered Sentry data above; it is always present, so never report Sentry as unchecked. Classify by blast radius: an issue affecting many users or growing fast is HIGH, a warning-level issue with a handful of events is LOW. Only reach for `mcp__plugin_sentry_sentry__get_sentry_resource` (stack trace, breadcrumbs) or `analyze_issue_with_seer` when you are about to dispatch a fix agent for that issue. If the probe returned a non-null `error`, say Sentry could not be read and why — an empty list is not proof production is clean.
 3. **CI** — parse CI data for failing pipelines, broken main/dev branches.
 4. **GitHub Actions** — `gh run list --limit 20 --json status,conclusion,name,headBranch,createdAt 2>/dev/null`
 5. **External projects** — parse ops-external data. Flag `auth_expired` as HIGH (credential rotation needed), `unreachable`/`degraded` as MEDIUM, `not_configured` as LOW.
@@ -175,8 +190,9 @@ ECS HEALTH
 CI STATUS
 [repo] [branch] [workflow] [status] [last run]
 
-SENTRY (top errors, 24h)
-[error] [count] [first seen] [project]
+SENTRY (unresolved, 24h — by event count)
+[short_id] [title truncated] [events]ev [users]u [project] [last seen]
+[If the probe returned an error, print that instead of an empty section]
 
 EXTERNAL PROJECTS
 [alias] [source] [status] [details — e.g. auth_expired, unreachable]

--- a/claude-ops/skills/ops-orchestrate/SKILL.md
+++ b/claude-ops/skills/ops-orchestrate/SKILL.md
@@ -27,7 +27,7 @@ allowed-tools:
   - CronCreate
   - CronList
   - LSP
-  - mcp__sentry__search_issues
+  - mcp__plugin_sentry_sentry__search_issues
   - mcp__linear__list_issues
   - mcp__linear__update_issue
   - mcp__linear__create_issue
@@ -178,7 +178,7 @@ gh run list --repo <repo> --workflow "<workflow>" --limit 5 --json conclusion,he
 
 Run these in parallel with the audit agents:
 
-- **Sentry**: `mcp__sentry__search_issues` or `sentry-cli issues list` — P0/P1 unresolved errors
+- **Sentry**: `mcp__plugin_sentry_sentry__search_issues` or `sentry-cli issues list` — P0/P1 unresolved errors
 - **Linear**: `mcp__linear__list_issues` for current sprint — in-progress and unstarted
 - **GitHub Issues**: `gh issue list --state open` per repo
 - **Conversation context**: Scan current conversation for todos, requests, and incomplete work the user mentioned

--- a/claude-ops/skills/ops-triage/SKILL.md
+++ b/claude-ops/skills/ops-triage/SKILL.md
@@ -18,8 +18,8 @@ allowed-tools:
   - WebFetch
   - WebSearch
   - LSP
-  - mcp__sentry__search_issues
-  - mcp__sentry__get_issue_details
+  - mcp__plugin_sentry_sentry__search_issues
+  - mcp__plugin_sentry_sentry__get_sentry_resource
   - mcp__linear__list_issues
   - mcp__linear__update_issue
   - mcp__linear__get_issue


### PR DESCRIPTION
Sentry was listed as check 2 of `/ops:fires` but never actually ran. Two silent causes.

**The tool names were wrong.** The frontmatter declared `mcp__sentry__search_issues` and `mcp__sentry__get_issue_details`; the plugin registers them as `mcp__plugin_sentry_sentry__*`. The declared names matched nothing, so the tools were never available and the skill reported "Sentry unavailable" every run — which reads as a connectivity problem, not a typo. Same wrong names were in `ops-triage`, `ops-orchestrate`, `deploy-fix` and `build-fix`; corrected everywhere.

**Sentry was the only signal that had to be remembered.** Infra, CI, FinOps and external projects all arrive pre-gathered in the prompt. Sentry needed a live tool call, and a step that depends on remembering gets skipped. `bin/ops-sentry` puts it on the same footing.

## bin/ops-sentry

- Token: `$SENTRY_AUTH_TOKEN` → `$SENTRY_TOKEN` → `doppler claude-ops/prd`
- Org and region from `preferences.json` `.partner_registry.sentry.{org,region_url}`, with org auto-discovery as fallback
- Always exits 0 with valid JSON. The skill inlines this output, so a broken probe must degrade the dashboard rather than corrupt the prompt.
- A non-null `error` is surfaced as a gap. An empty issue list is not evidence production is clean, and the skill now says so explicitly.

Two details worth keeping:

- **Sentry is region-sharded.** Issues come from the org region host (`us.sentry.io`), not `sentry.io`. The wrong region returns an empty list rather than an error — the same silent failure in a new costume.
- **Auth failures are attributed to auth.** Org discovery runs first, so a dead token previously surfaced as "could not resolve org".

## Verification

Live against the `healify` org: 1.7s, output identical to the MCP tool. It immediately surfaced a P1 `healify-api` p95-latency issue from four minutes earlier that the old path missed entirely.

Failure paths, all returning valid JSON with exit 0:

| case | result |
|---|---|
| bad token | `Sentry auth failed: Invalid token` |
| nonexistent org | `Sentry API error: The requested resource does not exist` |
| 1s timeout | `Sentry API returned no response for org healify` |
| no doppler on PATH | falls through to env token, 1 issue |
| invoked as the skill does (`$CLAUDE_PLUGIN_ROOT`) | 2 issues |

Not verified: only the `healify` org exists on this token, so multi-org discovery is exercised but not the tie-break between several orgs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)