### PR TITLE
fix(hooks): stop advising a local WhatsApp bridge restart

### DIFF
--- a/claude-ops/bin/ops-pretool-wacli-health
+++ b/claude-ops/bin/ops-pretool-wacli-health
@@ -15,7 +15,7 @@ HEALTH_FILE="$HOME/.wacli/.health"
 if [[ -f "$HEALTH_FILE" ]]; then
   STATUS=$(grep "^status=" "$HEALTH_FILE" | cut -d= -f2)
   if [[ "$STATUS" == "needs_auth" ]] || [[ "$STATUS" == "needs_reauth" ]]; then
-    echo "⚠ WhatsApp bridge may not be running. Check: launchctl list com.${USER}.whatsapp-bridge"
+    echo "⚠ WhatsApp may need re-auth. It runs on ai-hub only (both numbers); this machine is a client. Never start or pair a local bridge." >&2
     # Don't block — just warn. The skill's own health check will handle it.
   fi
 fi

--- a/claude-ops/bin/ops-pretool-whatsapp-bridge-health
+++ b/claude-ops/bin/ops-pretool-whatsapp-bridge-health
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
-# PreToolUse hook: fast whatsapp-bridge health check (backgrounded to avoid blocking)
+# PreToolUse hook: fast WhatsApp reachability check (backgrounded to avoid blocking)
 # Event JSON arrives on stdin (Claude + Grok). Optional argv kept for old callers.
+#
+# WhatsApp runs on the always-on host (ai-hub), for both numbers. This machine is
+# only ever a CLIENT: the MCP reaches the remote bridge through local reverse
+# proxies. There is no local bridge and there must never be one -- starting or
+# pairing a bridge here hijacks the remote session and logs it out.
+#
+# So this hook checks the CLIENT LEGS, never a local bridge, and never advises
+# starting one. A remote read failure should fail loudly, not fall back to
+# anything local. Advisory only: it always exits 0 and never blocks a tool call.
 set -e
 if [[ -n "${1:-}" ]]; then
   INPUT="$1"
@@ -9,14 +18,28 @@ else
 fi
 echo "$INPUT" | grep -q "whatsapp" || exit 0
 
-# Background the slow checks (lsof, launchctl) so this hook returns instantly.
-# If bridge is down, the skill's own health check will catch it.
+# Local client proxy ports, overridable for hosts wired differently.
+WA_CLIENT_PORT_NL="${OPS_WA_CLIENT_PORT_NL:-8483}"
+WA_CLIENT_PORT_US="${OPS_WA_CLIENT_PORT_US:-8482}"
+
+# Background the slow checks (lsof) so this hook returns instantly.
+# If a leg is down, the skill's own health check will catch it too.
 (
   sleep 0.1
-  if ! (lsof -i :8080 2>/dev/null | grep -q LISTEN); then
+  down=""
+  for entry in "NL:${WA_CLIENT_PORT_NL}" "US:${WA_CLIENT_PORT_US}"; do
+    label="${entry%%:*}"
+    port="${entry##*:}"
+    if ! lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+      down="${down} ${label}(:${port})"
+    fi
+  done
+  if [[ -n "$down" ]]; then
     cat <<EOF >&2
-⚠ WhatsApp bridge not on :8080. Restart:
-  launchctl kickstart -k gui/$(id -u)/com.${USER}.whatsapp-bridge
+⚠ WhatsApp client leg down:${down}
+  WhatsApp runs on ai-hub only (both numbers); this machine is just a client.
+  Do NOT start, pair or kickstart a local bridge -- that hijacks the hub session.
+  Check the local reverse proxy and the tunnel to the hub, then retry.
 EOF
   fi
 ) &


### PR DESCRIPTION
## Problem

`bin/ops-pretool-whatsapp-bridge-health` probed `:8080` and, when nothing answered, wrote this to stderr on **every** whatsapp-related tool call:

```
⚠ WhatsApp bridge not on :8080. Restart:
  launchctl kickstart -k gui/501/com.samrenders.whatsapp-bridge
```

Verified on the affected machine:

- nothing listens on `:8080` (`lsof -nP -iTCP:8080 -sTCP:LISTEN` → empty)
- `~/Library/LaunchAgents/com.*.whatsapp-bridge*.plist` does not exist
- `launchctl list | grep whatsapp` → no such job

So the check fired constantly and the remedy was dead. Worse, it is harmful advice: WhatsApp runs on the always-on host (ai-hub) for both numbers, and this machine is only a client that reaches the remote bridge through local reverse proxies. Starting or pairing a bridge locally **hijacks the hub's session and logs it out** — precisely the failure the hook was steering agents into.

## Fix

Check the **client legs** instead of a local bridge, and never offer a restart:

- probes `:8483` (NL) and `:8482` (US), overridable via `OPS_WA_CLIENT_PORT_NL` / `OPS_WA_CLIENT_PORT_US` for hosts wired differently
- names only the leg that is actually down
- states the rule ("runs on ai-hub only; do not start a local bridge") rather than a command that breaks things

Contract is unchanged and still advisory: stdout stays untouched, diagnostics go to stderr, always `exit 0`, never blocks a tool call, slow `lsof` still backgrounded. This hook approves nothing, so nothing is weakened — only the text it prints changed.

Also removes the same dead plist reference from the deprecated `ops-pretool-wacli-health` shim (not registered in `hooks.json`) and routes its warning to stderr instead of stdout.

## Verification

`tests/test-hooks.sh` → **25 passed, 0 failed**, including the stdin-payload assertion for this hook.

Manual, old vs new, stdout/stderr captured separately, under `/bin/bash` 3.2 (what launchd and login shells get here):

| case | old stderr | new stderr |
|---|---|---|
| whatsapp event JSON | dead kickstart advice | silent (both legs genuinely up) |
| empty stdin | silent | silent |
| multi-line, quotes, non-ASCII (`Renée Müller`, `třetí řádek ✓`) | dead kickstart advice | silent |
| non-whatsapp event | silent | silent |

stdout was 0 bytes in all eight runs; exit code 0 in all eight.

Warning path proven by forcing dead ports:

```
$ OPS_WA_CLIENT_PORT_NL=59483 OPS_WA_CLIENT_PORT_US=59482 ops-pretool-whatsapp-bridge-health < event.json
⚠ WhatsApp client leg down: NL(:59483) US(:59482)
  WhatsApp runs on ai-hub only (both numbers); this machine is just a client.
  Do NOT start, pair or kickstart a local bridge -- that hijacks the hub session.
  Check the local reverse proxy and the tunnel to the hub, then retry.
```

With only NL forced dead it correctly reports `NL(:59483)` alone while the real `:8482` passes.

## Note for the reviewer

The default ports `8483`/`8482` match this machine's reverse-proxy layout. If other installs front the remote bridge on different ports, the env overrides cover it — but say the word and I will make the defaults fully configuration-driven instead.

Not merged, and no release cut, on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)