### PR TITLE
fix(post-update-migrate): never record a staging path as installPath

### DIFF
--- a/claude-ops/bin/ops-post-update-migrate
+++ b/claude-ops/bin/ops-post-update-migrate
@@ -82,10 +82,52 @@ trap 'rmdir "$LOCK_DIR" 2>/dev/null' EXIT
 # including same-version force-reinstalls where the per-version sentinel already exists.
 refresh_current_directory() {
   local cache_parent current_dir installed_json root_real current_real current_version
-  local refuse_refresh=0
+  local refuse_refresh=0 plugins_real canonical_current recorded_path
   cache_parent="$(dirname "$PLUGIN_ROOT")"
   current_dir="$cache_parent/current"
   installed_json="$PLUGINS_DIR/installed_plugins.json"
+  plugins_real="$(cd "$PLUGINS_DIR" 2>/dev/null && pwd -P || echo "$PLUGINS_DIR")"
+  canonical_current="$plugins_real/cache/ops-marketplace/ops/current"
+
+  # PLUGIN_ROOT is not always inside the plugins cache. ops-update stages a new
+  # version in a `mktemp -d` tree and fires SessionStart hooks from there, and a
+  # developer checkout runs them from ~/Developer. Deriving current/ from
+  # dirname(PLUGIN_ROOT) then yields e.g. /var/folders/../T/tmp.XXXX/current and
+  # writes THAT into installed_plugins.json. macOS reaps /var/folders, so days
+  # later the recorded installPath is gone and Claude Code loads the plugin as
+  # nothing at all: no skills, no commands, no error — the plugin still reads as
+  # enabled, so the failure is invisible. Observed live 2026-09-12, with all 66
+  # ops skills missing from a session whose config looked perfectly healthy.
+  #
+  # So: never rsync a tree from outside the cache over the live current/, and
+  # never record an installPath outside the cache. Out there we only REPAIR —
+  # and only when the recorded path is already broken.
+  root_real="$(cd "$PLUGIN_ROOT" 2>/dev/null && pwd -P || echo "$PLUGIN_ROOT")"
+  if [[ "$root_real/" != "$plugins_real"/* ]]; then
+    refuse_refresh=1
+    current_dir="$canonical_current"
+    recorded_path="$(python3 - "$installed_json" <<'PYEOF' 2>/dev/null || true
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(0)
+for e in d.get("plugins", {}).get("ops@ops-marketplace", []):
+    if e.get("scope") == "user":
+        print(e.get("installPath", ""))
+        break
+PYEOF
+)"
+    if [[ -n "$recorded_path" && -d "$recorded_path" ]]; then
+      log "  skip: PLUGIN_ROOT ($PLUGIN_ROOT) is outside $plugins_real and the recorded installPath still resolves — leaving it alone"
+      return 0
+    fi
+    if [[ ! -d "$canonical_current" ]]; then
+      log "  warn: recorded installPath is broken (${recorded_path:-<unset>}) and $canonical_current does not exist — cannot repair"
+      return 0
+    fi
+    log "  info: repairing broken installPath (${recorded_path:-<unset>}) → $canonical_current"
+  fi
 
   # current/ must be a real rsynced directory, not a symlink. A legacy or
   # dangling symlink (e.g. left pointing at a version pruned by ops-update
@@ -98,7 +140,6 @@ refresh_current_directory() {
     log "  info: removed symlink at $current_dir (current/ must be a real directory)"
   fi
 
-  root_real="$(cd "$PLUGIN_ROOT" 2>/dev/null && pwd -P || echo "$PLUGIN_ROOT")"
   current_real="$(cd "$current_dir" 2>/dev/null && pwd -P || echo "$current_dir")"
 
   # SessionStart also fires in long-lived sessions whose PLUGIN_ROOT still
@@ -168,10 +209,18 @@ PYEOF
   # entries itself.
 
   if [[ -f "$installed_json" ]]; then
-    if python3 - "$installed_json" "$current_dir" <<'PYEOF' 2>/dev/null
+    if python3 - "$installed_json" "$current_dir" "$plugins_real" <<'PYEOF' 2>/dev/null
 import json, os, stat, sys, tempfile
 
-path, current = sys.argv[1], sys.argv[2]
+path, current, plugins_dir = sys.argv[1], sys.argv[2], sys.argv[3]
+
+# Belt to the caller's braces: an installPath outside the plugins directory is
+# never correct. A temp staging tree (/var/folders/..., /tmp/...) is reaped by
+# the OS and the plugin then loads as nothing, silently. Refuse rather than
+# record a path that is going to evaporate.
+if os.path.commonpath([os.path.realpath(current), os.path.realpath(plugins_dir)]) != os.path.realpath(plugins_dir):
+    sys.exit("refusing installPath outside %s: %s" % (plugins_dir, current))
+
 with open(path) as f:
     d = json.load(f)
 changed = False

--- a/claude-ops/tests/test-post-update-migrate-current-guard.sh
+++ b/claude-ops/tests/test-post-update-migrate-current-guard.sh
@@ -19,9 +19,9 @@ fail() {
 run_case() {
 	local label="$1" mode="$2"
 	local base="$TMP/$label"
-	local plugin_root="$base/cache/ops-marketplace/ops/2.0.0"
-	local current_dir="$base/cache/ops-marketplace/ops/current"
 	local config_dir="$base/config"
+	local plugin_root="$config_dir/plugins/cache/ops-marketplace/ops/2.0.0"
+	local current_dir="$config_dir/plugins/cache/ops-marketplace/ops/current"
 	local data_dir="$base/data"
 	local installed="$config_dir/plugins/installed_plugins.json"
 
@@ -137,9 +137,9 @@ PY
 
 run_downgrade_case() {
 	local base="$TMP/refuse-downgrade"
-	local plugin_root="$base/cache/ops-marketplace/ops/2.0.0"
-	local current_dir="$base/cache/ops-marketplace/ops/current"
 	local config_dir="$base/config"
+	local plugin_root="$config_dir/plugins/cache/ops-marketplace/ops/2.0.0"
+	local current_dir="$config_dir/plugins/cache/ops-marketplace/ops/current"
 	local data_dir="$base/data"
 
 	mkdir -p "$plugin_root/.claude-plugin" "$plugin_root/bin" \
@@ -169,9 +169,9 @@ run_downgrade_case() {
 
 run_forward_update_case() {
 	local base="$TMP/allow-forward-update"
-	local plugin_root="$base/cache/ops-marketplace/ops/3.0.0"
-	local current_dir="$base/cache/ops-marketplace/ops/current"
 	local config_dir="$base/config"
+	local plugin_root="$config_dir/plugins/cache/ops-marketplace/ops/3.0.0"
+	local current_dir="$config_dir/plugins/cache/ops-marketplace/ops/current"
 	local data_dir="$base/data"
 
 	mkdir -p "$plugin_root/.claude-plugin" "$plugin_root/bin" \
@@ -204,9 +204,102 @@ run_forward_update_case() {
 	printf 'ok: allow-forward-update\n'
 }
 
+# ops-update stages a new version in a `mktemp -d` tree and fires SessionStart
+# from there, so PLUGIN_ROOT sits outside the plugins cache. Deriving current/
+# from dirname(PLUGIN_ROOT) then recorded /var/folders/../T/tmp.XXXX/current as
+# the installPath. macOS reaps that directory, and Claude Code subsequently
+# loaded the plugin as nothing at all — no skills, no commands, no error, while
+# the plugin still read as enabled. Seen live 2026-09-12 with all 66 ops skills
+# silently absent. A temp path must never reach installed_plugins.json.
+#
+# $1 = label, $2 = "live" (recorded installPath still resolves) | "broken"
+run_outside_cache_case() {
+	local label="$1" recorded_state="$2"
+	local base="$TMP/$label"
+	local staged="$base/staging/tmp.XXXX/current"
+	local cache_current="$base/config/plugins/cache/ops-marketplace/ops/current"
+	local config_dir="$base/config"
+	local data_dir="$base/data"
+	local installed="$config_dir/plugins/installed_plugins.json"
+	local recorded
+
+	mkdir -p "$staged/.claude-plugin" "$staged/bin" \
+		"$cache_current/.claude-plugin" "$cache_current/bin" \
+		"$config_dir/plugins" "$data_dir/.migrated" "$base/home"
+	printf '{"version":"4.0.0"}\n' >"$staged/.claude-plugin/plugin.json"
+	printf 'staged\n' >"$staged/bin/staged-marker"
+	printf '{"version":"4.0.0"}\n' >"$cache_current/.claude-plugin/plugin.json"
+	printf 'live\n' >"$cache_current/bin/live-marker"
+	touch "$data_dir/.migrated/v4.0.0"
+
+	if [[ "$recorded_state" == "live" ]]; then
+		recorded="$cache_current"
+	else
+		recorded="$base/staging/tmp.GONE/current"
+	fi
+
+	cat >"$installed" <<JSON
+{
+  "plugins": {
+    "ops@ops-marketplace": [
+      {
+        "scope": "user",
+        "installPath": "$recorded",
+        "version": "4.0.0"
+      }
+    ]
+  }
+}
+JSON
+	chmod 600 "$installed"
+
+	HOME="$base/home" \
+		CLAUDE_PLUGIN_ROOT="$staged" \
+		CLAUDE_CONFIG_DIR="$config_dir" \
+		CLAUDE_PLUGIN_DATA_DIR="$data_dir" \
+		bash "$SCRIPT"
+
+	# The staging tree is never rsynced over the live cache — otherwise a
+	# developer checkout running SessionStart would overwrite the installed
+	# plugin with whatever is on their branch.
+	[[ ! -e "$cache_current/bin/staged-marker" ]] ||
+		fail "$label: staging tree outside the cache was rsynced over live current/"
+	[[ -f "$cache_current/bin/live-marker" ]] ||
+		fail "$label: live current/ payload was destroyed"
+
+	python3 - "$installed" "$config_dir/plugins" "$cache_current" "$recorded_state" "$recorded" "$base/staging" <<'PY' || fail "$label: installed_plugins.json assertions failed"
+import json, os, sys
+path, plugins_dir, cache_current, state, recorded, staging = sys.argv[1:7]
+with open(path) as f:
+    d = json.load(f)
+got = d["plugins"]["ops@ops-marketplace"][0]["installPath"]
+
+
+def under(child, parent):
+    child, parent = os.path.realpath(child), os.path.realpath(parent)
+    return os.path.commonpath([child, parent]) == parent
+
+
+assert under(got, plugins_dir), f"installPath {got!r} escaped the plugins dir {plugins_dir!r}"
+assert not under(got, staging), f"a staging path reached installPath: {got!r}"
+def same(a, b):
+    return os.path.realpath(a) == os.path.realpath(b)
+
+
+if state == "live":
+    assert same(got, recorded), f"a resolving installPath was rewritten: {got!r}"
+else:
+    assert same(got, cache_current), f"broken installPath not repaired: {got!r} want {cache_current!r}"
+PY
+
+	printf 'ok: %s\n' "$label"
+}
+
 run_case rsync-path rsync
 run_case cp-fallback nossync
 run_downgrade_case
 run_forward_update_case
+run_outside_cache_case outside-cache-live live
+run_outside_cache_case outside-cache-broken broken
 
-printf 'PASS: current/ stays free of cache-GC markers, blocks downgrades, permits forward updates, and rewrites installed_plugins.json atomically\n'
+printf 'PASS: current/ stays free of cache-GC markers, blocks downgrades, permits forward updates, keeps staging paths out of installPath, and rewrites installed_plugins.json atomically\n'


### PR DESCRIPTION
## The failure

A session on 2026-09-12 had all 66 ops skills missing. The plugin read as enabled, nothing was disabled in `skillOverrides`, and no error appeared anywhere. `installed_plugins.json` said:

```
"ops@ops-marketplace": installPath = /var/folders/kb/.../T/tmp.6uCfH3or3P/current
```

That directory no longer existed. macOS had reaped it. A plugin whose `installPath` is gone loads as nothing at all — silently.

## Where it comes from

`refresh_current_directory` derived `current/` from `dirname(PLUGIN_ROOT)`:

```bash
cache_parent="$(dirname "$PLUGIN_ROOT")"
current_dir="$cache_parent/current"
```

`ops-update` stages a new version in a `mktemp -d` tree and fires SessionStart hooks from there, so `PLUGIN_ROOT` is `/var/folders/.../tmp.XXXX/...` and that temp path gets written into `installed_plugins.json` as the permanent install location. Every install is a delayed self-destruct.

## The change

Outside the plugins cache the migration now only **repairs**, never refreshes:

- recorded `installPath` still resolves → leave it alone
- recorded `installPath` is broken → repair it to the canonical `<plugins>/cache/ops-marketplace/ops/current`
- never rsync a tree from outside the cache over the live `current/`

That last point also fixes a second hazard: a developer checkout running SessionStart would previously rsync whatever is on their branch over the installed plugin.

The writer refuses any path outside the plugins directory as a second line of defence, so a future caller cannot reintroduce this from another direction.

## Proof

Two regression cases, one per state (`outside-cache-live`, `outside-cache-broken`).

Against the previous script:

```
ok: rsync-path
ok: cp-fallback
ok: refuse-downgrade
ok: allow-forward-update
AssertionError: installPath '.../staging/tmp.XXXX/current' escaped the plugins dir '.../config/plugins'
FAIL: outside-cache-live
```

Against this branch: all six pass.

The four pre-existing cases pass on both. They never caught this because their fixtures put the cache at `$base/cache`, outside the config dir, while Claude Code always keeps it at `<config>/plugins/cache`. They now use the real layout.

## Note

`stat -c %i` in the existing test is GNU-only, so the suite needs coreutils on macOS. Not touched here — flagging it, not fixing it in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
