### PR TITLE
fix(dash): render calendar times in one resolved display zone

### DIFF
--- a/claude-ops/CHANGELOG.md
+++ b/claude-ops/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Fixed
+- `ops-dash` now converts every CALENDAR event into one display zone before
+  printing it, instead of showing the raw clock half of each timestamp. Events
+  from a calendar in a different zone previously rendered at that calendar's
+  wall-clock time, so unrelated events could appear minutes apart and look like
+  a conflict. The zone is resolved from `$OPS_TZ`, then `timezone` in
+  `preferences.json`, then the system zone. All-day events are passed through
+  unconverted so they cannot be dragged onto an adjacent day.
+
 ## [3.10.15] - 2026-09-11
 
 ### Changed

--- a/claude-ops/bin/ops-dash
+++ b/claude-ops/bin/ops-dash
@@ -9,6 +9,8 @@ PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 . "${PLUGIN_ROOT}/lib/registry-path.sh"
 # Schema-tolerant registry readers (GSD schema has no .repos[]/.paths[]/.gsd).
 . "${PLUGIN_ROOT}/lib/registry-resolve.sh"
+# Display-zone resolution + calendar time localization (ops_calendar_rows).
+. "${PLUGIN_ROOT}/lib/calendar-tz.sh"
 PREFS="${OPS_DATA_DIR}/preferences.json"
 
 # ── Mobile / SSH detection (Rule 7) ─────────────────────────────────────────
@@ -1052,18 +1054,17 @@ render_section_calendar() {
   # Mobile: just count + first 3 titles
   if [[ "$MOBILE_MODE" -eq 1 ]]; then
     p "calendar: ${EVENT_COUNT} events today"
-    echo "$CALENDAR_JSON" | jq -r '.events[0:3][] | "  \(.start | split("T")[1] // "all-day" | .[0:5])  \(.summary)"' 2>/dev/null \
-      | while IFS= read -r line; do [[ -n "$line" ]] && p "$line"; done
+    echo "$CALENDAR_JSON" | ops_calendar_rows 3 \
+      | while IFS=$'\t' read -r time summary cal; do
+          [[ -z "$summary" ]] && continue
+          [[ "$time" == "ALLDAY" || -z "$time" ]] && time="all-day"
+          p "  ${time}  ${summary}"
+        done
     p ""; return
   fi
 
   # Desktop: time + title + calendar label (max 8)
-  echo "$CALENDAR_JSON" | jq -r '.events[0:8][] |
-    if .allday then
-      "ALLDAY\t\(.summary)\t\(.calendar)"
-    else
-      "\(.start | split("T")[1] // "" | .[0:5])\t\(.summary)\t\(.calendar)"
-    end' 2>/dev/null \
+  echo "$CALENDAR_JSON" | ops_calendar_rows 8 \
     | while IFS=$'\t' read -r time summary cal; do
         # Trim calendar to short label (before @)
         cal_short="${cal%@*}"

--- a/claude-ops/lib/calendar-tz.sh
+++ b/claude-ops/lib/calendar-tz.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# lib/calendar-tz.sh — resolve the dashboard display zone and localize calendar
+# event times into it.
+#
+# Why this exists: calendar feeds return each event in the zone of the calendar
+# that owns it, so a single day's events arrive as a mix of offsets. Printing
+# the raw clock half of the timestamp renders every event as if the viewer were
+# standing in that calendar's zone, which makes unrelated events look adjacent.
+# Every time must be moved to ONE display zone before it is printed.
+#
+# Sourcing convention (after lib/registry-path.sh, which exports OPS_DATA_DIR):
+#   . "${PLUGIN_ROOT}/lib/calendar-tz.sh"
+#
+# Exports:
+#   ops_display_tz       — echo the zone to render in. Resolution order:
+#                            1. $OPS_TZ
+#                            2. .timezone in $OPS_DATA_DIR/preferences.json
+#                            3. "" — meaning the system zone
+#                          Never a literal zone name: the operator's location is
+#                          configuration, not source.
+#   ops_calendar_rows N  — read dashboard calendar JSON on stdin, write at most N
+#                          TSV rows "<time>\t<summary>\t<calendar>" on stdout,
+#                          where <time> is HH:MM in the display zone, or the
+#                          literal ALLDAY for an all-day event.
+
+ops_display_tz() {
+  local tz prefs
+  tz="${OPS_TZ:-}"
+  if [ -z "$tz" ]; then
+    prefs="${OPS_DATA_DIR:-${CLAUDE_PLUGIN_DATA_DIR:-$HOME/.claude/plugins/data/ops-ops-marketplace}}/preferences.json"
+    if [ -f "$prefs" ] && command -v jq >/dev/null 2>&1; then
+      tz="$(jq -r '.timezone // ""' "$prefs" 2>/dev/null || printf '')"
+      [ "$tz" = "null" ] && tz=""
+    fi
+  fi
+  printf '%s' "$tz"
+}
+
+# Fallback used only when python3 is unavailable: previous behaviour, raw clock.
+# It is wrong across zones, but it is better than an empty CALENDAR section, and
+# it is never reached on a machine that has python3.
+_ops_calendar_rows_raw() {
+  local limit="$1"
+  jq -r --argjson n "$limit" '.events[0:$n][] |
+    if .allday then
+      "ALLDAY\t\(.summary)\t\(.calendar)"
+    else
+      "\(.start | split("T")[1] // "" | .[0:5])\t\(.summary)\t\(.calendar)"
+    end' 2>/dev/null || true
+}
+
+ops_calendar_rows() {
+  local limit="${1:-8}" tz
+  tz="$(ops_display_tz)"
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    _ops_calendar_rows_raw "$limit"
+    return 0
+  fi
+
+  python3 -c '
+import json, sys
+
+from datetime import datetime
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover - very old interpreters
+    ZoneInfo = None
+
+limit = int(sys.argv[1])
+tzname = sys.argv[2]
+
+target = None
+if tzname and ZoneInfo is not None:
+    try:
+        target = ZoneInfo(tzname)
+    except Exception:
+        # An unusable configured zone must not blank the section; fall through
+        # to the system zone, which is still one consistent zone.
+        target = None
+
+
+def localize(value):
+    """HH:MM in the display zone. Never invents an offset it was not given."""
+    if not value or "T" not in value:
+        return ""
+    wall = value.split("T", 1)[1][:5]
+    try:
+        stamp = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return wall
+    if stamp.tzinfo is None:
+        # No offset in the feed means we do not know which zone this clock is
+        # in. Shifting it would be a guess, so print it unchanged.
+        return wall
+    stamp = stamp.astimezone(target) if target is not None else stamp.astimezone()
+    return stamp.strftime("%H:%M")
+
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+
+events = data.get("events") or []
+out = []
+for event in events[:limit]:
+    summary = str(event.get("summary") or "(no title)")
+    calendar = str(event.get("calendar") or "")
+    if event.get("allday"):
+        # An all-day event has no instant, only a date. Converting it is the
+        # classic regression: it drags the event onto the previous or next day
+        # for any viewer west or east of the calendar. Pass it through.
+        when = "ALLDAY"
+    else:
+        when = localize(str(event.get("start") or ""))
+    out.append("\t".join(part.replace("\t", " ").replace("\n", " ")
+                         for part in (when, summary, calendar)))
+
+sys.stdout.write("".join(line + "\n" for line in out))
+' "$limit" "$tz" 2>/dev/null || true
+}

--- a/claude-ops/tests/test-ops-dash-calendar-timezone.sh
+++ b/claude-ops/tests/test-ops-dash-calendar-timezone.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Regression: the CALENDAR section must convert every event into ONE display
+# zone before printing.
+#
+# The bug: the renderer printed the clock half of each timestamp verbatim, so an
+# event stored with a +02:00 offset showed its +02:00 wall clock to a viewer
+# four hours behind UTC. Two events almost six hours apart then rendered five
+# minutes apart, inventing a conflict. Events already stored in the viewer's own
+# zone rendered correctly, which is why it went unnoticed.
+#
+# All data below is synthetic and uses fixed-offset zones only, so the test
+# gives the same answer on every machine and names nobody's location.
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DASH="$PLUGIN_ROOT/bin/ops-dash"
+LIB="$PLUGIN_ROOT/lib/calendar-tz.sh"
+
+fail=0
+note() { echo "FAIL: $*"; fail=1; }
+
+[ -f "$LIB" ] || { echo "FAIL: missing lib/calendar-tz.sh"; exit 1; }
+# shellcheck source=../lib/calendar-tz.sh
+. "$LIB"
+
+# Viewer sits four hours behind UTC. Etc/GMT+4 is that zone (POSIX inverts the
+# sign) and is a fixed offset, so there is no DST ambiguity to argue about.
+VIEWER="Etc/GMT+4"
+
+FIXTURE=$(cat <<'EOF'
+{"configured":true,"events":[
+ {"summary":"Sync A","calendar":"team-a@example.invalid","start":"2026-09-12T17:05:00+02:00","end":"2026-09-12T17:35:00+02:00","allday":false},
+ {"summary":"Sync B","calendar":"team-b@example.invalid","start":"2026-09-12T17:00:00-04:00","end":"2026-09-12T17:30:00-04:00","allday":false},
+ {"summary":"Offsite","calendar":"team-a@example.invalid","start":"2026-09-12","end":"2026-09-13","allday":true}
+]}
+EOF
+)
+
+rows=$(printf '%s' "$FIXTURE" | OPS_TZ="$VIEWER" ops_calendar_rows 8)
+
+got_a=$(printf '%s\n' "$rows" | awk -F'\t' '$2=="Sync A"{print $1}')
+got_b=$(printf '%s\n' "$rows" | awk -F'\t' '$2=="Sync B"{print $1}')
+got_all=$(printf '%s\n' "$rows" | awk -F'\t' '$2=="Offsite"{print $1}')
+
+# 17:05+02:00 is 15:05 UTC, which is 11:05 for this viewer.
+[ "$got_a" = "11:05" ] || note "event stored at +02:00 rendered '$got_a', expected 11:05"
+# Already in the viewer's zone: must survive the conversion untouched.
+[ "$got_b" = "17:00" ] || note "event already in the viewer zone rendered '$got_b', expected 17:00"
+# The false conflict: these two must not land minutes apart.
+[ "$got_a" != "$got_b" ] || note "two distinct instants collapsed onto the same clock time"
+# All-day has no instant. Converting it drags it onto an adjacent day.
+[ "$got_all" = "ALLDAY" ] || note "all-day event rendered '$got_all', expected ALLDAY"
+
+# Same fixture, a different display zone, must move the offset events and leave
+# the all-day event alone.
+rows_utc=$(printf '%s' "$FIXTURE" | OPS_TZ="Etc/UTC" ops_calendar_rows 8)
+[ "$(printf '%s\n' "$rows_utc" | awk -F'\t' '$2=="Sync A"{print $1}')" = "15:05" ] \
+  || note "display zone is not applied: +02:00 event did not render as 15:05 in UTC"
+[ "$(printf '%s\n' "$rows_utc" | awk -F'\t' '$2=="Offsite"{print $1}')" = "ALLDAY" ] \
+  || note "all-day event shifted when the display zone changed"
+
+# A timestamp with no offset must not be shifted; we do not know its zone.
+naive=$(printf '%s' '{"events":[{"summary":"Naive","calendar":"c@example.invalid","start":"2026-09-12T09:30:00","allday":false}]}' \
+  | OPS_TZ="$VIEWER" ops_calendar_rows 8 | awk -F'\t' '{print $1}')
+[ "$naive" = "09:30" ] || note "offset-less timestamp was shifted to '$naive', expected 09:30"
+
+# Degenerate inputs must stay quiet rather than break the section.
+for bad in '' '{}' '{"configured":true,"events":[]}' 'not json'; do
+  out=$(printf '%s' "$bad" | OPS_TZ="$VIEWER" ops_calendar_rows 8 || true)
+  [ -z "$out" ] || note "input '$bad' produced output: $out"
+done
+
+# The limit argument still caps the row count.
+n=$(printf '%s' "$FIXTURE" | OPS_TZ="$VIEWER" ops_calendar_rows 2 | grep -c . || true)
+[ "$n" = "2" ] || note "row limit not honoured: got $n rows for a limit of 2"
+
+# The renderer must go through the helper, not slice the raw timestamp again.
+if grep -Eq '\.start \| split\("T"\)' "$DASH"; then
+  note "ops-dash still prints a raw wall clock from the timestamp"
+fi
+grep -Fq 'ops_calendar_rows' "$DASH" || note "ops-dash does not use ops_calendar_rows"
+
+# The display zone is configuration, never a literal in the source.
+grep -Fq 'OPS_TZ' "$LIB" || note "lib/calendar-tz.sh does not honour \$OPS_TZ"
+grep -Fq 'preferences.json' "$LIB" || note "lib/calendar-tz.sh does not fall back to preferences.json"
+
+[ "$fail" -eq 0 ]
+echo "PASS: ops-dash calendar times render in one resolved display zone; all-day events unshifted"

--- a/claude-ops/tests/test-ops-dash-calendar-timezone.sh
+++ b/claude-ops/tests/test-ops-dash-calendar-timezone.sh
@@ -27,6 +27,20 @@ note() { echo "FAIL: $*"; fail=1; }
 # sign) and is a fixed offset, so there is no DST ambiguity to argue about.
 VIEWER="Etc/GMT+4"
 
+# The conversion needs a zone database. On a stripped container there is none,
+# and the helper then correctly falls back to the system zone — which would make
+# the assertions below fail for a reason that is not the bug. Say so plainly
+# instead of reporting a misleading wrong time.
+if ! python3 -c 'from zoneinfo import ZoneInfo; ZoneInfo("Etc/GMT+4")' 2>/dev/null; then
+  echo "SKIP: no zone database available; cannot assert cross-zone rendering"
+  grep -Eq '\.start \| split\("T"\)' "$DASH" \
+    && { echo "FAIL: ops-dash still prints a raw wall clock from the timestamp"; exit 1; }
+  grep -Fq 'ops_calendar_rows' "$DASH" \
+    || { echo "FAIL: ops-dash does not use ops_calendar_rows"; exit 1; }
+  echo "PASS: structural checks only (zone database unavailable)"
+  exit 0
+fi
+
 FIXTURE=$(cat <<'EOF'
 {"configured":true,"events":[
  {"summary":"Sync A","calendar":"team-a@example.invalid","start":"2026-09-12T17:05:00+02:00","end":"2026-09-12T17:35:00+02:00","allday":false},


### PR DESCRIPTION
## The bug

The `ops-dash` CALENDAR section printed the clock half of each event timestamp verbatim, discarding the UTC offset that came with it.

Calendar feeds return each event in the zone of the calendar that owns it, so a single day arrives as a mix of offsets. Printing those raw renders every event as if the viewer were standing in that calendar's zone.

An event carrying a `+02:00` offset displayed its `+02:00` wall clock to a viewer four hours behind UTC, where it should have read four hours earlier. Two events almost six hours apart could render five minutes apart and look like a scheduling conflict that did not exist.

Events already stored in the viewer's own zone rendered correctly, which is why this went unnoticed.

Reproduced with a synthetic fixture, viewer four hours behind UTC:

```
before                       after
  17:05    Sync A              11:05    Sync A     <- carries a +02:00 offset
  17:00    Sync B              17:00    Sync B     <- already in the viewer's zone
  all-day  Offsite             all-day  Offsite
```

The two events are 5h55m apart. Before the fix they render five minutes apart.

## The fix

New `lib/calendar-tz.sh`:

- `ops_display_tz` resolves one display zone: `$OPS_TZ`, then the `timezone` key in `preferences.json` under the plugin data dir, then the system zone. No zone is named in source, so the operator's location stays configuration and the repo's IANA-literal gate still passes.
- `ops_calendar_rows N` converts every event into that zone before emitting TSV rows.

Both the desktop and mobile render paths in `bin/ops-dash` now share the helper, replacing two separate inline `jq` expressions that each sliced the raw timestamp.

### All-day events

Passed through unconverted, explicitly. An all-day event carries a date and no instant, so converting it is the classic regression here: it drags the event onto the previous or next day for any viewer east or west of the calendar. Asserted in both directions in the test.

A timestamp that arrives with no offset at all is also left unshifted, since its zone is unknown and moving it would be a guess.

The mobile path additionally stops truncating `all-day` to `all-d`.

## Tests

`tests/test-ops-dash-calendar-timezone.sh`, synthetic data only, fixed-offset zones so the result is identical on every machine.

Verified it fails before the fix and passes after, by running the new test against a shim reproducing the old raw-clock behaviour:

```
BEFORE  FAIL: event stored at +02:00 rendered '17:05', expected 11:05
        FAIL: display zone is not applied: +02:00 event did not render as 15:05 in UTC
        exit=1

AFTER   PASS: ops-dash calendar times render in one resolved display zone; all-day events unshifted
        exit=0
```

Full suite: **52 of 53 suites pass.** `test-no-secrets.sh` is 31/31 including the IANA timezone gate and the operator-identity checks; `test-pii-gate-fires.sh` is 12/12; `test-bin-scripts.sh` is 270/270.

The one failing suite, `test-post-update-migrate-current-guard.sh`, fails identically on an untouched `main` checkout (`stat: illegal option -- c`, a GNU-ism against BSD `stat` on macOS). It is unrelated to this change and left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
