### PR TITLE
release: v3.10.13

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "ops",
       "description": "Business operations command center for Claude Code — 66 skills, 21 agents, smart background daemon. Manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (AWS), revenue (Stripe+RevenueCat), e-commerce, marketing, monitoring (Datadog/New Relic/OTEL), voice, and smart home (Homey Pro). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (macos-toolkit CLI suite), /ops:ops-home control surface, and YOLO autonomous mode with 4 parallel C-suite agents.",
       "source": "./claude-ops",
-      "version": "3.10.12",
+      "version": "3.10.13",
       "category": "productivity",
       "keywords": [
         "ops",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Business Operating System for Claude Code**
 
-![Version](https://img.shields.io/badge/version-3.10.12-blue)
+![Version](https://img.shields.io/badge/version-3.10.13-blue)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet.svg)
 ![Skills](https://img.shields.io/badge/skills-66-success)

--- a/claude-ops/.claude-plugin/plugin.json
+++ b/claude-ops/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ops",
-  "version": "3.10.12",
+  "version": "3.10.13",
   "description": "Business operations command center for Claude Code — 66 skills, 21 agents, and a smart background daemon that manage communications (WhatsApp/Email/Slack/Telegram), projects, infrastructure (all AWS services), revenue (Stripe + RevenueCat), e-commerce (Shopify), marketing (Klaviyo/Meta/GA4/GSC), monitoring (Datadog/New Relic/OTEL), and voice (Bland AI/ElevenLabs/Whisper). Includes /ops:ops-ar A&R (audio analysis + demo verdict cards), /gtm go-to-market planner, /ops:projects portfolio dashboard, /ops:ops-mac macOS diagnose-and-fix (bundles the macos-toolkit CLI suite — security, launchd, network, disk, system health), YOLO mode for autonomous operation with 4 parallel C-suite agents, /ops:ops-home smart home control via Homey Pro, /ops:ops-unifi UniFi network control (Site Manager + Network + Protect APIs), and /ops:ops-feature-dev overlay for the feature-dev companion plugin.",
   "author": {
     "name": "Lifecycle Innovations Limited",

--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [3.10.13] - 2026-09-10
+
 - Removed every hard-coded Claude model id and `model:` frontmatter pin; agents, skills and cron scripts now inherit the session default (env-overridable per script).
 
 - Fixed `ops-release` to move the existing `Unreleased` body into the new version once, leaving a blank `Unreleased` heading for future changes.
@@ -189,6 +191,7 @@
 - **ops-desk (new skill):** `/ops:ops-desk` desk sweep — fans out read-only context agents (batched, Workflow tool) over the owner's open decisions/drafts/payments/sign-offs and returns a ranked, ready-to-approve action queue worked down under the per-draft outbound gate. Complements `/ops:ops-inbox`.
 - **ops-ecom:** `channels` | `agentic` | `shop` verbs — sales channel inventory, agentic storefront health, Shop Campaigns readiness (read-only; Rule 5 / stage-only spend).
 - **ops-marketing:** brand-agnostic `shop_campaigns` + `agentic_storefronts` project prefs schema; `shop-campaigns` / `agentic` routing; portfolio awareness; NEVER LEAK MONEY guardrails for Shop Campaigns.
+
 
 ## [3.10.12] - 2026-09-09
 

--- a/claude-ops/docs/INDEX.md
+++ b/claude-ops/docs/INDEX.md
@@ -4,7 +4,7 @@
 
 _Top-level map of every doc file in `claude-ops/docs/`._
 
-[![version](https://img.shields.io/badge/version-3.10.12-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.10.13-blue)](../CHANGELOG.md)
 
 </div>
 

--- a/claude-ops/docs/agents-reference.md
+++ b/claude-ops/docs/agents-reference.md
@@ -4,7 +4,7 @@
 
 _All 21 agents that power claude-ops — scanners, fixers, C-suite analysts, and the daemon brain_
 
-[![version](https://img.shields.io/badge/version-3.10.12-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.10.13-blue)](../CHANGELOG.md)
 [![agents](https://img.shields.io/badge/agents-21-8b5cf6)](.)
 [![sonnet](https://img.shields.io/badge/model-sonnet--4--6-6366f1)](.)
 [![opus](https://img.shields.io/badge/model-opus--4--6-ef4444)](.)

--- a/claude-ops/docs/skills-reference.md
+++ b/claude-ops/docs/skills-reference.md
@@ -4,7 +4,7 @@
 
 _All 66 skills available in claude-ops — your business operations command surface (v2.0 added `/ops:deploy-fix`, `/ops:recap`, `/ops:rotate`, `/ops:rotate-setup`; v2.0.6 added `/ops:credentials`; v2.0.8 added multi-workspace Slack; feature-dev overlay via `/ops:ops-feature-dev`)_
 
-[![version](https://img.shields.io/badge/version-3.10.12-blue)](../CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-3.10.13-blue)](../CHANGELOG.md)
 [![skills](https://img.shields.io/badge/skills-66-8b5cf6)](.)
 [![license](https://img.shields.io/badge/license-MIT-22c55e)](../LICENSE)
 [![platform](https://img.shields.io/badge/platform-macOS%20%7C%20Linux-f59e0b)](.)

--- a/claude-ops/hermes-plugin/plugin.yaml
+++ b/claude-ops/hermes-plugin/plugin.yaml
@@ -1,4 +1,4 @@
 name: ops
-version: "3.10.12"
+version: "3.10.13"
 description: "claude-ops on Hermes — slash commands and skills for inbox, deploy, revenue, and the rest of the ops suite. Enable with plugins.enabled: [ops]."
 author: Lifecycle Innovations Limited

--- a/claude-ops/package.json
+++ b/claude-ops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ops-bin",
-  "version": "3.10.12",
+  "version": "3.10.13",
   "private": true,
   "description": "Runtime dependencies for claude-ops bin scripts (ops-telegram-autolink.mjs, ops-slack-autolink.mjs). Installed separately from telegram-server/ so the .mjs scripts resolve modules from claude-ops/node_modules regardless of invocation cwd.",
   "type": "module",

--- a/installer/README.md
+++ b/installer/README.md
@@ -56,7 +56,7 @@ version: 1
 source:
   type: git
   url: https://github.com/Lifecycle-Innovations-Limited/claude-ops.git
-  ref: v3.10.12
+  ref: v3.10.13
 
 agents:
   claude:    { enabled: true }

--- a/installer/src/config.mjs
+++ b/installer/src/config.mjs
@@ -17,7 +17,7 @@ export const DEFAULT_CONFIG = {
   source: {
     type: "git",
     url: "https://github.com/Lifecycle-Innovations-Limited/claude-ops.git",
-    ref: "v3.10.12",
+    ref: "v3.10.13",
   },
   agents: {
     claude: { enabled: true, type: "marketplace" },


### PR DESCRIPTION
Release **v3.10.13** (was 3.10.12).

- plugin.json + marketplace.json (registry) + claude-ops/package.json bumped
- CHANGELOG updated

- Removed every hard-coded Claude model id and `model:` frontmatter pin; agents, skills and cron scripts now inherit the session default (env-overridable per script).

- Fixed `ops-release` to move the existing `Unreleased` body into the new version once, leaving a blank `Unreleased` heading for future changes.

- fix(security): a third party's identifiers can no longer reach this public
  repo. Every identity check was denylist-driven, and a denylist can only hold
  the operator's OWN terms — it structurally cannot hold a client's workspace
  UUIDs, their team key, or their issue ids, because nobody knows those in
  advance. Ten client Linear UUIDs, their team key in ~25 places plus a
  filename, and their real issue ids sat here while the scanner reported PASS.

  The rule is now inverted for identifier-shaped literals. `test-no-secrets.sh`
  fails every UUID and every `<KEY>-<number>` unless it is listed in the new
  `tests/known-public-constants.txt` with a stated reason, and fails an IANA
  timezone in code or config outright. The three checks need no configuration,
  sweep every tracked file including `tests/` (which `EXCLUDE_DIRS` drops, so
  the scanner's own directory was the one unscanned place), and cannot SKIP:
  a check that could not run counts as a failure. `.githooks/pre-commit` runs
  the same patterns over the staged diff so the blocked line is named.

  `tests/test-pii-gate-fires.sh` is the negative control — it plants the exact
  shapes that leaked and asserts each gate refuses them, plus a clean-tree
  control so a scanner that fails on everything cannot pass. It found four real
  defects on its first run: `grep -o` omits the filename when given a single
  file, which silently disabled every `:`-anchored filter; the issue-key regex
  stopped at six characters, so `<CLIENT>TEAM-<n>` was never seen; and both
  affected checks skipped instead of failing when the file list was empty.

  Also fixed: `PLUGIN_ROOT` now resolves with `pwd -P`. `git rev-parse
  --show-toplevel` returns a physical path, so under a symlinked checkout the
  comparison matched nothing and the sweep passed over an empty file list.

  Residual `Europe/Amsterdam` in two daemon cron notes and one script header —
  found by the new check, missed by a manual scrub — are now stated in UTC.

- fix(hooks): the pre-commit hook printed `BLOCKED` and committed anyway. It
  applied an amnesty to `$FAILED` *after* every check had run: if the only email
  hits were example domains it reset the flag to 0, clearing every other check
  that had already failed with it. The first commit of the gate above tripped
  three BLOCKED lines and landed regardless — loud and inert at once, which is
  worse than silent, because the output reads like enforcement.

  The example-domain filter now applies inside the email check, where it belongs,
  and the post-hoc reset is gone. The hook also honours the same path-exact
  exemption as the scanner, so the negative-control suites can hold the shapes
  they forbid without `--no-verify`.

  `tests/test-pre-commit-hook-blocks.sh` is the negative control for the hook
  itself: eight cases driven through a real `git commit`, asserting the exit
  status rather than the output, because the exit status is the only part of a
  hook that stops anything. Case 6 is this regression — a forbidden identifier
  in the same commit as a harmless `@example.com` address must still be refused.

- fix(hooks): UserPromptSubmit inbox autosync no longer interpolates `$INPUT`.
  Grok treats `$VAR` in a hook command as a required env var and skips the
  hook when it is unset. The script already reads the event JSON from stdin.
  Guard: `tests/test-hooks.sh` now flags `$INPUT` the same way as `$TOOL_INPUT`.

- fix(daemon): write `daemon-health.json` with builtin `printf` + `mv`, not
  `cat >file <<EOF`. Under launchd stdin is `/dev/null`, so bash's 16KiB
  heredoc pipe never drains and the first health write deadlocks — empty
  health file, no monitor loop. `check_self_upgrade` now picks the newest
  semver cache dir only, ignoring `current` and `ops-daemon-launcher.sh`.

- docs(whatsapp): dual-account MCP names are `whatsapp-nl` / `whatsapp-us` (or
  `whatsapp-<label>`). `whatsapp-cos` and a bare `whatsapp` client pointing at
  `/servers/whatsapp-cos/mcp` are not accounts — sending on them is a
  wrong-number send. Rule 8, ops-inbox, and `scripts/whatsapp/ENDPOINTS.md`
  now say so.

- fix(marketing): `ops-marketing-dash --project` no longer inherits the
  default brand's env / plugin-config / owner-level Amplitude, AppsFlyer,
  RevenueCat, Klaviyo, or Instagram credentials. A named project that is not
  `marketing.default_project` is isolated: missing project keys render as
  `null`, not another brand's numbers. Owner-brand fallback (no `--project`,
  or `--project` equal to the default) is unchanged. Guard:
  `tests/test-ops-marketing-dash-brand-isolation.sh`.

- fix(ops-inbox): always query every configured calendar, mailbox, and messaging
  channel before a schedule claim or NEEDS_REPLY draft. Google Calendar primary
  is not the show/tour SSOT — Notion show-schedule / calendar / appointments
  databases count when Notion is configured. A miss on one store is not absence.
  Rule 9, `ops-go`, and `tonight` carry the same gate. Owner-local calendar IDs
  live in `$PREFS_PATH` `.channels.notion.calendars`, never in this repo.

- fix(hooks): PreToolUse WhatsApp bridge health no longer interpolates `$TOOL_INPUT`.
  Grok treats `$VAR` in a hook command as a required env var and skips the hook
  when it is unset (`hook not executed: required env var(s) not set: ${TOOL_INPUT}`).
  Claude Code still sends the event JSON on stdin, so the script now reads stdin
  (argv kept for old callers). Do not put `$TOOL_INPUT` / `$TOOL_RESULT` /
  `$USER_PROMPT` in `hooks.json` command strings.

- fix(whatsapp): `ops-wa-accounts` resolves client-of-remote-bridge accounts from
  `$PREFS_PATH` `.channels.whatsapp` (written by `/ops:setup` step 3b) and
  `$OPS_DATA_DIR/registry.json` `.whatsapp`, with legacy
  `~/.config/whatsapp/agent-policy.json` as fallback. Policy `api` /
  `bridge_port` wins over a leftover local store. Inbox skills probe the
  resolved `api` (or `ssh` + `remote_store`); they never guess `:8080` and
  never `launchctl kickstart` a leftover local bridge. `ops-inbox-autosync`
  posts `/api/backfill` to each resolved `api`. Template:
  `scripts/registry.example.json`. Tests in `tests/test-ops-wa-accounts.sh`.

- fix(hermes): stop the native plugin registering duplicate `/ops-*` handlers.
  Hermes displays a plugin command handler's return value as the final reply,
  so those handlers echoed an instruction to load the skill and ended the turn
  before the agent ran anything. The cross-CLI installer already mirrors every
  claude-ops skill into Hermes' normal skills directory; those native skill
  slash commands now remain unshadowed and enter the agent loop as intended.

- fix(deploy-fix): `scripts/ops-deploy-monitor.sh` no longer calls `gh run watch`.
  That call blocks, polls every 2-5s with no tick cap, and is the exact pattern
  `hooks/gh-watch-guard.sh` denies for every other caller. The monitor is spawned
  by a PostToolUse hook on any `gh pr merge`, so one merge could arm an uncapped
  poller. It now polls `gh api repos/{owner}/{repo}/actions/runs/{id}` on a 30s
  sleep floor, capped at 60 ticks and a 1800s wall-clock deadline. PR and run
  lookups moved from `gh pr view --json` / `gh run list --json` (GraphQL-backed)
  to `gh api repos/...` (REST). `gh api rate_limit` — which spends no quota —
  gates every polling phase and bails out with a log line below 200 remaining.
  The same banned patterns were removed from `skills/ops-deploy/SKILL.md`,
  `skills/ops-merge/SKILL.md` and `skills/ops-merge/references/cli.md`, which
  had been telling agents to run them. `tests/mocks/gh` now serves the REST
  endpoints and exits 90 if anything invokes `gh run watch`; test case 12 in
  `tests/test-deploy-fix-hooks.sh` guards the script against regression.

- Slim `ops-inbox` SKILL.md (~6k → ~2k words): runtime, Workflow JS, and Agent Teams moved to `references/`. Rewrite remaining skill descriptions with real NL triggers (Claude / Grok / Hermes share the same `skills/` tree).
- Sync harness ports: `hermes-plugin/plugin.yaml` version matches `plugin.json`; installer default ref tracks the latest tag; `ops-release` bumps both. Grok still loads the Claude plugin (no `.grok-plugin`). Docs: `.mcp.json` is empty on purpose.

- feat(cliproxy-heal): unattended hub healer puts seats back in rotation as soon as any leftover or reset quota is observed (no hysteresis). A seat sits out only on certain "quota exhausted" plus a parseable reschedule stamp, then re-enters at that stamp. An AI advisor runs on every seat and cannot override those rules. `applied=reauth` only after `CLIPROXY_REAUTH_CMD` (`cliproxy-reauth-one.sh` → hub `bu_reauth_lib.py` / `xai_device_reauth.py`); otherwise the seat is recorded blocked. Hub systemd timer `cliproxy-heal.timer`; Mac stays client-only. `runHealTick` denies healing unless both gates are satisfied: the `CLIPROXY_HUB_HEAL=1` env var, and the presence of the `/opt/crsproxy/.heal-account-optin` marker file that only `install-heal.sh` writes (not the systemd unit's `Environment=` lines), so editing the unit alone cannot satisfy both. Tests in `scripts/account-rotation/__tests__/cliproxy-heal-policy.test.mjs`.
- fix(ops-mac): the application firewall is opt-in. `/ops:mac fix` no longer offers to enable it and no longer lists it as a recommendation; the audit reports its state and stops. Turning the firewall on breaks local listeners (dev servers, MCP proxies, VNC, tunnels) and the user rarely connects the breakage to a `fix` run they asked for other reasons. `socketfilterfw` now runs only when the user asks for the firewall by name in that turn.
- **Removed the CRS relay backend.** claude-relay-service handed every session a
  static `cr_` bearer token pinned into `settings.json`, and the plugin had to keep
  base URL and token in lockstep across respawns, settings overlays and daemons.
  CLIProxyAPI is now the only supported path for multi-account rotation and OAuth
  seat management: it holds one OAuth seat file per account, and `rotate.mjs`
  already writes those files during a rotation.
  Deleted: the `crs-*` daemons in `scripts/account-rotation/`, the three
  `install-crs-*.sh` installers, the five `crs-*` systemd units, the
  `com.claude-ops.crs-*` plists, and `docs/runbooks/crs-full-tuning-plan.md`.
  Kept: `scripts/crsproxy-reauth/`. An earlier draft of this entry listed it as
  deleted, but it survived the CRS removal and still carries the Browser Use
  OAuth reauthentication helpers, which are cliproxy-facing rather than CRS-only.
  It is covered by `tests/test-crsproxy-reauth.sh`.
  Renamed, same behaviour: `crs-pool-config.mjs` → `rotation-config.mjs`,
  `crs-refresh-lock.mjs` → `refresh-lock.mjs`, `crs-reconciler-state.mjs` →
  `reconciler-state.mjs`.
  Migration on an existing machine: route mode `crs-oauth` is read as `oauth`, a
  `crs` config block is read as the `rotation` block, `CRS_REFRESH_*` env names
  still work, and reconciler state files fall back to their old names. Background
  respawn strips a leftover relay base URL, `cr_` token and `--settings` overlay
  rather than re-applying them. `claude-stack doctor` reports a leftover pair as
  `legacy_relay_env`; `claude-stack route --mode oauth` clears it.
  `ops-accounts crs` and `crs-tick` now print where rotation lives and exit 2.
- fix(whatsapp): `apply-patches.py` Fix Q no longer appends a duplicate `/api/app_state_status` route. The sentinel gated on the comment text, which Fix Y later rewrote to `Fix Q/Y`, so on any tree that had taken Fix Y the check missed and a second `http.HandleFunc` for the same path was added. Go panics at startup on a duplicate pattern, so the bridge died on the next `go build`. The sentinel is now the handler registration itself, which is stable across variants.
- docs(whatsapp): stop assuming the MCP server is named `whatsapp`. Multi-account installs run one bridge and one server per account (`whatsapp-<label>`) and have no plain `mcp__whatsapp__*`, so every hardcoded reference failed with an unknown tool. Adds CLAUDE.md Rule 8 (resolve the name at runtime, pick the account deliberately, never send from the wrong number, Rule 6 applies to every variant) and points ops-inbox, ops-comms, comms-scanner, and `scripts/whatsapp/ENDPOINTS.md` at it. Also warns that `allowed-tools` entries are exact strings and that host send-gate hook matchers pinned to the literal `mcp__whatsapp__send_message` silently stop firing when an account is renamed or added.
- Security: replace direct/unattended Claude browser reauthentication with short-lived HMAC-approved, single-use staged enrollment and atomic rollback activation; legacy reauth wrappers now fail closed.
- ops-accounts-gateway skeleton (:3005 health/auth/grok hop; CLI gateway subcommand)
- feat(crs-priority-daemon): dual-mode `backend=crs|local` file seat-state without CRS Docker

- ops-accounts: dual-write + OPS_ACCOUNTS_BACKEND auto/crs/local; grok-cli-auth-proxy; local no-op reconcilers; gateway design doc

### Changed

- **ops-accounts multi-provider plan:** every provider (Claude, Grok, OpenAI/Codex, Factory, Cursor) gets Anthropic-shaped OAuth, reauth, util, switch/LB under `/ops:accounts`.
- **CLIProxyAPI gateway path:** absorb gateway + Claude seat policy + Grok OAuth proxy into ops-accounts so default installs use CLIProxyAPI-compatible relay behavior without requiring the deprecated relay stack; external legacy CRS stays advanced-only. See `docs/ops/OPS-ACCOUNTS-VISION.md`.
- **ops-accounts seat policy (local):** `seat-policy-tick.mjs` applies conservative 5h/7d schedulable thresholds to local seat-state without a relay; `ops-accounts seats tick`.
- **ops-accounts local seat-state:** `seat-state.mjs` file-backed multi-provider seat store (schedulable/util) for local policy backend; `ops-accounts seats` command.
- **ops-accounts skill merge:** `/ops:accounts` is canonical multi-provider entry; `/ops:rotate` and `/ops:rotate-setup` are aliases. Expanded `bin/ops-accounts` (status/util/switch/refresh/reauth/setup/crs). Added `grok-reauth-egress.sh` residential cascade (EFG SOCKS → Bright Data tiers) for Grok device OAuth.

- **Required companion co-install:** companions essential to ops commands are no longer optional setup prompts. `plugin-dependencies.json` marks `desktop-act`, `gsd`, `gstack` (skills clone), `superpowers`, and `feature-dev` as `required: true` with `updateWithOps: always` and `essentialFor` command lists. `scripts/install-companions.sh` always installs missing required companions (even under `--update-only`), and `--status` exits 1 when any required companion is missing. `/ops:setup` Step 2b runs the SSOT script without Skip for required deps. `/ops:update` step 9 co-installs the full required set (still skippable only via `--no-companions` / `OPS_SKIP_COMPANIONS=1`). Adds `scripts/install-gstack-companion.sh` (env-templated `GSTACK_REPO`/`GSTACK_DIR`/`GSTACK_BRANCH`).


### Added

- **ops-update companions:** step 9 runs `scripts/install-companions.sh` from `plugin-dependencies.json` — co-install/update all **required** companions (`desktop-act`, `gsd`, `gstack` skills-clone, `superpowers`, `feature-dev`). Flag: `--no-companions`.
- **ops-accounts phase 0 surface:** `skills/ops-accounts` + `bin/ops-accounts` router (status/switch/refresh/reauth) over Claude rotate-magic, grok-rotate/oauth-reauth, and codex-rotate when present.

- **Standalone captcha cascade (no CRS required):** port portable captcha stack into `scripts/account-rotation/` — `captcha-helper.mjs`, `visual-captcha-solver.mjs`, `bright-data-cascade.mjs`, orchestration `captcha-cascade.mjs`, thin `rotate-magic.mjs` entry. Plugin `rotate.mjs` soft-loads the cascade after magic-link verify. Contract: `CAPTCHA-CASCADE.md`. Gap report: `docs/ops/HOST-VS-PLUGIN-ROTATE-GAP.md`.
- **CRS optional UX:** `/ops:rotate-setup` Step 4.4 detects CRS (PATH / health / `crs.enabled`) and asks install vs standalone rotate-magic (recommended for single/few accounts) vs skip. `/ops:rotate` documents standalone `reauth` and never treats missing CRS as failure. `--standalone` flag on setup.
- **ops-accounts vision (phase 0):** multi-provider `/ops:accounts` is the north star (Claude/Codex/Grok adapters, refresh+reauth dispatcher). Claude captcha port + CRS-optional are enablers under that contract, not a late rename. `docs/ops/OPS-ACCOUNTS-VISION.md` — future rename ops-rotate → multi-provider ops-accounts; cherry-pick balancer ideas; no fork in this release.

- **desktop-act marketplace companion:** `desktop-act` is published in `ops-marketplace` next to `ops` (source `./desktop-act`). Declared as a co-install dependency in `plugin.json` + `plugin-dependencies.json`. `scripts/install-desktop-act-companion.sh` installs via `claude plugin install desktop-act@ops-marketplace` (idempotent). `/ops:setup` and `/ops:update` co-install by default (`desktop_act_co_install`). Launcher resolves `ops-marketplace/desktop-act` before cache clone; default bootstrap repo is Lifecycle-Innovations-Limited/desktop-act.
- **magic-link-autoloop reauth env (portable):** unattended re-auth child now inherits an env-templated headed seat + captcha cascade contract (`reauth-env.mjs`, `CAPTCHA-CASCADE.md`). Defaults: headed display from `CLAUDE_DESKTOP_DISPLAY` / `DESKTOP_ACT_DISPLAY`, visual + desktop-act + VNC layers on when present, 20m rotate timeout, no steal-lock, sticky `SKIP_TOKEN_SOLVERS=1` cleared. Dispatch mode `setup` (default) or `magic-link` via `$CRS_MAGIC_LINK_DISPATCH` / `crs.magicLinkDispatch`. Shell wrapper resolves plugin via `$CLAUDE_PLUGIN_ROOT` (no host hardcodes). Launchd template + `config.example.json` document the knobs.
- **installer (`claude-ops-installer`, v0.1.0):** cross-CLI `npx claude-ops-installer install` — auto-detects Claude Code, Codex, Gemini CLI, OpenClaw, Hermes, and OpenCode, mirrors upstream skills + binstubs into each agent's expected layout, ships with a central `~/.config/claude-ops-installer/config.yaml`, and supports `install` / `update` / `verify` / `doctor` / `uninstall` / `agents` subcommands. One source of truth (the upstream marketplace repo at the pinned ref); per-agent manifest at `~/.cache/claude-ops-installer/manifest.json` enables surgical uninstall. Public-repo clean: no PII, no hardcoded paths, no embedded credentials.

- **ops-desk (new skill):** `/ops:ops-desk` desk sweep — fans out read-only context agents (batched, Workflow tool) over the owner's open decisions/drafts/payments/sign-offs and returns a ranked, ready-to-approve action queue worked down under the per-draft outbound gate. Complements `/ops:ops-inbox`.
- **ops-ecom:** `channels` | `agentic` | `shop` verbs — sales channel inventory, agentic storefront health, Shop Campaigns readiness (read-only; Rule 5 / stage-only spend).
- **ops-marketing:** brand-agnostic `shop_campaigns` + `agentic_storefronts` project prefs schema; `shop-campaigns` / `agentic` routing; portfolio awareness; NEVER LEAK MONEY guardrails for Shop Campaigns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)