### PR TITLE
fix(config): stop calling a plugin subcommand that does not exist

### DIFF
--- a/claude-ops/agents/marketing-optimizer.md
+++ b/claude-ops/agents/marketing-optimizer.md
@@ -40,8 +40,9 @@ If ops-marketing-dash data is unavailable, pull directly:
 **Meta Ads (last 7d):**
 
 ```bash
-META_TOKEN=$(claude plugin config get meta_ads_token 2>/dev/null || echo "$META_ADS_TOKEN")
-META_ACCOUNT=$(claude plugin config get meta_ad_account_id 2>/dev/null || echo "$META_AD_ACCOUNT_ID")
+PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+META_TOKEN=$(jq -r '.user_config.meta_ads_token // empty' "$PREFS_PATH" 2>/dev/null || echo "${META_ADS_TOKEN}")
+META_ACCOUNT=$(jq -r '.user_config.meta_ad_account_id // empty' "$PREFS_PATH" 2>/dev/null || echo "${META_AD_ACCOUNT_ID}")
 curl -s "https://graph.facebook.com/v20.0/${META_ACCOUNT}/insights?fields=spend,actions,action_values,impressions,clicks&date_preset=last_7d&level=account" \
   -H "Authorization: Bearer ${META_TOKEN}"
 ```

--- a/claude-ops/bin/ops-marketing-dash
+++ b/claude-ops/bin/ops-marketing-dash
@@ -18,6 +18,40 @@ PREFS="${OPS_DATA_DIR}/preferences.json"
 
 # Pull a value from preferences.json marketing.projects.<project>.<channel>.<field>.
 # $1 project, $2 channel, $3 field. Echoes nothing if missing or prefs absent.
+# Read a value the owner saved into preferences.json .user_config.<key>.
+#
+# This replaces `claude plugin config get <key>`, which never worked: Claude
+# Code has no `plugin config` subcommand (it errors with "unknown command
+# 'config'" and the 2>/dev/null swallowed it), so that tier silently returned
+# empty on every call. Every value /ops:setup wrote into .user_config was
+# therefore unreachable, and the settings screen looked configured while the
+# resolver saw nothing. Verified against Claude Code 2.1.269.
+# Persist a value into preferences.json .user_config.<key>.
+#
+# Replaces `claude plugin config set`, which does not exist either: it failed
+# silently, so a discovered id was thrown away and rediscovered on every run.
+# Writes via temp + atomic rename so a concurrent reader never sees a partial
+# file, and preserves the file mode because preferences.json holds credentials.
+user_config_set() {
+  local key="$1" value="$2" tmp
+  [ -n "$key" ] || return 0
+  [ -f "$PREFS" ] || return 0
+  tmp="$(mktemp "${PREFS}.XXXXXX")" || return 0
+  if jq --arg k "$key" --arg v "$value" '.user_config[$k] = $v' "$PREFS" >"$tmp" 2>/dev/null; then
+    chmod --reference="$PREFS" "$tmp" 2>/dev/null || chmod 600 "$tmp"
+    mv -f "$tmp" "$PREFS"
+  else
+    rm -f "$tmp"
+  fi
+}
+
+user_config_get() {
+  local key="$1"
+  [ -n "$key" ] || return 0
+  [ -f "$PREFS" ] || return 0
+  jq -r --arg k "$key" '.user_config[$k] // empty' "$PREFS" 2>/dev/null || true
+}
+
 prefs_get() {
   [ -f "$PREFS" ] || return 0
   jq -r --arg p "$1" --arg c "$2" --arg f "$3" \
@@ -77,7 +111,7 @@ prefs_marketing_cred() {
 
 # Credential resolution — four-tier:
 #   1. Project config in preferences.json marketing.projects.<p>.<c>.<f> (project mode)
-#   2. Flat env / `claude plugin config get` (legacy)
+#   2. Flat env / preferences.json .user_config (legacy)
 #   3. Doppler with bare key name (legacy)
 #   4. channels.marketing.<channel>.<key_field> owner-level Doppler-ref (NEW) —
 #      this tier is what lets the morning briefing resolve creds that live in
@@ -104,7 +138,7 @@ get_cred() {
     fi
   fi
   if [ -z "$val" ]; then val="${!env_var:-}"; fi
-  if [ -z "$val" ]; then val="$(claude plugin config get "$plugin_key" 2>/dev/null || echo "")"; fi
+  if [ -z "$val" ]; then val="$(user_config_get "$plugin_key")"; fi
   if [ -z "$val" ] && [ -n "$doppler_key" ]; then
     val="$(doppler secrets get "$doppler_key" --plain 2>/dev/null || echo "")"
   fi
@@ -149,11 +183,11 @@ if [ -z "${GA4_SERVICE_ACCOUNT_KEY_FILE:-}" ] && [ -f "$PREFS" ]; then
 fi
 GSC_SITE="$(get_cred 'gsc.site_url' GOOGLE_SEARCH_CONSOLE_SITE google_search_console_site)"
 GADS_DEV_TOKEN="$(get_cred 'google_ads.developer_token' GOOGLE_ADS_DEVELOPER_TOKEN google_ads_developer_token GOOGLE_ADS_DEVELOPER_TOKEN google_ads dev_token_key)"
-GADS_CLIENT_ID="${GOOGLE_ADS_CLIENT_ID:-$(claude plugin config get google_ads_client_id 2>/dev/null || echo "")}"
-GADS_CLIENT_SECRET="${GOOGLE_ADS_CLIENT_SECRET:-$(claude plugin config get google_ads_client_secret 2>/dev/null || echo "")}"
+GADS_CLIENT_ID="${GOOGLE_ADS_CLIENT_ID:-$(user_config_get google_ads_client_id)}"
+GADS_CLIENT_SECRET="${GOOGLE_ADS_CLIENT_SECRET:-$(user_config_get google_ads_client_secret)}"
 GADS_REFRESH_TOKEN="$(get_cred 'google_ads.refresh_token' GOOGLE_ADS_REFRESH_TOKEN google_ads_refresh_token GOOGLE_ADS_REFRESH_TOKEN google_ads refresh_token_key)"
 GADS_CUSTOMER_ID="$(get_cred 'google_ads.customer_id' GOOGLE_ADS_CUSTOMER_ID google_ads_customer_id)"
-GADS_LOGIN_CUSTOMER_ID="${GOOGLE_ADS_LOGIN_CUSTOMER_ID:-$(claude plugin config get google_ads_login_customer_id 2>/dev/null || echo "")}"
+GADS_LOGIN_CUSTOMER_ID="${GOOGLE_ADS_LOGIN_CUSTOMER_ID:-$(user_config_get google_ads_login_customer_id)}"
 INSTAGRAM_ACCOUNT_ID="$(get_cred 'instagram.account_id' INSTAGRAM_ACCOUNT_ID instagram_account_id)"
 # Meta app secret enables appsecret_proof (required for system-user tokens).
 # prefs stores it under channels.marketing.meta.app_secret_key (Doppler ref);
@@ -438,7 +472,7 @@ gather_instagram() {
   if [ -z "$IG_ID" ]; then
     IG_ID=$(curl -gsS --max-time 5 "https://graph.facebook.com/v21.0/me/accounts?fields=instagram_business_account${META_PROOF_QS}" \
       -H "Authorization: Bearer ${META_TOKEN}" 2>/dev/null | jq -r '.data[0].instagram_business_account.id // empty')
-    [ -n "$IG_ID" ] && claude plugin config set instagram_account_id "$IG_ID" 2>/dev/null
+    [ -n "$IG_ID" ] && user_config_set instagram_account_id "$IG_ID"
   fi
 
   if [ -z "$IG_ID" ]; then

--- a/claude-ops/skills/ops-marketing/references/details.md
+++ b/claude-ops/skills/ops-marketing/references/details.md
@@ -68,7 +68,8 @@ Resolve credentials in this order for each service:
 ### Klaviyo
 
 ```bash
-KLAVIYO_KEY="${KLAVIYO_PRIVATE_KEY:-$(claude plugin config get klaviyo_private_key 2>/dev/null)}"
+PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+KLAVIYO_KEY="${KLAVIYO_PRIVATE_KEY:-$(jq -r '.user_config.klaviyo_private_key // empty' "$PREFS_PATH" 2>/dev/null)}"
 if [ -z "$KLAVIYO_KEY" ]; then
   KLAVIYO_KEY="$(doppler secrets get KLAVIYO_PRIVATE_KEY --plain 2>/dev/null)"
 fi
@@ -77,8 +78,9 @@ fi
 ### Meta Ads
 
 ```bash
-META_TOKEN="${META_ADS_TOKEN:-$(claude plugin config get meta_ads_token 2>/dev/null)}"
-META_ACCOUNT="${META_AD_ACCOUNT_ID:-$(claude plugin config get meta_ad_account_id 2>/dev/null)}"
+PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+META_TOKEN="${META_ADS_TOKEN:-$(jq -r '.user_config.meta_ads_token // empty' "$PREFS_PATH" 2>/dev/null)}"
+META_ACCOUNT="${META_AD_ACCOUNT_ID:-$(jq -r '.user_config.meta_ad_account_id // empty' "$PREFS_PATH" 2>/dev/null)}"
 if [ -z "$META_TOKEN" ]; then
   META_TOKEN="$(doppler secrets get META_ADS_TOKEN --plain 2>/dev/null)"
 fi
@@ -87,7 +89,8 @@ fi
 ### GA4
 
 ```bash
-GA4_PROPERTY="${GA4_PROPERTY_ID:-$(claude plugin config get ga4_property_id 2>/dev/null)}"
+PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+GA4_PROPERTY="${GA4_PROPERTY_ID:-$(jq -r '.user_config.ga4_property_id // empty' "$PREFS_PATH" 2>/dev/null)}"
 # GA4 uses gcloud application default credentials — check if configured:
 gcloud auth application-default print-access-token 2>/dev/null
 ```
@@ -95,20 +98,22 @@ gcloud auth application-default print-access-token 2>/dev/null
 ### Google Search Console
 
 ```bash
-GSC_SITE="${GOOGLE_SEARCH_CONSOLE_SITE:-$(claude plugin config get google_search_console_site 2>/dev/null)}"
+PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+GSC_SITE="${GOOGLE_SEARCH_CONSOLE_SITE:-$(jq -r '.user_config.google_search_console_site // empty' "$PREFS_PATH" 2>/dev/null)}"
 # Uses same gcloud ADC as GA4
 ```
 
 ### Google Ads
 
 ```bash
+PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
 GADS_API_VERSION="v23"
-GADS_DEV_TOKEN="${GOOGLE_ADS_DEVELOPER_TOKEN:-$(claude plugin config get google_ads_developer_token 2>/dev/null)}"
-GADS_CLIENT_ID="${GOOGLE_ADS_CLIENT_ID:-$(claude plugin config get google_ads_client_id 2>/dev/null)}"
-GADS_CLIENT_SECRET="${GOOGLE_ADS_CLIENT_SECRET:-$(claude plugin config get google_ads_client_secret 2>/dev/null)}"
-GADS_REFRESH_TOKEN="${GOOGLE_ADS_REFRESH_TOKEN:-$(claude plugin config get google_ads_refresh_token 2>/dev/null)}"
-GADS_CUSTOMER_ID="${GOOGLE_ADS_CUSTOMER_ID:-$(claude plugin config get google_ads_customer_id 2>/dev/null)}"
-GADS_LOGIN_CUSTOMER_ID="${GOOGLE_ADS_LOGIN_CUSTOMER_ID:-$(claude plugin config get google_ads_login_customer_id 2>/dev/null)}"
+GADS_DEV_TOKEN="${GOOGLE_ADS_DEVELOPER_TOKEN:-$(jq -r '.user_config.google_ads_developer_token // empty' "$PREFS_PATH" 2>/dev/null)}"
+GADS_CLIENT_ID="${GOOGLE_ADS_CLIENT_ID:-$(jq -r '.user_config.google_ads_client_id // empty' "$PREFS_PATH" 2>/dev/null)}"
+GADS_CLIENT_SECRET="${GOOGLE_ADS_CLIENT_SECRET:-$(jq -r '.user_config.google_ads_client_secret // empty' "$PREFS_PATH" 2>/dev/null)}"
+GADS_REFRESH_TOKEN="${GOOGLE_ADS_REFRESH_TOKEN:-$(jq -r '.user_config.google_ads_refresh_token // empty' "$PREFS_PATH" 2>/dev/null)}"
+GADS_CUSTOMER_ID="${GOOGLE_ADS_CUSTOMER_ID:-$(jq -r '.user_config.google_ads_customer_id // empty' "$PREFS_PATH" 2>/dev/null)}"
+GADS_LOGIN_CUSTOMER_ID="${GOOGLE_ADS_LOGIN_CUSTOMER_ID:-$(jq -r '.user_config.google_ads_login_customer_id // empty' "$PREFS_PATH" 2>/dev/null)}"
 
 # Doppler fallback
 if [ -z "$GADS_REFRESH_TOKEN" ]; then
@@ -534,6 +539,7 @@ Upload an image and create an ad. Collect via AskUserQuestion:
 Then collect headline (free text, up to 40 characters) via a second AskUserQuestion.
 
 ```bash
+PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
 # Step 1: Upload image
 if [[ "$IMAGE_INPUT" == http* ]]; then
   # Upload by URL
@@ -556,10 +562,10 @@ fi
 # Resolve the Facebook Page ID. Meta's `object_story_spec.page_id` requires a
 # real Page ID — the ad account ID (with `act_` stripped) is NOT a Page ID and
 # the API call will fail. Require META_PAGE_ID in env or plugin prefs.
-META_PAGE_ID="${META_PAGE_ID:-$(claude plugin config get meta_page_id 2>/dev/null || echo "")}"
+META_PAGE_ID="${META_PAGE_ID:-$(jq -r '.user_config.meta_page_id // empty' "$PREFS_PATH" 2>/dev/null)}"
 if [ -z "$META_PAGE_ID" ]; then
   echo "META_PAGE_ID is required to create an ad creative. Set it via:"
-  echo "  claude plugin config set meta_page_id <your_fb_page_id>"
+  echo "  set .user_config.meta_page_id = <your_fb_page_id> in preferences.json"
   echo "Find your Page ID at https://www.facebook.com/<your-page>/about_profile_transparency"
   exit 0
 fi
@@ -1224,12 +1230,24 @@ Instagram publishing and insights via Instagram Graph API (same `META_TOKEN` as 
 **Resolve IG account ID at the start of every instagram invocation:**
 
 ```bash
-IG_ACCOUNT_ID=$(claude plugin config get instagram_account_id 2>/dev/null)
+ops_user_config_set() {  # write into preferences.json .user_config.<key>
+  local key="$1" value="$2" tmp
+  [ -n "$key" ] && [ -f "$PREFS_PATH" ] || return 0
+  tmp="$(mktemp "${PREFS_PATH}.XXXXXX")" || return 0
+  if jq --arg k "$key" --arg v "$value" '.user_config[$k] = $v' "$PREFS_PATH" >"$tmp" 2>/dev/null; then
+    chmod 600 "$tmp"; mv -f "$tmp" "$PREFS_PATH"
+  else
+    rm -f "$tmp"
+  fi
+}
+
+PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+IG_ACCOUNT_ID=$(jq -r '.user_config.instagram_account_id // empty' "$PREFS_PATH" 2>/dev/null)
 if [ -z "$IG_ACCOUNT_ID" ]; then
   IG_ACCOUNT_ID=$(curl -s "https://graph.facebook.com/v21.0/me/accounts?fields=instagram_business_account" \
     -H "Authorization: Bearer ${META_TOKEN}" | jq -r '.data[0].instagram_business_account.id // empty')
   # Cache it
-  [ -n "$IG_ACCOUNT_ID" ] && claude plugin config set instagram_account_id "$IG_ACCOUNT_ID" 2>/dev/null
+  [ -n "$IG_ACCOUNT_ID" ] && ops_user_config_set instagram_account_id "$IG_ACCOUNT_ID"
 fi
 if [ -z "$IG_ACCOUNT_ID" ]; then
   echo "Instagram Business account not linked to your Meta token. Ensure your Facebook Page has an Instagram Business account connected."
@@ -2437,6 +2455,7 @@ For any channel with missing credentials, show `[not configured — /ops:marketi
 **Before asking for anything**, auto-scan ALL sources for existing credentials. Run in a single background batch:
 
 ```bash
+PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
 # Env vars
 printenv KLAVIYO_API_KEY KLAVIYO_PRIVATE_KEY META_ACCESS_TOKEN FACEBOOK_ACCESS_TOKEN META_AD_ACCOUNT_ID GA4_PROPERTY_ID GA_MEASUREMENT_ID 2>/dev/null
 printenv GOOGLE_ADS_DEVELOPER_TOKEN GOOGLE_ADS_CLIENT_ID GOOGLE_ADS_CLIENT_SECRET GOOGLE_ADS_REFRESH_TOKEN GOOGLE_ADS_CUSTOMER_ID 2>/dev/null

--- a/claude-ops/skills/ops-whatsapp-biz/SKILL.md
+++ b/claude-ops/skills/ops-whatsapp-biz/SKILL.md
@@ -26,9 +26,9 @@ WhatsApp Business Cloud API — distinct from wacli personal WhatsApp.
 PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
 
 # WhatsApp Business credentials (separate from wacli personal)
-WABA_TOKEN="${WHATSAPP_BUSINESS_TOKEN:-$(claude plugin config get whatsapp_business_token 2>/dev/null)}"
-WABA_PHONE_ID="${WHATSAPP_PHONE_NUMBER_ID:-$(claude plugin config get whatsapp_phone_number_id 2>/dev/null)}"
-WABA_ACCOUNT_ID="${WHATSAPP_BUSINESS_ACCOUNT_ID:-$(claude plugin config get whatsapp_business_account_id 2>/dev/null)}"
+WABA_TOKEN="${WHATSAPP_BUSINESS_TOKEN:-$(jq -r '.user_config.whatsapp_business_token // empty' "$PREFS_PATH" 2>/dev/null)}"
+WABA_PHONE_ID="${WHATSAPP_PHONE_NUMBER_ID:-$(jq -r '.user_config.whatsapp_phone_number_id // empty' "$PREFS_PATH" 2>/dev/null)}"
+WABA_ACCOUNT_ID="${WHATSAPP_BUSINESS_ACCOUNT_ID:-$(jq -r '.user_config.whatsapp_business_account_id // empty' "$PREFS_PATH" 2>/dev/null)}"
 
 # Doppler fallback
 if [ -z "$WABA_TOKEN" ]; then
@@ -325,6 +325,7 @@ Configure WhatsApp Business API credentials.
 **Before asking**, auto-scan for existing credentials:
 
 ```bash
+PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
 # Scan env vars
 printenv WHATSAPP_BUSINESS_TOKEN WHATSAPP_PHONE_NUMBER_ID WHATSAPP_BUSINESS_ACCOUNT_ID 2>/dev/null
 
@@ -340,9 +341,9 @@ done
 grep -h 'WHATSAPP_BUSINESS\|WHATSAPP_PHONE' ~/.zshrc ~/.bashrc ~/.zprofile ~/.envrc 2>/dev/null | grep -v '^#'
 
 # Existing plugin config
-claude plugin config get whatsapp_business_token 2>/dev/null && echo "✓ whatsapp_business_token already configured"
-claude plugin config get whatsapp_phone_number_id 2>/dev/null && echo "✓ whatsapp_phone_number_id already configured"
-claude plugin config get whatsapp_business_account_id 2>/dev/null && echo "✓ whatsapp_business_account_id already configured"
+jq -r '.user_config.whatsapp_business_token // empty' "$PREFS_PATH" 2>/dev/null && echo "✓ whatsapp_business_token already configured"
+jq -r '.user_config.whatsapp_phone_number_id // empty' "$PREFS_PATH" 2>/dev/null && echo "✓ whatsapp_phone_number_id already configured"
+jq -r '.user_config.whatsapp_business_account_id // empty' "$PREFS_PATH" 2>/dev/null && echo "✓ whatsapp_business_account_id already configured"
 ```
 
 **If credentials not found**, guide user:
@@ -363,9 +364,21 @@ claude plugin config get whatsapp_business_account_id 2>/dev/null && echo "✓ w
 3. Save via plugin config:
 
 ```bash
-claude plugin config set whatsapp_business_token "$WABA_TOKEN"
-claude plugin config set whatsapp_phone_number_id "$WABA_PHONE_ID"
-claude plugin config set whatsapp_business_account_id "$WABA_ACCOUNT_ID"
+PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+ops_user_config_set() {  # write into preferences.json .user_config.<key>
+  local key="$1" value="$2" tmp
+  [ -n "$key" ] && [ -f "$PREFS_PATH" ] || return 0
+  tmp="$(mktemp "${PREFS_PATH}.XXXXXX")" || return 0
+  if jq --arg k "$key" --arg v "$value" '.user_config[$k] = $v' "$PREFS_PATH" >"$tmp" 2>/dev/null; then
+    chmod 600 "$tmp"; mv -f "$tmp" "$PREFS_PATH"
+  else
+    rm -f "$tmp"
+  fi
+}
+
+ops_user_config_set whatsapp_business_token "$WABA_TOKEN"
+ops_user_config_set whatsapp_phone_number_id "$WABA_PHONE_ID"
+ops_user_config_set whatsapp_business_account_id "$WABA_ACCOUNT_ID"
 ```
 
 4. Smoke test:

--- a/claude-ops/skills/setup/channels/marketing.md
+++ b/claude-ops/skills/setup/channels/marketing.md
@@ -375,10 +375,11 @@ Expect `approved` / `disapproved` counts; `null` means merchant ID or auth missi
 Auto-scan for:
 
 ```bash
+PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
 printenv WHATSAPP_BUSINESS_TOKEN WHATSAPP_PHONE_NUMBER_ID WHATSAPP_BUSINESS_ACCOUNT_ID 2>/dev/null
-claude plugin config get whatsapp_business_token 2>/dev/null && echo "waba_token: already configured"
-claude plugin config get whatsapp_phone_number_id 2>/dev/null && echo "waba_phone_id: already configured"
-claude plugin config get whatsapp_business_account_id 2>/dev/null && echo "waba_account_id: already configured"
+jq -r '.user_config.whatsapp_business_token // empty' "$PREFS_PATH" 2>/dev/null && echo "waba_token: already configured"
+jq -r '.user_config.whatsapp_phone_number_id // empty' "$PREFS_PATH" 2>/dev/null && echo "waba_phone_id: already configured"
+jq -r '.user_config.whatsapp_business_account_id // empty' "$PREFS_PATH" 2>/dev/null && echo "waba_account_id: already configured"
 ```
 
 Where to find credentials:
@@ -390,9 +391,21 @@ Where to find credentials:
 Collect each via AskUserQuestion (free text) if not found. Save:
 
 ```bash
-claude plugin config set whatsapp_business_token "$WABA_TOKEN"
-claude plugin config set whatsapp_phone_number_id "$WABA_PHONE_ID"
-claude plugin config set whatsapp_business_account_id "$WABA_ACCOUNT_ID"
+PREFS_PATH="${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}/preferences.json"
+ops_user_config_set() {  # write into preferences.json .user_config.<key>
+  local key="$1" value="$2" tmp
+  [ -n "$key" ] && [ -f "$PREFS_PATH" ] || return 0
+  tmp="$(mktemp "${PREFS_PATH}.XXXXXX")" || return 0
+  if jq --arg k "$key" --arg v "$value" '.user_config[$k] = $v' "$PREFS_PATH" >"$tmp" 2>/dev/null; then
+    chmod 600 "$tmp"; mv -f "$tmp" "$PREFS_PATH"
+  else
+    rm -f "$tmp"
+  fi
+}
+
+ops_user_config_set whatsapp_business_token "$WABA_TOKEN"
+ops_user_config_set whatsapp_phone_number_id "$WABA_PHONE_ID"
+ops_user_config_set whatsapp_business_account_id "$WABA_ACCOUNT_ID"
 ```
 
 Smoke test:


### PR DESCRIPTION
## The command does not exist

`get_cred()` in `bin/ops-marketing-dash` resolves a credential through five tiers. Tier 3 is:

```bash
val="$(claude plugin config get "$plugin_key" 2>/dev/null || echo "")"
```

Claude Code has no `plugin config` subcommand. Verified on 2.1.269:

```
$ claude plugin config get klaviyo_private_key
error: unknown command 'config'
```

The `2>/dev/null` sent that straight to the floor, so the tier returned empty on every call and nothing upstream could tell the difference between "not configured" and "I asked a command that isn't there".

`claude plugin config set` doesn't exist either — so setup flows that discovered an id (Instagram account id, WhatsApp Business credentials) threw it away and rediscovered it on the next run.

## What it broke

`preferences.json` has a `user_config` object that `/ops:setup` writes into. On the machine where this was found it held 15 real values — `klaviyo_private_key`, `meta_ads_token`, `stripe_secret_key`, `shopify_admin_token`, `revenuecat_api_key` and more. **Nothing could read any of them.** The settings screen showed them as configured, `get_cred()` saw nothing, and the only thing that still worked was whatever also happened to be exported as an env var.

That is the worst shape a config bug can take: it looks configured and behaves unconfigured, with no error anywhere.

## The change

The values were always in `preferences.json`. Read and write that file instead.

- `user_config_get` / `user_config_set` added to `bin/ops-marketing-dash`
- all 33 call sites replaced across the executable, `agents/marketing-optimizer.md`, and the `ops-whatsapp-biz`, `ops-marketing` and `setup/channels/marketing` skills
- the writer uses temp + atomic rename at mode 600 — `preferences.json` holds credentials, and a torn write there loses every one of them
- bash blocks in the skills that now dereference `$PREFS_PATH` declare it, so a copied snippet still runs on its own
- doc lines that told the user to run `claude plugin config set <key> <value>` now name the file to edit

## Proof

Same key, old path and new path, side by side:

```
oud pad (claude plugin config get):
  -> error: unknown command 'config'
nieuw pad (user_config_get):
  OK   klaviyo_private_key      37 tekens
  OK   meta_ads_token           193 tekens
  OK   shopify_store_url        21 tekens
  leeg revenuecat_project_id
  leeg nietbestaand
```

A key that is genuinely absent still returns empty, so callers that branch on emptiness keep working unchanged.

`bash -n` passes on the executable. No secret values appear in this diff — the added lines are variable references only.

## Not in this PR

Tier 5 (`channels.marketing.*`) is `{}` on the machine this was found on, so the owner-level Doppler-ref fallback resolves nothing. That is configuration, not code, and belongs in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
