### PR TITLE
fix(orchestrate,next): read the synced registry schema, not the example one

### DIFF
--- a/claude-ops/skills/ops-next/SKILL.md
+++ b/claude-ops/skills/ops-next/SKILL.md
@@ -101,7 +101,8 @@ ${CLAUDE_PLUGIN_ROOT}/bin/ops-unread 2>/dev/null || echo '{}'
 ### GSD active phases
 
 ```!
-for d in $(jq -r '.projects[] | select(.gsd == true) | .paths[]' "${CLAUDE_PLUGIN_ROOT}/scripts/registry.json" 2>/dev/null); do
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}" . "${CLAUDE_PLUGIN_ROOT}/lib/registry-path.sh"
+for d in $(jq -r '.projects[] | select(.has_roadmap == true) | .path' "$REGISTRY" 2>/dev/null); do
   expanded="${d/#\~/$HOME}"
   if [ -f "$expanded/.planning/STATE.md" ]; then
     alias=$(basename "$expanded")
@@ -165,7 +166,7 @@ Find highest-priority issue that is in progress or unstarted.
 ### Priority 6 — GSD WORK
 
 From GSD state, find the highest revenue-impact active phase across all projects.
-Revenue weighting: read `revenue.stage` and `priority` from `scripts/registry.json` — projects with lower priority numbers (higher priority) and revenue stage of `growth` or `active` outrank `pre-launch` or `development`. Within the same tier, prioritize closest-to-done phases.
+Revenue weighting: the synced registry (`${OPS_DATA_DIR}/registry.json`, schema `name/path/remote_url/status/phase/branch`) carries no `revenue` or `priority` field. Rank by `status` (`active` > `paused` > `none`), then `last_commit_ts` (newest first), then `remaining_tasks` (fewest first). Any `priority`/`revenue` values live in `preferences.json` under `projects.<name>`, if set.
 
 ---
 

--- a/claude-ops/skills/ops-orchestrate/SKILL.md
+++ b/claude-ops/skills/ops-orchestrate/SKILL.md
@@ -140,11 +140,14 @@ If `--teams` or `--hybrid` is requested but the flag is off, warn and fall back 
 **GLOBAL mode**: Scan the project registry:
 
 ```bash
-REGISTRY="${CLAUDE_PLUGIN_ROOT}/scripts/registry.json"
-jq -r '.projects[] | "\(.alias)|\(.paths[0])|\(.repos[0] // "none")|\(.gsd // false)"' "$REGISTRY" 2>/dev/null
+# registry.json is written by scripts/ops-gsd-registry-sync.sh into the data dir.
+# Its schema is name/path/remote_url/status/phase/branch — NOT the alias/paths/repos/gsd
+# shape of registry.example.json. lib/registry-path.sh resolves the real file.
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}" . "${CLAUDE_PLUGIN_ROOT}/lib/registry-path.sh"
+jq -r '.projects[] | "\(.name)|\(.path)|\(.remote_url // "none")|\(.has_roadmap // false)|\(.status // "")|\(.phase // "")|\(.branch // "")"' "$REGISTRY" 2>/dev/null
 ```
 
-For each project path, verify it exists on disk. Skip missing paths.
+For each project path, verify it exists on disk. Skip missing paths. Skip entries under `archives/`, `scratch/` or `.worktrees/` unless `--project` names them; the sync dedupes on `remote_url` and keeps the extra copies in `aliases`.
 
 ### 1b. Parallel audit dispatch
 

--- a/claude-ops/tests/fixtures/registry-synced-schema.json
+++ b/claude-ops/tests/fixtures/registry-synced-schema.json
@@ -1,0 +1,50 @@
+{
+  "updated": "2026-09-08T20:40:08Z",
+  "total": 2,
+  "projects": [
+    {
+      "name": "example-api",
+      "path": "/tmp/example-api/",
+      "source": "Developer",
+      "remote_url": "https://github.com/example-org/example-api.git",
+      "last_commit_ts": 1787758201,
+      "phase": "none",
+      "status": "paused",
+      "milestone": "",
+      "next_action": "",
+      "plan_ref": "",
+      "remaining_tasks": "0",
+      "blockers": "0",
+      "has_git": true,
+      "branch": "dev",
+      "uncommitted": 0,
+      "has_roadmap": true,
+      "has_milestones": true,
+      "has_handoff": false,
+      "total_phases": "1",
+      "aliases": []
+    },
+    {
+      "name": "example-web",
+      "path": "/tmp/example-web/",
+      "source": "Developer",
+      "remote_url": "https://github.com/example-org/example-web.git",
+      "last_commit_ts": 1787700000,
+      "phase": "2",
+      "status": "active",
+      "milestone": "",
+      "next_action": "",
+      "plan_ref": "",
+      "remaining_tasks": "3",
+      "blockers": "0",
+      "has_git": true,
+      "branch": "main",
+      "uncommitted": 0,
+      "has_roadmap": false,
+      "has_milestones": false,
+      "has_handoff": false,
+      "total_phases": "0",
+      "aliases": []
+    }
+  ]
+}

--- a/claude-ops/tests/run-all.sh
+++ b/claude-ops/tests/run-all.sh
@@ -82,6 +82,7 @@ run_suite "$TESTS_DIR/test-ops-dns-provision.sh"
 run_suite "$TESTS_DIR/test-ops-marketing-dash-brand-isolation.sh"
 run_suite "$TESTS_DIR/test-ops-release-changelog-heading.sh"
 run_suite "$TESTS_DIR/../templates/statusline/tests/run-tests.sh"
+run_suite "$TESTS_DIR/test-registry-schema-skills.sh"
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "SUMMARY"

--- a/claude-ops/tests/test-registry-schema-skills.sh
+++ b/claude-ops/tests/test-registry-schema-skills.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# test-registry-schema-skills.sh — the jq queries embedded in ops-orchestrate and
+# ops-next must read the schema that scripts/ops-gsd-registry-sync.sh actually
+# writes (name/path/remote_url/status/phase/branch), not the hand-written
+# alias/paths/repos/gsd shape of registry.example.json.
+#
+# Regression for 2026-09-09: both skills queried .alias/.paths/.gsd against the
+# synced file and got "null|null|none|false" for all 98 projects, so GLOBAL
+# mode found nothing to orchestrate.
+#
+# Runs against the REAL registry when present ($OPS_DATA_DIR/registry.json),
+# otherwise against a fixture with the synced schema.
+set -euo pipefail
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
+pass=0; fail=0
+ok()   { echo "  ✓ $1"; pass=$((pass+1)); }
+bad()  { echo "  ✗ $1"; fail=$((fail+1)); }
+
+. "$PLUGIN_ROOT/lib/registry-path.sh"
+if [ ! -s "$REGISTRY" ]; then
+  REGISTRY="$TESTS_DIR/fixtures/registry-synced-schema.json"
+  echo "  (real registry absent — using fixture $REGISTRY)"
+else
+  echo "  (using real registry $REGISTRY)"
+fi
+
+extract_jq() {
+  # first jq -r '...' "$REGISTRY" line in a SKILL.md, filter only
+  grep -m1 -o "jq -r '[^']*'" "$1" | sed "s/^jq -r '//; s/'$//"
+}
+
+check_skill() {
+  local skill="$1" file="$PLUGIN_ROOT/skills/$1/SKILL.md"
+  local filter; filter="$(extract_jq "$file")"
+  [ -n "$filter" ] || { bad "$skill: no jq filter found in SKILL.md"; return; }
+
+  if grep -q 'scripts/registry.json' "$file"; then
+    bad "$skill: still hardcodes scripts/registry.json instead of lib/registry-path.sh"
+  else
+    ok "$skill: resolves registry via lib/registry-path.sh"
+  fi
+  if grep -qE '\.alias\b|\.paths\[|\.repos\[|\.gsd\b' "$file"; then
+    bad "$skill: queries example-schema fields (.alias/.paths/.repos/.gsd)"
+  else
+    ok "$skill: no example-schema fields"
+  fi
+
+  local out; out="$(jq -r "$filter" "$REGISTRY" 2>&1 | head -50)" || { bad "$skill: jq filter errors: $out"; return; }
+  local n; n="$(printf '%s\n' "$out" | grep -c . || true)"
+  [ "$n" -gt 0 ] || { bad "$skill: jq filter returns no rows"; return; }
+  if printf '%s\n' "$out" | grep -qE '^null\||\|null\||\|null$|^null$'; then
+    bad "$skill: jq filter yields null fields against synced registry:"
+    printf '%s\n' "$out" | head -3 | sed 's/^/      /'
+  else
+    ok "$skill: $n rows, no null fields"
+  fi
+}
+
+echo "test-registry-schema-skills"
+check_skill ops-orchestrate
+check_skill ops-next
+
+echo "  $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Wat

`ops-orchestrate` en `ops-next` lazen `.alias/.paths/.repos/.gsd` uit `scripts/registry.json`. Dat is het handgeschreven schema van `registry.example.json`. Het bestand dat de daemon echt schrijft (`ops-gsd-registry-sync.sh` -> `$OPS_DATA_DIR/registry.json`) heeft `name/path/remote_url/status/phase/branch`. GLOBAL mode gaf daardoor `null|null|none|false` voor alle 98 projecten en dispatchte niets (9 sep 2026).

## Fix

- Beide skills resolven het bestand via `lib/registry-path.sh` en queryen de gesyncte velden.
- `ops-next` rangschikt op `status` / `last_commit_ts` / `remaining_tasks`; het gesyncte bestand heeft geen `revenue`/`priority`.
- Nieuwe regressietest `tests/test-registry-schema-skills.sh`: draait de exacte jq-filters uit beide SKILL.md's tegen het echte registry (fixture in CI) en faalt op een `null`-veld of een overgebleven example-veldnaam. Geregistreerd in `run-all.sh`.

## Bewijs

- Nieuwe test: 6/6 op het echte bestand, 6/6 op de fixture.
- `test-skills-lint.sh`: 791 passed, 0 failed.
- Oude filter van `main` tegen het echte bestand: `null|null|none|false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)