### PR TITLE
fix(marketing): record successful empty blog runs

### DIFF
--- a/claude-ops/scripts/ops-cron-seo-blog-gen.sh
+++ b/claude-ops/scripts/ops-cron-seo-blog-gen.sh
@@ -29,6 +29,7 @@ export CLAUDE_OPS_USE_CREDIT_POOL="${CLAUDE_OPS_USE_CREDIT_POOL:-0}"
 
 DATA_DIR="${OPS_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}"
 PREFS="${OPS_AUTOPILOT_PREFS:-${DATA_DIR}/preferences.json}"
+SUCCESS_MARKER="${DATA_DIR}/cache/content-seo-blog-last-success"
 
 DRY_RUN=false
 SINGLE_PROJECT=""
@@ -372,4 +373,9 @@ else
     [ -z "$proj" ] && continue
     _process_project "$proj" || true
   done < <(prefs_projects)
+fi
+
+if [ "$DRY_RUN" = "false" ]; then
+  mkdir -p "$(dirname "$SUCCESS_MARKER")"
+  touch "$SUCCESS_MARKER"
 fi

--- a/claude-ops/tests/test-ops-content-seo.sh
+++ b/claude-ops/tests/test-ops-content-seo.sh
@@ -10,6 +10,7 @@
 #   6. GSC filter: excludes out-of-range rows
 #   7. manifest.json created after live run
 #   8. script has no project-specific branding defaults
+#   9. successful live run writes freshness marker; dry-run does not
 set -euo pipefail
 
 PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -223,6 +224,24 @@ if grep -qiE 'my-project|health, wellness' "${SCRIPT}" 2>/dev/null; then
   err "script contains project-specific defaults" "found project vocab"
 else
   ok "script has no project-specific branding defaults"
+fi
+
+# ── Test 9: freshness marker records successful live runs only ────────────────
+echo "Test 9: freshness marker records successful live runs only"
+MARKER="${OPS_DATA_DIR}/cache/content-seo-blog-last-success"
+rm -f "$MARKER"
+run_script "$PREFS_FULL" testproject --dry-run >/dev/null 2>&1 || true
+if [ ! -e "$MARKER" ]; then
+  ok "dry-run does not write freshness marker"
+else
+  err "dry-run must not write freshness marker" "path: $MARKER"
+fi
+
+run_script "$PREFS_FULL" testproject >/dev/null 2>&1 || true
+if [ -f "$MARKER" ]; then
+  ok "live run writes freshness marker"
+else
+  err "live run should write freshness marker" "path: $MARKER"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
Fixes the content SEO blog freshness contract: successful runs with zero qualifying GSC keywords now touch `cache/content-seo-blog-last-success`, while dry-runs do not.

## Changes
- `claude-ops/scripts/ops-cron-seo-blog-gen.sh`: touch `$SUCCESS_MARKER` when `$DRY_RUN = "false"` after processing projects.
- `claude-ops/tests/test-ops-content-seo.sh`: add Test 9 asserting that dry-runs do not touch the marker and successful live runs do.

## Verification
- `bash claude-ops/tests/test-ops-content-seo.sh`: 12 passed, 0 failed
- `npm test` (in `claude-ops/`): 31 passed, 0 failed