### PR TITLE
docs(changelog): record the ops-release and ops-rules changes in 3.10.11

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -188,6 +188,21 @@
 
 ## [3.10.11] - 2026-09-09
 
+### Fixed
+
+- fix(ops-release): a `--notes` body that already opens its own
+  `### Added|Changed|Fixed|Removed` section no longer gets an empty
+  `### Changed` prepended. The GitHub release workflow awk-parses the CHANGELOG
+  section verbatim, so v3.10.10's published notes opened with a heading that had
+  nothing under it and had to be patched by hand.
+  `tests/test-ops-release-changelog-heading.sh` lifts the block straight out of
+  `bin/ops-release`, so the test cannot drift from the shipped code; it is red
+  against v3.10.10 and green here.
+
+### Changed
+
+- docs(ops-rules): precedence tiers plus rules 11-17.
+
 ### Testing
 
 - test(hooks): `tests/test-hooks.sh` fails any hook that is neither


### PR DESCRIPTION
## Wat

De v3.10.11-sectie in de CHANGELOG beschrijft alleen de hook-timeout-guard uit #949. Onder diezelfde tag landden ook #950 (`ops-release` plakte een lege `### Changed` boven elke `--notes`-body) en #941 (ops-rules precedence tiers, regels 11-17). De gepubliceerde release notes zijn awk-geparsed uit die sectie, dus wat er is uitgebracht en wat er staat lopen uiteen.

Deze PR vult de sectie aan met `### Fixed` en `### Changed`. Geen code, alleen de CHANGELOG.

Na merge moet de body van de bestaande GitHub-release v3.10.11 eenmalig worden bijgewerkt — de workflow draait alleen op een tag-push en de tag staat er al.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
