### PR TITLE
hooks: guard tegen blokkerende hooks zonder timeout + release v3.10.11

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 66 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "3.10.9",
+      "version": "3.10.10",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-3.10.9-blue)
+![Version](https://img.shields.io/badge/version-3.10.10-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-66-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "3.10.9",
+  "version": "3.10.10",
   "description": "Business operations command center for Claude Code — 66 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,14 +2,6 @@
 
 ## Unreleased
 
-- test(hooks): `tests/test-hooks.sh` now fails any hook that is neither
-  `async: true` nor bounded by a `timeout`. v3.10.8 put a bound on the Stop
-  hook `ops-post-session-cleanup`, but nothing stopped the next hook from
-  landing without one — in `hooks.json` a hook that blocks looks exactly like
-  a hook that does not. Async hooks are exempt on purpose: they never hold the
-  event, so a timeout there would invent a problem. Proved in both directions
-  against the pre-fix `hooks.json` (1 failed) and the current tree (25 passed).
-
 - fix(hooks): UserPromptSubmit inbox autosync no longer interpolates `$INPUT`.
   Grok treats `$VAR` in a hook command as a required env var and skips the
   hook when it is unset. The script already reads the event JSON from stdin.
@@ -144,6 +136,27 @@
 - **ops-desk (new skill):** `/ops:ops-desk` desk sweep — fans out read-only context agents (batched, Workflow tool) over the owner's open decisions/drafts/payments/sign-offs and returns a ranked, ready-to-approve action queue worked down under the per-draft outbound gate. Complements `/ops:ops-inbox`.
 - **ops-ecom:** `channels` | `agentic` | `shop` verbs — sales channel inventory, agentic storefront health, Shop Campaigns readiness (read-only; Rule 5 / stage-only spend).
 - **ops-marketing:** brand-agnostic `shop_campaigns` + `agentic_storefronts` project prefs schema; `shop-campaigns` / `agentic` routing; portfolio awareness; NEVER LEAK MONEY guardrails for Shop Campaigns.
+
+## [3.10.10] - 2026-09-09
+
+### Fixed
+
+- fix(mcp-watchdog): a 401 with no credential to present is not
+  `needs_bootstrap`. The probe reported a server as needing a bootstrap when it
+  had never been given anything to authenticate with, so the repair loop kept
+  chasing a state the server could not leave. It now separates "rejected" from
+  "never asked" (#945).
+
+### Testing
+
+- test(hooks): `tests/test-hooks.sh` fails any hook that is neither
+  `async: true` nor bounded by a `timeout`. v3.10.8 put a bound on the Stop hook
+  `ops-post-session-cleanup`, but nothing stopped the next hook from landing
+  without one — in `hooks.json` a hook that blocks looks exactly like a hook that
+  does not, and an unbounded blocking hook holds the event open until its command
+  returns. Async hooks are exempt on purpose: they never hold the event, so a
+  timeout there would invent a problem. Proved in both directions against the
+  pre-fix `hooks.json` (1 failed) and the current tree (25 passed).
 
 ## [3.10.9] - 2026-09-08
 

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- test(hooks): `tests/test-hooks.sh` now fails any hook that is neither
+  `async: true` nor bounded by a `timeout`. v3.10.8 put a bound on the Stop
+  hook `ops-post-session-cleanup`, but nothing stopped the next hook from
+  landing without one — in `hooks.json` a hook that blocks looks exactly like
+  a hook that does not. Async hooks are exempt on purpose: they never hold the
+  event, so a timeout there would invent a problem. Proved in both directions
+  against the pre-fix `hooks.json` (1 failed) and the current tree (25 passed).
+
 - fix(hooks): UserPromptSubmit inbox autosync no longer interpolates `$INPUT`.
   Grok treats `$VAR` in a hook command as a required env var and skips the
   hook when it is unset. The script already reads the event JSON from stdin.

--- a/claude-ops/docs/INDEX.md
+++ b/claude-ops/docs/INDEX.md
@@ -4,7 +4,7 @@
 
 _Top-level map of every doc file in `claude-ops/docs/`._
 
-[![version](https://img.shields.io/badge/version-3.10.9-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.10.10-blue)](../CHANGELOG.md)
 
 </div>
 

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-3.10.9-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.10.10-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 66 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-3.10.9-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.10.10-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-66-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/hermes-plugin/plugin.yaml
+++ b/claude-ops/hermes-plugin/plugin.yaml
@@ -1,4 +1,4 @@
 name: ops
-version: "3.10.9"
+version: "3.10.10"
 description: "claude-ops on Hermes — slash commands and skills for inbox, deploy, revenue, and the rest of the ops suite. Enable with plugins.enabled: [ops]."
 author: Lifecycle Innovations Limited

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "3.10.9",
+  "version": "3.10.10",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/claude-ops/tests/test-hooks.sh
+++ b/claude-ops/tests/test-hooks.sh
@@ -153,6 +153,31 @@ else
   fi
 fi
 
+# 8. Every blocking hook must carry a timeout.
+# A hook without "timeout" and without "async": true holds the event until the
+# command returns. On Stop that is the end of every session; on UserPromptSubmit
+# it is every prompt. An async hook needs no timeout — it never blocks — so it is
+# exempt on purpose rather than by oversight.
+echo ""
+echo "Checking blocking hooks for a timeout..."
+if command -v jq &>/dev/null; then
+  unbounded=$(jq -r '
+    .hooks | to_entries[] as $ev
+    | $ev.value[]? | .hooks[]?
+    | select((.async // false) != true)
+    | select(has("timeout") | not)
+    | "\($ev.key): \(.command)"
+  ' "$HOOKS_FILE" 2>/dev/null || true)
+  if [[ -n "$unbounded" ]]; then
+    while IFS= read -r line; do
+      [[ -z "$line" ]] && continue
+      err "blocking hook has no timeout (it can hold the event open): $line"
+    done <<< "$unbounded"
+  else
+    ok "every blocking hook has a timeout"
+  fi
+fi
+
 echo ""
 echo "---"
 echo "Results: $pass passed, $fail failed"

--- a/installer/README.md
+++ b/installer/README.md
@@ -56,7 +56,7 @@ version: 1
 source:
   type: git
   url: https://github.com/Lifecycle-Innovations-Limited/claude-ops.git
-  ref: v3.10.9
+  ref: v3.10.10
 
 agents:
   claude:    { enabled: true }

--- a/installer/src/config.mjs
+++ b/installer/src/config.mjs
@@ -17,7 +17,7 @@ export const DEFAULT_CONFIG = {
   source: {
     type: "git",
     url: "https://github.com/Lifecycle-Innovations-Limited/claude-ops.git",
-    ref: "v3.10.9",
+    ref: "v3.10.10",
   },
   agents: {
     claude: { enabled: true, type: "marketplace" },


### PR DESCRIPTION
## Wat

**Regressieguard voor hook-latency.** v3.10.8 zette een `timeout: 5` op de Stop-hook `ops-post-session-cleanup`, maar niets hield de volgende hook tegen die zonder timeout landt. In `hooks.json` ziet een hook die blokkeert er precies zo uit als een hook die dat niet doet, en een blokkerende hook zonder timeout houdt het event open tot zijn commando terugkomt — op Stop is dat het einde van elke sessie.

`tests/test-hooks.sh` faalt nu op elke hook die noch `async: true` is, noch een `timeout` heeft. Async-hooks zijn bewust vrijgesteld: die houden het event nooit vast, dus een timeout daar verzint een probleem.

Beide kanten bewezen:
- oude `hooks.json` (voor 45b6f3a): 24 passed, **1 failed** — `blocking hook has no timeout: Stop: bash ${CLAUDE_PLUGIN_ROOT}/bin/ops-post-session-cleanup`
- huidige tree: **25 passed, 0 failed**

**Release v3.10.11.** Dezelfde bestanden die `ops-release` aanraakt (plugin.json, marketplace.json, package.json, hermes plugin.yaml, installer config.mjs + README), plus `ops-sync-docs` voor de doc-tellingen.

Deze PR stond eerst op v3.10.10. Terwijl hij openstond landde #948 diezelfde versie op main met de mcp-watchdog-fix, dus is dit doorgeschoven naar 3.10.11 en dekt de changelogsectie alleen nog de guard. Main is hier in gemerged; de netto diff tegen main is 12 bestanden, 48 insertions.

Reden dat de bump op deze branch staat en niet via `ops-release`: dat script releaset vanuit `origin/main` in een eigen worktree en zou de guard overslaan. Zo landt één merge beide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)