### PR TITLE
fix(fires): pre-gather Sentry, want de MCP-toolnaam bestond niet

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -1,5 +1,35 @@
 ## Unreleased
 
+- fix(fires): `/ops:fires` reported Sentry as unavailable on every run. The
+  `allowed-tools` frontmatter named `mcp__sentry__*`, but the plugin registers
+  the tools as `mcp__plugin_sentry_sentry__*`, so the tool never existed under
+  the name the skill asked for and the skill dutifully said "unavailable".
+  Sentry is now pre-gathered via `bin/ops-sentry` (REST), the same way infra, CI
+  and external health already are, so it no longer depends on the model
+  remembering to call a tool. The tool names are corrected in `ops-fires`,
+  `ops-triage`, `ops-orchestrate`, `build-fix` and `deploy-fix` for the paths
+  that still use MCP (stack traces, Seer). A non-null `error` from the probe now
+  reads as a gap in coverage, never as "production is clean". The script never
+  exits non-zero and never prints anything but valid JSON — the skill inlines
+  its output, and one stray error line would corrupt the prompt. It also honours
+  the org's region host: Sentry is region-sharded and the wrong region returns
+  an empty list rather than an error.
+
+  Found the hard way: a fires run showed 22 CI failures (19 of them stale cache,
+  already green) and zero Sentry issues, while `ServiceUnavailableException` on
+  Bedrock `Converse` with `reached max retries: 0` had been affecting 4 users
+  for thirteen hours. The only fire with real user impact was the one missing
+  from the board.
+
+- fix(projects): `ops-projects` rendered `None` for any field whose JSON value
+  was an explicit `null`. `.get(key, default)` returns the `null`, not the
+  default; now `or`.
+
+- fix(daemon): leave a deliberate daemon wrapper in the plugin data dir alone
+  instead of rewriting the plist back to `$PLUGIN_ROOT`. The data-dir plist
+  guard wrote the wrapper path straight back, and each write booted the daemon
+  out before it finished its first monitor pass.
+
 - fix(hooks): UserPromptSubmit inbox autosync no longer interpolates `$INPUT`.
   Grok treats `$VAR` in a hook command as a required env var and skips the
   hook when it is unset. The script already reads the event JSON from stdin.

--- a/claude-ops/bin/ops-projects
+++ b/claude-ops/bin/ops-projects
@@ -116,14 +116,14 @@ for p in projects:
         idle.append(p)
 
 def fmt_proj(p, indent="  "):
-    name = p.get("name","?")
-    phase = p.get("phase","—")
-    status = p.get("status","—")
-    branch = p.get("branch","—")
-    dirty = p.get("uncommitted",0)
+    name = p.get("name") or "?"
+    phase = p.get("phase") or "—"
+    status = p.get("status") or "—"
+    branch = p.get("branch") or "—"
+    dirty = p.get("uncommitted") or 0
     source = p.get("source","")
-    blockers = p.get("blockers","0")
-    next_action = p.get("next_action","")[:40] or "—"
+    blockers = p.get("blockers") or "0"
+    next_action = (p.get("next_action") or "")[:40] or "—"
     short_status = status[:30] if status else "—"
     return f"{indent}{name:<22} {phase:<8} {short_status:<32} {branch:<12} {dirty} dirty  {next_action}"
 

--- a/claude-ops/bin/ops-sentry
+++ b/claude-ops/bin/ops-sentry
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# ops-sentry — Unresolved Sentry issues for the FIRES dashboard → JSON
+#
+# Why this exists: /ops:fires used to declare the Sentry MCP in allowed-tools
+# and hope the model would call it. It never did reliably — the tool name in
+# the frontmatter (mcp__sentry__*) does not match the name the plugin actually
+# registers (mcp__plugin_sentry_sentry__*), so the tool was never available and
+# every run reported Sentry as "unavailable". Pre-gathering it via the REST API
+# puts Sentry on the same footing as infra, CI and external projects: the data
+# is simply in the prompt, with nothing left to remember.
+#
+# Emits {"org":..., "issues":[...], "error":...}. NEVER exits non-zero and
+# never emits anything but valid JSON — the skill inlines this and a bare
+# error string would corrupt the prompt.
+#
+# Token:  env SENTRY_AUTH_TOKEN → env SENTRY_TOKEN → doppler claude-ops/prd
+# Org:    $1 → preferences.json .partner_registry.sentry.org → auto-discover
+# Region: preferences.json .partner_registry.sentry.region_url → us.sentry.io
+#         (Sentry is region-sharded; the org's regionUrl is authoritative and
+#          a wrong region returns an empty list rather than an error.)
+
+set -uo pipefail   # deliberately no -e: a failed probe must degrade, not abort
+
+API_VERSION="0"
+PERIOD="${OPS_SENTRY_PERIOD:-24h}"
+LIMIT="${OPS_SENTRY_LIMIT:-10}"
+CURL_TIMEOUT="${OPS_SENTRY_TIMEOUT:-12}"
+DEFAULT_REGION="https://us.sentry.io"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+OPS_PLUGIN_ROOT_FALLBACK="${SCRIPT_DIR}/.." . "${SCRIPT_DIR}/../lib/registry-path.sh" 2>/dev/null || true
+PREFS="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+
+# Bail out with valid JSON and exit 0, always.
+emit_error() {
+  jq -nc --arg e "$1" '{org:null, issues:[], error:$e}'
+  exit 0
+}
+
+command -v jq >/dev/null 2>&1 || { printf '{"org":null,"issues":[],"error":"jq not installed"}\n'; exit 0; }
+command -v curl >/dev/null 2>&1 || emit_error "curl not installed"
+
+pref() {
+  [ -f "$PREFS" ] || return 0
+  jq -r "$1 // empty" "$PREFS" 2>/dev/null || true
+}
+
+# ---- token -----------------------------------------------------------------
+TOKEN="${SENTRY_AUTH_TOKEN:-${SENTRY_TOKEN:-}}"
+if [ -z "$TOKEN" ] && command -v doppler >/dev/null 2>&1; then
+  TOKEN=$(doppler secrets get SENTRY_AUTH_TOKEN --project claude-ops --config prd --plain 2>/dev/null || true)
+fi
+[ -z "$TOKEN" ] && emit_error "no Sentry token (env SENTRY_AUTH_TOKEN / SENTRY_TOKEN / doppler claude-ops/prd)"
+
+REGION_URL="$(pref '.partner_registry.sentry.region_url')"
+[ -z "$REGION_URL" ] && REGION_URL="$DEFAULT_REGION"
+REGION_URL="${REGION_URL%/}"
+
+api() {
+  curl -sS --max-time "$CURL_TIMEOUT" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Accept: application/json" \
+    "$@" 2>/dev/null
+}
+
+# ---- org -------------------------------------------------------------------
+ORG="${1:-}"
+[ -z "$ORG" ] && ORG="$(pref '.partner_registry.sentry.org')"
+if [ -z "$ORG" ]; then
+  # Org listing is not region-sharded; the control silo answers for every org.
+  ORG_RAW=$(api "https://sentry.io/api/${API_VERSION}/organizations/")
+  if printf '%s' "$ORG_RAW" | jq -e 'type=="array"' >/dev/null 2>&1; then
+    ORG=$(printf '%s' "$ORG_RAW" | jq -r '.[0].slug // empty' 2>/dev/null || true)
+  else
+    # An object here means the token was rejected. Say so, rather than blaming
+    # the org — a bad token and a missing org need different fixes.
+    AUTH_DETAIL=$(printf '%s' "$ORG_RAW" | jq -r '.detail // .error // empty' 2>/dev/null || true)
+    [ -n "$AUTH_DETAIL" ] && emit_error "Sentry auth failed: ${AUTH_DETAIL}"
+  fi
+fi
+[ -z "$ORG" ] && emit_error "could not resolve a Sentry org (set .partner_registry.sentry.org in preferences.json)"
+
+# ---- issues ----------------------------------------------------------------
+# statsPeriod bounds the window; query filters to still-open issues.
+RAW=$(api -G "${REGION_URL}/api/${API_VERSION}/organizations/${ORG}/issues/" \
+  --data-urlencode "query=is:unresolved" \
+  --data-urlencode "statsPeriod=${PERIOD}" \
+  --data-urlencode "limit=${LIMIT}" \
+  --data-urlencode "sort=freq")
+
+[ -z "$RAW" ] && emit_error "Sentry API returned no response for org ${ORG} (region ${REGION_URL})"
+
+# An error body is a JSON object; a good body is an array. Distinguish, so an
+# expired token reads as "expired token" and not as "zero issues".
+if ! printf '%s' "$RAW" | jq -e 'type=="array"' >/dev/null 2>&1; then
+  DETAIL=$(printf '%s' "$RAW" | jq -r '.detail // .error // "unrecognised response"' 2>/dev/null || echo "unparseable response")
+  jq -nc --arg o "$ORG" --arg e "Sentry API error: $DETAIL" '{org:$o, issues:[], error:$e}'
+  exit 0
+fi
+
+printf '%s' "$RAW" | jq -c --arg o "$ORG" --arg p "$PERIOD" '{
+  org: $o,
+  period: $p,
+  issues: [ .[] | {
+    short_id:   .shortId,
+    title:      .title,
+    culprit:    .culprit,
+    project:    (.project.slug // null),
+    level:      .level,
+    events:     (.count      // "0"),
+    users:      (.userCount  // 0),
+    first_seen: .firstSeen,
+    last_seen:  .lastSeen,
+    url:        .permalink
+  } ],
+  error: null
+}' 2>/dev/null || emit_error "failed to parse Sentry issue list"

--- a/claude-ops/prompts/build-fix.md
+++ b/claude-ops/prompts/build-fix.md
@@ -11,7 +11,7 @@ You are headless inside Claude Code with full claude-ops tooling:
 | Mobile / Expo / RN / iOS Fastlane  | spawn the `Mobile App Specialist` subagent                                  |
 | TypeScript / type errors           | spawn the `typescript-reviewer` subagent                                    |
 | Cross-repo contract breakage       | spawn the `fullstack-mobile-architect` subagent                             |
-| Sentry context for runtime crashes | `mcp__sentry__search_events`                                                |
+| Sentry context for runtime crashes | `mcp__plugin_sentry_sentry__search_events`                                                |
 | Apple Developer / TestFlight state | `python3 scripts/asc-manage-builds.py` (in your mobile repo)                |
 | Doppler secret resolution          | `doppler secrets get <KEY> --project <your-project> --config <env> --plain` |
 | Library version drift              | `npx expo install --check`, `npm ls <pkg>`, Context7 MCP for docs           |

--- a/claude-ops/prompts/deploy-fix.md
+++ b/claude-ops/prompts/deploy-fix.md
@@ -10,7 +10,7 @@ You are running headless inside a Claude Code session with full claude-ops tooli
 | -------------------------------------------- | ------------------------------------------------------------ |
 | Fetch failed CI logs                         | `gh run view {{RUN_ID}} --repo {{REPO}} --log-failed`        |
 | Inspect ECS / AWS state                      | `/ops:ops-fires`, `/ops:ops-monitor`, raw `aws` CLI          |
-| Sentry context for related errors            | `/ops:ops-triage` or `mcp__sentry__search_events`            |
+| Sentry context for related errors            | `/ops:ops-triage` or `mcp__plugin_sentry_sentry__search_events`            |
 | Find prior fixes for similar failures        | `gh search prs --repo {{REPO}} 'fix(deploy)' --state merged` |
 | My-Project mobile crashes / iOS build issues | spawn the `Mobile App Specialist` subagent                   |
 | My-Project backend / NestJS issues           | spawn the `Health Data Expert` subagent                      |

--- a/claude-ops/scripts/ops-daemon-manager.sh
+++ b/claude-ops/scripts/ops-daemon-manager.sh
@@ -310,8 +310,29 @@ cmd_ensure_current() {
   if [[ "$plist_script" == "$current_script" ]]; then
     exit 0
   fi
+  # A wrapper living in the plugin DATA dir is a deliberate local override, not
+  # stale drift. It resolves the newest plugin version itself at every start, so
+  # rewriting the plist back to $PLUGIN_ROOT gains nothing — and costs a restart
+  # loop: the data-dir plist guard watches this file and writes the wrapper path
+  # straight back, each write booting the daemon out before it finishes its first
+  # monitor pass. Leave an intentional wrapper alone.
+  if [[ -n "$plist_script" ]] && _is_data_dir_wrapper "$plist_script"; then
+    log "plist points at data-dir wrapper ($plist_script) — leaving it in place"
+    exit 0
+  fi
   log "plist points at stale version ($plist_script); upgrading to $PLUGIN_ROOT"
   cmd_upgrade
+}
+
+# True when PATH is an executable ops daemon wrapper inside the plugin data dir.
+# Both conditions matter: the prefix proves it is ours, and the exec bit proves
+# it can actually run — a stale path under the data dir must still be repaired.
+_is_data_dir_wrapper() {
+  local candidate="$1"
+  local data_root="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+  [[ "$candidate" == "$data_root"/* ]] || return 1
+  [[ -x "$candidate" ]] || return 1
+  return 0
 }
 
 cmd_uninstall() {

--- a/claude-ops/skills/ops-fires/SKILL.md
+++ b/claude-ops/skills/ops-fires/SKILL.md
@@ -17,8 +17,9 @@ allowed-tools:
   - Monitor
   - WebFetch
   - WebSearch
-  - mcp__sentry__search_issues
-  - mcp__sentry__get_issue_details
+  - mcp__plugin_sentry_sentry__search_issues
+  - mcp__plugin_sentry_sentry__get_sentry_resource
+  - mcp__plugin_sentry_sentry__find_organizations
 effort: medium
 maxTurns: 30
 ---
@@ -41,7 +42,8 @@ Before executing, load available context:
    - First: check `$AWS_ACCESS_KEY_ID` / `$AWS_PROFILE` env vars
    - Then: `doppler secrets get AWS_ACCESS_KEY_ID --plain` (if `doppler` configured in prefs)
    - Then: use `password_manager_config.query_cmd` from preferences
-   - Sentry token: `$SENTRY_AUTH_TOKEN` → Doppler `SENTRY_AUTH_TOKEN` → vault
+   - Sentry token: `$SENTRY_AUTH_TOKEN` → `$SENTRY_TOKEN` → Doppler `claude-ops/prd/SENTRY_AUTH_TOKEN`. Resolved by `bin/ops-sentry`; no action needed here.
+   - Sentry org and region: `preferences.json` `.partner_registry.sentry.{org,region_url}`. Sentry is region-sharded — issues are served by the org's own region host (e.g. `https://us.sentry.io`), not `sentry.io`, and querying the wrong region returns an empty list rather than an error. Omit `org` and the script discovers the first org the token can see.
 
 3. **Preferences**: Read `${CLAUDE_PLUGIN_DATA_DIR}/preferences.json` for `secrets_manager` config to know which vault to query.
 
@@ -67,7 +69,9 @@ Before executing, load available context:
 | Command                                                                                                                          | Usage                             | Output     |
 | -------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- | ---------- |
 | `sentry-cli issues list --project <slug> --status unresolved`                                                                    | Unresolved issues                 | Issue list |
-| `curl -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" "https://sentry.io/api/0/projects/<org>/<proj>/issues/?query=is:unresolved"` | API fallback when MCP unavailable | JSON array |
+| `bin/ops-sentry [org]` | Pre-gather path (already inlined below) | JSON `{org,issues,error}` |
+| `OPS_SENTRY_PERIOD=7d OPS_SENTRY_LIMIT=25 bin/ops-sentry` | Widen the window or cap | JSON |
+| `curl -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" "https://us.sentry.io/api/0/organizations/<org>/issues/?query=is:unresolved"` | Manual probe (note: region host, org-scoped) | JSON array |
 
 ---
 
@@ -111,6 +115,17 @@ ${CLAUDE_PLUGIN_ROOT}/scripts/finops-bridge.sh anomalies high 2>/dev/null || ech
 ${CLAUDE_PLUGIN_ROOT}/bin/ops-ci 2>/dev/null || echo '[]'
 ```
 
+## Sentry — unresolved issues (last 24h)
+
+Pre-gathered so Sentry is never skipped. Sorted by event frequency. An
+`error` field that is not null means the probe itself failed (missing or
+expired token, unreachable API) — report that as a gap, and do NOT read an
+empty `issues` list as "no errors in production".
+
+```!
+${CLAUDE_PLUGIN_ROOT}/bin/ops-sentry 2>/dev/null || echo '{"org":null,"issues":[],"error":"sentry probe failed"}'
+```
+
 ## External projects health
 
 ```!
@@ -132,7 +147,7 @@ fi
 Analyze the pre-gathered data — including external projects. Then run parallel checks:
 
 1. **ECS health** — parse infra data for unhealthy services, stopped tasks, failed deployments.
-2. **Sentry** — if Sentry MCP is connected, query recent unresolved errors. Otherwise note it's unavailable.
+2. **Sentry** — parse the pre-gathered Sentry data above; it is always present, so never report Sentry as unchecked. Classify by blast radius: an issue affecting many users or growing fast is HIGH, a warning-level issue with a handful of events is LOW. Only reach for `mcp__plugin_sentry_sentry__get_sentry_resource` (stack trace, breadcrumbs) or `analyze_issue_with_seer` when you are about to dispatch a fix agent for that issue. If the probe returned a non-null `error`, say Sentry could not be read and why — an empty list is not proof production is clean.
 3. **CI** — parse CI data for failing pipelines, broken main/dev branches.
 4. **GitHub Actions** — `gh run list --limit 20 --json status,conclusion,name,headBranch,createdAt 2>/dev/null`
 5. **External projects** — parse ops-external data. Flag `auth_expired` as HIGH (credential rotation needed), `unreachable`/`degraded` as MEDIUM, `not_configured` as LOW.
@@ -175,8 +190,9 @@ ECS HEALTH
 CI STATUS
 [repo] [branch] [workflow] [status] [last run]
 
-SENTRY (top errors, 24h)
-[error] [count] [first seen] [project]
+SENTRY (unresolved, 24h — by event count)
+[short_id] [title truncated] [events]ev [users]u [project] [last seen]
+[If the probe returned an error, print that instead of an empty section]
 
 EXTERNAL PROJECTS
 [alias] [source] [status] [details — e.g. auth_expired, unreachable]

--- a/claude-ops/skills/ops-orchestrate/SKILL.md
+++ b/claude-ops/skills/ops-orchestrate/SKILL.md
@@ -27,7 +27,7 @@ allowed-tools:
   - CronCreate
   - CronList
   - LSP
-  - mcp__sentry__search_issues
+  - mcp__plugin_sentry_sentry__search_issues
   - mcp__linear__list_issues
   - mcp__linear__update_issue
   - mcp__linear__create_issue
@@ -178,7 +178,7 @@ gh run list --repo <repo> --workflow "<workflow>" --limit 5 --json conclusion,he
 
 Run these in parallel with the audit agents:
 
-- **Sentry**: `mcp__sentry__search_issues` or `sentry-cli issues list` — P0/P1 unresolved errors
+- **Sentry**: `mcp__plugin_sentry_sentry__search_issues` or `sentry-cli issues list` — P0/P1 unresolved errors
 - **Linear**: `mcp__linear__list_issues` for current sprint — in-progress and unstarted
 - **GitHub Issues**: `gh issue list --state open` per repo
 - **Conversation context**: Scan current conversation for todos, requests, and incomplete work the user mentioned

--- a/claude-ops/skills/ops-triage/SKILL.md
+++ b/claude-ops/skills/ops-triage/SKILL.md
@@ -18,8 +18,8 @@ allowed-tools:
   - WebFetch
   - WebSearch
   - LSP
-  - mcp__sentry__search_issues
-  - mcp__sentry__get_issue_details
+  - mcp__plugin_sentry_sentry__search_issues
+  - mcp__plugin_sentry_sentry__get_sentry_resource
   - mcp__linear__list_issues
   - mcp__linear__update_issue
   - mcp__linear__get_issue


### PR DESCRIPTION
## Waarom

`/ops:fires` meldde Sentry structureel als "unavailable". Geen token- of netwerkprobleem: de `allowed-tools` in de frontmatter noemden `mcp__sentry__*`, terwijl de plugin de tools registreert als `mcp__plugin_sentry_sentry__*`. Onder een naam die niet bestaat is een tool er voor het model niet, dus de skill concludeerde braaf "Sentry unavailable" en niemand keek verder.

Vandaag kostte dat een echte fire. Het bord toonde 22 CI-failures — waarvan 19 stale cache, inmiddels groen — en nul Sentry-issues. Ondertussen liep `HEALIFY-AGENTCORE-2M` sinds 06:14 UTC:

```
ServiceUnavailableException ... calling the Converse operation
(reached max retries: 0): Bedrock is unable to process your request.
```

11 events, **4 gebruikers geraakt**. De enige fire met echte gebruikersimpact stond niet op het bord, terwijl negentien false positives er wel op stonden.

## Wat dit doet

- **`bin/ops-sentry`** haalt unresolved issues via de REST API op en zet ze in de prompt, net zoals infra, CI en external al gepre-gathered worden. Sentry hangt daarmee niet meer af van de vraag of het model eraan denkt een tool aan te roepen.
- Corrigeert de toolnamen in `ops-fires`, `ops-triage`, `ops-orchestrate`, `build-fix` en `deploy-fix`, zodat de MCP-route werkt waar hij nog nodig is (stack traces, Seer).
- De skill leest een niet-null `error` nu expliciet als een gat in de dekking, niet als "productie is schoon". Een lege lijst is geen bewijs.

Twee bewuste eigenschappen van het script. Het exit **nooit** non-zero en print nooit iets anders dan geldige JSON, omdat de skill de output inlinet en één losse foutregel de prompt zou corrumperen. En het respecteert de region-host: Sentry is region-sharded en een query naar de verkeerde region geeft een lege lijst in plaats van een fout — precies de stilte die deze bug ook had.

## Geverifieerd, niet aangenomen

| geval | uitkomst |
| --- | --- |
| echte org | exit 0, valid JSON, 2 issues (org `healify`) |
| ongeldig token | exit 0, valid JSON, `error: "Sentry auth failed: Invalid token"` |
| onbekende org meegegeven | exit 0, valid JSON, `error: "resource does not exist"` |
| `jq` ontbreekt op PATH | exit 0, valid JSON, `error: "jq not installed"` |
| `grep -r mcp__sentry__` | nul hits in de hele plugin |
| `bash -n` | schoon |

Onderweg corrigeerde ik nog een eigen misconclusie: een eerste test leek te zeggen dat het script zonder `jq` exit 127 gaf, maar die 127 kwam van `timeout` zelf, dat op de uitgeklede PATH ontbrak. Met `jq` daadwerkelijk afwezig vuurt de guard correct.

## Meegenomen

Twee fixes uit dezelfde geïnstalleerde kopie, die los geen zin hebben:

- `ops-projects` gebruikte `.get(key, default)`, wat een expliciete JSON `null` doorlaat en dan `None` in de tabel zet. Nu `or`.
- `ops-daemon-manager` laat een bewuste wrapper in de plugin-data-dir staan in plaats van het plist terug te schrijven. Dat terugschrijven startte de daemon elke keer opnieuw eruit voor zijn eerste monitor-pass klaar was.

## Buiten scope, met opzet

De `hooks.json` in de geïnstalleerde kopie wijst 14× naar machine-lokale wrappers onder `$HOME/.claude/scripts/hooks/`. Dat is een lokale keuze, geen plugin-gedrag, dus die blijft buiten deze PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
