### PR TITLE
fix(ops-dash): loading bar killed the probes on first run

### DIFF
--- a/claude-ops/bin/ops-dash
+++ b/claude-ops/bin/ops-dash
@@ -325,8 +325,9 @@ TOTAL_PROBES=13
 
 # 5) Marketing — iterate ALL configured projects in parallel subshells
 (
-  MK_TMPDIR=$(mktemp -d)
-  trap 'rm -rf "$MK_TMPDIR"' EXIT
+  # Subdir of TMPDIR_DASH: one tmpdir, one trap, cleaned after the final wait.
+  MK_TMPDIR="$TMPDIR_DASH/marketing"
+  mkdir -p "$MK_TMPDIR"
 
   # Read project list from preferences; fall back to default_project only
   if [ -f "$PREFS" ]; then
@@ -568,7 +569,10 @@ if [[ "$MOBILE_MODE" -eq 0 && -z "${NO_COLOR:-}" && "${TERM:-dumb}" != "dumb" ]]
   _start_time=$(date +%s)
   _tick=0
   while true; do
-    _done=$(ls "$TMPDIR_DASH"/done_* 2>/dev/null | wc -l | tr -d ' ')
+    # find never fails on zero matches. `ls done_*` exits 2 before the first
+    # probe finishes; with `set -e` + pipefail that killed the script and the
+    # EXIT trap removed TMPDIR_DASH while the workers were still writing.
+    _done=$(find "$TMPDIR_DASH" -maxdepth 1 -name 'done_*' 2>/dev/null | wc -l | tr -d ' ')
     _pct=$(( (_done * 100) / TOTAL_PROBES ))
     _filled=$(( (_done * _bar_width) / TOTAL_PROBES ))
     _empty=$(( _bar_width - _filled ))


### PR DESCRIPTION
## What

`bin/ops-dash` printed `DASH_RENDER_FAILED` on the first run while its background workers logged `No such file or directory` for files under `TMPDIR_DASH`. A second run worked.

## Why

The loading bar counted finished probes with `ls "$TMPDIR_DASH"/done_*`. Before the first probe finishes, the glob matches nothing, `ls` exits 2, and under `set -euo pipefail` the pipeline failure exits the script. The EXIT trap then removes `TMPDIR_DASH` while the workers are still writing to it. On a warm run a probe finishes before the first tick, so the bug hid.

Reproduced in isolation:

```
bash -c 'set -euo pipefail; d=$(mktemp -d); trap "echo TRAP_FIRED" EXIT; _done=$(ls "$d"/done_* 2>/dev/null | wc -l)'   # exit 1, TRAP_FIRED
```

## Fix

- Count with `find -name 'done_*'`, which exits 0 on zero matches.
- Marketing worker uses `$TMPDIR_DASH/marketing` instead of a second `mktemp -d` plus its own `trap ... EXIT`, so there is one tmpdir and one cleanup after the final `wait`.

Bash 3.2 compatible.

## Proof

Fixed script, three consecutive runs: exit 0, 161 lines rendered, no `DASH_RENDER_FAILED`, no `No such file` on stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
