### PR TITLE
fix(daemon): stop de restart-loop van twee vechtende plist-writers

### DIFF
--- a/claude-ops/scripts/ops-daemon-manager.sh
+++ b/claude-ops/scripts/ops-daemon-manager.sh
@@ -310,8 +310,29 @@ cmd_ensure_current() {
   if [[ "$plist_script" == "$current_script" ]]; then
     exit 0
   fi
+  # A wrapper living in the plugin DATA dir is a deliberate local override, not
+  # stale drift. It resolves the newest plugin version itself at every start, so
+  # rewriting the plist back to $PLUGIN_ROOT gains nothing — and costs a restart
+  # loop: the data-dir plist guard watches this file and writes the wrapper path
+  # straight back, each write booting the daemon out before it finishes its first
+  # monitor pass. Leave an intentional wrapper alone.
+  if [[ -n "$plist_script" ]] && _is_data_dir_wrapper "$plist_script"; then
+    log "plist points at data-dir wrapper ($plist_script) — leaving it in place"
+    exit 0
+  fi
   log "plist points at stale version ($plist_script); upgrading to $PLUGIN_ROOT"
   cmd_upgrade
+}
+
+# True when PATH is an executable ops daemon wrapper inside the plugin data dir.
+# Both conditions matter: the prefix proves it is ours, and the exec bit proves
+# it can actually run — a stale path under the data dir must still be repaired.
+_is_data_dir_wrapper() {
+  local candidate="$1"
+  local data_root="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
+  [[ "$candidate" == "$data_root"/* ]] || return 1
+  [[ -x "$candidate" ]] || return 1
+  return 0
 }
 
 cmd_uninstall() {

--- a/claude-ops/tests/test-daemon-ensure-current-wrapper.sh
+++ b/claude-ops/tests/test-daemon-ensure-current-wrapper.sh
@@ -1,0 +1,88 @@
+#!/opt/homebrew/bin/bash
+# End-to-end: run the real `ensure-current` against a fake HOME and assert it
+# leaves a data-dir wrapper plist untouched, but still repairs a genuinely
+# stale plugin-version path.
+set -uo pipefail
+
+MGR="$1"
+T="$(mktemp -d)"
+trap 'rm -rf "$T"' EXIT
+
+FAKE_HOME="$T/home"
+DATA="$FAKE_HOME/.claude/plugins/data/ops-ops-marketplace"
+NEWROOT="$FAKE_HOME/.claude/plugins/cache/ops-marketplace/ops/9.9.9"
+OLDROOT="$FAKE_HOME/.claude/plugins/cache/ops-marketplace/ops/1.0.0"
+AGENTS="$FAKE_HOME/Library/LaunchAgents"
+PLIST="$AGENTS/com.claude-ops.daemon.plist"
+
+mkdir -p "$DATA/bin" "$NEWROOT/scripts" "$OLDROOT/scripts" "$AGENTS"
+printf '#!/bin/sh\n' > "$DATA/bin/ops-daemon.sh";       chmod 755 "$DATA/bin/ops-daemon.sh"
+printf '#!/bin/sh\n' > "$NEWROOT/scripts/ops-daemon.sh"; chmod 755 "$NEWROOT/scripts/ops-daemon.sh"
+printf '#!/bin/sh\n' > "$OLDROOT/scripts/ops-daemon.sh"; chmod 755 "$OLDROOT/scripts/ops-daemon.sh"
+# The manager needs its own plist template to be able to rewrite.
+cp "$(dirname "$MGR")/com.claude-ops.daemon.plist" "$NEWROOT/scripts/" 2>/dev/null || true
+
+write_plist() {
+  cat > "$PLIST" <<PLISTEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.claude-ops.daemon</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/opt/homebrew/bin/bash</string>
+		<string>$1</string>
+	</array>
+</dict>
+</plist>
+PLISTEOF
+}
+
+plist_target() {
+  /usr/libexec/PlistBuddy -c "Print :ProgramArguments:1" "$PLIST" 2>/dev/null
+}
+
+fails=0
+check() {
+  local desc="$1" want="$2" got="$3"
+  if [[ "$want" == "$got" ]]; then
+    printf 'PASS  %s\n' "$desc"
+  else
+    printf 'FAIL  %s\n        want=%s\n         got=%s\n' "$desc" "$want" "$got"
+    fails=$((fails + 1))
+  fi
+}
+
+# ── Case 1: plist points at the data-dir wrapper. Must be left alone. ────────
+write_plist "$DATA/bin/ops-daemon.sh"
+before="$(plist_target)"
+HOME="$FAKE_HOME" CLAUDE_PLUGIN_DATA_DIR="$DATA" \
+  /opt/homebrew/bin/bash "$MGR" ensure-current --plugin-root "$NEWROOT" --dry-run >"$T/out1" 2>&1
+rc1=$?
+after="$(plist_target)"
+check "wrapper plist unchanged by ensure-current" "$before" "$after"
+check "ensure-current exits 0 on wrapper"          "0"       "$rc1"
+if grep -q "leaving it in place" "$T/out1"; then
+  echo "PASS  logged the deliberate-override decision"
+else
+  echo "FAIL  expected 'leaving it in place' in output; got:"
+  sed 's/^/        /' "$T/out1"
+  fails=$((fails + 1))
+fi
+
+# ── Case 2: plist points at an OLD plugin version. Must still be repaired. ──
+write_plist "$OLDROOT/scripts/ops-daemon.sh"
+HOME="$FAKE_HOME" CLAUDE_PLUGIN_DATA_DIR="$DATA" \
+  /opt/homebrew/bin/bash "$MGR" ensure-current --plugin-root "$NEWROOT" --dry-run >"$T/out2" 2>&1
+if grep -q "stale version" "$T/out2"; then
+  echo "PASS  genuine stale-version drift still detected"
+else
+  echo "FAIL  expected 'stale version' for old plugin path; got:"
+  sed 's/^/        /' "$T/out2"
+  fails=$((fails + 1))
+fi
+
+echo "--- $fails failure(s) ---"
+exit $(( fails > 0 ? 1 : 0 ))

--- a/claude-ops/tests/test-daemon-plist-wrapper-detect.sh
+++ b/claude-ops/tests/test-daemon-plist-wrapper-detect.sh
@@ -1,0 +1,58 @@
+#!/opt/homebrew/bin/bash
+# Focused test for _is_data_dir_wrapper from ops-daemon-manager.sh.
+set -uo pipefail
+
+MGR="$1"
+T="$(mktemp -d)"
+trap 'rm -rf "$T"' EXIT
+
+mkdir -p "$T/data" "$T/plugin/scripts"
+: > "$T/plugin/scripts/ops-daemon.sh"
+printf '#!/bin/sh\n' > "$T/data/bin-wrapper.sh"; chmod 755 "$T/data/bin-wrapper.sh"
+printf '#!/bin/sh\n' > "$T/data/not-exec.sh";    chmod 644 "$T/data/not-exec.sh"
+
+# Pull only the helper out of the manager, so we test it without running the CLI.
+sed -n '/^_is_data_dir_wrapper()/,/^}/p' "$MGR" > "$T/fn.sh"
+if [[ ! -s "$T/fn.sh" ]]; then
+  echo "FAIL: could not extract _is_data_dir_wrapper from $MGR"
+  exit 1
+fi
+echo "--- extracted helper ---"
+cat "$T/fn.sh"
+echo "--- results ---"
+
+export CLAUDE_PLUGIN_DATA_DIR="$T/data"
+# shellcheck source=/dev/null
+source "$T/fn.sh"
+
+fails=0
+check() {
+  local desc="$1" want="$2" got="$3"
+  if [[ "$want" == "$got" ]]; then
+    printf 'PASS  %-46s got=%s\n' "$desc" "$got"
+  else
+    printf 'FAIL  %-46s want=%s got=%s\n' "$desc" "$want" "$got"
+    fails=$((fails + 1))
+  fi
+}
+
+run() { _is_data_dir_wrapper "$1" && echo true || echo false; }
+
+check "exec wrapper inside data dir"      true  "$(run "$T/data/bin-wrapper.sh")"
+check "non-exec file inside data dir"     false "$(run "$T/data/not-exec.sh")"
+check "plugin script outside data dir"    false "$(run "$T/plugin/scripts/ops-daemon.sh")"
+check "empty path"                        false "$(run "")"
+check "missing file inside data dir"      false "$(run "$T/data/absent.sh")"
+check "data-dir prefix lookalike sibling" false "$(run "${T}/data-evil/bin.sh")"
+
+# The real caller runs under set -u; prove the helper survives it.
+set -u
+if _is_data_dir_wrapper "$T/data/bin-wrapper.sh"; then
+  echo "PASS  survives set -u                            got=exit0"
+else
+  echo "FAIL  survives set -u"
+  fails=$((fails + 1))
+fi
+
+echo "--- $fails failure(s) ---"
+exit $(( fails > 0 ? 1 : 0 ))


### PR DESCRIPTION
## Wat er stuk was

De ops-daemon herstartte elke ~10 seconden. Niet door een stale plist, maar
doordat twee scripts om dezelfde plist vochten.

`cmd_ensure_current` zag elk pad behalve `$PLUGIN_ROOT/scripts/ops-daemon.sh`
als stale drift en schreef het terug. Op deze machine wijst de plist bewust
naar een wrapper in de plugin data-dir, omdat de meegeleverde daemon op
bash 5.3 vastloopt op `cat > "$HEALTH_FILE" <<EOF` (de heredoc-pipe draineert
nooit onder launchd's `/dev/null` stdin).

Daardoor waren er twee eigenaars van één bestand:

- de SessionStart-hook schreef het marketplace-pad;
- de `daemon-health-write-guard` LaunchAgent watcht die plist en schreef het
  wrapper-pad meteen terug, met een `bootout`/`bootstrap` erachteraan.

Elke write kostte een herstart, dus de daemon kreeg SIGTERM na ~10s en bereikte
zijn eerste monitorpas nooit.

## Gemeten effect

Alle 14 services stonden op `scheduled` en hebben nooit gedraaid —
`briefing-pre-warm`, `memory-extractor`, `infra-monitor`, de hele set. De
health-file leek de hele tijd vers, omdat elk nieuw proces hem herschreef vóór
het stierf. Dat is waarom een gewone health-check dit groen noemt.

Waargenomen tijdens debuggen:

```
WRITE 22:30:19 [...]/marketplaces/ops-marketplace/current/scripts/ops-daemon.sh
WRITE 22:30:20 [...]/data/ops-ops-marketplace/bin/ops-daemon.sh
```

## De fix

`ensure-current` herkent een executable wrapper onder de plugin data-dir nu als
bewuste override en laat hem staan. Wat níet verandert:

- echte versie-drift wordt nog steeds gerepareerd;
- een niet-executable of dood pad onder de data-dir geldt nog steeds als kapot;
- de helper werkt onder `set -u`.

## Verificatie

- `tests/test-daemon-plist-wrapper-detect.sh` — 7 gevallen, nieuw
- `tests/test-daemon-ensure-current-wrapper.sh` — 4 end-to-end gevallen tegen een
  fake `HOME`, nieuw; dekt zowel "laat wrapper staan" als "repareer echte drift"
- `tests/test-ops-daemon-manager.sh` — 18/18, bestaand, ongewijzigd

Live gemeten na installatie: één PID over 100 seconden (was een nieuwe elke
~10s), nul plist-writes, en `briefing-pre-warm` + `marketing-prewarm` hebben
voor het eerst een `last_success`.

Het commando dat de loop veroorzaakte zegt nu:

```
[daemon-manager] plist points at data-dir wrapper (...) — leaving it in place
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
