### PR TITLE
fix(marketing): GA4 + Search Console read as "no data" instead of working

### DIFF
--- a/claude-ops/bin/ops-marketing-autopilot
+++ b/claude-ops/bin/ops-marketing-autopilot
@@ -2830,8 +2830,13 @@ run_health_check() {
   # --- GA4 SA key validity ---
   local ga4_prop; ga4_prop="$(chan_cred "$proj" ga4 property_id)"
   if [ -n "$ga4_prop" ]; then
-    local ga4_tok
-    ga4_tok="$(gcloud auth application-default print-access-token 2>/dev/null || true)"
+    # Probe with the SAME credential the data path uses (ga4_auth_token, which
+    # prefers the project's provisioned SA key). Probing raw ADC here reported
+    # every project unhealthy while GA4 pulls were in fact working — a false
+    # alarm that hid the real per-project failures underneath it.
+    local ga4_tok ga4_sa_ref
+    ga4_sa_ref="$(resolve_cred "$(jq -r --arg p "$proj" '.marketing.projects[$p].ga4.sa_key_file_ref // empty' "$PREFS" 2>/dev/null)")"
+    ga4_tok="$(GA4_SERVICE_ACCOUNT_KEY_FILE="$ga4_sa_ref" ga4_auth_token 2>/dev/null || true)"
     if [ -n "$ga4_tok" ]; then
       local ga4_resp
       ga4_resp="$(curl -gsS --max-time 10 -X POST \
@@ -2856,8 +2861,9 @@ run_health_check() {
   # --- GSC site authorization ---
   local gsc_site; gsc_site="$(chan_cred "$proj" gsc site_url)"
   if [ -n "$gsc_site" ]; then
-    local gsc_tok
-    gsc_tok="$(gcloud auth application-default print-access-token 2>/dev/null || true)"
+    local gsc_tok gsc_sa_ref
+    gsc_sa_ref="$(resolve_cred "$(jq -r --arg p "$proj" '.marketing.projects[$p].ga4.sa_key_file_ref // empty' "$PREFS" 2>/dev/null)")"
+    gsc_tok="$(GA4_SERVICE_ACCOUNT_KEY_FILE="$gsc_sa_ref" ga4_auth_token 2>/dev/null || true)"
     if [ -n "$gsc_tok" ]; then
       local gsc_resp
       gsc_resp="$(curl -gsS --max-time 10 \

--- a/claude-ops/bin/ops-marketing-dash
+++ b/claude-ops/bin/ops-marketing-dash
@@ -136,7 +136,14 @@ fi
 # channels.marketing.ga4.sa_json; export it so ga4_auth_token (ga4-data-api.sh)
 # picks it up. Expand a leading ~ to $HOME.
 if [ -z "${GA4_SERVICE_ACCOUNT_KEY_FILE:-}" ] && [ -f "$PREFS" ]; then
-  _ga4_sa="$(jq -r '.channels.marketing.ga4.sa_json // empty' "$PREFS" 2>/dev/null)"
+  # Project tier first: marketing.projects.<key>.ga4.sa_key_file_ref is what
+  # ops-marketing-provision actually writes (and what the autopilot reads).
+  # The owner-level channels.marketing.ga4.sa_json below is the legacy name and
+  # is absent on provisioned installs — reading only that made every GA4 pull
+  # fall through to gcloud ADC, and return null the moment ADC expired.
+  _ga4_sa="$(get_cred 'ga4.sa_key_file_ref' GA4_SERVICE_ACCOUNT_KEY_FILE ga4_sa_key_file 2>/dev/null || true)"
+  [ -z "$_ga4_sa" ] && _ga4_sa="$(jq -r '.channels.marketing.ga4.sa_json // empty' "$PREFS" 2>/dev/null)"
+  _ga4_sa="${_ga4_sa#file:}"
   [ -n "$_ga4_sa" ] && GA4_SERVICE_ACCOUNT_KEY_FILE="${_ga4_sa/#\~/$HOME}"
   export GA4_SERVICE_ACCOUNT_KEY_FILE
 fi
@@ -383,7 +390,10 @@ gather_gsc() {
     return
   fi
 
-  GSC_TOKEN=$(gcloud auth application-default print-access-token 2>/dev/null || echo "")
+  # ga4_auth_token, not raw ADC: the service-account key is the credential that
+  # is actually provisioned and it now carries webmasters.readonly. ADC remains
+  # the last-resort fallback inside that helper.
+  GSC_TOKEN=$(ga4_auth_token 2>/dev/null || echo "")
   if [ -z "$GSC_TOKEN" ]; then
     echo "null"
     return

--- a/claude-ops/scripts/lib/ga4-data-api.sh
+++ b/claude-ops/scripts/lib/ga4-data-api.sh
@@ -14,6 +14,18 @@
 [ -n "${_GA4_DATA_API_LOADED:-}" ] && return 0
 _GA4_DATA_API_LOADED=1
 
+# Scopes minted onto the service-account JWT.
+#
+# webmasters.readonly is NOT optional padding: callers share this one token
+# between the GA4 Data API and the Search Console API (see the GSC paths in
+# ops-marketing-dash and ops-marketing-autopilot). A token minted with only
+# analytics.readonly authenticates fine and then fails every GSC call with
+# HTTP 403 "Request had insufficient authentication scopes" — which the
+# callers degrade to a null envelope, so SEO data silently reads as absent
+# rather than broken. Requesting an unGRANTED scope is harmless; omitting a
+# needed one is not.
+GA4_SA_SCOPES="${GA4_SA_SCOPES:-https://www.googleapis.com/auth/analytics.readonly https://www.googleapis.com/auth/webmasters.readonly}"
+
 # ga4_auth_token [sa_key_file]
 # Resolution order:
 #   1) explicit arg
@@ -30,8 +42,8 @@ ga4_auth_token() {
     now=$(date +%s)
     exp=$((now + 3600))
     header=$(printf '{"alg":"RS256","typ":"JWT"}' | base64 | tr -d '=' | tr '+/' '-_' | tr -d '\n')
-    payload=$(printf '{"iss":"%s","scope":"https://www.googleapis.com/auth/analytics.readonly","aud":"https://oauth2.googleapis.com/token","exp":%d,"iat":%d}' \
-      "$(jq -r '.client_email' "$sa_key_file")" "$exp" "$now" \
+    payload=$(printf '{"iss":"%s","scope":"%s","aud":"https://oauth2.googleapis.com/token","exp":%d,"iat":%d}' \
+      "$(jq -r '.client_email' "$sa_key_file")" "$GA4_SA_SCOPES" "$exp" "$now" \
       | base64 | tr -d '=' | tr '+/' '-_' | tr -d '\n')
     sig=$(printf '%s.%s' "$header" "$payload" \
       | openssl dgst -sha256 -sign <(jq -r '.private_key' "$sa_key_file") 2>/dev/null \

--- a/claude-ops/scripts/lib/ga4-resolve.sh
+++ b/claude-ops/scripts/lib/ga4-resolve.sh
@@ -36,6 +36,14 @@ resolve_cred() {
       local var="${ref#env:}"
       printf '%s' "${!var:-}"
       ;;
+    file:*)
+      # file:/abs/path — a path-valued ref, used by ga4.sa_key_file_ref. Without
+      # this case the "file:" prefix survived into GA4_SERVICE_ACCOUNT_KEY_FILE,
+      # so the key file never existed, every SA mint was skipped, and callers
+      # fell through to gcloud ADC. Expand a leading ~ as well.
+      local _p="${ref#file:}"
+      printf '%s' "${_p/#\~/$HOME}"
+      ;;
     doppler:*)
       local path="${ref#doppler:}"
       local proj="${path%%/*}"

--- a/claude-ops/tests/test-resolve-cred-strict.sh
+++ b/claude-ops/tests/test-resolve-cred-strict.sh
@@ -116,6 +116,43 @@ fi
 
 export PATH="$_orig_path"
 
+# ── Case 8: file: ref strips the prefix ──────────────────────────────────────
+# Regression: resolve_cred had no file:* case, so a ga4.sa_key_file_ref of
+# "file:/path/key.json" resolved to that literal string. The prefix survived
+# into GA4_SERVICE_ACCOUNT_KEY_FILE, [ -f "$f" ] was false, the SA mint was
+# skipped, and every GA4/GSC caller fell through to gcloud ADC — reading as
+# "no data" the moment ADC expired.
+val=""; rc=0
+val="$(_strict "file:/tmp/some-key.json" 2>/dev/null)" || rc=$?
+if [ "$rc" = "0" ] && [ "$val" = "/tmp/some-key.json" ]; then
+  ok "file: ref → rc=0, prefix stripped"
+else
+  err "file: ref → rc=0, prefix stripped" 0 "$rc" "$val"
+fi
+
+# ── Case 9: file: ref expands a leading ~ ────────────────────────────────────
+val=""; rc=0
+val="$(_strict "file:~/k.json" 2>/dev/null)" || rc=$?
+if [ "$rc" = "0" ] && [ "$val" = "$HOME/k.json" ]; then
+  ok "file: ref → leading ~ expanded"
+else
+  err "file: ref → leading ~ expanded" 0 "$rc" "$val"
+fi
+
+# ── Case 10: the minted SA scope must cover Search Console ───────────────────
+# GSC callers share ga4_auth_token's token. analytics.readonly alone yields
+# HTTP 403 insufficient scopes on every GSC request.
+_api_lib="$(cd "$(dirname "$0")/.." && pwd)/scripts/lib/ga4-data-api.sh"
+unset _GA4_DATA_API_LOADED
+# shellcheck disable=SC1090
+. "$_api_lib"
+case "${GA4_SA_SCOPES:-}" in
+  *analytics.readonly*webmasters.readonly*|*webmasters.readonly*analytics.readonly*)
+    ok "GA4_SA_SCOPES covers analytics + webmasters" ;;
+  *)
+    err "GA4_SA_SCOPES covers analytics + webmasters" "both scopes" "${GA4_SA_SCOPES:-<unset>}" ;;
+esac
+
 echo ""
 echo "Results: ${pass} passed, ${fail} failed"
 [ "$fail" -eq 0 ]


### PR DESCRIPTION
## What was broken

Every GA4 and Google Search Console number in the marketing stack read as absent. `ops-marketing-dash --project healify` returned `"ga4": null, "gsc": null`, and `--health-check` reported `ga4_sa_key: no gcloud ADC token` / `gsc_auth: no gcloud ADC token` on all five live projects.

The ADC token *was* expired (`invalid_grant`), which made it look like the whole cause. It was not — the service-account key that is actually provisioned works fine, and had never once been used.

## Root cause, in order

1. **`resolve_cred` had no `file:*` case.** Every project's `ga4.sa_key_file_ref` is `file:/path/key.json`. The `file:` prefix survived into `GA4_SERVICE_ACCOUNT_KEY_FILE`, so `[ -f "$f" ]` was false, the SA mint was skipped, and every caller fell through to `gcloud` ADC. This is the one that defeated the whole chain.
2. **The SA JWT requested only `analytics.readonly`.** Callers share that single token with the Search Console API, which answers `403 insufficient authentication scopes`. Now `GA4_SA_SCOPES` adds `webmasters.readonly`.
3. **`ops-marketing-dash` read the wrong prefs tier** — owner-level `channels.marketing.ga4.sa_json`, absent on provisioned installs — ignoring the project-tier `sa_key_file_ref` the provisioner writes. Its GSC path also called ADC directly instead of `ga4_auth_token`.
4. **The health-check probes called raw ADC**, so they reported failure even though the data path was healthy — a false alarm masking the real per-project failures beneath it.

Each layer degrades failed auth to a null envelope, so nothing ever raised. The dashboard just showed zeroes, which is indistinguishable from a quiet week.

## Verification

Against the live APIs, not mocks:

- GA4 `:runReport` → `200`, real rows (healify: 20 sessions / 29 pageviews, 7d)
- GSC `searchAnalytics` → `200`, real rows (222 clicks / 29,827 impressions, 28d)
- `--health-check`: `ga4_sa_key` and `gsc_auth` now pass on all five live projects

The three new cases in `test-resolve-cred-strict.sh` **fail against the unpatched tree** (verified on a clean `origin/main` worktree) and pass here. Also green: `test-ga4-data-api-lib.sh`, `test-marketing-kpis.sh` (39), `test-ops-marketing-dash-brand-isolation.sh`, `test-no-secrets.sh` (27).

`test-ops-marketing-auth-prewarm.sh` fails identically on `origin/main` — pre-existing, untouched here.

## Still failing, out of scope

`google_ads_oauth: invalid_grant` on all five projects, and Meta config gaps (`healify` `account_status=2`; `mango.talk` / `carrier.llc` tokens unset). Both need credential work, not code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
